### PR TITLE
Fix repeatable agent session renames

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4409,7 +4409,9 @@ async def _rename_current_session_via_rest(
     try:
         info_response = await server_client.get(
             f"/v1/sessions/{conversation_id}",
-            params={"include_items": "false"},
+            # Skip the transcript and the runner/host liveness lookup — the
+            # probe only needs parent_session_id.
+            params={"include_items": "false", "include_liveness": "false"},
             timeout=30.0,
         )
     except Exception as exc:  # noqa: BLE001

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4376,12 +4376,11 @@ async def _rename_current_session_via_rest(
     conversation_id: str | None,
     server_client: httpx.AsyncClient | None,
 ) -> str:
-    """Conditionally rename the calling session through the server API.
+    """Rename the calling session through the server API.
 
-    Automatic naming is framework metadata, never a prerequisite for the
-    user's turn. Every failure therefore becomes a tool-result envelope so a
-    missing route, unavailable server, or malformed response cannot abort the
-    harness session.
+    Session naming is metadata, never a prerequisite for the user's turn.
+    Every failure therefore becomes a tool-result envelope so a missing route,
+    unavailable server, or malformed response cannot abort the harness session.
     """
     if server_client is None:
         return json.dumps({"error": "sys_session_rename requires server access"})
@@ -4390,10 +4389,17 @@ async def _rename_current_session_via_rest(
     title = args.get("title")
     if not isinstance(title, str):
         return json.dumps({"error": "sys_session_rename requires a string 'title'"})
+    if len(title) < 2 or len(title) > 60:
+        return json.dumps({"error": "sys_session_rename title must be 2-60 characters"})
+    if "\n" in title or "\r" in title:
+        return json.dumps({"error": "sys_session_rename title must be a single line"})
+    normalized_title = " ".join(title.split())
+    if len(normalized_title) < 2:
+        return json.dumps({"error": "sys_session_rename title must be 2-60 characters"})
     try:
-        response = await server_client.post(
-            f"/v1/sessions/{conversation_id}/auto-title",
-            json={"title": title},
+        response = await server_client.patch(
+            f"/v1/sessions/{conversation_id}",
+            json={"title": normalized_title},
             timeout=30.0,
         )
     except Exception as exc:  # noqa: BLE001
@@ -4411,7 +4417,10 @@ async def _rename_current_session_via_rest(
         return json.dumps({"error": f"sys_session_rename returned invalid JSON: {exc}"})
     if not isinstance(payload, dict):
         return json.dumps({"error": "sys_session_rename returned a non-object response"})
-    return json.dumps(payload)
+    updated_title = payload.get("title")
+    if not isinstance(updated_title, str):
+        return json.dumps({"error": "sys_session_rename response omitted the updated title"})
+    return json.dumps({"renamed": True, "title": updated_title, "reason": None})
 
 
 async def _collect_sub_agents(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -296,6 +296,12 @@ _SESSION_QUERY_TOOLS = frozenset(
 
 _SESSION_SELF_WRITE_TOOLS = frozenset({SysSessionRenameTool.name()})
 
+# The title bound the rename tool advertises to the LLM — read once from the
+# tool schema so the dispatcher can never drift from the published contract.
+_SESSION_RENAME_TITLE_MAX_CHARS: int = SysSessionRenameTool().get_schema()["function"][
+    "parameters"
+]["properties"]["title"]["maxLength"]
+
 # Grantee sentinel for an anonymous, public read-only share. Mirrors the
 # server's RESERVED_USER_PUBLIC; only specs with
 # ``agent_session_sharing: public`` may grant it (enforced in
@@ -4389,12 +4395,8 @@ async def _rename_current_session_via_rest(
     title = args.get("title")
     if not isinstance(title, str):
         return json.dumps({"error": "sys_session_rename requires a string 'title'"})
-    # Enforce exactly the bounds the tool schema advertises to the LLM, so the
-    # dispatcher can never drift from the published contract.
-    title_schema = SysSessionRenameTool().get_schema()["function"]["parameters"]["properties"][
-        "title"
-    ]
-    max_chars = title_schema["maxLength"]
+    # Enforce exactly the bounds the tool schema advertises to the LLM.
+    max_chars = _SESSION_RENAME_TITLE_MAX_CHARS
     if len(title) < 2 or len(title) > max_chars:
         return json.dumps({"error": f"sys_session_rename title must be 2-{max_chars} characters"})
     if "\n" in title or "\r" in title:
@@ -4429,13 +4431,20 @@ async def _rename_current_session_via_rest(
         return json.dumps({"error": f"sys_session_rename returned invalid JSON: {exc}"})
     # Fail closed: only a payload that positively shows a parentless session
     # may proceed — a malformed or version-skewed snapshot must not let a
-    # child rename slip through and corrupt its continuation address.
+    # child rename slip through and corrupt its continuation address. Exactly
+    # None means top-level; a non-empty string means child; anything else
+    # (empty string, wrong type) is malformed and blocks the rename.
     if not isinstance(info_payload, dict) or "parent_session_id" not in info_payload:
         return json.dumps(
             {"error": "sys_session_rename could not verify the session is top-level"}
         )
-    if info_payload.get("parent_session_id"):
-        return json.dumps({"renamed": False, "title": None, "reason": "not_top_level"})
+    parent_session_id = info_payload["parent_session_id"]
+    if parent_session_id is not None:
+        if isinstance(parent_session_id, str) and parent_session_id:
+            return json.dumps({"renamed": False, "title": None, "reason": "not_top_level"})
+        return json.dumps(
+            {"error": "sys_session_rename could not verify the session is top-level"}
+        )
     try:
         response = await server_client.patch(
             f"/v1/sessions/{conversation_id}",

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4389,13 +4389,51 @@ async def _rename_current_session_via_rest(
     title = args.get("title")
     if not isinstance(title, str):
         return json.dumps({"error": "sys_session_rename requires a string 'title'"})
-    if len(title) < 2 or len(title) > 60:
-        return json.dumps({"error": "sys_session_rename title must be 2-60 characters"})
+    # Enforce exactly the bounds the tool schema advertises to the LLM, so the
+    # dispatcher can never drift from the published contract.
+    title_schema = SysSessionRenameTool().get_schema()["function"]["parameters"]["properties"][
+        "title"
+    ]
+    max_chars = title_schema["maxLength"]
+    if len(title) < 2 or len(title) > max_chars:
+        return json.dumps({"error": f"sys_session_rename title must be 2-{max_chars} characters"})
     if "\n" in title or "\r" in title:
         return json.dumps({"error": "sys_session_rename title must be a single line"})
     normalized_title = " ".join(title.split())
     if len(normalized_title) < 2:
-        return json.dumps({"error": "sys_session_rename title must be 2-60 characters"})
+        return json.dumps({"error": f"sys_session_rename title must be 2-{max_chars} characters"})
+    # Only a top-level session may rename itself: a sub-agent's title is its
+    # (parent, title) continuation address for sys_session_send, so a child
+    # rename would corrupt sibling addressing. Refuse explicitly, matching
+    # the old seed-gated endpoint's response for child sessions.
+    try:
+        info_response = await server_client.get(
+            f"/v1/sessions/{conversation_id}",
+            params={"include_items": "false"},
+            timeout=30.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_rename failed: {exc}"})
+    if info_response.status_code >= 400:
+        return json.dumps(
+            {
+                "error": f"sys_session_rename returned {info_response.status_code}",
+                "detail": info_response.text[:200],
+            }
+        )
+    try:
+        info_payload = info_response.json()
+    except ValueError as exc:
+        return json.dumps({"error": f"sys_session_rename returned invalid JSON: {exc}"})
+    # Fail closed: only a payload that positively shows a parentless session
+    # may proceed — a malformed or version-skewed snapshot must not let a
+    # child rename slip through and corrupt its continuation address.
+    if not isinstance(info_payload, dict) or "parent_session_id" not in info_payload:
+        return json.dumps(
+            {"error": "sys_session_rename could not verify the session is top-level"}
+        )
+    if info_payload.get("parent_session_id"):
+        return json.dumps({"renamed": False, "title": None, "reason": "not_top_level"})
     try:
         response = await server_client.patch(
             f"/v1/sessions/{conversation_id}",

--- a/omnigent/tools/builtins/session_rename.py
+++ b/omnigent/tools/builtins/session_rename.py
@@ -19,10 +19,10 @@ class SysSessionRenameTool(Tool):
     def description(cls) -> str:
         """Return the LLM-facing description."""
         return (
-            "Rename the current top-level session with a short summary-style title "
+            "Rename the current session with a short summary-style title "
             "(3-6 words, action-first). Strip filler and keep the noun plus verb. "
             "Never copy a conversational question or greeting verbatim. "
-            "The rename is ignored if the session title changed concurrently."
+            "The rename is silent and can be updated again as the work evolves."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/omnigent/tools/builtins/session_rename.py
+++ b/omnigent/tools/builtins/session_rename.py
@@ -19,7 +19,7 @@ class SysSessionRenameTool(Tool):
     def description(cls) -> str:
         """Return the LLM-facing description."""
         return (
-            "Rename the current session with a short summary-style title "
+            "Rename the current top-level session with a short summary-style title "
             "(3-6 words, action-first). Strip filler and keep the noun plus verb. "
             "Never copy a conversational question or greeting verbatim. "
             "The rename is silent and can be updated again as the work evolves."

--- a/omnigent/tools/builtins/session_rename.py
+++ b/omnigent/tools/builtins/session_rename.py
@@ -22,7 +22,8 @@ class SysSessionRenameTool(Tool):
             "Rename the current top-level session with a short summary-style title "
             "(3-6 words, action-first). Strip filler and keep the noun plus verb. "
             "Never copy a conversational question or greeting verbatim. "
-            "The rename is silent and can be updated again as the work evolves."
+            "The rename is silent and can be updated again as the work evolves. "
+            "Sub-agent sessions cannot rename themselves (returns not_top_level)."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/tests/e2e/test_session_rename_repeatable.py
+++ b/tests/e2e/test_session_rename_repeatable.py
@@ -1,0 +1,264 @@
+"""E2E: an explicit ``sys_session_rename`` must work after the first title lands.
+
+``sys_session_rename`` used to dispatch to ``POST /v1/sessions/{id}/auto-title``,
+a one-shot compare-and-swap that only succeeds while the session title still
+equals the deterministic first-message seed. The background titler consumes
+that slot on turn one, so every subsequent explicit rename returned
+``{"renamed": false, "title": null, "reason": "title_changed"}`` forever, even
+with no concurrent writer.
+
+Journey exercised (all through the live server + runner + mock LLM):
+
+1. Create a runner-bound session; the first user message seeds the
+   deterministic title.
+2. Consume the one-shot auto-title slot exactly the way the background titler
+   does — a successful ``POST /auto-title`` replacing seed with a generated
+   title.
+3. The agent (mock LLM) calls ``sys_session_rename``; the runner dispatches it.
+   Broken build: the tool result is ``renamed=false / reason="title_changed"``.
+   Fixed build: ``renamed=true`` and the title is persisted.
+4. A second ``sys_session_rename`` in a later turn must also succeed — the
+   rename is repeatable, not another one-shot.
+
+Runs against the mock LLM server — no real API key needed::
+
+    pytest tests/e2e/test_session_rename_repeatable.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import POLL_INTERVAL_S
+
+
+def _get_session_title(client: httpx.Client, session_id: str) -> str | None:
+    """Return the current title of *session_id* via ``GET /v1/sessions/{id}``.
+
+    :param client: HTTP client pointed at the live server.
+    :param session_id: Session id, e.g. ``"conv_abc123"``.
+    :returns: The title string, or ``None`` when the session has no title yet.
+    """
+    resp = client.get(f"/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("title")
+
+
+def _wait_for_seed_title(
+    client: httpx.Client,
+    session_id: str,
+    *,
+    timeout: float = 30.0,
+) -> str:
+    """Poll until the server seeds a title from the first message.
+
+    :param client: HTTP client pointed at the live server.
+    :param session_id: Session id.
+    :param timeout: Maximum seconds to wait.
+    :returns: The seed title.
+    :raises AssertionError: If no title appears within *timeout* seconds.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        title = _get_session_title(client, session_id)
+        if title is not None:
+            return title
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"Session {session_id!r} never received a seed title after the first "
+        "message. The title-seeding step may have changed."
+    )
+
+
+def _rename_tool_result(
+    body: dict[str, Any],
+    call_id: str,
+) -> dict[str, Any]:
+    """Extract and parse the ``sys_session_rename`` tool result for *call_id*.
+
+    :param body: Terminal response body from
+        :func:`poll_session_until_terminal`.
+    :param call_id: The mock-issued tool call id, e.g. ``"call_rename_1"``.
+    :returns: The parsed JSON payload the runner returned to the LLM.
+    :raises AssertionError: If no tool result for *call_id* is present.
+    """
+    for item in body.get("output", []):
+        if item.get("type") == "function_call_output" and item.get("call_id") == call_id:
+            output = item.get("output")
+            assert isinstance(output, str), (
+                f"tool output for {call_id!r} is not a string: {item!r}"
+            )
+            return json.loads(output)
+    raise AssertionError(
+        f"No function_call_output for {call_id!r} in session output: "
+        f"{[i.get('type') for i in body.get('output', [])]}"
+    )
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_sys_session_rename_succeeds_after_first_title_landed(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str | None,
+) -> None:
+    """An agent rename works — repeatedly — once the seed title was replaced.
+
+    **Failure mode this guards:** the rename tool and the background titler
+    shared the one-shot ``/auto-title`` CAS slot. After the titler's first
+    write (seed → generated title), every ``sys_session_rename`` returned
+    ``{"renamed": false, "title": null, "reason": "title_changed"}`` even
+    with no concurrent writer — the tool was permanently dead.
+
+    **What fixed looks like:** the tool routes through the repeatable session
+    rename path, so it returns ``{"renamed": true, "title": <requested>}``
+    and the title is persisted, on the first call and on later calls alike.
+
+    :param http_client: HTTP client pointed at the live server.
+    :param live_runner_id: Runner id registered with the live server.
+    :param mock_llm_server_url: Mock LLM server URL (``None`` when using a
+        real LLM, in which case the mock-llm configure calls are no-ops).
+    """
+    # Unique per-run queue key — no shared-state reset needed (and a reset
+    # would clear other tests' queues on the session-scoped mock server).
+    model = f"mock-rename-{uuid.uuid4().hex[:8]}"
+
+    first_rename_title = "Investigate flaky auth timeout"
+    second_rename_title = "Verify auth timeout fix"
+
+    # Turn 1: plain ack (lets the first message complete and seed the title).
+    # Turn 2: the agent calls sys_session_rename, then acks the result.
+    # Turn 3: a second sys_session_rename, then acks — proves repeatability.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "Acknowledged the task."},
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_rename_1",
+                        "name": "sys_session_rename",
+                        "arguments": json.dumps({"title": first_rename_title}),
+                    }
+                ]
+            },
+            {"text": "Renamed the session once."},
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_rename_2",
+                        "name": "sys_session_rename",
+                        "arguments": json.dumps({"title": second_rename_title}),
+                    }
+                ]
+            },
+            {"text": "Renamed the session again."},
+        ],
+        key=model,
+    )
+
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"rename-fix-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a terse assistant.",
+        mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+
+    # Step 1 — first user message; the server seeds the deterministic title.
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="investigate the authentication timeout in the production database",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=120
+    )
+    assert body["status"] == "completed", (
+        f"first turn did not complete: status={body.get('status')!r}, error={body.get('error')!r}"
+    )
+    seed_title = _wait_for_seed_title(http_client, session_id)
+
+    # Step 2 — consume the one-shot auto-title slot exactly the way the
+    # background titler does: a successful seed → generated-title CAS. After
+    # this, the session title no longer matches the seed, which is the state
+    # every real session reaches after its first turn.
+    generated_title = "Debug production database access"
+    auto_resp = http_client.post(
+        f"/v1/sessions/{session_id}/auto-title",
+        json={"title": generated_title},
+        timeout=10.0,
+    )
+    assert auto_resp.status_code == 200, (
+        f"POST /auto-title returned {auto_resp.status_code}: {auto_resp.text}"
+    )
+    auto_body = auto_resp.json()
+    assert auto_body.get("renamed") is True, (
+        f"The first (titler-style) auto-title write should succeed while the "
+        f"seed {seed_title!r} is intact, got: {auto_body!r}"
+    )
+
+    # Step 3 — the agent renames the session. On the broken build the tool
+    # result is renamed=false/reason="title_changed" because the one-shot
+    # slot is gone; on a fixed build it succeeds.
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Rename this session to reflect the investigation.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=120
+    )
+    assert body["status"] == "completed", (
+        f"rename turn did not complete: status={body.get('status')!r}, error={body.get('error')!r}"
+    )
+    result = _rename_tool_result(body, "call_rename_1")
+    assert result.get("renamed") is True, (
+        f"sys_session_rename failed after the first title landed: {result!r}\n"
+        f"Expected renamed=true — an explicit rename must not share the "
+        f"background titler's one-shot seed slot."
+    )
+    assert _get_session_title(http_client, session_id) == first_rename_title, (
+        "The rename reported success but the title was not persisted."
+    )
+
+    # Step 4 — a second rename must also succeed: the fix makes the rename
+    # repeatable, not merely a second one-shot.
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Rename the session again, the work moved on.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=120
+    )
+    assert body["status"] == "completed", (
+        f"second rename turn did not complete: status={body.get('status')!r}, "
+        f"error={body.get('error')!r}"
+    )
+    result = _rename_tool_result(body, "call_rename_2")
+    assert result.get("renamed") is True, (
+        f"The second sys_session_rename failed: {result!r}\n"
+        f"Renames must be repeatable as the session's work evolves."
+    )
+    assert _get_session_title(http_client, session_id) == second_rename_title, (
+        "The second rename reported success but the title was not persisted."
+    )

--- a/tests/runner/test_session_rename_dispatch.py
+++ b/tests/runner/test_session_rename_dispatch.py
@@ -26,37 +26,73 @@ def test_native_relay_exposes_session_rename(spec: AgentSpec | None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_rename_dispatches_to_current_session() -> None:
+async def test_session_rename_dispatches_repeatable_patch_to_current_session() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
-        return httpx.Response(
-            200,
-            json={"renamed": True, "title": "Debug auth timeout", "reason": None},
-        )
+        return httpx.Response(200, json={"id": "conv_current", **json.loads(request.content)})
 
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://server",
     ) as server_client:
+        outputs = [
+            await execute_tool(
+                tool_name="sys_session_rename",
+                arguments=json.dumps({"title": title}),
+                server_client=server_client,
+                conversation_id="conv_current",
+                agent_spec=AgentSpec(spec_version=1),
+            )
+            for title in ("Debug auth timeout", "Verify auth timeout fix")
+        ]
+
+    assert [json.loads(output) for output in outputs] == [
+        {"renamed": True, "title": "Debug auth timeout", "reason": None},
+        {"renamed": True, "title": "Verify auth timeout fix", "reason": None},
+    ]
+    assert len(requests) == 2
+    assert all(request.method == "PATCH" for request in requests)
+    assert all(request.url.path == "/v1/sessions/conv_current" for request in requests)
+    assert [json.loads(request.content) for request in requests] == [
+        {"title": "Debug auth timeout"},
+        {"title": "Verify auth timeout fix"},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("title", "expected_error"),
+    [
+        ("x", "2-60 characters"),
+        ("  ", "2-60 characters"),
+        ("x" * 61, "2-60 characters"),
+        ("Debug auth\ntimeout", "single line"),
+    ],
+)
+async def test_session_rename_rejects_invalid_titles_before_request(
+    title: str,
+    expected_error: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: requests.append(request) or httpx.Response(500)
+        ),
+        base_url="http://server",
+    ) as server_client:
         output = await execute_tool(
             tool_name="sys_session_rename",
-            arguments=json.dumps({"title": "Debug auth timeout"}),
+            arguments=json.dumps({"title": title}),
             server_client=server_client,
             conversation_id="conv_current",
             agent_spec=AgentSpec(spec_version=1),
         )
 
-    assert json.loads(output) == {
-        "renamed": True,
-        "title": "Debug auth timeout",
-        "reason": None,
-    }
-    assert len(requests) == 1
-    assert requests[0].method == "POST"
-    assert requests[0].url.path == "/v1/sessions/conv_current/auto-title"
-    assert json.loads(requests[0].content) == {"title": "Debug auth timeout"}
+    assert expected_error in json.loads(output)["error"]
+    assert requests == []
 
 
 @pytest.mark.asyncio
@@ -66,6 +102,10 @@ async def test_session_rename_dispatches_to_current_session() -> None:
         (httpx.Response(503, text="server unavailable"), "returned 503"),
         (httpx.Response(200, text="not-json"), "returned invalid JSON"),
         (httpx.Response(200, json=["unexpected"]), "returned a non-object response"),
+        (
+            httpx.Response(200, json={"id": "conv_current", "title": None}),
+            "response omitted the updated title",
+        ),
     ],
 )
 async def test_session_rename_server_failures_are_tool_results(

--- a/tests/runner/test_session_rename_dispatch.py
+++ b/tests/runner/test_session_rename_dispatch.py
@@ -13,6 +13,23 @@ from omnigent.runner.tool_dispatch import (
     execute_tool,
 )
 from omnigent.spec.types import AgentSpec
+from omnigent.tools.builtins.session_rename import SysSessionRenameTool
+
+_TITLE_MAX_CHARS: int = SysSessionRenameTool().get_schema()["function"]["parameters"][
+    "properties"
+]["title"]["maxLength"]
+
+
+def _top_level_session_handler(request: httpx.Request) -> httpx.Response | None:
+    """Answer the dispatcher's top-level check for a parentless session.
+
+    :param request: The intercepted request.
+    :returns: A session snapshot for the GET probe, ``None`` for other
+        requests (so the caller's handler decides).
+    """
+    if request.method == "GET" and request.url.path == "/v1/sessions/conv_current":
+        return httpx.Response(200, json={"id": "conv_current", "parent_session_id": None})
+    return None
 
 
 @pytest.mark.parametrize("spec", [AgentSpec(spec_version=1), None])
@@ -27,10 +44,13 @@ def test_native_relay_exposes_session_rename(spec: AgentSpec | None) -> None:
 
 @pytest.mark.asyncio
 async def test_session_rename_dispatches_repeatable_patch_to_current_session() -> None:
-    requests: list[httpx.Request] = []
+    patch_requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
+        probe = _top_level_session_handler(request)
+        if probe is not None:
+            return probe
+        patch_requests.append(request)
         return httpx.Response(200, json={"id": "conv_current", **json.loads(request.content)})
 
     async with httpx.AsyncClient(
@@ -52,22 +72,100 @@ async def test_session_rename_dispatches_repeatable_patch_to_current_session() -
         {"renamed": True, "title": "Debug auth timeout", "reason": None},
         {"renamed": True, "title": "Verify auth timeout fix", "reason": None},
     ]
-    assert len(requests) == 2
-    assert all(request.method == "PATCH" for request in requests)
-    assert all(request.url.path == "/v1/sessions/conv_current" for request in requests)
-    assert [json.loads(request.content) for request in requests] == [
+    assert len(patch_requests) == 2
+    assert all(request.method == "PATCH" for request in patch_requests)
+    assert all(request.url.path == "/v1/sessions/conv_current" for request in patch_requests)
+    assert [json.loads(request.content) for request in patch_requests] == [
         {"title": "Debug auth timeout"},
         {"title": "Verify auth timeout fix"},
     ]
 
 
 @pytest.mark.asyncio
+async def test_session_rename_refuses_child_sessions() -> None:
+    """A sub-agent must not rename itself — its title is its address.
+
+    A child's ``(parent, title)`` pair is how ``sys_session_send``
+    continuations find it, so a self-rename would corrupt sibling
+    addressing. The dispatcher refuses before issuing any PATCH.
+    """
+    patch_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_child":
+            return httpx.Response(
+                200,
+                json={"id": "conv_child", "parent_session_id": "conv_parent"},
+            )
+        patch_requests.append(request)
+        return httpx.Response(200, json={"id": "conv_child", **json.loads(request.content)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_rename",
+            arguments=json.dumps({"title": "Debug auth timeout"}),
+            server_client=server_client,
+            conversation_id="conv_child",
+            agent_spec=AgentSpec(spec_version=1),
+        )
+
+    assert json.loads(output) == {
+        "renamed": False,
+        "title": None,
+        "reason": "not_top_level",
+    }
+    assert patch_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "info_payload",
+    [["unexpected"], {"id": "conv_current"}],
+    ids=["non-dict", "missing-parent-field"],
+)
+async def test_session_rename_fails_closed_on_unverifiable_session(
+    info_payload: object,
+) -> None:
+    """A snapshot that can't prove the session is top-level blocks the PATCH.
+
+    A malformed or version-skewed GET payload must not be read as "no
+    parent" — failing open here would let a child rename slip through and
+    corrupt its continuation address.
+    """
+    patch_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=info_payload)
+        patch_requests.append(request)
+        return httpx.Response(200, json={"id": "conv_current", **json.loads(request.content)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_rename",
+            arguments=json.dumps({"title": "Debug auth timeout"}),
+            server_client=server_client,
+            conversation_id="conv_current",
+            agent_spec=AgentSpec(spec_version=1),
+        )
+
+    assert "could not verify the session is top-level" in json.loads(output)["error"]
+    assert patch_requests == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("title", "expected_error"),
     [
-        ("x", "2-60 characters"),
-        ("  ", "2-60 characters"),
-        ("x" * 61, "2-60 characters"),
+        ("x", f"2-{_TITLE_MAX_CHARS} characters"),
+        ("  ", f"2-{_TITLE_MAX_CHARS} characters"),
+        ("x" * (_TITLE_MAX_CHARS + 1), f"2-{_TITLE_MAX_CHARS} characters"),
         ("Debug auth\ntimeout", "single line"),
     ],
 )
@@ -96,6 +194,32 @@ async def test_session_rename_rejects_invalid_titles_before_request(
 
 
 @pytest.mark.asyncio
+async def test_session_rename_accepts_titles_up_to_the_generated_cap() -> None:
+    """The dispatcher enforces exactly the cap the tool schema advertises."""
+    title = "T" * _TITLE_MAX_CHARS
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        probe = _top_level_session_handler(request)
+        if probe is not None:
+            return probe
+        return httpx.Response(200, json={"id": "conv_current", **json.loads(request.content)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_rename",
+            arguments=json.dumps({"title": title}),
+            server_client=server_client,
+            conversation_id="conv_current",
+            agent_spec=AgentSpec(spec_version=1),
+        )
+
+    assert json.loads(output) == {"renamed": True, "title": title, "reason": None}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("response", "expected_error"),
     [
@@ -114,8 +238,14 @@ async def test_session_rename_server_failures_are_tool_results(
 ) -> None:
     """Rename metadata failures never escape into the active session turn."""
 
+    def handler(request: httpx.Request) -> httpx.Response:
+        probe = _top_level_session_handler(request)
+        if probe is not None:
+            return probe
+        return response
+
     async with httpx.AsyncClient(
-        transport=httpx.MockTransport(lambda _request: response),
+        transport=httpx.MockTransport(handler),
         base_url="http://server",
     ) as server_client:
         output = await execute_tool(

--- a/tests/runner/test_session_rename_dispatch.py
+++ b/tests/runner/test_session_rename_dispatch.py
@@ -123,8 +123,13 @@ async def test_session_rename_refuses_child_sessions() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "info_payload",
-    [["unexpected"], {"id": "conv_current"}],
-    ids=["non-dict", "missing-parent-field"],
+    [
+        ["unexpected"],
+        {"id": "conv_current"},
+        {"id": "conv_current", "parent_session_id": ""},
+        {"id": "conv_current", "parent_session_id": 0},
+    ],
+    ids=["non-dict", "missing-parent-field", "empty-string-parent", "non-string-parent"],
 )
 async def test_session_rename_fails_closed_on_unverifiable_session(
     info_payload: object,


### PR DESCRIPTION
## Related issue

Closes #4256

Related: #4061 also makes agent-driven renames repeatable, but as part of a much broader change covering title provenance, title-length limits, Claude sub-agent labels, and UI rendering. This PR intentionally follows the narrower fix proposed in #4256: keep `/auto-title` seed-gated and route the explicit rename tool through the existing session PATCH API.

## Summary

- Route `sys_session_rename` through the normal `PATCH /v1/sessions/{id}` update path instead of the seed-gated `/auto-title` endpoint.
- Keep the automatic title endpoint unchanged, so background title generation still uses its compare-and-swap guard and does not overwrite an explicit title.
- Preserve the tool's compact result shape while validating title length, single-line input, and malformed server responses locally.
- Update the tool description so agents are no longer told that a normal rename is discarded after the title changes.

**ELI5:** the tool was using a one-time "replace the placeholder" operation even after the placeholder had already been replaced. It now uses the same regular rename operation as the web UI, so a session can be renamed again as the work changes.

```text
Before: sys_session_rename ──> /auto-title ──> seed no longer matches ──> title_changed

After:  background titler ───> /auto-title ──> guarded first title
        sys_session_rename ──> PATCH /sessions/{id} ──> repeatable rename
```

## Test Plan

- `uv sync --frozen --extra all --extra dev`
- `.venv/bin/pre-commit run`
- Ran 26 focused tests covering:
  - repeatable dispatcher calls and response compatibility;
  - title validation and transport/server failures;
  - the general session PATCH route and edit permissions;
  - the existing seed-gated automatic-title behavior;
  - Claude/Codex bridge registration and tool exposure.
- Started an isolated local server from this branch on port `6877` and invoked the real dispatcher twice against one session. Both calls returned `renamed: true`, and the second title was persisted by `GET /v1/sessions/{id}`.

## Demo

Live UI validation against this PR branch: the sidebar starts with the existing
generated title, then updates after the first and second `sys_session_rename` calls.

![Omnigent sidebar title changing after two sys_session_rename calls](https://raw.githubusercontent.com/Guntas07/omnigent/pr-demo-assets/issue-4256/repeatable-session-rename-ui.gif)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the current branch and an isolated SQLite data directory. A disposable session was created with an existing generated title, renamed twice through `sys_session_rename`, and read back from the server after the second rename. The existing integration suite verifies that `/auto-title` remains seed-gated and that `PATCH /v1/sessions/{id}` retains its `LEVEL_EDIT` permission requirement.

## Changelog

Session rename tools can update a session title repeatedly instead of failing after automatic title generation.
