### PR TITLE
fix(web): relax chat prose line spacing

### DIFF
--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -433,7 +433,16 @@ export const MessageResponse = memo(
 
     return (
       <Streamdown
-        className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+        // `leading-[1.75]` (unitless, so it still tracks the Appearance
+        // font-size setting) relaxes the prose line-height above the 1.6 the
+        // shared `text-ui` token carries — that value packed wrapped lines of a
+        // paragraph too tightly to read comfortably. Scoped to the markdown
+        // wrapper, not MessageContent, so tool rows / "See N steps" lines that
+        // share the column keep their tighter rhythm.
+        className={cn(
+          "size-full leading-[1.75] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          className,
+        )}
         plugins={STREAMDOWN_PLUGINS}
         // Let links open on a plain click (and cmd/ctrl-click in a new tab)
         // instead of Streamdown's default "Open external link?" modal.


### PR DESCRIPTION
## Related issue

N/A — reported via Slack (chat messages felt cramped). No GitHub issue filed.

## Summary

- Chat message prose (assistant + user bubbles) inherits `line-height: 1.6`
  from the shared `text-ui` token. On a multi-line paragraph that packed the
  wrapped lines too tightly to read comfortably — the reported problem.
- Bump the markdown-prose wrapper (`MessageResponse`'s `Streamdown`) to a
  unitless `leading-[1.75]`, so paragraphs get more breathing room while still
  tracking the Appearance font-size setting (no fixed px that would ignore it).
- Scoped to the prose wrapper only — **not** `MessageContent` or the global
  `--text-ui` token — so tool rows ("See N steps"), reasoning lines, buttons,
  and menus keep their existing tighter rhythm.

## Test Plan

- Ran the omnigent backend + `pnpm run dev` (Vite) locally and drove a
  deterministic mocked transcript (reusing the `tests/e2e_ui/visual`
  stub strategy) through headless Chromium to capture the assistant bubble
  **before** and **after** the change on the same dev server (HMR).
- The captured bubble grows from 360px → 385px tall for the identical text —
  the extra height is the relaxed leading; inline-code chips, headings, lists,
  and code blocks are visually unchanged.
- `pnpm run type-check` ✅ · `pnpm run lint` ✅ · `prettier` clean.

## Demo

<!-- Drag `~/Desktop/spacing_diff.png` (before | after side-by-side) here. -->

Before (line-height 1.6) → After (line-height 1.75): wrapped lines of a
paragraph gain noticeably more vertical breathing room; everything else is
unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: captured before/after screenshots of the assistant bubble
against the live dev server (headless Chromium, mocked transcript) to confirm
the relaxed leading and that nothing else shifted. The existing `tests/e2e_ui`
chat + visual-snapshot suites continue to exercise this rendering path; a
line-height value isn't worth a dedicated assertion.

## Changelog

Relaxed the line spacing in chat messages so wrapped paragraphs are easier to read.

This pull request and its description were written by Isaac.
