### PR TITLE
fix(harnesses): report Codex ready when its config provider authenticates itself

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -43,6 +43,7 @@ from omnigent.codex_native_app_server import (
     codex_session_meta_model_provider,
     codex_terminal_env,
     native_codex_launch_base_url,
+    native_codex_launch_pins_model_provider,
     normalize_codex_permission_launch_args,
     preload_codex_thread_for_resume,
     resolve_native_codex_launch,
@@ -124,9 +125,16 @@ _CODEX_THREAD_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
 
 @dataclass(frozen=True)
 class _CodexAuthSource:
-    """Resolved source for Codex authentication material."""
+    """Resolved source for Codex authentication material.
+
+    :param auth_path: Codex's ``auth.json``, the credential for a launch that
+        defers to Codex's own login.
+    :param config_path: Codex's ``config.toml``, whose effective
+        ``model_provider`` can carry a credential of its own instead.
+    """
 
     auth_path: Path
+    config_path: Path
 
 
 def _resolve_codex_auth_source() -> _CodexAuthSource:
@@ -143,7 +151,11 @@ def _resolve_codex_auth_source() -> _CodexAuthSource:
     """
     from omnigent.inner.codex_executor import _codex_home_config_source_from_env
 
-    return _CodexAuthSource(auth_path=_codex_home_config_source_from_env() / "auth.json")
+    codex_home = _codex_home_config_source_from_env()
+    return _CodexAuthSource(
+        auth_path=codex_home / "auth.json",
+        config_path=codex_home / "config.toml",
+    )
 
 
 def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
@@ -224,6 +236,19 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
     fail-open the ``claude-sdk`` / ``openai-agents`` gateway harnesses already
     rely on: their gateway token is a runtime mint the daemon can't observe.
 
+    "Defers to Codex" is not the same as "uses ``auth.json``", though: when the
+    launch leaves Codex's provider selection alone, Codex resolves its own
+    effective ``model_provider`` from ``config.toml``, and a custom provider
+    there authenticates from that table (an auth command, an inline bearer, or
+    an ``env_key``) without ever reading ``auth.json``. That config is checked
+    before ``auth.json`` (see
+    :func:`omnigent.onboarding.codex_auth_readiness.codex_config_effective_auth`), so
+    a self-authenticating provider is not reported as needing a ``codex login``
+    that would add a second, competing credential. A launch that pins
+    ``model_provider`` itself — the dismissed-custom-provider case, which pins
+    the built-in ``openai`` — overrides that selection, so Codex's config cannot
+    authenticate and ``auth.json`` decides.
+
     The check stays synchronous and local: it resolves the launch (local config
     reads) and, only on the defer-to-login path, inspects the local auth source.
     It never runs ``codex login`` or a status command; the CLI ``--version``
@@ -232,9 +257,10 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
     onto the ``auth.json`` check.
 
     :returns: ``"binary-missing"`` when the CLI is absent, ``"needs-auth"``
-        when the launch would defer to Codex's own login but ``auth.json`` is
-        missing, malformed, or carries no credential, and ``None`` when a
-        provider will route the launch or a login credential is configured.
+        when a config-selected provider's declared env credential is missing
+        or the launch uses Codex login without a usable ``auth.json``, and
+        ``None`` when a provider will route the launch, Codex's own config is
+        provider-ready, or a login credential is configured.
         Token *validity* (revoked/expired refresh, an unreachable gateway) is
         not judged locally — it surfaces at the first turn via the executor.
     """
@@ -250,6 +276,7 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
         return HARNESS_VERSION_TOO_LOW
     # On a host with no configured provider this may run ambient detection.
     # configured_harness_map shares one probe across all Codex aliases.
+    defers_to_codex_config = False
     try:
         launch = resolve_native_codex_launch(model=None)
         routes_through_provider = (
@@ -257,15 +284,29 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
             or codex_session_meta_model_provider(launch) != "openai"
             or native_codex_launch_base_url(launch) is not None
         )
+        defers_to_codex_config = not native_codex_launch_pins_model_provider(launch)
     except Exception:  # noqa: BLE001 - readiness must never raise; fail onto auth.json.
         _logger.debug("codex readiness: launch resolve failed; using auth.json", exc_info=True)
         routes_through_provider = False
-    if routes_through_provider:
+    if routes_through_provider and not defers_to_codex_config:
         return None
-    source = _resolve_codex_auth_source()
-    if not _codex_auth_json_has_available_credential(source.auth_path):
+    try:
+        source = _resolve_codex_auth_source()
+        if defers_to_codex_config:
+            from omnigent.inner.codex_executor import _clean_codex_env
+            from omnigent.onboarding.codex_auth_readiness import codex_config_effective_auth
+
+            config_auth = codex_config_effective_auth(source.config_path, env=_clean_codex_env())
+            if config_auth == "provider-ready":
+                return None
+            if config_auth == "provider-auth-missing":
+                return HARNESS_NEEDS_AUTH
+        if not _codex_auth_json_has_available_credential(source.auth_path):
+            return HARNESS_NEEDS_AUTH
+        return None
+    except Exception:  # noqa: BLE001 - readiness must never raise.
+        _logger.debug("codex readiness: local auth check failed", exc_info=True)
         return HARNESS_NEEDS_AUTH
-    return None
 
 
 def _update_startup_progress(

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -2266,6 +2266,23 @@ class NativeCodexLaunch:
     summary: str = ""
 
 
+_MODEL_PROVIDER_OVERRIDE_PREFIX = "model_provider="
+
+
+def native_codex_launch_pins_model_provider(launch: NativeCodexLaunch) -> bool:
+    """Whether a launch overrides Codex's config-file provider choice.
+
+    Profiles route through generated provider config. Explicit
+    ``model_provider=`` overrides cover CLI-config, configured-provider, and
+    literal built-in OpenAI paths. An empty-override, profile-free launch alone
+    defers to the user's top-level ``config.toml`` provider.
+    """
+    return launch.profile is not None or any(
+        override.startswith(_MODEL_PROVIDER_OVERRIDE_PREFIX)
+        for override in launch.config_overrides
+    )
+
+
 def codex_session_meta_model_provider(launch: NativeCodexLaunch) -> str:
     """Return the provider id a launch routes through, for rollout synthesis.
 
@@ -2291,10 +2308,9 @@ def codex_session_meta_model_provider(launch: NativeCodexLaunch) -> str:
     :returns: Provider id for ``session_meta.model_provider``, e.g.
         ``"omnigent_databricks"``.
     """
-    prefix = "model_provider="
     for override in launch.config_overrides:
-        if override.startswith(prefix):
-            decoded: object = json.loads(override.removeprefix(prefix))
+        if override.startswith(_MODEL_PROVIDER_OVERRIDE_PREFIX):
+            decoded: object = json.loads(override.removeprefix(_MODEL_PROVIDER_OVERRIDE_PREFIX))
             if not isinstance(decoded, str):
                 raise ValueError("model_provider override must decode to a string")
             return decoded
@@ -2316,6 +2332,8 @@ def native_codex_launch_base_url(launch: NativeCodexLaunch) -> str | None:
     :returns: The base URL the launch routes through, or ``None`` when the
         launch pins none.
     """
+    # Profiles are pins too, but must resolve through their Databricks host
+    # before the generic provider-name path below.
     if launch.profile is not None:
         host = _databricks_gateway_host(launch.profile)
         if not host:
@@ -2339,22 +2357,12 @@ def native_codex_launch_base_url(launch: NativeCodexLaunch) -> str | None:
     # A cli-config entry pins only a provider *name*; its table (with the
     # base_url) lives in the user's shared ~/.codex/config.toml. Read that
     # file to resolve the base URL a cli-config launch actually routes through.
-    if _launch_pins_model_provider(launch):
+    if native_codex_launch_pins_model_provider(launch):
         return _cli_config_provider_base_url(codex_session_meta_model_provider(launch))
     # No provider pinned at all: the deliberate config-default path leaves
     # overrides empty so Codex uses its own config.toml top-level
     # ``model_provider`` default (a Databricks-wide setup). Resolve that.
     return _config_default_provider_base_url()
-
-
-def _launch_pins_model_provider(launch: NativeCodexLaunch) -> bool:
-    """Whether a launch carries an explicit ``model_provider=`` override.
-
-    Distinguishes a launch that pins a provider name (cli-config, or the
-    literal ``model_provider="openai"`` the subscription / dismissed paths
-    set) from the empty-override config-default launch, which pins none.
-    """
-    return any(override.startswith("model_provider=") for override in launch.config_overrides)
 
 
 def _config_default_provider_base_url() -> str | None:

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -36,9 +36,8 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit
 
-import tomllib
-
 from omnigent.env_credentials import getenv_nonempty_with_omnigent_prefix
+from omnigent.onboarding import codex_auth_readiness
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 from omnigent.onboarding.providers import PROVIDER_ENV_VARS
 
@@ -54,15 +53,6 @@ KEY_KIND: DetectedKind = "key"
 SUBSCRIPTION_KIND: DetectedKind = "subscription"
 LOCAL_KIND: DetectedKind = "local"
 CLI_CONFIG_KIND: DetectedKind = "cli-config"
-
-# Codex's built-in model provider ids (openai/codex,
-# ``codex-rs/model-provider-info/src/lib.rs``). A ``model_provider`` set to
-# one of these is not a *custom* provider: ``openai`` is the subscription /
-# API-key path (covered by the auth.json detection), ``ollama`` / ``lmstudio``
-# are local servers (ollama is covered by the TCP-probe detection), and
-# ``amazon-bedrock`` resolves auth from the AWS environment — none of them is
-# a config-defined credential this detection should adopt.
-_CODEX_BUILTIN_PROVIDERS = frozenset({"openai", "amazon-bedrock", "ollama", "lmstudio"})
 
 # Ollama's default OpenAI-compatible endpoint.
 _OLLAMA_HOST = "localhost"
@@ -255,92 +245,6 @@ class CodexConfigProvider:
     display_name: str
 
 
-def _provider_table_has_self_contained_auth(table: dict[str, object]) -> bool:
-    """Return whether a Codex ``[model_providers.X]`` table carries its own auth.
-
-    "Self-contained" means the Codex CLI can authenticate against the
-    provider from the config table alone — no ``auth.json`` login and no
-    environment variable that omnigents would have to thread into the codex
-    subprocess. Mirrors Codex's own provider auth fields (``openai/codex``,
-    ``codex-rs/model-provider-info/src/lib.rs``):
-
-    - ``[X.auth]`` — a token-printing command (``command`` + ``args``), the
-      shape ``isaac configure codex`` writes (``jq`` reading a cached
-      Databricks Model Serving token);
-    - ``experimental_bearer_token`` — an inline static bearer token;
-    - ``[X.aws]`` — AWS SigV4 request signing (Bedrock-style);
-    - ``http_headers`` containing an ``Authorization`` header — a static
-      auth header.
-
-    Deliberately **excluded** (each with a reason):
-
-    - ``env_key`` / ``env_http_headers`` — auth via an environment
-      variable. The codex executor launches the CLI with a scrubbed
-      environment (``_clean_codex_env``), so an arbitrary env var would not
-      reach the subprocess and the provider would 401 at run time despite
-      detecting as "configured". Supporting these needs an env-passthrough
-      design first.
-    - ``requires_openai_auth = true`` — the provider rides the ChatGPT
-      login, which is exactly the ``auth.json`` subscription detection's
-      territory (checked separately by the caller).
-
-    :param table: The raw ``[model_providers.X]`` mapping parsed from
-        ``config.toml``, e.g. ``{"name": "Databricks AI Gateway",
-        "base_url": "...", "auth": {"command": "jq", ...}}``.
-    :returns: ``True`` when the table carries self-contained auth.
-    """
-    auth = table.get("auth")
-    if isinstance(auth, dict):
-        command = auth.get("command")
-        if isinstance(command, str) and command.strip():
-            return True
-    bearer = table.get("experimental_bearer_token")
-    if isinstance(bearer, str) and bearer.strip():
-        return True
-    if isinstance(table.get("aws"), dict):
-        return True
-    headers = table.get("http_headers")
-    if isinstance(headers, dict):
-        for key, value in headers.items():
-            if (
-                isinstance(key, str)
-                and key.lower() == "authorization"
-                and isinstance(value, str)
-                and value.strip()
-            ):
-                return True
-    return False
-
-
-def _effective_codex_model_provider(config: dict[str, object]) -> str | None:
-    """Resolve the effective default ``model_provider`` id from a Codex config.
-
-    Mirrors Codex's own profile-merge resolution (``openai/codex``,
-    ``codex-rs/core/src/config``): the active profile's ``model_provider``
-    (top-level ``profile = "name"`` selecting ``[profiles.name]``) wins over
-    the top-level ``model_provider``.
-
-    :param config: The parsed ``config.toml`` mapping, e.g.
-        ``{"model_provider": "Databricks", "model_providers": {...}}``.
-    :returns: The effective provider id, e.g. ``"Databricks"``, or ``None``
-        when neither the active profile nor the top level sets one (Codex
-        then defaults to the built-in ``openai`` provider).
-    """
-    provider_id: object = config.get("model_provider")
-    active_profile = config.get("profile")
-    if isinstance(active_profile, str) and active_profile.strip():
-        profiles = config.get("profiles")
-        if isinstance(profiles, dict):
-            profile_table = profiles.get(active_profile)
-            if isinstance(profile_table, dict) and isinstance(
-                profile_table.get("model_provider"), str
-            ):
-                provider_id = profile_table["model_provider"]
-    if isinstance(provider_id, str) and provider_id.strip():
-        return provider_id
-    return None
-
-
 def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | None:
     """Detect a custom, auth-carrying default model provider in a Codex config.
 
@@ -353,7 +257,8 @@ def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | Non
 
     A config counts when its **effective default provider** is a custom
     (non-built-in) ``[model_providers.X]`` table with self-contained auth
-    (see :func:`_provider_table_has_self_contained_auth`). The effective
+    (see :func:`codex_auth_readiness.provider_table_has_self_contained_auth`).
+    The effective
     provider mirrors Codex's own resolution (``openai/codex``,
     ``codex-rs/core/src/config``): the active profile's ``model_provider``
     (top-level ``profile = "name"`` selecting ``[profiles.name]``) wins
@@ -371,19 +276,13 @@ def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | Non
         malformed, the effective provider is built-in or unset, its table
         is absent, or the table carries no self-contained auth.
     """
-    try:
-        raw = config_path.read_bytes()
-    except OSError:
-        # Missing or unreadable file — nothing configured.
-        return None
-    try:
-        config = tomllib.loads(raw.decode("utf-8"))
-    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
-        # Malformed TOML — treat as not configured rather than crash setup.
+    config = codex_auth_readiness.load_codex_config(config_path)
+    if config is None:
+        # Missing, unreadable, or malformed — treat as not configured.
         return None
 
-    provider_id = _effective_codex_model_provider(config)
-    if provider_id is None or provider_id in _CODEX_BUILTIN_PROVIDERS:
+    provider_id = codex_auth_readiness.effective_codex_model_provider(config)
+    if provider_id is None or provider_id in codex_auth_readiness.CODEX_BUILTIN_PROVIDERS:
         return None
 
     providers = config.get("model_providers")
@@ -398,7 +297,7 @@ def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | Non
         # Rides the ChatGPT login — the auth.json subscription detection's
         # territory, not a config-defined credential.
         return None
-    if not _provider_table_has_self_contained_auth(table):
+    if not codex_auth_readiness.provider_table_has_self_contained_auth(table):
         return None
 
     name = table.get("name")
@@ -452,13 +351,8 @@ def codex_config_provider_transport(
         missing / malformed, the table is absent, or it declares no
         ``base_url``.
     """
-    try:
-        raw = config_path.read_bytes()
-    except OSError:
-        return None
-    try:
-        config = tomllib.loads(raw.decode("utf-8"))
-    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+    config = codex_auth_readiness.load_codex_config(config_path)
+    if config is None:
         return None
 
     providers = config.get("model_providers")

--- a/omnigent/onboarding/codex_auth_readiness.py
+++ b/omnigent/onboarding/codex_auth_readiness.py
@@ -1,0 +1,169 @@
+"""Read Codex's effective provider auth without spawning the Codex CLI.
+
+The readiness verdict mirrors Codex's ``auth.credentials`` check: a provider
+that requires OpenAI auth uses ``auth.json``; a provider with ``env_key`` is
+ready only when that variable is populated; and any other non-OpenAI provider
+handles auth itself. This deliberately remains a local, structural check. It
+may be wrong about token validity, but it is cheap enough for the host's
+periodic readiness refresh and never probes the network.
+
+This module also owns the shared ``config.toml`` parsing primitives used by
+ambient provider adoption. Adoption and readiness ask different questions:
+adoption requires self-contained auth, while readiness asks how Codex itself
+would authenticate the selected provider.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal
+
+import tomllib
+
+CODEX_BUILTIN_PROVIDERS = frozenset(
+    {"openai", "amazon-bedrock", "amazon-bedrock-runtime", "ollama", "lmstudio"}
+)
+_CODEX_AUTH_HEADER_NAMES = frozenset({"authorization", "api-key", "x-api-key"})
+
+CodexConfigAuth = Literal["provider-ready", "provider-auth-missing", "codex-login"]
+
+
+def load_codex_config(config_path: Path) -> dict[str, object] | None:
+    """Parse a Codex ``config.toml``, returning ``None`` when unusable."""
+    try:
+        raw = config_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        return tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return None
+
+
+def effective_codex_model_provider(config: dict[str, object]) -> str | None:
+    """Resolve Codex's effective provider (active profile before top-level)."""
+    provider_id: object = config.get("model_provider")
+    active_profile = config.get("profile")
+    if isinstance(active_profile, str) and active_profile.strip():
+        profiles = config.get("profiles")
+        if isinstance(profiles, dict):
+            profile_table = profiles.get(active_profile)
+            if isinstance(profile_table, dict) and isinstance(
+                profile_table.get("model_provider"), str
+            ):
+                provider_id = profile_table["model_provider"]
+    if isinstance(provider_id, str) and provider_id.strip():
+        return provider_id
+    return None
+
+
+def effective_custom_provider_table(
+    config: dict[str, object],
+) -> tuple[str, dict[str, object]] | None:
+    """Return the effective custom provider id and table, when both exist."""
+    provider_id = effective_codex_model_provider(config)
+    if provider_id is None or provider_id in CODEX_BUILTIN_PROVIDERS:
+        return None
+    providers = config.get("model_providers")
+    if not isinstance(providers, dict):
+        return None
+    table = providers.get(provider_id)
+    if not isinstance(table, dict):
+        return None
+    return provider_id, table
+
+
+def provider_table_has_self_contained_auth(table: dict[str, object]) -> bool:
+    """Return whether a custom provider table carries adoption-safe auth.
+
+    Env-based auth is intentionally excluded: adopting such a provider would
+    require forwarding an arbitrary variable through the scrubbed Codex launch
+    environment. Readiness handles ``env_key`` separately because Codex keeps
+    its own provider config on that path.
+    """
+    auth = table.get("auth")
+    if isinstance(auth, dict):
+        command = auth.get("command")
+        if isinstance(command, str) and command.strip():
+            return True
+    bearer = table.get("experimental_bearer_token")
+    if isinstance(bearer, str) and bearer.strip():
+        return True
+    if isinstance(table.get("aws"), dict):
+        return True
+    headers = table.get("http_headers")
+    if isinstance(headers, dict):
+        return any(
+            isinstance(key, str)
+            and key.lower() in _CODEX_AUTH_HEADER_NAMES
+            and isinstance(value, str)
+            and value.strip()
+            for key, value in headers.items()
+        )
+    return False
+
+
+def codex_config_effective_auth(
+    config_path: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> CodexConfigAuth:
+    """Return how Codex authenticates its effective provider.
+
+    Mirrors Codex's provider-specific auth check:
+
+    * unset / built-in ``openai`` / ``requires_openai_auth = true`` →
+      ``"codex-login"`` (inspect ``auth.json``);
+    * non-OpenAI provider declaring ``env_key`` → ``"provider-ready"`` only
+      when the variable is non-empty, otherwise ``"provider-auth-missing"``;
+    * any other non-OpenAI provider → ``"provider-ready"`` because Codex
+      considers provider-specific auth sufficient or unnecessary.
+
+    Built-in provider definitions in ``[model_providers]`` are ignored here,
+    matching Codex's catalog merge (except Bedrock's supported endpoint/auth
+    overrides, which do not change this verdict). For example, Ollama needs no
+    credential; Bedrock may still fail later if its AWS credential chain is
+    unavailable, which is intentionally outside this local status check.
+
+    ``requires_openai_auth`` intentionally wins over ``env_key`` when both are
+    set, matching Codex's readiness diagnostic for that contradictory config.
+
+    The caller should pass the environment the launch will actually receive.
+    Host-wide readiness has no agent spec, so it cannot include a particular
+    spec's ``sandbox.env_passthrough`` additions; such a custom session may work
+    while the host-level picker conservatively reports ``needs-auth``.
+    """
+    config = load_codex_config(config_path)
+    if config is None:
+        return "codex-login"
+
+    provider_id = effective_codex_model_provider(config)
+    if provider_id is None:
+        return "codex-login"
+
+    # Configured entries cannot replace the built-in OpenAI, Ollama, or LM
+    # Studio providers. Bedrock accepts only limited endpoint/auth overrides;
+    # none changes whether it requires Codex login.
+    if provider_id in CODEX_BUILTIN_PROVIDERS:
+        return "codex-login" if provider_id == "openai" else "provider-ready"
+
+    providers = config.get("model_providers")
+    configured_table = providers.get(provider_id) if isinstance(providers, dict) else None
+    table = configured_table if isinstance(configured_table, dict) else None
+    if table is None:
+        # A selected custom provider without a table is invalid. Do not let an
+        # unrelated auth.json credential mask the broken selection.
+        return "provider-auth-missing"
+
+    if table.get("requires_openai_auth") is True:
+        return "codex-login"
+
+    env_key = table.get("env_key")
+    if not isinstance(env_key, str) or not env_key.strip():
+        return "provider-ready"
+    value = (os.environ if env is None else env).get(env_key.strip())
+    if isinstance(value, str) and value.strip():
+        return "provider-ready"
+    return "provider-auth-missing"

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import pytest
 
 from omnigent.onboarding import ambient
-from omnigent.onboarding.ambient import DetectedProvider, detect_providers
+from omnigent.onboarding.ambient import (
+    DetectedProvider,
+    detect_providers,
+)
 
 # Every provider env var ambient may read — cleared in the base fixture so
 # the host's own keys don't leak into the deterministic detection tests.
@@ -665,6 +668,11 @@ def test_codex_config_not_detected(clean_env, label: str, body: str) -> None:
         (
             "authorization-header",
             '[model_providers.Custom.http_headers]\nAuthorization = "Bearer tok"',
+        ),
+        # Azure-style API key header.
+        (
+            "api-key-header",
+            '[model_providers.Custom.http_headers]\napi-key = "ak-test"',
         ),
     ],
 )

--- a/tests/onboarding/test_codex_auth_readiness.py
+++ b/tests/onboarding/test_codex_auth_readiness.py
@@ -1,0 +1,157 @@
+"""Tests for the local mirror of Codex's provider-auth readiness logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.onboarding.codex_auth_readiness import (
+    codex_config_effective_auth,
+    effective_codex_model_provider,
+    load_codex_config,
+    provider_table_has_self_contained_auth,
+)
+
+
+def _config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+_ENV_KEY_CONFIG = """\
+model_provider = "gateway"
+
+[model_providers.gateway]
+env_key = "GATEWAY_TOKEN"
+"""
+
+
+def test_active_profile_provider_wins(tmp_path: Path) -> None:
+    path = _config(
+        tmp_path,
+        """\
+profile = "work"
+model_provider = "top"
+
+[profiles.work]
+model_provider = "profile-provider"
+""",
+    )
+    parsed = load_codex_config(path)
+    assert parsed is not None
+    assert effective_codex_model_provider(parsed) == "profile-provider"
+
+
+@pytest.mark.parametrize("value", ["token", " token "])
+def test_env_key_present_is_provider_ready(tmp_path: Path, value: str) -> None:
+    path = _config(tmp_path, _ENV_KEY_CONFIG)
+    assert codex_config_effective_auth(path, env={"GATEWAY_TOKEN": value}) == "provider-ready"
+
+
+@pytest.mark.parametrize("env", [{}, {"GATEWAY_TOKEN": ""}, {"GATEWAY_TOKEN": "   "}])
+def test_env_key_missing_is_provider_auth_missing(tmp_path: Path, env: dict[str, str]) -> None:
+    path = _config(tmp_path, _ENV_KEY_CONFIG)
+    assert codex_config_effective_auth(path, env=env) == "provider-auth-missing"
+
+
+def test_profile_selected_env_key_is_checked(tmp_path: Path) -> None:
+    path = _config(
+        tmp_path,
+        """\
+profile = "work"
+
+[profiles.work]
+model_provider = "gateway"
+
+[model_providers.gateway]
+env_key = "GATEWAY_TOKEN"
+""",
+    )
+    assert codex_config_effective_auth(path, env={}) == "provider-auth-missing"
+
+
+@pytest.mark.parametrize(
+    "provider_body",
+    [
+        "[model_providers.gateway]\n",
+        '[model_providers.gateway.auth]\ncommand = "print-token"\n',
+        '[model_providers.gateway]\nexperimental_bearer_token = "token"\n',
+        '[model_providers.gateway.http_headers]\napi-key = "token"\n',
+    ],
+)
+def test_non_openai_provider_without_env_key_is_ready(tmp_path: Path, provider_body: str) -> None:
+    path = _config(tmp_path, f'model_provider = "gateway"\n{provider_body}')
+    # Mirrors Codex: absent env_key means provider-specific auth is sufficient
+    # or unnecessary. Credential validity remains a runtime concern.
+    assert codex_config_effective_auth(path, env={}) == "provider-ready"
+
+
+def test_requires_openai_auth_uses_codex_login(tmp_path: Path) -> None:
+    path = _config(
+        tmp_path,
+        """\
+model_provider = "gateway"
+
+[model_providers.gateway]
+requires_openai_auth = true
+""",
+    )
+    assert codex_config_effective_auth(path, env={}) == "codex-login"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "",
+        'model_provider = "openai"\n',
+        "model_provider = [broken\n",
+    ],
+)
+def test_configs_that_cannot_supply_provider_auth_use_codex_login(
+    tmp_path: Path, body: str
+) -> None:
+    assert codex_config_effective_auth(_config(tmp_path, body), env={}) == "codex-login"
+
+
+@pytest.mark.parametrize(
+    "provider", ["ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"]
+)
+def test_non_openai_builtin_provider_is_ready(tmp_path: Path, provider: str) -> None:
+    path = _config(tmp_path, f'model_provider = "{provider}"\n')
+    assert codex_config_effective_auth(path, env={}) == "provider-ready"
+
+
+def test_missing_custom_provider_table_is_not_masked_by_login(tmp_path: Path) -> None:
+    path = _config(tmp_path, 'model_provider = "missing-table"\n')
+    assert codex_config_effective_auth(path, env={}) == "provider-auth-missing"
+
+
+def test_redefined_ollama_table_is_ignored(tmp_path: Path) -> None:
+    path = _config(
+        tmp_path,
+        'model_provider = "ollama"\n[model_providers.ollama]\nenv_key = "OLLAMA_TOKEN"\n',
+    )
+    assert codex_config_effective_auth(path, env={}) == "provider-ready"
+
+
+def test_redefined_openai_table_is_ignored(tmp_path: Path) -> None:
+    path = _config(
+        tmp_path,
+        'model_provider = "openai"\n[model_providers.openai]\nrequires_openai_auth = false\n',
+    )
+    assert codex_config_effective_auth(path, env={}) == "codex-login"
+
+
+def test_missing_config_uses_codex_login(tmp_path: Path) -> None:
+    assert codex_config_effective_auth(tmp_path / "missing.toml", env={}) == "codex-login"
+
+
+@pytest.mark.parametrize("header", ["Authorization", "api-key", "x-api-key"])
+def test_auth_headers_are_self_contained_for_adoption(header: str) -> None:
+    assert provider_table_has_self_contained_auth({"http_headers": {header: "credential"}})
+
+
+def test_env_key_is_not_self_contained_for_adoption() -> None:
+    assert not provider_table_has_self_contained_auth({"env_key": "GATEWAY_TOKEN"})

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -51,6 +51,7 @@ def _point_codex_auth_check_at(
     *,
     binary_present: bool,
     launch: Any | None = None,
+    config_toml: str | None = None,
 ) -> None:
     """Redirect Codex availability checks away from the real machine state.
 
@@ -59,6 +60,9 @@ def _point_codex_auth_check_at(
     set → resolves to ``"openai"``), which is exactly the case where
     ``auth.json`` is the credential that decides availability. Provider-routed
     tests pass an explicit launch.
+
+    ``config_toml`` writes Codex's config next to ``auth.json``; omitted
+    means only ``auth.json`` can carry a credential.
     """
     if launch is None:
         launch = codex_native_app_server.NativeCodexLaunch(
@@ -67,11 +71,15 @@ def _point_codex_auth_check_at(
     # Isolate the shared codex config.toml the config-default launch reads, so a
     # defer-to-login test doesn't pick up the real machine's provider default.
     monkeypatch.setenv("CODEX_HOME", str(auth_path.parent))
+    config_path = auth_path.parent / "config.toml"
+    if config_toml is not None:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(config_toml, encoding="utf-8")
     monkeypatch.setattr(codex_native, "resolve_native_codex_launch", lambda model=None: launch)
     monkeypatch.setattr(
         codex_native,
         "_resolve_codex_auth_source",
-        lambda: codex_native._CodexAuthSource(auth_path=auth_path),
+        lambda: codex_native._CodexAuthSource(auth_path=auth_path, config_path=config_path),
     )
     monkeypatch.setattr(
         codex_native,
@@ -261,6 +269,253 @@ def test_codex_auth_unavailable_reason_explicit_openai_needs_auth(
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 
 
+@pytest.mark.parametrize(
+    ("launch", "expected"),
+    [
+        (
+            codex_native_app_server.NativeCodexLaunch([], None, None),
+            False,
+        ),
+        (
+            codex_native_app_server.NativeCodexLaunch([], None, "profile"),
+            True,
+        ),
+        (
+            codex_native_app_server.NativeCodexLaunch(['model_provider="openai"'], None, None),
+            True,
+        ),
+    ],
+)
+def test_native_codex_launch_pins_model_provider(
+    launch: codex_native_app_server.NativeCodexLaunch, expected: bool
+) -> None:
+    """Provider-pin detection is owned beside the override parser."""
+    assert codex_native_app_server.native_codex_launch_pins_model_provider(launch) is expected
+
+
+#: A Codex ``config.toml`` selecting a custom gateway provider that
+#: authenticates from an environment variable, the shape reported in the
+#: "needs-auth with an authenticated custom provider" bug. The variable is
+#: ``OPENAI_``-prefixed so the native launch's env filter passes it through.
+_ENV_KEY_CONFIG_TOML = """\
+model_provider = "aigateway"
+
+[model_providers.aigateway]
+name = "AI Gateway"
+base_url = "https://gateway.example.com/openai/v1"
+env_key = "OPENAI_EXAMPLE_GATEWAY_TOKEN"
+wire_api = "responses"
+"""
+
+
+def test_codex_auth_unavailable_reason_config_env_key_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A config-selected provider with a populated ``env_key`` is available.
+
+    The reported bug: the launch leaves Codex's own provider selection alone, so
+    Codex routes through the custom ``[model_providers.X]`` table and never reads
+    ``auth.json`` — gating on the (legitimately absent) ``auth.json`` reported
+    ``needs-auth`` and told the user to run ``codex login``, which would add a
+    second credential that bypasses the gateway.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch, auth_path, binary_present=True, config_toml=_ENV_KEY_CONFIG_TOML
+    )
+    monkeypatch.setenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", "gw-token")
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_codex_auth_unavailable_reason_config_env_key_unset_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, value: str | None
+) -> None:
+    """A config-selected provider whose ``env_key`` is unset/empty needs auth.
+
+    The credential the config names is not there, and no ``auth.json`` backs it
+    up, so Codex would fail to authenticate — the warning is correct here.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch, auth_path, binary_present=True, config_toml=_ENV_KEY_CONFIG_TOML
+    )
+    if value is None:
+        monkeypatch.delenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", value)
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_missing_provider_env_ignores_auth_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A custom provider's missing env key is not masked by a Codex login.
+
+    Codex selects the custom provider before considering ``auth.json``. Its
+    declared env credential is therefore the gate even when a valid login file
+    also exists.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(
+        monkeypatch, auth_path, binary_present=True, config_toml=_ENV_KEY_CONFIG_TOML
+    )
+    monkeypatch.delenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", raising=False)
+    _write_codex_auth(auth_path, {"OPENAI_API_KEY": "sk-unused"})
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_config_env_key_scrubbed_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An ``env_key`` the launch env scrubs is not reported as available.
+
+    Readiness resolves the variable in the same filtered env the launch hands
+    the CLI, so a variable outside Codex's allowed env families (here a bare
+    ``EXAMPLE_GATEWAY_TOKEN``) cannot mark the harness ready and then 401 on the
+    first turn.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml=_ENV_KEY_CONFIG_TOML.replace(
+            'env_key = "OPENAI_EXAMPLE_GATEWAY_TOKEN"', 'env_key = "EXAMPLE_GATEWAY_TOKEN"'
+        ),
+    )
+    monkeypatch.setenv("EXAMPLE_GATEWAY_TOKEN", "gw-token")
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_config_auth_command_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A config-selected provider with a token-printing auth command is available.
+
+    Same generic rule as the ``env_key`` case, a different credential shape: the
+    config names the credential, so no vendor is special-cased.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml=(
+            'model_provider = "gw"\n'
+            "[model_providers.gw]\n"
+            'base_url = "https://gateway.example.com/openai/v1"\n'
+            "[model_providers.gw.auth]\n"
+            'command = "print-token"\n'
+        ),
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_config_local_provider_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A local provider needs no ``auth.json`` credential."""
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml='model_provider = "ollama"\n',
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_config_builtin_provider_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A config selecting the built-in provider still gates on ``auth.json``.
+
+    ``model_provider = "openai"`` is Codex's own login, so an absent
+    ``auth.json`` is a real ``needs-auth`` — the config check must not fail open
+    for every config file that happens to exist.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml='model_provider = "openai"\nmodel = "gpt-5.4"\n',
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_dismissed_config_provider_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A launch pinning the built-in provider ignores the config's credential.
+
+    When the user removed (dismissed) the detected config provider, the launch
+    pins ``model_provider="openai"``, so the config table is not what Codex
+    routes through and its ``env_key`` cannot make the harness available.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=['model_provider="openai"'], model=None, profile=None
+    )
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        launch=launch,
+        config_toml=_ENV_KEY_CONFIG_TOML,
+    )
+    monkeypatch.setenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", "gw-token")
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_missing_provider_table_ignores_auth_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A broken custom-provider selection is not masked by a Codex login."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml='model_provider = "missing-table"\n',
+    )
+    _write_codex_auth(auth_path, {"OPENAI_API_KEY": "sk-unused"})
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_local_auth_failure_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unexpected local-auth errors never escape the readiness refresh."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml=_ENV_KEY_CONFIG_TOML,
+    )
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("broken local auth check")
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.codex_auth_readiness.codex_config_effective_auth",
+        _boom,
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
 def test_codex_auth_unavailable_reason_resolver_failure_falls_back_to_auth_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -274,6 +529,27 @@ def test_codex_auth_unavailable_reason_resolver_failure_falls_back_to_auth_json(
     monkeypatch.setattr(codex_native, "resolve_native_codex_launch", _boom)
 
     # No auth.json → falls through to needs-auth rather than propagating.
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_resolver_failure_skips_config_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed launch resolution cannot assume the config provider is active."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(
+        monkeypatch,
+        auth_path,
+        binary_present=True,
+        config_toml=_ENV_KEY_CONFIG_TOML,
+    )
+    monkeypatch.setenv("OPENAI_EXAMPLE_GATEWAY_TOKEN", "gw-token")
+
+    def _boom(model: object = None) -> object:
+        raise RuntimeError("corrupt config")
+
+    monkeypatch.setattr(codex_native, "resolve_native_codex_launch", _boom)
+
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 
 


### PR DESCRIPTION
## Related issue

Closes #2984

Linear: OMNI-1860

## Summary

- Codex readiness treated "the launch defers to Codex" as "the credential is
  `auth.json`". Codex resolves its own effective `model_provider` from
  `config.toml` first, and a custom `[model_providers.X]` table authenticates
  from that table (an auth command, an inline bearer, or an `env_key`) without
  ever reading `auth.json` — so an authenticated gateway user was reported
  `needs-auth` and told to run `codex login`, which would add a second
  credential that bypasses the configured gateway.
- `_codex_auth_unavailable_reason` now asks Codex's own config before falling
  back to `auth.json`, via a new `codex_config_provider_has_credential` that
  mirrors Codex's provider resolution (active profile > top-level
  `model_provider`) and accepts any credential shape the table names. The
  variable/command comes from the config, so no vendor or gateway is
  special-cased. `requires_openai_auth`, a built-in/unset provider, an
  undefined provider table, and a launch that pins `model_provider` itself
  (the dismissed-provider case) all still gate on `auth.json`.
- The `env_key` value is resolved in the same filtered environment the native
  launch hands the CLI (`_clean_codex_env`), so readiness and the launch read
  the same variables instead of marking a scrubbed variable ready and 401ing on
  the first turn.
- Ambient *adoption* detection is unchanged: it still skips `env_key` providers,
  since adopting one re-routes it through Omnigent's own config. Only the
  readiness question changed. TOML loading shared by the three config readers is
  factored into one `_load_codex_config` helper.

```text
codex readiness (defer-to-Codex launch)
  before:  auth.json?  ──no──> needs-auth        ("run codex login")
  after:   config.toml effective provider credential? ──yes──> available
                                │no
                                └─> auth.json? ──no──> needs-auth
```

## Test Plan

- `uv run pytest tests/test_codex_native.py tests/onboarding/test_ambient.py`
  (293 passed) — new status-level cases at `_codex_auth_unavailable_reason`:
  populated `env_key` with no `auth.json` → available; unset/empty/whitespace
  `env_key` → `needs-auth`; `env_key` scrubbed by the launch env → `needs-auth`;
  auth-command provider → available; built-in `model_provider` → `needs-auth`;
  launch-pinned (dismissed) provider → `needs-auth`; resolver failure still
  gates on `auth.json` alone. Plus unit cases for the new ambient helper
  (`env_http_headers`, profile-selected provider, `requires_openai_auth`,
  missing table, malformed TOML, explicit `env` argument).
- `uv run pytest tests/onboarding` — 1013 passed, 1 pre-existing unrelated
  failure (`test_claude_ready_via_configured_provider_without_cli_login`, a
  Gemini login probe; fails identically on a clean tree).
- Reproduced first with the reported config (`model_provider = "aigateway"` +
  `env_key`, no `auth.json`): `configured_harness_map()` returned
  `needs-auth` for `codex` / `codex-native` / `native-codex`, and `True` for all
  three after the fix.
- `uv run pre-commit run --all-files` — passes except the VS Code `tsc` hook,
  which fails locally for missing `editors/vscode/node_modules` (no TS touched).

## Demo

N/A — daemon-side readiness computation; the user-visible effect is the absence
of the "Codex needs Codex authentication" warning.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified on a host whose `CODEX_HOME/config.toml` selects a custom
gateway provider with an `[auth] command` and has no `auth.json`: the old logic
(`auth.json` only) resolved to `needs-auth`, the new config check resolves to
available. The env-scrubbing case is covered by a unit test rather than manually.

## Changelog

Codex no longer asks for `codex login` when it is already authenticated through
a custom model provider in `~/.codex/config.toml`
