### PR TITLE
fix(antigravity-native): scope the CLI agy launch to a per-session gemini dir

### DIFF
--- a/dev/verify_agy_gemini_dir.py
+++ b/dev/verify_agy_gemini_dir.py
@@ -73,7 +73,9 @@ async def _run(sandbox: Path) -> tuple[list[str], dict[str, str], Path, set[str]
     # Stand in for a signed-in user who also has their own agy MCP config + settings.
     (real_gemini / "oauth_creds.json").write_text('{"access_token": "real-token"}')
     (real_gemini / "google_accounts.json").write_text('{"active": "user@example.com"}')
-    (real_gemini / "antigravity-cli" / "settings.json").write_text('{"model": "gemini-3-pro"}')
+    # An opaque placeholder, not a real model id: this only has to be a setting of
+    # the user's that the launch must leave alone.
+    (real_gemini / "antigravity-cli" / "settings.json").write_text('{"model": "user-picked"}')
     (real_gemini / "config" / "mcp_config.json").write_text('{"mcpServers": {"mine": {}}}')
 
     # Redirect HOME so the real ~/.gemini is untouched, and re-point the two module

--- a/dev/verify_agy_gemini_dir.py
+++ b/dev/verify_agy_gemini_dir.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Verify the antigravity-native (agy) CLI launch is scoped to a per-session Gemini dir.
+
+Run this on macOS (or Linux) before and after the #1477 / #1194 fix. It answers
+four questions without a server, a runner, or a real agy launch:
+
+1. Does the CLI launch pass ``--gemini_dir=<per-session dir>``?
+2. Does the Omnigent MCP relay config land in that dir (so agy gets ``sys_*``)?
+3. Is ``HOME`` left real (so a keyring/Keychain-backed OAuth token still resolves)?
+4. Is the user's real ``~/.gemini`` left byte-for-byte untouched?
+
+Your real ``~/.gemini`` is never written: the home directory is redirected to a
+throwaway copy first, so this is safe to run on a signed-in machine.
+
+Usage::
+
+    .venv/bin/python dev/verify_agy_gemini_dir.py
+
+Exit code 0 = every check passed (post-fix). Non-zero = at least one failed, with
+the failure printed and the sandbox kept for inspection. A passing run then prints
+the manual steps for the part only a real agy can prove: that an agy launched this
+way is actually signed in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+import omnigent.antigravity_native as agy_cli
+import omnigent.antigravity_native_bridge as bridge
+
+
+class _StubClient:
+    """Answers the terminal create/patch calls without a server."""
+
+    async def post(self, url: str, **_kwargs: Any) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"id": "terminal_antigravity_main", "metadata": {}},
+            request=httpx.Request("POST", url),
+        )
+
+    async def patch(self, url: str, **_kwargs: Any) -> httpx.Response:
+        return httpx.Response(200, json={}, request=httpx.Request("PATCH", url))
+
+    async def get(self, url: str, **_kwargs: Any) -> httpx.Response:
+        return httpx.Response(200, json={}, request=httpx.Request("GET", url))
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    """Map every file under *root* to its contents, for an exact-equality diff."""
+    return {
+        str(path.relative_to(root)): path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+async def _run(sandbox: Path) -> tuple[list[str], dict[str, str], Path, set[str]]:
+    """Drive the real CLI launch path against a fake home; return what agy would get."""
+    fake_home = sandbox / "home"
+    real_gemini = fake_home / ".gemini"
+    (real_gemini / "antigravity-cli").mkdir(parents=True)
+    (real_gemini / "config").mkdir(parents=True)
+    # Stand in for a signed-in user who also has their own agy MCP config + settings.
+    (real_gemini / "oauth_creds.json").write_text('{"access_token": "real-token"}')
+    (real_gemini / "google_accounts.json").write_text('{"active": "user@example.com"}')
+    (real_gemini / "antigravity-cli" / "settings.json").write_text('{"model": "gemini-3-pro"}')
+    (real_gemini / "config" / "mcp_config.json").write_text('{"mcpServers": {"mine": {}}}')
+
+    # Redirect HOME so the real ~/.gemini is untouched, and re-point the two module
+    # constants that captured Path.home() at import time (a Path.home patch alone
+    # leaves them aimed at the real home).
+    Path.home = classmethod(lambda _cls: fake_home)  # type: ignore[method-assign]
+    bridge.AGY_APP_DATA_DIR = real_gemini / "antigravity-cli"
+    bridge._AGY_ONBOARDING_MARKER = bridge.AGY_APP_DATA_DIR / "cache" / "onboarding.json"
+    bridge._BRIDGE_ROOT = sandbox / "omnigent" / "antigravity-native"
+
+    # agy itself is never launched: stub the binary resolution and the terminal call.
+    agy_cli.build_agy_launch = lambda **kwargs: (  # type: ignore[assignment]
+        ["agy", *(("--model", kwargs["model"]) if kwargs.get("model") else ())],
+        {},
+    )
+    captured: dict[str, Any] = {}
+
+    async def _fake_terminal(
+        _client: Any, _session_id: str, *, argv: list[str], env: dict[str, str], **_kw: Any
+    ) -> Any:
+        captured["argv"], captured["env"] = list(argv), dict(env)
+        return agy_cli.LaunchedAntigravityTerminal(
+            terminal_id="terminal_antigravity_main", tmux_socket=None, tmux_target=None
+        )
+
+    agy_cli._launch_antigravity_terminal = _fake_terminal  # type: ignore[assignment]
+
+    bridge_id = "verify_agy_gemini_dir"
+    bridge_dir = bridge.prepare_bridge_dir(bridge_id)
+    before = _snapshot(real_gemini)
+
+    await agy_cli._launch_and_record(
+        _StubClient(),  # type: ignore[arg-type]
+        session_id="conv_verify",
+        bridge_id=bridge_id,
+        conversation_id="agy_conv_placeholder",
+        resume=False,
+        antigravity_args=(),
+        command="agy",
+        model=None,
+        permission_mode=None,
+        headless=True,
+        startup_progress=None,
+    )
+
+    after = _snapshot(real_gemini)
+    changed = {name for name in set(before) | set(after) if before.get(name) != after.get(name)}
+    return captured["argv"], captured["env"], bridge_dir, changed
+
+
+def main() -> int:
+    # Kept on disk until every check passes, so a failure can be inspected.
+    sandbox = Path(tempfile.mkdtemp(prefix="agy-verify-"))
+    argv, env, bridge_dir, changed = asyncio.run(_run(sandbox))
+
+    iso_gemini = bridge.agy_gemini_dir(bridge_dir)
+    relay_config = iso_gemini / "config" / "mcp_config.json"
+    gemini_dir_flag = next((arg for arg in argv if arg.startswith("--gemini_dir=")), None)
+
+    failures: list[str] = []
+
+    print("agy argv:", " ".join(argv))
+    print("agy env overrides:", sorted(env) or "(none)")
+    print()
+
+    # 1. The flag agy needs to read a per-session config at all.
+    if gemini_dir_flag == f"--gemini_dir={iso_gemini}":
+        print(f"PASS  --gemini_dir points at the per-session dir\n      {iso_gemini}")
+    else:
+        failures.append(
+            f"--gemini_dir missing or wrong (got {gemini_dir_flag!r}); agy will read the "
+            "user's real ~/.gemini, so it sees no Omnigent relay and no sys_* tools"
+        )
+
+    # 2. The relay config, in the dir the flag points at.
+    if relay_config.is_file():
+        tools = json.loads(relay_config.read_text())["mcpServers"]["omnigent"]["enabledTools"]
+        print(f"PASS  relay mcp_config.json written ({len(tools)} tools enabled)")
+    else:
+        failures.append(f"no relay mcp_config.json at {relay_config}")
+
+    # 3. HOME must stay real or a Keychain/keyring token cannot be unlocked.
+    if "HOME" not in env:
+        print("PASS  HOME not overridden (keyring / macOS Keychain auth still resolves)")
+    else:
+        failures.append(f"HOME overridden to {env['HOME']!r}; breaks macOS Keychain auth")
+
+    # 4. The user's own agy config must survive untouched.
+    if not changed:
+        print("PASS  the real ~/.gemini is byte-for-byte unchanged")
+    else:
+        failures.append(f"the real ~/.gemini was modified: {sorted(changed)}")
+
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for item in failures:
+            print("  -", item)
+        print(f"\nsandbox kept for inspection: {sandbox}")
+        return 1
+
+    shutil.rmtree(sandbox, ignore_errors=True)
+    print("All checks passed.\n")
+    print("Still worth confirming by hand on macOS (only a real agy can prove auth):")
+    print("  1. agy --version                          # installed, and you are signed in")
+    print("  2. agy --gemini_dir=<a fresh empty dir> --help   # the flag is accepted")
+    print("  3. omnigent antigravity --server <url>    # then in the agy TUI: /mcp")
+    print("     Expect '✓ omnigent' with sys_* tools, and NO login prompt.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -38,7 +38,13 @@ Differences from the Codex / Claude wrappers (Phase 1 scope):
 * **Workspace = the agy terminal cwd.** agy runs tools in its process working
   directory, so the terminal cwd is pinned to the session working dir; no
   ``--add-dir`` is needed.
-* **Auth is inherited from ``~/.gemini``** — no credential seeding.
+* **Auth stays on the real HOME; config is per-session.** agy launches with
+  ``--gemini_dir=<bridge_dir>/agy-home/.gemini``, so its MCP relay config and
+  settings are session-scoped and the user's real ``~/.gemini`` is never
+  rewritten. ``HOME`` is deliberately left real, because agy's OAuth token can
+  live in the OS keyring (macOS Keychain), which a relocated HOME cannot unlock
+  (#1477); file-based credential markers are copied into the isolated dir for
+  the platforms that use them.
 
 The runner OWNS the agy terminal: binding a runner triggers its idempotent
 auto-create of the antigravity terminal (``runner/app.py``
@@ -88,15 +94,18 @@ from omnigent.antigravity_native_bridge import (
     AGY_PLACEHOLDER_CONVERSATION_PREFIX,
     ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
     AntigravityNativeBridgeState,
+    agy_gemini_dir,
+    agy_home_dir,
     bridge_dir_for_bridge_id,
     clear_bridge_state,
     ensure_agy_feedback_survey_disabled,
-    ensure_agy_onboarding_complete,
     is_placeholder_conversation_id,
     prepare_bridge_dir,
     read_bridge_state,
+    seed_isolated_agy_home,
     update_conversation_id,
     write_bridge_state,
+    write_mcp_config,
     write_tmux_target,
 )
 from omnigent.antigravity_native_launch import (
@@ -962,10 +971,11 @@ async def _launch_and_record(
     # Clear stale turn/conversation state so a fresh launch rediscovers this run's
     # real agy conversation id instead of binding to the previous run's.
     await asyncio.to_thread(clear_bridge_state, bridge_dir)
-    # Pre-accept agy's first-run onboarding wizard (HOME-global) so a headless /
-    # detached launch does not hang waiting for a TTY answer. Idempotent and
-    # offloaded to a thread (file I/O), mirroring the bridge-state writes below.
-    await asyncio.to_thread(ensure_agy_onboarding_complete)
+    # agy's first-run onboarding wizard has no TTY to answer it on a headless /
+    # detached launch, so its completion marker is pre-accepted below by
+    # ``seed_isolated_agy_home`` — in the isolated dir agy actually reads under
+    # ``--gemini_dir``. Seeding the real ``~/.gemini`` marker as well would write
+    # the user's tree for a file this launch never reads.
     argv, env_overrides = build_agy_launch(
         conversation_id=conversation_id if resume else None,
         model=model,
@@ -974,14 +984,29 @@ async def _launch_and_record(
         headless=headless,
         extra_args=antigravity_args,
     )
+    # Scope agy to a per-session isolated Gemini dir, exactly as the runner-owned
+    # launch does. agy has no --mcp-config flag and ignores every ANTIGRAVITY_* env
+    # knob, so its MCP relay config and its settings can only be scoped through the
+    # hidden --gemini_dir. Without this the CLI launch read the user's real
+    # ~/.gemini: agy saw no Omnigent relay (hence no sys_* tools, #1194), and the
+    # survey/trust seeds below rewrote the user's own settings.json. HOME stays real
+    # so keyring-backed auth (macOS Keychain) keeps working (#1477).
+    await asyncio.to_thread(write_mcp_config, bridge_dir)
+    env_overrides = {
+        **env_overrides,
+        **await asyncio.to_thread(
+            seed_isolated_agy_home,
+            bridge_dir,
+            trusted_workspace=Path.cwd().resolve(),
+        ),
+    }
     # agy's feedback survey shares its "esc to cancel" footer with the running-turn
     # marker, so a web turn injected into this CLI-launched session while the survey
-    # is up would be silently lost (#1494). Disable it in the launch HOME before agy
-    # starts. This path emits no HOME override, so agy runs under the real ~/.gemini.
-    await asyncio.to_thread(
-        ensure_agy_feedback_survey_disabled,
-        Path(env_overrides.get("HOME") or Path.home()),
-    )
+    # is up would be silently lost (#1494). Disable it in the isolated dir agy reads
+    # under --gemini_dir, never the user's real ~/.gemini.
+    await asyncio.to_thread(ensure_agy_feedback_survey_disabled, agy_home_dir(bridge_dir))
+    # Lead the args so the flag is never swallowed by a later positional.
+    argv = [argv[0], f"--gemini_dir={agy_gemini_dir(bridge_dir)}", *argv[1:]]
     _update_progress(startup_progress, "Starting Antigravity terminal...")
     launched = await _launch_antigravity_terminal(
         client,

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -82,9 +82,14 @@ def ensure_agy_onboarding_complete() -> None:
     Idempotently seeds ``onboardingComplete`` (and the sibling consumer/enterprise
     flags) into agy's ``~/.gemini/antigravity-cli/cache/onboarding.json`` so the
     interactive TUI onboarding wizard does not stall a host-spawned or headless
-    ``agy`` launch that has no TTY to answer it. Call once before launching agy
-    (see :func:`omnigent.runner.app._auto_create_antigravity_terminal` and the CLI
-    ``_launch_and_record`` path).
+    ``agy`` launch that has no TTY to answer it.
+
+    .. deprecated:: 0.9.0
+        No longer called by either launch path; slated for removal in 0.10.0.
+        Both launches now scope agy to a per-session ``--gemini_dir``, where
+        :func:`seed_isolated_agy_home` writes this same marker — so seeding the
+        real ``~/.gemini`` copy only wrote the user's tree for a file agy never
+        reads. Use :func:`seed_isolated_agy_home` instead.
 
     Any unrecognised keys already in the file are preserved (the three known keys
     are merged over them), and the write is skipped entirely when all three
@@ -333,6 +338,10 @@ _AGY_ENABLED_TOOLS = [
 # of the real tree).
 _AGY_SEED_FILES = (
     Path("oauth_creds.json"),
+    # Account identity agy writes beside the credential. Without it agy can hold a
+    # valid token yet still prompt for account selection in a fresh Gemini dir,
+    # which reads as "not signed in" on a headless launch (#1477).
+    Path("google_accounts.json"),
     Path("antigravity-cli") / "antigravity-oauth-token",
     Path("installation_id"),
     Path("antigravity-cli") / "installation_id",
@@ -624,16 +633,12 @@ def ensure_agy_feedback_survey_disabled(home: Path) -> None:
     if data.get(_AGY_FEEDBACK_SURVEY_SETTING) is False:
         return  # already disabled — avoid a needless rewrite
     data[_AGY_FEEDBACK_SURVEY_SETTING] = False
-    # The write is atomic (mkstemp + os.replace) so a concurrent reader/writer
-    # never sees a torn file. On macOS the harness runs agy under the user's REAL
-    # ~/.gemini (the #1477 Keychain trade-off), so this file is shared across
-    # concurrent sessions and with agy itself: the atomic replace prevents
-    # corruption but not lost updates. That window is self-limiting — the
-    # idempotent short-circuit above makes every launch after the first disable
-    # read-only, so a racing agy trust/model write can only be clobbered on the
-    # one-time first disable, and the clobbered values fail safe (lost trust is
-    # re-prompted, lost model defaults). A cross-process lock is intentionally not
-    # taken (a separately-launched agy would not honor it).
+    # The write is atomic (mkstemp + os.replace) so a concurrent reader/writer never
+    # sees a torn file. Both launch paths pass the per-session isolated agy dir, so
+    # the only writer that can race here is the session's own agy; the idempotent
+    # short-circuit above makes every launch after the first disable read-only, and
+    # a clobbered value fails safe (lost trust is re-prompted, lost model defaults).
+    # A cross-process lock is intentionally not taken (agy would not honor it).
     try:
         settings_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         fd, tmp_name = tempfile.mkstemp(prefix="settings.json.", dir=str(settings_path.parent))

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4515,7 +4515,6 @@ async def _auto_create_antigravity_terminal(
         agy_home_dir,
         clear_bridge_state,
         ensure_agy_feedback_survey_disabled,
-        ensure_agy_onboarding_complete,
         prepare_bridge_dir,
         seed_isolated_agy_home,
         write_bridge_state,
@@ -4586,11 +4585,11 @@ async def _auto_create_antigravity_terminal(
     # conversation id (the cold-start mints it below) instead of a prior run's.
     clear_bridge_state(bridge_dir)
 
-    # Pre-accept agy's first-run onboarding wizard (HOME-global) before launch:
-    # a host-spawned agy terminal has no TTY to answer it and would hang with a
-    # blank web UI. Mirrors the ``ensure_claude_workspace_trusted`` seed on the
-    # Claude auto-create path. Idempotent; offloaded to a thread (file I/O).
-    await asyncio.to_thread(ensure_agy_onboarding_complete)
+    # agy's first-run onboarding wizard would hang a host-spawned terminal (no TTY
+    # to answer it, blank web UI). Its completion marker is pre-accepted below by
+    # ``seed_isolated_agy_home``, in the isolated dir agy reads under
+    # ``--gemini_dir``; seeding the real ``~/.gemini`` marker as well would write
+    # the user's tree for a file this launch never reads.
 
     argv, env_overrides = build_agy_launch(
         conversation_id=external_session_id if resume else None,

--- a/tests/test_antigravity_native.py
+++ b/tests/test_antigravity_native.py
@@ -619,6 +619,68 @@ async def test_launch_and_record_threads_headless_skip_flag(
     assert "--dangerously-skip-permissions" in captured_args
 
 
+async def test_launch_and_record_isolates_gemini_dir_and_wires_relay(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CLI launch scopes agy to a per-session Gemini dir, like the runner path.
+
+    agy loads MCP servers and settings only from the dir its ``--gemini_dir``
+    points at. Without the flag this path read the user's real ``~/.gemini``: agy
+    saw no Omnigent relay (so no ``sys_*`` tools, #1194) and the survey/trust
+    seeds rewrote the user's own ``settings.json``. Asserts the relay config lands
+    in the isolated dir, the flag points at it, and ``HOME`` stays real so
+    keyring-backed auth (macOS Keychain) still resolves (#1477).
+    """
+    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    real_home = tmp_path / "real-home"
+    (real_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+    user_settings = real_home / ".gemini" / "antigravity-cli" / "settings.json"
+    user_settings.write_text('{"model":"gemini-3-pro"}', encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: real_home))
+
+    captured_args: list[str] = []
+    captured_env: dict[str, str] = {}
+
+    def _capture_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured_args.extend(body["spec"]["args"])
+        captured_env.update(body["spec"]["env"])
+        return httpx.Response(200, json={"id": "terminal_antigravity_main", "metadata": {}})
+
+    async with _mock_client(_capture_handler) as client:
+        await _mod._launch_and_record(
+            client,
+            session_id="conv_abc123",
+            bridge_id="bridge_gemini_dir_test",
+            conversation_id=_PLACEHOLDER_ID,
+            resume=False,
+            antigravity_args=(),
+            command="agy",
+            model=None,
+            permission_mode=None,
+            headless=True,
+            startup_progress=None,
+        )
+
+    bridge_dir = bridge_mod.bridge_dir_for_bridge_id("bridge_gemini_dir_test")
+    iso_gemini = bridge_mod.agy_gemini_dir(bridge_dir)
+    # The flag leads the args so it is never swallowed by a later positional.
+    assert captured_args[0] == f"--gemini_dir={iso_gemini}"
+    # HOME must stay real: relocating it breaks keyring-backed auth on macOS.
+    assert "HOME" not in captured_env
+    # The relay config + token exist, so the wrapped agy can reach the sys_* tools.
+    relay_config = iso_gemini / "config" / "mcp_config.json"
+    payload = json.loads(relay_config.read_text(encoding="utf-8"))
+    assert "sys_session_create" in payload["mcpServers"]["omnigent"]["enabledTools"]
+    assert (bridge_dir / "bridge.json").is_file()
+    # The survey/trust seeds landed in the isolated dir, never the user's own file.
+    iso_settings = json.loads(
+        (iso_gemini / "antigravity-cli" / "settings.json").read_text(encoding="utf-8")
+    )
+    assert iso_settings["showFeedbackSurvey"] is False
+    assert user_settings.read_text(encoding="utf-8") == '{"model":"gemini-3-pro"}'
+
+
 # ---------------------------------------------------------------------------
 # _attach_terminal teardown: the eager terminal-close decision
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the residual half of #1477 / #1194: a **CLI-launched** agy (`omnigent antigravity`) had **no Omnigent `sys_*` tools** and **silently rewrote the user's own `~/.gemini/antigravity-cli/settings.json`**.

The runner-owned (web) launch already scoped agy to an isolated `--gemini_dir` and wrote the MCP relay config there. `_launch_and_record` did neither, so agy loaded the user's real `~/.gemini` — which has no Omnigent relay entry.

```
# before, on this Mac
argv:                 ['agy']            # no --gemini_dir
iso mcp_config.json:  False              # relay never written
real ~/.gemini:        MODIFIED          # settings.json + onboarding.json
```

## What #1477 asked for vs. what was actually wrong

Worth flagging, since the issue text is now stale: **both layers #1477 describes were already fixed by #1598.** Layer 2 was solved by *abandoning* HOME relocation — agy's hidden `--gemini_dir` scopes config per session while `HOME` stays real, so a Keychain-backed token still unlocks. So the issue's own suggested fix (a) *"don't isolate HOME on macOS"* is the regression #1598 undid, and this PR deliberately does **not** relocate `HOME`.

What remained was the CLI path never being wired at all.

## Changes

- **`_launch_and_record`**: call `write_mcp_config` + `seed_isolated_agy_home` (pre-trusting the CLI cwd) and prepend `--gemini_dir=<isolated dir>` ahead of every generated flag.
- **Removed the dead real-HOME write.** `ensure_agy_onboarding_complete()` wrote the real `~/.gemini` on **both** launch paths for a marker agy no longer reads — `seed_isolated_agy_home` already writes the identical file into the isolated dir, before launch. Dropped from both callers, so nothing writes the user's tree now. Function kept + `deprecated:: 0.9.0` (remove in 0.10.0), since 8 tests still cover it.
- **`google_accounts.json` added to `_AGY_SEED_FILES`** — the one-line seed #1477 asked for that never landed. It sits beside `oauth_creds.json` on a signed-in Mac (confirmed here on macOS 26.5.2); without it agy can hold a valid token yet still prompt for account selection in a fresh Gemini dir. Seeded best-effort, so a missing file is skipped.
- Corrected three comments this falsifies, including one asserting macOS runs agy under the real `~/.gemini` as "the #1477 Keychain trade-off" — untrue on both paths now.

## Test plan

Verified on **macOS 26.5.2 (arm64)**, which is what #1477 is about.

`dev/verify_agy_gemini_dir.py` (added) drives the real `_launch_and_record` against a redirected fake HOME — no server, runner, or real `agy` needed, and safe to run on a signed-in machine:

```
$ .venv/bin/python dev/verify_agy_gemini_dir.py
PASS  --gemini_dir points at the per-session dir
PASS  relay mcp_config.json written (26 tools enabled)
PASS  HOME not overridden (keyring / macOS Keychain auth still resolves)
PASS  the real ~/.gemini is byte-for-byte unchanged
```

Baseline is clean: **3 failures pre-fix → 0 post-fix** (stash `antigravity_native.py` to reproduce).

- **144 passed** across `test_antigravity_native{,_bridge,_launch}.py`; **89 passed** on the two runner terminal suites.
- The new regression test **fails on unfixed code** (`assert '--dangerousl...' == '--gemini_dir...'`), so it genuinely guards this.
- `ruff format --check` + `ruff check` clean.

## Caveats

- **`agy` is not installed on this machine**, so the last mile — `/mcp` showing `✓ omnigent` with `sys_*` and no login prompt — is unverified by me. The claim that `--gemini_dir` preserves Keychain auth rests on #1598's "verified live (agy 1.0.12)". The offline harness covers everything else.
- 3 pre-existing failures in `test_app_sessions_native_terminals_runtime.py::*pi_cwd*` show up on a developer Mac. **Not from this PR** — they reproduce on pristine `main` and pass with a clean `HOME`; they're the ambient `~/.databrickscfg` leak tracked in #4279.

Closes #1194
Closes #1477

`#1194` (relay unwired → no `sys_*` tools) was half-fixed by #1216/#1598 on the
runner-owned path; this PR wires the CLI path, which was the last launch path
still reading the user's real `~/.gemini`. Its other four asks are already
satisfied on main: the relay starter is passed on the runner path,
`enabledTools` advertises the `sys_*` surface, and the false spec comments were
corrected.

`#1477` is closed as **fixed, but not as written** — see the section above. Both
layers it describes were resolved by #1598 (layer 2 by dropping HOME relocation
in favour of `--gemini_dir`, so its suggested fix (a) would be a regression). The
one concrete ask still outstanding was seeding `google_accounts.json`, which
lands here. The macOS-host CUJ in its repro steps goes through the runner path
and has worked since #1598.

This pull request and its description were written by Isaac.

