### PR TITLE
feat(web): show timestamps on prompts and responses in agent sessions

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1537,6 +1537,7 @@ def _publish_input_consumed(
             type=item.type,
             data=item.data.model_dump() if item.data is not None else {},
             created_by=item.created_by,
+            created_at=item.created_at,
             cleared_pending_id=cleared_pending_id,
         ),
     )
@@ -6242,18 +6243,23 @@ async def _relay_persist(
     conversation_store: ConversationStore | None,
     session_id: str,
     item: NewConversationItem,
-) -> None:
+) -> ConversationItem | None:
     """
     Persist a single conversation item from the relay.
 
     :param conversation_store: Store instance, or ``None`` to skip.
     :param session_id: Session/conversation identifier.
     :param item: The item to persist.
+    :returns: The persisted item (carrying the store-assigned id and
+        ``created_at``), or ``None`` when persistence was skipped or
+        failed. The relay patches the live event with the persisted
+        ``created_at`` so streamed items carry the same clock as
+        history.
     """
     if conversation_store is None:
-        return
+        return None
     try:
-        await asyncio.to_thread(
+        persisted = await asyncio.to_thread(
             conversation_store.append,
             session_id,
             [item],
@@ -6263,6 +6269,8 @@ async def _relay_persist(
             "Relay persist failed for session=%s",
             session_id,
         )
+        return None
+    return persisted[0] if persisted else None
 
 
 async def _flush_relay_text(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5603,11 +5603,26 @@ async def _relay_runner_stream(
                         response_id=_persist_rid,
                     )
                     if conv_item is not None:
-                        await _relay_persist(
+                        _persisted_relay_item = await _relay_persist(
                             conversation_store,
                             session_id,
                             conv_item,
                         )
+                        # Patch the live frame with the store's creation
+                        # stamp so streamed items carry the same clock the
+                        # snapshot serves (drives the web's bubble
+                        # timestamps). The runner's raw item has none —
+                        # only the store knows when it was persisted.
+                        if _persisted_relay_item is not None and isinstance(
+                            event.get("item"), dict
+                        ):
+                            event = {
+                                **event,
+                                "item": {
+                                    **event["item"],
+                                    "created_at": _persisted_relay_item.created_at,
+                                },
+                            }
 
                     # On ANY terminal event (not just completed), persist the
                     # final text segment: narration streamed before a failure /

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3028,6 +3028,10 @@ class SessionInputConsumedPayload(BaseModel):
         e.g. ``"alice@example.com"``. ``None`` for agent/tool/system
         items and single-user mode. Mirrors
         :meth:`ConversationItem.to_api_dict` for live attribution.
+    :param created_at: Unix epoch seconds the item was persisted at,
+        e.g. ``1717171717``. Mirrors
+        :meth:`ConversationItem.to_api_dict` so clients can stamp the
+        live bubble with the same server clock history hydration uses.
     :param cleared_pending_id: When this consumed message drains a
         :mod:`omnigent.runtime.pending_inputs` entry (a native-
         terminal web message round-tripping back from the transcript),
@@ -3043,6 +3047,7 @@ class SessionInputConsumedPayload(BaseModel):
     # (matches :class:`SessionEventInput.data`).
     data: dict[str, Any]
     created_by: str | None = None
+    created_at: int | None = None
     cleared_pending_id: str | None = None
 
     model_config = ConfigDict(extra="ignore")

--- a/openapi.json
+++ b/openapi.json
@@ -4018,6 +4018,19 @@
             "description": "When this consumed message drains a `omnigent.runtime.pending_inputs` entry (a native- terminal web message round-tripping back from the transcript), the drained entry's id, e.g. `\"pending_a1b2c3\"`. Lets a client drop the matching optimistic bubble by id instead of by position. `None` for non-native messages and for messages that matched no pending entry (e.g. typed directly in the TUI).",
             "title": "Cleared Pending Id"
           },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Unix epoch seconds the item was persisted at, e.g. `1717171717`. Mirrors `ConversationItem.to_api_dict` so clients can stamp the live bubble with the same server clock history hydration uses.",
+            "title": "Created At"
+          },
           "created_by": {
             "anyOf": [
               {

--- a/tests/e2e_ui/chat/test_message_timestamps.py
+++ b/tests/e2e_ui/chat/test_message_timestamps.py
@@ -1,0 +1,100 @@
+"""E2E: wall-clock timestamps render on prompt and response bubbles.
+
+Message timestamps ride the server's ``created_at`` clock end to end:
+the live path stamps the user bubble from ``session.input.consumed``
+and the assistant bubble from ``response.output_item.done``, while a
+reload re-derives both from history hydration (``itemsToBlocks``). The
+Settings → Appearance toggle ``ShowMessageTimestampsControl``
+(``pages/SettingsPage.tsx``) writes
+``localStorage["omnigent:show-message-timestamps"]`` — on by default,
+and turning it off removes the stamps.
+
+This drives all three surfaces against the rendered UI: a real turn
+round-trips and both bubbles show a stamp (live path), a reload shows
+the same stamps (history path), and flipping the real Switch off hides
+them.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm
+
+_COMPOSER = "Ask the agent anything…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+_USER_STAMP = '[data-role="user"] [data-testid="message-timestamp"]'
+_ASSISTANT_STAMP = '[data-role="assistant"] [data-testid="message-timestamp"]'
+
+_TOGGLE_KEY = "omnigent:show-message-timestamps"
+
+# Locale-agnostic "looks like a clock time" check (e.g. "3:42 PM", "15:42").
+_TIME_RE = re.compile(r"\d{1,2}:\d{2}")
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send."""
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def test_message_timestamps_render_and_toggle_off(
+    page: Page,
+    seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """Stamps show by default on both bubbles, survive reload, and toggle off.
+
+    1. **live turn** — after a prompt round-trips, the user bubble carries a
+       stamp (from ``session.input.consumed``'s ``created_at``) and the
+       assistant bubble carries one (from the finalized item's stamp).
+    2. **reload** — the same stamps re-derive from history hydration.
+    3. **toggle off** — flipping the real Settings → Appearance Switch
+       persists the preference and removes every stamp from the transcript.
+    """
+    base_url, session_id = seeded_session
+    configure_mock_llm(
+        mock_llm_server_url, [{"text": "stamped reply"}], key="ts", match="timestamp check"
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _send(page, "timestamp check")
+
+    # Turn terminal: the reply rendered and the working shimmer is gone.
+    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+
+    # 1. Live path: both bubbles show a clock-shaped stamp.
+    expect(page.locator(_USER_STAMP).first).to_be_visible(timeout=15_000)
+    expect(page.locator(_USER_STAMP).first).to_contain_text(_TIME_RE)
+    expect(page.locator(_ASSISTANT_STAMP).first).to_be_visible(timeout=15_000)
+    expect(page.locator(_ASSISTANT_STAMP).first).to_contain_text(_TIME_RE)
+
+    # 2. History path: a cold reload re-derives the stamps from the
+    #    persisted items' created_at.
+    page.reload()
+    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_USER_STAMP).first).to_be_visible(timeout=15_000)
+    expect(page.locator(_ASSISTANT_STAMP).first).to_be_visible(timeout=15_000)
+
+    # 3. Flip the real Settings → Appearance Switch off and confirm it
+    #    persists to localStorage.
+    page.goto(f"{base_url}/settings/appearance")
+    toggle = page.get_by_test_id("show-message-timestamps-toggle")
+    expect(toggle).to_be_visible(timeout=30_000)
+    expect(toggle).to_have_attribute("aria-checked", "true")
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "false")
+    stored = page.evaluate(f"() => window.localStorage.getItem('{_TOGGLE_KEY}')")
+    assert stored == "false", f"toggle did not persist (got {stored!r})"
+
+    # Back on the transcript, every stamp is gone (conditionally rendered,
+    # never just hidden) while the bubbles themselves remain.
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=30_000)
+    expect(page.locator('[data-testid="message-timestamp"]')).to_have_count(0)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -1625,6 +1625,54 @@ async def test_external_user_message_drain_publishes_cleared_pending_id(
         pending_inputs.reset_for_tests()
 
 
+async def test_input_consumed_carries_created_at(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``session.input.consumed`` carries the persisted item's ``created_at``.
+
+    The web client stamps the live user bubble with this value so a live
+    send and a reloaded session show the same server clock. A ``None`` or
+    missing field silently degrades every live bubble to "no timestamp",
+    so pin both the presence and the equality with the snapshot's stamp.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "stamp me"}],
+                },
+                "response_id": "native_turn_1",
+            },
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    consumed = [ev for _sid, ev in published if ev.get("type") == "session.input.consumed"]
+    assert len(consumed) == 1, f"expected one consumed event, got {published}"
+    created_at = consumed[0]["data"]["created_at"]
+    assert isinstance(created_at, int) and created_at > 0
+
+    # Same clock the session snapshot serves for this item.
+    snap = await client.get(f"/v1/sessions/{session['id']}")
+    assert snap.status_code == 200
+    items = snap.json()["items"]
+    assert len(items) == 1
+    assert items[0]["created_at"] == created_at
+
+
 @pytest.mark.parametrize(
     "interrupt_text",
     ["[Request interrupted by user]", "[Request interrupted by user for tool use]"],

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -3373,6 +3373,70 @@ async def test_relay_routing_decision_live_event_carries_persisted_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_relay_message_live_event_carries_persisted_created_at() -> None:
+    """The relayed live message frame carries the store's ``created_at``.
+
+    The runner's raw ``output_item.done`` has no creation stamp — only the
+    store knows when the item was persisted. The relay must patch the live
+    frame with the persisted ``created_at`` so streamed items carry the
+    same clock the snapshot serves (drives the web's bubble timestamps);
+    without it, live turns render stampless until a reload.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes.sessions import _relay_runner_stream
+
+    published: list[dict[str, Any]] = []
+    message_seen = asyncio.Event()
+
+    async def _consume() -> None:
+        async for event in session_stream.subscribe("79b22ebd2309e48fdeb450c65611d51b"):
+            published.append(event)
+            item = event.get("item")
+            if isinstance(item, dict) and item.get("type") == "message":
+                message_seen.set()
+
+    consumer = asyncio.create_task(_consume())
+    await asyncio.sleep(0)
+    try:
+        store = _ConversationStore()
+        client = _FakeStreamingRunnerClient(
+            [
+                _sse_frame({"type": "response.in_progress", "response": {"id": "resp_turn"}}),
+                _sse_frame(
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "Stamped."}],
+                            "agent": "databricks-claude-haiku-4-5",
+                        },
+                    }
+                ),
+                "data: [DONE]\n\n",
+            ]
+        )
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
+        await asyncio.wait_for(message_seen.wait(), timeout=1)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+
+    message_items = [i for i in store.appended_items if i.type == "message"]
+    assert len(message_items) == 1, f"expected 1 persisted message, got {store.appended_items}"
+
+    message_live = [
+        e
+        for e in published
+        if isinstance(e.get("item"), dict) and e["item"].get("type") == "message"
+    ]
+    assert len(message_live) == 1, f"expected 1 live message frame, got {published}"
+    assert message_live[0]["item"]["created_at"] == message_items[0].created_at
+    assert message_items[0].created_at > 0
+
+
+@pytest.mark.asyncio
 async def test_relay_drops_malformed_routing_decision() -> None:
     """A malformed routing item (empty model) is dropped, not persisted.
 

--- a/web/src/lib/blockStream.test.ts
+++ b/web/src/lib/blockStream.test.ts
@@ -1751,3 +1751,62 @@ describe("BlockStream — naming a turn already in flight", () => {
     expect(blocks.filter((b) => b.type === "reasoning_start")).toHaveLength(1);
   });
 });
+
+describe("BlockStream — message_done createdAtS threading", () => {
+  it("stamps the delta-accumulated text block with the finalizing item's stamp", () => {
+    // The common streaming shape: deltas build the text, message_done
+    // closes it. The closing item's server `created_at` must land on the
+    // resulting text_done block (feeds the bubble timestamp).
+    const blocks = reduce([
+      { type: "response_created", response: makeResponse({ responseId: "resp_1" }) },
+      { type: "text_delta", delta: "Hello" },
+      {
+        type: "message_done",
+        content: [],
+        itemId: "msg_item_1",
+        responseId: "resp_1",
+        createdAtS: 1_754_000_000,
+      },
+      { type: "response_completed", response: makeResponse({ responseId: "resp_1" }) },
+    ]);
+    const done = blocks.find((b): b is TextDone => b.type === "text_done");
+    expect(done?.ctx.itemId).toBe("msg_item_1");
+    expect(done?.ctx.createdAtS).toBe(1_754_000_000);
+  });
+
+  it("stamps a message_done that arrives without preceding deltas", () => {
+    const blocks = reduce([
+      { type: "response_created", response: makeResponse({ responseId: "resp_1" }) },
+      {
+        type: "message_done",
+        content: [{ type: "output_text", text: "direct" }],
+        itemId: "msg_item_1",
+        responseId: "resp_1",
+        createdAtS: 1_754_000_000,
+      },
+    ]);
+    const done = blocks.find((b): b is TextDone => b.type === "text_done");
+    expect(done?.fullText).toBe("direct");
+    expect(done?.ctx.createdAtS).toBe(1_754_000_000);
+  });
+
+  it("does not stamp the previous response's text on a response switch", () => {
+    // On a switch, event.createdAtS belongs to the NEW message — the old
+    // text block being closed must not inherit it (mirrors the itemId rule).
+    const blocks = reduce([
+      { type: "response_created", response: makeResponse({ responseId: "resp_1" }) },
+      { type: "text_delta", delta: "old turn text" },
+      {
+        type: "message_done",
+        content: [{ type: "output_text", text: "new turn text" }],
+        itemId: "msg_new",
+        responseId: "resp_2",
+        createdAtS: 1_754_000_000,
+      },
+    ]);
+    const dones = blocks.filter((b): b is TextDone => b.type === "text_done");
+    expect(dones).toHaveLength(2);
+    expect(dones[0]!.ctx.createdAtS).toBeUndefined();
+    expect(dones[1]!.ctx.createdAtS).toBe(1_754_000_000);
+  });
+});

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -192,6 +192,7 @@ function ctx(
   state: ReducerState,
   itemId: string | null = null,
   responseId: string | null = null,
+  createdAtS?: number,
 ): BlockContext {
   const agent = state.agent;
   const depth = agent ? (agent.match(/\./g)?.length ?? 0) : 0;
@@ -205,6 +206,9 @@ function ctx(
     // under the item's true id without moving the reducer's active id.
     responseId: responseId || state.responseId,
     itemId,
+    // Server persistence stamp from the finalizing item, when the wire
+    // carried one — the same clock history hydration uses.
+    ...(createdAtS !== undefined ? { createdAtS } : {}),
   };
 }
 
@@ -247,9 +251,14 @@ function* closeReasoning(state: ReducerState): Generator<AnyBlock> {
  * `TextDone.ctx.itemId` so renderers can correlate the streamed text
  * back to its persisted item. `null` when the closure is fired by a
  * non-message boundary (tool call, terminal event without a preceding
- * message_done).
+ * message_done). `createdAtS` is the finalizing item's server
+ * persistence time, threaded onto the block for timestamp display.
  */
-function* closeText(state: ReducerState, itemId: string | null = null): Generator<AnyBlock> {
+function* closeText(
+  state: ReducerState,
+  itemId: string | null = null,
+  createdAtS?: number,
+): Generator<AnyBlock> {
   if (!state.inText) return;
   if (state.accumulated) {
     yield {
@@ -261,7 +270,7 @@ function* closeText(state: ReducerState, itemId: string | null = null): Generato
   }
   yield {
     type: "text_done",
-    ctx: ctx(state, itemId),
+    ctx: ctx(state, itemId, null, createdAtS),
     fullText: state.fullText,
     hasCodeBlocks: state.fullText.includes("```"),
   } satisfies TextDone;
@@ -696,8 +705,12 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
       yield* closeReasoning(state);
       if (hadOpenText) {
         // On a response switch, event.itemId belongs to the new message — don't
-        // attach it to the old text block being closed.
-        yield* closeText(state, isResponseSwitch ? null : event.itemId || null);
+        // attach it (or its persistence stamp) to the old text block being closed.
+        yield* closeText(
+          state,
+          isResponseSwitch ? null : event.itemId || null,
+          isResponseSwitch ? undefined : event.createdAtS,
+        );
       }
 
       // A message_done with a new id is a genuine turn transition (the
@@ -729,7 +742,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
       if (text) {
         yield {
           type: "text_done",
-          ctx: ctx(state, event.itemId || null),
+          ctx: ctx(state, event.itemId || null, null, event.createdAtS),
           fullText: text,
           hasCodeBlocks: text.includes("```"),
         } satisfies TextDone;

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -291,6 +291,12 @@ export interface MessageDone {
   content: Record<string, unknown>[];
   itemId: string;
   responseId: string;
+  /**
+   * Server persistence time (unix epoch seconds), when the wire item
+   * carried `created_at`. Stamps the finalized text block with the same
+   * clock history hydration uses, so live turns get timestamps too.
+   */
+  createdAtS?: number;
 }
 
 /**
@@ -653,6 +659,11 @@ export interface SessionInputConsumedEvent {
    * and single-user sends. Threaded onto the bubble for live attribution.
    */
   createdBy?: string;
+  /**
+   * Server persistence time (unix epoch seconds), when sent. Threaded
+   * onto the committed bubble so live sends match reloaded history.
+   */
+  createdAtS?: number;
   /** Decoded item payload — heterogeneous, `itemType`-specific. */
   data: Record<string, unknown>;
   /**

--- a/web/src/lib/messageTime.test.ts
+++ b/web/src/lib/messageTime.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { formatMessageTime } from "./messageTime";
+
+// Fixed "now" so day-boundary branches are deterministic: a local-time
+// morning, mid-year. Expected labels are built with the same `toLocale*`
+// calls the formatter uses, so assertions hold in any test-runner locale —
+// what's under test is the branch selection, not the locale's rendering.
+const NOW = new Date(2026, 2, 6, 10, 0, 0);
+
+function time(date: Date): string {
+  return date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+describe("formatMessageTime", () => {
+  it("renders time-only for a same-day stamp", () => {
+    const at = new Date(2026, 2, 6, 15, 42);
+    expect(formatMessageTime(at.getTime() / 1000, NOW)).toBe(time(at));
+  });
+
+  it('prefixes "Yesterday" for the previous calendar day', () => {
+    // 23:59 the day before — calendar-day comparison, not a 24h window.
+    const at = new Date(2026, 2, 5, 23, 59);
+    expect(formatMessageTime(at.getTime() / 1000, NOW)).toBe(`Yesterday ${time(at)}`);
+  });
+
+  it("renders month + day for an older same-year stamp", () => {
+    const at = new Date(2026, 0, 15, 9, 5);
+    const day = at.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    expect(formatMessageTime(at.getTime() / 1000, NOW)).toBe(`${day}, ${time(at)}`);
+  });
+
+  it("includes the year for a prior-year stamp", () => {
+    const at = new Date(2025, 11, 31, 18, 0);
+    const day = at.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    expect(formatMessageTime(at.getTime() / 1000, NOW)).toBe(`${day}, ${time(at)}`);
+  });
+
+  it("returns an empty string for malformed stamps", () => {
+    // A zeroed/absent server field must render nothing, not "Invalid Date"
+    // or a 1970 epoch label.
+    expect(formatMessageTime(Number.NaN, NOW)).toBe("");
+    expect(formatMessageTime(0, NOW)).toBe("");
+    expect(formatMessageTime(-5, NOW)).toBe("");
+    expect(formatMessageTime(Number.POSITIVE_INFINITY, NOW)).toBe("");
+  });
+});

--- a/web/src/lib/messageTime.ts
+++ b/web/src/lib/messageTime.ts
@@ -1,0 +1,34 @@
+// Wall-clock label for a transcript message ("3:42 PM", "Yesterday 3:42 PM",
+// "Mar 4, 3:42 PM"). Absolute rather than relative: a transcript is read
+// top-to-bottom as a record, so "5m ago" would go stale line-by-line while
+// an absolute stamp stays true. Locale-aware via `toLocale*String`.
+
+/**
+ * Format a message's server creation time for display next to its bubble.
+ *
+ * - Same calendar day as `now`: time only ("3:42 PM").
+ * - The day before: "Yesterday 3:42 PM".
+ * - Same year: "Mar 4, 3:42 PM".
+ * - Older: "Mar 4, 2025, 3:42 PM".
+ *
+ * @param createdAtS - Server creation time in unix epoch seconds.
+ * @param now - The current instant (injectable for tests and for callers
+ *   driving freshness from the shared `useNow()` tick).
+ * @returns The label, or `""` for a non-finite or non-positive stamp so a
+ *   malformed item renders nothing rather than "Invalid Date".
+ */
+export function formatMessageTime(createdAtS: number, now: Date = new Date()): string {
+  if (!Number.isFinite(createdAtS) || createdAtS <= 0) return "";
+  const date = new Date(createdAtS * 1000);
+  const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  if (date.toDateString() === now.toDateString()) return time;
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (date.toDateString() === yesterday.toDateString()) return `Yesterday ${time}`;
+  const day = date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(date.getFullYear() !== now.getFullYear() ? { year: "numeric" } : {}),
+  });
+  return `${day}, ${time}`;
+}

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -112,6 +112,32 @@ describe("buildBubbles — bubble grouping", () => {
     expect(user.createdBy).toBeUndefined();
   });
 
+  it("propagates ctx.createdAtS onto the user bubble", () => {
+    // Feeds the visible timestamp label — history hydration and the live
+    // consumed event both land here via BlockContext.
+    const blocks: AnyBlock[] = [
+      {
+        type: "user_message",
+        ctx: ctx({ itemId: "u1", responseId: "resp_1", createdAtS: 1_754_000_000 }),
+        content: [{ type: "input_text", text: "Hello" }],
+      },
+    ];
+    const user = buildBubbles(blocks, null)[0] as Extract<Bubble, { kind: "user" }>;
+    expect(user.createdAtS).toBe(1_754_000_000);
+  });
+
+  it("leaves user bubble createdAtS undefined when ctx omits it", () => {
+    const blocks: AnyBlock[] = [
+      {
+        type: "user_message",
+        ctx: ctx({ itemId: "u1", responseId: "resp_1" }),
+        content: [{ type: "input_text", text: "Hello" }],
+      },
+    ];
+    const user = buildBubbles(blocks, null)[0] as Extract<Bubble, { kind: "user" }>;
+    expect(user.createdAtS).toBeUndefined();
+  });
+
   it("propagates a user_message block's stableKey onto its bubble", () => {
     // A block promoted from an optimistic bubble on session.input.consumed
     // carries stableKey = the optimistic temp id; buildBubbles must surface
@@ -2634,6 +2660,27 @@ describe("bubblesEqual — React.memo comparator", () => {
     expect(bubblesEqual(alice, bob)).toBe(false);
     expect(bubblesEqual(none, alice)).toBe(false);
     expect(bubblesEqual(alice, alice)).toBe(true);
+  });
+
+  it("reports not-equal when a user bubble's createdAtS differs", () => {
+    // The stamp feeds the visible timestamp label, so a consumed event
+    // landing after the optimistic→committed swap must repaint the bubble.
+    const content: MessageContentBlock[] = [{ type: "input_text", text: "Hello" }];
+    const unstamped: Bubble = { kind: "user", itemId: "u1", content };
+    const stamped: Bubble = { kind: "user", itemId: "u1", content, createdAtS: 1_754_000_000 };
+    const later: Bubble = { kind: "user", itemId: "u1", content, createdAtS: 1_754_000_060 };
+    expect(bubblesEqual(unstamped, stamped)).toBe(false);
+    expect(bubblesEqual(stamped, later)).toBe(false);
+    expect(bubblesEqual(stamped, { ...stamped })).toBe(true);
+  });
+
+  it("reports not-equal when an assistant bubble's lastActivityAtS differs", () => {
+    // Drives the assistant bubble's timestamp label; without the compare a
+    // memoized bubble would freeze its stamp at first paint.
+    const base = assistant("Done", "completed") as Extract<Bubble, { kind: "assistant" }>;
+    const stamped: Bubble = { ...base, lastActivityAtS: 1_754_000_000 };
+    expect(bubblesEqual(base, stamped)).toBe(false);
+    expect(bubblesEqual(stamped, { ...stamped })).toBe(true);
   });
 });
 

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -137,6 +137,8 @@ export type Bubble =
       content: MessageContentBlock[];
       /** Human author email, when known. */
       createdBy?: string;
+      /** Server persistence time (unix epoch seconds), when known. */
+      createdAtS?: number;
       /**
        * Stable React key when promoted from an optimistic
        * `pendingUserMessages` entry — carries that entry's client temp
@@ -676,6 +678,7 @@ function walkBubbles(
         itemId: b.ctx.itemId ?? `user_${i}`,
         content: b.content,
         ...(b.ctx.createdBy !== undefined ? { createdBy: b.ctx.createdBy } : {}),
+        ...(b.ctx.createdAtS !== undefined ? { createdAtS: b.ctx.createdAtS } : {}),
         // Carry the optimistic temp id (when promoted) so bubbleKey holds
         // steady across the optimistic→committed swap — no remount/flink.
         stableKey: b.stableKey,
@@ -1510,7 +1513,9 @@ export function bubblesEqual(a: Bubble, b: Bubble): boolean {
       a.lifecycle !== b.lifecycle ||
       a.error !== b.error ||
       // Flips when a later bubble continues this turn — the fold depends on it.
-      Boolean(a.continued) !== Boolean(b.continued)
+      Boolean(a.continued) !== Boolean(b.continued) ||
+      // Drives the visible bubble timestamp — a stale memo would freeze it.
+      a.lastActivityAtS !== b.lastActivityAtS
     ) {
       return false;
     }
@@ -1526,6 +1531,7 @@ export function bubblesEqual(a: Bubble, b: Bubble): boolean {
     if (
       a.itemId !== b.itemId ||
       a.createdBy !== b.createdBy ||
+      a.createdAtS !== b.createdAtS ||
       a.stableKey !== b.stableKey ||
       a.content.length !== b.content.length
     )

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -181,3 +181,49 @@ describe("parseEvent — session.mcp_startup", () => {
     ).toBeNull();
   });
 });
+
+describe("parseEvent — created_at threading", () => {
+  it("carries a finalized message item's created_at as createdAtS", () => {
+    const ev = parseEvent("response.output_item.done", {
+      item: {
+        id: "msg_1",
+        type: "message",
+        response_id: "resp_1",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hi" }],
+        created_at: 1_754_000_000,
+      },
+    });
+    expect(ev).toMatchObject({ type: "message_done", createdAtS: 1_754_000_000 });
+  });
+
+  it("omits createdAtS when the wire item lacks a usable created_at", () => {
+    // Absent and zeroed stamps both read as "unknown" — a 0 would render
+    // as a 1970 label.
+    for (const created_at of [undefined, 0]) {
+      const ev = parseEvent("response.output_item.done", {
+        item: {
+          id: "msg_1",
+          type: "message",
+          response_id: "resp_1",
+          content: [],
+          ...(created_at !== undefined ? { created_at } : {}),
+        },
+      });
+      expect(ev).not.toBeNull();
+      expect((ev as { createdAtS?: number }).createdAtS).toBeUndefined();
+    }
+  });
+
+  it("session.input.consumed carries created_at as createdAtS", () => {
+    const ev = parseEvent("session.input.consumed", {
+      data: {
+        item_id: "msg_1",
+        type: "message",
+        data: { role: "user", content: [{ type: "input_text", text: "hi" }] },
+        created_at: 1_754_000_000,
+      },
+    });
+    expect(ev).toMatchObject({ type: "session_input_consumed", createdAtS: 1_754_000_000 });
+  });
+});

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -675,6 +675,7 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
     // created_by is at the payload level (beside item_id/type), not in
     // the nested item data. Keep only a real string so null carries no author.
     const createdBy = p.created_by;
+    const createdAt = p.created_at;
     const clearedPendingId = p.cleared_pending_id;
     return {
       type: "session_input_consumed",
@@ -682,6 +683,7 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
       itemType,
       isMeta: payload.is_meta === true,
       ...(typeof createdBy === "string" ? { createdBy } : {}),
+      ...(typeof createdAt === "number" && createdAt > 0 ? { createdAtS: createdAt } : {}),
       data: payload,
       clearedPendingId: typeof clearedPendingId === "string" ? clearedPendingId : null,
     } satisfies SessionInputConsumedEvent;
@@ -1015,9 +1017,13 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
   if (itemType === "message") {
     if (rec.is_meta === true) return null;
     const content = rec.content;
+    const createdAt = rec.created_at;
     return {
       type: "message_done",
       content: Array.isArray(content) ? (content as Record<string, unknown>[]) : [],
+      // Keep only a positive epoch stamp so a missing/zeroed field carries
+      // no timestamp (mirrors itemsToBlocks' history-hydration guard).
+      ...(typeof createdAt === "number" && createdAt > 0 ? { createdAtS: createdAt } : {}),
       itemId,
       responseId,
     } satisfies MessageDone;

--- a/web/src/lib/timestampPreferences.test.ts
+++ b/web/src/lib/timestampPreferences.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SHOW_MESSAGE_TIMESTAMPS,
+  readShowMessageTimestamps,
+  useShowMessageTimestamps,
+  writeShowMessageTimestamps,
+} from "./timestampPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("timestampPreferences", () => {
+  it("defaults to on when nothing is stored", () => {
+    expect(DEFAULT_SHOW_MESSAGE_TIMESTAMPS).toBe(true);
+    expect(readShowMessageTimestamps()).toBe(true);
+  });
+
+  it("round-trips both boolean values", () => {
+    writeShowMessageTimestamps(false);
+    expect(readShowMessageTimestamps()).toBe(false);
+
+    writeShowMessageTimestamps(true);
+    expect(readShowMessageTimestamps()).toBe(true);
+  });
+
+  it('treats any non-"false" stored value as on (defensive against hand edits)', () => {
+    // Only the exact string "false" disables the stamps; garbage or a stale
+    // format falls back to the default (on) rather than silently hiding them.
+    localStorage.setItem("omnigent:show-message-timestamps", "0");
+    expect(readShowMessageTimestamps()).toBe(true);
+
+    localStorage.setItem("omnigent:show-message-timestamps", "no");
+    expect(readShowMessageTimestamps()).toBe(true);
+
+    localStorage.setItem("omnigent:show-message-timestamps", "false");
+    expect(readShowMessageTimestamps()).toBe(false);
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API.
+    // Both helpers must swallow them — a broken preference must not break
+    // the transcript or settings.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeShowMessageTimestamps(false)).not.toThrow();
+    expect(readShowMessageTimestamps()).toBe(true);
+  });
+
+  it("notifies mounted subscribers when the toggle flips", () => {
+    // Message bubbles sit behind a React.memo boundary, so the Settings
+    // toggle reaches them through the subscription hook — a write with no
+    // notification would leave already-rendered bubbles stale.
+    const { result } = renderHook(() => useShowMessageTimestamps());
+    expect(result.current).toBe(true);
+
+    act(() => writeShowMessageTimestamps(false));
+    expect(result.current).toBe(false);
+
+    act(() => writeShowMessageTimestamps(true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/web/src/lib/timestampPreferences.ts
+++ b/web/src/lib/timestampPreferences.ts
@@ -1,0 +1,71 @@
+// Persisted, per-device preference for showing wall-clock timestamps next to
+// transcript messages (user prompts and assistant responses).
+//
+// On by default: session transcripts double as a record of when work
+// happened, so the stamps carry signal out of the box. It's a device-local
+// UI preference — no account or session state is changed — so it lives in
+// localStorage like the other `*Preferences` helpers.
+//
+// Unlike most preference helpers, this one also exposes a subscription hook:
+// message bubbles are memoized deep inside the transcript, so a Settings
+// toggle must notify them directly rather than rely on a remount.
+
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "omnigent:show-message-timestamps";
+
+export const DEFAULT_SHOW_MESSAGE_TIMESTAMPS = true;
+
+const listeners = new Set<() => void>();
+
+/**
+ * Read the persisted "show message timestamps" preference. Returns the
+ * default (on) when nothing is stored, on a server render (no `window`), or
+ * when the stored value is malformed — never throws, so a corrupt entry can't
+ * break the app.
+ */
+export function readShowMessageTimestamps(): boolean {
+  if (typeof window === "undefined") return DEFAULT_SHOW_MESSAGE_TIMESTAMPS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_SHOW_MESSAGE_TIMESTAMPS;
+    return raw !== "false";
+  } catch {
+    return DEFAULT_SHOW_MESSAGE_TIMESTAMPS;
+  }
+}
+
+/**
+ * Persist the "show message timestamps" preference and notify subscribed
+ * components. Swallows quota/access errors so a failed write can't break
+ * the app.
+ */
+export function writeShowMessageTimestamps(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+  for (const listener of listeners) listener();
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function getSnapshot(): boolean {
+  return readShowMessageTimestamps();
+}
+
+/**
+ * The live "show message timestamps" preference. Re-renders the subscriber
+ * when the Settings toggle flips, including bubbles already mounted behind
+ * a memo boundary. SSR-safe (returns the default).
+ */
+export function useShowMessageTimestamps(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -104,6 +104,10 @@ import {
   liveCandidateAssistantIndex,
 } from "@/lib/renderItems";
 import { getCurrentAuthorId } from "@/lib/identity";
+import { formatMessageTime } from "@/lib/messageTime";
+import { useShowMessageTimestamps } from "@/lib/timestampPreferences";
+import { absoluteTime } from "@/lib/relativeTime";
+import { useNow } from "@/hooks/useNow";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { codexEffortLevelsForModel, findNativeModelOption } from "@/lib/codexNativeModels";
 import {
@@ -3449,8 +3453,30 @@ function useCopyMessage(getText: () => string): {
   return { isCopied, handleCopy };
 }
 
+/**
+ * Muted wall-clock stamp for a message bubble ("3:42 PM"). Subscribes to the
+ * shared 30s tick so the label rolls over at day boundaries; the full
+ * date-time rides on the hover tooltip.
+ */
+function MessageTimestamp({ createdAtS }: { createdAtS: number }) {
+  const now = useNow();
+  const label = formatMessageTime(createdAtS, now);
+  if (!label) return null;
+  return (
+    <time
+      dateTime={new Date(createdAtS * 1000).toISOString()}
+      title={absoluteTime(createdAtS * 1000)}
+      className="text-xs whitespace-nowrap text-muted-foreground/70"
+      data-testid="message-timestamp"
+    >
+      {label}
+    </time>
+  );
+}
+
 function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const sessionId = useChatStore((s) => s.conversationId);
+  const showTimestamps = useShowMessageTimestamps();
   // Author labels only matter once the session is shared with someone else.
   const isSessionShared = useContext(SessionSharedContext);
   // Plain-text path is the common case.
@@ -3610,12 +3636,19 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           {text && <FilePathAwareMessageResponse breaks>{text}</FilePathAwareMessageResponse>}
         </MessageContent>
       </div>
-      {text && (
-        <MessageActions className="ml-auto opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
-          <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
-            {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
-          </MessageAction>
-        </MessageActions>
+      {(text || (showTimestamps && bubble.createdAtS !== undefined)) && (
+        <div className="ml-auto flex items-center gap-1.5">
+          {showTimestamps && bubble.createdAtS !== undefined && (
+            <MessageTimestamp createdAtS={bubble.createdAtS} />
+          )}
+          {text && (
+            <MessageActions className="opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+              <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
+                {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+              </MessageAction>
+            </MessageActions>
+          )}
+        </div>
       )}
     </Message>
   );
@@ -3649,6 +3682,7 @@ function AssistantBubble({
   const { isCopied, handleCopy } = useCopyMessage(() => collectBubbleMarkdown(bubble.items));
   // null outside AppShell's provider (isolated tests) → hide the action.
   const forkDialog = useForkDialog();
+  const showTimestamps = useShowMessageTimestamps();
 
   if (bubble.items.length === 0) return null;
 
@@ -3708,30 +3742,40 @@ function AssistantBubble({
             <span>Interrupted</span>
           </p>
         )}
-        {/* Skipped on a fold-only bubble: the actions belong to content
-            the user can see, and hanging them off a collapsed row spaced
+        {/* Skipped on a fold-only bubble: the row belongs to content
+            the user can see, and hanging it off a collapsed row spaced
             consecutive rows unevenly depending on hidden narration. */}
-        {markdownText && !foldOnly && (
-          <MessageActions className="opacity-40 transition-opacity md:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
-            <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
-              {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
-            </MessageAction>
-            {/* Fork from this response: clone the session with history
-                truncated after this turn. Hidden while the response is
-                still streaming (its items aren't committed yet) and when
-                the session can't be forked (sub-agent / isolated mount). */}
-            {forkDialog?.canFork && bubble.lifecycle !== "streaming" && (
-              <MessageAction
-                tooltip="Fork from here"
-                size="icon-xxs"
-                data-testid="fork-from-response"
-                onClick={() => forkDialog.openForkDialog({ upToResponseId: bubble.responseId })}
-              >
-                <GitForkIcon size={14} />
-              </MessageAction>
-            )}
-          </MessageActions>
-        )}
+        {(markdownText || (showTimestamps && bubble.lastActivityAtS !== undefined)) &&
+          !foldOnly && (
+            <div className="flex items-center gap-1.5">
+              {showTimestamps && bubble.lastActivityAtS !== undefined && (
+                <MessageTimestamp createdAtS={bubble.lastActivityAtS} />
+              )}
+              {markdownText && (
+                <MessageActions className="opacity-40 transition-opacity md:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
+                  <MessageAction tooltip="Copy" size="icon-xxs" onClick={handleCopy}>
+                    {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+                  </MessageAction>
+                  {/* Fork from this response: clone the session with history
+                      truncated after this turn. Hidden while the response is
+                      still streaming (its items aren't committed yet) and when
+                      the session can't be forked (sub-agent / isolated mount). */}
+                  {forkDialog?.canFork && bubble.lifecycle !== "streaming" && (
+                    <MessageAction
+                      tooltip="Fork from here"
+                      size="icon-xxs"
+                      data-testid="fork-from-response"
+                      onClick={() =>
+                        forkDialog.openForkDialog({ upToResponseId: bubble.responseId })
+                      }
+                    >
+                      <GitForkIcon size={14} />
+                    </MessageAction>
+                  )}
+                </MessageActions>
+              )}
+            </div>
+          )}
       </Message>
 
       {bubble.lifecycle === "failed" && (

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Bubble } from "@/lib/renderItems";
+import { writeShowMessageTimestamps } from "@/lib/timestampPreferences";
 import { FileViewerContext } from "@/shell/FileViewerContext";
 import { BubbleView } from "./ChatPage";
 
@@ -325,5 +326,44 @@ describe("UserBubble @-mention attachment chips", () => {
     expect(screen.getByText("@src/server.ts")).toBeInTheDocument();
     // ...the materialized upload does not.
     expect(screen.queryByText(/uploads\/image\.png/)).toBeNull();
+  });
+});
+
+describe("message timestamps", () => {
+  // The preference defaults to on; tests that flip it clean up after
+  // themselves so the module-level default holds for the other suites.
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the prompt's wall-clock stamp when the bubble carries one", () => {
+    renderBubble(userBubble("hello", { createdAtS: 1_754_000_000 }));
+    const stamp = screen.getByTestId("message-timestamp");
+    expect(stamp.textContent).not.toBe("");
+    // Full date-time rides on the hover tooltip.
+    expect(stamp.getAttribute("title")).not.toBeNull();
+  });
+
+  it("omits the stamp when the bubble has no server time", () => {
+    // Optimistic bubbles and pre-stamp history have no createdAtS — the
+    // label must simply be absent, not render a bogus epoch.
+    renderBubble(userBubble("hello"));
+    expect(screen.queryByTestId("message-timestamp")).toBeNull();
+  });
+
+  it("hides timestamps when the preference is off", () => {
+    writeShowMessageTimestamps(false);
+    renderBubble(userBubble("hello", { createdAtS: 1_754_000_000 }));
+    expect(screen.queryByTestId("message-timestamp")).toBeNull();
+  });
+
+  it("shows the response's completion stamp on the assistant bubble", () => {
+    renderBubble({ ...assistantBubble("completed"), lastActivityAtS: 1_754_000_000 });
+    expect(screen.getByTestId("message-timestamp").textContent).not.toBe("");
+  });
+
+  it("omits the assistant stamp while none of the turn's items are finalized", () => {
+    renderBubble(assistantBubble("streaming"));
+    expect(screen.queryByTestId("message-timestamp")).toBeNull();
   });
 });

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -459,6 +459,8 @@ describe("SettingsPage", () => {
     });
     fireEvent.click(screen.getByTestId("workspace-panel-default-collapsed"));
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
+    // Timestamps default on, so the tweak turns them OFF.
+    fireEvent.click(screen.getByTestId("show-message-timestamps-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.change(screen.getByTestId("ui-font-family-input") as HTMLInputElement, {
@@ -471,6 +473,7 @@ describe("SettingsPage", () => {
     });
 
     // Sanity: the non-default choices were persisted.
+    expect(localStorage.getItem("omnigent:show-message-timestamps")).toBe("false");
     expect(localStorage.getItem("omnigent:terminal-theme")).toBe("dark");
     expect(localStorage.getItem("omnigent:ui-theme-palette")).toBe(JSON.stringify("github"));
     expect(localStorage.getItem("omnigent:ui-font-size")).toBe("15");
@@ -507,6 +510,13 @@ describe("SettingsPage", () => {
       "aria-checked",
       "false",
     );
+
+    // Message timestamps are back on and the override key is cleared.
+    expect(screen.getByTestId("show-message-timestamps-toggle")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(localStorage.getItem("omnigent:show-message-timestamps")).toBeNull();
   });
 
   it("lets you clear and retype the font size without clamping mid-edit", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -144,6 +144,11 @@ import {
   writeHideUnconfiguredHarnesses,
 } from "@/lib/harnessVisibilityPreferences";
 import {
+  DEFAULT_SHOW_MESSAGE_TIMESTAMPS,
+  readShowMessageTimestamps,
+  writeShowMessageTimestamps,
+} from "@/lib/timestampPreferences";
+import {
   applyThemePalette,
   DEFAULT_PALETTE,
   isThemeSelection,
@@ -823,6 +828,40 @@ function HideUnconfiguredHarnessesControl() {
   );
 }
 
+/**
+ * Wall-clock timestamps next to transcript messages (user prompts and
+ * assistant responses). On by default; turning it off declutters the
+ * transcript for sessions where timing doesn't matter.
+ */
+function ShowMessageTimestampsControl() {
+  const [value, setValue] = useState(() => readShowMessageTimestamps());
+  const labelId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setValue(next);
+    writeShowMessageTimestamps(next);
+  }, []);
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Show message timestamps
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Show when each prompt was sent and each response finished next to its message in the
+          transcript.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={value}
+        onCheckedChange={toggle}
+        data-testid="show-message-timestamps-toggle"
+        className="mt-0.5 shrink-0"
+      />
+    </div>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns light/dark, so the Mode and Color theme pickers
   // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
@@ -848,6 +887,8 @@ function AppearanceSection() {
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
 
+    writeShowMessageTimestamps(DEFAULT_SHOW_MESSAGE_TIMESTAMPS);
+
     applyDesktopUiFontSize(UI_FONT_SIZE_DEFAULT);
     applyUiFontFamily(UI_FONT_FAMILY_DEFAULT);
 
@@ -870,6 +911,7 @@ function AppearanceSection() {
           "omnigent:custom-theme",
           "omnigent:default-workspace-panel",
           "omnigent:hide-unconfigured-harnesses",
+          "omnigent:show-message-timestamps",
         ]) {
           window.localStorage.removeItem(key);
         }
@@ -913,6 +955,8 @@ function AppearanceSection() {
         <WorkspacePanelDefaultControl />
 
         <HideUnconfiguredHarnessesControl />
+
+        <ShowMessageTimestampsControl />
 
         <UiFontSizeControl />
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -6393,6 +6393,7 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
           role: "assistant",
           content: [{ type: "output_text", text: segment }],
           model: "polly",
+          created_at: 1_754_000_000,
         },
       }),
     );
@@ -6410,6 +6411,9 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
     // reconnect reconciliation (itemId-keyed) won't splice the
     // persisted copy in as a duplicate — the original #3146 hole.
     expect(dones[0]!.ctx.itemId).toBe("msg_seg1");
+    // ...and its server persistence stamp, which feeds the assistant
+    // bubble's timestamp (the streamed deltas carried none).
+    expect(dones[0]!.ctx.createdAtS).toBe(1_754_000_000);
     // The text keeps its streamed position ABOVE the tool call; an
     // appended copy would render below it.
     const types = blocks.map((b) => b.type);
@@ -9465,5 +9469,41 @@ describe("chatStore — attributing pre-turn blocks to the turn", () => {
 
     const rids = useChatStore.getState().blocks.map((b) => b.ctx.responseId);
     expect(rids).toEqual(["", "codex_prev", "codex_now"]);
+  });
+});
+
+describe("chatStore — session_input_consumed createdAtS stamping", () => {
+  it("stamps the committed bubble with the server persistence time", () => {
+    // The consumed event's `created_at` is the same clock history hydration
+    // reads, so a live send and a reloaded session show identical stamps.
+    useChatStore.setState({ conversationId: "conv_abc" });
+
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_stamped",
+      itemType: "message",
+      createdAtS: 1_754_000_000,
+      data: { role: "user", content: [{ type: "input_text", text: "when was this?" }] },
+    });
+
+    const block = useChatStore.getState().blocks.at(-1) as UserMessageBlock;
+    expect(block.type).toBe("user_message");
+    expect(block.ctx.itemId).toBe("msg_stamped");
+    expect(block.ctx.createdAtS).toBe(1_754_000_000);
+  });
+
+  it("omits createdAtS when the event carries no stamp (older servers)", () => {
+    useChatStore.setState({ conversationId: "conv_abc" });
+
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_unstamped",
+      itemType: "message",
+      data: { role: "user", content: [{ type: "input_text", text: "no stamp" }] },
+    });
+
+    const block = useChatStore.getState().blocks.at(-1) as UserMessageBlock;
+    expect(block.ctx.itemId).toBe("msg_unstamped");
+    expect(block.ctx.createdAtS).toBeUndefined();
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -3808,6 +3808,13 @@ export async function pumpStreamEvents(
         // FIFO (findIndex): the relay flushes segments in order, so the
         // first unstamped match is the one this item persisted.
         const itemId = block.ctx.itemId;
+        // The persisted copy also carries the server creation time —
+        // stamp it alongside the id so the streamed block gains its
+        // timestamp (the deltas that painted it had none).
+        const stamp = {
+          itemId,
+          ...(block.ctx.createdAtS !== undefined ? { createdAtS: block.ctx.createdAtS } : {}),
+        };
         const matchesStreamed = (b: AnyBlock): b is TextDone =>
           b.type === "text_done" &&
           !b.ctx.itemId &&
@@ -3816,7 +3823,7 @@ export async function pumpStreamEvents(
         const bufferAt = buffer.findIndex(matchesStreamed);
         if (bufferAt !== -1) {
           const streamed = buffer[bufferAt] as TextDone;
-          buffer[bufferAt] = { ...streamed, ctx: { ...streamed.ctx, itemId } };
+          buffer[bufferAt] = { ...streamed, ctx: { ...streamed.ctx, ...stamp } };
           continue;
         }
         if (get().blocks.some(matchesStreamed)) {
@@ -3828,7 +3835,7 @@ export async function pumpStreamEvents(
             if (at === -1) return {};
             const streamed = s.blocks[at]!;
             const next = s.blocks.slice();
-            next[at] = { ...streamed, ctx: { ...streamed.ctx, itemId } };
+            next[at] = { ...streamed, ctx: { ...streamed.ctx, ...stamp } };
             return { blocks: next };
           });
           continue;
@@ -4020,6 +4027,7 @@ function committedUserBlock(
   content: MessageContentBlock[],
   stableKey?: string,
   createdBy?: string,
+  createdAtS?: number,
 ): UserMessageBlock {
   return {
     type: "user_message",
@@ -4033,6 +4041,9 @@ function committedUserBlock(
       // Live human-author attribution (multi-user); omit when absent so
       // null carries no author. Mirrors itemsToBlocks on cold load.
       ...(createdBy !== undefined ? { createdBy } : {}),
+      // Server persistence stamp from the consumed event; omit when the
+      // server didn't send one. Mirrors itemsToBlocks on cold load.
+      ...(createdAtS !== undefined ? { createdAtS } : {}),
     },
     content,
     stableKey,
@@ -4649,6 +4660,7 @@ export function handleSessionEvent(event: StreamEvent): void {
                   content,
                   matched.tempId,
                   event.createdBy ?? matched.author,
+                  event.createdAtS,
                 ),
               ],
             };
@@ -4682,6 +4694,7 @@ export function handleSessionEvent(event: StreamEvent): void {
                 content,
                 head.tempId,
                 event.createdBy ?? head.author,
+                event.createdAtS,
               ),
             ],
           };
@@ -4693,7 +4706,13 @@ export function handleSessionEvent(event: StreamEvent): void {
         return {
           blocks: [
             ...s.blocks,
-            committedUserBlock(event.itemId, eventContent, undefined, event.createdBy),
+            committedUserBlock(
+              event.itemId,
+              eventContent,
+              undefined,
+              event.createdBy,
+              event.createdAtS,
+            ),
           ],
         };
       });


### PR DESCRIPTION
## Related issue

Closes omnigent-ai/omnigent#4263

## Summary

* Every prompt and response bubble now shows a muted wall-clock stamp — when the prompt was accepted and when the response finished — sourced from the persisted `created_at` clock in **both** the live-streaming path and history reloads, so a streaming session and a reloaded one show identical times.
* Backend: `session.input.consumed` gains an optional `created_at` field, and the runner relay patches live `output_item.done` frames with the store's stamp before publishing (`openapi.json` regenerated).
* Web: the stamp threads through `sse.ts → blockStream.ts → renderItems.ts` into the bubbles; new Settings → Appearance toggle **"Show message timestamps"** (on by default, wired into "Reset to defaults") updates already-mounted bubbles live via a small subscription hook.

**ELI5:** the database always knew when each message happened — the UI just never said. Now each bubble quietly shows its time ("3:42 PM", "Yesterday 3:42 PM", full date on hover), and you can turn it off in Settings.

```mermaid
flowchart LR
    S["store.append()\nstamps created_at"] --> IC["session.input.consumed\n(+ created_at)"]
    S --> RP["relay patches live\noutput_item.done"]
    S --> H["GET /v1/sessions/:id\n(history)"]
    IC --> CTX["BlockContext.createdAtS"]
    RP --> CTX
    H --> CTX
    CTX --> UB["user bubble stamp"]
    CTX --> AB["assistant bubble stamp\n(turn's newest item)"]
```

Bubbles with no server stamp yet (optimistic sends, mid-turn streams) show nothing rather than a guessed client time — the label appears when the server acknowledges the item, keeping the page-relative and server clocks strictly separate (the existing invariant in `blocks.ts`).

## Test Plan

* `uv run pytest tests/server/...` — schema, OpenAPI-drift, relay, and sessions-endpoint suites (775 passing), including new pins: `created_at` present on the consumed event and equal to the snapshot's stamp; relayed live message frames carry the persisted `created_at`.
* `cd web && pnpm test` — full vitest suite green (5,355 tests), with new coverage for `formatMessageTime` branches, the preference round-trip/subscription, bubble propagation, `bubblesEqual` comparators, `message_done` stamp threading (including the response-switch guard), and the in-place id+stamp reconciliation.
* `uv run pytest tests/e2e_ui/chat/test_message_timestamps.py` — new Playwright e2e: live send → both bubbles stamped, reload → same stamps from history, Settings toggle off → stamps removed.
* `pre-commit run` clean on all changed files.

## Demo

Timestamps on (default) — prompt and response each carry their server-side time:

![Transcript with timestamps under the user prompt and assistant response](https://raw.githubusercontent.com/bradfordchang/omnigent/timestamps-demo-assets/demo/demo-timestamps-on.png)

Settings → Appearance toggle, and the same transcript toggled off:

![Settings Appearance section with the Show message timestamps switch](https://raw.githubusercontent.com/bradfordchang/omnigent/timestamps-demo-assets/demo/demo-settings-toggle.png)

![The same transcript with no timestamps after turning the setting off](https://raw.githubusercontent.com/bradfordchang/omnigent/timestamps-demo-assets/demo/demo-timestamps-off.png)

## Type of change

- [ ] Bug fix
- [X] Feature
- [X] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [X] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove a live dev-pod session and captured the Demo screenshots above — live prompt stamp on send, both stamps after reload, and the toggle removing them without a reload. The mock-LLM leg of the new e2e (live assistant stamp) can't complete on my corp-network machine (pre-existing: `test_multi_turn_chat.py` fails identically on a clean tree there), so that path relies on CI plus the unit/integration pins listed above.

## Changelog

Prompts and responses in agent sessions show when they happened; toggle under Settings → Appearance → "Show message timestamps"

---

This pull request and its description were written by Isaac.