### PR TITLE
feat: discover repo-declared agents from .omnigent/ (ACP commands + agent configs)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -54,6 +54,8 @@ from omnigent.host.frames import (
     HostListWorktreesResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostPackageWorkspaceAgentFrame,
+    HostPackageWorkspaceAgentResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -2215,6 +2217,7 @@ class HostProcess:
                 command_binary_on_path,
                 workspace_acp_agents,
             )
+            from omnigent.spec.workspace_agents import scan_workspace_agent_configs
 
             entries = await asyncio.to_thread(workspace_acp_agents, Path(frame.path))
             agents: list[dict[str, object]] = [
@@ -2229,6 +2232,11 @@ class HostProcess:
                 }
                 for entry in entries
             ]
+            configs = await asyncio.to_thread(
+                scan_workspace_agent_configs,
+                Path(frame.path),
+            )
+            agent_configs = [config.as_dict() for config in configs]
         except Exception:
             _logger.exception("Failed to discover workspace harnesses")
             return HostWorkspaceHarnessesResultFrame(
@@ -2240,6 +2248,41 @@ class HostProcess:
             request_id=frame.request_id,
             status="ok",
             agents=agents,
+            agent_configs=agent_configs,
+        )
+
+    async def _handle_package_workspace_agent(
+        self,
+        frame: HostPackageWorkspaceAgentFrame,
+    ) -> HostPackageWorkspaceAgentResultFrame:
+        """Package a repo-declared agent config into bundle bytes.
+
+        Deterministic tar (see ``omnigent.spec.workspace_agents``): the
+        client hashes and uploads exactly these bytes, so the digest the
+        user consents to is the digest of what runs. Containment and the
+        size ceiling are enforced by the packager.
+        """
+        import base64
+
+        try:
+            from omnigent.spec.workspace_agents import package_workspace_agent
+
+            bundle = await asyncio.to_thread(
+                package_workspace_agent,
+                Path(frame.path),
+                frame.config_path,
+            )
+        except Exception as exc:
+            _logger.exception("Failed to package workspace agent")
+            return HostPackageWorkspaceAgentResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=f"failed to package workspace agent: {exc}",
+            )
+        return HostPackageWorkspaceAgentResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            bundle_b64=base64.b64encode(bundle).decode("ascii"),
         )
 
     @staticmethod
@@ -2893,6 +2936,8 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))
         elif isinstance(frame, HostWorkspaceHarnessesFrame):
             await ws.send(encode_host_frame(await self._handle_workspace_harnesses(frame)))
+        elif isinstance(frame, HostPackageWorkspaceAgentFrame):
+            await ws.send(encode_host_frame(await self._handle_package_workspace_agent(frame)))
 
 
 def run_host_process(

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2228,6 +2228,7 @@ class HostProcess:
                     "model": entry.model,
                     "session_id_mode": entry.session_id_mode,
                     "send_model": entry.send_model,
+                    "omnigent_mcp": entry.omnigent_mcp,
                     "command_found": command_binary_on_path(entry.command),
                 }
                 for entry in entries

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -65,6 +65,8 @@ from omnigent.host.frames import (
     HostStopRunnerResultFrame,
     HostStoreSecretFrame,
     HostStoreSecretResultFrame,
+    HostWorkspaceHarnessesFrame,
+    HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
     encode_host_frame,
 )
@@ -2198,6 +2200,48 @@ class HostProcess:
             routable_models=list(config.routable_models) if config is not None else [],
         )
 
+    async def _handle_workspace_harnesses(
+        self,
+        frame: HostWorkspaceHarnessesFrame,
+    ) -> HostWorkspaceHarnessesResultFrame:
+        """Discover repo-declared ACP agents in a workspace's ``.omnigent/``.
+
+        Reads only the project-level config, so every returned row is
+        attributable to the repo. ``command_found`` is a soft PATH hint for
+        the picker, never a gate — the agent owns its own install.
+        """
+        try:
+            from omnigent.onboarding.acp_auth import (
+                command_binary_on_path,
+                workspace_acp_agents,
+            )
+
+            entries = await asyncio.to_thread(workspace_acp_agents, Path(frame.path))
+            agents: list[dict[str, object]] = [
+                {
+                    "slug": entry.slug,
+                    "name": entry.name,
+                    "command": entry.command,
+                    "model": entry.model,
+                    "session_id_mode": entry.session_id_mode,
+                    "send_model": entry.send_model,
+                    "command_found": command_binary_on_path(entry.command),
+                }
+                for entry in entries
+            ]
+        except Exception:
+            _logger.exception("Failed to discover workspace harnesses")
+            return HostWorkspaceHarnessesResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error="failed to discover workspace harnesses",
+            )
+        return HostWorkspaceHarnessesResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            agents=agents,
+        )
+
     @staticmethod
     def _dispatch_fs_op(
         reader: object,
@@ -2847,6 +2891,8 @@ class HostProcess:
             await ws.send(encode_host_frame(fs_result))
         elif isinstance(frame, HostModelOptionsFrame):
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))
+        elif isinstance(frame, HostWorkspaceHarnessesFrame):
+            await ws.send(encode_host_frame(await self._handle_workspace_harnesses(frame)))
 
 
 def run_host_process(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -73,6 +73,8 @@ class HostFrameKind(str, Enum):
     FS_RESULT = "host.fs_result"
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
+    WORKSPACE_HARNESSES = "host.workspace_harnesses"
+    WORKSPACE_HARNESSES_RESULT = "host.workspace_harnesses_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -849,6 +851,32 @@ class HostModelOptionsResultFrame:
     routable_models: list[str] = field(default_factory=list)
 
 
+@dataclass
+class HostWorkspaceHarnessesFrame:
+    """Server → host: discover repo-declared harnesses in a workspace.
+
+    :param path: Absolute workspace path whose ``.omnigent/config.yaml``
+        should be read.
+    """
+
+    request_id: str
+    path: str
+
+
+@dataclass
+class HostWorkspaceHarnessesResultFrame:
+    """Host → server: repo-declared ACP agents found in the workspace.
+
+    :param agents: One row per declared agent: ``{slug, name, command,
+        model, session_id_mode, send_model, command_found}``.
+    """
+
+    request_id: str
+    status: str
+    agents: list[_JsonObject] = field(default_factory=list)
+    error: str | None = None
+
+
 HostFrame = (
     HostHelloFrame
     | HostHarnessReadinessFrame
@@ -881,6 +909,8 @@ HostFrame = (
     | HostFsResultFrame
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
+    | HostWorkspaceHarnessesFrame
+    | HostWorkspaceHarnessesResultFrame
 )
 
 
@@ -1233,6 +1263,24 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "routable_models": frame.routable_models,
             }
         )
+    if isinstance(frame, HostWorkspaceHarnessesFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.WORKSPACE_HARNESSES.value,
+                "request_id": frame.request_id,
+                "path": frame.path,
+            }
+        )
+    if isinstance(frame, HostWorkspaceHarnessesResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.WORKSPACE_HARNESSES_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "agents": frame.agents,
+                "error": frame.error,
+            }
+        )
     raise TypeError(f"unknown host frame type: {type(frame).__name__}")
 
 
@@ -1355,6 +1403,10 @@ def _decode_known_host_frame(
             return _decode_model_options(msg)
         case HostFrameKind.MODEL_OPTIONS_RESULT:
             return _decode_model_options_result(msg)
+        case HostFrameKind.WORKSPACE_HARNESSES:
+            return _decode_workspace_harnesses(msg)
+        case HostFrameKind.WORKSPACE_HARNESSES_RESULT:
+            return _decode_workspace_harnesses_result(msg)
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 
@@ -1870,6 +1922,27 @@ def _decode_model_options_result(msg: _JsonObject) -> HostModelOptionsResultFram
         models=models,
         error=_optional_nullable_str(msg, "error"),
         routable_models=routable,
+    )
+
+
+def _decode_workspace_harnesses(msg: _JsonObject) -> HostWorkspaceHarnessesFrame:
+    """Decode a host.workspace_harnesses request frame."""
+    return HostWorkspaceHarnessesFrame(
+        request_id=_required_str(msg, "request_id"),
+        path=_required_str(msg, "path"),
+    )
+
+
+def _decode_workspace_harnesses_result(msg: _JsonObject) -> HostWorkspaceHarnessesResultFrame:
+    """Decode a host.workspace_harnesses_result frame."""
+    agents = msg.get("agents", [])
+    if not isinstance(agents, list) or not all(isinstance(agent, dict) for agent in agents):
+        raise ValueError("frame field must be a list of JSON objects: 'agents'")
+    return HostWorkspaceHarnessesResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        agents=agents,
+        error=_optional_nullable_str(msg, "error"),
     )
 
 

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -75,6 +75,8 @@ class HostFrameKind(str, Enum):
     MODEL_OPTIONS_RESULT = "host.model_options_result"
     WORKSPACE_HARNESSES = "host.workspace_harnesses"
     WORKSPACE_HARNESSES_RESULT = "host.workspace_harnesses_result"
+    PACKAGE_WORKSPACE_AGENT = "host.package_workspace_agent"
+    PACKAGE_WORKSPACE_AGENT_RESULT = "host.package_workspace_agent_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -865,15 +867,42 @@ class HostWorkspaceHarnessesFrame:
 
 @dataclass
 class HostWorkspaceHarnessesResultFrame:
-    """Host → server: repo-declared ACP agents found in the workspace.
+    """Host → server: repo-declared agents found in the workspace.
 
-    :param agents: One row per declared agent: ``{slug, name, command,
-        model, session_id_mode, send_model, command_found}``.
+    :param agents: One row per declared ACP agent: ``{slug, name,
+        command, model, session_id_mode, send_model, command_found}``.
+    :param agent_configs: One row per agent config under
+        ``.omnigent/agent-configs/`` (see
+        ``omnigent.spec.workspace_agents.WorkspaceAgentConfig.as_dict``).
     """
 
     request_id: str
     status: str
     agents: list[_JsonObject] = field(default_factory=list)
+    agent_configs: list[_JsonObject] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class HostPackageWorkspaceAgentFrame:
+    """Server → host: package a repo-declared agent config for upload.
+
+    :param path: Absolute workspace path (containment root).
+    :param config_path: Workspace-relative path of a discovered config.
+    """
+
+    request_id: str
+    path: str
+    config_path: str
+
+
+@dataclass
+class HostPackageWorkspaceAgentResultFrame:
+    """Host → server: deterministic ``.tar.gz`` bundle bytes, base64d."""
+
+    request_id: str
+    status: str
+    bundle_b64: str | None = None
     error: str | None = None
 
 
@@ -911,6 +940,8 @@ HostFrame = (
     | HostModelOptionsResultFrame
     | HostWorkspaceHarnessesFrame
     | HostWorkspaceHarnessesResultFrame
+    | HostPackageWorkspaceAgentFrame
+    | HostPackageWorkspaceAgentResultFrame
 )
 
 
@@ -1278,6 +1309,26 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "request_id": frame.request_id,
                 "status": frame.status,
                 "agents": frame.agents,
+                "agent_configs": frame.agent_configs,
+                "error": frame.error,
+            }
+        )
+    if isinstance(frame, HostPackageWorkspaceAgentFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.PACKAGE_WORKSPACE_AGENT.value,
+                "request_id": frame.request_id,
+                "path": frame.path,
+                "config_path": frame.config_path,
+            }
+        )
+    if isinstance(frame, HostPackageWorkspaceAgentResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.PACKAGE_WORKSPACE_AGENT_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "bundle_b64": frame.bundle_b64,
                 "error": frame.error,
             }
         )
@@ -1407,6 +1458,10 @@ def _decode_known_host_frame(
             return _decode_workspace_harnesses(msg)
         case HostFrameKind.WORKSPACE_HARNESSES_RESULT:
             return _decode_workspace_harnesses_result(msg)
+        case HostFrameKind.PACKAGE_WORKSPACE_AGENT:
+            return _decode_package_workspace_agent(msg)
+        case HostFrameKind.PACKAGE_WORKSPACE_AGENT_RESULT:
+            return _decode_package_workspace_agent_result(msg)
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 
@@ -1938,10 +1993,37 @@ def _decode_workspace_harnesses_result(msg: _JsonObject) -> HostWorkspaceHarness
     agents = msg.get("agents", [])
     if not isinstance(agents, list) or not all(isinstance(agent, dict) for agent in agents):
         raise ValueError("frame field must be a list of JSON objects: 'agents'")
+    agent_configs = msg.get("agent_configs", [])
+    if not isinstance(agent_configs, list) or not all(
+        isinstance(entry, dict) for entry in agent_configs
+    ):
+        raise ValueError("frame field must be a list of JSON objects: 'agent_configs'")
     return HostWorkspaceHarnessesResultFrame(
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
         agents=agents,
+        agent_configs=agent_configs,
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_package_workspace_agent(msg: _JsonObject) -> HostPackageWorkspaceAgentFrame:
+    """Decode a host.package_workspace_agent request frame."""
+    return HostPackageWorkspaceAgentFrame(
+        request_id=_required_str(msg, "request_id"),
+        path=_required_str(msg, "path"),
+        config_path=_required_str(msg, "config_path"),
+    )
+
+
+def _decode_package_workspace_agent_result(
+    msg: _JsonObject,
+) -> HostPackageWorkspaceAgentResultFrame:
+    """Decode a host.package_workspace_agent_result frame."""
+    return HostPackageWorkspaceAgentResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        bundle_b64=_optional_nullable_str(msg, "bundle_b64"),
         error=_optional_nullable_str(msg, "error"),
     )
 

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import re
 import shutil
 from dataclasses import dataclass
+from pathlib import Path
 
 from omnigent.onboarding.provider_config import load_config
 
@@ -127,6 +128,26 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
             )
         )
     return entries
+
+
+def workspace_acp_agents(workspace: Path) -> list[AcpAgentEntry]:
+    """Return the ACP agents declared in a workspace's ``.omnigent/config.yaml``.
+
+    Reads the project-level ``acp:`` block only — the global config is not
+    merged in, so callers can attribute every returned entry to the repo.
+    Any failure (missing/unreadable file, malformed YAML) yields ``[]``; a
+    broken repo config must never break discovery.
+
+    :param workspace: The working directory the repo config lives under.
+    :returns: The repo-declared agents (possibly empty).
+    """
+    from omnigent.config import load_local_config
+
+    try:
+        config_path = Path(workspace).expanduser() / ".omnigent" / "config.yaml"
+        return acp_agents(config=load_local_config(path=config_path))
+    except Exception:
+        return []
 
 
 def resolve_acp_agent(slug: str, config: dict[str, object] | None = None) -> AcpAgentEntry | None:

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -141,12 +141,14 @@ def workspace_acp_agents(workspace: Path) -> list[AcpAgentEntry]:
     :param workspace: The working directory the repo config lives under.
     :returns: The repo-declared agents (possibly empty).
     """
+    import yaml
+
     from omnigent.config import load_local_config
 
     try:
         config_path = Path(workspace).expanduser() / ".omnigent" / "config.yaml"
         return acp_agents(config=load_local_config(path=config_path))
-    except Exception:
+    except (OSError, ValueError, yaml.YAMLError):
         return []
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -598,11 +598,12 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
     return schemas
 
 
-# sys_agent_list: locally-authored agent config YAMLs live under this
-# subdirectory of the agent's os_env cwd, so the list tool can find them
-# and the agent can read/edit them via sys_os_* (configs are authored with
-# sys_os_write, e.g. following the ``build-omnigent`` skill).
-_AGENT_CONFIG_SUBDIR = ".omnigent/agent-configs"
+# sys_agent_list: locally-authored agent config YAMLs live under the
+# ``omnigent.spec.workspace_agents.AGENT_CONFIG_SUBDIR`` subdirectory of the
+# agent's os_env cwd, so the list tool can find them and the agent can
+# read/edit them via sys_os_* (configs are authored with sys_os_write,
+# e.g. following the ``build-omnigent`` skill). Imported lazily at the use
+# site — this module keeps spec imports off its import path.
 
 # Broad page size for the sys_agent_list fan-out reads. Orchestrators want
 # the full launchable surface in one call, not a 20-row default page.
@@ -4417,7 +4418,9 @@ async def _agent_list_via_rest(
     sessions_raw = await _agent_list_fetch("/v1/sessions", server_client)
     spec = _effective_runner_os_env_spec(agent_spec, conversation_id, runner_workspace)
     assert spec.cwd is not None
-    configs_dir = Path(spec.cwd) / _AGENT_CONFIG_SUBDIR
+    from omnigent.spec.workspace_agents import AGENT_CONFIG_SUBDIR
+
+    configs_dir = Path(spec.cwd) / AGENT_CONFIG_SUBDIR
     local_configs = await asyncio.to_thread(_scan_local_agent_configs, configs_dir)
     listing = _project_agent_list(builtins_raw, sessions_raw, local_configs)
     listing["builtins"] = _in_spawn_family(

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1613,10 +1613,15 @@ def _build_acp_spawn_env(
         omnigent_mcp = embedded.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("executor acp_agent omnigent_mcp must be a boolean")
+        model = embedded.get("model")
+        mode = embedded.get("session_id_mode")
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
             command=command.strip(),
+            model=model.strip() if isinstance(model, str) and model.strip() else None,
+            session_id_mode=mode if mode in ("server", "client") else "server",
+            send_model=bool(embedded.get("send_model", False)),
             omnigent_mcp=omnigent_mcp,
         )
     else:

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -259,6 +259,8 @@ class HostConnection:
         ``error_code``, and ``error``.
     :param pending_model_options: Per-``request_id`` futures for pre-launch
         model catalogs resolved by the selected host.
+    :param pending_workspace_harnesses: Per-``request_id`` futures for
+        repo-declared harness discovery in a workspace's ``.omnigent/``.
     """
 
     workspace_id: int
@@ -313,6 +315,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_model_options: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_workspace_harnesses: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
 

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -261,6 +261,8 @@ class HostConnection:
         model catalogs resolved by the selected host.
     :param pending_workspace_harnesses: Per-``request_id`` futures for
         repo-declared harness discovery in a workspace's ``.omnigent/``.
+    :param pending_package_workspace_agents: Per-``request_id`` futures
+        for packaging a repo-declared agent config into bundle bytes.
     """
 
     workspace_id: int
@@ -318,6 +320,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_workspace_harnesses: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_package_workspace_agents: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1720,6 +1720,38 @@ def _resolve_harness_impl(conv: Conversation | None) -> str | None:
         return None
 
 
+def _harness_for_launch_gate(conv: Conversation | None) -> str | None:
+    """
+    Harness to send on the ``host.launch_runner`` frame.
+
+    Same resolution as :func:`_resolve_harness`, except a spec embedding a
+    one-shot ``acp_agent`` returns ``None``: the command rides in the spec,
+    so the host's global ``acp`` readiness doesn't apply and must not refuse
+    the launch. ``None`` skips the host-side check — fail open.
+    """
+    harness = _resolve_harness(conv)
+    if harness != "acp" or conv is None or conv.agent_id is None:
+        return harness
+    try:
+        from omnigent.runtime import get_agent_cache
+        from omnigent.runtime._globals import _agent_store
+
+        if _agent_store is None:
+            return harness
+        agent = _agent_store.get(conv.agent_id)
+        if agent is None:
+            return harness
+        loaded = get_agent_cache().load(
+            agent.id, agent.bundle_location, expand_env=agent.session_id is None
+        )
+        config = loaded.spec.executor.config
+        if isinstance(config, dict) and "acp_agent" in config:
+            return None
+    except (KeyError, AttributeError, ValueError, ImportError, OSError):
+        pass
+    return harness
+
+
 def _validated_harness_override(value: str | None, agent: Agent) -> str | None:
     """
     Validate + canonicalize a session-create ``harness_override``.
@@ -4334,10 +4366,11 @@ async def _launch_runner_on_host_impl(
             binding_token=binding_token,
             workspace=conv.workspace,
             session_id=conv.id,
-            # Canonical harness (see _resolve_harness) so the host runs the
-            # same configuration check it does at create-time launch. None
-            # (agent not resolvable) skips the host-side check — fail open.
-            harness=_resolve_harness(conv),
+            # Canonical harness so the host runs the same configuration
+            # check it does at create-time launch. None (agent not
+            # resolvable, or a self-contained embedded ACP agent) skips
+            # the host-side check — fail open.
+            harness=_harness_for_launch_gate(conv),
         )
     )
     try:

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -38,6 +38,7 @@ from omnigent.host.frames import (
     HostListDirResultFrame,
     HostListWorktreesResultFrame,
     HostModelOptionsResultFrame,
+    HostPackageWorkspaceAgentResultFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
     HostRunnerStatusResultFrame,
@@ -698,6 +699,19 @@ async def _receive_loop(
                     {
                         "status": frame.status,
                         "agents": frame.agents,
+                        "agent_configs": frame.agent_configs,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostPackageWorkspaceAgentResultFrame):
+            package_future = conn.pending_package_workspace_agents.pop(frame.request_id, None)
+            if package_future is not None and not package_future.done():
+                package_future.set_result(
+                    {
+                        "status": frame.status,
+                        "bundle_b64": frame.bundle_b64,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -44,6 +44,7 @@ from omnigent.host.frames import (
     HostStatResultFrame,
     HostStopRunnerResultFrame,
     HostStoreSecretResultFrame,
+    HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
 )
 from omnigent.host.identity import MANAGED_HOST_TOKEN_HEADER
@@ -685,6 +686,18 @@ async def _receive_loop(
                         "status": frame.status,
                         "models": frame.models,
                         "routable_models": frame.routable_models,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostWorkspaceHarnessesResultFrame):
+            harnesses_future = conn.pending_workspace_harnesses.pop(frame.request_id, None)
+            if harnesses_future is not None and not harnesses_future.done():
+                harnesses_future.set_result(
+                    {
+                        "status": frame.status,
+                        "agents": frame.agents,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -37,6 +37,7 @@ from omnigent.host.frames import (
     HostLaunchRunnerFrame,
     HostListDirFrame,
     HostStoreSecretFrame,
+    HostWorkspaceHarnessesFrame,
     encode_host_frame,
     optional_str_bool_map,
 )
@@ -71,6 +72,10 @@ _LIST_DIR_MAX_LIMIT = 1000
 # for transient network slowness without making the picker feel hung.
 _CREATE_DIR_TIMEOUT_S = 5.0
 _MODEL_OPTIONS_TIMEOUT_S = 15.0
+# Per-call timeout for host.workspace_harnesses round-trips. Reading one
+# small YAML file on the host is cheap; a short cap also bounds the wait
+# when an older host daemon silently ignores the unknown frame kind.
+_WORKSPACE_HARNESSES_TIMEOUT_S = 10.0
 # Per-call timeout for host.install_harness round-trips. The host runs
 # `npm install -g <pkg>` — install_harness_cli caps that subprocess at 300s —
 # then recomputes readiness and sends the result back over the tunnel. The
@@ -115,6 +120,42 @@ async def _proxy_model_options(
                 f"{_MODEL_OPTIONS_TIMEOUT_S:.0f}s"
             ),
         ) from exc
+
+
+async def _proxy_workspace_harnesses(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    path: str,
+) -> dict[str, Any]:
+    """Ask a host for the repo-declared harnesses in a workspace."""
+    request_id = secrets.token_hex(8)
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    host_conn.pending_workspace_harnesses[request_id] = future
+    frame = encode_host_frame(
+        HostWorkspaceHarnessesFrame(request_id=request_id, path=path),
+    )
+    try:
+        try:
+            host_registry.send_text(host_conn, frame)
+        except ConnectionError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"host '{host_conn.host_id}' connection lost",
+            ) from exc
+        try:
+            return await asyncio.wait_for(future, timeout=_WORKSPACE_HARNESSES_TIMEOUT_S)
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(
+                status_code=504,
+                detail=(
+                    f"host '{host_conn.host_id}' did not resolve workspace harnesses "
+                    f"within {_WORKSPACE_HARNESSES_TIMEOUT_S:.0f}s"
+                ),
+            ) from exc
+    finally:
+        host_conn.pending_workspace_harnesses.pop(request_id, None)
 
 
 async def _proxy_list_dir(
@@ -517,7 +558,15 @@ async def _resolve_agent_harness(
     if agent is None or agent.bundle_location is None:
         return None
     loaded = await asyncio.to_thread(agent_cache.load, agent.id, agent.bundle_location)
-    return canonicalize_harness(loaded.spec.executor.harness_kind)
+    executor = loaded.spec.executor
+    harness = canonicalize_harness(executor.harness_kind)
+    # A spec embedding a one-shot ``acp_agent`` is self-contained — the
+    # command rides in the spec, so the host's global ``acp`` readiness
+    # doesn't apply. None skips the host-side check (fail open).
+    config = getattr(executor, "config", None)
+    if harness == "acp" and isinstance(config, dict) and "acp_agent" in config:
+        return None
+    return harness
 
 
 def create_hosts_router(
@@ -686,6 +735,56 @@ def create_hosts_router(
             )
         models = result.get("models")
         return {"models": models if isinstance(models, list) else []}
+
+    @router.get("/hosts/{host_id}/workspace-harnesses")
+    async def get_host_workspace_harnesses(
+        request: Request,
+        host_id: str,
+        path: str = Query(min_length=1),
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return the harnesses a workspace's ``.omnigent/`` declares.
+
+        Reads ``<path>/.omnigent/config.yaml`` on the selected host and
+        returns its ``acp:`` agents so the picker can suggest repo-declared
+        harnesses. Owner-scoped like the filesystem endpoints; discovery
+        only — launching a discovered agent still goes through the client's
+        explicit consent flow.
+
+        :param request: FastAPI request (for auth).
+        :param host_id: Host identifier.
+        :param path: Absolute or tilde-prefixed workspace path on the host.
+        :returns: ``{"agents": [...]}`` (empty when nothing is declared).
+        :raises HTTPException: 404 (host missing), 403 (not owner), 409
+            (offline), 400 (path validation), 504 (timeout), 502 (host
+            failure).
+        """
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        if "\x00" in path:
+            raise HTTPException(
+                status_code=400,
+                detail="path must not contain NUL bytes",
+            )
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+
+        result = await _proxy_workspace_harnesses(
+            host_registry=host_registry,
+            host_conn=conn,
+            path=path,
+        )
+        if result.get("status") != "ok":
+            raise HTTPException(
+                status_code=502,
+                detail=str(result.get("error") or "workspace harness discovery failed"),
+            )
+        agents = result.get("agents")
+        return {"agents": agents if isinstance(agents, list) else []}
 
     @router.post("/hosts/{host_id}/runners")
     async def launch_runner(

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -22,7 +22,7 @@ import os
 import secrets
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from omnigent.db.utils import now_epoch
@@ -36,6 +36,7 @@ from omnigent.host.frames import (
     HostInstallHarnessFrame,
     HostLaunchRunnerFrame,
     HostListDirFrame,
+    HostPackageWorkspaceAgentFrame,
     HostStoreSecretFrame,
     HostWorkspaceHarnessesFrame,
     encode_host_frame,
@@ -76,6 +77,9 @@ _MODEL_OPTIONS_TIMEOUT_S = 15.0
 # small YAML file on the host is cheap; a short cap also bounds the wait
 # when an older host daemon silently ignores the unknown frame kind.
 _WORKSPACE_HARNESSES_TIMEOUT_S = 10.0
+# Per-call timeout for host.package_workspace_agent round-trips. Tarring a
+# text-config bundle is fast; the 10 MB packager ceiling bounds the work.
+_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S = 15.0
 # Per-call timeout for host.install_harness round-trips. The host runs
 # `npm install -g <pkg>` — install_harness_cli caps that subprocess at 300s —
 # then recomputes readiness and sends the result back over the tunnel. The
@@ -156,6 +160,50 @@ async def _proxy_workspace_harnesses(
             ) from exc
     finally:
         host_conn.pending_workspace_harnesses.pop(request_id, None)
+
+
+async def _proxy_package_workspace_agent(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    path: str,
+    config_path: str,
+) -> dict[str, Any]:
+    """Ask a host to package a repo-declared agent config for upload."""
+    request_id = secrets.token_hex(8)
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    host_conn.pending_package_workspace_agents[request_id] = future
+    frame = encode_host_frame(
+        HostPackageWorkspaceAgentFrame(
+            request_id=request_id,
+            path=path,
+            config_path=config_path,
+        ),
+    )
+    try:
+        try:
+            host_registry.send_text(host_conn, frame)
+        except ConnectionError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"host '{host_conn.host_id}' connection lost",
+            ) from exc
+        try:
+            return await asyncio.wait_for(
+                future,
+                timeout=_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(
+                status_code=504,
+                detail=(
+                    f"host '{host_conn.host_id}' did not package the workspace agent "
+                    f"within {_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S:.0f}s"
+                ),
+            ) from exc
+    finally:
+        host_conn.pending_package_workspace_agents.pop(request_id, None)
 
 
 async def _proxy_list_dir(
@@ -442,6 +490,18 @@ async def _proxy_detect_credentials(
             ) from exc
     finally:
         host_conn.pending_credential_detects.pop(request_id, None)
+
+
+class PackageWorkspaceAgentRequest(BaseModel):
+    """Body for ``POST /v1/hosts/{id}/workspace-agents/package``.
+
+    :param path: Absolute workspace path on the host.
+    :param config_path: Workspace-relative path of a discovered config,
+        e.g. ``".omnigent/agent-configs/helper.yaml"``.
+    """
+
+    path: str
+    config_path: str
 
 
 class CreateDirectoryRequest(BaseModel):
@@ -784,7 +844,69 @@ def create_hosts_router(
                 detail=str(result.get("error") or "workspace harness discovery failed"),
             )
         agents = result.get("agents")
-        return {"agents": agents if isinstance(agents, list) else []}
+        agent_configs = result.get("agent_configs")
+        return {
+            "agents": agents if isinstance(agents, list) else [],
+            "agent_configs": agent_configs if isinstance(agent_configs, list) else [],
+        }
+
+    @router.post("/hosts/{host_id}/workspace-agents/package")
+    async def package_host_workspace_agent(
+        request: Request,
+        host_id: str,
+        body: PackageWorkspaceAgentRequest,
+    ) -> Response:
+        """Package a repo-declared agent config into bundle bytes.
+
+        The host materializes ``<path>/<config_path>`` (a discovered
+        single-file YAML or bundle directory) into a deterministic
+        ``.tar.gz`` and returns the bytes. The client hashes them for
+        the consent grant and uploads them verbatim via the standard
+        multipart session create, so what the user approved is exactly
+        what the server validates and runs.
+
+        :returns: The raw ``application/gzip`` bundle bytes.
+        :raises HTTPException: 404 (host missing), 403 (not owner), 409
+            (offline), 400 (path validation), 504 (timeout), 502 (host
+            failure).
+        """
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        if not body.path or "\x00" in body.path or "\x00" in body.config_path:
+            raise HTTPException(
+                status_code=400,
+                detail="path and config_path must be non-empty and NUL-free",
+            )
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+
+        result = await _proxy_package_workspace_agent(
+            host_registry=host_registry,
+            host_conn=conn,
+            path=body.path,
+            config_path=body.config_path,
+        )
+        bundle_b64 = result.get("bundle_b64")
+        if result.get("status") != "ok" or not isinstance(bundle_b64, str):
+            raise HTTPException(
+                status_code=502,
+                detail=str(result.get("error") or "workspace agent packaging failed"),
+            )
+        import base64
+
+        try:
+            bundle = base64.b64decode(bundle_b64, validate=True)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="host returned malformed bundle bytes",
+            ) from exc
+        return Response(content=bundle, media_type="application/gzip")
 
     @router.post("/hosts/{host_id}/runners")
     async def launch_runner(

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -135,30 +135,27 @@ async def _proxy_workspace_harnesses(
 ) -> dict[str, Any]:
     """Ask a host for the repo-declared harnesses in a workspace."""
     request_id = secrets.token_hex(8)
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
     host_conn.pending_workspace_harnesses[request_id] = future
     frame = encode_host_frame(
         HostWorkspaceHarnessesFrame(request_id=request_id, path=path),
     )
     try:
-        try:
-            host_registry.send_text(host_conn, frame)
-        except ConnectionError as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"host '{host_conn.host_id}' connection lost",
-            ) from exc
-        try:
-            return await asyncio.wait_for(future, timeout=_WORKSPACE_HARNESSES_TIMEOUT_S)
-        except asyncio.TimeoutError as exc:
-            raise HTTPException(
-                status_code=504,
-                detail=(
-                    f"host '{host_conn.host_id}' did not resolve workspace harnesses "
-                    f"within {_WORKSPACE_HARNESSES_TIMEOUT_S:.0f}s"
-                ),
-            ) from exc
+        host_registry.send_text(host_conn, frame)
+        return await asyncio.wait_for(future, timeout=_WORKSPACE_HARNESSES_TIMEOUT_S)
+    except ConnectionError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"host '{host_conn.host_id}' connection lost",
+        ) from exc
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"host '{host_conn.host_id}' did not resolve workspace harnesses "
+                f"within {_WORKSPACE_HARNESSES_TIMEOUT_S:.0f}s"
+            ),
+        ) from exc
     finally:
         host_conn.pending_workspace_harnesses.pop(request_id, None)
 
@@ -172,8 +169,7 @@ async def _proxy_package_workspace_agent(
 ) -> dict[str, Any]:
     """Ask a host to package a repo-declared agent config for upload."""
     request_id = secrets.token_hex(8)
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
     host_conn.pending_package_workspace_agents[request_id] = future
     frame = encode_host_frame(
         HostPackageWorkspaceAgentFrame(
@@ -183,26 +179,21 @@ async def _proxy_package_workspace_agent(
         ),
     )
     try:
-        try:
-            host_registry.send_text(host_conn, frame)
-        except ConnectionError as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"host '{host_conn.host_id}' connection lost",
-            ) from exc
-        try:
-            return await asyncio.wait_for(
-                future,
-                timeout=_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S,
-            )
-        except asyncio.TimeoutError as exc:
-            raise HTTPException(
-                status_code=504,
-                detail=(
-                    f"host '{host_conn.host_id}' did not package the workspace agent "
-                    f"within {_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S:.0f}s"
-                ),
-            ) from exc
+        host_registry.send_text(host_conn, frame)
+        return await asyncio.wait_for(future, timeout=_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S)
+    except ConnectionError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"host '{host_conn.host_id}' connection lost",
+        ) from exc
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"host '{host_conn.host_id}' did not package the workspace agent "
+                f"within {_PACKAGE_WORKSPACE_AGENT_TIMEOUT_S:.0f}s"
+            ),
+        ) from exc
     finally:
         host_conn.pending_package_workspace_agents.pop(request_id, None)
 

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -17,6 +17,7 @@ from the DB so a host connected to replica B reads back as
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
 import secrets
@@ -897,11 +898,9 @@ def create_hosts_router(
                 status_code=502,
                 detail=str(result.get("error") or "workspace agent packaging failed"),
             )
-        import base64
-
         try:
             bundle = base64.b64decode(bundle_b64, validate=True)
-        except Exception as exc:
+        except ValueError as exc:
             raise HTTPException(
                 status_code=502,
                 detail="host returned malformed bundle bytes",

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -91,7 +91,7 @@ _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
 
 # ``executor.config`` keys kept as their nested YAML structure instead of
 # string-coerced — their consumers read the nested mapping/list shape.
-_STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
+_STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset({"acp_agent"})
 
 # Copy the resolver dict onto the subclass before mutating — it's inherited
 # from SafeLoader by reference, so in-place edits below would strip
@@ -656,6 +656,13 @@ def _parse_executor(
         profile = str(profile_raw)
     if etype == "omnigent" and profile is not None and "profile" not in config:
         config["profile"] = profile
+    # Mirror a top-level ``executor.acp_agent`` (one-shot embedded ACP
+    # agent) into config, like ``profile`` above — the runtime adapter
+    # reads it from the raw executor mapping, but server-side consumers
+    # (e.g. the launch gate) only see the parsed spec.
+    acp_agent_raw = raw.get("acp_agent")
+    if etype == "omnigent" and isinstance(acp_agent_raw, dict) and "acp_agent" not in config:
+        config["acp_agent"] = acp_agent_raw
     raw_cw = raw.get("context_window")
     context_window: int | None = (
         _parse_int_field(raw_cw, "executor.context_window") if raw_cw is not None else None

--- a/omnigent/spec/workspace_agents.py
+++ b/omnigent/spec/workspace_agents.py
@@ -1,0 +1,259 @@
+"""Discovery and packaging of workspace-authored agent configs.
+
+A repo can carry agent definitions under ``.omnigent/agent-configs/`` —
+the same subdirectory the runner's ``sys_agent_list`` tool scans (see
+``omnigent.runner.tool_dispatch._AGENT_CONFIG_SUBDIR``). Two shapes are
+recognized, matching :func:`omnigent.spec.materialize_bundle`:
+
+- flat ``*.yaml`` files (the single-file omnigent dialect), and
+- ``<name>/config.yaml`` directories (full agent images with tools,
+  skills, and ``agents/`` sub-agent images).
+
+The scanner returns light summaries for the picker and consent dialog;
+the packager builds deterministic ``.tar.gz`` bytes for the standard
+multipart bundle upload, so the digest a user consents to is exactly the
+digest of what gets uploaded. Both are read-only and never execute
+anything from the workspace.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import re
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+AGENT_CONFIG_SUBDIR = ".omnigent/agent-configs"
+
+# Ceiling for packaged bundle bytes. Bundles are text configs plus small
+# tool/skill files; anything larger is almost certainly a mistake (or a
+# repo trying to smuggle bulk data through the discovery path).
+MAX_PACKAGED_BUNDLE_BYTES = 10 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class WorkspaceAgentConfig:
+    """One repo-declared agent config, summarized for discovery.
+
+    :param slug: Stable id derived from the display name (unique within
+        one scan; collisions get ``-2`` / ``-3`` … suffixes).
+    :param name: Display name (config ``name:``, else the file/dir stem).
+    :param path: Path relative to the workspace root, e.g.
+        ``".omnigent/agent-configs/helper.yaml"`` — the packager input.
+    :param kind: ``"file"`` (single-file YAML) or ``"bundle"``
+        (directory image).
+    :param description: Config ``description:``, when present.
+    :param harness: Declared harness (``executor.config.harness`` else
+        ``executor.type``), when readable.
+    :param sub_agents: ``tools.agents`` allowlist names (bundles only).
+    :param has_local_tools: Bundle declares ``tools/python|typescript``.
+    :param has_mcp_servers: Bundle declares ``tools/mcp/*.yaml``.
+    """
+
+    slug: str
+    name: str
+    path: str
+    kind: str
+    description: str | None = None
+    harness: str | None = None
+    sub_agents: tuple[str, ...] = ()
+    has_local_tools: bool = False
+    has_mcp_servers: bool = False
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize for the host frame / REST payload."""
+        return {
+            "slug": self.slug,
+            "name": self.name,
+            "path": self.path,
+            "kind": self.kind,
+            "description": self.description,
+            "harness": self.harness,
+            "sub_agents": list(self.sub_agents),
+            "has_local_tools": self.has_local_tools,
+            "has_mcp_servers": self.has_mcp_servers,
+        }
+
+
+def _slugify(name: str) -> str:
+    """Lowercase, non-alnum runs to ``-``; empty falls back to ``agent``."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug or "agent"
+
+
+def _read_mapping(path: Path) -> dict[str, object] | None:
+    """Load a YAML mapping, or ``None`` on any read/parse failure."""
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _declared_harness(config: dict[str, object]) -> str | None:
+    """Pull the declared harness out of an ``executor:`` block, if any."""
+    executor = config.get("executor")
+    if not isinstance(executor, dict):
+        return None
+    exec_config = executor.get("config")
+    if isinstance(exec_config, dict):
+        harness = exec_config.get("harness")
+        if isinstance(harness, str) and harness:
+            return harness
+    etype = executor.get("type")
+    return etype if isinstance(etype, str) and etype else None
+
+
+def _sub_agent_names(config: dict[str, object]) -> tuple[str, ...]:
+    """The ``tools.agents`` allowlist, as a tuple of names."""
+    tools = config.get("tools")
+    if not isinstance(tools, dict):
+        return ()
+    agents = tools.get("agents")
+    if not isinstance(agents, list):
+        return ()
+    return tuple(a for a in agents if isinstance(a, str))
+
+
+def scan_workspace_agent_configs(workspace: Path) -> list[WorkspaceAgentConfig]:
+    """Summarize the agent configs a workspace declares.
+
+    Scans ``<workspace>/.omnigent/agent-configs/`` for flat ``*.yaml``
+    files and ``<name>/config.yaml`` bundle directories, in sorted
+    order. Unreadable or non-mapping entries are skipped; any failure
+    yields ``[]`` — a broken repo config must never break discovery.
+
+    :param workspace: The selected working directory.
+    :returns: Discovered configs (possibly empty).
+    """
+    try:
+        configs_dir = Path(workspace).expanduser() / AGENT_CONFIG_SUBDIR
+        if not configs_dir.is_dir():
+            return []
+
+        entries: list[WorkspaceAgentConfig] = []
+        seen: dict[str, int] = {}
+
+        def _add(
+            *,
+            name: str,
+            path: Path,
+            kind: str,
+            config: dict[str, object],
+            sub_agents: tuple[str, ...] = (),
+            has_local_tools: bool = False,
+            has_mcp_servers: bool = False,
+        ) -> None:
+            base = _slugify(name)
+            count = seen.get(base, 0) + 1
+            seen[base] = count
+            description = config.get("description")
+            entries.append(
+                WorkspaceAgentConfig(
+                    slug=base if count == 1 else f"{base}-{count}",
+                    name=name,
+                    path=str(path.relative_to(Path(workspace).expanduser())),
+                    kind=kind,
+                    description=description if isinstance(description, str) else None,
+                    harness=_declared_harness(config),
+                    sub_agents=sub_agents,
+                    has_local_tools=has_local_tools,
+                    has_mcp_servers=has_mcp_servers,
+                )
+            )
+
+        for child in sorted(configs_dir.iterdir()):
+            if child.is_file() and child.suffix.lower() in {".yaml", ".yml"}:
+                config = _read_mapping(child)
+                if config is None:
+                    continue
+                raw_name = config.get("name")
+                _add(
+                    name=raw_name if isinstance(raw_name, str) and raw_name else child.stem,
+                    path=child,
+                    kind="file",
+                    config=config,
+                )
+            elif child.is_dir() and (child / "config.yaml").is_file():
+                config = _read_mapping(child / "config.yaml")
+                if config is None:
+                    continue
+                raw_name = config.get("name")
+                tools_dir = child / "tools"
+                _add(
+                    name=raw_name if isinstance(raw_name, str) and raw_name else child.name,
+                    path=child,
+                    kind="bundle",
+                    config=config,
+                    sub_agents=_sub_agent_names(config),
+                    has_local_tools=any(
+                        (tools_dir / lang).is_dir() and any((tools_dir / lang).iterdir())
+                        for lang in ("python", "typescript")
+                    ),
+                    has_mcp_servers=(tools_dir / "mcp").is_dir()
+                    and any((tools_dir / "mcp").glob("*.yaml")),
+                )
+        return entries
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+
+
+def package_workspace_agent(
+    workspace: Path,
+    config_path: str,
+    *,
+    max_bytes: int = MAX_PACKAGED_BUNDLE_BYTES,
+) -> bytes:
+    """Build deterministic ``.tar.gz`` bundle bytes for a repo config.
+
+    Materializes the source (file or directory) into the uniform bundle
+    shape via :func:`omnigent.spec.materialize_bundle`, then tars it
+    with pinned mtimes/modes and sorted members so identical content
+    always yields identical bytes — the client hashes these bytes for
+    the consent grant and uploads them verbatim, so what the user
+    approved is exactly what runs.
+
+    :param workspace: The selected working directory (containment root).
+    :param config_path: Workspace-relative path of a discovered config.
+    :param max_bytes: Ceiling for the total packaged size.
+    :raises ValueError: If the path escapes the workspace, isn't a
+        recognized config shape, or the package exceeds *max_bytes*.
+    :raises FileNotFoundError: If the source does not exist.
+    """
+    import tempfile
+
+    from omnigent.spec import materialize_bundle
+
+    root = Path(workspace).expanduser().resolve()
+    source = (root / config_path).resolve()
+    if not source.is_relative_to(root):
+        raise ValueError("config_path escapes the workspace")
+    is_yaml_file = source.is_file() and source.suffix.lower() in {".yaml", ".yml"}
+    if not is_yaml_file and not (source.is_dir() and (source / "config.yaml").is_file()):
+        raise ValueError("config_path is not an agent YAML or bundle directory")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bundle_dir = materialize_bundle(source, Path(tmpdir) / "bundle")
+        buf = io.BytesIO()
+        total = 0
+        with (
+            gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+            tarfile.open(fileobj=gz, mode="w") as tar,
+        ):
+            for file_path in sorted(bundle_dir.rglob("*")):
+                if not file_path.is_file():
+                    continue
+                data = file_path.read_bytes()
+                total += len(data)
+                if total > max_bytes:
+                    raise ValueError(f"packaged bundle exceeds {max_bytes} bytes")
+                info = tarfile.TarInfo(str(file_path.relative_to(bundle_dir)))
+                info.size = len(data)
+                info.mtime = 0
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(data))
+        return buf.getvalue()

--- a/openapi.json
+++ b/openapi.json
@@ -2492,6 +2492,27 @@
         "title": "OutputTextDeltaEvent",
         "type": "object"
       },
+      "PackageWorkspaceAgentRequest": {
+        "description": "Body for `POST /v1/hosts/{id}/workspace-agents/package`.",
+        "properties": {
+          "config_path": {
+            "description": "Workspace-relative path of a discovered config, e.g. `\".omnigent/agent-configs/helper.yaml\"`.",
+            "title": "Config Path",
+            "type": "string"
+          },
+          "path": {
+            "description": "Absolute workspace path on the host.",
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "config_path"
+        ],
+        "title": "PackageWorkspaceAgentRequest",
+        "type": "object"
+      },
       "PaginatedList": {
         "description": "A paginated list response following cursor-based pagination.",
         "properties": {
@@ -7792,6 +7813,120 @@
           }
         },
         "summary": "Launch Runner",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/workspace-agents/package": {
+      "post": {
+        "description": "Package a repo-declared agent config into bundle bytes.\n\nThe host materializes `<path>/<config_path>` (a discovered\nsingle-file YAML or bundle directory) into a deterministic\n`.tar.gz` and returns the bytes. The client hashes them for\nthe consent grant and uploads them verbatim via the standard\nmultipart session create, so what the user approved is exactly\nwhat the server validates and runs.\n\n**Returns:** The raw `application/gzip` bundle bytes.\n\n**Raises**\n\n- `HTTPException` \u2014 404 (host missing), 403 (not owner), 409 (offline), 400 (path validation), 504 (timeout), 502 (host failure).",
+        "operationId": "package_host_workspace_agent_v1_hosts__host_id__workspace_agents_package_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageWorkspaceAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Package Host Workspace Agent",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/workspace-harnesses": {
+      "get": {
+        "description": "Return the harnesses a workspace's `.omnigent/` declares.\n\nReads `<path>/.omnigent/config.yaml` on the selected host and\nreturns its `acp:` agents so the picker can suggest repo-declared\nharnesses. Owner-scoped like the filesystem endpoints; discovery\nonly \u2014 launching a discovered agent still goes through the client's\nexplicit consent flow.\n\n**Returns:** `{\"agents\": [...]}` (empty when nothing is declared).\n\n**Raises**\n\n- `HTTPException` \u2014 404 (host missing), 403 (not owner), 409 (offline), 400 (path validation), 504 (timeout), 502 (host failure).",
+        "operationId": "get_host_workspace_harnesses_v1_hosts__host_id__workspace_harnesses_get",
+        "parameters": [
+          {
+            "description": "Host identifier.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Absolute or tilde-prefixed workspace path on the host.",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Path",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Host Workspace Harnesses V1 Hosts  Host Id  Workspace Harnesses Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Host Workspace Harnesses",
         "tags": [
           "hosts"
         ]

--- a/tests/e2e_ui/start_session/test_repo_declared_agents.py
+++ b/tests/e2e_ui/start_session/test_repo_declared_agents.py
@@ -330,12 +330,23 @@ async def _drive_acp_consent(base_url: str, session_id: str) -> None:
             await page.get_by_test_id("new-chat-landing-input").fill("review the changes")
             await page.get_by_test_id("new-chat-landing-submit").click()
             await expect(page.get_by_test_id("repo-config-consent-summary")).to_be_visible()
-            await page.get_by_role("button", name="Cancel", exact=True).click()
+            # Radix animates the dialog open; a Cancel click landing during the
+            # animation can be swallowed by the overlay's pointer-events guard,
+            # leaving the modal up to block the next picker click. Click until
+            # the dialog actually closes.
+            dialog = page.get_by_test_id("repo-harness-consent-dialog")
+            for _ in range(3):
+                await page.get_by_role("button", name="Cancel", exact=True).click()
+                try:
+                    await expect(dialog).to_be_hidden(timeout=2_000)
+                    break
+                except AssertionError:
+                    continue
+            await expect(dialog).to_be_hidden()
 
             await page.get_by_test_id("new-chat-landing-agent-select").click()
             await page.get_by_test_id("new-chat-landing-agent-repo-acp:repo-echo").click()
             await page.get_by_test_id("new-chat-landing-submit").click()
-            dialog = page.get_by_test_id("repo-harness-consent-dialog")
             await expect(dialog).to_be_visible()
             await expect(dialog.locator("pre")).to_have_text(_ACP_ROW["command"])
             assert create_buffers == [], "consent must gate the create"

--- a/tests/e2e_ui/start_session/test_repo_declared_agents.py
+++ b/tests/e2e_ui/start_session/test_repo_declared_agents.py
@@ -1,0 +1,417 @@
+"""New Chat flows for repo-declared agents (`.omnigent/` discovery).
+
+Covers the three user-facing behaviors this feature adds to the landing
+composer:
+
+- discovery rows: agents a workspace's repo declares (ACP commands from
+  ``.omnigent/config.yaml``, agent configs from ``.omnigent/agent-configs/``)
+  lead their picker groups with a "From this repo" badge;
+- first-use consent: launching a repo-declared agent always shows exactly
+  what will run (the shell command, or the packaged definition's summary +
+  digest) before anything is created, and an approval never outlives the
+  pick it was granted for;
+- the freeze guarantee: the bundle bytes uploaded on confirm are byte-
+  identical to the bytes the consent dialog hashed, so a repo edit between
+  consent and create cannot swap the content.
+
+The shared e2e_ui server registers no host daemon (see conftest), so —
+following the ``test_start_session`` stub strategy — every host-scoped
+endpoint the flows touch is intercepted per-test: ``/v1/hosts``, the
+``workspace-harnesses`` discovery read, the ``workspace-agents/package``
+packaging call, the multipart ``POST /v1/sessions`` create, and the
+``POST /v1/hosts/{id}/runners`` launch. The create is captured as raw
+bytes (it is multipart, not JSON) and answered with a real pre-seeded
+session id so the post-send navigation lands on a real page.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import io
+import json
+import re
+import tarfile
+import threading
+from typing import Any
+
+import pytest
+from playwright.async_api import Route, async_playwright, expect
+
+_HOST_ID = "host_e2e_repo"
+_WORKSPACE = "/work/demo-repo"
+
+_ACP_ROW = {
+    "slug": "repo-echo",
+    "name": "Repo Echo",
+    "command": "echo-agent --acp --flag",
+    "model": None,
+    "session_id_mode": "server",
+    "send_model": False,
+    "omnigent_mcp": True,
+    "command_found": True,
+}
+_CONFIG_ROW = {
+    "slug": "repo-reviewer",
+    "name": "repo-reviewer",
+    "path": ".omnigent/agent-configs/reviewer",
+    "kind": "bundle",
+    "description": "Reviews changes in this repo.",
+    "harness": "claude-sdk",
+    "sub_agents": ["worker"],
+    "has_local_tools": True,
+    "has_mcp_servers": False,
+}
+
+
+def _run_in_fresh_loop(coro) -> None:
+    """Run *coro* in a dedicated thread with its own event loop.
+
+    Same rationale as ``test_start_session._run_in_fresh_loop``: once a sync
+    pytest-playwright test has run, pytest-asyncio can't start a loop on the
+    main thread, and the request-interception these tests need is only
+    ergonomic on the async API.
+    """
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:  # noqa: BLE001 — re-raised on the test thread
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _bundle_bytes() -> bytes:
+    """Deterministic tar.gz the packaging stub returns.
+
+    Content is irrelevant to the flow (the create is intercepted before any
+    server-side validation); what matters is that the exact bytes can be
+    recognized inside the captured multipart upload.
+    """
+    config = b"spec_version: 1\nname: repo-reviewer\n"
+    buf = io.BytesIO()
+    with (
+        gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+        tarfile.open(fileobj=gz, mode="w") as tar,
+    ):
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(config)
+        tar.addfile(info, io.BytesIO(config))
+    return buf.getvalue()
+
+
+async def _register_routes(
+    page,
+    *,
+    created_session_id: str,
+    create_buffers: list[bytes],
+    launch_bodies: list[dict[str, Any]],
+    package_bytes: bytes,
+    package_calls: list[dict[str, Any]],
+) -> None:
+    """Install the host/discovery/create/launch stubs these flows touch.
+
+    :param created_session_id: Real pre-seeded session id the faked create
+        returns, so post-send navigation lands on a real page.
+    :param create_buffers: Sink for the raw multipart ``POST /v1/sessions``
+        bodies (bytes — the byte-identity assertions read these).
+    :param launch_bodies: Sink for ``POST /v1/hosts/{id}/runners`` bodies.
+    :param package_bytes: The tar.gz the packaging endpoint stub returns.
+    :param package_calls: Sink for the packaging request bodies.
+    """
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "hosts": [
+                        {
+                            "host_id": _HOST_ID,
+                            "name": "e2e-repo-host",
+                            "owner": "e2e",
+                            "status": "online",
+                        }
+                    ]
+                }
+            ),
+        )
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "ag_claude_e2e",
+                            "name": "claude-native-ui",
+                            "display_name": "Claude Code",
+                            "description": "Anthropic's coding agent",
+                            "harness": None,
+                            "skills": [],
+                        }
+                    ]
+                }
+            ),
+        )
+
+    async def handle_agent_scan(route: Route) -> None:
+        # Neutralize session-derived agent discovery so only the stubs feed
+        # the picker (see test_start_session for why leakage matters).
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
+        )
+
+    async def handle_discovery(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"agents": [_ACP_ROW], "agent_configs": [_CONFIG_ROW]}),
+        )
+
+    async def handle_package(route: Route) -> None:
+        package_calls.append(route.request.post_data_json)
+        await route.fulfill(status=200, content_type="application/gzip", body=package_bytes)
+
+    async def handle_sessions(route: Route) -> None:
+        # Capture ONLY the composer's create POST — as raw bytes, because the
+        # repo-agent paths upload multipart bundles, not JSON.
+        if route.request.method == "POST":
+            create_buffers.append(route.request.post_data_buffer or b"")
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id, "session_id": created_session_id}),
+            )
+        else:
+            await route.continue_()
+
+    async def handle_launch(route: Route) -> None:
+        launch_bodies.append(route.request.post_data_json)
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"runner_id": "runner_token_e2e", "status": "launching"}),
+        )
+
+    async def handle_events(route: Route) -> None:
+        # Swallow the auto-sent initial prompt so no real LLM turn runs.
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+    await page.route(re.compile(r"/v1/hosts/[^/]+/workspace-harnesses"), handle_discovery)
+    await page.route(re.compile(r"/v1/hosts/[^/]+/workspace-agents/package"), handle_package)
+    await page.route(re.compile(r"/v1/sessions$"), handle_sessions)
+    await page.route(re.compile(r"/v1/hosts/[^/]+/runners"), handle_launch)
+    await page.route("**/v1/sessions/*/events", handle_events)
+
+
+async def _open_landing(page, base_url: str) -> None:
+    """Seed host + workspace prefs and open the landing composer."""
+    await page.add_init_script(
+        f"""
+        window.localStorage.setItem("omnigent:last-host-choice", "{_HOST_ID}");
+        window.localStorage.setItem(
+          "omnigent:recent-workspaces",
+          JSON.stringify({{ "{_HOST_ID}": ["{_WORKSPACE}"] }})
+        );
+        """
+    )
+    await page.goto(f"{base_url}/")
+    await page.get_by_test_id("new-chat-landing-input").wait_for(state="visible", timeout=30_000)
+
+
+def _gunzip_first_member(buffer: bytes) -> bytes:
+    """Decompress the first gzip stream inside a multipart body."""
+    start = buffer.find(b"\x1f\x8b")
+    assert start >= 0, "no gzip stream found in captured create body"
+    import zlib
+
+    return zlib.decompressobj(wbits=31).decompress(buffer[start:])
+
+
+@pytest.mark.timeout(300)
+def test_repo_declared_agents_rank_in_picker(seeded_session: tuple[str, str]) -> None:
+    """Discovered repo agents lead their picker groups, badged with provenance.
+
+    A workspace whose repo declares an ACP command and an agent config must
+    surface both in the agent picker — the command in the Harnesses group,
+    the config in the Agents group — each carrying a "From this repo" badge,
+    with nothing auto-selected (the built-in stays the default pick).
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_picker_rows(base_url, session_id))
+
+
+async def _drive_picker_rows(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_buffers=[],
+                launch_bodies=[],
+                package_bytes=_bundle_bytes(),
+                package_calls=[],
+            )
+            await _open_landing(page, base_url)
+
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-repo-acp:repo-echo")
+            ).to_be_visible()
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-repo-cfg:repo-reviewer")
+            ).to_be_visible()
+            await expect(
+                page.get_by_test_id("new-chat-landing-repo-badge-repo-echo")
+            ).to_have_text("From this repo")
+            await expect(
+                page.get_by_test_id("new-chat-landing-repo-cfg-badge-repo-reviewer")
+            ).to_have_text("From this repo")
+        finally:
+            await browser.close()
+
+
+@pytest.mark.timeout(300)
+def test_repo_acp_consent_gates_create(seeded_session: tuple[str, str]) -> None:
+    """The ACP consent dialog gates the create and binds to the exact pick.
+
+    Sending with a repo-declared command selected must open the consent
+    dialog showing the exact shell string, with nothing created yet.
+    Cancelling one agent's dialog and switching to another repo agent must
+    re-prompt (an approval never outlives its pick — the regression guard
+    for the one-shot-flag leak). Confirming must produce exactly one
+    multipart create whose bundle embeds the consented command, followed by
+    a runner launch against the selected host and workspace.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_acp_consent(base_url, session_id))
+
+
+async def _drive_acp_consent(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_buffers: list[bytes] = []
+            launch_bodies: list[dict[str, Any]] = []
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_buffers=create_buffers,
+                launch_bodies=launch_bodies,
+                package_bytes=_bundle_bytes(),
+                package_calls=[],
+            )
+            await _open_landing(page, base_url)
+
+            # Open the config agent's dialog first, then cancel — the later
+            # ACP pick must still be gated by its own consent.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-agent-repo-cfg:repo-reviewer").click()
+            await page.get_by_test_id("new-chat-landing-input").fill("review the changes")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+            await expect(page.get_by_test_id("repo-config-consent-summary")).to_be_visible()
+            await page.get_by_role("button", name="Cancel", exact=True).click()
+
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-agent-repo-acp:repo-echo").click()
+            await page.get_by_test_id("new-chat-landing-submit").click()
+            dialog = page.get_by_test_id("repo-harness-consent-dialog")
+            await expect(dialog).to_be_visible()
+            await expect(dialog.locator("pre")).to_have_text(_ACP_ROW["command"])
+            assert create_buffers == [], "consent must gate the create"
+
+            await page.get_by_test_id("repo-harness-consent-confirm").click()
+            await page.wait_for_url(re.compile(r"/c/"), timeout=30_000)
+
+            assert len(create_buffers) == 1, "confirm must create exactly one session"
+            config_yaml = _gunzip_first_member(create_buffers[0])
+            assert b"acp_agent:" in config_yaml
+            assert _ACP_ROW["command"].encode() in config_yaml
+            assert launch_bodies and launch_bodies[0]["session_id"] == session_id
+            assert launch_bodies[0]["workspace"] == _WORKSPACE
+        finally:
+            await browser.close()
+
+
+@pytest.mark.timeout(300)
+def test_repo_agent_config_upload_matches_consented_bytes(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The bundle uploaded on confirm is byte-identical to what was consented.
+
+    Selecting a repo-declared agent config and sending must call the
+    host-side packaging endpoint, show the consent summary (kind, harness,
+    sub-agents, digest), and — on confirm — upload the exact bytes the
+    packaging stub returned inside the multipart create. This pins the
+    feature's core trust property: what the user approved is what runs.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_config_consent(base_url, session_id))
+
+
+async def _drive_config_consent(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_buffers: list[bytes] = []
+            launch_bodies: list[dict[str, Any]] = []
+            package_calls: list[dict[str, Any]] = []
+            package_bytes = _bundle_bytes()
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_buffers=create_buffers,
+                launch_bodies=launch_bodies,
+                package_bytes=package_bytes,
+                package_calls=package_calls,
+            )
+            await _open_landing(page, base_url)
+
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-agent-repo-cfg:repo-reviewer").click()
+            await page.get_by_test_id("new-chat-landing-input").fill("review the changes")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            summary = page.get_by_test_id("repo-config-consent-summary")
+            await expect(summary).to_be_visible()
+            await expect(summary).to_contain_text("agent bundle")
+            await expect(summary).to_contain_text("claude-sdk")
+            await expect(summary).to_contain_text("worker")
+            await expect(summary).to_contain_text("digest")
+            assert package_calls and package_calls[0] == {
+                "path": _WORKSPACE,
+                "config_path": _CONFIG_ROW["path"],
+            }
+            assert create_buffers == [], "consent must gate the create"
+
+            await page.get_by_test_id("repo-harness-consent-confirm").click()
+            await page.wait_for_url(re.compile(r"/c/"), timeout=30_000)
+
+            assert len(create_buffers) == 1
+            assert package_bytes in create_buffers[0], (
+                "uploaded bundle must be byte-identical to the consented bytes"
+            )
+            assert launch_bodies and launch_bodies[0]["workspace"] == _WORKSPACE
+        finally:
+            await browser.close()

--- a/tests/e2e_ui/start_session/test_repo_declared_agents.py
+++ b/tests/e2e_ui/start_session/test_repo_declared_agents.py
@@ -77,7 +77,7 @@ def _run_in_fresh_loop(coro) -> None:
     def _worker() -> None:
         try:
             asyncio.run(coro)
-        except Exception as exc:  # noqa: BLE001 — re-raised on the test thread
+        except Exception as exc:
             captured["error"] = exc
 
     thread = threading.Thread(target=_worker)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -50,6 +50,8 @@ from omnigent.host.frames import (
     HostStopRunnerResultFrame,
     HostStoreSecretFrame,
     HostStoreSecretResultFrame,
+    HostWorkspaceHarnessesFrame,
+    HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
 )
 from omnigent.host.identity import HostIdentity
@@ -539,6 +541,57 @@ async def test_handle_model_options_reports_the_endpoints_wider_catalog(
         "system.ai.claude-opus-5",
         "system.ai.claude-opus-4-8",
     ]
+
+async def test_handle_workspace_harnesses_reads_repo_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repo-declared ACP agents are discovered from the workspace on the host."""
+    import yaml
+
+    (tmp_path / ".omnigent").mkdir()
+    (tmp_path / ".omnigent" / "config.yaml").write_text(
+        yaml.safe_dump({"acp": {"agents": [{"name": "Repo Echo", "command": "echo-agent --acp"}]}})
+    )
+    from omnigent.onboarding import acp_auth
+
+    monkeypatch.setattr(acp_auth, "command_binary_on_path", lambda command: False)
+    host = _make_host_process()
+
+    result = await host._handle_workspace_harnesses(
+        HostWorkspaceHarnessesFrame(request_id="req_ws", path=str(tmp_path)),
+    )
+
+    assert result == HostWorkspaceHarnessesResultFrame(
+        request_id="req_ws",
+        status="ok",
+        agents=[
+            {
+                "slug": "repo-echo",
+                "name": "Repo Echo",
+                "command": "echo-agent --acp",
+                "model": None,
+                "session_id_mode": "server",
+                "send_model": False,
+                "command_found": False,
+            }
+        ],
+    )
+
+
+async def test_handle_workspace_harnesses_empty_when_unconfigured(tmp_path: Path) -> None:
+    """A workspace without `.omnigent/config.yaml` yields ok + no agents."""
+    host = _make_host_process()
+
+    result = await host._handle_workspace_harnesses(
+        HostWorkspaceHarnessesFrame(request_id="req_ws", path=str(tmp_path)),
+    )
+
+    assert result == HostWorkspaceHarnessesResultFrame(
+        request_id="req_ws",
+        status="ok",
+        agents=[],
+    )
 
 
 def _make_host_process() -> HostProcess:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -543,6 +543,7 @@ async def test_handle_model_options_reports_the_endpoints_wider_catalog(
         "system.ai.claude-opus-4-8",
     ]
 
+
 async def test_handle_workspace_harnesses_reads_repo_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -574,6 +575,7 @@ async def test_handle_workspace_harnesses_reads_repo_config(
                 "model": None,
                 "session_id_mode": "server",
                 "send_model": False,
+                "omnigent_mcp": True,
                 "command_found": False,
             }
         ],

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -41,6 +41,7 @@ from omnigent.host.frames import (
     HostListDirResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostPackageWorkspaceAgentFrame,
     HostRunnerExitedFrame,
     HostRunnerStatusFrame,
     HostRunnerStatusResultFrame,
@@ -577,6 +578,71 @@ async def test_handle_workspace_harnesses_reads_repo_config(
             }
         ],
     )
+
+
+async def test_handle_workspace_harnesses_includes_agent_configs(tmp_path: Path) -> None:
+    """Agent configs under .omnigent/agent-configs/ ride the discovery result."""
+    import yaml
+
+    configs = tmp_path / ".omnigent" / "agent-configs"
+    configs.mkdir(parents=True)
+    (configs / "helper.yaml").write_text(
+        yaml.safe_dump(
+            {"name": "Repo Helper", "prompt": "hi", "executor": {"harness": "claude-sdk"}}
+        )
+    )
+    host = _make_host_process()
+
+    result = await host._handle_workspace_harnesses(
+        HostWorkspaceHarnessesFrame(request_id="req_ws", path=str(tmp_path)),
+    )
+
+    assert result.status == "ok"
+    assert result.agents == []
+    assert [(c["slug"], c["kind"]) for c in result.agent_configs] == [("repo-helper", "file")]
+
+
+async def test_handle_package_workspace_agent_round_trips(tmp_path: Path) -> None:
+    """Packaged bytes decode as a tar.gz containing the materialized config."""
+    import base64
+    import io
+    import tarfile
+
+    import yaml
+
+    configs = tmp_path / ".omnigent" / "agent-configs"
+    configs.mkdir(parents=True)
+    (configs / "helper.yaml").write_text(
+        yaml.safe_dump({"name": "helper", "prompt": "hi", "executor": {"harness": "claude-sdk"}})
+    )
+    host = _make_host_process()
+
+    result = await host._handle_package_workspace_agent(
+        HostPackageWorkspaceAgentFrame(
+            request_id="req_pkg",
+            path=str(tmp_path),
+            config_path=".omnigent/agent-configs/helper.yaml",
+        ),
+    )
+
+    assert result.status == "ok"
+    assert result.bundle_b64 is not None
+    bundle = base64.b64decode(result.bundle_b64)
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as tar:
+        assert tar.getnames() == ["helper.yaml"]
+
+
+async def test_handle_package_workspace_agent_rejects_escape(tmp_path: Path) -> None:
+    host = _make_host_process()
+    result = await host._handle_package_workspace_agent(
+        HostPackageWorkspaceAgentFrame(
+            request_id="req_pkg",
+            path=str(tmp_path),
+            config_path="../outside.yaml",
+        ),
+    )
+    assert result.status == "failed"
+    assert result.bundle_b64 is None
 
 
 async def test_handle_workspace_harnesses_empty_when_unconfigured(tmp_path: Path) -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -40,6 +40,8 @@ from omnigent.host.frames import (
     HostStopRunnerResultFrame,
     HostStoreSecretFrame,
     HostStoreSecretResultFrame,
+    HostWorkspaceHarnessesFrame,
+    HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
     encode_host_frame,
 )
@@ -97,6 +99,70 @@ def test_model_options_frames_round_trip() -> None:
         "system.ai.claude-opus-5",
         "system.ai.claude-opus-4-8",
     ]
+
+
+def test_workspace_harnesses_frames_round_trip() -> None:
+    """Repo-declared harness discovery survives both directions of the tunnel."""
+    request = decode_host_frame(
+        encode_host_frame(
+            HostWorkspaceHarnessesFrame(request_id="req_ws", path="/Users/corey/universe"),
+        )
+    )
+    assert request == HostWorkspaceHarnessesFrame(
+        request_id="req_ws",
+        path="/Users/corey/universe",
+    )
+
+    result = decode_host_frame(
+        encode_host_frame(
+            HostWorkspaceHarnessesResultFrame(
+                request_id="req_ws",
+                status="ok",
+                agents=[
+                    {
+                        "slug": "repo-echo",
+                        "name": "Repo Echo",
+                        "command": "echo-agent --acp",
+                        "model": None,
+                        "session_id_mode": "server",
+                        "send_model": False,
+                        "command_found": True,
+                    }
+                ],
+            )
+        )
+    )
+    assert isinstance(result, HostWorkspaceHarnessesResultFrame)
+    assert result.agents[0]["slug"] == "repo-echo"
+    assert result.agents[0]["command_found"] is True
+
+    failure = decode_host_frame(
+        encode_host_frame(
+            HostWorkspaceHarnessesResultFrame(
+                request_id="req_ws",
+                status="failed",
+                error="boom",
+            )
+        )
+    )
+    assert failure == HostWorkspaceHarnessesResultFrame(
+        request_id="req_ws",
+        status="failed",
+        agents=[],
+        error="boom",
+    )
+
+
+def test_workspace_harnesses_result_rejects_non_object_agents() -> None:
+    """Malformed ``agents`` payloads fail decode instead of leaking through."""
+    frame = json.loads(
+        encode_host_frame(
+            HostWorkspaceHarnessesResultFrame(request_id="req_ws", status="ok"),
+        )
+    )
+    frame["agents"] = ["not-an-object"]
+    with pytest.raises(ValueError, match="agents"):
+        decode_host_frame(json.dumps(frame))
 
 
 def test_encode_injects_traceparent_under_active_span() -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -29,6 +29,8 @@ from omnigent.host.frames import (
     HostListWorktreesResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostPackageWorkspaceAgentFrame,
+    HostPackageWorkspaceAgentResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -150,6 +152,64 @@ def test_workspace_harnesses_frames_round_trip() -> None:
         status="failed",
         agents=[],
         error="boom",
+    )
+
+
+def test_workspace_harnesses_result_carries_agent_configs() -> None:
+    """Agent-config summaries ride the discovery result; absent decodes empty."""
+    result = decode_host_frame(
+        encode_host_frame(
+            HostWorkspaceHarnessesResultFrame(
+                request_id="req_ws",
+                status="ok",
+                agent_configs=[{"slug": "reviewer", "kind": "bundle"}],
+            )
+        )
+    )
+    assert isinstance(result, HostWorkspaceHarnessesResultFrame)
+    assert result.agent_configs == [{"slug": "reviewer", "kind": "bundle"}]
+
+    # An older host's result (no agent_configs key) decodes to [].
+    legacy = json.loads(
+        encode_host_frame(
+            HostWorkspaceHarnessesResultFrame(request_id="req_ws", status="ok"),
+        )
+    )
+    del legacy["agent_configs"]
+    decoded = decode_host_frame(json.dumps(legacy))
+    assert isinstance(decoded, HostWorkspaceHarnessesResultFrame)
+    assert decoded.agent_configs == []
+
+
+def test_package_workspace_agent_frames_round_trip() -> None:
+    request = decode_host_frame(
+        encode_host_frame(
+            HostPackageWorkspaceAgentFrame(
+                request_id="req_pkg",
+                path="/Users/corey/universe",
+                config_path=".omnigent/agent-configs/reviewer",
+            ),
+        )
+    )
+    assert request == HostPackageWorkspaceAgentFrame(
+        request_id="req_pkg",
+        path="/Users/corey/universe",
+        config_path=".omnigent/agent-configs/reviewer",
+    )
+
+    result = decode_host_frame(
+        encode_host_frame(
+            HostPackageWorkspaceAgentResultFrame(
+                request_id="req_pkg",
+                status="ok",
+                bundle_b64="aGk=",
+            )
+        )
+    )
+    assert result == HostPackageWorkspaceAgentResultFrame(
+        request_id="req_pkg",
+        status="ok",
+        bundle_b64="aGk=",
     )
 
 

--- a/tests/onboarding/test_workspace_acp.py
+++ b/tests/onboarding/test_workspace_acp.py
@@ -1,0 +1,88 @@
+"""Tests for :func:`omnigent.onboarding.acp_auth.workspace_acp_agents`.
+
+The reader sources the *project-level* ``.omnigent/config.yaml`` only — it must
+never merge the global config (every returned entry is attributed to the repo)
+and must never raise (a broken repo config can't break discovery).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.onboarding.acp_auth import workspace_acp_agents
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory):
+    """Point OMNIGENT_CONFIG_HOME away from the real global config."""
+    config_home = tmp_path_factory.mktemp("config-home")
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump({"acp": {"agents": [{"name": "Global Agent", "command": "global --acp"}]}})
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+
+
+def _write_workspace_config(workspace: Path, payload: object) -> None:
+    (workspace / ".omnigent").mkdir(parents=True, exist_ok=True)
+    (workspace / ".omnigent" / "config.yaml").write_text(
+        payload if isinstance(payload, str) else yaml.safe_dump(payload)
+    )
+
+
+def test_reads_repo_declared_agents(tmp_path: Path) -> None:
+    _write_workspace_config(
+        tmp_path,
+        {
+            "acp": {
+                "agents": [
+                    {"name": "Repo Echo", "command": "echo-agent --acp"},
+                    {"name": "Repo Goose", "command": "goose acp", "model": "gpt-5.3"},
+                ]
+            }
+        },
+    )
+    entries = workspace_acp_agents(tmp_path)
+    assert [(e.slug, e.name, e.command) for e in entries] == [
+        ("repo-echo", "Repo Echo", "echo-agent --acp"),
+        ("repo-goose", "Repo Goose", "goose acp"),
+    ]
+    assert entries[1].model == "gpt-5.3"
+
+
+def test_global_config_is_not_merged(tmp_path: Path) -> None:
+    """Repo discovery must not surface globally-configured agents."""
+    _write_workspace_config(tmp_path, {"acp": {"agents": []}})
+    assert workspace_acp_agents(tmp_path) == []
+
+
+def test_missing_config_returns_empty(tmp_path: Path) -> None:
+    assert workspace_acp_agents(tmp_path) == []
+    assert workspace_acp_agents(tmp_path / "does-not-exist") == []
+
+
+def test_malformed_yaml_returns_empty(tmp_path: Path) -> None:
+    _write_workspace_config(tmp_path, "acp: [unclosed")
+    assert workspace_acp_agents(tmp_path) == []
+
+
+def test_non_mapping_block_returns_empty(tmp_path: Path) -> None:
+    _write_workspace_config(tmp_path, {"acp": "not-a-mapping"})
+    assert workspace_acp_agents(tmp_path) == []
+
+
+def test_slug_collisions_get_suffixes(tmp_path: Path) -> None:
+    _write_workspace_config(
+        tmp_path,
+        {
+            "acp": {
+                "agents": [
+                    {"name": "Helper", "command": "one --acp"},
+                    {"name": "helper!", "command": "two --acp"},
+                ]
+            }
+        },
+    )
+    assert [e.slug for e in workspace_acp_agents(tmp_path)] == ["helper", "helper-2"]

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6040,7 +6040,8 @@ async def test_sys_agent_list_merges_three_sources(tmp_path: Path) -> None:
     :param tmp_path: Pytest temp dir used as the runner workspace, so the
         local-config scan reads a real directory.
     """
-    from omnigent.runner.tool_dispatch import _AGENT_CONFIG_SUBDIR, execute_tool
+    from omnigent.runner.tool_dispatch import execute_tool
+    from omnigent.spec.workspace_agents import AGENT_CONFIG_SUBDIR as _AGENT_CONFIG_SUBDIR
 
     # Author a local config on disk so the scan has something to find.
     configs_dir = tmp_path / _AGENT_CONFIG_SUBDIR

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -146,6 +146,49 @@ def test_embedded_omnigent_mcp_flag_forwarded() -> None:
     )
     assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
 
+def test_embedded_agent_takes_precedence_over_config(_isolate_config: Path) -> None:
+    """An embedded ``acp_agent`` wins over the slug's configured command."""
+    _write_acp_config(_isolate_config)
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:goose",
+            acp_agent={"name": "Repo Goose", "command": "goose acp --repo"},
+        )
+    )
+    assert env["HARNESS_ACP_COMMAND"] == "goose acp --repo"
+    assert env["HARNESS_ACP_NAME"] == "Repo Goose"
+
+
+def test_embedded_agent_optional_fields_forwarded(_isolate_config: Path) -> None:
+    """Embedded ``model`` / ``session_id_mode`` / ``send_model`` are honored."""
+    _write_acp_config(_isolate_config, agents=[])
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:repo-qwen",
+            acp_agent={
+                "name": "Repo Qwen",
+                "command": "qwen --acp",
+                "model": "qwen3-coder",
+                "session_id_mode": "client",
+                "send_model": True,
+            },
+        )
+    )
+    assert env["HARNESS_ACP_MODEL"] == "qwen3-coder"
+    assert env["HARNESS_ACP_SESSION_ID_MODE"] == "client"
+    assert env["HARNESS_ACP_SEND_MODEL"] == "1"
+
+
+def test_embedded_agent_invalid_mode_falls_back_to_server(_isolate_config: Path) -> None:
+    _write_acp_config(_isolate_config, agents=[])
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:helper",
+            acp_agent={"name": "Helper", "command": "helper --acp", "session_id_mode": "bogus"},
+        )
+    )
+    assert env["HARNESS_ACP_SESSION_ID_MODE"] == "server"
+
 
 @pytest.mark.parametrize(
     "acp_agent",

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -146,6 +146,7 @@ def test_embedded_omnigent_mcp_flag_forwarded() -> None:
     )
     assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
 
+
 def test_embedded_agent_takes_precedence_over_config(_isolate_config: Path) -> None:
     """An embedded ``acp_agent`` wins over the slug's configured command."""
     _write_acp_config(_isolate_config)

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -28,6 +28,8 @@ from omnigent.host.frames import (
     HostListDirResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostWorkspaceHarnessesFrame,
+    HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
     encode_host_frame,
 )
@@ -187,6 +189,22 @@ async def fs_setup(
                                 request_id=frame.request_id,
                                 status=reply.get("status", "ok"),
                                 models=reply.get("models", []),
+                                error=reply.get("error"),
+                            )
+                        ),
+                    }
+                )
+                continue
+            if isinstance(frame, HostWorkspaceHarnessesFrame):
+                reply = replies.get(f"ws:{frame.path}", {})
+                await comm.send_input(
+                    {
+                        "type": "websocket.receive",
+                        "text": encode_host_frame(
+                            HostWorkspaceHarnessesResultFrame(
+                                request_id=frame.request_id,
+                                status=reply.get("status", "ok"),
+                                agents=reply.get("agents", []),
                                 error=reply.get("error"),
                             )
                         ),
@@ -400,6 +418,124 @@ async def test_list_filesystem_tilde_path_forwards_unchanged(
         resp = await client.get(f"/v1/hosts/{_HOST_ID}/filesystem/~/projects")
     assert resp.status_code == 200, resp.text
     assert resp.json()["data"][0]["name"] == "myapp"
+
+
+async def test_workspace_harnesses_returns_repo_declared_agents(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """The REST endpoint proxies the workspace's repo-declared ACP agents."""
+    app, _reg, _comm, replies, _drain = fs_setup
+    agents = [
+        {
+            "slug": "repo-echo",
+            "name": "Repo Echo",
+            "command": "echo-agent --acp",
+            "model": None,
+            "session_id_mode": "server",
+            "send_model": False,
+            "command_found": True,
+        }
+    ]
+    replies["ws:/Users/corey/universe"] = {"agents": agents}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/workspace-harnesses",
+            params={"path": "/Users/corey/universe"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"agents": agents}
+
+
+async def test_workspace_harnesses_host_failure_returns_502(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    app, _reg, _comm, replies, _drain = fs_setup
+    replies["ws:/Users/corey/universe"] = {"status": "failed", "error": "boom"}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/workspace-harnesses",
+            params={"path": "/Users/corey/universe"},
+        )
+
+    assert resp.status_code == 502
+
+
+async def test_workspace_harnesses_unknown_host_returns_404(
+    fs_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    app, _reg, _hs, _cs = fs_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/hosts/7139b7e896ef9478abca6480107d1677/workspace-harnesses",
+            params={"path": "/tmp"},
+        )
+    assert resp.status_code == 404
+
+
+async def test_workspace_harnesses_offline_host_returns_409(
+    fs_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    app, _reg, host_store, _cs = fs_app
+    host_store.upsert_on_connect(
+        host_id="3d9665477127e41f42de3f4109418173",
+        name="offline-host",
+        user_id="local",
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/hosts/3d9665477127e41f42de3f4109418173/workspace-harnesses",
+            params={"path": "/tmp"},
+        )
+    assert resp.status_code == 409
+
+
+async def test_workspace_harnesses_nul_path_returns_400(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    app, _reg, _comm, _replies, _drain = fs_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/workspace-harnesses",
+            params={"path": "/tmp/\x00evil"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_workspace_harnesses_missing_path_returns_422(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """The path query param is required — FastAPI validation rejects its absence."""
+    app, _reg, _comm, _replies, _drain = fs_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/workspace-harnesses")
+    assert resp.status_code == 422
 
 
 # ── Error paths ─────────────────────────────────────────

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -28,6 +28,8 @@ from omnigent.host.frames import (
     HostListDirResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostPackageWorkspaceAgentFrame,
+    HostPackageWorkspaceAgentResultFrame,
     HostWorkspaceHarnessesFrame,
     HostWorkspaceHarnessesResultFrame,
     decode_host_frame,
@@ -205,6 +207,23 @@ async def fs_setup(
                                 request_id=frame.request_id,
                                 status=reply.get("status", "ok"),
                                 agents=reply.get("agents", []),
+                                agent_configs=reply.get("agent_configs", []),
+                                error=reply.get("error"),
+                            )
+                        ),
+                    }
+                )
+                continue
+            if isinstance(frame, HostPackageWorkspaceAgentFrame):
+                reply = replies.get(f"pkg:{frame.config_path}", {})
+                await comm.send_input(
+                    {
+                        "type": "websocket.receive",
+                        "text": encode_host_frame(
+                            HostPackageWorkspaceAgentResultFrame(
+                                request_id=frame.request_id,
+                                status=reply.get("status", "ok"),
+                                bundle_b64=reply.get("bundle_b64"),
                                 error=reply.get("error"),
                             )
                         ),
@@ -451,7 +470,116 @@ async def test_workspace_harnesses_returns_repo_declared_agents(
         )
 
     assert resp.status_code == 200
-    assert resp.json() == {"agents": agents}
+    assert resp.json() == {"agents": agents, "agent_configs": []}
+
+
+async def test_workspace_harnesses_returns_agent_configs(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """Agent-config summaries ride the discovery response."""
+    app, _reg, _comm, replies, _drain = fs_setup
+    configs = [
+        {
+            "slug": "reviewer",
+            "name": "Repo Reviewer",
+            "path": ".omnigent/agent-configs/reviewer",
+            "kind": "bundle",
+            "description": None,
+            "harness": "claude-sdk",
+            "sub_agents": ["worker"],
+            "has_local_tools": True,
+            "has_mcp_servers": False,
+        }
+    ]
+    replies["ws:/Users/corey/universe"] = {"agent_configs": configs}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/workspace-harnesses",
+            params={"path": "/Users/corey/universe"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"agents": [], "agent_configs": configs}
+
+
+async def test_package_workspace_agent_returns_bundle_bytes(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    """The package endpoint decodes the host's base64 into raw gzip bytes."""
+    import base64
+
+    app, _reg, _comm, replies, _drain = fs_setup
+    replies["pkg:.omnigent/agent-configs/helper.yaml"] = {
+        "bundle_b64": base64.b64encode(b"gzip-bytes").decode("ascii"),
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            f"/v1/hosts/{_HOST_ID}/workspace-agents/package",
+            json={
+                "path": "/Users/corey/universe",
+                "config_path": ".omnigent/agent-configs/helper.yaml",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/gzip"
+    assert resp.content == b"gzip-bytes"
+
+
+async def test_package_workspace_agent_host_failure_returns_502(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    app, _reg, _comm, replies, _drain = fs_setup
+    replies["pkg:.omnigent/agent-configs/helper.yaml"] = {"status": "failed", "error": "boom"}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            f"/v1/hosts/{_HOST_ID}/workspace-agents/package",
+            json={
+                "path": "/Users/corey/universe",
+                "config_path": ".omnigent/agent-configs/helper.yaml",
+            },
+        )
+
+    assert resp.status_code == 502
+
+
+async def test_package_workspace_agent_nul_path_returns_400(
+    fs_setup: tuple[
+        FastAPI,
+        HostRegistry,
+        ApplicationCommunicator,
+        dict[str, dict[str, Any]],
+        asyncio.Task[None],
+    ],
+) -> None:
+    app, _reg, _comm, _replies, _drain = fs_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            f"/v1/hosts/{_HOST_ID}/workspace-agents/package",
+            json={"path": "/tmp/\x00evil", "config_path": "x.yaml"},
+        )
+    assert resp.status_code == 400
 
 
 async def test_workspace_harnesses_host_failure_returns_502(

--- a/tests/server/test_launch_gate_harness.py
+++ b/tests/server/test_launch_gate_harness.py
@@ -1,0 +1,112 @@
+"""Tests for the host launch-gate harness resolution.
+
+A spec embedding a one-shot ``executor.acp_agent`` is self-contained — the
+command rides in the spec — so both launch paths must send ``harness=None``
+on the ``host.launch_runner`` frame, the documented fail-open that skips the
+host's configured-harness refusal. Without it, a repo-declared ACP agent
+could never launch on a host with no global ``acp:`` config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from omnigent.server.routes._sessions.helpers import _harness_for_launch_gate
+from omnigent.server.routes.hosts import _resolve_agent_harness
+from omnigent.spec.parser import parse
+from omnigent.spec.types import AgentSpec
+
+_EMBEDDED_EXECUTOR = {
+    "type": "omnigent",
+    "acp_agent": {"name": "Repo Echo", "command": "echo-agent --acp"},
+    "config": {"harness": "acp:repo-echo"},
+}
+
+
+def _parse_spec(tmp_path: Path, executor: dict[str, object]) -> AgentSpec:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"spec_version": 1, "name": "agent", "executor": executor})
+    )
+    return parse(tmp_path)
+
+
+def _stubs(
+    spec: AgentSpec,
+) -> tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace]:
+    """Duck-typed conv/agent_store/agent_cache carrying the given spec."""
+    agent = SimpleNamespace(id="agent1", bundle_location="/bundles/agent1", session_id=None)
+    agent_store = SimpleNamespace(get=lambda agent_id: agent)
+    agent_cache = SimpleNamespace(
+        load=lambda agent_id, location, expand_env=True: SimpleNamespace(spec=spec)
+    )
+    conv = SimpleNamespace(
+        id="conv1",
+        agent_id="agent1",
+        harness_override=None,
+        sub_agent_name=None,
+    )
+    return conv, agent_store, agent_cache
+
+
+# ── create-launch path (POST /v1/hosts/{id}/runners) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_embedded_acp_agent_skips_launch_gate(tmp_path: Path) -> None:
+    spec = _parse_spec(tmp_path, _EMBEDDED_EXECUTOR)
+    conv, store, cache = _stubs(spec)
+    assert await _resolve_agent_harness(conv, store, cache) is None
+
+
+@pytest.mark.asyncio
+async def test_plain_acp_slug_still_gated(tmp_path: Path) -> None:
+    """Without an embed, the slug resolves via global config — keep the gate."""
+    spec = _parse_spec(tmp_path, {"type": "omnigent", "config": {"harness": "acp:gemini-cli"}})
+    conv, store, cache = _stubs(spec)
+    assert await _resolve_agent_harness(conv, store, cache) == "acp"
+
+
+@pytest.mark.asyncio
+async def test_non_acp_harness_unaffected_by_embed_check(tmp_path: Path) -> None:
+    spec = _parse_spec(tmp_path, {"type": "omnigent", "config": {"harness": "claude-sdk"}})
+    conv, store, cache = _stubs(spec)
+    assert await _resolve_agent_harness(conv, store, cache) == "claude-sdk"
+
+
+# ── relaunch path (_harness_for_launch_gate) ─────────────────────────────
+
+
+def _patch_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    store: SimpleNamespace,
+    cache: SimpleNamespace,
+) -> None:
+    monkeypatch.setattr("omnigent.runtime._globals._agent_store", store)
+    monkeypatch.setattr("omnigent.runtime.get_agent_cache", lambda: cache)
+
+
+def test_relaunch_gate_skips_embedded_acp_agent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = _parse_spec(tmp_path, _EMBEDDED_EXECUTOR)
+    conv, store, cache = _stubs(spec)
+    _patch_runtime(monkeypatch, store, cache)
+    assert _harness_for_launch_gate(conv) is None
+
+
+def test_relaunch_gate_keeps_plain_acp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    spec = _parse_spec(tmp_path, {"type": "omnigent", "config": {"harness": "acp:gemini-cli"}})
+    conv, store, cache = _stubs(spec)
+    _patch_runtime(monkeypatch, store, cache)
+    assert _harness_for_launch_gate(conv) == "acp"
+
+
+def test_relaunch_gate_keeps_non_acp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    spec = _parse_spec(tmp_path, {"type": "omnigent", "config": {"harness": "claude-sdk"}})
+    conv, store, cache = _stubs(spec)
+    _patch_runtime(monkeypatch, store, cache)
+    assert _harness_for_launch_gate(conv) == "claude-sdk"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3220,6 +3220,50 @@ def test_executor_profile_field_lifted_for_non_omnigent(tmp_path: Path) -> None:
     assert "profile" not in spec.executor.config
 
 
+def test_executor_acp_agent_mirrored_into_config(tmp_path: Path) -> None:
+    """
+    Top-level ``executor.acp_agent`` mirrors into ``config["acp_agent"]``
+    as a structured mapping (not string-coerced), like ``profile`` above —
+    the runtime adapter reads it from the raw executor mapping, but
+    server-side consumers (e.g. the launch gate) only see the parsed spec.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "agent",
+        "executor": {
+            "type": "omnigent",
+            "acp_agent": {"name": "Repo Echo", "command": "echo-agent --acp"},
+            "config": {"harness": "acp:repo-echo"},
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.executor.config.get("acp_agent") == {
+        "name": "Repo Echo",
+        "command": "echo-agent --acp",
+    }
+
+
+def test_executor_acp_agent_in_config_not_stringified(tmp_path: Path) -> None:
+    """A config-level ``acp_agent`` mapping keeps its nested YAML shape."""
+    config = {
+        "spec_version": 1,
+        "name": "agent",
+        "executor": {
+            "type": "omnigent",
+            "config": {
+                "harness": "acp:repo-echo",
+                "acp_agent": {"name": "Repo Echo", "command": "echo-agent --acp"},
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    acp_agent = spec.executor.config.get("acp_agent")
+    assert isinstance(acp_agent, dict)
+    assert acp_agent["command"] == "echo-agent --acp"
+
+
 def test_omnigent_and_default_executor_minimal_configs_still_parse(tmp_path: Path) -> None:
     """Both legacy ``omnigent`` and default minimal YAMLs continue to parse cleanly."""
     omni_config = {

--- a/tests/spec/test_workspace_agents.py
+++ b/tests/spec/test_workspace_agents.py
@@ -1,0 +1,177 @@
+"""Tests for :mod:`omnigent.spec.workspace_agents`.
+
+The scanner summarizes ``.omnigent/agent-configs/`` entries (flat YAMLs
+and bundle directories) without executing anything; the packager builds
+deterministic tar.gz bytes whose digest anchors the client-side consent
+grant. Both must never raise on broken repo content.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.spec import load
+from omnigent.spec.workspace_agents import (
+    package_workspace_agent,
+    scan_workspace_agent_configs,
+)
+
+
+def _configs_dir(workspace: Path) -> Path:
+    d = workspace / ".omnigent" / "agent-configs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_single_file(workspace: Path, filename: str, payload: dict) -> Path:
+    path = _configs_dir(workspace) / filename
+    path.write_text(yaml.safe_dump(payload))
+    return path
+
+
+def _write_bundle(workspace: Path, dirname: str, config: dict) -> Path:
+    bundle = _configs_dir(workspace) / dirname
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "config.yaml").write_text(yaml.safe_dump(config))
+    return bundle
+
+
+# ── scanner ──────────────────────────────────────────────
+
+
+def test_scans_flat_yaml_and_bundle_dirs(tmp_path: Path) -> None:
+    _write_single_file(
+        tmp_path,
+        "helper.yaml",
+        {"name": "Repo Helper", "prompt": "hi", "executor": {"type": "omnigent"}},
+    )
+    bundle = _write_bundle(
+        tmp_path,
+        "reviewer",
+        {
+            "spec_version": 1,
+            "name": "Repo Reviewer",
+            "description": "Reviews PRs.",
+            "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+            "tools": {"agents": ["claude_code", "codex"]},
+        },
+    )
+    (bundle / "tools" / "python").mkdir(parents=True)
+    (bundle / "tools" / "python" / "tool.py").write_text("x = 1\n")
+    (bundle / "tools" / "mcp").mkdir(parents=True)
+    (bundle / "tools" / "mcp" / "server.yaml").write_text("name: s\n")
+
+    entries = scan_workspace_agent_configs(tmp_path)
+
+    assert [(e.slug, e.kind) for e in entries] == [
+        ("repo-helper", "file"),
+        ("repo-reviewer", "bundle"),
+    ]
+    helper, reviewer = entries
+    assert helper.path == ".omnigent/agent-configs/helper.yaml"
+    assert helper.harness == "omnigent"
+    assert reviewer.path == ".omnigent/agent-configs/reviewer"
+    assert reviewer.description == "Reviews PRs."
+    assert reviewer.harness == "claude-sdk"
+    assert reviewer.sub_agents == ("claude_code", "codex")
+    assert reviewer.has_local_tools is True
+    assert reviewer.has_mcp_servers is True
+
+
+def test_missing_dir_and_malformed_entries(tmp_path: Path) -> None:
+    assert scan_workspace_agent_configs(tmp_path) == []
+    _configs_dir(tmp_path)
+    (_configs_dir(tmp_path) / "broken.yaml").write_text("acp: [unclosed")
+    (_configs_dir(tmp_path) / "notes.txt").write_text("not yaml")
+    (_configs_dir(tmp_path) / "empty-dir").mkdir()
+    assert scan_workspace_agent_configs(tmp_path) == []
+
+
+def test_name_falls_back_to_stem_and_slugs_dedupe(tmp_path: Path) -> None:
+    _write_single_file(tmp_path, "helper.yaml", {"prompt": "hi"})
+    _write_bundle(tmp_path, "zz-helper", {"spec_version": 1, "name": "helper!"})
+    entries = scan_workspace_agent_configs(tmp_path)
+    assert [e.slug for e in entries] == ["helper", "helper-2"]
+    assert entries[0].name == "helper"
+
+
+# ── packager ─────────────────────────────────────────────
+
+
+def test_package_single_file_is_deterministic_and_loadable(tmp_path: Path) -> None:
+    _write_single_file(
+        tmp_path,
+        "helper.yaml",
+        {"name": "helper", "prompt": "You are terse.", "executor": {"harness": "claude-sdk"}},
+    )
+    rel = ".omnigent/agent-configs/helper.yaml"
+    first = package_workspace_agent(tmp_path, rel)
+    second = package_workspace_agent(tmp_path, rel)
+    assert first == second
+
+    spec = load(first, dest=tmp_path / "extract")
+    assert spec.name == "helper"
+
+
+def test_package_bundle_includes_sub_agents(tmp_path: Path) -> None:
+    bundle = _write_bundle(
+        tmp_path,
+        "reviewer",
+        {
+            "spec_version": 1,
+            "name": "reviewer",
+            "instructions": "AGENTS.md",
+            "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+            "tools": {"agents": ["worker"]},
+        },
+    )
+    (bundle / "AGENTS.md").write_text("Review things.\n")
+    worker = bundle / "agents" / "worker"
+    worker.mkdir(parents=True)
+    (worker / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "name": "worker",
+                "instructions": "AGENTS.md",
+                "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+            }
+        )
+    )
+    (worker / "AGENTS.md").write_text("Work.\n")
+
+    bundle_bytes = package_workspace_agent(tmp_path, ".omnigent/agent-configs/reviewer")
+    with tarfile.open(fileobj=io.BytesIO(bundle_bytes), mode="r:gz") as tar:
+        names = sorted(tar.getnames())
+    assert names == [
+        "AGENTS.md",
+        "agents/worker/AGENTS.md",
+        "agents/worker/config.yaml",
+        "config.yaml",
+    ]
+
+    spec = load(bundle_bytes, dest=tmp_path / "extract")
+    assert spec.name == "reviewer"
+    assert [sub.name for sub in spec.sub_agents] == ["worker"]
+
+
+def test_package_rejects_escape_and_unknown_shapes(tmp_path: Path) -> None:
+    (tmp_path / "outside.yaml").write_text("name: x\nprompt: hi\n")
+    with pytest.raises(ValueError, match="escapes the workspace"):
+        package_workspace_agent(tmp_path / "sub", "../outside.yaml")
+    _configs_dir(tmp_path)
+    (_configs_dir(tmp_path) / "plain").mkdir()
+    with pytest.raises(ValueError, match="not an agent YAML or bundle"):
+        package_workspace_agent(tmp_path, ".omnigent/agent-configs/plain")
+
+
+def test_package_enforces_size_ceiling(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path, "big", {"spec_version": 1, "name": "big"})
+    (bundle / "blob.bin").write_bytes(b"x" * 2048)
+    with pytest.raises(ValueError, match="exceeds"):
+        package_workspace_agent(tmp_path, ".omnigent/agent-configs/big", max_bytes=1024)

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -108,6 +108,51 @@ export function useHostModelOptions(hostId: string | null, harness: string, enab
   });
 }
 
+/** One ACP agent declared in a workspace's `.omnigent/config.yaml`. */
+export interface WorkspaceAcpAgent {
+  slug: string;
+  name: string;
+  command: string;
+  model: string | null;
+  session_id_mode: "server" | "client";
+  send_model: boolean;
+  /** Soft hint: the command's binary resolves on the host's PATH. */
+  command_found: boolean;
+}
+
+async function fetchWorkspaceHarnesses(
+  hostId: string,
+  workspace: string,
+): Promise<WorkspaceAcpAgent[]> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/workspace-harnesses?path=${encodeURIComponent(workspace)}`,
+  );
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = (await res.json()) as { agents?: WorkspaceAcpAgent[] };
+  return body.agents ?? [];
+}
+
+/**
+ * Harnesses declared by the selected workspace's repo (`.omnigent/config.yaml`),
+ * resolved on the selected host. Errors (offline host, older host daemon that
+ * doesn't speak the frame) degrade to an empty list.
+ */
+export function useWorkspaceHarnesses(hostId: string | null, workspace: string, enabled = true) {
+  return useQuery({
+    queryKey: ["workspace-harnesses", hostId, workspace],
+    queryFn: async () => {
+      try {
+        return await fetchWorkspaceHarnesses(hostId as string, workspace);
+      } catch {
+        return [];
+      }
+    },
+    enabled: enabled && hostId !== null && workspace.length > 0,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
 interface InstallHarnessResult {
   object: "harness_install";
   harness: string;

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -120,37 +120,88 @@ export interface WorkspaceAcpAgent {
   command_found: boolean;
 }
 
+/** One agent config declared under a workspace's `.omnigent/agent-configs/`. */
+export interface WorkspaceAgentConfigEntry {
+  slug: string;
+  name: string;
+  /** Workspace-relative path, e.g. ".omnigent/agent-configs/helper.yaml". */
+  path: string;
+  /** "file" (single-file YAML) or "bundle" (directory image). */
+  kind: "file" | "bundle";
+  description: string | null;
+  harness: string | null;
+  sub_agents: string[];
+  has_local_tools: boolean;
+  has_mcp_servers: boolean;
+}
+
+/** Everything a workspace's repo declares as runnable. */
+export interface WorkspaceDiscovery {
+  agents: WorkspaceAcpAgent[];
+  agentConfigs: WorkspaceAgentConfigEntry[];
+}
+
+const EMPTY_DISCOVERY: WorkspaceDiscovery = { agents: [], agentConfigs: [] };
+
 async function fetchWorkspaceHarnesses(
   hostId: string,
   workspace: string,
-): Promise<WorkspaceAcpAgent[]> {
+): Promise<WorkspaceDiscovery> {
   const res = await authenticatedFetch(
     `/v1/hosts/${encodeURIComponent(hostId)}/workspace-harnesses?path=${encodeURIComponent(workspace)}`,
   );
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const body = (await res.json()) as { agents?: WorkspaceAcpAgent[] };
-  return body.agents ?? [];
+  const body = (await res.json()) as {
+    agents?: WorkspaceAcpAgent[];
+    agent_configs?: WorkspaceAgentConfigEntry[];
+  };
+  return { agents: body.agents ?? [], agentConfigs: body.agent_configs ?? [] };
 }
 
 /**
- * Harnesses declared by the selected workspace's repo (`.omnigent/config.yaml`),
- * resolved on the selected host. Errors (offline host, older host daemon that
- * doesn't speak the frame) degrade to an empty list.
+ * Agents the selected workspace's repo declares — ACP commands from
+ * `.omnigent/config.yaml` plus agent configs under
+ * `.omnigent/agent-configs/` — resolved on the selected host. Errors
+ * (offline host, older host daemon that doesn't speak the frame)
+ * degrade to empty lists.
  */
 export function useWorkspaceHarnesses(hostId: string | null, workspace: string, enabled = true) {
   return useQuery({
     queryKey: ["workspace-harnesses", hostId, workspace],
-    queryFn: async () => {
+    queryFn: async (): Promise<WorkspaceDiscovery> => {
       try {
         return await fetchWorkspaceHarnesses(hostId as string, workspace);
       } catch {
-        return [];
+        return EMPTY_DISCOVERY;
       }
     },
     enabled: enabled && hostId !== null && workspace.length > 0,
     staleTime: 30_000,
     retry: false,
   });
+}
+
+/**
+ * Package a repo-declared agent config into deterministic `.tar.gz`
+ * bytes on the host. The caller hashes these bytes for the consent
+ * grant and uploads them verbatim, so what the user approved is exactly
+ * what the server validates and runs.
+ */
+export async function packageWorkspaceAgent(
+  hostId: string,
+  workspace: string,
+  configPath: string,
+): Promise<ArrayBuffer> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/workspace-agents/package`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: workspace, config_path: configPath }),
+    },
+  );
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.arrayBuffer();
 }
 
 interface InstallHarnessResult {

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -116,6 +116,8 @@ export interface WorkspaceAcpAgent {
   model: string | null;
   session_id_mode: "server" | "client";
   send_model: boolean;
+  /** Lend Omnigent's builtin MCP relay in session/new (default true). */
+  omnigent_mcp: boolean;
   /** Soft hint: the command's binary resolves on the host's PATH. */
   command_found: boolean;
 }

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -141,8 +141,6 @@ export interface WorkspaceDiscovery {
   agentConfigs: WorkspaceAgentConfigEntry[];
 }
 
-const EMPTY_DISCOVERY: WorkspaceDiscovery = { agents: [], agentConfigs: [] };
-
 async function fetchWorkspaceHarnesses(
   hostId: string,
   workspace: string,
@@ -161,20 +159,15 @@ async function fetchWorkspaceHarnesses(
 /**
  * Agents the selected workspace's repo declares — ACP commands from
  * `.omnigent/config.yaml` plus agent configs under
- * `.omnigent/agent-configs/` — resolved on the selected host. Errors
- * (offline host, older host daemon that doesn't speak the frame)
- * degrade to empty lists.
+ * `.omnigent/agent-configs/` — resolved on the selected host. Failures
+ * (offline host, older host daemon that doesn't speak the frame) land in
+ * the query's error state; consumers default to empty lists, so
+ * discovery degrades silently in the picker.
  */
 export function useWorkspaceHarnesses(hostId: string | null, workspace: string, enabled = true) {
   return useQuery({
     queryKey: ["workspace-harnesses", hostId, workspace],
-    queryFn: async (): Promise<WorkspaceDiscovery> => {
-      try {
-        return await fetchWorkspaceHarnesses(hostId as string, workspace);
-      } catch {
-        return EMPTY_DISCOVERY;
-      }
-    },
+    queryFn: () => fetchWorkspaceHarnesses(hostId as string, workspace),
     enabled: enabled && hostId !== null && workspace.length > 0,
     staleTime: 30_000,
     retry: false,

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -197,4 +197,49 @@ describe("buildAgentBundle", () => {
     expect(yaml).toContain("harness: openai-agents");
     expect(yaml).toContain("model: gpt-4o");
   });
+
+  it("omits the model line when no model is given", async () => {
+    const input: AgentBundleInput = {
+      name: "acp-agent",
+      harness: "acp:repo-echo",
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).not.toContain("model:");
+    expect(yaml).toContain("harness: acp:repo-echo");
+  });
+
+  it("embeds acp_agent under executor, before config", async () => {
+    const input: AgentBundleInput = {
+      name: "repo-agent",
+      harness: "acp:repo-echo",
+      acpAgent: {
+        name: "Repo Echo",
+        command: "echo-agent --acp --flag",
+        model: "gpt-5.3",
+        sessionIdMode: "client",
+        sendModel: true,
+      },
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("executor:\n  type: omnigent\n  acp_agent:");
+    expect(yaml).toContain("    name: Repo Echo");
+    expect(yaml).toContain("    command: echo-agent --acp --flag");
+    expect(yaml).toContain("    model: gpt-5.3");
+    expect(yaml).toContain("    session_id_mode: client");
+    expect(yaml).toContain("    send_model: true");
+    expect(yaml).toContain("harness: acp:repo-echo");
+  });
+
+  it("omits default acp_agent knobs", async () => {
+    const input: AgentBundleInput = {
+      name: "repo-agent",
+      harness: "acp:repo-echo",
+      acpAgent: { name: "Repo Echo", command: "echo-agent --acp" },
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("  acp_agent:");
+    expect(yaml).not.toContain("session_id_mode");
+    expect(yaml).not.toContain("send_model");
+    expect(yaml).not.toContain("model:");
+  });
 });

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -241,5 +241,16 @@ describe("buildAgentBundle", () => {
     expect(yaml).not.toContain("session_id_mode");
     expect(yaml).not.toContain("send_model");
     expect(yaml).not.toContain("model:");
+    expect(yaml).not.toContain("omnigent_mcp");
+  });
+
+  it("emits omnigent_mcp only when disabled", async () => {
+    const input: AgentBundleInput = {
+      name: "repo-agent",
+      harness: "acp:repo-echo",
+      acpAgent: { name: "Repo Echo", command: "echo-agent --acp", omnigentMcp: false },
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("    omnigent_mcp: false");
   });
 });

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -42,6 +42,8 @@ export interface AgentBundleInput {
     model?: string;
     sessionIdMode?: "server" | "client";
     sendModel?: boolean;
+    /** Lend Omnigent's builtin MCP relay (default true; emitted only when false). */
+    omnigentMcp?: boolean;
   };
   /** MCP server declarations to include as inline tools entries. */
   mcpServers?: MCPServerInput[];
@@ -82,6 +84,9 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
     }
     if (input.acpAgent.sendModel) {
       lines.push("    send_model: true");
+    }
+    if (input.acpAgent.omnigentMcp === false) {
+      lines.push("    omnigent_mcp: false");
     }
   }
   lines.push("  config:");

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -29,8 +29,20 @@ export interface AgentBundleInput {
   instructions?: string;
   /** Harness kind, e.g. "claude-sdk", "openai-agents". */
   harness: string;
-  /** Model identifier, e.g. "claude-sonnet-4-20250514". Required by the omnigent executor. */
-  model: string;
+  /** Model identifier, e.g. "claude-sonnet-4-20250514". Omitted for harnesses that own their model (e.g. ACP agents). */
+  model?: string;
+  /**
+   * One-shot ACP agent embedded as `executor.acp_agent` (takes precedence
+   * over the host's global `acp:` config at spawn). Used to launch
+   * repo-declared agents with the exact command the user consented to.
+   */
+  acpAgent?: {
+    name: string;
+    command: string;
+    model?: string;
+    sessionIdMode?: "server" | "client";
+    sendModel?: boolean;
+  };
   /** MCP server declarations to include as inline tools entries. */
   mcpServers?: MCPServerInput[];
 }
@@ -53,7 +65,25 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
 
   lines.push("executor:");
   lines.push("  type: omnigent");
-  lines.push(`  model: ${input.model}`);
+  if (input.model) {
+    lines.push(`  model: ${input.model}`);
+  }
+  // The spec adapter reads `acp_agent` from the raw executor mapping and
+  // carries it into executor.config, so it sits under executor:, not config:.
+  if (input.acpAgent) {
+    lines.push("  acp_agent:");
+    lines.push(`    name: ${yamlQuote(input.acpAgent.name)}`);
+    lines.push(`    command: ${yamlQuote(input.acpAgent.command)}`);
+    if (input.acpAgent.model) {
+      lines.push(`    model: ${yamlQuote(input.acpAgent.model)}`);
+    }
+    if (input.acpAgent.sessionIdMode && input.acpAgent.sessionIdMode !== "server") {
+      lines.push(`    session_id_mode: ${input.acpAgent.sessionIdMode}`);
+    }
+    if (input.acpAgent.sendModel) {
+      lines.push("    send_model: true");
+    }
+  }
   lines.push("  config:");
   lines.push(`    harness: ${input.harness}`);
   lines.push("");

--- a/web/src/lib/repoHarnessTrust.test.ts
+++ b/web/src/lib/repoHarnessTrust.test.ts
@@ -1,0 +1,40 @@
+// jsdom provides localStorage; crypto.subtle comes from the node webcrypto
+// shim vitest wires up. The persisted key format is part of the contract:
+// changing it silently invalidates every stored grant.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  digestBundleBytes,
+  isRepoCommandTrusted,
+  isRepoDigestTrusted,
+  trustRepoCommand,
+  trustRepoDigest,
+} from "./repoHarnessTrust";
+
+const HOST = "host_abc";
+const WS = "/tmp/demo|repo"; // deliberately contains the old delimiter
+
+describe("repoHarnessTrust", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("grants and checks a command by exact content", async () => {
+    expect(await isRepoCommandTrusted(HOST, WS, "echo", "run --acp")).toBe(false);
+    await trustRepoCommand(HOST, WS, "echo", "run --acp");
+    expect(await isRepoCommandTrusted(HOST, WS, "echo", "run --acp")).toBe(true);
+    // Any change to the command re-prompts.
+    expect(await isRepoCommandTrusted(HOST, WS, "echo", "run --acp --evil")).toBe(false);
+  });
+
+  it("keeps command and bundle grants in separate namespaces", async () => {
+    const digest = await digestBundleBytes(new TextEncoder().encode("bundle").buffer);
+    await trustRepoDigest(HOST, WS, "echo", digest);
+    expect(await isRepoDigestTrusted(HOST, WS, "echo", digest)).toBe(true);
+    // A bundle grant must never satisfy a command check for the same slug.
+    expect(await isRepoCommandTrusted(HOST, WS, "echo", digest)).toBe(false);
+  });
+
+  it("does not confuse delimiter-shaped path segments", async () => {
+    await trustRepoCommand(HOST, "/a|b", "s", "cmd");
+    expect(await isRepoCommandTrusted(HOST, "/a", "b|s", "cmd")).toBe(false);
+  });
+});

--- a/web/src/lib/repoHarnessTrust.ts
+++ b/web/src/lib/repoHarnessTrust.ts
@@ -1,29 +1,40 @@
 /**
- * Client-side trust ledger for repo-declared harness commands.
+ * Client-side trust ledger for repo-declared agents.
  *
- * A `.omnigent/config.yaml` checked into a repo can declare arbitrary shell
- * commands, so the first launch of a discovered agent always goes through an
- * explicit consent dialog. "Always allow" persists a grant keyed by
- * (host, workspace, slug, SHA-256 of the exact command) — any change to the
- * command re-prompts. Per-browser only; server-side trust is a follow-up.
+ * Repo content is arbitrary code from a clone, so the first launch of a
+ * discovered agent always goes through an explicit consent dialog.
+ * "Always allow" persists a grant keyed by a JSON-encoded tagged tuple —
+ * `["cmd", host, workspace, slug, sha256(command)]` for ACP commands,
+ * `["bundle", host, workspace, slug, sha256(bundle bytes)]` for agent
+ * configs — so the two grant types can never collide, path characters
+ * can't be confused for delimiters, and any change to the command or
+ * bundle content re-prompts. Per-browser only; server-side trust is a
+ * follow-up.
  */
 
 const STORAGE_KEY = "omnigent.repoHarnessTrust";
 
-async function sha256Hex(text: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+async function sha256Hex(data: string | ArrayBuffer): Promise<string> {
+  const bytes = typeof data === "string" ? new TextEncoder().encode(data) : data;
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 }
 
-async function grantKey(
+/** SHA-256 hex of raw bundle bytes — the identity a bundle grant is keyed on. */
+export async function digestBundleBytes(bytes: ArrayBuffer): Promise<string> {
+  return sha256Hex(bytes);
+}
+
+function grantKey(
+  kind: "cmd" | "bundle",
   hostId: string,
   workspace: string,
   slug: string,
-  command: string,
-): Promise<string> {
-  return `${hostId}|${workspace}|${slug}|${await sha256Hex(command)}`;
+  digestHex: string,
+): string {
+  return JSON.stringify([kind, hostId, workspace, slug, digestHex]);
 }
 
 function readGrants(): Record<string, true> {
@@ -36,6 +47,16 @@ function readGrants(): Record<string, true> {
   }
 }
 
+function writeGrant(key: string): void {
+  const grants = readGrants();
+  grants[key] = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(grants));
+  } catch {
+    // Quota/private-mode failures just mean re-prompting next time.
+  }
+}
+
 /** Whether this exact command was previously granted "always allow". */
 export async function isRepoCommandTrusted(
   hostId: string,
@@ -43,7 +64,8 @@ export async function isRepoCommandTrusted(
   slug: string,
   command: string,
 ): Promise<boolean> {
-  return readGrants()[await grantKey(hostId, workspace, slug, command)] === true;
+  const key = grantKey("cmd", hostId, workspace, slug, await sha256Hex(command));
+  return readGrants()[key] === true;
 }
 
 /** Persist an "always allow" grant for this exact command. */
@@ -53,49 +75,25 @@ export async function trustRepoCommand(
   slug: string,
   command: string,
 ): Promise<void> {
-  const grants = readGrants();
-  grants[await grantKey(hostId, workspace, slug, command)] = true;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(grants));
-  } catch {
-    // Quota/private-mode failures just mean re-prompting next time.
-  }
-}
-
-/** SHA-256 hex of raw bundle bytes — the identity a bundle grant is keyed on. */
-export async function digestBundleBytes(bytes: ArrayBuffer): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function digestKey(hostId: string, workspace: string, slug: string, digestHex: string): string {
-  return `${hostId}|${workspace}|${slug}|${digestHex}`;
+  writeGrant(grantKey("cmd", hostId, workspace, slug, await sha256Hex(command)));
 }
 
 /** Whether this exact bundle digest was previously granted "always allow". */
-export function isRepoDigestTrusted(
+export async function isRepoDigestTrusted(
   hostId: string,
   workspace: string,
   slug: string,
   digestHex: string,
-): boolean {
-  return readGrants()[digestKey(hostId, workspace, slug, digestHex)] === true;
+): Promise<boolean> {
+  return readGrants()[grantKey("bundle", hostId, workspace, slug, digestHex)] === true;
 }
 
 /** Persist an "always allow" grant for this exact bundle digest. */
-export function trustRepoDigest(
+export async function trustRepoDigest(
   hostId: string,
   workspace: string,
   slug: string,
   digestHex: string,
-): void {
-  const grants = readGrants();
-  grants[digestKey(hostId, workspace, slug, digestHex)] = true;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(grants));
-  } catch {
-    // Quota/private-mode failures just mean re-prompting next time.
-  }
+): Promise<void> {
+  writeGrant(grantKey("bundle", hostId, workspace, slug, digestHex));
 }

--- a/web/src/lib/repoHarnessTrust.ts
+++ b/web/src/lib/repoHarnessTrust.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side trust ledger for repo-declared harness commands.
+ *
+ * A `.omnigent/config.yaml` checked into a repo can declare arbitrary shell
+ * commands, so the first launch of a discovered agent always goes through an
+ * explicit consent dialog. "Always allow" persists a grant keyed by
+ * (host, workspace, slug, SHA-256 of the exact command) — any change to the
+ * command re-prompts. Per-browser only; server-side trust is a follow-up.
+ */
+
+const STORAGE_KEY = "omnigent.repoHarnessTrust";
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function grantKey(
+  hostId: string,
+  workspace: string,
+  slug: string,
+  command: string,
+): Promise<string> {
+  return `${hostId}|${workspace}|${slug}|${await sha256Hex(command)}`;
+}
+
+function readGrants(): Record<string, true> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, true>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Whether this exact command was previously granted "always allow". */
+export async function isRepoCommandTrusted(
+  hostId: string,
+  workspace: string,
+  slug: string,
+  command: string,
+): Promise<boolean> {
+  return readGrants()[await grantKey(hostId, workspace, slug, command)] === true;
+}
+
+/** Persist an "always allow" grant for this exact command. */
+export async function trustRepoCommand(
+  hostId: string,
+  workspace: string,
+  slug: string,
+  command: string,
+): Promise<void> {
+  const grants = readGrants();
+  grants[await grantKey(hostId, workspace, slug, command)] = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(grants));
+  } catch {
+    // Quota/private-mode failures just mean re-prompting next time.
+  }
+}

--- a/web/src/lib/repoHarnessTrust.ts
+++ b/web/src/lib/repoHarnessTrust.ts
@@ -61,3 +61,41 @@ export async function trustRepoCommand(
     // Quota/private-mode failures just mean re-prompting next time.
   }
 }
+
+/** SHA-256 hex of raw bundle bytes — the identity a bundle grant is keyed on. */
+export async function digestBundleBytes(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function digestKey(hostId: string, workspace: string, slug: string, digestHex: string): string {
+  return `${hostId}|${workspace}|${slug}|${digestHex}`;
+}
+
+/** Whether this exact bundle digest was previously granted "always allow". */
+export function isRepoDigestTrusted(
+  hostId: string,
+  workspace: string,
+  slug: string,
+  digestHex: string,
+): boolean {
+  return readGrants()[digestKey(hostId, workspace, slug, digestHex)] === true;
+}
+
+/** Persist an "always allow" grant for this exact bundle digest. */
+export function trustRepoDigest(
+  hostId: string,
+  workspace: string,
+  slug: string,
+  digestHex: string,
+): void {
+  const grants = readGrants();
+  grants[digestKey(hostId, workspace, slug, digestHex)] = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(grants));
+  } catch {
+    // Quota/private-mode failures just mean re-prompting next time.
+  }
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -84,7 +84,7 @@ vi.mock("@/hooks/useHosts", () => ({
     ],
   })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
-  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: { agents: [], agentConfigs: [] } })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));
 vi.mock("@/hooks/useAvailableAgents", () => ({

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@/hooks/useHosts", () => ({
     ],
   })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));
 vi.mock("@/hooks/useAvailableAgents", () => ({

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
-  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: { agents: [], agentConfigs: [] } })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -56,6 +56,7 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
   // The setup dialog mounts these; default to inert so tests that don't
   // exercise install / credential-write don't need to wire them up.
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -56,7 +56,7 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(),
-  useWorkspaceHarnesses: vi.fn(() => ({ data: [] })),
+  useWorkspaceHarnesses: vi.fn(() => ({ data: { agents: [], agentConfigs: [] } })),
   // The setup dialog mounts these; default to inert so tests that don't
   // exercise install / credential-write don't need to wire them up.
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2173,10 +2173,16 @@ export function NewChatLandingScreen() {
     digest: string;
   } | null>(null);
   const [repoConsentAlways, setRepoConsentAlways] = useState(false);
-  const repoConsentGrantedRef = useRef(false);
-  // Bytes approved in the consent dialog, carried into the re-entered
-  // handleCreate so the upload is byte-identical to what was shown.
-  const approvedRepoBundleRef = useRef<{ bytes: ArrayBuffer; digest: string } | null>(null);
+  // Approval granted by the consent dialog, carried into the re-entered
+  // handleCreate. A VALUE bound to exactly what was approved (slug +
+  // command / digest + bytes), read-and-cleared at the top of the create,
+  // so an early return can never leak a stale approval onto a different
+  // pick, and the upload stays byte-identical to what the dialog showed.
+  const repoApprovalRef = useRef<
+    | { kind: "command"; slug: string; command: string }
+    | { kind: "bundle"; slug: string; digest: string; bytes: ArrayBuffer }
+    | null
+  >(null);
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
@@ -3630,59 +3636,73 @@ export function NewChatLandingScreen() {
     // because the create outlives an unmount; a create that fails hands the
     // draft back via returnDraftToUser.
     submittedRef.current = true;
+    // Consume any dialog-granted approval immediately: it applies to this
+    // create only, and only if it still matches the current pick.
+    const repoApproval = repoApprovalRef.current;
+    repoApprovalRef.current = null;
     try {
       // Repo-declared command: explicit first-use consent (the command is
       // arbitrary shell from a cloned repo). The dialog's confirm re-enters
-      // via the one-shot granted ref; "Always allow" grants persist per
-      // (host, workspace, slug, command hash) so an edited command re-prompts.
-      if (pickedRepoAgent && !repoConsentGrantedRef.current) {
+      // with an approval bound to the exact command; "Always allow" grants
+      // persist per (host, workspace, slug, command hash) so an edited
+      // command re-prompts.
+      if (pickedRepoAgent) {
+        const approved =
+          repoApproval?.kind === "command" &&
+          repoApproval.slug === pickedRepoAgent.slug &&
+          repoApproval.command === pickedRepoAgent.command;
         const trusted =
-          selectedHostId !== null &&
-          (await isRepoCommandTrusted(
-            selectedHostId,
-            workspace.trim(),
-            pickedRepoAgent.slug,
-            pickedRepoAgent.command,
-          ));
+          approved ||
+          (selectedHostId !== null &&
+            (await isRepoCommandTrusted(
+              selectedHostId,
+              workspace.trim(),
+              pickedRepoAgent.slug,
+              pickedRepoAgent.command,
+            )));
         if (!trusted) {
           setRepoConsentAgent(pickedRepoAgent);
           return;
         }
       }
       // Repo-declared agent config: package on the host (deterministic
-      // bytes), hash, and gate on the digest. The consent dialog holds the
-      // exact bytes so confirm uploads what was approved — a repo edit
-      // between consent and create can't swap the content.
+      // bytes), hash, and gate on the digest. An approval carries the exact
+      // bytes the dialog showed, so the upload is byte-identical to what
+      // was approved — a repo edit between consent and create can't swap
+      // the content.
       let repoConfigBundle: { file: File; digest: string } | null = null;
       if (pickedRepoConfig && selectedHostId !== null) {
-        let approved = approvedRepoBundleRef.current;
-        approvedRepoBundleRef.current = null;
-        if (approved === null) {
-          const bytes = await packageWorkspaceAgent(
-            selectedHostId,
-            workspace.trim(),
-            pickedRepoConfig.path,
-          );
-          approved = { bytes, digest: await digestBundleBytes(bytes) };
-        }
+        const approvedBundle =
+          repoApproval?.kind === "bundle" && repoApproval.slug === pickedRepoConfig.slug
+            ? { bytes: repoApproval.bytes, digest: repoApproval.digest }
+            : null;
+        const bundle =
+          approvedBundle ??
+          (await (async () => {
+            const bytes = await packageWorkspaceAgent(
+              selectedHostId,
+              workspace.trim(),
+              pickedRepoConfig.path,
+            );
+            return { bytes, digest: await digestBundleBytes(bytes) };
+          })());
         const trusted =
-          repoConsentGrantedRef.current ||
-          isRepoDigestTrusted(
+          approvedBundle !== null ||
+          (await isRepoDigestTrusted(
             selectedHostId,
             workspace.trim(),
             pickedRepoConfig.slug,
-            approved.digest,
-          );
+            bundle.digest,
+          ));
         if (!trusted) {
-          setRepoConsentConfig({ entry: pickedRepoConfig, ...approved });
+          setRepoConsentConfig({ entry: pickedRepoConfig, ...bundle });
           return;
         }
         repoConfigBundle = {
-          file: new File([approved.bytes], "agent.tar.gz", { type: "application/gzip" }),
-          digest: approved.digest,
+          file: new File([bundle.bytes], "agent.tar.gz", { type: "application/gzip" }),
+          digest: bundle.digest,
         };
       }
-      repoConsentGrantedRef.current = false;
       const trimmedBranch = branchName.trim();
       // `shouldCreateWorktree` (component scope): true only when a branch is
       // named and the workspace isn't already an existing worktree. Starting
@@ -4027,9 +4047,9 @@ export function NewChatLandingScreen() {
     ? `Start a new session in ${selectedProject}`
     : "Describe a task to start a new session…";
 
-  // Confirm handler for the repo-command consent dialog: optionally persist
-  // the "always allow" grant, then re-enter handleCreate through the one-shot
-  // granted ref so this run doesn't re-prompt.
+  // Confirm handler for the repo consent dialog: optionally persist the
+  // "always allow" grant, then re-enter handleCreate with an approval bound
+  // to exactly what the dialog showed.
   async function confirmRepoConsent() {
     const agent = repoConsentAgent;
     const config = repoConsentConfig;
@@ -4038,18 +4058,18 @@ export function NewChatLandingScreen() {
       if (agent !== null) {
         await trustRepoCommand(selectedHostId, workspace.trim(), agent.slug, agent.command);
       } else if (config !== null) {
-        trustRepoDigest(selectedHostId, workspace.trim(), config.entry.slug, config.digest);
+        await trustRepoDigest(selectedHostId, workspace.trim(), config.entry.slug, config.digest);
       }
     }
-    if (config !== null) {
-      // Carry the approved bytes into the re-entered create so the upload
-      // is byte-identical to what the dialog showed.
-      approvedRepoBundleRef.current = { bytes: config.bytes, digest: config.digest };
-    }
+    repoApprovalRef.current =
+      agent !== null
+        ? { kind: "command", slug: agent.slug, command: agent.command }
+        : config !== null
+          ? { kind: "bundle", slug: config.entry.slug, digest: config.digest, bytes: config.bytes }
+          : null;
     setRepoConsentAgent(null);
     setRepoConsentConfig(null);
     setRepoConsentAlways(false);
-    repoConsentGrantedRef.current = true;
     await handleCreate();
   }
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3777,17 +3777,18 @@ export function NewChatLandingScreen() {
         : null;
       const bundleInput =
         repoBundleInput ?? (effectiveAgentId === PENDING_AGENT_ID ? pendingAgent : null);
+      // A repo config launches from its packaged (consented) File; the other
+      // bundled paths build the tar client-side from an AgentBundleInput.
+      const bundleSource: File | AgentBundleInput | null = repoConfigBundle?.file ?? bundleInput;
 
-      if (repoConfigBundle !== null || bundleInput) {
+      if (bundleSource !== null) {
         // Custom agent path: build bundle client-side and use multipart POST.
         // The multipart create only stores the agent + session rows — it does
         // NOT launch a runner on the host. We must follow up with launchRunner
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
         const bundle =
-          repoConfigBundle !== null
-            ? repoConfigBundle.file
-            : await buildAgentBundle(bundleInput as AgentBundleInput);
+          bundleSource instanceof File ? bundleSource : await buildAgentBundle(bundleSource);
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
         // Born-filed: stamp the project's `omni_project` label so a bundled

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -140,7 +140,14 @@ import {
   nativeCodingAgentForAvailableAgent,
   nativeWrapperLabelsForAgent,
 } from "@/lib/nativeCodingAgents";
-import { useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
+import {
+  useHostModelOptions,
+  useHosts,
+  useWorkspaceHarnesses,
+  type Host,
+  type WorkspaceAcpAgent,
+} from "@/hooks/useHosts";
+import { isRepoCommandTrusted, trustRepoCommand } from "@/lib/repoHarnessTrust";
 import {
   controlHost,
   getHostIdentity,
@@ -338,6 +345,14 @@ const CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY = "omnigent.codex_native.bypass_sand
 // option in the Codex approval dropdown (Codex only; OpenCode shares the
 // presets above but has no bypass). It rides as a conversation label, not
 // terminal_launch_args, so its `args` are empty and it's handled specially.
+// Picker-row id prefix for harnesses discovered in the selected workspace's
+// `.omnigent/config.yaml`. UI-local only — never sent to the server; the
+// launch path embeds the discovered entry into a generated agent bundle.
+const REPO_ACP_ID_PREFIX = "repo-acp:";
+// Stable default for the picker's optional repoAgents prop (a literal default
+// would be re-created per render and defeat memoization downstream).
+const NO_REPO_AGENTS: WorkspaceAcpAgent[] = [];
+
 const CODEX_NATIVE_BYPASS_APPROVAL_VALUE = "bypass";
 const CODEX_NATIVE_BYPASS_APPROVAL_OPTION = {
   value: CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
@@ -910,6 +925,8 @@ export function AgentHarnessPicker({
   onSelectPending,
   onCreateCustomAgent,
   sandboxSelected,
+  repoAgents = NO_REPO_AGENTS,
+  onSelectRepoAgent,
   allowCreateCustomAgent = true,
   onOpenChange,
   dropdownModal = true,
@@ -934,6 +951,12 @@ export function AgentHarnessPicker({
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
   sandboxSelected: boolean;
+  /** Harnesses declared by the selected workspace's repo (`.omnigent/`).
+   *  Rendered at the top of the Harnesses group with a "From this repo"
+   *  badge. Defaults empty, so existing call sites are unchanged. */
+  repoAgents?: WorkspaceAcpAgent[];
+  /** Selection callback for a repo-declared harness row. */
+  onSelectRepoAgent?: (agent: WorkspaceAcpAgent) => void;
   /** Whether to offer the "Create custom agent" action. Defaults true; an
    *  embedder that only picks an existing agent (e.g. project settings) can
    *  hide it since it has no interactive create flow. */
@@ -1020,6 +1043,40 @@ export function AgentHarnessPicker({
         )}
       </Badge>
     ) : null;
+
+  // Repo-declared harness rows — discovered in the selected workspace's
+  // `.omnigent/config.yaml`, so they lead the Harnesses group with a
+  // provenance badge. A missing binary is a soft hint (the agent owns its
+  // own install), shown as a muted note rather than a warning badge.
+  const renderRepoEntry = (agent: WorkspaceAcpAgent): ReactNode => {
+    const id = REPO_ACP_ID_PREFIX + agent.slug;
+    const active = id === effectiveAgentId;
+    return (
+      <DropdownMenuItem
+        key={id}
+        data-testid={`new-chat-landing-agent-${id}`}
+        data-active={active ? "true" : undefined}
+        onSelect={() => onSelectRepoAgent?.(agent)}
+        className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+      >
+        <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+          <span className="truncate">{agent.name}</span>
+          {!agent.command_found && (
+            <span className="truncate text-[11px] text-muted-foreground/70">
+              command not found on host
+            </span>
+          )}
+        </div>
+        <Badge
+          variant="outline"
+          className="ml-auto self-center border-sky-300 bg-sky-50 text-[11px] text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400"
+          data-testid={`new-chat-landing-repo-badge-${agent.slug}`}
+        >
+          From this repo
+        </Badge>
+      </DropdownMenuItem>
+    );
+  };
 
   // Each entry is a plain selectable row — selecting commits the pick and
   // closes the menu. Run-config knobs moved to the gear-icon config modal.
@@ -1249,9 +1306,12 @@ export function AgentHarnessPicker({
             {/* Harnesses group — the native terminal CLIs (Claude Code is the
             default), so the most-used picks lead. Ready-to-use harnesses list
             inline; "needs setup" ones fold into a "More" group. */}
-            {(readyHarnessEntries.length > 0 || moreHarnessEntries.length > 0) && (
+            {(repoAgents.length > 0 ||
+              readyHarnessEntries.length > 0 ||
+              moreHarnessEntries.length > 0) && (
               <>
                 <PickerSectionHeader>Harnesses</PickerSectionHeader>
+                {repoAgents.map(renderRepoEntry)}
                 {readyHarnessEntries.map(renderEntry)}
                 {moreHarnessEntries.length > 0 &&
                   (isMobile ? (
@@ -2031,6 +2091,22 @@ export function NewChatLandingScreen() {
     () => landingDraft?.sandboxRepoBranch ?? "",
   );
   const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
+  // Harnesses declared by the selected workspace's repo (`.omnigent/config.yaml`),
+  // read on the selected host. Suggest-and-rank only: rows lead the picker's
+  // Harnesses group but nothing is auto-selected.
+  const { data: repoAcpAgentsData } = useWorkspaceHarnesses(
+    selectedHostId,
+    workspace.trim(),
+    !sandboxSelected,
+  );
+  const repoAcpAgents = useMemo(() => repoAcpAgentsData ?? [], [repoAcpAgentsData]);
+  // First-use consent for a repo-declared command (arbitrary shell from a
+  // cloned repo). Non-null = the consent dialog is open for that agent;
+  // the ref is a one-shot bypass so the dialog's confirm can re-enter
+  // handleCreate without re-prompting.
+  const [repoConsentAgent, setRepoConsentAgent] = useState<WorkspaceAcpAgent | null>(null);
+  const [repoConsentAlways, setRepoConsentAlways] = useState(false);
+  const repoConsentGrantedRef = useRef(false);
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
@@ -2514,11 +2590,20 @@ export function NewChatLandingScreen() {
   // bundled agent. So a pending pick made before switching to a sandbox is
   // dropped there, falling back to a real agent; off the sandbox it's kept.
   const pendingAgentAllowedOnTarget = !sandboxSelected;
+  // A picked repo-declared harness only wins while its workspace still
+  // declares it (and off the sandbox) — changing the workspace or a repo
+  // config edit that drops the entry falls back to the default agent.
+  const pickedRepoAgent =
+    !sandboxSelected && pickedAgentId?.startsWith(REPO_ACP_ID_PREFIX)
+      ? (repoAcpAgents.find((a) => REPO_ACP_ID_PREFIX + a.slug === pickedAgentId) ?? null)
+      : null;
   const effectiveAgentId =
     pickedAgentId === PENDING_AGENT_ID && pendingAgentAllowedOnTarget
       ? PENDING_AGENT_ID
-      : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
-        null);
+      : pickedRepoAgent
+        ? pickedAgentId
+        : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
+          null);
   const selectedAgent = useMemo(
     () =>
       effectiveAgentId === PENDING_AGENT_ID && pendingAgent
@@ -2530,8 +2615,17 @@ export function NewChatLandingScreen() {
             harness: pendingAgent.harness ?? null,
             skills: [],
           } satisfies AvailableAgent)
-        : agentList.find((a) => a.id === effectiveAgentId),
-    [agentList, effectiveAgentId, pendingAgent],
+        : pickedRepoAgent
+          ? ({
+              id: REPO_ACP_ID_PREFIX + pickedRepoAgent.slug,
+              name: pickedRepoAgent.name,
+              display_name: pickedRepoAgent.name,
+              description: null,
+              harness: "acp",
+              skills: [],
+            } satisfies AvailableAgent)
+          : agentList.find((a) => a.id === effectiveAgentId),
+    [agentList, effectiveAgentId, pendingAgent, pickedRepoAgent],
   );
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
@@ -2803,10 +2897,12 @@ export function NewChatLandingScreen() {
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
   const isNativeTerminalAgent = isNativeCodingAgent(selectedAgent);
-  const selectedAgentUnconfigured = harnessUnconfiguredOnHost(
-    selectedAgent?.harness,
-    harnessWarningHost,
-  );
+  // A repo-declared agent embeds its own command, so the host's global `acp`
+  // readiness (configured iff ~/.omnigent has ACP agents) doesn't apply to
+  // it — its only readiness signal is the soft command_found hint.
+  const selectedAgentUnconfigured =
+    pickedRepoAgent === null &&
+    harnessUnconfiguredOnHost(selectedAgent?.harness, harnessWarningHost);
   // Smart Routing routes between native Claude Code and Codex, so both wrapper
   // agents must be registered and both CLIs ready on the target host — a router
   // with one arm is just that arm. The Claude wrapper is the placeholder the
@@ -3366,6 +3462,12 @@ export function NewChatLandingScreen() {
     setPickedAgentId(PENDING_AGENT_ID);
     setPickedHarness(null);
   };
+  // Repo-declared picks are workspace-specific, so they're not persisted as
+  // the sticky last agent — a stale sentinel would just fall back anyway.
+  const handleSelectRepoAgent = (agent: WorkspaceAcpAgent) => {
+    setPickedAgentId(REPO_ACP_ID_PREFIX + agent.slug);
+    setPickedHarness(null);
+  };
 
   function selectHost(hostId: string) {
     // Persist the explicit pick even when it matches the current selection, so
@@ -3442,6 +3544,25 @@ export function NewChatLandingScreen() {
     // draft back via returnDraftToUser.
     submittedRef.current = true;
     try {
+      // Repo-declared command: explicit first-use consent (the command is
+      // arbitrary shell from a cloned repo). The dialog's confirm re-enters
+      // via the one-shot granted ref; "Always allow" grants persist per
+      // (host, workspace, slug, command hash) so an edited command re-prompts.
+      if (pickedRepoAgent && !repoConsentGrantedRef.current) {
+        const trusted =
+          selectedHostId !== null &&
+          (await isRepoCommandTrusted(
+            selectedHostId,
+            workspace.trim(),
+            pickedRepoAgent.slug,
+            pickedRepoAgent.command,
+          ));
+        if (!trusted) {
+          setRepoConsentAgent(pickedRepoAgent);
+          return;
+        }
+      }
+      repoConsentGrantedRef.current = false;
       const trimmedBranch = branchName.trim();
       // `shouldCreateWorktree` (component scope): true only when a branch is
       // named and the workspace isn't already an existing worktree. Starting
@@ -3515,13 +3636,36 @@ export function NewChatLandingScreen() {
 
       let data: { id: string };
 
-      if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
+      // A repo-declared agent launches as a one-shot bundle embedding the
+      // exact consented command as `executor.acp_agent` — frozen at create
+      // time, so a later repo edit can't swap what runs.
+      const repoBundleInput: AgentBundleInput | null = pickedRepoAgent
+        ? {
+            // Spec names must match [a-zA-Z0-9_-]+; the slug is that by
+            // construction. The human-readable name rides on acp_agent/
+            // description instead.
+            name: pickedRepoAgent.slug,
+            description: pickedRepoAgent.name,
+            harness: `acp:${pickedRepoAgent.slug}`,
+            acpAgent: {
+              name: pickedRepoAgent.name,
+              command: pickedRepoAgent.command,
+              model: pickedRepoAgent.model ?? undefined,
+              sessionIdMode: pickedRepoAgent.session_id_mode,
+              sendModel: pickedRepoAgent.send_model,
+            },
+          }
+        : null;
+      const bundleInput =
+        repoBundleInput ?? (effectiveAgentId === PENDING_AGENT_ID ? pendingAgent : null);
+
+      if (bundleInput) {
         // Custom agent path: build bundle client-side and use multipart POST.
         // The multipart create only stores the agent + session rows — it does
         // NOT launch a runner on the host. We must follow up with launchRunner
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
-        const bundle = await buildAgentBundle(pendingAgent);
+        const bundle = await buildAgentBundle(bundleInput);
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
         // Born-filed: stamp the project's `omni_project` label so a bundled
@@ -3545,8 +3689,9 @@ export function NewChatLandingScreen() {
               : undefined;
           await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts);
         }
-        // Clear pending agent after successful creation.
-        setPendingAgent(null);
+        // Clear pending agent after successful creation (repo-declared
+        // launches leave the pending custom agent untouched).
+        if (!repoBundleInput) setPendingAgent(null);
       } else {
         // Normal path: bind to an existing registered agent.
         // Which pushed row is ours: the one this tab has never seen, bound
@@ -3756,6 +3901,21 @@ export function NewChatLandingScreen() {
   const placeholderText = selectedProject
     ? `Start a new session in ${selectedProject}`
     : "Describe a task to start a new session…";
+
+  // Confirm handler for the repo-command consent dialog: optionally persist
+  // the "always allow" grant, then re-enter handleCreate through the one-shot
+  // granted ref so this run doesn't re-prompt.
+  async function confirmRepoConsent() {
+    const agent = repoConsentAgent;
+    if (agent === null) return;
+    if (repoConsentAlways && selectedHostId !== null) {
+      await trustRepoCommand(selectedHostId, workspace.trim(), agent.slug, agent.command);
+    }
+    setRepoConsentAgent(null);
+    setRepoConsentAlways(false);
+    repoConsentGrantedRef.current = true;
+    await handleCreate();
+  }
 
   // The working-directory chip — a single Popover trigger button that opens
   // the file browser. The directory-conflict warning lives inside the browser
@@ -4093,6 +4253,8 @@ export function NewChatLandingScreen() {
                     onSelectPending={handleSelectPending}
                     onCreateCustomAgent={() => setCreateAgentOpen(true)}
                     sandboxSelected={sandboxSelected}
+                    repoAgents={sandboxSelected ? [] : repoAcpAgents}
+                    onSelectRepoAgent={handleSelectRepoAgent}
                     triggerTooltip={
                       smartRoutingHarnessSelected ? AUTO_HARNESS_DESCRIPTION : undefined
                     }
@@ -4796,6 +4958,62 @@ export function NewChatLandingScreen() {
           setPickedHarness(null);
         }}
       />
+
+      {/* First-use consent for a repo-declared harness command. Shows the
+          exact shell string the repo's .omnigent/config.yaml declares; the
+          create embeds this same string, so what the user approves is what
+          runs. "Always allow" persists per (host, workspace, agent, command
+          hash) — editing the command in the repo re-prompts. */}
+      <Dialog
+        open={repoConsentAgent !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRepoConsentAgent(null);
+            setRepoConsentAlways(false);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg" data-testid="repo-harness-consent-dialog">
+          <DialogHeader>
+            <DialogTitle>Run an agent declared by this repo?</DialogTitle>
+            <DialogDescription>
+              “{repoConsentAgent?.name}” comes from <code>.omnigent/config.yaml</code> in{" "}
+              {workspaceTrimmed || "the selected workspace"}. Starting the session runs this command
+              on {selectedHost?.name ?? "the selected host"}:
+            </DialogDescription>
+          </DialogHeader>
+          <pre className="overflow-x-auto rounded-md border bg-muted/50 px-3 py-2 font-mono text-xs">
+            {repoConsentAgent?.command}
+          </pre>
+          <label className="flex items-center gap-2 text-13 text-muted-foreground">
+            <Switch
+              checked={repoConsentAlways}
+              onCheckedChange={setRepoConsentAlways}
+              data-testid="repo-harness-consent-always"
+            />
+            Always allow this command for this repo
+          </label>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setRepoConsentAgent(null);
+                setRepoConsentAlways(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              data-testid="repo-harness-consent-confirm"
+              onClick={() => void confirmRepoConsent()}
+            >
+              Start session
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1079,7 +1079,7 @@ export function AgentHarnessPicker({
         className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
       >
         <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
-          <span className="truncate">{agent.name}</span>
+          <span className="max-w-48 shrink-0 truncate">{agent.name}</span>
           {!agent.command_found && (
             <span className="truncate text-[11px] text-muted-foreground/70">
               command not found on host
@@ -1112,7 +1112,7 @@ export function AgentHarnessPicker({
         className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
       >
         <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
-          <span className="truncate">{entry.name}</span>
+          <span className="max-w-48 shrink-0 truncate">{entry.name}</span>
           {entry.description && (
             <span className="truncate text-[11px] text-muted-foreground/70">
               {entry.description}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -45,6 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import {
   CLAUDE_NATIVE_EFFORTS,
@@ -3772,6 +3773,7 @@ export function NewChatLandingScreen() {
               model: pickedRepoAgent.model ?? undefined,
               sessionIdMode: pickedRepoAgent.session_id_mode,
               sendModel: pickedRepoAgent.send_model,
+              omnigentMcp: pickedRepoAgent.omnigent_mcp,
             },
           }
         : null;

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -141,13 +141,21 @@ import {
   nativeWrapperLabelsForAgent,
 } from "@/lib/nativeCodingAgents";
 import {
+  packageWorkspaceAgent,
   useHostModelOptions,
   useHosts,
   useWorkspaceHarnesses,
   type Host,
   type WorkspaceAcpAgent,
+  type WorkspaceAgentConfigEntry,
 } from "@/hooks/useHosts";
-import { isRepoCommandTrusted, trustRepoCommand } from "@/lib/repoHarnessTrust";
+import {
+  digestBundleBytes,
+  isRepoCommandTrusted,
+  isRepoDigestTrusted,
+  trustRepoCommand,
+  trustRepoDigest,
+} from "@/lib/repoHarnessTrust";
 import {
   controlHost,
   getHostIdentity,
@@ -349,9 +357,13 @@ const CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY = "omnigent.codex_native.bypass_sand
 // `.omnigent/config.yaml`. UI-local only — never sent to the server; the
 // launch path embeds the discovered entry into a generated agent bundle.
 const REPO_ACP_ID_PREFIX = "repo-acp:";
+// Picker-row id prefix for agent configs discovered under the selected
+// workspace's `.omnigent/agent-configs/` (single-file YAMLs or bundle dirs).
+const REPO_CFG_ID_PREFIX = "repo-cfg:";
 // Stable default for the picker's optional repoAgents prop (a literal default
 // would be re-created per render and defeat memoization downstream).
 const NO_REPO_AGENTS: WorkspaceAcpAgent[] = [];
+const NO_REPO_AGENT_CONFIGS: WorkspaceAgentConfigEntry[] = [];
 
 const CODEX_NATIVE_BYPASS_APPROVAL_VALUE = "bypass";
 const CODEX_NATIVE_BYPASS_APPROVAL_OPTION = {
@@ -927,6 +939,8 @@ export function AgentHarnessPicker({
   sandboxSelected,
   repoAgents = NO_REPO_AGENTS,
   onSelectRepoAgent,
+  repoAgentConfigs = NO_REPO_AGENT_CONFIGS,
+  onSelectRepoAgentConfig,
   allowCreateCustomAgent = true,
   onOpenChange,
   dropdownModal = true,
@@ -957,6 +971,11 @@ export function AgentHarnessPicker({
   repoAgents?: WorkspaceAcpAgent[];
   /** Selection callback for a repo-declared harness row. */
   onSelectRepoAgent?: (agent: WorkspaceAcpAgent) => void;
+  /** Agent configs declared under the workspace's `.omnigent/agent-configs/`.
+   *  Rendered at the top of the Agents group with a "From this repo" badge. */
+  repoAgentConfigs?: WorkspaceAgentConfigEntry[];
+  /** Selection callback for a repo-declared agent-config row. */
+  onSelectRepoAgentConfig?: (entry: WorkspaceAgentConfigEntry) => void;
   /** Whether to offer the "Create custom agent" action. Defaults true; an
    *  embedder that only picks an existing agent (e.g. project settings) can
    *  hide it since it has no interactive create flow. */
@@ -1071,6 +1090,39 @@ export function AgentHarnessPicker({
           variant="outline"
           className="ml-auto self-center border-sky-300 bg-sky-50 text-[11px] text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400"
           data-testid={`new-chat-landing-repo-badge-${agent.slug}`}
+        >
+          From this repo
+        </Badge>
+      </DropdownMenuItem>
+    );
+  };
+
+  // Repo-declared agent-config rows — full agent definitions (tools,
+  // sub-agents, skills) discovered under `.omnigent/agent-configs/`, so
+  // they lead the Agents group with a provenance badge.
+  const renderRepoConfigEntry = (entry: WorkspaceAgentConfigEntry): ReactNode => {
+    const id = REPO_CFG_ID_PREFIX + entry.slug;
+    const active = id === effectiveAgentId;
+    return (
+      <DropdownMenuItem
+        key={id}
+        data-testid={`new-chat-landing-agent-${id}`}
+        data-active={active ? "true" : undefined}
+        onSelect={() => onSelectRepoAgentConfig?.(entry)}
+        className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+      >
+        <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+          <span className="truncate">{entry.name}</span>
+          {entry.description && (
+            <span className="truncate text-[11px] text-muted-foreground/70">
+              {entry.description}
+            </span>
+          )}
+        </div>
+        <Badge
+          variant="outline"
+          className="ml-auto self-center border-sky-300 bg-sky-50 text-[11px] text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400"
+          data-testid={`new-chat-landing-repo-cfg-badge-${entry.slug}`}
         >
           From this repo
         </Badge>
@@ -1344,8 +1396,10 @@ export function AgentHarnessPicker({
                 <DropdownMenuSeparator />
               </>
             )}
-            {/* Agents group — built-in bundle agents (Polly / Debby) inline. */}
+            {/* Agents group — repo-declared agent configs lead, then the
+            built-in bundle agents (Polly / Debby) inline. */}
             <PickerSectionHeader>Agents</PickerSectionHeader>
+            {repoAgentConfigs.map(renderRepoConfigEntry)}
             {bundleEntries.map(renderEntry)}
             {/* Existing custom agents fold into a "Custom agents" submenu (with
             the pending upload and the create action). With no custom agents the
@@ -2091,22 +2145,37 @@ export function NewChatLandingScreen() {
     () => landingDraft?.sandboxRepoBranch ?? "",
   );
   const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
-  // Harnesses declared by the selected workspace's repo (`.omnigent/config.yaml`),
-  // read on the selected host. Suggest-and-rank only: rows lead the picker's
-  // Harnesses group but nothing is auto-selected.
-  const { data: repoAcpAgentsData } = useWorkspaceHarnesses(
+  // Agents the selected workspace's repo declares — ACP commands from
+  // `.omnigent/config.yaml` plus agent configs under
+  // `.omnigent/agent-configs/`. Suggest-and-rank only: rows lead their
+  // picker groups but nothing is auto-selected.
+  const { data: workspaceDiscovery } = useWorkspaceHarnesses(
     selectedHostId,
     workspace.trim(),
     !sandboxSelected,
   );
-  const repoAcpAgents = useMemo(() => repoAcpAgentsData ?? [], [repoAcpAgentsData]);
+  const repoAcpAgents = useMemo(() => workspaceDiscovery?.agents ?? [], [workspaceDiscovery]);
+  const repoAgentConfigs = useMemo(
+    () => workspaceDiscovery?.agentConfigs ?? [],
+    [workspaceDiscovery],
+  );
   // First-use consent for a repo-declared command (arbitrary shell from a
   // cloned repo). Non-null = the consent dialog is open for that agent;
   // the ref is a one-shot bypass so the dialog's confirm can re-enter
   // handleCreate without re-prompting.
   const [repoConsentAgent, setRepoConsentAgent] = useState<WorkspaceAcpAgent | null>(null);
+  // Same consent flow for a repo-declared agent config: the dialog holds the
+  // packaged bytes + digest so confirm uploads exactly what was approved.
+  const [repoConsentConfig, setRepoConsentConfig] = useState<{
+    entry: WorkspaceAgentConfigEntry;
+    bytes: ArrayBuffer;
+    digest: string;
+  } | null>(null);
   const [repoConsentAlways, setRepoConsentAlways] = useState(false);
   const repoConsentGrantedRef = useRef(false);
+  // Bytes approved in the consent dialog, carried into the re-entered
+  // handleCreate so the upload is byte-identical to what was shown.
+  const approvedRepoBundleRef = useRef<{ bytes: ArrayBuffer; digest: string } | null>(null);
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
@@ -2597,10 +2666,14 @@ export function NewChatLandingScreen() {
     !sandboxSelected && pickedAgentId?.startsWith(REPO_ACP_ID_PREFIX)
       ? (repoAcpAgents.find((a) => REPO_ACP_ID_PREFIX + a.slug === pickedAgentId) ?? null)
       : null;
+  const pickedRepoConfig =
+    !sandboxSelected && pickedAgentId?.startsWith(REPO_CFG_ID_PREFIX)
+      ? (repoAgentConfigs.find((e) => REPO_CFG_ID_PREFIX + e.slug === pickedAgentId) ?? null)
+      : null;
   const effectiveAgentId =
     pickedAgentId === PENDING_AGENT_ID && pendingAgentAllowedOnTarget
       ? PENDING_AGENT_ID
-      : pickedRepoAgent
+      : pickedRepoAgent || pickedRepoConfig
         ? pickedAgentId
         : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
           null);
@@ -2624,8 +2697,17 @@ export function NewChatLandingScreen() {
               harness: "acp",
               skills: [],
             } satisfies AvailableAgent)
-          : agentList.find((a) => a.id === effectiveAgentId),
-    [agentList, effectiveAgentId, pendingAgent, pickedRepoAgent],
+          : pickedRepoConfig
+            ? ({
+                id: REPO_CFG_ID_PREFIX + pickedRepoConfig.slug,
+                name: pickedRepoConfig.name,
+                display_name: pickedRepoConfig.name,
+                description: pickedRepoConfig.description,
+                harness: pickedRepoConfig.harness,
+                skills: [],
+              } satisfies AvailableAgent)
+            : agentList.find((a) => a.id === effectiveAgentId),
+    [agentList, effectiveAgentId, pendingAgent, pickedRepoAgent, pickedRepoConfig],
   );
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
@@ -3468,6 +3550,10 @@ export function NewChatLandingScreen() {
     setPickedAgentId(REPO_ACP_ID_PREFIX + agent.slug);
     setPickedHarness(null);
   };
+  const handleSelectRepoAgentConfig = (entry: WorkspaceAgentConfigEntry) => {
+    setPickedAgentId(REPO_CFG_ID_PREFIX + entry.slug);
+    setPickedHarness(null);
+  };
 
   function selectHost(hostId: string) {
     // Persist the explicit pick even when it matches the current selection, so
@@ -3561,6 +3647,39 @@ export function NewChatLandingScreen() {
           setRepoConsentAgent(pickedRepoAgent);
           return;
         }
+      }
+      // Repo-declared agent config: package on the host (deterministic
+      // bytes), hash, and gate on the digest. The consent dialog holds the
+      // exact bytes so confirm uploads what was approved — a repo edit
+      // between consent and create can't swap the content.
+      let repoConfigBundle: { file: File; digest: string } | null = null;
+      if (pickedRepoConfig && selectedHostId !== null) {
+        let approved = approvedRepoBundleRef.current;
+        approvedRepoBundleRef.current = null;
+        if (approved === null) {
+          const bytes = await packageWorkspaceAgent(
+            selectedHostId,
+            workspace.trim(),
+            pickedRepoConfig.path,
+          );
+          approved = { bytes, digest: await digestBundleBytes(bytes) };
+        }
+        const trusted =
+          repoConsentGrantedRef.current ||
+          isRepoDigestTrusted(
+            selectedHostId,
+            workspace.trim(),
+            pickedRepoConfig.slug,
+            approved.digest,
+          );
+        if (!trusted) {
+          setRepoConsentConfig({ entry: pickedRepoConfig, ...approved });
+          return;
+        }
+        repoConfigBundle = {
+          file: new File([approved.bytes], "agent.tar.gz", { type: "application/gzip" }),
+          digest: approved.digest,
+        };
       }
       repoConsentGrantedRef.current = false;
       const trimmedBranch = branchName.trim();
@@ -3659,13 +3778,16 @@ export function NewChatLandingScreen() {
       const bundleInput =
         repoBundleInput ?? (effectiveAgentId === PENDING_AGENT_ID ? pendingAgent : null);
 
-      if (bundleInput) {
+      if (repoConfigBundle !== null || bundleInput) {
         // Custom agent path: build bundle client-side and use multipart POST.
         // The multipart create only stores the agent + session rows — it does
         // NOT launch a runner on the host. We must follow up with launchRunner
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
-        const bundle = await buildAgentBundle(bundleInput);
+        const bundle =
+          repoConfigBundle !== null
+            ? repoConfigBundle.file
+            : await buildAgentBundle(bundleInput as AgentBundleInput);
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
         // Born-filed: stamp the project's `omni_project` label so a bundled
@@ -3691,7 +3813,7 @@ export function NewChatLandingScreen() {
         }
         // Clear pending agent after successful creation (repo-declared
         // launches leave the pending custom agent untouched).
-        if (!repoBundleInput) setPendingAgent(null);
+        if (!repoBundleInput && repoConfigBundle === null) setPendingAgent(null);
       } else {
         // Normal path: bind to an existing registered agent.
         // Which pushed row is ours: the one this tab has never seen, bound
@@ -3907,11 +4029,22 @@ export function NewChatLandingScreen() {
   // granted ref so this run doesn't re-prompt.
   async function confirmRepoConsent() {
     const agent = repoConsentAgent;
-    if (agent === null) return;
+    const config = repoConsentConfig;
+    if (agent === null && config === null) return;
     if (repoConsentAlways && selectedHostId !== null) {
-      await trustRepoCommand(selectedHostId, workspace.trim(), agent.slug, agent.command);
+      if (agent !== null) {
+        await trustRepoCommand(selectedHostId, workspace.trim(), agent.slug, agent.command);
+      } else if (config !== null) {
+        trustRepoDigest(selectedHostId, workspace.trim(), config.entry.slug, config.digest);
+      }
+    }
+    if (config !== null) {
+      // Carry the approved bytes into the re-entered create so the upload
+      // is byte-identical to what the dialog showed.
+      approvedRepoBundleRef.current = { bytes: config.bytes, digest: config.digest };
     }
     setRepoConsentAgent(null);
+    setRepoConsentConfig(null);
     setRepoConsentAlways(false);
     repoConsentGrantedRef.current = true;
     await handleCreate();
@@ -4255,6 +4388,8 @@ export function NewChatLandingScreen() {
                     sandboxSelected={sandboxSelected}
                     repoAgents={sandboxSelected ? [] : repoAcpAgents}
                     onSelectRepoAgent={handleSelectRepoAgent}
+                    repoAgentConfigs={sandboxSelected ? [] : repoAgentConfigs}
+                    onSelectRepoAgentConfig={handleSelectRepoAgentConfig}
                     triggerTooltip={
                       smartRoutingHarnessSelected ? AUTO_HARNESS_DESCRIPTION : undefined
                     }
@@ -4965,10 +5100,11 @@ export function NewChatLandingScreen() {
           runs. "Always allow" persists per (host, workspace, agent, command
           hash) — editing the command in the repo re-prompts. */}
       <Dialog
-        open={repoConsentAgent !== null}
+        open={repoConsentAgent !== null || repoConsentConfig !== null}
         onOpenChange={(open) => {
           if (!open) {
             setRepoConsentAgent(null);
+            setRepoConsentConfig(null);
             setRepoConsentAlways(false);
           }
         }}
@@ -4977,21 +5113,52 @@ export function NewChatLandingScreen() {
           <DialogHeader>
             <DialogTitle>Run an agent declared by this repo?</DialogTitle>
             <DialogDescription>
-              “{repoConsentAgent?.name}” comes from <code>.omnigent/config.yaml</code> in{" "}
-              {workspaceTrimmed || "the selected workspace"}. Starting the session runs this command
-              on {selectedHost?.name ?? "the selected host"}:
+              “{repoConsentAgent?.name ?? repoConsentConfig?.entry.name}” comes from{" "}
+              <code>
+                {repoConsentAgent !== null
+                  ? ".omnigent/config.yaml"
+                  : repoConsentConfig?.entry.path}
+              </code>{" "}
+              in {workspaceTrimmed || "the selected workspace"}.{" "}
+              {repoConsentAgent !== null
+                ? `Starting the session runs this command on ${selectedHost?.name ?? "the selected host"}:`
+                : `Starting the session uploads and runs this agent definition on ${selectedHost?.name ?? "the selected host"}:`}
             </DialogDescription>
           </DialogHeader>
-          <pre className="overflow-x-auto rounded-md border bg-muted/50 px-3 py-2 font-mono text-xs">
-            {repoConsentAgent?.command}
-          </pre>
+          {repoConsentAgent !== null ? (
+            <pre className="overflow-x-auto rounded-md border bg-muted/50 px-3 py-2 font-mono text-xs">
+              {repoConsentAgent.command}
+            </pre>
+          ) : repoConsentConfig !== null ? (
+            <ul
+              className="rounded-md border bg-muted/50 px-3 py-2 text-xs text-muted-foreground [&>li]:py-0.5"
+              data-testid="repo-config-consent-summary"
+            >
+              <li>
+                Kind: {repoConsentConfig.entry.kind === "bundle" ? "agent bundle" : "agent YAML"}
+              </li>
+              {repoConsentConfig.entry.harness && (
+                <li>Harness: {repoConsentConfig.entry.harness}</li>
+              )}
+              {repoConsentConfig.entry.sub_agents.length > 0 && (
+                <li>Sub-agents: {repoConsentConfig.entry.sub_agents.join(", ")}</li>
+              )}
+              {repoConsentConfig.entry.has_local_tools && (
+                <li>Declares local (Python/TypeScript) tools</li>
+              )}
+              {repoConsentConfig.entry.has_mcp_servers && <li>Declares MCP servers</li>}
+              <li className="font-mono">digest {repoConsentConfig.digest.slice(0, 12)}…</li>
+            </ul>
+          ) : null}
           <label className="flex items-center gap-2 text-13 text-muted-foreground">
             <Switch
               checked={repoConsentAlways}
               onCheckedChange={setRepoConsentAlways}
               data-testid="repo-harness-consent-always"
             />
-            Always allow this command for this repo
+            {repoConsentAgent !== null
+              ? "Always allow this command for this repo"
+              : "Always allow this exact agent version for this repo"}
           </label>
           <DialogFooter>
             <Button
@@ -4999,6 +5166,7 @@ export function NewChatLandingScreen() {
               variant="ghost"
               onClick={() => {
                 setRepoConsentAgent(null);
+                setRepoConsentConfig(null);
                 setRepoConsentAlways(false);
               }}
             >


### PR DESCRIPTION
## Related issue

Closes #4051

## Summary

When a working directory is selected in New Chat, the picker now surfaces what that repo declares as runnable — suggest and rank, never auto-select, and always behind a first-use consent dialog:

- **ACP commands** from `.omnigent/config.yaml` (`acp: {agents: [...]}`, the same schema as the global block) appear at the top of the **Harnesses** group with a "From this repo" badge. Launching embeds the exact consented command as `executor.acp_agent` in a one-shot bundle, frozen at create time; the launch gate treats such self-contained specs as fail-open (`harness=None`) on both the create-launch and relaunch paths.
- **Agent configs** from `.omnigent/agent-configs/` — the existing convention the runner's `sys_agent_list` already scans — appear at the top of the **Agents** group. Both shapes are supported: single-file agent YAMLs and full agent-image bundle directories (tools, skills, `agents/` sub-agent images). Launching packages the config on the host into a deterministic tar.gz, shows a summary (kind, harness, sub-agents, declared local tools / MCP servers) plus content digest in the consent dialog, and uploads the exact approved bytes through the standard multipart create + `validate_agent_bundle` path.

**Trust model:** repo content is arbitrary code from a clone, so the first launch always shows what will run — the exact shell command for ACP agents, the definition summary + digest for agent configs. "Always allow" persists per (host, workspace, agent, SHA-256) client-side; any change to the command or bundle content re-prompts. Packaged bytes are hashed and uploaded verbatim, so what the user approved is byte-identical to what the server validates and runs — repo edits between consent and launch can't swap the content.

**ELI5:** a repo can now say "here are the agents we use for this codebase" — either "run this agent CLI" or a full omnigent agent definition with tools and sub-agents — and anyone opening that repo in Omnigent sees them offered first, after approving exactly what will run.

```mermaid
sequenceDiagram
    participant UI as Web UI (New Chat)
    participant S as Server
    participant H as Host daemon
    UI->>S: GET /v1/hosts/{id}/workspace-harnesses?path=…
    S->>H: host.workspace_harnesses
    H->>H: read .omnigent/config.yaml + scan .omnigent/agent-configs/
    H-->>S: acp agents + agent-config summaries
    S-->>UI: picker rows ("From this repo")
    alt agent config picked
        UI->>S: POST …/workspace-agents/package
        S->>H: host.package_workspace_agent
        H-->>S: deterministic tar.gz
        S-->>UI: bundle bytes (client hashes for consent)
    end
    UI->>UI: consent dialog (exact command / summary + digest)
    UI->>S: multipart create (embedded acp_agent | approved bundle bytes)
    S->>H: host.launch_runner
```

New pieces per layer: `workspace_acp_agents()` + `omnigent/spec/workspace_agents.py` (scanner + packager), `host.workspace_harnesses` / `host.package_workspace_agent` frame pairs + handlers (host), discovery + package routes and the launch-gate skip (server), `acp_agent` mirrored into `executor.config` by the spec parser (structured, following the `profile` precedent), embedded-agent `model`/`session_id_mode`/`send_model` honored (runtime), and the hooks / picker rows / consent dialog / trust helper / bundle-builder support (web).

## Test Plan

- Unit/integration: `tests/spec/test_workspace_agents.py` (scanner shapes, slug dedupe, deterministic packaging, sub-agent inclusion, containment escape, size ceiling), `tests/onboarding/test_workspace_acp.py`, `tests/server/test_launch_gate_harness.py`, frame codec round-trips (including legacy decode without `agent_configs`), host handler tests, discovery + package route tests (200/400/404/409/502/422), embedded spawn-env field tests, parser mirror tests; web vitest for the bundle builder and dialog flows; `tests/e2e_ui/start_session/test_repo_declared_agents.py` drives the three user-facing flows end-to-end in Playwright (picker badges, consent gating + re-prompt after a pick switch, and the byte-identity guarantee between consented and uploaded bundle bytes). Full affected suites pass (`tests/spec`, `tests/host`, `tests/onboarding`, hosts/sessions integration suites; `pnpm vitest run` full suite — 4822 passed).
- Live e2e on a local server + connected host (ACP path): declared a `Repo Echo` agent in `/tmp/demo-repo/.omnigent/config.yaml`, verified discovery through the tunnel, picker badge + ranking, consent showing the exact command, "always allow" + re-prompt after edit, session create + runner launch through the embedded command, fallback when the workspace changes.

## Demo

The agent picker on a workspace whose repo declares both an ACP command (`.omnigent/config.yaml`) and an agent bundle (`.omnigent/agent-configs/reviewer/`) — repo entries lead their groups with a "From this repo" badge:

![Picker with repo-declared entries](https://raw.githubusercontent.com/joncarter1/omnigent/pr-4243-demo-assets/1-picker-repo-agents.png)

First-use consent for the agent bundle — definition summary (kind, harness, sub-agents, declared tools) and content digest; "always allow" is keyed to this exact version:

![Agent-config consent dialog](https://raw.githubusercontent.com/joncarter1/omnigent/pr-4243-demo-assets/2-consent-agent-config.png)

First-use consent for the ACP command — the exact shell string that will run:

![ACP command consent dialog](https://raw.githubusercontent.com/joncarter1/omnigent/pr-4243-demo-assets/3-consent-acp-command.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered both UI journeys against a live local server, host daemon, and Vite dev build: the ACP path end-to-end including a real runner launch (see Test Plan), and the agent-config path through the browser (discovery → picker → packaging round-trip → consent summary dialog with digest), driven headless via Playwright. The discovery, packaging, and launch endpoints were also exercised directly with curl. The consent dialog flows are now covered by the e2e_ui Playwright tests; localStorage trust persistence has unit coverage pinning the persisted grant-key format.

Known follow-ups (tracked in #4051): git-root walking from subdirectories, server-side trust persistence, other picker surfaces, and the JSON-create-path gate edge for previously-registered embedded-ACP agents.

## Changelog

Repos can declare their own agents — ACP commands in `.omnigent/config.yaml` and full agent definitions under `.omnigent/agent-configs/` — and the New Chat picker suggests them for that working directory after a first-use consent showing exactly what will run.
