### PR TITLE
Queue Address All comments as separate agent turns

### DIFF
--- a/web/src/hooks/useComments.test.ts
+++ b/web/src/hooks/useComments.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for the comments API helpers and TanStack Query hooks:
 // the URL/encoding/method contract of each request, the throw-on-non-2xx
 // guard, the cache-invalidation fan-out on mutation success, and the
-// send-to-agent dispatch that calls useChatStore.send().
+// send-to-agent dispatch that queues one agent turn per comment.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -35,13 +35,13 @@ function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): 
 }
 
 const fetchMock = vi.fn();
-const sendMock = vi.fn();
+const enqueueMock = vi.fn();
 
 beforeEach(() => {
   fetchMock.mockReset();
-  sendMock.mockReset();
+  enqueueMock.mockReset();
   vi.mocked(useChatStore.getState).mockReturnValue({
-    send: sendMock,
+    enqueueMessage: enqueueMock,
   } as unknown as ReturnType<typeof useChatStore.getState>);
   vi.stubGlobal("fetch", fetchMock);
 });
@@ -256,39 +256,75 @@ describe("useSendCommentsToAgent", () => {
     });
   }
 
-  it("POSTs the comment ids to the send endpoint", async () => {
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ formatted_message: "msg", sent_comment_ids: ["c1"] }),
-    );
+  it("POSTs each comment separately in order", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ formatted_message: "first", sent_comment_ids: ["c1"] }))
+      .mockResolvedValueOnce(
+        mockResponse({ formatted_message: "second", sent_comment_ids: ["c2"] }),
+      );
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const { result } = renderSend(queryClient);
-    result.current.mutate({ comment_ids: ["c1"], instruction: "fix" });
+    result.current.mutate({ comment_ids: ["c1", "c2"], instruction: "fix" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/v1/sessions/conv_1/comments/send");
-    expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toEqual({ comment_ids: ["c1"], instruction: "fix" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/v1/sessions/conv_1/comments/send",
+      "/v1/sessions/conv_1/comments/send",
+    ]);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => JSON.parse((init as RequestInit).body as string)),
+    ).toEqual([
+      { comment_ids: ["c1"], instruction: "fix" },
+      { comment_ids: ["c2"], instruction: "fix" },
+    ]);
   });
 
-  it("dispatches the formatted message to the agent via the chat store on success", async () => {
-    // The whole point of this hook: the server-formatted message is sent
-    // to the agent immediately, no manual send. Regressing this leaves
-    // comments queued but never delivered.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ formatted_message: "please address these", sent_comment_ids: ["c1"] }),
-    );
+  it("queues each formatted comment as its own agent turn", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ formatted_message: "first", sent_comment_ids: ["c1"] }))
+      .mockResolvedValueOnce(
+        mockResponse({ formatted_message: "second", sent_comment_ids: ["c2"] }),
+      );
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const { result } = renderSend(queryClient);
-    result.current.mutate({ comment_ids: ["c1"] });
+    result.current.mutate({ comment_ids: ["c1", "c2"] });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sendMock).toHaveBeenCalledWith("please address these", "ag_1");
+    expect(enqueueMock.mock.calls).toEqual([
+      ["first", undefined, "ag_1"],
+      ["second", undefined, "ag_1"],
+    ]);
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1"] });
   });
 
-  it("throws on non-2xx and never dispatches to the agent", async () => {
+  it("formats every comment before starting the queue", async () => {
+    let resolveSecond!: (response: Response) => void;
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ formatted_message: "first", sent_comment_ids: ["c1"] }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderSend(queryClient);
+    result.current.mutate({ comment_ids: ["c1", "c2"] });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(enqueueMock).not.toHaveBeenCalled();
+
+    resolveSecond(mockResponse({ formatted_message: "second", sent_comment_ids: ["c2"] }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(enqueueMock.mock.calls).toEqual([
+      ["first", undefined, "ag_1"],
+      ["second", undefined, "ag_1"],
+    ]);
+  });
+
+  it("throws on non-2xx and never queues the failed comment", async () => {
     // A failed send must NOT call the chat store, or the user sees a
     // message dispatched while the comments stay unsent server-side.
     fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
@@ -296,6 +332,6 @@ describe("useSendCommentsToAgent", () => {
     const { result } = renderSend(queryClient);
     result.current.mutate({ comment_ids: ["c1"] });
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(sendMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/useComments.ts
+++ b/web/src/hooks/useComments.ts
@@ -2,8 +2,7 @@
 // POST/GET/PATCH/DELETE /v1/sessions/{id}/comments
 // POST /v1/sessions/{id}/comments/send
 //
-// `useSendCommentsToAgent` calls `useChatStore.send()` directly on success
-// so the message is submitted immediately without requiring a manual send.
+// `useSendCommentsToAgent` queues each comment as its own agent turn.
 // It requires a non-null `agentId`; for the FileViewer case where an
 // agent may not be registered, see `CommentSenderProvider` /
 // `useOptionalCommentSender` in `CommentSenderContext.tsx`.
@@ -160,22 +159,35 @@ export function useSendCommentsToAgent(sessionId: string, agentId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (payload: { comment_ids: string[]; instruction?: string }) => {
-      const res = await authenticatedFetch(
-        `/v1/sessions/${encodeURIComponent(sessionId)}/comments/send`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        },
+      const sentCommentIds: string[] = [];
+      const results = await Promise.allSettled(
+        payload.comment_ids.map(async (commentId) => {
+          const res = await authenticatedFetch(
+            `/v1/sessions/${encodeURIComponent(sessionId)}/comments/send`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...payload, comment_ids: [commentId] }),
+            },
+          );
+          if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+          const data = (await res.json()) as {
+            formatted_message: string;
+            sent_comment_ids: string[];
+          };
+          return data;
+        }),
       );
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      return (await res.json()) as {
-        formatted_message: string;
-        sent_comment_ids: string[];
-      };
+      for (const result of results) {
+        if (result.status === "rejected") continue;
+        useChatStore.getState().enqueueMessage(result.value.formatted_message, undefined, agentId);
+        sentCommentIds.push(...result.value.sent_comment_ids);
+      }
+      const failure = results.find((result) => result.status === "rejected");
+      if (failure?.status === "rejected") throw failure.reason;
+      return { sent_comment_ids: sentCommentIds };
     },
-    onSuccess: (data) => {
-      void useChatStore.getState().send(data.formatted_message, agentId);
+    onSettled: () => {
       void queryClient.invalidateQueries({
         queryKey: ["comments", sessionId],
       });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -556,11 +556,10 @@ export interface ChatState {
   // Actions.
   send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<void>;
   /**
-   * Queue a message client-side instead of POSTing it now, for a send made
-   * while the agent is busy. The head is flushed automatically (FIFO, one per
-   * turn) when the session next goes idle — see the `session_status` handler.
+   * Queue a message client-side. The head is flushed automatically (FIFO, one
+   * per turn) immediately when idle or when the session next goes idle.
    */
-  enqueueMessage: (text: string, files?: File[]) => void;
+  enqueueMessage: (text: string, files?: File[], agentId?: string) => void;
   /** Remove a queued message by id (the strip's per-row delete). */
   dequeueMessage: (queueId: string) => void;
   /**
@@ -977,9 +976,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   abortController: null,
   historyGeneration: 0,
 
-  enqueueMessage: (text, files) => {
+  enqueueMessage: (text, files, agentId) => {
     const { conversationId, boundAgentId } = get();
     if (conversationId === null) return;
+    const queuedAgentId = agentId ?? boundAgentId;
     queueSeq += 1;
     const queueId = `q_${queueSeq}`;
     set((s) => ({
@@ -989,7 +989,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           queueId,
           text,
           conversationId,
-          ...(boundAgentId !== null ? { agentId: boundAgentId } : {}),
+          ...(queuedAgentId !== null ? { agentId: queuedAgentId } : {}),
           ...(files && files.length > 0 ? { files } : {}),
         },
       ],


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Change **Address All** from one combined LLM request into one queued agent turn per review comment.
- Format all comments before enqueueing them, preventing transient idle states from flushing multiple comments into the active harness.
- Pin queued comments to the selected agent so model/binding changes do not redirect later turns.

**ELI5:** Address All now forms a line: one comment is handled, then the next starts when the agent is free.

```text
Address All → format each comment → FIFO queue → agent turn → idle → next turn
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `pnpm --dir web exec vitest run src/hooks/useComments.test.ts`
- `pnpm --dir web exec vitest run src/store/chatStore.test.ts -t "does not flush while busy"`
- `pnpm --dir web type-check`
- Manual verification:
  - With an idle agent, the first comment starts and the remaining comments stay queued.
  - With a running agent, every Address All comment stays queued and drains FIFO without steering the active turn.

## Demo

<img width="259" height="598" alt="Screenshot 2026-08-06 at 22 59 00" src="https://github.com/user-attachments/assets/e555f96e-f696-4389-b766-7de89e94502a" />

<img width="666" height="540" alt="Screenshot 2026-08-06 at 22 59 14" src="https://github.com/user-attachments/assets/92e08398-a43d-420c-84f8-bb402318905a" />

<img width="656" height="1027" alt="Screenshot 2026-08-06 at 23 00 26" src="https://github.com/user-attachments/assets/4348d182-6806-438f-b7eb-6b41ed38d819" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified both idle and busy harness states with multiple document comments. Unit coverage verifies per-comment formatting, ordered enqueueing, and that enqueueing does not begin until all formatting requests settle.

## Changelog

Address All handles review comments one at a time instead of sending them together.
