### PR TITLE
fix(hermes-native): advance the mirror cursor per row, not per item

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -236,9 +236,19 @@ class _ForwardState:
 
     :param hermes_session_id: The resolved Hermes ``sessions.id`` being tailed, or
         ``None`` before one is discovered.
-    :param last_id: Highest ``messages.id`` already processed (forwarded or
-        skipped). ``messages.id`` is autoincrement, so the high-water mark is
-        sufficient dedup with O(1) state.
+    :param last_id: Highest **fully** processed ``messages.id``: every item the row
+        expanded to was forwarded, or the row was skipped. ``messages.id`` is
+        autoincrement, so the high-water mark is sufficient dedup with O(1) state.
+    :param partial_row_id: The ``messages.id`` of a row whose mirroring failed
+        partway, or ``0`` when none is pending. One row expands to several items
+        (reasoning, prose, a call per tool call), so ``last_id`` cannot advance until
+        the last of them lands, or the row is skipped next poll and its undelivered
+        items are lost. Named explicitly (rather than implied as "the row after
+        ``last_id``") because compaction can soft-delete the row before the retry,
+        in which case the offset must not be applied to some other row.
+    :param partial_row_items: How many of *partial_row_id*'s items already posted.
+        The row is re-read whole and this many leading items are dropped rather than
+        posted twice.
     :param launch_epoch_s: This session's launch time (Unix seconds), used to
         scope discovery and to break ties when two sessions discover the same row:
         the earlier-launched (established) session keeps it. ``0.0`` for cold.
@@ -254,6 +264,8 @@ class _ForwardState:
 
     hermes_session_id: str | None = None
     last_id: int = 0
+    partial_row_id: int = 0
+    partial_row_items: int = 0
     launch_epoch_s: float = 0.0
     heartbeat_ms: int = 0
     active_turn_id: str | None = None
@@ -268,12 +280,25 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
         return _ForwardState()
     sid = data.get("hermes_session_id")
     last_id = data.get("last_id")
+    partial_id = data.get("partial_row_id")
+    partial_items = data.get("partial_row_items")
+    # Both or neither: a partial row id without a positive item count (or vice
+    # versa) is meaningless, and honoring half of it would drop or duplicate items.
+    if not (
+        isinstance(partial_id, int)
+        and partial_id > 0
+        and isinstance(partial_items, int)
+        and partial_items > 0
+    ):
+        partial_id, partial_items = 0, 0
     launch_epoch_s = data.get("launch_epoch_s")
     heartbeat_ms = data.get("heartbeat_ms")
     active_turn_id = data.get("active_turn_id")
     return _ForwardState(
         hermes_session_id=sid if isinstance(sid, str) else None,
         last_id=last_id if isinstance(last_id, int) else 0,
+        partial_row_id=partial_id,
+        partial_row_items=partial_items,
         launch_epoch_s=float(launch_epoch_s) if isinstance(launch_epoch_s, (int, float)) else 0.0,
         heartbeat_ms=heartbeat_ms if isinstance(heartbeat_ms, int) else 0,
         active_turn_id=active_turn_id
@@ -296,6 +321,8 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
                 {
                     "hermes_session_id": state.hermes_session_id,
                     "last_id": state.last_id,
+                    "partial_row_id": state.partial_row_id,
+                    "partial_row_items": state.partial_row_items,
                     "launch_epoch_s": state.launch_epoch_s,
                     "active_turn_id": state.active_turn_id,
                     # Stamp the heartbeat at persist time so every poll refreshes
@@ -714,6 +741,33 @@ def _read_new_items(
     return items
 
 
+def _drop_delivered_prefix(
+    items: list[_MirrorItem], row_id: int, delivered: int
+) -> list[_MirrorItem]:
+    """Drop the *delivered* leading items of row *row_id* from a re-read batch.
+
+    A row whose mirroring failed partway is re-read whole so its undelivered items
+    still land; its already-posted prefix is removed here so they are not mirrored
+    twice. Items of other rows pass through untouched, so if *row_id* is gone from
+    the batch (compaction soft-deleted it before the retry) this is a no-op rather
+    than trimming some other row.
+    """
+    kept: list[_MirrorItem] = []
+    seen = 0
+    for it in items:
+        if it.msg_id != row_id:
+            kept.append(it)
+            continue
+        # Count position within the row rather than compare items: two items of one
+        # row can be equal (identical repeated tool calls), so identity is the index.
+        # A row shorter than the recorded offset (schema/parse change) drops entirely:
+        # re-posting a delivered item duplicates it, which no later poll can undo.
+        if seen >= delivered:
+            kept.append(it)
+        seen += 1
+    return kept
+
+
 @dataclass
 class _TurnAction:
     """One ordered step when mirroring a poll batch.
@@ -721,7 +775,9 @@ class _TurnAction:
     ``kind`` is ``"running"`` (POST a ``running`` status edge) or ``"item"`` (POST
     a mirrored conversation item). ``turn_id_after`` is the turn id still active
     once this step is applied — persisted after each step so a turn that spans
-    polls (or a forwarder restart mid-turn) keeps its id.
+    polls (or a forwarder restart mid-turn) keeps its id. ``last_of_row`` marks the
+    final item of a ``msg_id`` group, the only point at which the row is fully
+    mirrored and the cursor may advance past it.
     """
 
     kind: str
@@ -729,6 +785,7 @@ class _TurnAction:
     turn_id_after: str | None
     response_id: str | None = None
     item: _MirrorItem | None = None
+    last_of_row: bool = False
 
 
 def _mirror_item_role(item: _MirrorItem) -> str | None:
@@ -788,10 +845,18 @@ def _annotate_turn_actions(
                 _TurnAction("running", msg_id, active_turn_id, response_id=active_turn_id)
             )
 
-        for it in group:
+        for ix, it in enumerate(group):
             if active_turn_id is not None:
                 it.response_id = active_turn_id
-            actions.append(_TurnAction("item", msg_id, active_turn_id, item=it))
+            actions.append(
+                _TurnAction(
+                    "item",
+                    msg_id,
+                    active_turn_id,
+                    item=it,
+                    last_of_row=ix == len(group) - 1,
+                )
+            )
 
         if terminal:
             active_turn_id = None
@@ -1040,6 +1105,11 @@ async def forward_hermes_store_to_session(
     persisted = _read_state(bridge_dir)
     hermes_session_id: str | None = persisted.hermes_session_id
     last_id = persisted.last_id if hermes_session_id is not None else 0
+    # A row whose mirroring failed partway, and how many of its items already
+    # posted; both ``0`` when ``last_id`` is a clean fully-mirrored high-water mark.
+    # Only meaningful alongside ``last_id``, so all three reset together.
+    partial_row_id = persisted.partial_row_id if hermes_session_id is not None else 0
+    partial_row_items = persisted.partial_row_items if hermes_session_id is not None else 0
     # The turn currently in flight (its shared ``response_id``), threaded through
     # every ``_write_state`` so it survives polls / a restart. Reset whenever the
     # tailed hermes session changes (discovery, claim-yield, compaction re-pin).
@@ -1065,9 +1135,10 @@ async def forward_hermes_store_to_session(
                         _session_claimed_by_other, bridge_dir, resolved, launch_epoch_s
                     ):
                         hermes_session_id = resolved
-                        last_id = (
-                            persisted.last_id if persisted.hermes_session_id == resolved else 0
-                        )
+                        resuming = persisted.hermes_session_id == resolved
+                        last_id = persisted.last_id if resuming else 0
+                        partial_row_id = persisted.partial_row_id if resuming else 0
+                        partial_row_items = persisted.partial_row_items if resuming else 0
                         # Discovery only (re)binds on a cold start or a
                         # claim-yield / compaction re-pin reacquire — never the
                         # mid-turn restart-resume case, which keeps its session
@@ -1080,6 +1151,8 @@ async def forward_hermes_store_to_session(
                             _ForwardState(
                                 hermes_session_id=resolved,
                                 last_id=last_id,
+                                partial_row_id=partial_row_id,
+                                partial_row_items=partial_row_items,
                                 launch_epoch_s=launch_epoch_s,
                                 active_turn_id=active_turn_id,
                             ),
@@ -1117,9 +1190,17 @@ async def forward_hermes_store_to_session(
                         hermes_session_id = None
                         active_turn_id = None
                     else:
+                        # ``last_id`` is the last row whose items ALL posted, so a row
+                        # that failed partway is re-read here. Drop the items of it
+                        # that already posted: the item POST carries no idempotency
+                        # key, so a replay would duplicate them in the conversation.
                         items = await asyncio.to_thread(
                             _read_new_items, db, hermes_session_id, last_id, agent_name
                         )
+                        if partial_row_id:
+                            items = _drop_delivered_prefix(
+                                items, partial_row_id, partial_row_items
+                            )
                         # Assign a per-turn response_id and interleave ``running``
                         # edges at turn starts; items are re-stamped in place so
                         # the turn's tool-call cards render live on the web.
@@ -1174,12 +1255,26 @@ async def forward_hermes_store_to_session(
                                 and action.item.response_id
                             ):
                                 closed_turn_id = action.item.response_id
-                            last_id = action.msg_id
+                            # A row expands to several items, so the cursor may only
+                            # advance once the LAST one lands. Until then record how
+                            # far into the row we got: a POST that fails on a later
+                            # item then resumes inside the row on the next poll,
+                            # instead of ``last_id`` moving past it and the rest of
+                            # its items being skipped forever.
+                            if action.last_of_row:
+                                last_id = action.msg_id
+                                partial_row_id = 0
+                                partial_row_items = 0
+                            else:
+                                partial_row_id = action.msg_id
+                                partial_row_items += 1
                             _write_state(
                                 bridge_dir,
                                 _ForwardState(
                                     hermes_session_id=hermes_session_id,
                                     last_id=last_id,
+                                    partial_row_id=partial_row_id,
+                                    partial_row_items=partial_row_items,
                                     launch_epoch_s=launch_epoch_s,
                                     active_turn_id=action.turn_id_after,
                                 ),
@@ -1217,6 +1312,8 @@ async def forward_hermes_store_to_session(
                                 ):
                                     hermes_session_id = child
                                     last_id = 0
+                                    partial_row_id = 0
+                                    partial_row_items = 0
                                     active_turn_id = None
                                     compaction_persisted = False
                                     _external_id_synced = False
@@ -1287,6 +1384,8 @@ async def forward_hermes_store_to_session(
                             _ForwardState(
                                 hermes_session_id=hermes_session_id,
                                 last_id=last_id,
+                                partial_row_id=partial_row_id,
+                                partial_row_items=partial_row_items,
                                 launch_epoch_s=launch_epoch_s,
                                 active_turn_id=active_turn_id,
                             ),

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -1197,6 +1197,9 @@ async def forward_hermes_store_to_session(
                         items = await asyncio.to_thread(
                             _read_new_items, db, hermes_session_id, last_id, agent_name
                         )
+                        # Dropping every item leaves the cursor parked until a newer
+                        # row lands, which is correct: there is nothing left to
+                        # deliver for it, and the next row restarts the count.
                         if partial_row_id:
                             items = _drop_delivered_prefix(
                                 items, partial_row_id, partial_row_items
@@ -1266,6 +1269,14 @@ async def forward_hermes_store_to_session(
                                 partial_row_id = 0
                                 partial_row_items = 0
                             else:
+                                # Count from 1 on a row we were not already inside.
+                                # A partial row can disappear before its retry
+                                # (compaction soft-deletes it, and the re-pin that
+                                # resets these is skipped when the session has no
+                                # child), so carrying its count into the next row
+                                # would over-drop that row's items as delivered.
+                                if partial_row_id != action.msg_id:
+                                    partial_row_items = 0
                                 partial_row_id = action.msg_id
                                 partial_row_items += 1
                             _write_state(
@@ -1337,6 +1348,8 @@ async def forward_hermes_store_to_session(
                                         _ForwardState(
                                             hermes_session_id=child,
                                             last_id=0,
+                                            partial_row_id=0,
+                                            partial_row_items=0,
                                             launch_epoch_s=launch_epoch_s,
                                             active_turn_id=None,
                                         ),

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -632,6 +632,10 @@ async def _noop() -> None:
     return None
 
 
+async def _ignore_status(_client, *, session_id, status, response_id=None) -> None:
+    """Stub for tests that assert on mirrored items, not live-card status edges."""
+
+
 async def test_forward_loop_rebases_idle_count_on_compaction_repin(tmp_path, monkeypatch) -> None:
     """Compaction re-pin rebases the idle posted-count to the child's count.
 
@@ -1694,6 +1698,167 @@ async def test_forward_loop_running_edge_does_not_advance_cursor_before_item(
     # last_id must still be 0, letting a restart re-read the opening row.
     assert ("running", "hermes_turn_1") in statuses
     assert f._read_state(bridge_dir).last_id == 0
+
+
+@pytest.mark.asyncio
+async def test_forward_loop_does_not_advance_cursor_mid_row(tmp_path, monkeypatch) -> None:
+    """A failed POST partway through one row's items must NOT advance last_id past
+    that row. One assistant row expands to several items sharing a msg_id (prose +
+    a function_call per tool call); advancing the cursor after each item means an
+    earlier item's success moves last_id past the row, so _read_new_items (WHERE
+    id > last_id) skips it and the undelivered items are dropped permanently."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", workspace, 1000.0),
+    )
+    calls = json.dumps([{"id": "c1", "function": {"name": "search", "arguments": "{}"}}])
+    con.executemany(
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        [
+            # id=1: user row, delivers cleanly, so the cursor may reach 1.
+            ("s1", "user", "do it", None, None, None, 1),
+            # id=2: assistant row with BOTH prose and a tool call, expands to
+            # [message(2), function_call(2)]; the function_call POST fails below.
+            ("s1", "assistant", "I'll search", None, calls, None, 1),
+        ],
+    )
+    con.commit()
+    con.close()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    posted: list[tuple[int, str]] = []
+
+    async def _post_until_second_item_of_row_2(_client, *, session_id, item):
+        if item.msg_id == 2 and item.item_type == "function_call":
+            raise RuntimeError("simulated transient failure on row 2's second item")
+        posted.append((item.msg_id, item.item_type))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _post_until_second_item_of_row_2)
+    monkeypatch.setattr(f, "_post_external_session_status", _ignore_status)
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_midrow",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # Row 2's prose delivered before its function_call failed, so the persisted
+    # cursor must still leave row 2 reachable: a resume from it has to replay the
+    # undelivered function_call. A cursor of plain id=2 (WHERE id > 2) skips the
+    # row and drops that item permanently.
+    assert (2, "message") in posted, "row 2's prose was not attempted before the failure"
+    state = f._read_state(bridge_dir)
+    resumed = f._read_new_items(db, "s1", state.last_id, "hermes-native-ui")
+    assert [(i.msg_id, i.item_type) for i in resumed if i.item_type] == [
+        (2, "message"),
+        (2, "function_call"),
+    ], "row 2 is unreachable from the persisted cursor, so its function_call is lost"
+
+
+@pytest.mark.asyncio
+async def test_forward_loop_redelivery_skips_already_posted_items(tmp_path, monkeypatch) -> None:
+    """Re-reading a partially-delivered row must not re-POST its delivered items.
+    The cursor stays at the last fully-delivered row, so the next poll re-reads the
+    row; without per-item delivery tracking its already-posted prose would be
+    mirrored twice, duplicating the assistant message in the conversation."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", workspace, 1000.0),
+    )
+    calls = json.dumps([{"id": "c1", "function": {"name": "search", "arguments": "{}"}}])
+    con.execute(
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        ("s1", "assistant", "I'll search", None, calls, None, 1),
+    )
+    con.commit()
+    con.close()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    posted: list[tuple[int, str]] = []
+    fail = {"on": True}
+
+    async def _fail_first_attempt_at_function_call(_client, *, session_id, item):
+        if fail["on"] and item.msg_id == 1 and item.item_type == "function_call":
+            fail["on"] = False  # the retry on the next poll succeeds
+            raise RuntimeError("simulated transient failure on row 1's second item")
+        posted.append((item.msg_id, item.item_type))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fail_first_attempt_at_function_call)
+    monkeypatch.setattr(f, "_post_external_session_status", _ignore_status)
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] >= 2:  # poll 1 fails mid-row, poll 2 retries
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_redeliver",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # Each item mirrored exactly once: the prose is not re-posted on the retry,
+    # and the function_call that failed the first time lands on the second poll.
+    assert posted == [(1, "message"), (1, "function_call")]
+    assert f._read_state(bridge_dir).last_id == 1
+
+
+def test_drop_delivered_prefix_only_trims_its_own_row() -> None:
+    """The delivered-prefix trim applies to the named row only. A row that vanished
+    before the retry (compaction soft-deletes rows) must leave the batch untouched
+    rather than trimming whichever row now happens to come first."""
+
+    def _item(msg_id: int, name: str) -> f._MirrorItem:
+        return f._MirrorItem(msg_id=msg_id, item_type=name, item_data={}, response_id="r")
+
+    batch = [_item(7, "message"), _item(7, "function_call"), _item(8, "message")]
+    # Row 7 delivered its first item: only that item is dropped.
+    assert f._drop_delivered_prefix(batch, 7, 1) == [
+        _item(7, "function_call"),
+        _item(8, "message"),
+    ]
+    # Row 7 is gone from the batch, so nothing is trimmed from rows 8+.
+    assert f._drop_delivered_prefix([_item(8, "message")], 7, 1) == [_item(8, "message")]
+    # A row shorter than the recorded offset drops entirely rather than re-posting.
+    assert f._drop_delivered_prefix([_item(7, "message")], 7, 3) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -1862,6 +1862,96 @@ def test_drop_delivered_prefix_only_trims_its_own_row() -> None:
 
 
 @pytest.mark.asyncio
+async def test_forward_loop_partial_count_resets_when_partial_row_vanishes(
+    tmp_path, monkeypatch
+) -> None:
+    """The in-row item count must restart on a row we were not already inside.
+
+    A row that failed partway can disappear before its retry: compaction
+    soft-deletes it (``active=0``) and the child re-pin that resets the partial
+    fields is skipped when the session has no child. Carrying its count into the
+    next row would treat that row's undelivered items as already delivered and
+    drop them, the same permanent loss this cursor is meant to prevent."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", workspace, 1000.0),
+    )
+    calls = json.dumps([{"id": "c1", "function": {"name": "search", "arguments": "{}"}}])
+    # Row 1 carries prose + a tool call, so it expands to two items; its second
+    # item's POST fails below, leaving the cursor inside row 1.
+    con.execute(
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        ("s1", "assistant", "I'll search", None, calls, None, 1),
+    )
+    con.commit()
+    con.close()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    posted: list[tuple[int, str]] = []
+    row_2_call_failed = {"yet": False}
+
+    async def _fail_each_row_second_item_once(_client, *, session_id, item):
+        if item.item_type == "function_call":
+            # Row 1 never retries (it is soft-deleted below); row 2 fails its
+            # first attempt so the retry has to replay it.
+            if item.msg_id == 1:
+                raise RuntimeError("simulated transient failure on row 1's second item")
+            if item.msg_id == 2 and not row_2_call_failed["yet"]:
+                row_2_call_failed["yet"] = True
+                raise RuntimeError("simulated transient failure on row 2's second item")
+        posted.append((item.msg_id, item.item_type))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fail_each_row_second_item_once)
+    monkeypatch.setattr(f, "_post_external_session_status", _ignore_status)
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] == 1:
+            # Between polls: compaction soft-deletes the partially-mirrored row 1
+            # and a fresh row 2 lands, which also carries prose + a tool call.
+            con = sqlite3.connect(db)
+            con.execute("UPDATE messages SET active = 0 WHERE id = 1")
+            con.execute(
+                "INSERT INTO messages"
+                "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+                " VALUES (?,?,?,?,?,?,?)",
+                ("s1", "assistant", "retrying", None, calls, None, 1),
+            )
+            con.commit()
+            con.close()
+        if iteration["n"] >= 3:  # poll 2 fails on row 2, poll 3 retries it
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_vanished",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # Both of row 2's items land exactly once. Inheriting row 1's count would make
+    # the retry drop row 2's prose as already delivered, losing it permanently.
+    assert [m for m in posted if m[0] == 2] == [(2, "message"), (2, "function_call")]
+    assert f._read_state(bridge_dir).last_id == 2
+
+
+@pytest.mark.asyncio
 async def test_forward_loop_empty_prose_terminal_closes_turn(tmp_path, monkeypatch) -> None:
     """An assistant terminal row with empty content (no prose, no tool_calls)
     yields a role-less sentinel, but must still CLOSE the turn: active_turn_id is


### PR DESCRIPTION
## Related issue

Closes #1657

## Summary

One Hermes `messages` row expands to several mirror items sharing a `msg_id` (a reasoning delta, the prose, one `function_call` per tool call), but the forwarder advanced and persisted `last_id = action.msg_id` after **each item**. If an earlier item of a row delivered and a later one's POST failed, the cursor had already moved past the row, so the next poll's `WHERE id > last_id` skipped it entirely and the undelivered items were lost permanently.

- **`last_id` now advances only at a row boundary**, marked by the new `_TurnAction.last_of_row`. A row that fails partway records `partial_row_id` / `partial_row_items`, and the retry re-reads that row with its already-delivered prefix dropped.
- **The prefix-drop is required, not defensive.** `_post_conversation_item` carries no idempotency key, so the plain "advance once per row" fix would re-POST the delivered prose as a duplicate. This is the #1594 interaction the issue flags, handled locally rather than blocking on server-side idempotency.
- **The in-row count restarts on a new row** (second commit, from Polly's review). A partially-failed row can vanish before its retry: compaction soft-deletes it, and the child re-pin that resets the partial fields is skipped when the session has no child. A carried-over count made the *next* row's retry drop undelivered items as already delivered, reintroducing the same silent loss.
- **The partial row is named explicitly** rather than implied as "the row after `last_id`": compaction soft-deletes rows, so an implied offset could be applied to the wrong row once the row it describes disappears. The per-poll heartbeat write and the compaction re-pin both carry or clear the new fields, so a later poll cannot silently zero them.

Note one detail differs from the issue text: `_message_to_items` emits prose **before** tool calls, so in practice the prose delivers and the `function_call` is what's dropped. The mechanism and impact are exactly as reported.

`goose_native_forwarder` already had the correct shape here (it advances after its whole `for item in items` loop); hermes flattened rows into actions and lost the row boundary.

### ELI5

The forwarder keeps a bookmark ("I've mirrored everything up to row N"). A single row can be several messages, and the bookmark was moving after each message instead of after the whole row. So if message 2 of 3 failed to send, the bookmark already said "row done" and message 3 was never looked at again.

```
BEFORE                                  AFTER
row 2 = [prose, function_call]           row 2 = [prose, function_call]
  prose  POST ok  -> last_id = 2           prose  POST ok  -> partial(2, 1)
  call   POST fail                         call   POST fail
next poll: WHERE id > 2                  next poll: WHERE id > 1
  -> row 2 skipped, call LOST               -> row 2 re-read, prose dropped
                                             as delivered, call retried
```

## Test Plan

Three loop-level regression tests plus one unit test for the trim helper, all in `tests/test_hermes_native_forwarder.py`. They drive the real `forward_hermes_store_to_session` against a seeded SQLite store and inject a POST failure partway through a row.

Verified before/after by reverting only the source file and keeping the tests:

```
BEFORE (main source + new tests):  3 failed, 52 passed
AFTER  (with fix):                 55 passed
```

The counter-reset commit adds a fourth test that drives the real loop through the vanished-row path (row 1 fails partway, compaction soft-deletes it, a new row 2 also fails partway, then retries). Verified the same way, reverting only the source:

```
BEFORE: assert [(2, 'message')] == [(2, 'message'), (2, 'function_call')]
        # row 2's function_call lost permanently
AFTER:  56 passed
```

The key BEFORE failure shows the data loss directly:

```
AssertionError: assert [] == [(2, 'message'), (2, 'function_call')]
  row 2 is unreachable from the persisted cursor, so its function_call is lost
```

Also verified:
- Full `tests/test_hermes_native_forwarder.py`: **56 passed**.
- A multi-row batch simulation (rows 7, 8 deliver fully; row 9 fails on its 2nd of 3 items) ends at `last_id=8, partial_row_id=9, partial_row_items=1`, and the replay yields exactly `[message, function_call]`: fully-delivered rows are not re-sent and the failed row's delivered reasoning item is not duplicated.
- `ruff check` / `ruff format` / `pyrefly` clean on both changed files.

Three hermes-adjacent tests fail identically on a pristine `origin/main` worktree (`test_overview_hermes_row_reflects_configured_model`, `test_overview_dispatches_to_correct_manager[5-_manage_hermes_harness]`, `test_resolve_hermes_executable_missing_raises_with_hint`): pre-existing and unrelated to this change.

## Demo

N/A. No user-visible UI change; the fix is a durable-cursor correctness fix in the forwarder.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The added tests exercise the poll loop end to end (seeded store, real `_read_new_items` / `_annotate_turn_actions` / cursor persistence, mocked HTTP posts), and each was confirmed to fail on unfixed main for the right reason rather than incidentally. The 52 pre-existing tests in the file cover the surrounding cursor, claim-guard, and compaction-repin behaviour and all still pass.

## Changelog

Fixed a hermes-native session losing an assistant turn's tool call or prose when a mirror post failed partway through a message row
