### PR TITLE
test(onboarding): pin the kimi floor boundary and guard its version series

### DIFF
--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 import omnigent._platform as _platform
 from omnigent.onboarding import harness_install as hi
@@ -1424,6 +1425,57 @@ def test_the_kimi_floor_accepts_the_cli_this_spec_installs(
 
     monkeypatch.setattr(hi.subprocess, "run", _run)
     assert hi.harness_cli_installed(hi.KIMI_KEY) is True
+
+
+@pytest.mark.parametrize("version", ["0.7.0", "0.32.0"])
+def test_the_kimi_floor_accepts_the_floor_and_the_reported_version(
+    monkeypatch: pytest.MonkeyPatch, version: str
+) -> None:
+    """The declared floor itself, and the build from #4278, must read as installed.
+
+    ``test_the_kimi_floor_accepts_the_cli_this_spec_installs`` covers the
+    general case at 0.34.0, and the default-floors parametrize covers 0.6.0 /
+    0.34.0. Neither pins the two values that carry the regression:
+
+    * ``0.7.0`` is the floor itself. An off-by-one there — ``>`` where the
+      comparison should be ``>=`` — rejects the exact version this spec
+      declares as supported, and every existing test still passes.
+    * ``0.32.0`` is the version the reporter ran when setup showed
+      "Kimi Code x Needs upgrade". Pinning the reported build is what makes
+      this a regression test for #4278 rather than for the floor in general.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=f"{version}\n", stderr=""
+            )
+        raise AssertionError(f"unexpected subprocess: {argv!r}")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_installed(hi.KIMI_KEY) is True
+
+
+def test_the_kimi_floor_stays_in_the_kimi_code_version_series() -> None:
+    """The kimi floor must name a ``kimi-code`` release, not a ``kimi-cli`` one.
+
+    ``test_the_kimi_floor_accepts_the_cli_this_spec_installs`` pins one shipping
+    version, so it catches the wrong-project regression only while ``kimi-code``
+    stays below that version. This guards the mistake itself: the two projects
+    share the ``kimi`` name and only their numbering tells them apart —
+    ``kimi-cli`` starts at 1.x, while the ``kimi-code`` binary this spec
+    installs is still a 0.x series. A floor re-derived from ``kimi-cli``'s
+    release list (#4278) is unreachable for every real install, so setup reads
+    "Needs upgrade" no matter how current the user's CLI is.
+
+    When ``kimi-code`` itself ships 1.0, this assertion is the deliberate stop:
+    raise the bound here alongside the floor rather than dropping the guard.
+    """
+    spec = hi.harness_install_spec(hi.KIMI_KEY)
+    assert spec is not None
+    assert spec.min_version is not None
+    assert Version(spec.min_version) < Version("1.0.0")
 
 
 def test_the_hermes_floor_accepts_the_shipping_version_line(


### PR DESCRIPTION
## Related issue

Regression tests for #4278. The production fix landed on `main` in #4314, which re-pointed `_KIMI_MIN_VERSION` at the kimi-code 0.x series (`0.7.0`).

## Summary

Test-only change — no production code is touched; `main`'s `_KIMI_MIN_VERSION = "0.7.0"` floor is kept as-is. #4314 fixed the #4278 regression (the Kimi floor had been derived from **kimi-cli**'s 1.x changelog, while the binary the spec actually installs is **kimi-code**, a 0.x series — making the floor unreachable for every real install). This PR adds the two regression guards that were not part of #4314:

- `test_the_kimi_floor_accepts_the_floor_and_the_reported_version` — pins `0.7.0` (the declared floor itself; catches an off-by-one `>` vs `>=` in `_harness_cli_version_satisfies` that no existing test detects) and `0.32.0` (the build the #4278 reporter was running when `omni setup` showed "Kimi Code ✗ Needs upgrade").
- `test_the_kimi_floor_stays_in_the_kimi_code_version_series` — asserts the declared floor is `< 1.0.0`, so a future edit can't silently re-import a floor from kimi-cli's 1.x release list. Verified load-bearing: restoring the old `1.47.0` floor fails this guard. When kimi-code itself ships 1.0, raise the bound alongside the floor rather than dropping the guard.

## Test Plan

```
pytest tests/onboarding/test_harness_install.py tests/onboarding/test_harness_readiness.py
ruff check tests/onboarding/test_harness_install.py
ruff format --check tests/onboarding/test_harness_install.py
```

Both new tests pass against `main`'s `0.7.0` floor; mutation checks confirmed each is load-bearing (an `<=` off-by-one in `_harness_cli_version_satisfies` fails only the `0.7.0` case; a restored `1.47.0` floor fails the series guard).

## Demo

N/A — test-only change with no runtime surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new tests stub `shutil.which` and the `--version` subprocess, so they cover the version-gate logic at the floor boundary and the reported build, but not a real CLI invocation.

## Changelog

N/A — test-only; the user-facing fix shipped in #4314.
