### PR TITLE
fix(runner): run git-status filesystem queries off the event loop

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7260,14 +7260,22 @@ def create_runner_app(
         session_id: str,
         environment_id: str,  # noqa: ARG001
     ) -> JSONResponse:
+        import asyncio as _asyncio
+
         from omnigent.runtime.filesystem_registry import GitStatusUnavailable
 
         await _require_os_env(session_id)
         await _ensure_session_registered(session_id)
         session_registry = await _resolve_session_fs_registry(session_id)
         try:
+            # ``list_changed_files`` shells out to ``git status`` synchronously,
+            # which on a large repo (cold untracked cache) can take seconds.
+            # Offload to a thread so it never blocks the event loop — a blocked
+            # loop can't answer the server's runner-stream relay probe and the
+            # session's first turn 503s with runner_unavailable.
             raw_changes = (
-                session_registry.list_changed_files(
+                await _asyncio.to_thread(
+                    session_registry.list_changed_files,
                     session_id,
                     limit=10_000,
                 )
@@ -7336,11 +7344,17 @@ def create_runner_app(
                 },
             )
 
+        import asyncio as _asyncio
+
         from omnigent.runtime.filesystem_registry import GitStatusUnavailable
 
         try:
+            # Offloaded like list_filesystem_changes: get_changed_file shells out
+            # to git (status + show) synchronously, so keep it off the loop.
             record = (
-                session_registry.get_changed_file(session_id, relative_path)
+                await _asyncio.to_thread(
+                    session_registry.get_changed_file, session_id, relative_path
+                )
                 if session_registry is not None
                 else None
             )
@@ -7363,8 +7377,6 @@ def create_runner_app(
                 },
             )
         is_deleted = record.get("status") == "deleted"
-
-        import asyncio as _asyncio
 
         before: str | None = (
             await _asyncio.to_thread(session_registry.get_baseline, relative_path)


### PR DESCRIPTION
## Related issue

<!-- No tracked issue; a latent runner-side bug found while testing host+UI sessions against a large monorepo workspace. -->

## Summary

The runner's filesystem-changes routes shell out to `git` **synchronously, inline on the asyncio event loop**:

- `list_filesystem_changes` (the `?view=changed` file panel) → `list_changed_files` → `git status --porcelain --untracked-files=all`
- `read_environment_file_diff` → `get_changed_file` → `git show` / `git diff`

On a large repository a cold `git status` takes several seconds (a ~1.2M-file monorepo measures **~6.4s** here, steady, even with the untracked cache enabled). While that blocking subprocess runs, the runner's event loop can't service anything else — including the server's runner-stream **relay subscription probe**. When a session's first turn (or the changed-files panel) lands inside that window, the relay misses its readiness budget and the turn fails with a **503 `runner_unavailable`** ("The runner didn't come online in time").

It presents as *flaky* because it only fires when the blocking git call overlaps the readiness window: a plain chat session whose init path never calls `/changes` slips through, while opening the UI on `?view=changed` during runner startup reproduces it reliably.

**Fix:** offload both git-backed calls with `asyncio.to_thread`, matching the sibling `get_baseline` call already in the same route. The git walk now runs on a worker thread and the event loop stays responsive regardless of repo size or cache warmth. Behavior is unchanged — same results, same `GitStatusUnavailable` handling; the redundant per-call `asyncio` import in the diff route is folded into one.

## Test Plan

- `pytest tests/runner/test_environment_filesystem.py` — 61 passed, including `test_worktree_session_uses_session_workspace_for_changes` (the `/changes` route) and the diff-route cases.
- `ruff check` / `ruff format --check` clean.
- Manual: reproduced the 503 on a host+UI session against a ~1.2M-file monorepo with `?view=changed` (git status ~6.4s blocking the loop); with the fix the first turn returns 202 and the session comes up, while `git status` latency is unchanged.

## Demo

N/A — no user-visible UI change (removes a spurious failure).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The change is a behavior-preserving offload (sync call → `await asyncio.to_thread(same call)`), so the existing `tests/runner/test_environment_filesystem.py` route tests exercise it unchanged. The failure it fixes is a timing/event-loop-starvation interaction with the server's relay readiness budget, which isn't reachable from the runner's own unit tests; it was verified manually against a large-repo workspace as described above.

## Changelog

Fix a spurious "runner didn't come online in time" failure when starting a session in a large git workspace, by running `git status` off the runner's event loop.
