### PR TITLE
fix(release): drop Intel from the Homebrew formula

### DIFF
--- a/.github/scripts/homebrew/generate_formula.py
+++ b/.github/scripts/homebrew/generate_formula.py
@@ -7,7 +7,7 @@ and every dependency `resource` stanza — into the hand-tuned template
 are owned by the template; this script owns the bits that change every release.
 
 Resolution: `uv pip compile` computes the exact transitive closure of
-`omnigent[<extras>]==<version>` for each target platform (macOS arm + intel by
+`omnigent[<extras>]==<version>` for each target platform (Apple Silicon only by
 default — the brew tap's `brew test-bot` matrix). The per-platform closures are
 unioned; for each package we then fetch the sdist URL + sha256 from the PyPI JSON
 API and emit a `resource` stanza. Every package in the closure must publish an
@@ -41,11 +41,18 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-# Default brew build matrix: macOS Apple Silicon + Intel (the tap's
-# `brew test-bot` runs on macos-15 / macos-15-intel / macos-26). The union of the
-# two closures captures platform-marker deps needed on either arch. Add
-# `x86_64-unknown-linux-gnu` here if the tap re-enables Linux builds.
-DEFAULT_PLATFORMS = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+# Default brew build matrix: Apple Silicon only (the tap's `brew test-bot` runs on
+# macos-15 / macos-26). Intel is deliberately absent -- homebrew-core no longer
+# publishes `sequoia` bottles for rust, cryptography, libyaml, pydantic, rpds-py
+# or tmux, so an Intel build had to compile all of those first and test-bot
+# skipped the formula outright ("has unbottled dependencies"). Every release since
+# 0.6.0 shipped arm-only bottles. The template's `depends_on arch: :arm64` is what
+# makes that explicit to users; keep the two in sync.
+#
+# Resolutions are still unioned across whatever platforms are listed, so adding
+# `x86_64-apple-darwin` back (or `x86_64-unknown-linux-gnu` for Linux) restores
+# multi-arch behaviour, including the `on_arm`/`on_intel` wheel stanzas.
+DEFAULT_PLATFORMS = ["aarch64-apple-darwin"]
 # Extras bundled as resources. The base install already pulls the Claude and
 # OpenAI Agents harnesses; this adds the opt-in `cursor` harness (pure-Python
 # sdist). antigravity is NOT bundled — no sdist (platform wheels only), no
@@ -620,7 +627,7 @@ def main(argv: list[str]) -> int:
         "--python-platform",
         action="append",
         default=None,
-        help="uv target platform (repeatable). Default: macOS arm + intel.",
+        help="uv target platform (repeatable). Default: Apple Silicon only.",
     )
     ap.add_argument(
         "--extra",

--- a/.github/scripts/homebrew/omnigent.rb.template
+++ b/.github/scripts/homebrew/omnigent.rb.template
@@ -34,6 +34,15 @@ class Omnigent < Formula
   # relocate them -- hence the Rust toolchain and the RUSTFLAGS below.
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
+  # Apple Silicon only. homebrew-core stopped publishing `sequoia` bottles for
+  # rust, cryptography, libyaml, pydantic, rpds-py and tmux, so an Intel install
+  # would have to build all of those from source first; test-bot skipped the
+  # formula there outright and every release since 0.6.0 shipped arm-only bottles.
+  # Fail fast with a clear message instead of pouring arm64 wheels onto an Intel
+  # Mac. Keep in sync with DEFAULT_PLATFORMS in generate_formula.py.
+  # Placement is what FormulaAudit/DependencyOrder wants: after `=> :build`, before
+  # the named runtime deps.
+  depends_on arch: :arm64
   # certifi, cryptography, pydantic (which bundles pydantic-core), and rpds-py
   # are provided by Homebrew formulae rather than built as virtualenv resources.
   # The compiled ones would otherwise need a Rust/C build, and their transitive


### PR DESCRIPTION
## Related issue

N/A

## Summary

The tap's `macos-15-intel` job has been reporting green without building anything:
homebrew-core no longer publishes `sequoia` bottles for `rust`, `cryptography`,
`libyaml`, `pydantic`, `rpds-py` or `tmux`, so test-bot bails with "omnigent has
unbottled dependencies, so a bottle will not be built" and marks the formula
SKIPPED. Every release since 0.6.0 has shipped arm-only bottles, so Intel support
was already notional -- just not stated anywhere.

- Resolve for Apple Silicon only (`DEFAULT_PLATFORMS`), so the closure reflects
  what we actually ship.
- Add `depends_on arch: :arm64` to the template. Without it, dropping the x86_64
  resolution would turn the four `on_arm`/`on_intel` wheel stanzas into bare
  arm64 URLs, and an Intel install would download arm64 wheels and fail somewhere
  deep in pip. Now it refuses immediately with a clear message.
- `--python-platform` still overrides, so adding x86_64 (or Linux) back restores
  multi-arch resolution and the arch-conditional stanzas.

Net effect on the formula: 100 resources -> 99, with the four arch conditionals
collapsing to single URLs. The dropped package is `greenlet`, which was only ever
present because of the x86_64 half of the union -- SQLAlchemy's marker is
`platform_machine == "aarch64"`, and Apple Silicon reports `arm64`, so it was
never required on the platform we ship.

## Test Plan

- Verified `greenlet` is genuinely unused before dropping it: no
  `create_async_engine`, `async_sessionmaker`, `AsyncSession`, aiosqlite or
  asyncpg anywhere in `omnigent/`. The one grep hit was prose in a comment in
  `omnigent/db/utils.py`. (Had it been in use, removing greenlet would have broken
  async SQLAlchemy on arm, since pip installs it there by accident of the union
  rather than by declaration.)
- Generated the 0.8.2 formula and checked it against every linter the tap's
  `--only-tap-syntax` step runs:
  `brew style` (1 file inspected, no offenses), `brew readall --os=all --arch=all`
  (OK), `brew audit --except=installed` (OK), plus `ruby -c`.
- Confirmed the output: 99 resources, `depends_on arch: :arm64` present, zero
  `on_intel` stanzas remaining, stable url still 0.8.2.
- Placement of `depends_on arch: :arm64` was taken from `brew style --fix` rather
  than guessed: `FormulaAudit/DependencyOrder` wants it after the `=> :build` deps
  and before the named runtime deps.

## Demo

N/A -- release tooling, no user-visible UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The generator has no test suite here and its contract is "the emitted formula is
accepted by Homebrew", which can only be checked by running Homebrew. Verified by
generating the 0.8.2 formula and passing it through the same three linters the tap
runs in CI, and by confirming the resource delta is exactly `greenlet`.

## Changelog

`brew install omnigent` now fails immediately on Intel Macs with a clear message
instead of attempting a build that cannot succeed.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

