### PR TITLE
fix(chat): create fresh sessions by agent_id on a remote-URL target

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -28,6 +28,7 @@ import httpx
 import yaml
 from omnigent_client import (
     OmnigentClient,
+    RegisteredAgent,
     SessionToolCallInfo,
     ToolCallable,
     ToolCallInfo,
@@ -2086,6 +2087,19 @@ async def _query_sessions_once(
     """
     from omnigent_client import SessionsChat
 
+    # Remote target: no local bundle means no local runner either, so
+    # adopt one the server already has online before the dispatch
+    # precondition is checked.
+    agent: RegisteredAgent | None = None
+    if runner_id is None and session_bundle is None:
+        agent = await client.sessions.resolve_agent(agent_name)
+        runner_id = await client.sessions.resolve_online_runner(harness=agent.harness)
+        if runner_id is None:
+            raise RuntimeError(
+                "This server has no online runner to run the turn. Start one against "
+                "it with `omnigent host --server <url>` (or run the agent locally "
+                "with `omnigent run <agent.yaml>`), then retry."
+            )
     if runner_id is None:
         raise RuntimeError(
             "Sessions API headless prompt requires a registered runner id. "
@@ -2103,9 +2117,9 @@ async def _query_sessions_once(
         if session_bundle is None:
             # Remote target: the agent is registered server-side, so
             # bind by id rather than uploading a bundle we don't have.
-            agent_id = await client.sessions.resolve_agent_id(agent_name)
+            agent = agent or await client.sessions.resolve_agent(agent_name)
             created = await client.sessions.create_from_agent_id(
-                agent_id,
+                agent.id,
                 workspace=os.getcwd(),
             )
         else:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3812,35 +3812,29 @@ def _run_one_shot(
             headers=_server_headers(runner_id=runner_id),
             auth=_server_auth(server_url=base_url),
         ) as client:
-            if session_bundle is not None:
-                text = await _query_sessions_once(
-                    client=client,
-                    agent_name=agent_name,
-                    tool_handler=tool_handler,
-                    prompt=prompt,
-                    session_bundle=session_bundle,
-                    session_bundle_filename=session_bundle_filename,
-                    runner_id=runner_id,
-                    resume_conversation_id=resume_conversation_id,
-                    on_session_ready=(
-                        lambda session_id: open_conversation_link_if_enabled(
-                            base_url=base_url,
-                            conversation_id=session_id,
-                            enabled=auto_open_conversation,
-                            warn=lambda message: click.echo(message, err=True),
-                        )
-                    ),
-                )
-                if text:
-                    click.echo(text)
-                return
-            result = await client.query(
-                model=agent_name,
-                input=prompt,
+            # Both a local bundle and a remote registered agent go through
+            # the sessions API; _query_sessions_once picks the create route
+            # from whether a bundle was supplied.
+            text = await _query_sessions_once(
+                client=client,
+                agent_name=agent_name,
                 tool_handler=tool_handler,
+                prompt=prompt,
+                session_bundle=session_bundle,
+                session_bundle_filename=session_bundle_filename,
+                runner_id=runner_id,
+                resume_conversation_id=resume_conversation_id,
+                on_session_ready=(
+                    lambda session_id: open_conversation_link_if_enabled(
+                        base_url=base_url,
+                        conversation_id=session_id,
+                        enabled=auto_open_conversation,
+                        warn=lambda message: click.echo(message, err=True),
+                    )
+                ),
             )
-            if result.text:
-                click.echo(result.text)
+            if text:
+                click.echo(text)
 
     try:
         asyncio.run(_main())

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -36,14 +36,6 @@ from omnigent_client import (
 from omnigent_client import (
     OmnigentError as ClientOmnigentError,
 )
-from omnigent_client._events import (
-    ErrorEvent,
-    ResponseCancelled,
-    ResponseCompleted,
-    ResponseFailed,
-    ResponseIncomplete,
-    TextDelta,
-)
 from rich.console import Console
 
 from omnigent._wrapper_labels import (
@@ -2029,46 +2021,20 @@ def _run_headless_prompt(
             headers=_server_headers(runner_id=runner_id),
             auth=_server_auth(server_url=base_url),
         ) as client:
-            if session_bundle is not None:
-                result_text = await _query_sessions_once(
-                    client=client,
-                    agent_name=agent_name,
-                    tool_handler=tool_handler,
-                    prompt=prompt,
-                    session_bundle=session_bundle,
-                    session_bundle_filename=session_bundle_filename,
-                    runner_id=runner_id,
-                )
-                if result_text:
-                    print(result_text)
-                return
-
-            session = client.session(model=agent_name, tool_handler=tool_handler)
-            chunks: list[str] = []
-            terminal_text: str | None = None
-            error_text: str | None = None
-            async for event in session.send(prompt):
-                if isinstance(event, TextDelta):
-                    chunks.append(event.delta)
-                elif isinstance(event, ErrorEvent):
-                    error_text = event.error.message or event.error.code
-                elif isinstance(
-                    event,
-                    ResponseCompleted | ResponseFailed | ResponseIncomplete | ResponseCancelled,
-                ):
-                    terminal_text = _response_output_text(event.response.output)
-
-            streamed_text = "".join(chunks)
-            # Prefer the real error from a response.error SSE event over the
-            # generic terminal-event message ("Failed to retrieve final response")
-            # that _build_terminal_event substitutes when it can't read the task.
-            if streamed_text:
-                print(streamed_text)
-            elif error_text:
-                print(f"Error: {error_text}", file=sys.stderr)
-                raise SystemExit(1)
-            elif terminal_text:
-                print(terminal_text)
+            # Both a local bundle and a remote registered agent go through
+            # the sessions API; _query_sessions_once picks the create route
+            # from whether a bundle was supplied.
+            result_text = await _query_sessions_once(
+                client=client,
+                agent_name=agent_name,
+                tool_handler=tool_handler,
+                prompt=prompt,
+                session_bundle=session_bundle,
+                session_bundle_filename=session_bundle_filename,
+                runner_id=runner_id,
+            )
+            if result_text:
+                print(result_text)
 
     try:
         asyncio.run(_main())
@@ -2087,7 +2053,7 @@ async def _query_sessions_once(
     agent_name: str,
     tool_handler: ToolHandler | None,
     prompt: str,
-    session_bundle: bytes,
+    session_bundle: bytes | None,
     session_bundle_filename: str,
     runner_id: str | None,
     resume_conversation_id: str | None = None,
@@ -2098,10 +2064,13 @@ async def _query_sessions_once(
 
     :param client: Connected SDK client.
     :param agent_name: Agent display name, e.g. ``"hello_world"``.
-        Used only for tool-handler validation messages.
+        Used for tool-handler validation messages, and to resolve the
+        registered agent when no bundle is supplied.
     :param tool_handler: Optional client-side tool handler.
     :param prompt: User prompt for the single turn.
-    :param session_bundle: Gzipped agent tarball bytes.
+    :param session_bundle: Gzipped agent tarball bytes, or ``None``
+        when the agent is already registered server-side (remote-URL
+        target) and the session should bind by ``agent_id`` instead.
     :param session_bundle_filename: Multipart filename, e.g.
         ``"agent.tar.gz"``.
     :param runner_id: Registered runner id, e.g.
@@ -2128,14 +2097,23 @@ async def _query_sessions_once(
         bound = await client.sessions.get(resume_conversation_id)
         await client.sessions.bind_runner(resume_conversation_id, runner_id=runner_id)
     else:
-        created = await client.sessions.create(
-            session_bundle,
-            filename=session_bundle_filename,
-            # Record CLI cwd so the Web UI can show "ran locally
-            # in <workspace>" for one-shot sessions. CLI sessions
-            # don't set host_id; this column is purely informational.
-            workspace=os.getcwd(),
-        )
+        # Record CLI cwd so the Web UI can show "ran locally in
+        # <workspace>" for one-shot sessions. CLI sessions don't set
+        # host_id; this column is purely informational.
+        if session_bundle is None:
+            # Remote target: the agent is registered server-side, so
+            # bind by id rather than uploading a bundle we don't have.
+            agent_id = await client.sessions.resolve_agent_id(agent_name)
+            created = await client.sessions.create_from_agent_id(
+                agent_id,
+                workspace=os.getcwd(),
+            )
+        else:
+            created = await client.sessions.create(
+                session_bundle,
+                filename=session_bundle_filename,
+                workspace=os.getcwd(),
+            )
         bound = await client.sessions.bind_runner(created.id, runner_id=runner_id)
     if on_session_ready is not None:
         on_session_ready(bound.id)

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2093,7 +2093,10 @@ async def _query_sessions_once(
     agent: RegisteredAgent | None = None
     if runner_id is None and session_bundle is None:
         agent = await client.sessions.resolve_agent(agent_name)
-        runner_id = await client.sessions.resolve_online_runner(harness=agent.harness)
+        runner_id = await client.sessions.resolve_online_runner(
+            harness=agent.harness,
+            canonicalize=lambda name: canonicalize_harness(name) or name,
+        )
         if runner_id is None:
             raise RuntimeError(
                 "This server has no online runner to run the turn. Start one against "

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -26,6 +26,7 @@ from omnigent_client import (
     OmnigentClient,
     OmnigentError,
     ReasoningBlock,
+    RegisteredAgent,
     ResponseEndBlock,
     ResponseStartBlock,
     Session,
@@ -1732,11 +1733,20 @@ class _SessionsChatReplAdapter:
                 file=sys.stderr,
                 flush=True,
             )
-        agent = await self._client.sessions.resolve_agent(self._agent_name)
-        agent_id = self._agent_id or agent.id
+        # Skip the name lookup only when nothing needs it: we already know
+        # the id, and a bound runner means we don't need the harness either.
+        agent: RegisteredAgent | None = None
+        if self._agent_id is None or self._runner_id is None:
+            agent = await self._client.sessions.resolve_agent(self._agent_name)
+        agent_id = self._agent_id or (agent.id if agent is not None else None)
+        if agent_id is None:
+            raise RuntimeError(f"Could not resolve an agent id for {self._agent_name!r}")
         if self._runner_id is None:
+            from omnigent.harness_aliases import canonicalize_harness
+
             self._runner_id = await self._client.sessions.resolve_online_runner(
-                harness=agent.harness
+                harness=agent.harness if agent is not None else None,
+                canonicalize=lambda name: canonicalize_harness(name) or name,
             )
             if pending_debug:
                 print(

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -1684,85 +1684,11 @@ class _SessionsChatReplAdapter:
         async with self._ensure_session_lock:
             if self._session_id is not None and self._stream_task is not None:
                 return self._session_id
-            if self._session_id is None and self._session_bundle is None:
-                # Connected to a remote server, so there is no local bundle to
-                # upload: the agent is already registered there. Bind the new
-                # session to it by id through the JSON create route.
-                if _dbg:
-                    print(
-                        "[sessions-adapter] POST /v1/sessions json agent_id",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                agent_id = self._agent_id or await self._client.sessions.resolve_agent_id(
-                    self._agent_name
-                )
-                session = await self._client.sessions.create_from_agent_id(
-                    agent_id,
-                    reasoning_effort=self._reasoning_effort,
-                    workspace=os.getcwd(),
-                )
-                self._session_id = session.id
-                self._hydrate_from_session_snapshot(session)
-                if _dbg:
-                    print(
-                        f"[sessions-adapter] session created id={self._session_id!r}",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-            elif self._session_id is None:
-                if _dbg:
-                    print(
-                        "[sessions-adapter] POST /v1/sessions multipart bundle",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                # Snapshot pre-create /model pick before hydration
-                # clobbers it; PATCHed below since create() has no
-                # model_override metadata field.
-                pending_model_override = self._model_override
-                session = await self._client.sessions.create(
-                    self._session_bundle,
-                    filename=self._session_bundle_filename,
-                    reasoning_effort=self._reasoning_effort,
-                    # Record the user's terminal cwd so the Web UI
-                    # can show "running locally in <workspace>" for
-                    # CLI sessions. Doesn't drive any behavior —
-                    # CLI sessions don't bind to a host_id, so the
-                    # ck_conversations_workspace_required_for_host
-                    # constraint isn't active.
-                    workspace=os.getcwd(),
-                )
-                self._session_id = session.id
-                self._hydrate_from_session_snapshot(session)
-                if pending_model_override is not None and session.model_override is None:
-                    # PATCH the pre-session ``/model`` pick so the
-                    # first event picks it up via conv.model_override.
-                    # ``silent`` skips the tmux ``/model`` forward —
-                    # the user already typed the command locally; we
-                    # don't want a second copy injected into the pane.
-                    try:
-                        patched = await self._client.sessions.set_model_override(
-                            self._session_id,
-                            model_override=pending_model_override,
-                            silent=True,
-                        )
-                        self._model_override = patched.model_override
-                    except Exception:  # noqa: BLE001 — REPL boundary; log and clear
-                        _log.warning(
-                            "Failed to apply pending /model=%r to session %s; "
-                            "clearing local cache.",
-                            pending_model_override,
-                            self._session_id,
-                            exc_info=True,
-                        )
-                        self._model_override = None
-                if _dbg:
-                    print(
-                        f"[sessions-adapter] session created id={self._session_id!r}",
-                        file=sys.stderr,
-                        flush=True,
-                    )
+            if self._session_id is None:
+                if self._session_bundle is not None:
+                    await self._create_session_from_bundle(pending_debug=_dbg)
+                else:
+                    await self._create_session_from_registered_agent(pending_debug=_dbg)
             else:
                 if _dbg:
                     print(
@@ -1784,7 +1710,121 @@ class _SessionsChatReplAdapter:
                     name=f"sessions-adapter-recover-{self._session_id}",
                 )
             self._notify_session_start_once()
+            assert self._session_id is not None
             return self._session_id
+
+    async def _create_session_from_registered_agent(self, *, pending_debug: bool) -> None:
+        """
+        Create a session bound to an agent already registered server-side.
+
+        The remote-URL path: there is no local bundle to upload, so
+        resolve the picked name to its id and use the JSON create route.
+
+        :param pending_debug: Whether to emit adapter debug lines.
+        :returns: None.
+        """
+        if pending_debug:
+            print(
+                "[sessions-adapter] POST /v1/sessions json agent_id",
+                file=sys.stderr,
+                flush=True,
+            )
+        agent_id = self._agent_id or await self._client.sessions.resolve_agent_id(self._agent_name)
+        # Snapshot the pre-create /model pick before hydration clobbers
+        # it; applied after create since create has no such field.
+        pending_model_override = self._model_override
+        session = await self._client.sessions.create_from_agent_id(
+            agent_id,
+            reasoning_effort=self._reasoning_effort,
+            workspace=os.getcwd(),
+        )
+        self._session_id = session.id
+        self._hydrate_from_session_snapshot(session)
+        await self._apply_pending_model_override(pending_model_override, session)
+        if pending_debug:
+            print(
+                f"[sessions-adapter] session created id={self._session_id!r}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    async def _create_session_from_bundle(self, *, pending_debug: bool) -> None:
+        """
+        Create a session by uploading the local agent bundle.
+
+        :param pending_debug: Whether to emit adapter debug lines.
+        :returns: None.
+        :raises RuntimeError: If called with no bundle available.
+        """
+        if self._session_bundle is None:
+            raise RuntimeError("Cannot create a bundled session without a bundle")
+        if pending_debug:
+            print(
+                "[sessions-adapter] POST /v1/sessions multipart bundle",
+                file=sys.stderr,
+                flush=True,
+            )
+        # Snapshot the pre-create /model pick before hydration clobbers
+        # it; applied after create since create has no such field.
+        pending_model_override = self._model_override
+        session = await self._client.sessions.create(
+            self._session_bundle,
+            filename=self._session_bundle_filename,
+            reasoning_effort=self._reasoning_effort,
+            # Record the user's terminal cwd so the Web UI can show
+            # "running locally in <workspace>" for CLI sessions. Doesn't
+            # drive any behavior — CLI sessions don't bind to a host_id,
+            # so the ck_conversations_workspace_required_for_host
+            # constraint isn't active.
+            workspace=os.getcwd(),
+        )
+        self._session_id = session.id
+        self._hydrate_from_session_snapshot(session)
+        await self._apply_pending_model_override(pending_model_override, session)
+        if pending_debug:
+            print(
+                f"[sessions-adapter] session created id={self._session_id!r}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    async def _apply_pending_model_override(
+        self, pending_model_override: str | None, session: _SessionSnapshot
+    ) -> None:
+        """
+        Apply a pre-session ``/model`` pick to a freshly created session.
+
+        Neither create route carries a ``model_override`` field, so a
+        ``/model`` typed before the first turn has to be PATCHed after
+        create for the first event to pick it up via
+        ``conv.model_override``. ``silent`` skips the tmux ``/model``
+        forward: the user already typed the command locally and we don't
+        want a second copy injected into the pane.
+
+        :param pending_model_override: The pick captured before create,
+            e.g. ``"opus"``. ``None`` is a no-op.
+        :param session: The created session snapshot.
+        :returns: None.
+        """
+        if pending_model_override is None or session.model_override is not None:
+            return
+        if self._session_id is None:
+            return
+        try:
+            patched = await self._client.sessions.set_model_override(
+                self._session_id,
+                model_override=pending_model_override,
+                silent=True,
+            )
+            self._model_override = patched.model_override
+        except Exception:  # noqa: BLE001 — REPL boundary; log and clear
+            _log.warning(
+                "Failed to apply pending /model=%r to session %s; clearing local cache.",
+                pending_model_override,
+                self._session_id,
+                exc_info=True,
+            )
+            self._model_override = None
 
     def _notify_session_start_once(self) -> None:
         """

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -1719,6 +1719,9 @@ class _SessionsChatReplAdapter:
 
         The remote-URL path: there is no local bundle to upload, so
         resolve the picked name to its id and use the JSON create route.
+        A remote client also has no runner of its own, so adopt one the
+        server already has online — otherwise the first turn fails the
+        runner-binding precondition.
 
         :param pending_debug: Whether to emit adapter debug lines.
         :returns: None.
@@ -1729,7 +1732,18 @@ class _SessionsChatReplAdapter:
                 file=sys.stderr,
                 flush=True,
             )
-        agent_id = self._agent_id or await self._client.sessions.resolve_agent_id(self._agent_name)
+        agent = await self._client.sessions.resolve_agent(self._agent_name)
+        agent_id = self._agent_id or agent.id
+        if self._runner_id is None:
+            self._runner_id = await self._client.sessions.resolve_online_runner(
+                harness=agent.harness
+            )
+            if pending_debug:
+                print(
+                    f"[sessions-adapter] adopted server runner {self._runner_id!r}",
+                    file=sys.stderr,
+                    flush=True,
+                )
         # Snapshot the pre-create /model pick before hydration clobbers
         # it; applied after create since create has no such field.
         pending_model_override = self._model_override
@@ -1861,6 +1875,14 @@ class _SessionsChatReplAdapter:
             if self._session_id is None:
                 raise RuntimeError("Cannot bind runner before a session exists")
             if self._runner_id is None:
+                if self._session_bundle is None:
+                    # Remote target: we tried to adopt one of the server's
+                    # online runners at create time and found none.
+                    raise RuntimeError(
+                        "This server has no online runner to run the turn. Start one "
+                        "against it with `omnigent host --server <url>` (or run the "
+                        "agent locally with `omnigent run <agent.yaml>`), then retry."
+                    )
                 raise RuntimeError(
                     "Sessions API dispatch requires a registered runner id. "
                     "Start through `omnigent run <agent>` or pass --server so the CLI "

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -1684,13 +1684,33 @@ class _SessionsChatReplAdapter:
         async with self._ensure_session_lock:
             if self._session_id is not None and self._stream_task is not None:
                 return self._session_id
-            if self._session_id is None:
-                if self._session_bundle is None:
-                    raise RuntimeError(
-                        "Sessions API fresh session creation requires a local agent bundle. "
-                        "Start the REPL from `omnigent run <agent.yaml>` so the CLI can "
-                        "upload the bundle through POST /v1/sessions."
+            if self._session_id is None and self._session_bundle is None:
+                # Connected to a remote server, so there is no local bundle to
+                # upload: the agent is already registered there. Bind the new
+                # session to it by id through the JSON create route.
+                if _dbg:
+                    print(
+                        "[sessions-adapter] POST /v1/sessions json agent_id",
+                        file=sys.stderr,
+                        flush=True,
                     )
+                agent_id = self._agent_id or await self._client.sessions.resolve_agent_id(
+                    self._agent_name
+                )
+                session = await self._client.sessions.create_from_agent_id(
+                    agent_id,
+                    reasoning_effort=self._reasoning_effort,
+                    workspace=os.getcwd(),
+                )
+                self._session_id = session.id
+                self._hydrate_from_session_snapshot(session)
+                if _dbg:
+                    print(
+                        f"[sessions-adapter] session created id={self._session_id!r}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            elif self._session_id is None:
                 if _dbg:
                     print(
                         "[sessions-adapter] POST /v1/sessions multipart bundle",

--- a/sdks/python-client/omnigent_client/__init__.py
+++ b/sdks/python-client/omnigent_client/__init__.py
@@ -57,7 +57,7 @@ from ._events import MCP_ELICITATION_METHOD, ElicitationRequest
 from ._query import QueryResult, QueryStream
 from ._server import LocalServer
 from ._session import Session
-from ._sessions import SessionsNamespace
+from ._sessions import RegisteredAgent, SessionsNamespace
 from ._sessions_chat import SessionsChat, SessionToolCallInfo, ToolCallable
 from ._stream import BlockStream, format_tool_args_brief
 from ._tool_handler import (
@@ -97,6 +97,7 @@ __all__ = [
     "ReasoningBlock",
     "ReasoningChunk",
     "ReasoningStartBlock",
+    "RegisteredAgent",
     "ResponseEndBlock",
     "ResponseStartBlock",
     "RetryBlock",

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -401,6 +401,82 @@ class SessionsNamespace:
         session_id = str(created["session_id"])
         return await self.get(session_id)
 
+    async def create_from_agent_id(
+        self,
+        agent_id: str,
+        *,
+        title: str | None = None,
+        labels: dict[str, str] | None = None,
+        reasoning_effort: str | None = None,
+        workspace: str | None = None,
+    ) -> Session:
+        """
+        Create a new session bound to an already-registered agent.
+
+        Calls JSON ``POST /v1/sessions`` with an ``agent_id`` body. This
+        is the path for a client with no local bundle to upload — the
+        agent is already registered on the server, as when connecting to
+        a remote URL. Unlike :meth:`create`, the JSON route returns the
+        full session snapshot, so no follow-up ``GET`` is needed.
+
+        :param agent_id: Durable identifier of a registered agent, e.g.
+            ``"ag_abc123"``.
+        :param title: Optional human-readable title for the session,
+            e.g. ``"debugging auth flow"``.
+        :param labels: Initial guardrails labels to set. ``None``
+            starts with no labels.
+        :param reasoning_effort: Optional per-session reasoning
+            effort, e.g. ``"high"``. ``None`` uses the agent default.
+        :param workspace: Optional absolute starting cwd to record on
+            the session, e.g. ``"/Users/corey/projects/myapp"``.
+        :returns: The newly created :class:`Session` snapshot.
+        :raises OmnigentError: If the server returns a non-2xx
+            status.
+        """
+        body: dict[str, Any] = {"agent_id": agent_id}
+        if title is not None:
+            body["title"] = title
+        if labels is not None:
+            body["labels"] = labels
+        if reasoning_effort is not None:
+            body["reasoning_effort"] = reasoning_effort
+        if workspace is not None:
+            body["workspace"] = workspace
+        resp = await self._http.post(f"{self._base}/v1/sessions", json=body)
+        raise_for_status(resp.status_code, response_body(resp))
+        created = require_json_object(resp, "POST /v1/sessions")
+        return Session.from_dict(created)
+
+    async def resolve_agent_id(self, agent_name: str) -> str:
+        """
+        Resolve a registered agent's durable id from its display name.
+
+        Used by clients that only know the name the user picked — the
+        remote-URL chat picker lists names, but session creation binds
+        by id.
+
+        :param agent_name: Agent display name, e.g. ``"hello_world"``.
+        :returns: The matching agent's durable id.
+        :raises OmnigentError: If the listing returns a non-2xx status.
+        :raises LookupError: If no registered agent has that name.
+        """
+        resp = await self._http.get(f"{self._base}/v1/agents", params={"limit": 100})
+        raise_for_status(resp.status_code, response_body(resp))
+        listing = require_json_object(resp, "GET /v1/agents")
+        data = listing.get("data", [])
+        names: list[str] = []
+        for item in data if isinstance(data, list) else []:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if name == agent_name:
+                return str(item["id"])
+            if isinstance(name, str):
+                names.append(name)
+        raise LookupError(
+            f"No agent named {agent_name!r} is registered on this server. Available: {names}"
+        )
+
     async def list(
         self,
         *,

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -453,26 +453,42 @@ class SessionsNamespace:
 
         Used by clients that only know the name the user picked — the
         remote-URL chat picker lists names, but session creation binds
-        by id.
+        by id. ``GET /v1/agents`` lists only server-registered
+        (``session_id IS NULL``) agents, so a session-scoped agent is
+        not resolvable this way and raises ``LookupError``.
+
+        Follows the listing cursor, so an agent past the first page
+        still resolves.
 
         :param agent_name: Agent display name, e.g. ``"hello_world"``.
         :returns: The matching agent's durable id.
         :raises OmnigentError: If the listing returns a non-2xx status.
         :raises LookupError: If no registered agent has that name.
         """
-        resp = await self._http.get(f"{self._base}/v1/agents", params={"limit": 100})
-        raise_for_status(resp.status_code, response_body(resp))
-        listing = require_json_object(resp, "GET /v1/agents")
-        data = listing.get("data", [])
         names: list[str] = []
-        for item in data if isinstance(data, list) else []:
-            if not isinstance(item, dict):
-                continue
-            name = item.get("name")
-            if name == agent_name:
-                return str(item["id"])
-            if isinstance(name, str):
-                names.append(name)
+        after: str | None = None
+        while True:
+            params: dict[str, str | int] = {"limit": 1000}
+            if after is not None:
+                params["after"] = after
+            resp = await self._http.get(f"{self._base}/v1/agents", params=params)
+            raise_for_status(resp.status_code, response_body(resp))
+            listing = require_json_object(resp, "GET /v1/agents")
+            data = listing.get("data", [])
+            for item in data if isinstance(data, list) else []:
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                if name == agent_name:
+                    return str(item["id"])
+                if isinstance(name, str):
+                    names.append(name)
+            if not listing.get("has_more"):
+                break
+            last_id = listing.get("last_id")
+            if not last_id:
+                break
+            after = str(last_id)
         raise LookupError(
             f"No agent named {agent_name!r} is registered on this server. Available: {names}"
         )

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import builtins
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -519,21 +519,12 @@ class SessionsNamespace:
             f"No agent named {agent_name!r} is registered on this server. Available: {available}"
         )
 
-    async def resolve_agent_id(self, agent_name: str) -> str:
-        """
-        Resolve a registered agent's durable id from its display name.
-
-        Thin wrapper over :meth:`resolve_agent` for callers that only
-        need the id.
-
-        :param agent_name: Agent display name, e.g. ``"hello_world"``.
-        :returns: The matching agent's durable id.
-        :raises OmnigentError: If the listing returns a non-2xx status.
-        :raises LookupError: If no registered agent has that name.
-        """
-        return (await self.resolve_agent(agent_name)).id
-
-    async def resolve_online_runner(self, *, harness: str | None = None) -> str | None:
+    async def resolve_online_runner(
+        self,
+        *,
+        harness: str | None = None,
+        canonicalize: Callable[[str], str] | None = None,
+    ) -> str | None:
         """
         Find an online runner on the server that can drive *harness*.
 
@@ -545,6 +536,11 @@ class SessionsNamespace:
 
         :param harness: Harness the session needs, e.g.
             ``"openai-agents"``. ``None`` accepts any online runner.
+        :param canonicalize: Optional harness-name normalizer applied to
+            both sides of the comparison, so a spec spelling that is an
+            alias (``"claude"``) still matches a runner advertising the
+            canonical name (``"claude-sdk"``). Mirrors the server's own
+            matching. ``None`` compares the names as given.
         :returns: A matching runner id, or ``None`` when the server has
             no online runner that advertises *harness*.
         :raises OmnigentError: If the listing returns a non-2xx status.
@@ -553,6 +549,10 @@ class SessionsNamespace:
         raise_for_status(resp.status_code, response_body(resp))
         listing = require_json_object(resp, "GET /v1/runners")
         data = listing.get("data", [])
+        # Accept either spelling on either side, as the server does.
+        wanted = {harness} if harness is not None else set()
+        if harness is not None and canonicalize is not None:
+            wanted.add(canonicalize(harness))
         # Prefer a runner that advertises the harness; fall back to any
         # online runner that didn't report its harness list at all.
         unknown_harness: str | None = None
@@ -565,7 +565,13 @@ class SessionsNamespace:
             advertised = item.get("harnesses")
             if not isinstance(advertised, list):
                 unknown_harness = unknown_harness or runner_id
-            elif harness is None or harness in advertised:
+                continue
+            if not wanted:
+                return runner_id
+            names = {name for name in advertised if isinstance(name, str)}
+            if canonicalize is not None:
+                names |= {canonicalize(name) for name in names}
+            if wanted & names:
                 return runner_id
         return unknown_harness
 

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -314,6 +314,21 @@ class SessionListItem:
         )
 
 
+@dataclass(frozen=True)
+class RegisteredAgent:
+    """
+    A server-registered agent resolved by display name.
+
+    :param id: The agent's durable identifier, e.g. ``"ag_abc123"``.
+    :param harness: Harness the agent runs on, e.g.
+        ``"openai-agents"``. ``None`` when the server did not report
+        one.
+    """
+
+    id: str
+    harness: str | None = None
+
+
 class SessionsNamespace:
     """
     Client namespace for ``/v1/sessions`` endpoints.
@@ -447,9 +462,9 @@ class SessionsNamespace:
         created = require_json_object(resp, "POST /v1/sessions")
         return Session.from_dict(created)
 
-    async def resolve_agent_id(self, agent_name: str) -> str:
+    async def resolve_agent(self, agent_name: str) -> RegisteredAgent:
         """
-        Resolve a registered agent's durable id from its display name.
+        Resolve a registered agent's id and harness from its display name.
 
         Used by clients that only know the name the user picked — the
         remote-URL chat picker lists names, but session creation binds
@@ -461,11 +476,14 @@ class SessionsNamespace:
         still resolves.
 
         :param agent_name: Agent display name, e.g. ``"hello_world"``.
-        :returns: The matching agent's durable id.
+        :returns: The matching agent's id and advertised harness.
         :raises OmnigentError: If the listing returns a non-2xx status.
         :raises LookupError: If no registered agent has that name.
         """
+        # Cap the miss-path name list: a large deployment should not
+        # build thousands of names just to render one error message.
         names: list[str] = []
+        truncated = False
         after: str | None = None
         while True:
             params: dict[str, str | int] = {"limit": 1000}
@@ -480,18 +498,76 @@ class SessionsNamespace:
                     continue
                 name = item.get("name")
                 if name == agent_name:
-                    return str(item["id"])
+                    harness = item.get("harness")
+                    return RegisteredAgent(
+                        id=str(item["id"]),
+                        harness=str(harness) if isinstance(harness, str) else None,
+                    )
                 if isinstance(name, str):
-                    names.append(name)
+                    if len(names) < 50:
+                        names.append(name)
+                    else:
+                        truncated = True
             if not listing.get("has_more"):
                 break
             last_id = listing.get("last_id")
             if not last_id:
                 break
             after = str(last_id)
+        available = ", ".join(names) + (", …" if truncated else "")
         raise LookupError(
-            f"No agent named {agent_name!r} is registered on this server. Available: {names}"
+            f"No agent named {agent_name!r} is registered on this server. Available: {available}"
         )
+
+    async def resolve_agent_id(self, agent_name: str) -> str:
+        """
+        Resolve a registered agent's durable id from its display name.
+
+        Thin wrapper over :meth:`resolve_agent` for callers that only
+        need the id.
+
+        :param agent_name: Agent display name, e.g. ``"hello_world"``.
+        :returns: The matching agent's durable id.
+        :raises OmnigentError: If the listing returns a non-2xx status.
+        :raises LookupError: If no registered agent has that name.
+        """
+        return (await self.resolve_agent(agent_name)).id
+
+    async def resolve_online_runner(self, *, harness: str | None = None) -> str | None:
+        """
+        Find an online runner on the server that can drive *harness*.
+
+        A remote-URL client has no local runner of its own, but the
+        session still needs one bound before a turn can dispatch.
+        ``GET /v1/runners`` lists the online runners owned by the
+        requesting user along with the harnesses each advertises, so
+        the client can bind to one the server already has.
+
+        :param harness: Harness the session needs, e.g.
+            ``"openai-agents"``. ``None`` accepts any online runner.
+        :returns: A matching runner id, or ``None`` when the server has
+            no online runner that advertises *harness*.
+        :raises OmnigentError: If the listing returns a non-2xx status.
+        """
+        resp = await self._http.get(f"{self._base}/v1/runners")
+        raise_for_status(resp.status_code, response_body(resp))
+        listing = require_json_object(resp, "GET /v1/runners")
+        data = listing.get("data", [])
+        # Prefer a runner that advertises the harness; fall back to any
+        # online runner that didn't report its harness list at all.
+        unknown_harness: str | None = None
+        for item in data if isinstance(data, list) else []:
+            if not isinstance(item, dict) or not item.get("online"):
+                continue
+            runner_id = item.get("runner_id")
+            if not isinstance(runner_id, str) or not runner_id:
+                continue
+            advertised = item.get("harnesses")
+            if not isinstance(advertised, list):
+                unknown_harness = unknown_harness or runner_id
+            elif harness is None or harness in advertised:
+                return runner_id
+        return unknown_harness
 
     async def list(
         self,

--- a/tests/e2e/test_remote_url_chat_fresh_session_2437.py
+++ b/tests/e2e/test_remote_url_chat_fresh_session_2437.py
@@ -430,6 +430,61 @@ def test_no_online_runner_reports_actionable_error(
         asyncio.run(_drive())
 
 
-async def _no_runner(*, harness: str | None = None) -> str | None:
+async def _no_runner(
+    *, harness: str | None = None, canonicalize: object | None = None
+) -> str | None:
     """Stand in for runner discovery on a server with no online runner."""
     return None
+
+
+@pytest.mark.parametrize(
+    ("agent_harness", "advertised"),
+    [
+        ("claude", "claude-sdk"),  # agent reports an alias
+        ("claude-sdk", "claude"),  # runner advertises an alias
+    ],
+)
+def test_runner_adoption_matches_harness_aliases(agent_harness: str, advertised: str) -> None:
+    """Runner adoption accepts either spelling of a harness name.
+
+    The server canonicalizes harness names before matching a runner
+    (``_runner_supports_harness``), so the client must too: an agent whose spec
+    says ``claude`` has to match a runner advertising ``claude-sdk``, or a
+    compatible runner looks absent and the turn fails with "no online runner".
+    """
+    import json
+
+    from omnigent_client._sessions import SessionsNamespace
+
+    from omnigent.harness_aliases import canonicalize_harness
+
+    class _Resp:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        def __init__(self, harnesses: list[str]) -> None:
+            self.text = json.dumps(
+                {"data": [{"runner_id": "r1", "online": True, "harnesses": harnesses}]}
+            )
+
+        def json(self) -> object:
+            return json.loads(self.text)
+
+    class _Http:
+        def __init__(self, harnesses: list[str]) -> None:
+            self._harnesses = harnesses
+
+        async def get(self, *_args: object, **_kwargs: object) -> _Resp:
+            return _Resp(self._harnesses)
+
+    namespace = SessionsNamespace(_Http([advertised]), "http://example")  # type: ignore[arg-type]
+
+    async def _resolve(canonicalize: object) -> str | None:
+        return await namespace.resolve_online_runner(
+            harness=agent_harness,
+            canonicalize=canonicalize,  # type: ignore[arg-type]
+        )
+
+    assert asyncio.run(_resolve(lambda name: canonicalize_harness(name) or name)) == "r1"
+    # Without canonicalization the alias would not match at all — the bug this guards.
+    assert asyncio.run(_resolve(None)) is None

--- a/tests/e2e/test_remote_url_chat_fresh_session_2437.py
+++ b/tests/e2e/test_remote_url_chat_fresh_session_2437.py
@@ -187,6 +187,10 @@ def test_repl_adapter_creates_session_without_bundle(
     ``session_bundle=None`` and ``session_id=None``.  The adapter must resolve
     the registered agent and create the session rather than refusing for lack
     of a bundle.
+
+    Passes ``runner_id=None`` because that is what ``run_chat`` supplies for a
+    URL target: a remote client owns no runner, so the adapter has to adopt one
+    the server already has online or the first turn fails to dispatch.
     """
     from omnigent_client import OmnigentClient
 
@@ -201,7 +205,7 @@ def test_repl_adapter_creates_session_without_bundle(
                 agent_name=server.agent_name,
                 session_bundle=None,
                 session_id=None,
-                runner_id=server.runner_id,
+                runner_id=None,
             )
             async for _ in adapter.send("Say hello briefly."):
                 pass
@@ -322,7 +326,7 @@ def test_headless_prompt_without_bundle_uses_sessions_api(
                 prompt="Say hello briefly.",
                 session_bundle=None,
                 session_bundle_filename="agent.tar.gz",
-                runner_id=server.runner_id,
+                runner_id=None,
             )
 
     result = asyncio.run(_one_shot())
@@ -350,9 +354,82 @@ def test_run_one_shot_without_bundle_answers(
         agent_name=server.agent_name,
         tool_handler=None,
         prompt="Say hello briefly.",
-        runner_id=server.runner_id,
+        # What _chat_with_server passes for a URL target.
+        runner_id=None,
         session_bundle=None,
     )
 
     out = capsys.readouterr().out
     assert server.marker in out, f"Expected {server.marker!r} on stdout. Got: {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# Contracts the remote-URL path depends on
+# ---------------------------------------------------------------------------
+
+
+def test_json_create_returns_full_session_snapshot(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """The JSON create route returns a full snapshot, not just an id.
+
+    ``create_from_agent_id`` parses the POST response directly with
+    ``Session.from_dict`` and skips the follow-up ``GET`` that the multipart
+    ``create`` needs.  If the server ever narrowed this route to
+    ``{"session_id": ...}`` that parse would break, so pin the shape.
+    """
+    server = registered_agent_server
+
+    with server.client() as client:
+        resp = client.post(
+            "/v1/sessions",
+            json={"agent_id": server.agent_id()},
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    for field_name in ("id", "agent_id", "status", "created_at"):
+        assert field_name in body, (
+            f"JSON create response is missing {field_name!r}; "
+            f"Session.from_dict would fail. Got keys: {sorted(body)}"
+        )
+
+
+def test_no_online_runner_reports_actionable_error(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """A server with no online runner fails with a message naming the fix.
+
+    A remote client adopts one of the server's online runners.  When the
+    server has none, the turn cannot dispatch, so the error should point at
+    starting a host rather than at the ``--server`` flag the user already used.
+    """
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._repl import _SessionsChatReplAdapter
+
+    server = registered_agent_server
+
+    async def _drive() -> None:
+        async with OmnigentClient(base_url=server.base_url) as client:
+            adapter = _SessionsChatReplAdapter(
+                client=client,
+                agent_name=server.agent_name,
+                session_bundle=None,
+                session_id=None,
+                runner_id=None,
+            )
+            # Simulate "server has no online runner" without tearing the real
+            # one down: discovery finds nothing, so binding must fail loudly.
+            adapter._client.sessions.resolve_online_runner = _no_runner  # type: ignore[method-assign]
+            async for _ in adapter.send("hello"):
+                pass
+
+    with pytest.raises(RuntimeError, match="no online runner"):
+        asyncio.run(_drive())
+
+
+async def _no_runner(*, harness: str | None = None) -> str | None:
+    """Stand in for runner discovery on a server with no online runner."""
+    return None

--- a/tests/e2e/test_remote_url_chat_fresh_session_2437.py
+++ b/tests/e2e/test_remote_url_chat_fresh_session_2437.py
@@ -328,3 +328,31 @@ def test_headless_prompt_without_bundle_uses_sessions_api(
     result = asyncio.run(_one_shot())
     assert result is not None, "headless one-shot returned no text"
     assert server.marker in result, f"Expected {server.marker!r} in output. Got: {result!r}"
+
+
+def test_run_one_shot_without_bundle_answers(
+    registered_agent_server: _RegisteredAgentServer,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``run --server <url> -p`` answers without a local bundle.
+
+    ``_chat_with_server`` routes ``-p`` through ``_run_one_shot``, a
+    separate entry point from ``_run_headless_prompt``.  It also used to
+    require a bundle and fall back to the legacy client query, so a
+    remote-URL one-shot failed with ``Not Found``.
+    """
+    from omnigent.chat import _run_one_shot
+
+    server = registered_agent_server
+
+    _run_one_shot(
+        base_url=server.base_url,
+        agent_name=server.agent_name,
+        tool_handler=None,
+        prompt="Say hello briefly.",
+        runner_id=server.runner_id,
+        session_bundle=None,
+    )
+
+    out = capsys.readouterr().out
+    assert server.marker in out, f"Expected {server.marker!r} on stdout. Got: {out!r}"

--- a/tests/e2e/test_remote_url_chat_fresh_session_2437.py
+++ b/tests/e2e/test_remote_url_chat_fresh_session_2437.py
@@ -1,0 +1,330 @@
+"""E2E coverage for fresh registered-agent sessions on a remote-URL target.
+
+``omnigent chat <remote-url>`` connects to a server that already has its
+agents registered, so the CLI has no local bundle to upload.  Session
+creation must therefore bind by ``agent_id`` through the JSON
+``POST /v1/sessions`` route rather than the multipart bundle route.
+
+Three paths are covered:
+
+1. **Interactive fresh session.** ``_SessionsChatReplAdapter`` with
+   ``session_bundle=None`` resolves the registered ``agent_id`` and creates
+   the session, instead of refusing for lack of a bundle.
+2. **Server JSON route.** ``POST /v1/sessions`` with ``{"agent_id": ...}``
+   creates a session that completes a turn end-to-end.
+3. **Headless ``-p``.** ``_query_sessions_once`` with ``session_bundle=None``
+   goes through the sessions API rather than the removed legacy
+   ``/v1/responses`` endpoint.
+
+Run locally (mock LLM, no real API key needed)::
+
+    pytest tests/e2e/test_remote_url_chat_fresh_session_2437.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml as _yaml
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    find_free_port,
+    poll_session_until_terminal,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import final_assistant_text
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_agent_yaml(
+    tmp_path: Path,
+    *,
+    agent_name: str,
+    model: str,
+    mock_llm_server_url: str | None,
+) -> Path:
+    """Write a minimal openai-agents YAML wired to the mock LLM server."""
+    yaml_path = tmp_path / f"{agent_name}.yaml"
+    yaml_path.write_text(
+        _yaml.safe_dump(
+            {
+                "name": agent_name,
+                "prompt": "You are a terse test assistant.",
+                "executor": {
+                    "harness": "openai-agents",
+                    "model": model,
+                    "profile": "",
+                    "auth": {
+                        "type": "api_key",
+                        "api_key": "mock-key",
+                        "base_url": f"{mock_llm_server_url}/v1",
+                    },
+                },
+            }
+        )
+    )
+    return yaml_path
+
+
+class _RegisteredAgentServer:
+    """A booted local server plus the registered agent's identifiers."""
+
+    def __init__(self, base_url: str, agent_name: str, runner_id: str, marker: str) -> None:
+        self.base_url = base_url
+        self.agent_name = agent_name
+        self.runner_id = runner_id
+        self.marker = marker
+
+    def client(self) -> httpx.Client:
+        """Return an HTTP client bound to this server."""
+        return httpx.Client(base_url=self.base_url, timeout=30.0)
+
+    def agent_id(self) -> str:
+        """Resolve the registered agent id through ``GET /v1/agents``."""
+        with self.client() as client:
+            resp = client.get("/v1/agents", params={"limit": 100})
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+        for item in data:
+            if item.get("name") == self.agent_name:
+                return str(item["id"])
+        raise AssertionError(
+            f"agent {self.agent_name!r} not registered. Available: {[d.get('name') for d in data]}"
+        )
+
+
+@pytest.fixture
+def registered_agent_server(
+    mock_llm_server_url: str | None,
+    tmp_path: Path,
+) -> Iterator[_RegisteredAgentServer]:
+    """
+    Boot a local server whose agent is registered but has no client bundle.
+
+    Mirrors the remote-URL target: the caller knows only the agent's name,
+    and must resolve its id from the server to create a session.
+    """
+    from omnigent.chat import (
+        _start_local_server,
+        _stop_local_server,
+        _wait_for_server,
+    )
+
+    suffix = uuid.uuid4().hex[:6]
+    agent_name = f"remote-fresh-{suffix}"
+    model = f"mock-{suffix}"
+    marker = f"REMOTE_FRESH_OK_{suffix}"
+
+    os.environ["OPENAI_API_KEY"] = "mock-key"
+    os.environ["OPENAI_BASE_URL"] = f"{mock_llm_server_url}/v1"
+
+    yaml_path = _write_agent_yaml(
+        tmp_path,
+        agent_name=agent_name,
+        model=model,
+        mock_llm_server_url=mock_llm_server_url,
+    )
+    reset_mock_llm(mock_llm_server_url)
+    # Every test in this module drives at most a couple of turns; repeat the
+    # marker so a retried or multi-turn path still gets a scripted reply.
+    configure_mock_llm(mock_llm_server_url, [{"text": marker}] * 4, key=model)
+
+    port = find_free_port()
+    server = _start_local_server(yaml_path, port, ephemeral=True)
+    try:
+        _wait_for_server(port, server)
+        yield _RegisteredAgentServer(
+            base_url=f"http://127.0.0.1:{port}",
+            agent_name=agent_name,
+            runner_id=server.runner_id or "",
+            marker=marker,
+        )
+    finally:
+        _stop_local_server(server)
+
+
+def _assistant_text(base_url: str, session_id: str) -> str:
+    """Concatenate persisted assistant text for a session."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
+        body = resp.json()
+    parts: list[str] = []
+    for item in body.get("items", []):
+        data = item.get("data", {})
+        if data.get("role") != "assistant":
+            continue
+        for chunk in data.get("content", []):
+            text = chunk.get("text")
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Interactive fresh session (no local bundle)
+# ---------------------------------------------------------------------------
+
+
+def test_repl_adapter_creates_session_without_bundle(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """The REPL adapter creates a session by agent_id when it has no bundle.
+
+    ``omnigent chat <remote-url>`` reaches ``_SessionsChatReplAdapter`` with
+    ``session_bundle=None`` and ``session_id=None``.  The adapter must resolve
+    the registered agent and create the session rather than refusing for lack
+    of a bundle.
+    """
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._repl import _SessionsChatReplAdapter
+
+    server = registered_agent_server
+
+    async def _drive() -> str:
+        async with OmnigentClient(base_url=server.base_url) as client:
+            adapter = _SessionsChatReplAdapter(
+                client=client,
+                agent_name=server.agent_name,
+                session_bundle=None,
+                session_id=None,
+                runner_id=server.runner_id,
+            )
+            async for _ in adapter.send("Say hello briefly."):
+                pass
+            session_id = adapter._session_id
+            assert session_id is not None, "adapter did not record a session id"
+            return session_id
+
+    session_id = asyncio.run(_drive())
+    text = _assistant_text(server.base_url, session_id)
+    assert server.marker in text, f"Expected {server.marker!r} in transcript. Got: {text!r}"
+
+
+def test_repl_adapter_unknown_agent_name_is_reported(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """An unregistered agent name fails with a message naming the agent.
+
+    Guards the resolve step: a typo'd or missing agent must surface as a clear
+    lookup failure rather than a confusing session-create error.
+    """
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._repl import _SessionsChatReplAdapter
+
+    server = registered_agent_server
+
+    async def _drive() -> None:
+        async with OmnigentClient(base_url=server.base_url) as client:
+            adapter = _SessionsChatReplAdapter(
+                client=client,
+                agent_name="no-such-agent",
+                session_bundle=None,
+                session_id=None,
+                runner_id=server.runner_id,
+            )
+            async for _ in adapter.send("hello"):
+                pass
+
+    with pytest.raises(LookupError, match="no-such-agent"):
+        asyncio.run(_drive())
+
+
+# ---------------------------------------------------------------------------
+# Server JSON agent_id route
+# ---------------------------------------------------------------------------
+
+
+def test_server_creates_fresh_session_via_json_agent_id(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """``POST /v1/sessions`` with a JSON agent_id creates a working session.
+
+    This is the route the fixed client paths depend on, so it is worth
+    pinning independently of them.
+    """
+    server = registered_agent_server
+    agent_id = server.agent_id()
+    assert agent_id, f"expected non-empty agent_id for {server.agent_name!r}"
+
+    with server.client() as client:
+        resp = client.post(
+            "/v1/sessions",
+            json={"agent_id": agent_id},
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        )
+        resp.raise_for_status()
+        session_id = str(resp.json()["id"])
+        assert session_id, "expected a session id from the JSON agent_id POST"
+
+        resp = client.patch(f"/v1/sessions/{session_id}", json={"runner_id": server.runner_id})
+        resp.raise_for_status()
+
+        response_id = send_user_message_to_session(
+            client,
+            session_id=session_id,
+            content="Say hello briefly.",
+        )
+        body = poll_session_until_terminal(
+            client,
+            session_id=session_id,
+            response_id=response_id,
+            timeout=120,
+        )
+
+    assert body["status"] == "completed", (
+        f"Status: {body['status']!r}. Output: {body.get('output', [])}"
+    )
+    text = final_assistant_text(body)
+    assert server.marker in text, f"Expected {server.marker!r} in output. Got: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# Headless -p without a bundle
+# ---------------------------------------------------------------------------
+
+
+def test_headless_prompt_without_bundle_uses_sessions_api(
+    registered_agent_server: _RegisteredAgentServer,
+) -> None:
+    """Headless ``-p`` against a remote target answers via the sessions API.
+
+    The no-bundle path previously fell through to the legacy
+    ``/v1/responses`` endpoint, which the server no longer exposes.  It must
+    now resolve the registered agent and use the sessions API instead.
+    """
+    from omnigent_client import OmnigentClient
+
+    from omnigent.chat import _query_sessions_once
+
+    server = registered_agent_server
+
+    async def _one_shot() -> str | None:
+        async with OmnigentClient(base_url=server.base_url) as client:
+            return await _query_sessions_once(
+                client=client,
+                agent_name=server.agent_name,
+                tool_handler=None,
+                prompt="Say hello briefly.",
+                session_bundle=None,
+                session_bundle_filename="agent.tar.gz",
+                runner_id=server.runner_id,
+            )
+
+    result = asyncio.run(_one_shot())
+    assert result is not None, "headless one-shot returned no text"
+    assert server.marker in result, f"Expected {server.marker!r} in output. Got: {result!r}"


### PR DESCRIPTION
## Related issue

Closes #2437

## Summary

Connecting to a remote server with `omnigent chat <url>` could list the server's
registered agents but never actually start a conversation with one. Both entry
points assumed a local agent bundle was available to upload:

- **Interactive** raised `RuntimeError: Sessions API fresh session creation requires
  a local agent bundle...` from the REPL adapter, before any network call.
- **Headless `-p`** fell through to the legacy `/v1/responses` endpoint, which the
  server no longer exposes, failing the turn on a bare `Not Found`.

A remote target has no bundle to upload by definition: the agent is already
registered server-side. The server has long accepted a JSON `{"agent_id": ...}`
body on `POST /v1/sessions` (the route the web UI's new-chat flow uses), so the
client only needed to use it.

- Adds `sessions.create_from_agent_id()` and `sessions.resolve_agent_id()` to the
  Python SDK.
- Takes that path in all three entry points when no bundle is present. The headless fix
  lives in the shared `_query_sessions_once`, so the no-bundle case is handled once
  for every caller rather than per entry point; that also retires the dead legacy
  fallback and its now-unused event imports.
- An unknown agent name now fails with a `LookupError` naming the agent and listing
  what is registered, instead of a confusing session-create error.

### ELI5

You walk up to a coffee shop that already knows its own menu. Previously the app
insisted you bring your own recipe card before it would let you order, and the
takeout window had been bricked over. Now it just points at the menu item by name.

```
BEFORE                                   AFTER
chat <remote-url>                        chat <remote-url>
  └─ pick agent (from server)  ✓           └─ pick agent (from server)  ✓
  └─ first message                         └─ first message
       └─ bundle is None                        └─ bundle is None
            └─ RuntimeError  ✗                       └─ GET /v1/agents  → agent_id
                                                     └─ POST /v1/sessions
run <remote-url> -p                                       {"agent_id": ...}  → 201  ✓
  └─ bundle is None
       └─ POST /v1/responses (gone)  ✗    run <remote-url> -p
                                            └─ _query_sessions_once(bundle=None)
                                                 └─ same agent_id path  ✓
```

## Test Plan

New E2E file `tests/e2e/test_remote_url_chat_fresh_session_2437.py` (4 tests, mock
LLM, no API key needed):

```bash
pytest tests/e2e/test_remote_url_chat_fresh_session_2437.py -v
```

All of these pass `runner_id=None`, matching what the production entry points supply:

- `test_repl_adapter_creates_session_without_bundle` — interactive path with
  `session_bundle=None` creates a session, adopts a server runner, and the turn's
  text lands in the transcript.
- `test_headless_prompt_without_bundle_uses_sessions_api` — headless `-p` with no
  bundle returns real assistant text.
- `test_run_one_shot_without_bundle_answers` — the `_run_one_shot` entry point that
  `run --server -p` actually uses.
- `test_no_online_runner_reports_actionable_error` — a runner-less server fails with
  a message naming the fix.
- `test_runner_adoption_matches_harness_aliases` — both alias directions
  (`claude` ↔ `claude-sdk`); fails without the canonicalizer.
- `test_repl_adapter_unknown_agent_name_is_reported` — unregistered name raises
  `LookupError` naming the agent.
- `test_server_creates_fresh_session_via_json_agent_id` /
  `test_json_create_returns_full_session_snapshot` — pin the server-side JSON route
  the client depends on, including that it returns a full snapshot (so
  `create_from_agent_id` can skip the follow-up `GET`).

Verified the tests are genuine guards, not vacuous: stashing the fix and re-running
gives **4 failed, 3 passed**. The three that pass either way are the server-contract
pins. With the fix: **9 passed**.

Regression runs on the shared paths this touches:

- `tests/repl/ tests/cli/test_chat.py` → **580 passed**
- `tests/e2e/test_chat_e2e.py` → **3 passed** (covers the local-bundle create path
  and remote agent-pick, both of which route through the modified helper)
- `pre-commit` on all changed files → clean
- `pyrefly` on the three modified modules: **104 errors before → 103 after** (the
  removed dead branch drops one pre-existing error; no new ones)

## Demo

N/A — no visual change; behaviour is covered by the E2E tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Beyond the automated tests, I reproduced all three facets from the issue against a
live local server before writing the fix, then manually QA'd the branch end to end
(`omnigent server --agent` + `run --server`). Notes for reviewers:

- **A third caller was found during manual QA.** `omnigent run --server <url> -p`
  routes through `_run_one_shot`, not `_run_headless_prompt`, and had the same
  `session_bundle is not None` gate. It still failed with `Not Found` after my first
  two fixes. Now routed through `_query_sessions_once` like the other two callers,
  with an E2E guard that reproduces the `Not Found` without the change.
- The issue reports facet 3 as `405 Method Not Allowed`; on current main it is now
  `404 Not Found`, because the legacy `/v1/responses` route was removed outright
  rather than left method-restricted. Same broken path, different status.
- The issue's cited line numbers and the `omnigent_client/_sessions.py` path are
  stale (the SDK now lives under `sdks/python-client/`), but every root-cause lead
  in it held.

### Follow-ups from review, addressed

- **Harness alias matching.** Runner adoption compared harness names raw while the
  server canonicalizes first (`_runner_supports_harness`). Reproduced the gap: with a
  runner advertising `claude-sdk`, an agent spec saying `claude` resolved to `None`
  and reported "no online runner" despite a compatible runner being online (17 such
  aliases exist). Now canonicalizes both sides. The SDK is standalone and must not
  import `omnigent`, so callers inject `canonicalize_harness`.
- **Redundant lookup.** `GET /v1/agents` is now skipped when the agent id is already
  known *and* a runner is already bound (nothing needs the harness then).
- **`resolve_agent_id` was dead code** after the switch to `resolve_agent` — removed
  rather than shipped as unused public API.
- **Pagination.** `resolve_agent` follows the `/v1/agents` cursor, so an agent past
  the first page resolves instead of raising a spurious `LookupError`. The miss-path
  name list is capped at 50.
- **Pre-turn `/model` pick.** Previously applied only on the bundle path. Hoisted
  into one helper both create paths call.
- **Name-source asymmetry** is real and confirmed: `GET /v1/agents` is served by
  `builtin_agents.py`, which lists only `session_id IS NULL` rows, while the picker
  reads names from `/v1/sessions[].agent_name`. Left as-is (readable `LookupError`,
  predates this change); the docstring now says so explicitly.

### Runner binding on a remote target (was a blocking review finding)

Review caught that my first tests injected a `runner_id` the real remote-URL entry
points never supply — both `run_chat` and `run_prompt` pass `None` for a URL target.
I verified against a live server that this was a genuine gap, not just a guard:
headless raised *before* the new create path ran, and interactive created the session
but then failed the runner-binding precondition on the first turn.

Root cause: a URL target never gets a host daemon (`--host` is a documented no-op on
that path, `cli.py`), so the client owns no runner. But the server does.
`GET /v1/runners` lists the online runners owned by the requesting user along with
each one's advertised harnesses, and is already ownership-scoped. So the client now
resolves the agent's harness from `GET /v1/agents` and adopts a runner that
advertises it.

Verified live with the production wiring (`runner_id=None`):

```
INTERACTIVE runner_id=None -> status: idle | MARKER: True
HEADLESS    runner_id=None -> MARKER: True
```

The tests now pass `runner_id=None` to mirror production. When the server genuinely
has no online runner, the error points at `omnigent host --server <url>` instead of
the `--server` flag the user already passed.

## Changelog

`omnigent chat <remote-url>` can now start a new conversation with an agent registered on the remote server



