### PR TITLE
feat(web): surface session environment in the composer

### DIFF
--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -4,9 +4,10 @@ import type * as UseHostsModule from "@/hooks/useHosts";
 import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Session } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
 
 // Composer reads workspace files via a TanStack query hook (for "@"-file
@@ -26,10 +27,11 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
 // renders deterministically without a QueryClient / RunnerHealth provider. The
 // default is "not host-bound", so the badge self-hides and the existing branch/
 // ring/harness assertions are unchanged; host-aware tests override per case.
-const { useSessionMock, useHostsMock, useSessionHostOnlineMock } = vi.hoisted(() => ({
+const { useSessionMock, useHostsMock, useSessionHostOnlineMock, copyTextMock } = vi.hoisted(() => ({
   useSessionMock: vi.fn(),
   useHostsMock: vi.fn(),
   useSessionHostOnlineMock: vi.fn(),
+  copyTextMock: vi.fn(),
 }));
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
   ...(await importOriginal<typeof UseSessionModule>()),
@@ -53,6 +55,9 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
     antigravity: "Antigravity",
     copilot: "Copilot",
   }),
+}));
+vi.mock("@/lib/clipboard", () => ({
+  copyText: (text: string) => copyTextMock(text),
 }));
 
 import { Composer, composerHarnessLabel, formatModelEffortStatusLabel } from "./ChatPage";
@@ -103,9 +108,9 @@ function statusLine(): Element | null {
 }
 
 /** Bind the active session to an online host named `name` so HostBadge shows. */
-function bindHost(name: string) {
+function bindHost(name: string, session: Partial<Session> = {}) {
   useSessionMock.mockReturnValue({
-    session: { hostId: "host_a1b2" },
+    session: { hostId: "host_a1b2", ...session },
     isLoading: false,
     error: null,
   });
@@ -117,16 +122,17 @@ function bindHost(name: string) {
   useSessionHostOnlineMock.mockReturnValue(true);
 }
 
-describe("Composer status line (branch + context ring)", () => {
+describe("Composer status line (environment + context ring)", () => {
   beforeEach(() => {
     // Default: no host bound, so HostBadge renders nothing.
     useSessionMock.mockReset().mockReturnValue({
-      session: { hostId: null },
+      session: { hostId: null, workspace: null },
       isLoading: false,
       error: null,
     });
     useHostsMock.mockReset().mockReturnValue({ data: [] });
     useSessionHostOnlineMock.mockReset().mockReturnValue(undefined);
+    copyTextMock.mockReset().mockResolvedValue(undefined);
     useChatStore.setState({
       conversationId: "conv_test",
       skills: [],
@@ -174,20 +180,6 @@ describe("Composer status line (branch + context ring)", () => {
     // 25k of 100k → 25% used; a wrong value means the ring wired the
     // wrong store fields through its props.
     expect(screen.getByLabelText("25% of context used")).toBeInTheDocument();
-  });
-
-  it("no longer renders the harness label in the status tray (moved to the config gear)", () => {
-    // The harness identity moved from the tray into the config gear's hover
-    // tooltip, so it must never resurface in the status line — for a native
-    // vendor session or an SDK/bundle session.
-    useChatStore.setState({ contextWindow: 100_000, tokensUsed: 25_000, sessionHarness: "pi" });
-    renderComposer({
-      modelPickerKind: "codex",
-      agents: [{ id: "a1", name: "polly" }],
-      selectedAgentId: "a1",
-    });
-
-    expect(screen.queryByTestId("composer-harness")).toBeNull();
   });
 
   it("no longer renders model/effort in the status tray (moved to the composer label)", () => {
@@ -253,6 +245,10 @@ describe("Composer status line (branch + context ring)", () => {
     // `truncate` (overflow-hidden + ellipsis + nowrap) is the guard that
     // keeps a long branch from wrapping the tray onto a second line.
     expect(branch).toHaveClass("truncate");
+    expect(screen.getByTestId("composer-worktree")).toHaveAttribute(
+      "title",
+      "Isolated worktree: feature/a-very-long-worktree-branch-name-that-would-wrap",
+    );
   });
 
   it("renders the tray with a branch even when the ring is absent", () => {
@@ -295,12 +291,100 @@ describe("Composer status line (branch + context ring)", () => {
     // host badge + context footer with it. A host-bound session (e.g. a codex
     // session with no worktree branch, before the ring populates) still shows
     // the tray so the host indicator is visible.
-    bindHost("mac-laptop");
+    bindHost("mac-laptop", { workspace: "/Users/alice/projects/omnigent" });
     useChatStore.setState({ gitBranch: null, contextWindow: null, tokensUsed: null });
     renderComposer();
 
     expect(statusLine()).not.toBeNull();
     expect(screen.getByTestId("host-badge")).toHaveTextContent("mac-laptop");
+    expect(screen.getByTestId("composer-workspace")).toHaveTextContent("…/projects/omnigent");
+  });
+
+  it("shows the working directory inline without a worktree branch", () => {
+    bindHost("mac-laptop", { workspace: "/Users/alice/projects/omnigent" });
+    useChatStore.setState({ gitBranch: null, contextWindow: null, tokensUsed: null });
+    renderComposer();
+
+    const trigger = screen.getByTestId("session-environment-trigger");
+    const workspace = screen.getByTestId("composer-workspace");
+    expect(trigger).toHaveAttribute("title", "/Users/alice/projects/omnigent");
+    expect(trigger).toHaveTextContent("Details");
+    expect(workspace).toHaveTextContent("…/projects/omnigent");
+    expect(workspace).toHaveClass("hidden", "truncate", "sm:block");
+    expect(screen.queryByTestId("composer-git-branch")).toBeNull();
+  });
+
+  it("shows host, directory, worktree, and native harness in one popover", async () => {
+    const workspacePath = "/Users/alice/omnigent-worktrees/feature-session-context";
+    const branch = `feature-${"x".repeat(80)}`;
+    bindHost("mac-laptop", { workspace: workspacePath });
+    useChatStore.setState({
+      gitBranch: branch,
+      sessionHarness: "codex-native",
+    });
+    renderComposer({ modelPickerKind: "codex" });
+
+    expect(screen.queryByTestId("session-environment-popover")).toBeNull();
+    fireEvent.click(screen.getByTestId("session-environment-trigger"));
+
+    const popover = await screen.findByTestId("session-environment-popover");
+    expect(
+      within(screen.getByTestId("session-environment-host")).getByText("mac-laptop"),
+    ).toBeInTheDocument();
+    const workspaceRow = screen.getByTestId("session-environment-workspace");
+    expect(workspaceRow).toHaveTextContent(workspacePath);
+    const copyButton = within(workspaceRow).getByRole("button", {
+      name: "Copy working directory",
+    });
+    fireEvent.click(copyButton);
+    expect(copyTextMock).toHaveBeenCalledWith(workspacePath);
+    const worktreeRow = screen.getByTestId("session-environment-worktree");
+    const worktreeBranch = within(worktreeRow).getByText(branch);
+    expect(worktreeBranch).toHaveClass("[overflow-wrap:anywhere]");
+    expect(worktreeRow).toHaveTextContent(workspacePath);
+    expect(screen.getByTestId("session-environment-harness")).toHaveTextContent("Codex");
+    expect(popover).toBeInTheDocument();
+  });
+
+  it("reports no worktree while keeping the directory and SDK harness available", async () => {
+    bindHost("mac-laptop", { workspace: "/Users/alice/projects/omnigent" });
+    useChatStore.setState({ sessionHarness: "pi", gitBranch: null });
+    renderComposer({
+      agents: [{ id: "a1", name: "polly" }],
+      selectedAgentId: "a1",
+    });
+
+    fireEvent.click(screen.getByTestId("session-environment-trigger"));
+    await screen.findByTestId("session-environment-popover");
+
+    expect(screen.getByTestId("session-environment-worktree")).toHaveTextContent("None");
+    expect(screen.getByTestId("session-environment-harness")).toHaveTextContent("Polly (Pi)");
+  });
+
+  it("shows environment details for a local session with no host binding", async () => {
+    useSessionMock.mockReturnValue({
+      session: { hostId: null, workspace: "/Users/alice/imported-session" },
+      isLoading: false,
+      error: null,
+    });
+    useChatStore.setState({ sessionHarness: "claude-sdk", gitBranch: null });
+    renderComposer({
+      agents: [{ id: "a1", name: "polly" }],
+      selectedAgentId: "a1",
+    });
+
+    expect(statusLine()).not.toBeNull();
+    expect(screen.queryByTestId("host-badge")).toBeNull();
+    expect(screen.getByTestId("composer-workspace")).toHaveTextContent("…/alice/imported-session");
+    fireEvent.click(screen.getByTestId("session-environment-trigger"));
+    await screen.findByTestId("session-environment-popover");
+
+    expect(screen.getByTestId("session-environment-host")).toHaveTextContent(
+      "Local (no host binding)",
+    );
+    expect(screen.getByTestId("session-environment-harness")).toHaveTextContent(
+      "Polly (Claude SDK)",
+    );
   });
 
   it("shows the host badge to the left of the worktree branch", () => {
@@ -356,6 +440,7 @@ describe("Composer status line (branch + context ring)", () => {
     renderComposer({ subAgentLabel: "check-eligibility" });
 
     expect(screen.queryByTestId("host-badge")).toBeNull();
+    expect(screen.queryByTestId("session-environment-trigger")).toBeNull();
     expect(screen.getByTestId("composer-git-branch")).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2,6 +2,7 @@ import {
   type DragEvent,
   type FormEvent,
   type KeyboardEvent,
+  type ReactNode,
   createContext,
   memo,
   useCallback,
@@ -17,11 +18,11 @@ import {
   BotIcon,
   CheckIcon,
   AlertTriangleIcon,
+  ChevronDownIcon,
   CornerUpLeftIcon,
   CopyIcon,
   FileTextIcon,
   FolderIcon,
-  GitBranchIcon,
   GitForkIcon,
   ImageIcon,
   Loader2Icon,
@@ -32,6 +33,13 @@ import {
   XIcon,
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { userColor, userColorTint, userInitials } from "@/lib/userBadge";
 import { useNavigate, useParams } from "@/lib/routing";
@@ -183,7 +191,7 @@ import { useServerInfo } from "@/lib/CapabilitiesContext";
 import type { ServerInfo } from "@/lib/capabilities";
 import { MainTerminalView } from "@/shell/MainTerminalView";
 import { UNTITLED_CONVERSATION_LABEL } from "@/shell/sidebarNav";
-import { NewChatLandingScreen } from "@/shell/NewChatDialog";
+import { NewChatLandingScreen, worktreePathTail } from "@/shell/NewChatDialog";
 import { ResumeWithDirectoryDialog } from "@/shell/ResumeWithDirectoryDialog";
 import { ReconnectSessionDialog } from "@/shell/ReconnectSessionDialog";
 import { useTerminalFirst } from "@/shell/TerminalFirstContext";
@@ -191,9 +199,9 @@ import { useForkDialog } from "@/shell/ForkDialogContext";
 import { supportsEffortControl } from "@/lib/sessionCapabilities";
 import { isCodexNativeSession } from "@/lib/codexPlanMode";
 import { getCliServerUrl } from "@/lib/host";
+import { copyText } from "@/lib/clipboard";
 import { SessionImage } from "@/components/SessionImage";
 import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/components/goal";
-import { copyText } from "@/lib/clipboard";
 import { showToast } from "@/components/ui/toast";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 
@@ -3889,11 +3897,10 @@ export function formatModelEffortStatusLabel(
 }
 
 /**
- * Identity label for the composer status tray: which harness/agent is
- * running this session. Native vendor wrappers read as the bare vendor
- * name ("Claude" / "Codex"); SDK/bundle agents read as the agent name
- * with the brain harness in parens ("Polly (Pi)"). Lives in the status tray
- * below the composer, separate from the read-only model/effort label.
+ * Identity label for the composer's session-environment popover. Native
+ * vendor wrappers read as the bare vendor name ("Claude" / "Codex");
+ * SDK/bundle agents read as the agent name with the brain harness in parens
+ * ("Polly (Pi)"). Kept separate from the read-only model/effort label.
  *
  * @param modelPickerKind - Native picker family, when the session is a
  *   claude-/codex-/cursor-native wrapper.
@@ -3918,17 +3925,145 @@ export function composerHarnessLabel(
   return display ?? harness;
 }
 
+function SessionEnvironmentRow({
+  label,
+  children,
+  testId,
+}: {
+  label: string;
+  children: ReactNode;
+  testId: string;
+}) {
+  return (
+    <div data-testid={testId} className="grid grid-cols-[7rem_minmax(0,1fr)] items-start gap-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 text-foreground">{children}</dd>
+    </div>
+  );
+}
+
+function SessionEnvironmentPopover({
+  conversationId,
+  workspace,
+  gitBranch,
+  harnessLabel,
+  isHostBound,
+  onHostReconnect,
+}: {
+  conversationId: string;
+  workspace: string | null;
+  gitBranch: string | null;
+  harnessLabel: string | null;
+  isHostBound: boolean;
+  onHostReconnect?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [workspaceCopied, setWorkspaceCopied] = useState(false);
+  const workspaceLabel = workspace ? worktreePathTail(workspace) : "Directory unavailable";
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) setWorkspaceCopied(false);
+  }
+
+  function handleCopyWorkspace() {
+    if (!workspace) return;
+    void copyText(workspace)
+      .then(() => setWorkspaceCopied(true))
+      .catch(() => setWorkspaceCopied(false));
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="session-environment-trigger"
+          className="flex min-w-0 max-w-[min(18rem,45vw)] items-center gap-1 rounded-md px-1.5 py-0.5 text-sm text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+          title={workspace ?? "Session environment"}
+          aria-label={`Session environment, working directory ${workspace ?? "unavailable"}`}
+        >
+          <FolderIcon className="ui-icon" aria-hidden="true" />
+          <span className="sm:hidden">Details</span>
+          <span data-testid="composer-workspace" className="hidden min-w-0 truncate sm:block">
+            {workspaceLabel}
+          </span>
+          <ChevronDownIcon className="size-3 shrink-0" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        data-testid="session-environment-popover"
+        align="start"
+        side="top"
+        className="w-[28rem] max-w-[calc(100vw-2rem)] gap-3"
+      >
+        <PopoverHeader>
+          <PopoverTitle>Session environment</PopoverTitle>
+        </PopoverHeader>
+        <dl className="grid gap-3 text-sm">
+          <SessionEnvironmentRow label="Host" testId="session-environment-host">
+            {isHostBound ? (
+              <HostBadge sessionId={conversationId} onReconnect={onHostReconnect} />
+            ) : (
+              <span className="text-muted-foreground">Local (no host binding)</span>
+            )}
+          </SessionEnvironmentRow>
+          <SessionEnvironmentRow label="Working directory" testId="session-environment-workspace">
+            <div className="flex min-w-0 items-start gap-1.5">
+              <code className="min-w-0 flex-1 text-xs [overflow-wrap:anywhere]">
+                {workspace ?? "Unavailable"}
+              </code>
+              {workspace && (
+                <button
+                  type="button"
+                  className="shrink-0 rounded-sm p-0.5 text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label="Copy working directory"
+                  title="Copy working directory"
+                  onClick={handleCopyWorkspace}
+                >
+                  {workspaceCopied ? (
+                    <CheckIcon className="size-3.5" />
+                  ) : (
+                    <CopyIcon className="size-3.5" />
+                  )}
+                </button>
+              )}
+            </div>
+          </SessionEnvironmentRow>
+          <SessionEnvironmentRow label="Worktree" testId="session-environment-worktree">
+            {gitBranch ? (
+              <div className="grid gap-0.5">
+                <span className="[overflow-wrap:anywhere]">{gitBranch}</span>
+                <code className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
+                  {workspace ?? "Path unavailable"}
+                </code>
+              </div>
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </SessionEnvironmentRow>
+          <SessionEnvironmentRow label="Harness" testId="session-environment-harness">
+            {harnessLabel ?? <span className="text-muted-foreground">Unknown</span>}
+          </SessionEnvironmentRow>
+        </dl>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 /**
- * Status tray under the composer: branch left, model/context right.
+ * Status tray under the composer: session environment left, context right.
  * Pulled up behind the card so a shelf peeks below; skips render when empty.
  * Session cost lives in the header agent-info popover, not here.
  */
 function ComposerStatusLine({
   goal,
+  harnessLabel,
   isSubAgentSession,
   onHostReconnect,
 }: {
   goal: Goal | null;
+  harnessLabel: string | null;
   isSubAgentSession: boolean;
   /**
    * Opens the reconnect help dialog, handed to the host badge — which turns
@@ -3950,6 +4085,7 @@ function ComposerStatusLine({
   // from the same source the badge does so the tray's render guard matches.
   const { session } = useSession(conversationId);
   const isHostBound = !!session?.hostId;
+  const workspace = session?.workspace ?? null;
 
   const showBranch = !!conversationId && !!gitBranch;
   // Host indicator (green/red dot + host name), left of the worktree branch.
@@ -3970,7 +4106,9 @@ function ComposerStatusLine({
   // the badge is where it lives and an unreachable session often has no
   // branch/ring at all.
   const showHostBadge = showHost && isHostBound;
-  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHostBadge) return null;
+  const showEnvironment =
+    showHost && (isHostBound || workspace !== null || harnessLabel !== null || gitBranch !== null);
+  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showEnvironment) return null;
 
   return (
     <div
@@ -3981,14 +4119,29 @@ function ComposerStatusLine({
         CHAT_COLUMN_WIDTH,
       )}
     >
-      {/* Left: host + branch. flex-1 keeps the right cluster pinned; truncate, no wrap. */}
+      {/* Left: host + directory + branch. flex-1 keeps the right cluster pinned. */}
       <div className="flex min-w-0 flex-1 items-center gap-3 text-sm text-muted-foreground">
-        {showHost && conversationId && (
+        {showHostBadge && conversationId && (
           <HostBadge sessionId={conversationId} onReconnect={onHostReconnect} />
         )}
+        {showEnvironment && conversationId && (
+          <SessionEnvironmentPopover
+            conversationId={conversationId}
+            workspace={workspace}
+            gitBranch={gitBranch}
+            harnessLabel={harnessLabel}
+            isHostBound={isHostBound}
+            onHostReconnect={onHostReconnect}
+          />
+        )}
         {showBranch && (
-          <span className="flex min-w-0 items-center gap-1.5">
-            <GitBranchIcon className="ui-icon" />
+          <span
+            data-testid="composer-worktree"
+            className="flex min-w-0 items-center gap-1.5"
+            title={`Isolated worktree: ${gitBranch}`}
+            aria-label={`Isolated worktree branch ${gitBranch}`}
+          >
+            <GitForkIcon className="ui-icon" aria-hidden="true" />
             <span data-testid="composer-git-branch" className="min-w-0 truncate" title={gitBranch}>
               {gitBranch}
             </span>
@@ -4180,7 +4333,7 @@ export function Composer({
   );
 
   const codexPlanMode = useChatStore((s) => s.codexPlanMode);
-  // Harness/agent identity shown in the status tray below the card, separate
+  // Harness/agent identity shown in the session-environment popover, separate
   // from the composer's read-only model/effort label.
   const sessionHarness = useChatStore((s) => s.sessionHarness);
   const subAgentName = useChatStore((s) => s.subAgentName);
@@ -5359,6 +5512,7 @@ export function Composer({
       </div>
       <ComposerStatusLine
         goal={goal}
+        harnessLabel={harnessLabel}
         isSubAgentSession={subAgentLabel != null}
         onHostReconnect={onShowReconnectHelp}
       />


### PR DESCRIPTION
## Related issue

Closes #4252

## Summary

- Show the active session's working-directory tail beside the existing host badge, with the full path available on hover.
- Add a session-environment popover that keeps Host, Working directory, Worktree, and Harness in one place. The directory can be copied directly from the popover.
- Mark isolated worktrees with a fork icon and an explicit tooltip instead of rendering them like a normal branch.
- Keep the tray on one line: desktop shows the directory tail, while narrow screens collapse it to a `Details` control.
- Support local/imported sessions that have workspace metadata without a host binding; their Host row reads `Local (no host binding)`.

**ELI5:** the chat previously showed which machine a session belonged to, but not which folder it could modify or which harness was running it. The status line now shows the folder immediately and opens one compact panel for the complete session environment.

```text
Before:  host  ·  branch

After:   host  ·  working directory  ·  isolated worktree
                       │
                       └── Host / Working directory / Worktree / Harness
```

## Test Plan

- Ran `codex review --uncommitted` three times. The first two passes found long-branch overflow and missing local/imported-session coverage; both were fixed with regression tests. The final pass reported no correctness findings.
- `.venv/bin/pre-commit run --files web/src/pages/ChatPage.tsx web/src/pages/ChatPage.statusLine.test.tsx`
- Node 22: 444 tests passed across all nine `ChatPage*` test files.
- `pnpm --dir web run build`
- Started an isolated local server and validated a host-bound Codex worktree session in Chromium at desktop and mobile widths. Confirmed:
  - directory tail is visible without opening the popover on desktop;
  - narrow screens show `Details` instead of the directory text;
  - Host, full working directory, worktree branch/path, and Harness are present in the popover;
  - the offline-host reconnect button remains independent from the environment trigger;
  - the tray remains one line at both widths.

## Demo

**Desktop — directory visible inline, full environment open**

![Desktop session environment popover](https://raw.githubusercontent.com/Guntas07/omnigent/pr-demo-assets/issue-4252/session-environment-desktop.png)

**Mobile — directory collapses to Details, full environment remains available**

![Mobile session environment popover](https://raw.githubusercontent.com/Guntas07/omnigent/pr-demo-assets/issue-4252/session-environment-mobile.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`ChatPage.statusLine.test.tsx` now covers host-bound sessions with and without worktrees, native and SDK harness labels, copy behavior, long branch wrapping, local sessions without a host binding, mobile directory collapse, sub-agent hiding, and the existing offline-host reconnect action. Manual browser verification covered the rendered desktop and mobile layouts against a real local server and production web build.

## Changelog

Session chats now show their working directory and provide one-click access to host, worktree, and harness details.
