### PR TITLE
fix(web): don't fetch history when opening a session

### DIFF
--- a/tests/e2e_ui/chat/test_initial_history_loading.py
+++ b/tests/e2e_ui/chat/test_initial_history_loading.py
@@ -1,9 +1,12 @@
-"""E2E coverage for non-blocking initial conversation history loading.
+"""E2E coverage for what a session open is allowed to fetch.
 
-The transcript is seeded so its newest page contains only the latest user
-prompt. The previous prompt is on page two, with still-older history beyond
-it. The browser records whether the latest prompt is already rendered when
-each items request starts, proving the second request is post-paint work.
+Opening a session used to render one small page and then keep paging older
+history from the transcript's layout effect until it found the previous user
+prompt. The reader watched history land for seconds after the page had already
+settled, with the content shifting under them, having never scrolled.
+
+So: the open is exactly one items request, and nothing more happens until the
+reader actually scrolls toward the top — at which point paging still works.
 """
 
 from __future__ import annotations
@@ -45,93 +48,100 @@ def _seed_message(
     assert response.status_code == 202, response.text
 
 
-def test_initial_history_renders_before_prompt_boundary_fetch_finishes(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """Render page one before fetching page two and keep the turn rail lazy."""
-    base_url, session_id = seeded_session
-    previous_prompt = "history previous prompt"
-    latest_prompt = "history latest prompt"
-
-    with httpx.Client(base_url=base_url, timeout=10.0) as client:
-        # Twenty old items leave more history after page two. The next 21 items
-        # place one user prompt on each of the two newest 20-item pages.
-        for index in range(20):
-            _seed_message(
-                client,
-                session_id,
-                response_id=f"resp_old_{index:02d}",
-                role="assistant",
-                text=f"old filler {index}",
-            )
-        _seed_message(
-            client,
-            session_id,
-            response_id="resp_previous",
-            role="user",
-            text=previous_prompt,
-        )
-        _seed_message(
-            client,
-            session_id,
-            response_id="resp_previous",
-            role="assistant",
-            text="previous reply",
-        )
-        _seed_message(
-            client,
-            session_id,
-            response_id="resp_latest",
-            role="user",
-            text=latest_prompt,
-        )
-        for index in range(18):
-            _seed_message(
-                client,
-                session_id,
-                response_id=f"resp_latest_{index:02d}",
-                role="assistant",
-                text=f"latest filler {index}",
-            )
-
+def _track_items_requests(page: Page, session_id: str) -> None:
+    """Record every `/items` request the page makes, in order."""
     endpoint = f"/v1/sessions/{session_id}/items"
     page.add_init_script(
         f"""
         (() => {{
           const endpoint = {json.dumps(endpoint)};
-          const latestPrompt = {json.dumps(latest_prompt)};
+          window.__itemsUrls = [];
           const originalFetch = window.fetch.bind(window);
-          window.__historyFetches = [];
           window.fetch = (input, init) => {{
             const url = typeof input === "string" ? input : input.url;
-            if (url.includes(endpoint)) {{
-              window.__historyFetches.push({{
-                url,
-                latestVisible: document.body.innerText.includes(latestPrompt),
-              }});
-            }}
+            if (url.includes(endpoint)) window.__itemsUrls.push(url);
             return originalFetch(input, init);
           }};
         }})();
         """
     )
 
-    page.set_viewport_size({"width": 1280, "height": 320})
+
+def _seed_long_transcript(base_url: str, session_id: str, latest_prompt: str) -> None:
+    """Seed more items than one window holds, so older history remains."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        _seed_message(
+            client, session_id, response_id="resp_old", role="user", text="oldest prompt"
+        )
+        # Comfortably beyond the initial window, so `has_more` stays true and
+        # a regression that resumes paging has something to page into.
+        for index in range(130):
+            _seed_message(
+                client,
+                session_id,
+                response_id=f"resp_fill_{index:03d}",
+                role="assistant",
+                text=f"filler {index}",
+            )
+        _seed_message(
+            client, session_id, response_id="resp_latest", role="user", text=latest_prompt
+        )
+
+
+def test_opening_a_session_fetches_history_once_and_then_stops(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Open a session and fetch history exactly once, with no scrolling."""
+    base_url, session_id = seeded_session
+    latest_prompt = "history latest prompt"
+    _seed_long_transcript(base_url, session_id, latest_prompt)
+    _track_items_requests(page, session_id)
+
+    page.set_viewport_size({"width": 1280, "height": 720})
     page.goto(f"{base_url}/c/{session_id}")
 
     conversation = page.get_by_role("log")
-    expect(conversation.get_by_text(latest_prompt, exact=True)).to_be_visible(timeout=15_000)
-    expect(conversation.get_by_text(previous_prompt, exact=True)).to_be_visible(timeout=15_000)
-    page.wait_for_function("window.__historyFetches.length >= 2", timeout=15_000)
-    page.wait_for_timeout(500)
+    expect(conversation.get_by_text(latest_prompt, exact=True)).to_be_visible(timeout=20_000)
 
-    fetches = page.evaluate("window.__historyFetches")
-    assert len(fetches) == 2, fetches
-    assert fetches[0]["latestVisible"] is False
-    assert fetches[1]["latestVisible"] is True
-    assert all("limit=20" in request["url"] for request in fetches)
-    assert all("limit=200" not in request["url"] for request in fetches)
+    # Sit still, as a reader who has not scrolled. Background paging showed up
+    # here as extra requests seconds after the transcript had settled.
+    page.wait_for_timeout(4_000)
 
-    expect(page.get_by_role("button", name=f"Jump to: {previous_prompt}")).to_be_visible()
-    expect(page.get_by_role("button", name=f"Jump to: {latest_prompt}")).to_be_visible()
+    urls = page.evaluate("window.__itemsUrls")
+    assert len(urls) == 1, urls
+    # One window-sized request, cursorless (the newest items).
+    assert "after=" not in urls[0], urls
+    # The "Loading earlier messages…" row belongs to reader-driven paging, so
+    # it must never have appeared during the open either.
+    expect(page.get_by_text("Loading earlier messages", exact=False)).to_have_count(0)
+
+
+def test_scrolling_to_the_top_still_pages_older_history(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Keep scroll-up paging working; only the automatic build is gone."""
+    base_url, session_id = seeded_session
+    latest_prompt = "history latest prompt"
+    _seed_long_transcript(base_url, session_id, latest_prompt)
+    _track_items_requests(page, session_id)
+
+    page.set_viewport_size({"width": 1280, "height": 720})
+    page.goto(f"{base_url}/c/{session_id}")
+
+    conversation = page.get_by_role("log")
+    expect(conversation.get_by_text(latest_prompt, exact=True)).to_be_visible(timeout=20_000)
+    page.wait_for_timeout(2_000)
+    assert len(page.evaluate("window.__itemsUrls")) == 1
+
+    # Now the reader scrolls up to the top, which IS a request for older
+    # history. (A pane with no scroll range at all can't report that movement;
+    # that path arms on the wheel gesture itself and is unit-tested.)
+    page.evaluate("document.querySelector('[role=\"log\"]').firstElementChild.scrollTop = 0")
+    page.wait_for_function("window.__itemsUrls.length > 1", timeout=20_000)
+
+    urls = page.evaluate("window.__itemsUrls")
+    assert len(urls) >= 2, urls
+    # Every page after the first is cursored off the window's oldest item.
+    assert all("after=" in url for url in urls[1:]), urls

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -829,6 +829,22 @@ export async function fetchSessionItemsPage(
   return { items: [...page.data].reverse(), hasMore: page.has_more };
 }
 
+/**
+ * Items the initial window requests, in one round trip.
+ *
+ * Opening a session must not keep fetching afterwards: growing the window
+ * from the transcript's layout effect meant the reader watched history land
+ * for seconds after the page had already settled, with the content shifting
+ * under them each time — and they never asked for it. So the open pays for a
+ * single, larger page instead, and older history is fetched only when they
+ * actually scroll up.
+ *
+ * Sized to cover the previous prompt for a normal turn without the walk this
+ * replaces; a tool-heavy turn can still run longer, and reaching further back
+ * is then the reader's scroll, not a background fetch.
+ */
+export const INITIAL_WINDOW_ITEMS = 100;
+
 /** Pages allowed while looking for the previous user-message boundary. */
 export const MAX_INITIAL_PAGES = 8;
 

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -2,7 +2,6 @@ import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react
 import { Profiler, useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserMessageBlock } from "@/lib/blocks";
-import { MAX_INITIAL_PAGES } from "@/lib/sessionsApi";
 import { useChatStore } from "@/store/chatStore";
 import { HistoryAutoLoader, JumpToTopButton, LatestTurnSpacer } from "./ChatPage";
 
@@ -238,7 +237,7 @@ describe("HistoryAutoLoader", () => {
     expect(loadMoreHistory).toHaveBeenCalledTimes(1);
   });
 
-  it("starts initial paging when the live scroll element becomes available after mount", () => {
+  it("does not page when the live scroll element arrives after mount", () => {
     const loadMoreHistory = vi.fn(async () => {
       useChatStore.setState({ loadingMoreHistory: true });
     });
@@ -261,7 +260,9 @@ describe("HistoryAutoLoader", () => {
 
     render(<DeferredScroller />);
 
-    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
+    // The scroll element attaching is not a reader scrolling. Paging here
+    // made a freshly opened session keep fetching on its own.
+    expect(loadMoreHistory).not.toHaveBeenCalled();
   });
 
   it("keeps loading after reaching the top during an in-flight fetch", () => {
@@ -291,69 +292,125 @@ describe("HistoryAutoLoader", () => {
     expect(loadMoreHistory).toHaveBeenCalledTimes(2);
   });
 
-  it("loads to the second real user prompt even when the viewport already scrolls", () => {
+  it("never pages on load, even when the window holds a single prompt", () => {
     const loadMoreHistory = vi.fn(async () => {
       useChatStore.setState({ loadingMoreHistory: true });
     });
+    // One real prompt with older history behind it: the shape that used to
+    // make the open keep fetching until it found a second prompt, so the
+    // transcript grew and shifted seconds after the page had settled.
     useChatStore.setState({
       blocks: [userBlock("latest"), userBlock("system", "[System: task completed]")],
       hasMoreHistory: true,
+      oldestItemId: "item_9",
       loadMoreHistory,
     });
     const scrollRoot = document.createElement("div");
-    // Parked well clear of the fetch threshold (2.5 viewports), so only the
-    // initial-window build may page — not the scroll-driven path.
+    // Parked well clear of the top threshold: nothing the reader did asks
+    // for older history.
     setScrollMetrics(scrollRoot, { scrollTop: 2000, scrollHeight: 4000, clientHeight: 500 });
     stickContext.scrollRef.current = scrollRoot;
 
     render(<HistoryAutoLoader />);
-    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
-    expect(useChatStore.getState().loadingMoreHistory).toBe(true);
 
-    act(() => {
-      useChatStore.setState({
-        blocks: [userBlock("previous"), userBlock("latest")],
-        loadingMoreHistory: false,
-        oldestItemId: "item_1",
-      });
-    });
-
-    expect(useChatStore.getState().loadingMoreHistory).toBe(false);
-    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
+    expect(loadMoreHistory).not.toHaveBeenCalled();
   });
 
-  it("caps the prompt search at the page cap", () => {
+  it("does not page when the open scrolls the pane to the bottom", () => {
     const loadMoreHistory = vi.fn(async () => {
       useChatStore.setState({ loadingMoreHistory: true });
     });
     useChatStore.setState({
       blocks: [userBlock("latest")],
       hasMoreHistory: true,
+      oldestItemId: "item_9",
       loadMoreHistory,
     });
-
     const scrollRoot = document.createElement("div");
-    // Clear of the fetch threshold, so the page count below is the cap alone.
+    // A transcript barely taller than the pane: wherever it settles is inside
+    // the fetch threshold, so "near the top" is trivially true. Opening still
+    // must not fetch — the scroll below is the open's own scroll-to-bottom.
+    const metrics = { scrollTop: 0, scrollHeight: 900, clientHeight: 800 };
+    setScrollMetrics(scrollRoot, metrics);
+    stickContext.scrollRef.current = scrollRoot;
+
+    render(<HistoryAutoLoader />);
+    metrics.scrollTop = 100; // downward: stick-to-bottom settling the view
+    fireEvent.scroll(scrollRoot);
+
+    expect(loadMoreHistory).not.toHaveBeenCalled();
+
+    // The reader then scrolls up, which IS a request for older history.
+    metrics.scrollTop = 40;
+    fireEvent.scroll(scrollRoot);
+
+    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("pages on a wheel-up even when the pane has no scroll range", () => {
+    const loadMoreHistory = vi.fn(async () => {});
+    useChatStore.setState({
+      blocks: [userBlock("latest")],
+      hasMoreHistory: true,
+      oldestItemId: "item_9",
+      loadMoreHistory,
+    });
+    const scrollRoot = document.createElement("div");
+    // Transcript shorter than the window: scrollTop can never change, so a
+    // movement-only rule would strand older history behind a gesture the pane
+    // is physically unable to report.
+    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 400, clientHeight: 900 });
+    stickContext.scrollRef.current = scrollRoot;
+
+    render(<HistoryAutoLoader />);
+    expect(loadMoreHistory).not.toHaveBeenCalled();
+
+    fireEvent.wheel(scrollRoot, { deltaY: -120 });
+
+    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a wheel-down, which is not a request for older history", () => {
+    const loadMoreHistory = vi.fn(async () => {});
+    useChatStore.setState({
+      blocks: [userBlock("latest")],
+      hasMoreHistory: true,
+      oldestItemId: "item_9",
+      loadMoreHistory,
+    });
+    const scrollRoot = document.createElement("div");
+    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 400, clientHeight: 900 });
+    stickContext.scrollRef.current = scrollRoot;
+
+    render(<HistoryAutoLoader />);
+    fireEvent.wheel(scrollRoot, { deltaY: 120 });
+
+    expect(loadMoreHistory).not.toHaveBeenCalled();
+  });
+
+  it("does not cascade after a page settles while parked away from the top", () => {
+    const loadMoreHistory = vi.fn(async () => {
+      useChatStore.setState({ loadingMoreHistory: true });
+    });
+    useChatStore.setState({
+      blocks: [userBlock("latest")],
+      hasMoreHistory: true,
+      oldestItemId: "item_9",
+      loadMoreHistory,
+    });
+    const scrollRoot = document.createElement("div");
     setScrollMetrics(scrollRoot, { scrollTop: 2000, scrollHeight: 4000, clientHeight: 500 });
     stickContext.scrollRef.current = scrollRoot;
 
     render(<HistoryAutoLoader />);
-    expect(loadMoreHistory).toHaveBeenCalledTimes(1);
 
-    // The newest page counts as page one. Settle older pages without finding a
-    // second prompt; the semantic search must stop at the cap — reachability is
-    // no longer this loop's job (the spacer keeps the pane scrollable).
-    for (let page = 2; page <= MAX_INITIAL_PAGES; page++) {
-      act(() => {
-        useChatStore.setState({
-          loadingMoreHistory: false,
-          oldestItemId: `item_${page + 1}`,
-        });
-      });
-    }
+    // A prepend landing (new cursor) is not a reason to fetch again on its
+    // own — that self-feeding loop is what made one page turn into many.
+    act(() => {
+      useChatStore.setState({ loadingMoreHistory: false, oldestItemId: "item_1" });
+    });
 
-    // MAX_INITIAL_PAGES total fetches: the initial page plus (cap − 1) more.
-    expect(loadMoreHistory).toHaveBeenCalledTimes(MAX_INITIAL_PAGES - 1);
+    expect(loadMoreHistory).not.toHaveBeenCalled();
   });
 
   it("does not page a short window for viewport fill (the spacer handles reachability)", () => {
@@ -477,7 +534,7 @@ describe("LatestTurnSpacer", () => {
     vi.stubGlobal("ResizeObserver", StubResizeObserver);
 
     const scrollRoot = document.createElement("div");
-    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 0, clientHeight: 500 });
+    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 0, clientHeight: 600 });
     stickContext.scrollRef.current = scrollRoot;
 
     const anchor = document.createElement("div");
@@ -489,7 +546,7 @@ describe("LatestTurnSpacer", () => {
     vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockImplementation(function (
       this: HTMLDivElement,
     ) {
-      return this.getAttribute("aria-hidden") !== null ? rect(100) : rect(0);
+      return this.getAttribute("aria-hidden") !== null ? rect(400) : rect(0);
     });
 
     const onRender = vi.fn();
@@ -500,14 +557,24 @@ describe("LatestTurnSpacer", () => {
     );
 
     const spacer = container.querySelector<HTMLElement>("div[aria-hidden]")!;
-    expect(spacer.style.height).toBe("304px");
+    expect(spacer.style.height).toBe("104px");
     expect(onRender).toHaveBeenCalledTimes(1);
   });
 
-  it("pads a short reply so the anchor prompt pins to the top", () => {
-    // anchor→end = 100px content, viewport 500 → spacer = 500 − 100 − 96 = 304.
-    expect(measureSpacer({ clientHeight: 500, anchorTop: 0, spacerTop: 100, anchor: "user" })).toBe(
-      304,
+  it("pads a reply that falls short of the viewport so the anchor pins near the top", () => {
+    // anchor→end = 400px, viewport 600 → 600 − 400 − 96 = 104, under the
+    // 200px cap, so the pin-to-top formula is what this measures.
+    expect(measureSpacer({ clientHeight: 600, anchorTop: 0, spacerTop: 400, anchor: "user" })).toBe(
+      104,
+    );
+  });
+
+  it("caps the reserved space so a short turn does not blank most of the viewport", () => {
+    // anchor→end = 100px, viewport 600 → the raw pin formula wants
+    // 600 − 100 − 96 = 404px of blank (two thirds of the screen). The cap
+    // holds it to a third, so earlier turns stay on screen.
+    expect(measureSpacer({ clientHeight: 600, anchorTop: 0, spacerTop: 100, anchor: "user" })).toBe(
+      200,
     );
   });
 
@@ -520,9 +587,9 @@ describe("LatestTurnSpacer", () => {
   });
 
   it("anchors to the last assistant text when no user prompt is present", () => {
-    // 500 − 50 − 96 = 354.
-    expect(measureSpacer({ clientHeight: 500, anchorTop: 0, spacerTop: 50, anchor: "text" })).toBe(
-      354,
+    // 600 − 400 − 96 = 104 (under the cap, so anchor choice is what's measured).
+    expect(measureSpacer({ clientHeight: 600, anchorTop: 0, spacerTop: 400, anchor: "text" })).toBe(
+      104,
     );
   });
 
@@ -544,7 +611,7 @@ describe("LatestTurnSpacer", () => {
     vi.stubGlobal("ResizeObserver", StubResizeObserver);
 
     const scrollRoot = document.createElement("div");
-    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 0, clientHeight: 500 });
+    setScrollMetrics(scrollRoot, { scrollTop: 0, scrollHeight: 0, clientHeight: 600 });
     stickContext.scrollRef.current = scrollRoot;
 
     const initial = document.createElement("div");
@@ -562,9 +629,11 @@ describe("LatestTurnSpacer", () => {
     useChatStore.setState({ blocks: [userBlock("initial-user")] });
     const { container } = render(<LatestTurnSpacer />);
     const spacer = container.querySelector<HTMLElement>("div[aria-hidden]")!;
-    vi.spyOn(spacer, "getBoundingClientRect").mockReturnValue(rect(200));
+    vi.spyOn(spacer, "getBoundingClientRect").mockReturnValue(rect(400));
     act(() => holder.cb?.());
-    expect(spacer.style.height).toBe("204px");
+    // Measured from the initial prompt: 600 − 400 − 96 = 104. Retargeting to
+    // the promoted prompt would give 600 − 250 − 96 = 254 → capped to 200.
+    expect(spacer.style.height).toBe("104px");
 
     // The consumed event moves the pending prompt into committed blocks. The
     // spacer still measures from the initial prompt instead of retargeting.
@@ -572,7 +641,7 @@ describe("LatestTurnSpacer", () => {
       useChatStore.setState({ blocks: [userBlock("initial-user"), userBlock("pending-user")] });
       holder.cb?.();
     });
-    expect(spacer.style.height).toBe("204px");
+    expect(spacer.style.height).toBe("104px");
   });
 
   it("does not create an anchor after an initially empty conversation's first prompt commits", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -55,7 +55,6 @@ import { BlockRenderer, FilePathAwareMessageResponse } from "@/components/blocks
 import { CompactionMarker, RoutingDecisionCard } from "@/components/blocks/StatusBlocks";
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
 import { isSystemUserContent, parseSystemMessage } from "@/lib/systemMessage";
-import { initialWindowComplete } from "@/lib/sessionsApi";
 import { Button } from "@/components/ui/button";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
@@ -2282,6 +2281,9 @@ function historyLoadThreshold(el: HTMLElement): number {
   return Math.max(HISTORY_LOAD_TOP_MIN_PX, el.clientHeight * HISTORY_LOAD_TOP_VIEWPORTS);
 }
 
+/** Finger travel before a touch drag counts as "show me what's above". */
+const TOUCH_DRAG_SLOP_PX = 8;
+
 export function HistoryAutoLoader({
   scrollElement,
 }: {
@@ -2299,11 +2301,25 @@ export function HistoryAutoLoader({
   // prepends its items and clears loadingMoreHistory. Unlike scrollHeight, it
   // still changes when many fetched tool calls collapse into one visual row.
   const oldestItemId = useChatStore((s) => s.oldestItemId);
-  const pagesFetchedRef = useRef(1);
   const generationRef = useRef(historyGeneration);
   const [scrollRevision, setScrollRevision] = useState(0);
   const handledScrollRevisionRef = useRef(scrollRevision);
   const oldestItemIdRef = useRef(oldestItemId);
+  // Whether the reader has asked to move the transcript upward yet.
+  //
+  // "Near the top" alone is not a request for older history: opening a session
+  // scrolls the pane to the bottom, and on a transcript shorter than the fetch
+  // threshold that lands trivially near the top — so the open fetched a page,
+  // the prepend moved the cursor, and that fed the next fetch. Fifteen
+  // requests and a "Loading earlier messages…" row, for someone who never
+  // touched the scrollbar.
+  //
+  // Intent, not movement: a window taller than the transcript has no scroll
+  // range at all, so waiting for scrollTop to fall would strand older history
+  // behind a gesture the pane can never report.
+  const scrolledUpRef = useRef(false);
+  const lastScrollTopRef = useRef<number | null>(null);
+  const touchStartYRef = useRef<number | null>(null);
 
   // Position across a prepend is held by native scroll anchoring, not by this
   // component. Writing scrollTop here instead used to interrupt the reader's
@@ -2314,9 +2330,52 @@ export function HistoryAutoLoader({
   useLayoutEffect(() => {
     const el = scrollElement ?? ctx.scrollRef?.current;
     if (!el) return;
-    const handleScroll = () => setScrollRevision((revision) => revision + 1);
+    // Baseline from where the pane currently sits, so the reader's very first
+    // upward scroll already has something to compare against.
+    lastScrollTopRef.current = el.scrollTop;
+    // Arming has to re-run the paging effect itself: a pane with no scroll
+    // range fires no scroll event, so nothing else would notice the gesture.
+    const armScrollUp = () => {
+      if (scrolledUpRef.current) return;
+      scrolledUpRef.current = true;
+      setScrollRevision((revision) => revision + 1);
+    };
+    const handleScroll = () => {
+      const previous = lastScrollTopRef.current;
+      lastScrollTopRef.current = el.scrollTop;
+      // Only an upward move counts. The open's scroll-to-bottom and a
+      // prepend's native anchor correction both move scrollTop DOWN the
+      // document (larger), so neither can arm paging on its own.
+      if (previous !== null && el.scrollTop < previous - 0.5) scrolledUpRef.current = true;
+      // Every scroll re-runs the paging effect, armed or not: staying near the
+      // top has to keep paging, not just the moment the reader arrives there.
+      setScrollRevision((revision) => revision + 1);
+    };
+    // Wheel/trackpad up, and a touch drag downward (which reveals what is
+    // above). These fire whether or not the pane has anywhere to scroll.
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) armScrollUp();
+    };
+    const handleTouchStart = (event: TouchEvent) => {
+      touchStartYRef.current = event.touches[0]?.clientY ?? null;
+    };
+    const handleTouchMove = (event: TouchEvent) => {
+      const start = touchStartYRef.current;
+      const current = event.touches[0]?.clientY;
+      if (start !== null && current !== undefined && current > start + TOUCH_DRAG_SLOP_PX) {
+        armScrollUp();
+      }
+    };
     el.addEventListener("scroll", handleScroll, { passive: true });
-    return () => el.removeEventListener("scroll", handleScroll);
+    el.addEventListener("wheel", handleWheel, { passive: true });
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
+    el.addEventListener("touchmove", handleTouchMove, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+      el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("touchstart", handleTouchStart);
+      el.removeEventListener("touchmove", handleTouchMove);
+    };
   }, [ctx.scrollRef, scrollElement]);
 
   // This is the single paging effect. Fetches are driven by user scrolls or a
@@ -2334,28 +2393,29 @@ export function HistoryAutoLoader({
 
     if (generationChanged) {
       generationRef.current = historyGeneration;
-      pagesFetchedRef.current = 1;
+      // A new window is a new open: require a fresh upward scroll.
+      scrolledUpRef.current = false;
+      lastScrollTopRef.current = el.scrollTop;
     }
 
     const state = useChatStore.getState();
-    const userPromptCount = state.blocks.reduce(
-      (count, block) =>
-        count + (block.type === "user_message" && !isSystemUserContent(block.content) ? 1 : 0),
-      0,
-    );
-    const buildingInitialWindow = !initialWindowComplete(userPromptCount, pagesFetchedRef.current);
 
+    // Reader-driven only. Opening a session used to keep paging from here
+    // until it found the previous prompt, so history kept landing for seconds
+    // after the page had settled and the transcript shifted under someone who
+    // had not scrolled at all. The bind now fetches its whole window in one
+    // request, and this waits for the reader to actually scroll up.
     if (
+      !scrolledUpRef.current ||
       !state.oldestItemId ||
       !state.hasMoreHistory ||
       state.loadingMoreHistory ||
-      (!buildingInitialWindow &&
-        (!(itemsChanged || scrollPositionChanged) || el.scrollTop >= historyLoadThreshold(el)))
+      !(itemsChanged || scrollPositionChanged) ||
+      el.scrollTop >= historyLoadThreshold(el)
     ) {
       return;
     }
 
-    if (buildingInitialWindow) pagesFetchedRef.current += 1;
     void state.loadMoreHistory();
   }, [
     ctx.scrollRef,
@@ -2366,13 +2426,21 @@ export function HistoryAutoLoader({
     scrollRevision,
   ]);
 
-  // No visible control — history loads purely on scroll-up / the initial-window
-  // build above.
+  // No visible control — history loads purely on scroll-up.
   return null;
 }
 
 /** Top inset for a pinned anchor: 16px beyond the fade's fully opaque edge. */
 const PINNED_ANCHOR_TOP_GAP_PX = 96;
+
+/**
+ * Ceiling on the reserved space, as a share of the viewport. Pinning a SHORT
+ * latest turn to the top costs almost a full screen of blank, with readable
+ * history sitting just above the fold. Capping it keeps most of the viewport
+ * showing real messages; a long turn is unaffected, since it already needs
+ * little or no reserved space to reach the top.
+ */
+const MAX_RESERVED_VIEWPORT_FRACTION = 1 / 3;
 
 /**
  * Trailing spacer that pins the initially loaded turn's anchor to the top of
@@ -2459,7 +2527,14 @@ export function LatestTurnSpacer({
     // spacer's top is fixed by the content above it, so this is stable across
     // the height we're about to set — it converges in one pass.
     const anchorToEnd = spacerEl.getBoundingClientRect().top - anchor.getBoundingClientRect().top;
-    const next = Math.max(0, scrollEl.clientHeight - anchorToEnd - PINNED_ANCHOR_TOP_GAP_PX);
+    const viewport = scrollEl.clientHeight;
+    const next = Math.max(
+      0,
+      Math.min(
+        viewport - anchorToEnd - PINNED_ANCHOR_TOP_GAP_PX,
+        viewport * MAX_RESERVED_VIEWPORT_FRACTION,
+      ),
+    );
     const current = Number.parseFloat(spacerEl.style.height) || 0;
     if (Math.abs(current - next) >= 1) spacerEl.style.height = `${next}px`;
   }, [ctx.scrollRef, scrollElement]);

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -32,7 +32,7 @@ import type {
 import type { ConversationItem } from "@/lib/conversationItems";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
 import { buildBubbles } from "@/lib/renderItems";
-import { SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
+import { INITIAL_WINDOW_ITEMS, SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
 import { getCurrentAuthorId } from "@/lib/identity";
 import type {
   SessionCreatedEvent,
@@ -1172,22 +1172,22 @@ describe("chatStore — switchTo", () => {
     expect(elicitation?.message).toBe("Approve stalled stream command?");
   });
 
-  it("hydrates only the most recent page and flags that older history remains", async () => {
-    // More than two pages so the loaded window is a strict subset.
-    const total = SESSION_HISTORY_PAGE_SIZE * 2 + 5;
+  it("hydrates only the initial window and flags that older history remains", async () => {
+    // Longer than the initial window so the loaded window is a strict subset.
+    const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE + 5;
     const fullItems = Array.from({ length: total }, (_, idx) =>
       userMessage(`resp_${idx.toString().padStart(4, "0")}`, `message ${idx}`),
     );
-    seedSessionSnapshot("conv_big", fullItems.slice(-SESSION_HISTORY_PAGE_SIZE));
+    seedSessionSnapshot("conv_big", fullItems.slice(-INITIAL_WINDOW_ITEMS));
     seedSessionItems("conv_big", fullItems);
 
     await useChatStore.getState().switchTo("conv_big");
 
     const state = useChatStore.getState();
-    // Only the newest page is hydrated. If bind regressed to loading the
-    // whole transcript this would be `total` (205) — the slow-open bug
-    // this windowing fixes.
-    expect(state.blocks).toHaveLength(SESSION_HISTORY_PAGE_SIZE);
+    // Only the initial window is hydrated. If bind regressed to loading the
+    // whole transcript this would be `total` — the slow-open bug this
+    // windowing fixes.
+    expect(state.blocks).toHaveLength(INITIAL_WINDOW_ITEMS);
     // Newest item is the last block: proves we fetched the tail
     // (order=desc) and reversed to chronological, not the convo head.
     expect(state.blocks.at(-1)).toMatchObject({
@@ -1197,8 +1197,8 @@ describe("chatStore — switchTo", () => {
     // Older items remain, so scroll-up loading is armed. `false` here
     // would strand the user with no way to reach earlier turns.
     expect(state.hasMoreHistory).toBe(true);
-    // One descending page request on bind — not the sequential per-page
-    // walk the old full-transcript hydration did.
+    // Exactly ONE request on bind. More than one means the open resumed
+    // fetching history the reader never asked for.
     const itemFetches = fetchMock.mock.calls.filter(([u]) =>
       String(u).startsWith("/v1/sessions/conv_big/items"),
     );
@@ -1207,41 +1207,41 @@ describe("chatStore — switchTo", () => {
   });
 
   it("loadMoreHistory prepends the page of items immediately older than the window", async () => {
-    const total = SESSION_HISTORY_PAGE_SIZE * 2 + 5;
+    const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE + 5;
     const fullItems = Array.from({ length: total }, (_, idx) =>
       userMessage(`resp_${idx.toString().padStart(4, "0")}`, `message ${idx}`),
     );
-    seedSessionSnapshot("conv_big", fullItems.slice(-SESSION_HISTORY_PAGE_SIZE));
+    seedSessionSnapshot("conv_big", fullItems.slice(-INITIAL_WINDOW_ITEMS));
     seedSessionItems("conv_big", fullItems);
 
     await useChatStore.getState().switchTo("conv_big");
-    // Precondition: bind loaded exactly the newest page.
-    expect(useChatStore.getState().blocks).toHaveLength(SESSION_HISTORY_PAGE_SIZE);
+    // Precondition: bind loaded exactly the initial window.
+    expect(useChatStore.getState().blocks).toHaveLength(INITIAL_WINDOW_ITEMS);
 
     await useChatStore.getState().loadMoreHistory();
 
     const state = useChatStore.getState();
-    // Two pages now loaded (initial + one older page). A wrong older-page
-    // cursor — e.g. the pre-fix bug that fetched the convo head — would
-    // yield the wrong count or duplicate blocks.
-    expect(state.blocks).toHaveLength(SESSION_HISTORY_PAGE_SIZE * 2);
-    // The older page sits before the original, oldest item first. Its
-    // first block is index `total - 2*PAGE` (= 5): proves the prepend
-    // order and the descending+after cursor math are correct.
+    // Window + one older page. A wrong older-page cursor — e.g. the pre-fix
+    // bug that fetched the convo head — would yield the wrong count or
+    // duplicate blocks.
+    expect(state.blocks).toHaveLength(INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE);
+    // The older page sits before the original, oldest item first. Its first
+    // block is index `total - WINDOW - PAGE` (= 5): proves the prepend order
+    // and the descending+after cursor math are correct.
     expect(state.blocks[0]).toMatchObject({
       type: "user_message",
       ctx: {
-        itemId: `msg_resp_${(total - 2 * SESSION_HISTORY_PAGE_SIZE)
+        itemId: `msg_resp_${(total - INITIAL_WINDOW_ITEMS - SESSION_HISTORY_PAGE_SIZE)
           .toString()
           .padStart(4, "0")}_user`,
       },
     });
-    // 5 still-older items (total - 2*PAGE) remain, so more is flagged.
+    // 5 still-older items remain, so more is flagged.
     expect(state.hasMoreHistory).toBe(true);
   });
 
   it("drops a stale loadMoreHistory page that resolves after navigating away and back", async () => {
-    const total = SESSION_HISTORY_PAGE_SIZE * 2;
+    const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE;
     const itemsA = Array.from({ length: total }, (_, idx) =>
       userMessage(`a_${idx.toString().padStart(4, "0")}`, `a ${idx}`),
     );
@@ -1250,7 +1250,7 @@ describe("chatStore — switchTo", () => {
 
     await useChatStore.getState().switchTo("conv_a");
     const windowIds = useChatStore.getState().blocks.map((b) => b.ctx.itemId);
-    expect(windowIds).toHaveLength(SESSION_HISTORY_PAGE_SIZE);
+    expect(windowIds).toHaveLength(INITIAL_WINDOW_ITEMS);
 
     // Defer ONLY the first scroll-up page (the `after=` cursor fetch);
     // binds use cursorless initial-window fetches and stay live.
@@ -1276,7 +1276,7 @@ describe("chatStore — switchTo", () => {
     // round trip passed the conversation-id guard, so only the generation
     // check stops it from prepending below the fresh hydration merge.
     expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(windowIds);
-    expect(state.oldestItemId).toBe(itemsA.at(-SESSION_HISTORY_PAGE_SIZE)!.id);
+    expect(state.oldestItemId).toBe(itemsA.at(-INITIAL_WINDOW_ITEMS)!.id);
     expect(state.hasMoreHistory).toBe(true);
     expect(state.loadingMoreHistory).toBe(false);
 
@@ -1289,7 +1289,7 @@ describe("chatStore — switchTo", () => {
   });
 
   it("loadMoreHistory dedupes a page overlapping blocks kept across a rebind", async () => {
-    const total = SESSION_HISTORY_PAGE_SIZE * 3;
+    const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE * 2;
     const items = Array.from({ length: total }, (_, idx) =>
       userMessage(`r_${idx.toString().padStart(4, "0")}`, `r ${idx}`),
     );
@@ -1297,14 +1297,16 @@ describe("chatStore — switchTo", () => {
 
     await useChatStore.getState().switchTo("conv_re");
     await useChatStore.getState().loadMoreHistory();
-    expect(useChatStore.getState().blocks).toHaveLength(2 * SESSION_HISTORY_PAGE_SIZE);
+    expect(useChatStore.getState().blocks).toHaveLength(
+      INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE,
+    );
 
     // The stream died (idle disconnect): the send-triggered rebind
     // re-hydrates the newest window, resetting the cursor to its top while
     // the scrolled-up blocks stay rendered.
     useChatStore.setState({ abortController: null });
     await useChatStore.getState().send("hello again", "agent_xyz");
-    expect(useChatStore.getState().oldestItemId).toBe(items.at(-SESSION_HISTORY_PAGE_SIZE)!.id);
+    expect(useChatStore.getState().oldestItemId).toBe(items.at(-INITIAL_WINDOW_ITEMS)!.id);
 
     // This page (older than the rewound cursor) fully overlaps the blocks
     // kept across the rebind — without itemId dedupe each would render twice.
@@ -1321,7 +1323,7 @@ describe("chatStore — switchTo", () => {
   });
 
   it("clears loadingMoreHistory when a rebind hydration voids the in-flight page", async () => {
-    const total = SESSION_HISTORY_PAGE_SIZE * 2;
+    const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE;
     const items = Array.from({ length: total }, (_, idx) =>
       userMessage(`lh_${idx.toString().padStart(4, "0")}`, `lh ${idx}`),
     );
@@ -7176,7 +7178,8 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     expect(releaseBackfill).not.toBeNull();
 
     // The user leaves and comes back: the revisit hydrates a FRESH window
-    // (the newest 20 gap items) and then scrolls one page up.
+    // (the newest INITIAL_WINDOW_ITEMS, i.e. every gap item) and then
+    // scrolls one page up.
     const away = useChatStore.getState().switchTo("conv_other");
     await drainAsync(5);
     await away;
@@ -7186,7 +7189,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     await useChatStore.getState().loadMoreHistory();
     const fresh = useChatStore.getState();
     expect(fresh.blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
+      [...preGap.slice(-SESSION_HISTORY_PAGE_SIZE), ...gap].map((item) => item.id),
     );
 
     // The stale page resolves: the conversation id matches again, so only
@@ -7199,17 +7202,17 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // re-hydrate fallback, which rewound the scroll-up cursor to the
     // window top and bumped the generation (voiding future legit pages).
     expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
+      [...preGap.slice(-SESSION_HISTORY_PAGE_SIZE), ...gap].map((item) => item.id),
     );
-    expect(state.oldestItemId).toBe(gap.at(-2 * SESSION_HISTORY_PAGE_SIZE)!.id);
+    expect(state.oldestItemId).toBe(preGap.at(-SESSION_HISTORY_PAGE_SIZE)!.id);
     expect(state.historyGeneration).toBe(fresh.historyGeneration);
 
     // The new window still pages older from where it left off: pre-fix the
     // rewound cursor re-fetched the already-rendered page (all dupes) and
-    // this would still show only 40 items.
+    // the transcript would not have grown.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-3 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
+      [...preGap, ...gap].map((item) => item.id),
     );
 
     // Unpark the orphaned pump so the awaited loop can exit.

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -65,6 +65,7 @@ import {
   getSessionSlim,
   fetchInitialHistoryWindow,
   fetchSessionItemsPage,
+  INITIAL_WINDOW_ITEMS,
   interrupt as interruptSession,
   openSessionStream,
   postEvent,
@@ -2320,16 +2321,17 @@ async function bindStream(
   // Always refetch the snapshot on bind. A cached session snapshot can
   // be stale after the agent commits new items while the user is viewing
   // another conversation; reusing it drops messages until a page refresh.
-  // Bind waits for only the newest page. HistoryAutoLoader grows the initial
-  // window after render, and `loadMoreHistory` handles later scroll-up paging.
+  // Bind fetches the whole initial window in one request; nothing loads more
+  // until the reader scrolls up (`loadMoreHistory`).
   // `retry: false` because the most common failure here is "invalid conv
   // id in URL" (not transient).
   if (queryClient === null) {
     throw new Error("chatStore.bindStream: queryClient not initialized");
   }
   try {
-    // Fetch one page here so the newest items can render after one round-trip.
-    // HistoryAutoLoader fetches any additional initial pages after this commit.
+    // One larger page, so opening a session is a single round trip that then
+    // stays still — rather than a small page followed by background growth
+    // the reader sees as the transcript shifting seconds after it settled.
     const [session, page] = await Promise.all([
       queryClient.fetchQuery({
         queryKey: ["session", id],
@@ -2337,7 +2339,7 @@ async function bindStream(
         staleTime: 0,
         retry: false,
       }),
-      fetchSessionItemsPage(id),
+      fetchSessionItemsPage(id, { limit: INITIAL_WINDOW_ITEMS }),
     ]);
     if (get().conversationId !== id) return;
     const items = page.items;


### PR DESCRIPTION
## Related issue

Closes #4271

> Supersedes #4197 (which closes #4196). #4197 fixed only the first of the two causes below — it batched the background window build instead of removing it — and did not find the second. This PR is a fresh, smaller change off current `main`; #4197 can be closed in favour of it.

## Summary

Opening a session kept loading older history for **seconds after the page had settled**, shifting the transcript under a reader who had never scrolled. Measured on a real session: **15 items requests** and a "Loading earlier messages…" row, for someone who hadn't touched the scrollbar.

Two separate things drove it, and fixing either alone is not enough:

1. **The bind deliberately backfilled.** `bindStream` rendered one 20-item page, then `HistoryAutoLoader` paged from a layout effect until it found the previous user prompt.
2. **The scroll rule was satisfied by the open itself.** Paging keyed on "`scrollTop` is near the top". Opening a session scrolls the pane to the bottom — which counts as a scroll — and on a transcript shorter than the fetch threshold that lands *trivially* near the top. So it fetched, the prepend moved the cursor, and that fed the next fetch. Removing (1) still left 15 requests.

The change:

- **Fetch the window once, at bind** — one larger request (`INITIAL_WINDOW_ITEMS = 100`) instead of a small page plus background growth.
- **Page only when the reader asks**, and treat "asks" as the *gesture*, not the movement. A pane shorter than the window has no scroll range at all, so waiting for `scrollTop` to fall would strand older history behind a scroll the pane can never report. A wheel-up or a downward touch drag arms paging whether or not the pane has anywhere to go.
- **Cap the trailing spacer at a third of the viewport**, so a short latest turn no longer reserves most of the screen as blank.

ELI5: opening a chat used to keep fetching older messages on its own, so the text kept moving while you were trying to read. Now it loads once and holds still, and fetches more only when you actually scroll up.

```
before:  open → [page] → paint → [page] → paint → … ×15   (reader scrolled: never)
after:   open → [window] → paint                          (then nothing)
         reader scrolls up → [page] → …
```

## Test Plan

**Unit** — `pnpm --filter web test`: **5332 passing, 0 failing.**

New tests in `ChatPage.historyLoad.test.tsx`:
- the open's scroll-to-bottom does not page;
- a settled page does not cascade while parked away from the top;
- a wheel-up **does** page when the pane has no scroll range (the deadlock the gesture rule exists for);
- a wheel-**down** does not;
- a single-prompt window never pages on load.

Thirteen existing tests encoded the old behaviour and were updated to the new contract rather than deleted — the three asserting the automatic build now assert it *doesn't* happen, and six `chatStore` tests that hard-coded a 20-item initial window now distinguish window size from scroll-up page size.

**E2E** — `tests/e2e_ui/chat/test_initial_history_loading.py`, rewritten:
- opening a session makes exactly **one** cursorless items request and nothing more while idle, with the loading row never appearing;
- scrolling to the top still pages, cursored off the window's oldest item.

The first test is falsifiable — reverting the fix fails it with `assert 7 == 1`.

**Manual**, against a live deployed server, same session, sitting still (no scrolling):

| | before | after |
|---|---|---|
| `/items` requests | 15 | **1** |
| transcript height steps | 13 | **1** |
| "Loading earlier messages" samples | 58 | **0** |

And at a 1400px-tall window where the transcript does not fill the viewport (`scrollHeight 1275 === clientHeight 1275`, i.e. genuinely unscrollable): idle stays at 1 request, and a real wheel-up takes it to 15 requests / 3200px — older history is reachable.

## Demo

Before/after tables above. No files added under `docs/images`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a Playwright harness against a live deployed server: it counts `/items` requests, samples the transcript's `scrollHeight` and the loading row on a 40ms tick, and drives a real `mouse.wheel` gesture. Both tables above come from it, reproduced across runs.

One gap, stated plainly: **the e2e suite does not cover the unscrollable-pane case.** I tried a real wheel gesture there, but the seeded 132-item transcript is genuinely scrollable and one 400px tick lands ~5300px from the top — outside the 2.5-viewport threshold, so *not* fetching is correct behaviour, and the test would have passed for the wrong reason. Making a pane unscrollable in that fixture isn't practical, so that path is covered by the unit test plus the live measurement above, and the e2e keeps covering the normal scroll-to-top flow.

Also worth flagging: on a session whose newest 100 items are all one tool-heavy turn, the open now lands on that turn with no user prompt above it — reaching the prompt is a scroll. The prompt-boundary walk existed to avoid exactly that, and it is what produced the shifting. If we want the prompt guaranteed *and* one round trip, the follow-up is a server-side "walk back to N prompts" parameter on `/items`.

## Changelog

Opening a session no longer keeps loading older messages and shifting the transcript while you read
