### PR TITLE
test: make the suite pass on a developer macOS checkout

### DIFF
--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import shutil
 import socket
 import ssl
+import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -20,6 +23,23 @@ from omnigent.inner.egress.ca import ensure_ca, ensure_ca_bundle
 from omnigent.inner.egress.certs import HostCertCache
 from omnigent.inner.egress.proxy import EgressProxy
 from omnigent.inner.egress.rules import parse_rules
+
+
+@pytest.fixture()
+def short_tmp_parent() -> Iterator[Path]:
+    """Short-pathed tmpdir under ``/tmp``. ``tmp_path`` overflows AF_UNIX on macOS.
+
+    macOS caps a Unix socket path at 104 bytes and its ``$TMPDIR`` is already
+    ~48, so pytest's ``tmp_path`` (which embeds the test name) overflows before
+    a socket file is even appended. Mirrors the fixture in
+    ``tests/inner/egress/test_relay.py``.
+    """
+    parent = Path("/tmp") / f"omni-proxy-{uuid.uuid4().hex[:8]}"
+    parent.mkdir(mode=0o700)
+    try:
+        yield parent
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
 
 
 @pytest.fixture()
@@ -51,13 +71,13 @@ async def test_proxy_start_stop_tcp(
 
 
 @pytest.mark.asyncio
-async def test_proxy_start_unix(ca_paths: tuple[Path, Path, Path], tmp_path: Path) -> None:
+async def test_proxy_start_unix(ca_paths: tuple[Path, Path, Path], short_tmp_parent: Path) -> None:
     """Proxy can listen on a Unix socket."""
     cert_path, key_path, _ = ca_paths
     rules = parse_rules(["GET example.com/**"])
     proxy = EgressProxy(rules, cert_path, key_path)
 
-    sock_path = tmp_path / "test.sock"
+    sock_path = short_tmp_parent / "test.sock"
     await proxy.start_unix(sock_path)
 
     # Socket file is created

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -53,6 +53,15 @@ from omnigent.inner.sandbox import SandboxPolicy, with_denied_unix_sockets
 
 BWRAP_AVAILABLE = shutil.which("bwrap") is not None
 
+# ``BwrapSandboxBackend.resolve`` hard-errors off Linux and again without the
+# binary, so every test that resolves a real policy needs BOTH. The negative
+# cases (``test_resolve_raises_on_non_linux`` / ``…_when_bwrap_missing``) patch
+# those checks instead and stay ungated — they are what covers this host.
+requires_bwrap_resolve = pytest.mark.skipif(
+    not (sys.platform.startswith("linux") and BWRAP_AVAILABLE),
+    reason="bwrap resolve() requires Linux and the bwrap binary",
+)
+
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -246,6 +255,7 @@ def _repo_root() -> Path:
 # ---------------------------------------------------------------------------
 
 
+@requires_bwrap_resolve
 def test_resolve_default_keeps_cwd_read_only() -> None:
     """
     ``write_paths`` omitted (the common case) leaves ``write_roots``
@@ -273,6 +283,7 @@ def test_resolve_default_keeps_cwd_read_only() -> None:
     assert policy.read_roots is None  # No spec-supplied read_paths.
 
 
+@requires_bwrap_resolve
 def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     """
     Setting ``write_paths: ["."]`` flips cwd to writable. This is the
@@ -289,6 +300,7 @@ def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     assert policy.write_roots == [Path.cwd().resolve(strict=False)]
 
 
+@requires_bwrap_resolve
 def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     """
     ``cwd_allow_hidden=None`` in the spec resolves to the documented
@@ -310,6 +322,7 @@ def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     )
 
 
+@requires_bwrap_resolve
 def test_resolve_explicit_cwd_allow_hidden_overrides_default() -> None:
     """
     An explicit ``cwd_allow_hidden`` in the spec replaces the default

--- a/tests/inner/test_claude_router_hook.py
+++ b/tests/inner/test_claude_router_hook.py
@@ -8,9 +8,27 @@ from typing import Any
 
 import pytest
 
-from omnigent.claude_model_vocabulary import claude_model_alias
+from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS, claude_model_alias
 from omnigent.inner.hook_scripts import claude_router_hook, subagent_router
 from tests.inner.conftest import advertise_relay_tools, advertise_router
+
+
+@pytest.fixture(autouse=True)
+def _unpinned_alias_vocabulary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the developer's own alias pinning so translation is deterministic.
+
+    ``claude_model_alias`` falls back to :data:`os.environ` when the session
+    records no vocabulary, and a MISMATCHED pin makes it return ``None`` by
+    design (it refuses to resolve an alias to a model nobody routed to). So a
+    developer whose shell pins ``ANTHROPIC_DEFAULT_SONNET_MODEL`` — anyone
+    driving Claude through a gateway — silently gets no translation, and tests
+    asserting a bare ``"sonnet"`` fail locally while passing in CI, where these
+    are unset. Clearing them reproduces CI's unpinned vocabulary; the tests that
+    exercise pinning pass an explicit mapping or a bridge ``model_env``, never
+    the process env, so nothing here is masked.
+    """
+    for env_var in ALIAS_MODEL_ENV_VARS.values():
+        monkeypatch.delenv(env_var, raising=False)
 
 
 def _payload(
@@ -138,8 +156,7 @@ def test_untranslatable_model_allows_spawn_unchanged(
 ) -> None:
     """An id with no Agent-tool alias must not be injected — the CLI 400s."""
     router_dir = advertise_router(tmp_path)
-    for env_var in ("ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL"):
-        monkeypatch.delenv(env_var, raising=False)
+    # Alias pinning is already cleared by ``_unpinned_alias_vocabulary``.
     out, _requests = _run_hook(
         monkeypatch,
         router_dir,

--- a/tests/inner/test_seccomp.py
+++ b/tests/inner/test_seccomp.py
@@ -212,6 +212,17 @@ def test_baseline_denylist_has_no_duplicates() -> None:
 # ---------------------------------------------------------------------------
 
 
+# seccomp is a Linux kernel facility: there is no ``prctl``/``seccomp_load`` to
+# call on macOS (the child dies with ``dlsym(RTLD_DEFAULT, prctl): symbol not
+# found``), so these probes can only assert anything on Linux. The denylist
+# CONTENT tests above stay ungated — they are pure data checks and run
+# everywhere.
+requires_seccomp = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="seccomp filters are a Linux kernel facility",
+)
+
+
 def _run_in_child(probe: str) -> int:
     """
     Fork-exec a fresh Python with *probe* and return the child exit code.
@@ -234,6 +245,7 @@ def _run_in_child(probe: str) -> int:
     return -1
 
 
+@requires_seccomp
 def test_apply_baseline_denylist_blocks_ptrace_in_child() -> None:
     """
     :func:`apply_baseline_denylist` actually engages the kernel:
@@ -276,6 +288,7 @@ def test_apply_baseline_denylist_blocks_ptrace_in_child() -> None:
     )
 
 
+@requires_seccomp
 def test_apply_baseline_denylist_does_not_break_subprocess_basics() -> None:
     """
     A child that loads the baseline can still ``read``, ``write``,
@@ -314,6 +327,7 @@ def test_apply_baseline_denylist_does_not_break_subprocess_basics() -> None:
     )
 
 
+@requires_seccomp
 def test_arg_filter_blocks_socket_family_only() -> None:
     """
     ``SCMP_CMP_EQ`` on ``socket(domain, ...)`` returns ``EPERM`` for
@@ -361,6 +375,7 @@ def test_arg_filter_blocks_socket_family_only() -> None:
     assert rc == 0
 
 
+@requires_seccomp
 def test_masked_eq_filter_blocks_clone_with_namespace_bit() -> None:
     """
     ``SCMP_CMP_MASKED_EQ`` on ``clone(flags, ...)`` returns ``EPERM``
@@ -402,6 +417,7 @@ def test_masked_eq_filter_blocks_clone_with_namespace_bit() -> None:
     assert rc == 0
 
 
+@requires_seccomp
 def test_unknown_syscall_silently_skipped() -> None:
     """
     A rule referencing a syscall name libseccomp can't resolve on

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 import sys
 import threading
+import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -366,9 +368,27 @@ async def test_is_alive_true_when_pane_live(
     assert instance.running is True
 
 
+@pytest.fixture()
+def short_tmp_parent() -> Iterator[Path]:
+    """Short-pathed tmpdir under ``/tmp``. ``tmp_path`` overflows AF_UNIX on macOS.
+
+    Only the real-tmux test needs this: macOS caps a Unix socket path at 104
+    bytes and its ``$TMPDIR`` is already ~48, so pytest's ``tmp_path`` (which
+    embeds the test name) makes ``tmux -S`` fail with "File name too long"
+    before the server ever starts. The stubbed tests never bind their socket,
+    so they keep using ``tmp_path``. Mirrors ``tests/inner/egress/test_relay.py``.
+    """
+    parent = Path("/tmp") / f"omni-term-{uuid.uuid4().hex[:8]}"
+    parent.mkdir(mode=0o700)
+    try:
+        yield parent
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
+
+
 @pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux binary")
 @pytest.mark.asyncio
-async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> None:
+async def test_server_survives_inner_process_exit_real_tmux(short_tmp_parent: Path) -> None:
     """
     The private tmux server outlives an inner-process exit (issue #540).
 
@@ -379,19 +399,19 @@ async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> N
     up (so control commands keep working and the dead pane stays capturable)
     while ``is_alive`` still reports the inner process as gone.
 
-    :param tmp_path: Temporary directory for the real tmux socket.
+    :param short_tmp_parent: Short-pathed directory for the real tmux socket.
     """
     instance = TerminalInstance(
         name="bash",
         session_key="s1",
-        socket_path=tmp_path / "tmux.sock",
-        private_dir=tmp_path,
+        socket_path=short_tmp_parent / "tmux.sock",
+        private_dir=short_tmp_parent,
         command="sh",
         args=["-c", "exit 0"],
         keep_alive_after_exit=True,
     )
     try:
-        await instance.launch(cwd=tmp_path)
+        await instance.launch(cwd=short_tmp_parent)
 
         # Wait for the inner `sh` to exit. is_alive() flips running -> False
         # once the pane is dead.

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -15,6 +15,7 @@ from omnigent import (
     kiro_native_bridge,
     qwen_native_bridge,
 )
+from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS
 from omnigent.claude_native_bridge import (
     bridge_dir_for_bridge_id,
     bridge_dir_for_conversation_id,
@@ -29,6 +30,23 @@ from tests.runner.conftest import (
     _ScriptedHarnessClient,
 )
 from tests.runner.helpers import NullServerClient
+
+
+@pytest.fixture(autouse=True)
+def _unpinned_alias_vocabulary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the developer's own alias pinning so the /model picker is deterministic.
+
+    The Claude picker's spellable vocabulary is read from the launch env's
+    ``ANTHROPIC_DEFAULT_*_MODEL`` pins (see
+    :func:`omnigent.claude_model_vocabulary.alias_pins`). A developer whose
+    shell pins those — anyone driving Claude through a gateway — gets a picker
+    that can spell real models, so a model-change these tests expect to fail
+    with ``claude_native_model_failed`` instead comes back
+    ``claude_native_model_unsupported``. CI has no pins, which is why this only
+    bites locally. Tests here that exercise pinning set their own env.
+    """
+    for env_var in ALIAS_MODEL_ENV_VARS.values():
+        monkeypatch.delenv(env_var, raising=False)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -158,6 +158,16 @@ async def test_create_session_threads_workspace_to_pi_cwd(
 ) -> None:
     """Pi pre-spawn receives the session workspace, not the bundle dir."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    # Isolate HOME too: the pi pre-spawn resolves credentials through ambient
+    # detection, which reads ~/.codex/config.toml and ~/.databrickscfg — both
+    # OUTSIDE OMNIGENT_CONFIG_HOME. On a developer box those make the pre-spawn
+    # 400 before any cwd is threaded (a cli-config provider it cannot use, or
+    # several ~/.databrickscfg profiles matching one host, which the SDK refuses
+    # to disambiguate). CI has neither file, which is why this only bites locally.
+    monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
     session_id = "18f39ab73f49285e4dab0c80ff7b8455"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()
@@ -226,6 +236,16 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
 ) -> None:
     """Pi pre-spawn falls back to runner workspace when session workspace is empty."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    # Isolate HOME too: the pi pre-spawn resolves credentials through ambient
+    # detection, which reads ~/.codex/config.toml and ~/.databrickscfg — both
+    # OUTSIDE OMNIGENT_CONFIG_HOME. On a developer box those make the pre-spawn
+    # 400 before any cwd is threaded (a cli-config provider it cannot use, or
+    # several ~/.databrickscfg profiles matching one host, which the SDK refuses
+    # to disambiguate). CI has neither file, which is why this only bites locally.
+    monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
     session_id = "3f1d20a97a7d0ba93e02cf17aeb92367"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -40,8 +40,16 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     Tests that need a specific global config write their own config.yaml
     into a separate temp dir and set OMNIGENT_CONFIG_HOME themselves —
     that setenv call wins because monkeypatch applies in call order.
+
+    ``HOME`` is redirected for the same reason: ambient detection also reads
+    ``~/.codex/config.toml``, which is OUTSIDE ``OMNIGENT_CONFIG_HOME``. A
+    developer with a codex CLI provider configured there gets it detected as a
+    ``cli-config`` provider that can only drive the ``codex`` harness, so these
+    tests die on an unrelated ``OmnigentError`` instead of asserting their env
+    vars. CI has no such file, which is why this only bites locally.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 def _make_spec(

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -26,10 +26,17 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     this file so the developer's real ``~/.omnigent/config.yaml`` (e.g.
     a default provider) cannot hijack the legacy-profile path under test.
 
+    ``HOME`` is redirected for the same reason: ambient detection also reads
+    ``~/.codex/config.toml``, which is OUTSIDE ``OMNIGENT_CONFIG_HOME``. A
+    developer with a codex CLI provider configured there gets it detected and
+    ranked ahead of the path under test, failing the run locally while CI —
+    which has no such file — passes.
+
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Temporary directory for the isolated config.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(
         "omnigent.runtime.workflow._resolve_catalog_default_model",
         lambda provider_name, family, *, context: f"catalog-{provider_name}-{family}-default",

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -89,11 +89,26 @@ def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     global config through this env var, so writing a ``config.yaml`` under
     *tmp_path* exercises the real file-loading path the runtime uses.
 
+    Also neutralizes ambient **CLI-login** detection. Several tests here set
+    ``HOME`` to isolate credentials, but that is not sufficient on macOS:
+    :func:`omnigent.onboarding.ambient._claude_login_detected` falls back to
+    running ``claude auth status``, which reads the **Keychain** — a location no
+    ``HOME`` override can hide. On any signed-in Mac that detection injects a
+    ``kind="subscription"`` anthropic provider which outranks the test's own
+    configured entry and emits no gateway vars, so the assertions die on a bare
+    ``KeyError``. Forcing it ``False`` reproduces the CI box (no ``claude``
+    login) and keeps these tests about the config they actually write. The
+    detection's own behavior is covered by ``tests/onboarding/test_ambient.py``.
+
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Per-test temp directory.
     :returns: The temp directory used as the config home.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "omnigent.onboarding.ambient._claude_login_detected",
+        lambda: False,
+    )
     return tmp_path
 
 
@@ -255,11 +270,20 @@ def test_detected_ambient_key_routes_with_no_config(
     (``effective_config_with_detected``) and route the claude-sdk harness
     through it, so "first run without configure" works. Failure means a
     fresh machine would emit no gateway vars and the harness would hit
-    api.anthropic.com with no key. HOME is isolated so a real CLI login on
-    the test box can't shadow the env-key detection.
+    api.anthropic.com with no key. HOME is isolated, and ``config_home``
+    additionally stubs CLI-login detection, so a real ``claude`` login on the
+    test box (Keychain-backed on macOS, which HOME cannot hide) can't shadow the
+    env-key detection.
     """
     monkeypatch.setenv("HOME", str(config_home))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # A bare ``ANTHROPIC_API_KEY`` is the whole point of this test, so drop the
+    # companion vars a gateway user's shell exports: detection deliberately
+    # folds ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` into the entry (a
+    # gateway key 401s against api.anthropic.com), which would otherwise
+    # redirect the assertions below at the developer's own gateway.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-detected")
     spec = _make_spec(harness="claude-sdk")  # no auth, no config file
 
@@ -385,7 +409,8 @@ def test_claude_sdk_falls_back_to_first_available_anthropic_credential(
     back to it via the same `first_available_provider`, so the brain launches
     instead of hitting api.anthropic.com with no key. Resolved per spawn; the
     config is not mutated; the readout resolver (`for_launch=False`) still
-    returns `None`. HOME is isolated so a real CLI login can't shadow the test.
+    returns `None`. HOME is isolated, and ``config_home`` additionally stubs
+    CLI-login detection, so a real ``claude`` login can't shadow the test.
     """
     monkeypatch.setenv("HOME", str(config_home))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

20 tests failed on a developer macOS checkout while passing in Linux CI, so `pytest`
was not a usable local signal on a Mac: you saw a red suite you did not cause, and a
real regression would hide in it. This fixes all 20. **Tests only — no product code
changes.**

Four independent causes, found by sweeping the macOS-gated surface Linux CI cannot
reach. Full evidence per class is in #4279.

| # | Cause | Tests | Fix |
|---|---|---|---|
| 1 | Linux-only tests with no platform gate | 9 | module-level `skipif` |
| 2 | AF_UNIX 104-byte socket path cap | 2 | reuse existing `short_tmp_parent` |
| 3 | Ambient `ANTHROPIC_DEFAULT_*_MODEL` alias pins | 4 | autouse fixture clearing pins |
| 4 | Host state outside `OMNIGENT_CONFIG_HOME` | 5 | redirect `HOME`; stub Keychain probe |

**1. Ungated Linux-only tests.** The 4 bwrap resolver tests call `resolve()`, which
hard-errors off Linux; 5 seccomp tests load a real BPF filter (no `prctl` on macOS).
Both files already had a skip marker, but it was defined *below* the affected tests
(`test_bwrap_sandbox.py:1507`) so it never decorated them. Their negative siblings
(`test_resolve_raises_on_non_linux`) stay ungated — those are what covers macOS.

**2. AF_UNIX path cap.** macOS allows a 103-byte socket path (measured; Linux 108) and
`$TMPDIR` is already ~48, so `tmp_path` overflows before the socket name is appended.
Reused the `short_tmp_parent` fixture pattern already in `egress/test_relay.py`.
**Production is unaffected** — real paths run ~85 bytes, so this was a test artifact,
not a shipping bug.

**3. Ambient alias pins.** `alias_pins()` falls back to `os.environ` and
`claude_model_alias` returns `None` on a *mismatched* pin by design, so any
gateway-pinned shell got no translation and the `/model` picker answered
`unsupported` instead of `failed`. The pinning tests pass explicit mappings or a bridge
`model_env` rather than the process env, so clearing these masks nothing.

**4. Host state outside the config home.** Detection also reads
`~/.codex/config.toml` and `~/.databrickscfg`, which live under `HOME`. On macOS
`_claude_login_detected()` additionally shells out to `claude auth status`, which reads
the **Keychain** — a location no `HOME` override can hide. Two docstrings asserted that
HOME isolation already prevented exactly this; I corrected them rather than leave them
misleading.

## Test plan

Verified on macOS 26.5.2 (arm64) with the CI extras
(`uv sync --locked --extra all --extra dev --extra databricks`):

- **Before:** `18 failed, 319 passed` on the directly comparable subset.
- **After:** `410 passed, 15 skipped` across all 10 changed files.
- Re-ran with the ambient vars stripped (`env -u ANTHROPIC_DEFAULT_*` etc.) to confirm
  the fixes hold in a CI-like environment and do not merely paper over local state.
- `ruff format --check` and `ruff check` clean. `pyrefly` reports the same 44
  pre-existing errors before and after (verified by diffing against a `git stash`), so
  this adds none.
- Linux CI on this PR is the real check that the new `skipif`s do not silently skip on
  Linux — the 9 gated tests should still run and pass there.

## Out of scope

While sweeping I also found **9 codex-native failures** in
`test_app_sessions_native_events_lifecycle.py` (`"no compatible model resolved from
provider 'databricks' for family 'openai'"`). Deliberately **not** touched here: they
reproduce on pristine `main`, that code path has no `sys.platform` branch, and they
survive full `HOME` + config isolation — so they should fail in Linux CI too. Likely
from `b2681303` (Smart Routing MVP #4074). Noted in #4279 for a separate fix.

Part of #4279

This pull request and its description were written by Isaac.
