### PR TITLE
feat: GitHub Copilot Enterprise support (readiness, live model catalog, per-model efforts)

### DIFF
--- a/omnigent/copilot_models.py
+++ b/omnigent/copilot_models.py
@@ -1,0 +1,96 @@
+"""Pre-launch model catalog for the GitHub Copilot harness.
+
+Mirrors ``omnigent.claude_native.claude_native_model_options`` for the SDK
+copilot harness: the host daemon calls this to answer the Web UI's pre-launch
+``/model-options`` probe. The catalog comes from the Copilot backend itself
+(``CopilotClient.list_models()``), so it reflects exactly the models the
+signed-in seat may use, enterprise policy included, rather than a
+hardcoded list.
+
+Auth and host mirror the executor's resolution, so the catalog is listed
+against the same backend the launched session will talk to: a token
+registered via ``omnigent setup``, else an ambient ``COPILOT_GITHUB_TOKEN`` /
+``GH_TOKEN`` / ``GITHUB_TOKEN``, else the ``gh`` CLI's stored login for the
+configured host, else ``None``, which leaves the SDK's auto-login on and
+lists models as the Copilot CLI's logged-in user. A configured GitHub
+Enterprise host (ambient ``COPILOT_GH_HOST`` or ``copilot.github_host``)
+reaches the bundled CLI through its environment, exactly as the executor
+hands it over at session start.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from typing import Any
+
+# One short-lived CLI subprocess is spawned per probe; bound the whole
+# start -> list dance so a wedged CLI can't hang the host tunnel reply.
+_LIST_MODELS_TIMEOUT_S = 30.0
+_STOP_TIMEOUT_S = 5.0
+
+
+async def copilot_model_options() -> list[dict[str, Any]]:
+    """Resolve the Copilot model catalog for the pre-launch picker.
+
+    :returns: Picker option dicts (``id`` / ``model`` / ``displayName`` /
+        ``isDefault``), in backend order.
+    :raises Exception: On SDK import, auth, spawn, or timeout failures; the
+        caller maps any failure to a failed model-options frame.
+    """
+    from copilot import CopilotClient  # lazy: optional dependency
+
+    from omnigent.onboarding.copilot_auth import (
+        COPILOT_HOST_ENV_VAR,
+        COPILOT_TOKEN_ENV_VARS,
+        copilot_github_host,
+        gh_cli_github_token,
+        resolve_copilot_github_token,
+    )
+
+    host = os.environ.get(COPILOT_HOST_ENV_VAR) or copilot_github_host()
+    token = resolve_copilot_github_token()
+    if token is None:
+        token = next(
+            (value for var in COPILOT_TOKEN_ENV_VARS if (value := os.environ.get(var))),
+            None,
+        )
+    if token is None:
+        token = gh_cli_github_token(host)
+    # The SDK replaces the CLI subprocess environment wholesale when ``env``
+    # is passed, so overlay the ambient one rather than sending the host alone.
+    env = {**os.environ, COPILOT_HOST_ENV_VAR: host} if host else None
+    # The SDK rejects a relative working_directory (same constraint the
+    # executor works around), so always hand it an absolute path.
+    client = CopilotClient(
+        github_token=token,
+        working_directory=os.path.abspath(os.getcwd()),
+        log_level="error",
+        env=env,
+    )
+
+    async def _start_and_list() -> list[Any]:
+        await client.start()
+        return list(await client.list_models())
+
+    try:
+        infos = await asyncio.wait_for(_start_and_list(), timeout=_LIST_MODELS_TIMEOUT_S)
+    finally:
+        # ``start()`` spawns the bundled CLI subprocess even when the call
+        # later fails; only ``stop()`` reaps it (same reason the executor
+        # stops on its bring-up error path). A reap failure must not mask
+        # the real outcome.
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(client.stop(), timeout=_STOP_TIMEOUT_S)
+
+    return [
+        {
+            "id": info.id,
+            "model": info.id,
+            "displayName": getattr(info, "name", None) or info.id,
+            "isDefault": False,
+        }
+        for info in infos
+        if getattr(info, "id", None)
+    ]

--- a/omnigent/copilot_models.py
+++ b/omnigent/copilot_models.py
@@ -30,12 +30,55 @@ from typing import Any
 _LIST_MODELS_TIMEOUT_S = 30.0
 _STOP_TIMEOUT_S = 5.0
 
+# Canonical ladder order for the per-model effort lists (mirrors
+# ``omnigent.reasoning_effort.format_supported``); values the backend sends
+# outside it keep their backend order after the known ones.
+_EFFORT_LADDER = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+
+def _policy_allows(info: Any) -> bool:
+    """Whether the seat's enterprise policy leaves the model selectable.
+
+    A model carries a ``policy`` object only when GitHub tracks a separate
+    terms opt-in for it; ``auto`` and some plain models ship without one, and
+    they are usable. So absence allows, and only an explicit non-``enabled``
+    state (``disabled`` / ``unconfigured``) filters the row out.
+    """
+    policy = getattr(info, "policy", None)
+    return policy is None or getattr(policy, "state", None) == "enabled"
+
+
+def _supported_efforts(info: Any) -> list[dict[str, str]]:
+    """The model's advertised reasoning efforts, in canonical ladder order."""
+    raw = getattr(info, "supported_reasoning_efforts", None) or []
+    values = [value for value in raw if isinstance(value, str) and value]
+    ordered = [value for value in _EFFORT_LADDER if value in values]
+    ordered += [value for value in values if value not in _EFFORT_LADDER]
+    return [{"reasoningEffort": value} for value in ordered]
+
+
+def _picker_option(info: Any) -> dict[str, Any]:
+    option: dict[str, Any] = {
+        "id": info.id,
+        "model": info.id,
+        "displayName": getattr(info, "name", None) or info.id,
+        # ``models.list`` carries no default marker; the executor treats an
+        # unset model as Copilot's ``auto`` server-side pick, so mirror that.
+        "isDefault": info.id == "auto",
+    }
+    efforts = _supported_efforts(info)
+    if efforts:
+        option["supportedReasoningEfforts"] = efforts
+    return option
+
 
 async def copilot_model_options() -> list[dict[str, Any]]:
     """Resolve the Copilot model catalog for the pre-launch picker.
 
     :returns: Picker option dicts (``id`` / ``model`` / ``displayName`` /
-        ``isDefault``), in backend order.
+        ``isDefault``, plus ``supportedReasoningEfforts`` for models that
+        take one), in backend order, filtered to what the seat's enterprise
+        policy allows.
     :raises Exception: On SDK import, auth, spawn, or timeout failures; the
         caller maps any failure to a failed model-options frame.
     """
@@ -85,12 +128,7 @@ async def copilot_model_options() -> list[dict[str, Any]]:
             await asyncio.wait_for(client.stop(), timeout=_STOP_TIMEOUT_S)
 
     return [
-        {
-            "id": info.id,
-            "model": info.id,
-            "displayName": getattr(info, "name", None) or info.id,
-            "isDefault": False,
-        }
+        _picker_option(info)
         for info in infos
-        if getattr(info, "id", None)
+        if getattr(info, "id", None) and _policy_allows(info)
     ]

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2354,6 +2354,24 @@ class HostProcess:
                 models=pi_models,
             )
 
+        if harness == "copilot":
+            try:
+                from omnigent.copilot_models import copilot_model_options
+
+                models = await copilot_model_options()
+            except Exception:
+                _logger.exception("Failed to resolve pre-launch Copilot model options")
+                return HostModelOptionsResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error="failed to resolve Copilot model options",
+                )
+            return HostModelOptionsResultFrame(
+                request_id=frame.request_id,
+                status="ok",
+                models=models,
+            )
+
         if harness != "claude-native":
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,

--- a/omnigent/onboarding/copilot_auth.py
+++ b/omnigent/onboarding/copilot_auth.py
@@ -31,7 +31,11 @@ accepted by Copilot.
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import re
 import subprocess
+from pathlib import Path
 
 from omnigent.errors import OmnigentError
 from omnigent.onboarding.extra_install import extra_install_command
@@ -59,6 +63,57 @@ COPILOT_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # never lock anyone out of their own token. Classic ``ghp_`` PATs are excluded
 # because Copilot rejects them.
 _GITHUB_TOKEN_PREFIXES = ("github_pat_", "gho_", "ghu_", "ghs_")
+
+# The Copilot CLI's state directory override (the CLI's own convention) and the
+# managed config file inside it that records the logged-in user.
+COPILOT_HOME_ENV_VAR = "COPILOT_HOME"
+_CLI_CONFIG_FILENAME = "config.json"
+_CLI_LOGIN_FIELD = "lastLoggedInUser"
+
+
+def _copilot_cli_config_path() -> Path:
+    """Return the Copilot CLI's managed config file path.
+
+    Honors the CLI's ``COPILOT_HOME`` override; defaults to ``~/.copilot``.
+
+    :returns: Path to ``config.json`` inside the Copilot CLI home.
+    """
+    home = os.environ.get(COPILOT_HOME_ENV_VAR, "").strip()
+    base = Path(home) if home else Path.home() / ".copilot"
+    return base / _CLI_CONFIG_FILENAME
+
+
+def copilot_cli_logged_in() -> bool:
+    """Return whether the Copilot CLI has a logged-in user on this machine.
+
+    With no GitHub token configured anywhere, the SDK leaves the CLI's
+    auto-login on (``use_logged_in_user``) and the runtime authenticates as
+    the user from ``copilot login``; the credential also carries its GitHub
+    host, which makes it the working auth source for GitHub Enterprise
+    data-residency seats (``copilot login --host <tenant>.ghe.com``). The
+    login itself lives in the OS keychain, but the CLI records the identity
+    in its managed ``config.json``; that marker is what this probe reads.
+
+    The file is JSONC (the CLI writes ``//`` line comments), so comment
+    lines are stripped before parsing. Any unreadable or unparseable state
+    reads as "not logged in"; this feeds a readiness probe, never an
+    error path.
+
+    :returns: ``True`` when a logged-in user is recorded.
+    """
+    try:
+        raw = _copilot_cli_config_path().read_text(encoding="utf-8")
+    except OSError:
+        return False
+    cleaned = re.sub(r"^\s*//.*$", "", raw, flags=re.M)
+    try:
+        doc = json.loads(cleaned)
+    except ValueError:
+        return False
+    if not isinstance(doc, dict):
+        return False
+    user = doc.get(_CLI_LOGIN_FIELD)
+    return isinstance(user, dict) and bool(user.get("login"))
 
 
 def gh_cli_github_token(host: str | None = None) -> str | None:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -250,12 +250,19 @@ def _harness_availability_core(harness: str) -> HarnessAvailability:
         # Copilot runs in-process via the ``github-copilot-sdk`` package (the
         # SDK bundles the CLI binary it drives, so there is no separate binary to
         # gate on) and authenticates against GitHub's Copilot backend with a
-        # GitHub token. So, like cursor, readiness is whether a token is
-        # resolvable — one stored by ``omnigent setup`` (the ``copilot:`` config
-        # block — see :mod:`omnigent.onboarding.copilot_auth`) or inherited from
-        # the environment. A bad / Copilot-less token surfaces at run time.
+        # GitHub token OR the Copilot CLI's own logged-in user: with no token
+        # configured anywhere, the SDK leaves the CLI's auto-login on and the
+        # runtime authenticates as the ``copilot login`` user (the only working
+        # source for GitHub Enterprise data-residency seats, whose stored
+        # credential carries its host). Gating on the token alone therefore
+        # blocks launches that would succeed. Readiness is: a resolvable token
+        # (stored by ``omnigent setup`` in the ``copilot:`` config block, see
+        # :mod:`omnigent.onboarding.copilot_auth`, or inherited from the
+        # environment) or a recorded CLI login. A bad / Copilot-less
+        # credential surfaces at run time.
         from omnigent.onboarding.copilot_auth import (
             COPILOT_TOKEN_ENV_VARS,
+            copilot_cli_logged_in,
             copilot_github_host,
             copilot_github_token_configured,
             gh_cli_github_token,
@@ -264,6 +271,12 @@ def _harness_availability_core(harness: str) -> HarnessAvailability:
         if copilot_github_token_configured() or any(
             os.environ.get(var) for var in COPILOT_TOKEN_ENV_VARS
         ):
+            return True
+        # The Copilot CLI's own ``copilot login`` is a usable credential too;
+        # its stored login carries the GitHub host, which makes it the working
+        # source on Enterprise data-residency seats. Checked first because it
+        # is a local file read, not a subprocess.
+        if copilot_cli_logged_in():
             return True
         # A ``gh auth login`` session is a usable Copilot credential, so a
         # logged-in user is ready without pasting a token into setup.

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -28,10 +28,12 @@ CODEX_EFFORTS = OPENAI_EFFORTS
 OPENAI_AGENTS_EFFORTS = OPENAI_EFFORTS
 GEMINI_EFFORTS = frozenset({"low", "medium", "high"})
 ANTIGRAVITY_EFFORTS = GEMINI_EFFORTS
-# The GitHub Copilot SDK's ``create_session(reasoning_effort=...)`` accepts
-# exactly these levels (``copilot.session.ReasoningEffort`` literal); per-model
-# support is gated by the Copilot backend (``list_models()``).
-COPILOT_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
+# The full effort ladder the GitHub Copilot CLI accepts
+# (``--reasoning-effort``, CLI 1.0.78); the SDK forwards the string to the
+# backend unvalidated, so this set only fences the vocabulary. Which subset a
+# given model takes is per model (``list_models()``'s
+# ``supported_reasoning_efforts``) and enforced by the backend.
+COPILOT_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
 
 
 def format_supported(values: Iterable[str]) -> str:

--- a/tests/e2e_ui/start_session/test_copilot_entry.py
+++ b/tests/e2e_ui/start_session/test_copilot_entry.py
@@ -1,0 +1,277 @@
+"""E2E: a copilot custom agent and its model/effort config modal.
+
+Covers the copilot chat flow in the landing composer (``NewChatLandingScreen``
+in ``web/src/shell/NewChatDialog.tsx``) end to end. Copilot deliberately has
+no top-level picker presence of its own (it is not a native terminal
+harness): it is reached through agents on the copilot harness, so the test
+drives a user-created custom agent. The agent lists behind the picker's
+"Custom agents" flyout and never inline, its gear modal offers the
+host-resolved model catalog with per-model reasoning efforts under the Agent
+Harness row, and the picked model + effort reach the create call as
+``model_override`` / ``reasoning_effort``.
+
+Stubbing mirrors ``test_start_session.py``: the e2e harness's runner
+registers no host and the CI machine has no Copilot seat, so ``/v1/hosts``,
+``/v1/agents``, and the copilot ``model-options`` probe are faked, and the
+create ``POST /v1/sessions`` is captured instead of really launching. The
+catalog stub mirrors the live probe's shape: the ``auto`` router (default,
+no efforts), a reasoning model with a ladder including ``max``, and an
+effort-less model, so the test exercises the per-model effort rules the
+backend's real catalog dictates.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+from tests.e2e_ui.start_session.test_start_session import (
+    _HOST_ID,
+    _SESSIONS_RE,
+    _pick_config_select,
+    _run_in_fresh_loop,
+    _save_config,
+    _wait_until,
+)
+
+# The copilot model-options probe the gear modal fires once the copilot
+# harness is the effective pick. Bare endpoint, no query expected.
+_MODEL_OPTIONS_RE = re.compile(r"/v1/hosts/[^/]+/harnesses/copilot/model-options")
+
+
+def _copilot_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: one user-created copilot agent.
+
+    ``harness: "copilot"`` is what keys the gear modal's Model/Effort rows to
+    the copilot catalog; the name is an ordinary custom-agent slug, so the
+    row files under the picker's "Custom agents" flyout. Sole agent, so it
+    auto-selects and the composer gear is directly reachable.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_copilot_e2e",
+                    "name": "my-copilot",
+                    "display_name": "My Copilot",
+                    "description": "GitHub Copilot",
+                    "harness": "copilot",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _copilot_ready_hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: one online host with copilot ready.
+
+    The readiness map keeps the "needs setup" badge off the agent's harness
+    row, so the test asserts the config surface rather than badge styling.
+    """
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": "e2e-host",
+                    "owner": "e2e",
+                    "status": "online",
+                    "configured_harnesses": {"copilot": True},
+                }
+            ]
+        }
+    )
+
+
+def _model_options_body() -> str:
+    """Stub body for the copilot model-options probe.
+
+    Mirrors the host's live answer (``copilot_model_options()``): the
+    ``auto`` router is the default and takes no effort, a reasoning model
+    carries its own ladder including ``max``, and an effort-less model has
+    no ``supportedReasoningEfforts`` at all.
+    """
+    return json.dumps(
+        {
+            "models": [
+                {"id": "auto", "model": "auto", "displayName": "Auto", "isDefault": True},
+                {
+                    "id": "claude-sonnet-5",
+                    "model": "claude-sonnet-5",
+                    "displayName": "Claude Sonnet 5",
+                    "isDefault": False,
+                    "supportedReasoningEfforts": [
+                        {"reasoningEffort": "low"},
+                        {"reasoningEffort": "medium"},
+                        {"reasoningEffort": "high"},
+                        {"reasoningEffort": "xhigh"},
+                        {"reasoningEffort": "max"},
+                    ],
+                },
+                {
+                    "id": "claude-haiku-4.5",
+                    "model": "claude-haiku-4.5",
+                    "displayName": "Claude Haiku 4.5",
+                    "isDefault": False,
+                },
+            ]
+        }
+    )
+
+
+def test_copilot_agent_model_and_effort_reach_the_create(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A copilot custom agent's model/effort pick reaches the create.
+
+    Asserts the behaviors this feature adds to the new chat flow: the agent
+    has no inline row of its own (it files under "Custom agents", keeping
+    copilot out of the top-level picker), the gear modal renders the
+    host-resolved catalog with per-model efforts (no effort row for
+    Default/auto or an effort-less model, the full ladder including Max for
+    a reasoning model), and the committed pick reaches ``POST /v1/sessions``
+    as ``model_override`` + ``reasoning_effort`` with no harness override
+    (the agent already runs on copilot).
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_copilot_agent(base_url, session_id))
+
+
+async def _drive_copilot_agent(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=_copilot_ready_hosts_body(),
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=_copilot_agents_body(),
+                )
+
+            async def handle_model_options(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=_model_options_body(),
+                )
+
+            async def handle_events(route: Route) -> None:
+                # Swallow the auto-sent initial prompt so no real turn runs.
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                # Capture only the composer's create POST; everything else
+                # (conversation list, agent-discovery scan) stays real.
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_id}),
+                    )
+                else:
+                    await route.continue_()
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route(_MODEL_OPTIONS_RE, handle_model_options)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+
+            # Neutralize agent discovery so only the stubbed copilot agent
+            # feeds the picker (see test_start_session for the rationale).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            # Seed a recent working directory so Send can enable without the
+            # (host-less) file browser.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Copilot has no top-level picker presence: the custom agent has
+            # no inline row and files under the "Custom agents" flyout.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            row = page.get_by_test_id("new-chat-landing-agent-ag_copilot_e2e")
+            await expect(row).to_have_count(0)
+            await page.get_by_test_id("new-chat-landing-custom-agents").hover()
+            await expect(row).to_be_visible()
+            await page.keyboard.press("Escape")
+
+            # Sole agent, so it auto-selected; the composer gear opens its
+            # config directly.
+            await page.get_by_test_id("new-chat-landing-config-gear").click()
+
+            # A copilot agent is a bundle agent, so the Agent Harness row
+            # renders, and the Model select rides under it with the
+            # host-resolved catalog. Default rides the backend's auto pick,
+            # which takes no effort, so no Effort row is rendered yet.
+            await expect(page.get_by_test_id("new-chat-landing-config-harness")).to_be_visible()
+            model = page.get_by_test_id("new-chat-landing-config-model")
+            await expect(model).to_be_visible()
+            await expect(page.get_by_test_id("new-chat-landing-config-effort")).to_have_count(0)
+            await model.click()
+            for label in ("Auto", "Claude Sonnet 5", "Claude Haiku 4.5"):
+                await expect(page.get_by_role("option", name=label, exact=True)).to_be_visible()
+            await page.get_by_role("option", name="Claude Sonnet 5", exact=True).click()
+
+            # A reasoning model brings its own ladder, including Max (which
+            # the static claude-native list never offered per model).
+            effort = page.get_by_test_id("new-chat-landing-config-effort")
+            await expect(effort).to_be_visible()
+            await _pick_config_select(page, "new-chat-landing-config-effort", "Max")
+            await expect(effort).to_contain_text("Max")
+
+            # An effort-less model hides the row entirely and drops the
+            # drafted effort; picking the reasoning model again re-offers it.
+            await _pick_config_select(page, "new-chat-landing-config-model", "Claude Haiku 4.5")
+            await expect(page.get_by_test_id("new-chat-landing-config-effort")).to_have_count(0)
+            await _pick_config_select(page, "new-chat-landing-config-model", "Claude Sonnet 5")
+            await _pick_config_select(page, "new-chat-landing-config-effort", "Max")
+            await _save_config(page)
+
+            await page.get_by_test_id("new-chat-landing-input").fill("write a haiku about CI")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_copilot_e2e", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body.get("model_override") == "claude-sonnet-5", body
+            assert body.get("reasoning_effort") == "max", body
+            # The agent already runs on copilot; no override was picked.
+            assert body.get("harness_override") is None, body
+        finally:
+            await browser.close()

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -252,14 +252,16 @@ def test_resolve_reasoning_effort() -> None:
     # No config / no effort -> None (model default).
     assert _resolve_reasoning_effort(None) is None
     assert _resolve_reasoning_effort(ExecutorConfig()) is None
-    # Supported Copilot levels pass through.
-    for level in ("low", "medium", "high", "xhigh"):
+    # The full CLI effort vocabulary passes through; which subset a given
+    # model takes is enforced by the Copilot backend, not here.
+    for level in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
         assert (
             _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": level})) == level
         )
-    # Values Copilot can't honor (OpenAI-style) are dropped, not raised.
-    assert _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": "minimal"})) is None
-    assert _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": "none"})) is None
+    # A value outside the vocabulary is dropped, not raised.
+    assert (
+        _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": "supersonic"})) is None
+    )
 
 
 def test_build_prompt_first_turn_history_and_latest() -> None:

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -23,10 +23,11 @@ def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
 
     Cursor readiness keys off a configured ``CURSOR_API_KEY`` and copilot off a
     GitHub token (the ``cursor:`` / ``copilot:`` config blocks or the
-    environment), so point the config home at an empty tmp dir and clear any
-    ambient ``CURSOR_API_KEY`` / ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
-    ``GITHUB_TOKEN`` — otherwise a developer's real key would flip their verdict
-    under these tests.
+    environment) or a Copilot CLI login, so point the config home at an empty
+    tmp dir, clear any ambient ``CURSOR_API_KEY`` / ``COPILOT_GITHUB_TOKEN`` /
+    ``GH_TOKEN`` / ``GITHUB_TOKEN``, and point ``COPILOT_HOME`` at a
+    nonexistent dir; otherwise a developer's real key or ``copilot login``
+    would flip their verdict under these tests.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("CURSOR_API_KEY", raising=False)
@@ -37,6 +38,9 @@ def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     import omnigent.onboarding.copilot_auth as _ca
 
     monkeypatch.setattr(_ca, "gh_cli_github_token", lambda host=None: None)
+    # Same for the Copilot CLI's own login marker: isolate ``COPILOT_HOME`` so
+    # a developer's real ``copilot login`` can't flip verdicts either.
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "copilot-home"))
     # Codex readiness resolves the binary via resolve_cli_binary, which honors
     # an OMNIGENT_CODEX_PATH override and probes on-disk global install dirs.
     # Clear the override and stub the fallback dirs so a developer's real codex
@@ -645,3 +649,38 @@ def test_antigravity_native_requires_credential(
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)
     assert harness_is_configured("antigravity-native") is True
     assert harness_is_configured("native-antigravity") is True
+
+
+def test_copilot_ready_via_cli_login_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A Copilot CLI login alone satisfies copilot readiness (no token anywhere).
+
+    With no token configured the SDK leaves the CLI's auto-login on and the
+    runtime authenticates as the ``copilot login`` user, so the probe must
+    accept that marker. Failed before the fix: readiness was
+    token-presence-only and blocked working CLI-login setups (e.g. GitHub
+    Enterprise data-residency seats, whose stored login carries its host).
+    """
+    home = tmp_path / "copilot-home"
+    home.mkdir()
+    (home / "config.json").write_text(
+        "// User settings belong in settings.json.\n"
+        '{"lastLoggedInUser": {"host": "https://example.ghe.com/", "login": "alice"}}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("COPILOT_HOME", str(home))
+    assert harness_is_configured("copilot") is True
+    assert harness_is_configured("github-copilot") is True
+
+
+def test_copilot_unready_without_token_or_cli_login() -> None:
+    """No token and no CLI login: copilot stays unconfigured.
+
+    The autouse fixture clears the token sources and points ``COPILOT_HOME``
+    at a nonexistent dir, so the setup hint remains truthful in the genuinely
+    unconfigured case.
+    """
+    assert harness_is_configured("copilot") is False
+    assert harness_is_configured("github-copilot") is False

--- a/tests/test_copilot_models.py
+++ b/tests/test_copilot_models.py
@@ -1,0 +1,193 @@
+"""Tests for the pre-launch Copilot model catalog (``copilot_models.py``)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from omnigent.copilot_models import copilot_model_options
+
+
+@pytest.fixture(autouse=True)
+def _isolate_copilot_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """Deterministic auth resolution: empty config home, no ambient credentials.
+
+    The ``gh`` CLI fallback is stubbed out too, so a developer machine's own
+    ``gh auth login`` can't leak a token into the assertions.
+    """
+    import omnigent.onboarding.copilot_auth as copilot_auth
+
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "COPILOT_GH_HOST"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", lambda host=None: None)
+
+
+class _Info:
+    def __init__(self, id: str, name: str | None = None) -> None:
+        self.id = id
+        self.name = name
+
+
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    infos: list[_Info] | None = None,
+    list_exc: Exception | None = None,
+) -> dict[str, Any]:
+    """Install a fake ``copilot`` module; return observed call state."""
+    state: dict[str, Any] = {"client_kwargs": [], "started": 0, "stopped": 0}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            state["client_kwargs"].append(kwargs)
+
+        async def start(self) -> None:
+            state["started"] += 1
+
+        async def stop(self) -> None:
+            state["stopped"] += 1
+
+        async def list_models(self) -> list[_Info]:
+            if list_exc is not None:
+                raise list_exc
+            return list(infos or [])
+
+    module = types.ModuleType("copilot")
+    module.CopilotClient = _FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "copilot", module)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_maps_backend_models_to_picker_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backend ``ModelInfo`` rows map to the picker option shape, in order."""
+    state = _install_fake_sdk(
+        monkeypatch,
+        infos=[
+            _Info("claude-sonnet-4.5", "Claude Sonnet 4.5"),
+            _Info("gpt-5.4", None),
+        ],
+    )
+    options = await copilot_model_options()
+    assert options == [
+        {
+            "id": "claude-sonnet-4.5",
+            "model": "claude-sonnet-4.5",
+            "displayName": "Claude Sonnet 4.5",
+            "isDefault": False,
+        },
+        {"id": "gpt-5.4", "model": "gpt-5.4", "displayName": "gpt-5.4", "isDefault": False},
+    ]
+    assert state["started"] == 1
+    # The bundled CLI subprocess must always be reaped.
+    assert state["stopped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_login_when_no_token_anywhere(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No configured or ambient token: the client keeps the SDK auto-login.
+
+    ``github_token=None`` is what leaves ``use_logged_in_user`` on, so the
+    catalog lists what the Copilot CLI's logged-in user may use, the working
+    path for GitHub Enterprise data-residency seats.
+    """
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    await copilot_model_options()
+    assert state["client_kwargs"][0]["github_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_ambient_token_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no stored token, an ambient ``GH_TOKEN`` reaches the client."""
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    monkeypatch.setenv("GH_TOKEN", "gho_ambient")
+    await copilot_model_options()
+    assert state["client_kwargs"][0]["github_token"] == "gho_ambient"
+
+
+@pytest.mark.asyncio
+async def test_gh_cli_login_token_is_the_last_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No stored or ambient token: the ``gh`` login for the configured host.
+
+    Mirrors the executor's resolution, so a seat authenticated only through
+    ``gh auth login`` gets the same catalog its sessions will run with.
+    """
+    import omnigent.onboarding.copilot_auth as copilot_auth
+
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    seen_hosts: list[str | None] = []
+
+    def fake_gh_token(host: str | None = None) -> str | None:
+        seen_hosts.append(host)
+        return "gho_gh_cli"
+
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", fake_gh_token)
+    monkeypatch.setattr(copilot_auth, "copilot_github_host", lambda config=None: "acme.ghe.com")
+    await copilot_model_options()
+    assert state["client_kwargs"][0]["github_token"] == "gho_gh_cli"
+    # The gh lookup must target the seat's own instance, not github.com.
+    assert seen_hosts == ["acme.ghe.com"]
+
+
+@pytest.mark.asyncio
+async def test_no_host_leaves_the_cli_environment_inherited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a configured host the probe passes no ``env`` at all."""
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    await copilot_model_options()
+    assert state["client_kwargs"][0]["env"] is None
+
+
+@pytest.mark.asyncio
+async def test_configured_host_reaches_the_cli_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured GHE host rides into the probe CLI's env, overlaid.
+
+    The SDK replaces the subprocess environment wholesale when ``env`` is
+    given, so the probe must overlay the ambient one; the marker variable
+    proves the inheritance survives.
+    """
+    import omnigent.onboarding.copilot_auth as copilot_auth
+
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    monkeypatch.setattr(copilot_auth, "copilot_github_host", lambda config=None: "acme.ghe.com")
+    monkeypatch.setenv("PROBE_ENV_MARKER", "kept")
+    await copilot_model_options()
+    env = state["client_kwargs"][0]["env"]
+    assert env["COPILOT_GH_HOST"] == "acme.ghe.com"
+    assert env["PROBE_ENV_MARKER"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_ambient_host_env_var_wins_over_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambient ``COPILOT_GH_HOST`` outranks the configured host, as at launch."""
+    import omnigent.onboarding.copilot_auth as copilot_auth
+
+    state = _install_fake_sdk(monkeypatch, infos=[])
+    monkeypatch.setenv("COPILOT_GH_HOST", "env.ghe.com")
+    monkeypatch.setattr(copilot_auth, "copilot_github_host", lambda config=None: "cfg.ghe.com")
+    await copilot_model_options()
+    assert state["client_kwargs"][0]["env"]["COPILOT_GH_HOST"] == "env.ghe.com"
+
+
+@pytest.mark.asyncio
+async def test_backend_failure_still_reaps_the_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``list_models`` failure propagates but never orphans the CLI subprocess."""
+    state = _install_fake_sdk(monkeypatch, list_exc=RuntimeError("not authenticated"))
+    with pytest.raises(RuntimeError):
+        await copilot_model_options()
+    assert state["stopped"] == 1

--- a/tests/test_copilot_models.py
+++ b/tests/test_copilot_models.py
@@ -26,10 +26,24 @@ def _isolate_copilot_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Any)
     monkeypatch.setattr(copilot_auth, "gh_cli_github_token", lambda host=None: None)
 
 
+class _Policy:
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
 class _Info:
-    def __init__(self, id: str, name: str | None = None) -> None:
+    def __init__(
+        self,
+        id: str,
+        name: str | None = None,
+        *,
+        policy: _Policy | None = None,
+        efforts: list[str] | None = None,
+    ) -> None:
         self.id = id
         self.name = name
+        self.policy = policy
+        self.supported_reasoning_efforts = efforts
 
 
 def _install_fake_sdk(
@@ -87,6 +101,78 @@ async def test_maps_backend_models_to_picker_options(
     assert state["started"] == 1
     # The bundled CLI subprocess must always be reaped.
     assert state["stopped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_filters_only_explicitly_blocked_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only an explicit non-enabled policy filters a model out.
+
+    A ``policy`` object exists only for models GitHub tracks a terms opt-in
+    for; ``auto`` and e.g. ``gpt-5.3-codex`` ship without one and are usable,
+    so absence must allow (an enabled-only allowlist would drop them).
+    """
+    _install_fake_sdk(
+        monkeypatch,
+        infos=[
+            _Info("auto", "Auto"),
+            _Info("claude-sonnet-5", "Claude Sonnet 5", policy=_Policy("enabled")),
+            _Info("gpt-5.3-codex", "GPT-5.3-Codex"),
+            _Info("gpt-5.4", "GPT-5.4", policy=_Policy("disabled")),
+            _Info("gemini-3.6-flash", "Gemini 3.6 Flash", policy=_Policy("unconfigured")),
+        ],
+    )
+    options = await copilot_model_options()
+    assert [option["id"] for option in options] == ["auto", "claude-sonnet-5", "gpt-5.3-codex"]
+
+
+@pytest.mark.asyncio
+async def test_auto_is_marked_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``auto`` carries the default marker; ``models.list`` itself has none."""
+    _install_fake_sdk(
+        monkeypatch,
+        infos=[_Info("auto", "Auto"), _Info("gpt-5.4", "GPT-5.4")],
+    )
+    options = await copilot_model_options()
+    assert [(option["id"], option["isDefault"]) for option in options] == [
+        ("auto", True),
+        ("gpt-5.4", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_efforts_are_emitted_in_ladder_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-model efforts ride along in canonical ladder order.
+
+    The backend's own order is not contractual, and unknown values append
+    after the known ladder instead of being dropped. A model without efforts
+    (``efforts=None``) omits the key entirely.
+    """
+    _install_fake_sdk(
+        monkeypatch,
+        infos=[
+            _Info("claude-sonnet-5", efforts=["max", "low", "xhigh", "medium", "high"]),
+            _Info("gpt-5.6-terra", efforts=["high", "supersonic", "none"]),
+            _Info("claude-haiku-4.5"),
+        ],
+    )
+    options = await copilot_model_options()
+    assert options[0]["supportedReasoningEfforts"] == [
+        {"reasoningEffort": "low"},
+        {"reasoningEffort": "medium"},
+        {"reasoningEffort": "high"},
+        {"reasoningEffort": "xhigh"},
+        {"reasoningEffort": "max"},
+    ]
+    assert options[1]["supportedReasoningEfforts"] == [
+        {"reasoningEffort": "none"},
+        {"reasoningEffort": "high"},
+        {"reasoningEffort": "supersonic"},
+    ]
+    assert "supportedReasoningEfforts" not in options[2]
 
 
 @pytest.mark.asyncio

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -119,6 +119,25 @@ export const CLAUDE_NATIVE_EFFORTS: { value: string; label: string }[] = [
   { value: "max", label: "Max" },
 ];
 
+// User-facing labels for the Copilot reasoning-effort ladder. Which subset a
+// given model accepts comes from the model-options probe
+// (`supportedReasoningEfforts` per model); the modal renders only those, so
+// this map only spells labels and never gates a level.
+export const COPILOT_EFFORT_LABELS: Record<string, string> = {
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "xHigh",
+  max: "Max",
+};
+
+/** Label for a Copilot effort value; unknown values pass through verbatim. */
+export function copilotEffortLabel(value: string): string {
+  return COPILOT_EFFORT_LABELS[value] ?? value;
+}
+
 /**
  * A labeled configuration row: bold label + muted sub-description on the left,
  * the control on the right. Mirrors the "Configure …" modal layout.

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -27,6 +27,21 @@ export const BRAIN_HARNESS_LABELS: Record<string, string> = {
   copilot: "Copilot",
 };
 
+/** The SDK copilot harness id, as the brain-harness map spells it. */
+export const COPILOT_HARNESS_ID = "copilot";
+
+/**
+ * Whether an agent's (or a drafted) brain harness is the copilot one, which
+ * carries its own Model/Effort knobs: the catalog is the Copilot backend's,
+ * resolved by the host, rather than a client-side list. Keyed on the harness
+ * an agent runs on, not a registry capability: copilot is an SDK harness
+ * reachable from any agent. Matches the canonical spelling only, the same
+ * gate the brain-harness map applies.
+ */
+export function isCopilotHarness(harness: string | null | undefined): boolean {
+  return harness === COPILOT_HARNESS_ID;
+}
+
 /** One raw setup step from the server's ``/v1/harnesses`` catalog. */
 export interface SetupStepWire {
   kind: string;

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -182,6 +182,28 @@ const CODEX_MODEL_OPTIONS_RESULT = {
   isLoading: false,
   isError: false,
 };
+// Mirrors the host's copilot model-options probe after policy filtering: the
+// auto router (default, no efforts), a reasoning model with its own ladder
+// (incl. "max", which only some models take), and an effort-less model.
+const COPILOT_MODEL_OPTIONS_RESULT = {
+  data: [
+    { id: "auto", displayName: "Auto", isDefault: true },
+    {
+      id: "claude-sonnet-5",
+      displayName: "Claude Sonnet 5",
+      supportedReasoningEfforts: [
+        { reasoningEffort: "low" },
+        { reasoningEffort: "medium" },
+        { reasoningEffort: "high" },
+        { reasoningEffort: "xhigh" },
+        { reasoningEffort: "max" },
+      ],
+    },
+    { id: "claude-haiku-4.5", displayName: "Claude Haiku 4.5" },
+  ],
+  isLoading: false,
+  isError: false,
+};
 
 const useHostModelOptionsMock = vi.mocked(useHostModelOptions);
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
@@ -755,6 +777,52 @@ function setupLandingMocks() {
     },
   ]);
 }
+
+/**
+ * A roster on (or switchable to) the copilot brain harness, plus the
+ * host-resolved copilot model catalog. Copilot deliberately has no top-level
+ * picker presence of its own: it is reached through agents on the copilot
+ * harness, so the fixtures are a user-created custom agent (sole agent, so it
+ * auto-selects) or a claude-sdk bundle agent whose Agent Harness select can
+ * pick Copilot.
+ */
+function setupCopilotMocks(agents: AvailableAgent[]) {
+  mockHosts([
+    {
+      ...host("online"),
+      configured_harnesses: { "claude-sdk": true, copilot: true },
+    } as Host,
+  ]);
+  useHostModelOptionsMock.mockImplementation(
+    (_hostId, harness) =>
+      (harness === "copilot"
+        ? COPILOT_MODEL_OPTIONS_RESULT
+        : harness === "codex-native"
+          ? CODEX_MODEL_OPTIONS_RESULT
+          : CLAUDE_MODEL_OPTIONS_RESULT) as unknown as ReturnType<typeof useHostModelOptions>,
+  );
+  mockAgents(agents);
+}
+
+/** A user-created custom agent on the copilot harness. */
+const CUSTOM_COPILOT_AGENT: AvailableAgent = {
+  id: "a3",
+  name: "my-copilot",
+  display_name: "My Copilot",
+  description: null,
+  harness: "copilot",
+  skills: [],
+} as AvailableAgent;
+
+/** A bundle agent whose brain harness can be switched to copilot. */
+const DEBBY_AGENT: AvailableAgent = {
+  id: "a4",
+  name: "debby",
+  display_name: "Debby",
+  description: null,
+  harness: "claude-sdk",
+  skills: [],
+} as AvailableAgent;
 
 function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
   const client = new QueryClient({
@@ -1547,6 +1615,92 @@ describe("NewChatLandingScreen", () => {
     expect(body.model_override).toBe("databricks-gpt-5-6");
     expect(body.reasoning_effort).toBeUndefined();
     expect(useHostModelOptionsMock).toHaveBeenCalledWith("host_1", "codex-native", true);
+  });
+
+  it("shows the Copilot catalog in the gear modal and no effort row on Default", () => {
+    setupCopilotMocks([CUSTOM_COPILOT_AGENT]);
+    renderLanding();
+    // Sole agent auto-selects, so the gear is directly reachable; a custom
+    // copilot agent needs no top-level picker presence of its own.
+    fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
+    // A copilot agent is a bundle agent, so the Agent Harness row renders,
+    // and the Model row rides under it with the host-resolved catalog.
+    expect(screen.getByTestId("new-chat-landing-config-harness")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-config-model")).toBeTruthy();
+    // Default rides the backend's auto pick, which takes no effort; the
+    // Effort row is absent entirely, not just empty.
+    expect(screen.queryByTestId("new-chat-landing-config-effort")).toBeNull();
+    // The model select offers the host-resolved (policy-filtered) catalog.
+    openSelect("new-chat-landing-config-model");
+    expect(screen.getByText("Auto")).toBeTruthy();
+    expect(screen.getByText("Claude Sonnet 5")).toBeTruthy();
+    expect(screen.getByText("Claude Haiku 4.5")).toBeTruthy();
+    closeMenu();
+  });
+
+  it("offers the selected Copilot model's own effort ladder", () => {
+    setupCopilotMocks([CUSTOM_COPILOT_AGENT]);
+    renderLanding();
+    fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
+    pickSelectOption("new-chat-landing-config-model", "Claude Sonnet 5");
+    // The row appears with exactly the model's advertised levels, including
+    // "max", which the static claude-native list never offered per model.
+    openSelect("new-chat-landing-config-effort");
+    expect(screen.getByText("xHigh")).toBeTruthy();
+    expect(screen.getByText("Max")).toBeTruthy();
+    closeMenu();
+  });
+
+  it("drops a stale Copilot effort when switching to an effort-less model", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    setupCopilotMocks([CUSTOM_COPILOT_AGENT]);
+    renderLanding();
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
+    pickSelectOption("new-chat-landing-config-model", "Claude Sonnet 5");
+    pickSelectOption("new-chat-landing-config-effort", "Max");
+    // Haiku advertises no reasoning efforts: the row disappears and the
+    // drafted "max" must not ride along into the create call.
+    pickSelectOption("new-chat-landing-config-model", "Claude Haiku 4.5");
+    expect(screen.queryByTestId("new-chat-landing-config-effort")).toBeNull();
+    saveConfig();
+
+    const { body } = await submitAndReadBody("run the build");
+    expect(body.agent_id).toBe("a3");
+    expect(body.model_override).toBe("claude-haiku-4.5");
+    expect(body.reasoning_effort).toBeUndefined();
+    // The agent already runs on copilot; no override is picked, none is sent.
+    expect(body.harness_override).toBeUndefined();
+  });
+
+  it("offers the Copilot catalog when a bundle agent's harness is switched to copilot", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    setupCopilotMocks([DEBBY_AGENT]);
+    renderLanding();
+
+    // Debby's declared brain is claude-sdk: no Model row of its own.
+    openAgentConfig("a4");
+    expect(screen.queryByTestId("new-chat-landing-config-model")).toBeNull();
+    // Switching the Agent Harness draft to Copilot brings the rows up live.
+    openSelect("new-chat-landing-config-harness");
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-copilot"));
+    expect(screen.getByTestId("new-chat-landing-config-model")).toBeTruthy();
+    pickSelectOption("new-chat-landing-config-model", "Claude Sonnet 5");
+    pickSelectOption("new-chat-landing-config-effort", "Max");
+    saveConfig();
+
+    // The create carries the harness override AND the copilot model/effort.
+    const { body } = await submitAndReadBody("run the build");
+    expect(body.agent_id).toBe("a4");
+    expect(body.harness_override).toBe("copilot");
+    expect(body.model_override).toBe("claude-sonnet-5");
+    expect(body.reasoning_effort).toBe("max");
   });
 
   it("arms codex full bypass as a plain Approval option, with no warning banner", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -62,7 +62,9 @@ import {
   MODEL_SELECT_DEFAULT,
   MODEL_SELECT_SMART,
   RoutingModelSelect,
+  copilotEffortLabel,
 } from "@/components/HarnessConfigControls";
+import { codexEffortLevelsForModel } from "@/lib/codexNativeModels";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -127,7 +129,9 @@ import {
   AUTO_HARNESS_DESCRIPTION,
   AUTO_HARNESS_ID,
   AUTO_NATIVE_HARNESS_ID,
+  COPILOT_HARNESS_ID,
   isAutoHarness,
+  isCopilotHarness,
   SMART_ROUTING_LABEL,
   useBrainHarnessLabels,
 } from "@/lib/agentLabels";
@@ -1495,6 +1499,8 @@ function HarnessConfigModal({
   codexModelsLoading,
   piModelOptions,
   piModelsLoading,
+  copilotModelOptions,
+  copilotModelsLoading,
   pickedEffort,
   pickedHarness,
   costControlMode,
@@ -1527,6 +1533,11 @@ function HarnessConfigModal({
   codexModelsLoading: boolean;
   piModelOptions: readonly { id: string; displayName: string }[];
   piModelsLoading: boolean;
+  copilotModelOptions: readonly Pick<
+    NativeModelOption,
+    "id" | "displayName" | "isDefault" | "supportedReasoningEfforts"
+  >[];
+  copilotModelsLoading: boolean;
   pickedEffort: string;
   pickedHarness: string | null;
   costControlMode: CostControlMode;
@@ -1606,6 +1617,17 @@ function HarnessConfigModal({
     () => codexModelOptions.map((m) => ({ id: m.id, label: displayModelId(m) })),
     [codexModelOptions],
   );
+  // Copilot Model/Effort rows key on the DRAFTED brain harness, so they
+  // appear and disappear live as the Agent Harness pick changes in the modal.
+  const copilotDraft = brainDefault != null && isCopilotHarness(draftHarness ?? brainDefault);
+  // Efforts for the drafted Copilot model, advertised per model by the
+  // backend's own catalog. Empty for a model without reasoning effort and for
+  // the Default pick (Copilot's auto router takes no effort), which hides the
+  // Effort row entirely.
+  const copilotEffortValues = copilotDraft
+    ? codexEffortLevelsForModel(copilotModelOptions, draftModel)
+    : [];
+  const copilotModelValue = draftModel || MODEL_SELECT_DEFAULT;
   const onModelChange = (value: string) => {
     if (value === MODEL_SELECT_SMART) {
       setDraftRouting("on");
@@ -1618,11 +1640,31 @@ function HarnessConfigModal({
       // "Default" = no override; defer routing to the spec default (null,
       // omitted from create) — never emit an explicit "on"/"off".
       setDraftRouting(null);
+      // Copilot's Default rides the backend's auto pick, which takes no
+      // effort; a stale effort draft must not ride along into the create.
+      if (copilotDraft) setDraftEffort("");
     } else {
       setDraftModel(value);
       // Picking an explicit model turns routing off (mutually exclusive).
       setDraftRouting(null);
+      // Efforts are per model on Copilot: drop a draft the new model can't
+      // honor rather than sending a value the backend would reject.
+      if (
+        copilotDraft &&
+        draftEffort &&
+        !codexEffortLevelsForModel(copilotModelOptions, value).includes(draftEffort)
+      ) {
+        setDraftEffort("");
+      }
     }
+  };
+  // Model and effort drafts are only meaningful for the copilot brain
+  // harness, so a harness switch drops them rather than carrying a pick the
+  // new harness can't interpret.
+  const onBrainHarnessChange = (value: string) => {
+    setDraftHarness(value);
+    setDraftModel("");
+    setDraftEffort("");
   };
 
   const save = () => {
@@ -1668,6 +1710,14 @@ function HarnessConfigModal({
     } else if (brainDefault) {
       // Picking the spec default clears the override so the session tracks it.
       setPickedHarness(draftHarness === brainDefault ? null : draftHarness, agent.id);
+      // Copilot's Model/Effort picks commit alongside the harness pick and are
+      // remembered per harness like the native pickers' knobs. Other brain
+      // harnesses have no model knob, so there is nothing to commit for them.
+      if (copilotDraft) {
+        setPickedModel(draftModel);
+        setPickedEffort(draftEffort);
+        writeHarnessOption(COPILOT_HARNESS_ID, { model: draftModel, effort: draftEffort });
+      }
     }
     // Smart Routing rides the Model dropdown on both routable harnesses
     // (Claude Code and Codex), so commit it outside the per-capability branches.
@@ -1893,7 +1943,7 @@ function HarnessConfigModal({
           read it back or switch away without cancelling. */}
           {!hasPermission && !hasApproval && !hasCursor && !hasAgySkip && brainDefault && (
             <ConfigRow label="Agent Harness" description="Underlying coding harness">
-              <Select value={draftHarness ?? brainDefault} onValueChange={setDraftHarness}>
+              <Select value={draftHarness ?? brainDefault} onValueChange={onBrainHarnessChange}>
                 <SelectTrigger
                   className="w-full cursor-pointer"
                   data-testid="new-chat-landing-config-harness"
@@ -1936,6 +1986,78 @@ function HarnessConfigModal({
                 </SelectContent>
               </Select>
             </ConfigRow>
+          )}
+
+          {/* Model + effort for the copilot brain harness, rendered under the
+          Agent Harness row whenever copilot is the (drafted) pick. The catalog
+          comes from the host's model-options probe (the Copilot backend's own,
+          policy-filtered list for the signed-in seat), and each model carries
+          the efforts it accepts; no effort row for a model without any. */}
+          {!autoRouting && copilotDraft && (
+            <>
+              <ConfigRow label="Model" description="Underlying LLM">
+                <Select value={copilotModelValue} onValueChange={onModelChange}>
+                  <SelectTrigger
+                    className="w-full cursor-pointer"
+                    data-testid="new-chat-landing-config-model"
+                    aria-label="Model"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent
+                    position="popper"
+                    align="start"
+                    className="[&_[data-slot=select-item]]:pl-2.5"
+                  >
+                    <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
+                    {copilotModelOptions.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.displayName ?? m.id}
+                      </SelectItem>
+                    ))}
+                    {copilotModelsLoading && (
+                      <div className="px-2.5 py-1 text-sm text-muted-foreground">
+                        Loading models…
+                      </div>
+                    )}
+                    {!copilotModelsLoading && copilotModelOptions.length === 0 && (
+                      <div className="px-2.5 py-1 text-sm text-muted-foreground">
+                        Models unavailable
+                      </div>
+                    )}
+                  </SelectContent>
+                </Select>
+              </ConfigRow>
+
+              {copilotEffortValues.length > 0 && (
+                <ConfigRow label="Effort" description="Reasoning depth vs. speed">
+                  <Select
+                    value={draftEffort || EFFORT_SELECT_NONE}
+                    onValueChange={(v) => setDraftEffort(v === EFFORT_SELECT_NONE ? "" : v)}
+                  >
+                    <SelectTrigger
+                      className="w-full cursor-pointer"
+                      data-testid="new-chat-landing-config-effort"
+                      aria-label="Reasoning effort"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent
+                      position="popper"
+                      align="start"
+                      className="w-(--radix-select-trigger-width) [&_[data-slot=select-item]]:pl-2.5"
+                    >
+                      <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
+                      {copilotEffortValues.map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {copilotEffortLabel(value)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </ConfigRow>
+              )}
+            </>
           )}
 
           {/* Top-level Smart Routing: the router owns the model, so Permissions
@@ -2791,6 +2913,29 @@ export function NewChatLandingScreen() {
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
   const supportsAgySkipPermissions = nativeAgentHasCapability(selectedAgent, "skipPermissions");
   const supportsModelPicker = nativeAgentHasCapability(selectedAgent, "modelPicker");
+  // The selected agent's effective brain harness: the modal's override when
+  // one is picked, else the agent's own declared harness. Copilot's
+  // Model/Effort knobs key on this, since copilot is an SDK harness any
+  // bundle agent can run on.
+  const selectedBrainHarness =
+    selectedAgent?.harness != null && selectedAgent.harness in brainHarnessLabelsAll
+      ? (pickedHarness ?? selectedAgent.harness)
+      : null;
+  const copilotHarnessSelected = isCopilotHarness(selectedBrainHarness);
+  // Copilot's catalog is resolved by the host from the Copilot backend itself
+  // (one short-lived CLI probe, cached 30s by the query layer), so unlike the
+  // always-on claude/codex fetches it is gated on the harness actually being
+  // the effective pick.
+  const { data: hostCopilotModelOptions, isLoading: hostCopilotModelsLoading } =
+    useHostModelOptions(
+      selectedHostId,
+      COPILOT_HARNESS_ID,
+      !sandboxSelected && copilotHarnessSelected,
+    );
+  const copilotModelOptions = useMemo(
+    () => (sandboxSelected ? [] : (hostCopilotModelOptions ?? [])),
+    [hostCopilotModelOptions, sandboxSelected],
+  );
   const hideUnconfiguredHarnesses = useMemo(() => readHideUnconfiguredHarnesses(), []);
   // The selected native harness, used to persist/seed its option knobs (mode /
   // model / effort), which are harness-specific. null for non-native agents,
@@ -2925,10 +3070,21 @@ export function NewChatLandingScreen() {
     }
     if (selectedAgent?.harness != null && selectedAgent.harness in brainHarnessLabelsAll) {
       const active = pickedHarness ?? selectedAgent.harness;
-      return [
-        { label: "Agent Harness", value: brainHarnessLabelsAll[active] ?? active },
-        ...routingRow,
-      ];
+      const harnessRow = { label: "Agent Harness", value: brainHarnessLabelsAll[active] ?? active };
+      // Copilot carries its own Model/Effort knobs, so mirror the modal's rows.
+      if (isCopilotHarness(active)) {
+        const modelValue =
+          copilotModelOptions.find((m) => m.id === pickedModel)?.displayName ??
+          (pickedModel || "Default");
+        const effortValue = pickedEffort ? copilotEffortLabel(pickedEffort) : "Default";
+        return [
+          harnessRow,
+          { label: "Model", value: modelValue },
+          { label: "Effort", value: effortValue },
+          ...routingRow,
+        ];
+      }
+      return [harnessRow, ...routingRow];
     }
     return routingRow;
   }, [
@@ -2945,6 +3101,7 @@ export function NewChatLandingScreen() {
     claudeModelOptions,
     codexModelOptions,
     piModelOptions,
+    copilotModelOptions,
     pickedEffort,
     permissionMode,
     approvalMode,
@@ -3046,6 +3203,27 @@ export function NewChatLandingScreen() {
     // capability flags are derived from the same harness and stay omitted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedNativeHarness, claudeModelOptions, codexModelOptions, piModelOptions]);
+  // Copilot's Model/Effort picks are remembered per harness like the native
+  // pickers' knobs, seeded whenever copilot becomes the effective brain
+  // harness (and re-validated once the host catalog resolves). This also
+  // drops model/effort state left over from a previously selected native
+  // entry, which the copilot catalog cannot express.
+  useEffect(() => {
+    if (!copilotHarnessSelected) return;
+    const stored = readHarnessOptions(COPILOT_HARNESS_ID);
+    const model =
+      stored.model != null && copilotModelOptions.some((m) => m.id === stored.model)
+        ? stored.model
+        : "";
+    setPickedModel(model);
+    setPickedEffort(
+      model &&
+        stored.effort != null &&
+        codexEffortLevelsForModel(copilotModelOptions, model).includes(stored.effort)
+        ? stored.effort
+        : "",
+    );
+  }, [copilotHarnessSelected, copilotModelOptions, setPickedModel]);
   // Smart Routing is remembered per harness alongside the mode/model
   // knobs, in its own effect because eligibility depends on the server flag
   // (which resolves after mount — this must reseed when it lands). A stored
@@ -3928,20 +4106,24 @@ export function NewChatLandingScreen() {
                       ? (AGY_NATIVE_SKIP_MODES.find((m) => m.value === agySkipMode)?.args ?? [])
                       : undefined,
             // Model + reasoning effort, persisted on the session row before
-            // the runner launches. Claude, Codex, and Pi read model_override at
-            // terminal launch; an unselected ("") knob is omitted so the
-            // harness keeps its own configured/default model.
+            // the runner launches. Claude, Codex, and Pi read model_override
+            // at terminal launch; the SDK copilot harness reads it as its
+            // spawn-env model override and the effort per turn. An unselected
+            // ("") knob is omitted so the harness keeps its own
+            // configured/default model.
             model_override:
               !smartRoutingHarnessSelected &&
               !routingOwnsModel &&
-              (agentSupportsModelPicker || nativeAgent?.harness === "codex-native") &&
+              (agentSupportsModelPicker ||
+                copilotHarnessSelected ||
+                nativeAgent?.harness === "codex-native") &&
               pickedModel
                 ? pickedModel
                 : undefined,
             reasoning_effort:
               !smartRoutingHarnessSelected &&
               !routingOwnsModel &&
-              agentSupportsPermissionMode &&
+              (agentSupportsPermissionMode || copilotHarnessSelected) &&
               pickedEffort
                 ? pickedEffort
                 : undefined,
@@ -4509,6 +4691,10 @@ export function NewChatLandingScreen() {
                     piModelOptions={piModelOptions}
                     piModelsLoading={
                       !sandboxSelected && selectedHostId !== null && hostPiModelsLoading
+                    }
+                    copilotModelOptions={copilotModelOptions}
+                    copilotModelsLoading={
+                      !sandboxSelected && selectedHostId !== null && hostCopilotModelsLoading
                     }
                     pickedEffort={pickedEffort}
                     pickedHarness={pickedHarness}


### PR DESCRIPTION
## Related issue

Closes #4248

## Summary

The copilot harness (GitHub Copilot SDK, in-process) has been part of omnigent for a while, but using it end to end had gaps: readiness rejected machines that authenticate via `copilot login` (the sign-in that works best on GitHub Enterprise data-residency seats), and an agent on the copilot harness offered no model selection at all, so there was no way to see or pick the models a seat actually has. This PR closes those gaps. It builds on #4396, which added the `gh` CLI login fallback and the `copilot.github_host` setup field; an earlier revision of this PR carried an equivalent GitHub Enterprise host implementation and dropped it in favor of #4396 after the rebase.

Following the review direction (thanks @TomeHirata): copilot keeps no presence in the top-level picker. The top-level rows are native terminal harnesses, and copilot is an SDK harness, so it stays where SDK harnesses live: agents. Everything below lands on that path.

### Copilot through agents on the copilot harness

![A copilot agent in the picker](https://raw.githubusercontent.com/mararn1618/omnigent/copilot-pr-assets/custom-agent-picker.png)

A user-created agent on the copilot harness is the entry point, filed under "Custom agents" like any other custom agent. An earlier revision of this PR added a picker entry and a seeded builtin agent; both were removed per review, and the config below now binds to the harness an agent runs on, so it works for any agent on the copilot harness, including a bundle agent switched over via the Agent Harness pick in the gear modal.

### Live, policy-filtered model catalog

![Live model list from the seat](https://raw.githubusercontent.com/mararn1618/omnigent/copilot-pr-assets/copilot-model-catalog.png)

The gear modal of a copilot-harness agent gains a Model row, resolved at pick time from the Copilot backend itself (`CopilotClient.list_models()`, one short-lived CLI probe with hard timeouts). The list therefore matches exactly what the signed-in seat may use, enterprise policy included, instead of a hardcoded selection that drifts out of date. Previously this path had no model catalog at all.

Details that matter for correctness:

- The filter is `policy is None or policy.state == "enabled"`. A model carries a `policy` object only when GitHub tracks a separate terms opt-in for it; `auto` and some regular models ship without one and are usable, so an enabled-only allowlist would wrongly drop them.
- `auto` is marked as the default, matching the executor's behavior of treating an unset model as Copilot's server-side auto pick.
- The probe mirrors the executor's auth and host resolution, so the catalog is listed against the same backend the launched session talks to: stored token, ambient token env vars, the `gh` CLI login for the configured host, then the Copilot CLI's own login. A configured `copilot.github_host` reaches the probe's bundled CLI the same way the executor hands it over at session start.

### Per-model reasoning efforts

![Per-model effort ladder](https://raw.githubusercontent.com/mararn1618/omnigent/copilot-pr-assets/copilot-effort-ladder.png)

Reasoning efforts are per model, taken from `supported_reasoning_efforts`. The effort select offers only the selected model's levels (including `max` where supported) and is hidden entirely for models without reasoning effort, so the UI can no longer offer a level the model would ignore. The committed pick reaches the create call as `model_override` / `reasoning_effort`, which the copilot harness already consumes.

### Readiness accepts the Copilot CLI login

Readiness accepts a resolvable GitHub token or, since #4396, a `gh` CLI login. A machine authenticated solely through `copilot login` was still rejected with 412 HARNESS_NOT_CONFIGURED even though sessions run fine on the CLI's stored credential. Readiness now also recognizes that login: the marker in `~/.copilot/config.json` is read JSONC-safely, honoring `COPILOT_HOME`, and any unreadable state still reads as not configured. On Enterprise seats this is the sign-in that works best, because the Copilot CLI login carries its own GitHub host. The new readiness tests were written first and fail without the change.

## Test Plan

- Unit tests per commit: readiness (red before fix), catalog filtering, host and token resolution of the probe, effort ordering, and the gear-modal cases in the web suite (including a bundle agent switched to copilot carrying `harness_override` plus model and effort into the create call).
- A Playwright test under `tests/e2e_ui/` drives a copilot custom agent end to end: the agent has no inline picker row and files under "Custom agents", the modal offers the stubbed catalog with per-model efforts, and the committed pick is asserted on the captured create call.
- Full web suite, the touched pytest packages, ruff, and tsc are green on the branch.
- Verified end to end against a live GitHub Enterprise data-residency seat: login-based auth, the model list matches the seat's enablement, and a session pinned to a model is billed on exactly that model.

## Demo

The screenshots above show the new behaviour, captured against a live GitHub Enterprise seat: the custom-agent entry point, the live model catalog, and the per-model effort ladder in the gear modal.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran against a live GitHub Enterprise data-residency seat: readiness turns ready from the Copilot CLI login alone, the model-options probe returns the seat's twelve enabled models with `auto` as the default and per-model efforts, and a session created with a pinned model and effort is billed on exactly that model.

## Changelog

Agents on the copilot harness get a live, policy-filtered model picker with per-model reasoning efforts, and Copilot readiness accepts the Copilot CLI login.
