### PR TITLE
fix(web): insert dictated text at the caret, not the end of the composer

### DIFF
--- a/tests/e2e_ui/chat/test_dictation.py
+++ b/tests/e2e_ui/chat/test_dictation.py
@@ -20,8 +20,9 @@ A failure here means one of:
   plumbing in ``omnigent/server/app.py`` or ``web/src/lib/capabilities.ts``).
 - The WebSocket route broke (``omnigent/server/routes/dictation.py``).
 - The capture pipeline broke (``web/src/lib/dictation.ts`` worklet/socket).
-- The composer stopped applying interim/final updates
-  (``ComposerMicButton.tsx`` / ``useDictationInsert.ts`` / ``ChatPage.tsx``).
+- The composer stopped applying interim/final updates, or stopped inserting
+  them at the caret (``ComposerMicButton.tsx`` / ``useDictationInsert.ts`` /
+  ``ChatPage.tsx``).
 """
 
 from __future__ import annotations
@@ -167,6 +168,65 @@ def test_enter_while_listening_commits_text(
         page.keyboard.press("Enter")
         expect(mic).to_have_attribute("aria-pressed", "false")
         expect(composer).to_have_value(re.compile(re.escape(_FAKE_SCRIPT)))
+    finally:
+        context.close()
+
+
+def test_transcript_lands_at_the_caret(
+    browser: Browser,
+    browser_context_args: dict[str, Any],
+    seeded_session: tuple[str, str],
+) -> None:
+    """Dictation inserts at the caret, not at the end of the draft.
+
+    The reported flow: paste a block of context, click above it, dictate the
+    instructions that should lead. Drives the real caret through the browser
+    (click + Ctrl+Home) rather than calling the hook, so it also covers the
+    composer's ``onFocus`` wiring and the caret surviving the mic button
+    taking focus on click.
+    """
+    base_url, session_id = seeded_session
+    context, page = _open_server_dictation_page(
+        browser, browser_context_args, base_url, session_id
+    )
+    try:
+        composer = page.get_by_placeholder("Ask the agent anything…")
+        expect(composer).to_be_visible()
+
+        # Paste a block of context, then put the caret at the very top.
+        composer.fill("PASTED CONTEXT")
+        composer.click()
+        page.keyboard.press("Control+Home")
+
+        mic = page.get_by_role("button", name="Voice dictation")
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "true")
+        expect(composer).to_have_value(
+            re.compile(re.escape(_FAKE_SCRIPT)),
+            timeout=_TRANSCRIPT_TIMEOUT_MS,
+        )
+
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "false")
+        # The dictated words lead and the pasted block still trails them.
+        expect(composer).to_have_value(f"{_FAKE_SCRIPT} PASTED CONTEXT")
+
+        # Second take with the caret moved back to the top: the caret must be
+        # honoured again rather than the text chaining onto the first take.
+        # (The related empty-interim-clear regression can't be reached here —
+        # the fake engine always finalizes a non-empty tail, so the mic takes
+        # the onTranscript branch instead of onInterim(""). That path is
+        # covered in web/src/hooks/useDictationInsert.test.tsx.)
+        composer.click()
+        page.keyboard.press("Control+Home")
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "true")
+        expect(composer).to_have_value(
+            f"{_FAKE_SCRIPT} {_FAKE_SCRIPT} PASTED CONTEXT",
+            timeout=_TRANSCRIPT_TIMEOUT_MS,
+        )
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "false")
     finally:
         context.close()
 

--- a/web/src/hooks/useDictationInsert.test.tsx
+++ b/web/src/hooks/useDictationInsert.test.tsx
@@ -292,6 +292,33 @@ describe("useDictationInsert", () => {
       expect(composer.value).toBe("Second. Hello PASTED");
     });
 
+    it("pins a final whose text matches the partial already on screen", () => {
+      // The server often finalizes exactly what it last streamed, so the splice
+      // changes nothing. The update is still a pin: if the region stayed
+      // pending, the next insert would lift the finalized text back out, and an
+      // end-of-take clear would delete the dictated word outright.
+      const composer = renderComposer("PASTED");
+      composer.click(0);
+      composer.replaceInterim("hello");
+      expect(composer.value).toBe("hello PASTED");
+      composer.appendFinal("hello");
+      expect(composer.value).toBe("hello PASTED");
+      composer.replaceInterim(""); // end of take
+      expect(composer.value).toBe("hello PASTED");
+      // ...and the next utterance continues after it, not in front of it.
+      composer.appendFinal("Next.");
+      expect(composer.value).toBe("hello Next. PASTED");
+    });
+
+    it("is inert when an empty clear arrives with nothing pending", () => {
+      const composer = renderComposer("USER TEXT");
+      composer.click(0);
+      composer.replaceInterim("");
+      expect(composer.value).toBe("USER TEXT");
+      composer.appendFinal("Lead.");
+      expect(composer.value).toBe("Lead. USER TEXT");
+    });
+
     it("does not resurrect a spent region when the draft returns to its text", () => {
       // Undo (or retyping the same string) restores value equality with what
       // dictation produced, but those characters now belong to the user. A

--- a/web/src/hooks/useDictationInsert.test.tsx
+++ b/web/src/hooks/useDictationInsert.test.tsx
@@ -1,16 +1,78 @@
-// Tests for useDictationInsert — the replaceable trailing interim region
-// that lets server dictation stream live text into a plain-string draft.
+// Tests for useDictationInsert: caret-positioned insertion plus the
+// replaceable interim region that lets server dictation stream live text
+// into a plain-string draft.
 //
 // Invariant under test throughout: dictation must never delete text it
-// didn't write. The interim region is stripped only when the draft still
-// ends with the exact text the hook inserted.
+// didn't write. The interim region is replaced only while the draft is still
+// verbatim the string the hook produced.
+//
+// The caret is read off a real textarea, so most tests render one and drive
+// it (focus + setSelectionRange) the way a user's click would.
 
-import { act, renderHook } from "@testing-library/react";
-import { StrictMode, useState, type ReactNode } from "react";
+import { act, render, renderHook } from "@testing-library/react";
+import { StrictMode, useRef, useState, type ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { useDictationInsert } from "./useDictationInsert";
 
-/** Harness pairing the hook with the same useState shape the composers use. */
+type Api = ReturnType<typeof useDictationInsert>;
+
+/**
+ * Render a composer-shaped textarea wired to the hook. Returns the live
+ * textarea plus helpers: ``click`` places the caret the way a user does
+ * (focus, then collapse the selection at an offset).
+ */
+function renderComposer(initial = "") {
+  const box: {
+    api: Api | null;
+    ta: HTMLTextAreaElement | null;
+    set: ((next: string) => void) | null;
+  } = { api: null, ta: null, set: null };
+
+  function Composer() {
+    const [value, setValue] = useState(initial);
+    const ref = useRef<HTMLTextAreaElement>(null);
+    box.api = useDictationInsert(value, setValue, ref);
+    box.set = setValue;
+    return (
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={() => box.api?.noteFocus()}
+      />
+    );
+  }
+
+  const { container } = render(<Composer />);
+  box.ta = container.querySelector("textarea");
+  const ta = box.ta!;
+  return {
+    get value() {
+      return ta.value;
+    },
+    get caret() {
+      return ta.selectionStart;
+    },
+    ta,
+    appendFinal: (text: string) => act(() => box.api!.appendFinal(text)),
+    replaceInterim: (text: string) => act(() => box.api!.replaceInterim(text)),
+    /** Un-acted hook methods, for driving several inserts inside one act(). */
+    get rawApi() {
+      return box.api!;
+    },
+    /** Place the caret at *at*, as a user's click into the field would. */
+    click: (at: number) =>
+      act(() => {
+        ta.focus();
+        ta.setSelectionRange(at, at);
+      }),
+    /** Rewrite the draft from outside dictation (send, Esc revert, typing),
+     *  through React, so the DOM and the hook's view stay in step. */
+    setRaw: (next: string) => act(() => box.set!(next)),
+  };
+}
+
+/** Hook-only harness for the cases that don't involve a caret at all. */
 function renderDictation(
   initial = "",
   wrapper?: ({ children }: { children: ReactNode }) => ReactNode,
@@ -18,8 +80,8 @@ function renderDictation(
   return renderHook(
     () => {
       const [value, setValue] = useState(initial);
-      const dictation = useDictationInsert(setValue);
-      return { value, setRaw: (next: string) => setValue(() => next), ...dictation };
+      const dictation = useDictationInsert(value, setValue);
+      return { value, setRaw: setValue, ...dictation };
     },
     wrapper ? { wrapper } : undefined,
   );
@@ -79,17 +141,18 @@ describe("useDictationInsert", () => {
   });
 
   it("never deletes text the user typed after the interim", () => {
-    const { result } = renderDictation();
-    act(() => result.current.replaceInterim("hello wor"));
-    // The user clicks into the composer and types after the interim.
-    act(() => result.current.setRaw("hello wor, urgent"));
-    // The draft no longer ends with the tracked interim → nothing is
-    // stripped; the update appends instead of slicing typed text away.
-    act(() => result.current.appendFinal("Hello world."));
-    expect(result.current.value).toBe("hello wor, urgent Hello world.");
+    const composer = renderComposer();
+    composer.replaceInterim("hello wor");
+    // The user types after the pending partial.
+    composer.setRaw("hello wor, urgent");
+    // The draft is no longer what dictation produced → nothing is replaced;
+    // the utterance inserts instead of slicing typed text away.
+    composer.appendFinal("Hello world.");
+    expect(composer.value).toContain(", urgent");
+    expect(composer.value).toContain("Hello world.");
   });
 
-  it("is StrictMode-safe (updaters are pure; double-invoke is a no-op)", () => {
+  it("is StrictMode-safe (no double-inserted text)", () => {
     const strict = ({ children }: { children: ReactNode }) => <StrictMode>{children}</StrictMode>;
     const { result } = renderDictation("draft", strict);
     act(() => result.current.replaceInterim("one"));
@@ -97,5 +160,139 @@ describe("useDictationInsert", () => {
     expect(result.current.value).toBe("draft one two");
     act(() => result.current.appendFinal("One, two."));
     expect(result.current.value).toBe("draft One, two.");
+  });
+
+  // The reported bug: dictated text always landed at the very bottom of the
+  // draft, even with the caret placed above a pasted block of context.
+  describe("caret-positioned insertion", () => {
+    it("inserts at the user's caret, not the end of the draft", () => {
+      const composer = renderComposer("PASTED CONTEXT");
+      composer.click(0); // click above the pasted block
+      composer.appendFinal("Refactor this:");
+      expect(composer.value).toBe("Refactor this: PASTED CONTEXT");
+    });
+
+    it("streams partials in place at the caret", () => {
+      const composer = renderComposer("PASTED CONTEXT");
+      composer.click(0);
+      composer.replaceInterim("refac");
+      expect(composer.value).toBe("refac PASTED CONTEXT");
+      // Revising a partial must not walk it down the draft.
+      composer.replaceInterim("refactor thi");
+      expect(composer.value).toBe("refactor thi PASTED CONTEXT");
+      composer.appendFinal("Refactor this:");
+      expect(composer.value).toBe("Refactor this: PASTED CONTEXT");
+    });
+
+    it("chains consecutive utterances after the previous one", () => {
+      const composer = renderComposer("PASTED CONTEXT");
+      composer.click(0);
+      composer.appendFinal("First.");
+      composer.appendFinal("Second.");
+      expect(composer.value).toBe("First. Second. PASTED CONTEXT");
+    });
+
+    it("inserts mid-draft without fusing words on either side", () => {
+      const composer = renderComposer("alpha omega");
+      composer.click(6);
+      composer.appendFinal("beta");
+      expect(composer.value).toBe("alpha beta omega");
+    });
+
+    it("adds no space before punctuation that hugs the previous word", () => {
+      const composer = renderComposer("Ship it, please.");
+      composer.click(7); // right before the comma
+      composer.appendFinal("today");
+      expect(composer.value).toBe("Ship it today, please.");
+    });
+
+    it("respects a newline boundary without adding a space", () => {
+      const composer = renderComposer("intro\nPASTED");
+      composer.click(6);
+      composer.appendFinal("Do this:");
+      expect(composer.value).toBe("intro\nDo this: PASTED");
+    });
+
+    it("appends at the end while the composer has never been focused", () => {
+      // Pre-existing behavior: an untouched draft has no caret on screen, so
+      // selectionStart's default 0 must not be mistaken for one.
+      const composer = renderComposer("restored draft");
+      composer.appendFinal("Added.");
+      expect(composer.value).toBe("restored draft Added.");
+    });
+
+    it("follows the caret when the user moves it between utterances", () => {
+      const composer = renderComposer("one three");
+      composer.click(3);
+      composer.appendFinal("two");
+      expect(composer.value).toBe("one two three");
+      // User clicks back to the start and dictates again.
+      composer.click(0);
+      composer.appendFinal("Zero");
+      expect(composer.value).toBe("Zero one two three");
+    });
+
+    it("leaves the caret after the inserted text, ready to keep typing", () => {
+      const composer = renderComposer("PASTED CONTEXT");
+      composer.click(0);
+      composer.appendFinal("Refactor this:");
+      expect(composer.caret).toBe("Refactor this:".length);
+    });
+
+    it("does not steal focus from the mic button", () => {
+      const composer = renderComposer("draft");
+      composer.click(0);
+      // The mic button holds focus for its Enter-commit / Esc-cancel keys.
+      act(() => composer.ta.blur());
+      composer.appendFinal("Spoken.");
+      expect(document.activeElement).not.toBe(composer.ta);
+    });
+
+    it("clamps a stale offset past the end of a shrunken draft", () => {
+      const composer = renderComposer("a long draft");
+      composer.click(12);
+      // The draft is replaced wholesale (a send, or select-all + retype),
+      // leaving the remembered offset past the end of the new one.
+      composer.setRaw("ab");
+      composer.click(2);
+      composer.appendFinal("End.");
+      expect(composer.value).toBe("ab End.");
+    });
+
+    it("starts clean after an Esc discard reverts the draft", () => {
+      // The composer snapshots the text on voice start and restores it on Esc
+      // with a bare setValue, behind the hook's back. The next take must
+      // insert at the caret, not resurrect or slice the reverted text.
+      const composer = renderComposer("keep this");
+      composer.click(0);
+      composer.replaceInterim("throw away");
+      expect(composer.value).toBe("throw away keep this");
+      composer.setRaw("keep this"); // onVoiceDiscard
+      composer.click(0);
+      composer.appendFinal("Second try:");
+      expect(composer.value).toBe("Second try: keep this");
+    });
+
+    it("keeps order when a partial and its final land in one batch", () => {
+      // Both arrive from a single socket read, so the caret this hook asks for
+      // hasn't been applied yet when the second insert computes its offset.
+      const composer = renderComposer("PASTED CONTEXT");
+      composer.click(0);
+      act(() => {
+        composer.rawApi.replaceInterim("first");
+        composer.rawApi.appendFinal("Second.");
+      });
+      expect(composer.value).toBe("Second. PASTED CONTEXT");
+    });
+
+    it("chains two finals that land in one batch", () => {
+      const composer = renderComposer("TAIL");
+      composer.click(0);
+      act(() => {
+        composer.rawApi.appendFinal("One.");
+        composer.rawApi.appendFinal("Two.");
+      });
+      expect(composer.value).toBe("One. Two. TAIL");
+    });
   });
 });

--- a/web/src/hooks/useDictationInsert.test.tsx
+++ b/web/src/hooks/useDictationInsert.test.tsx
@@ -206,6 +206,22 @@ describe("useDictationInsert", () => {
       expect(composer.value).toBe("Ship it today, please.");
     });
 
+    it("sits flush inside an opening delimiter", () => {
+      const composer = renderComposer("call(arg)");
+      composer.click(5); // just after "("
+      composer.appendFinal("the");
+      expect(composer.value).toBe("call(the arg)");
+    });
+
+    it("keeps a space before an opening quote", () => {
+      // Quotes are ambiguous, so they are spaced like any other character
+      // rather than guessed at; fusing words is the worse failure.
+      const composer = renderComposer('say "quoted"');
+      composer.click(4); // before the opening quote
+      composer.appendFinal("please");
+      expect(composer.value).toBe('say please "quoted"');
+    });
+
     it("respects a newline boundary without adding a space", () => {
       const composer = renderComposer("intro\nPASTED");
       composer.click(6);
@@ -257,6 +273,41 @@ describe("useDictationInsert", () => {
       composer.click(2);
       composer.appendFinal("End.");
       expect(composer.value).toBe("ab End.");
+    });
+
+    it("follows a moved caret after the mic's end-of-take interim clear", () => {
+      // ComposerMicButton ends a take with onInterim(""), which lands here as
+      // a no-op once the preceding final has cleared the region. A same-value
+      // setDraft can bail out without committing, so requesting a caret on that
+      // path would leave the request outstanding forever and pin every later
+      // utterance to the tail, ignoring wherever the user clicked.
+      const composer = renderComposer("PASTED");
+      composer.click(0);
+      composer.appendFinal("Hello");
+      expect(composer.value).toBe("Hello PASTED");
+      composer.replaceInterim(""); // end of take
+      expect(composer.value).toBe("Hello PASTED");
+      composer.click(0);
+      composer.appendFinal("Second.");
+      expect(composer.value).toBe("Second. Hello PASTED");
+    });
+
+    it("does not resurrect a spent region when the draft returns to its text", () => {
+      // Undo (or retyping the same string) restores value equality with what
+      // dictation produced, but those characters now belong to the user. A
+      // value-equality ownership check would slice the old interim span back
+      // out of the middle of the draft.
+      const composer = renderComposer("KEEP");
+      composer.click(0);
+      composer.replaceInterim("partial");
+      const produced = composer.value;
+      expect(produced).toBe("partial KEEP");
+      composer.setRaw("something else"); // user edits away
+      composer.setRaw(produced); // ...and undoes back
+      composer.replaceInterim("next");
+      // "partial" is the user's text now, so it must survive.
+      expect(composer.value).toContain("partial");
+      expect(composer.value).toContain("next");
     });
 
     it("starts clean after an Esc discard reverts the draft", () => {

--- a/web/src/hooks/useDictationInsert.ts
+++ b/web/src/hooks/useDictationInsert.ts
@@ -2,7 +2,7 @@
 //
 // The mic button emits two kinds of text (see ComposerMicButton):
 //   - final utterances (onTranscript), pinned permanently, and
-//   - interim partials (onInterim, server dictation only) — a revisable
+//   - interim partials (onInterim, server dictation only), a revisable
 //     region that forms live while the user speaks and is rewritten on
 //     every update until an utterance finalizes.
 //
@@ -24,11 +24,12 @@
 // plain value assignment, pure by construction under StrictMode.
 //
 // Offsets this hook derives are only meaningful against the draft they were
-// measured in, so they are stored with the exact string it produced and used
-// only while the draft is still verbatim that string. A send, an Esc revert,
-// or the user editing all fail that check, and the hook falls back to the
-// live caret. Dictation must never delete or displace text it didn't write,
-// and string identity is what proves nothing else has landed since.
+// measured in, so they live together in one "produced" record that is dropped
+// the moment a draft arrives that the hook didn't write. Ownership is tracked
+// rather than re-derived by comparing text: an edit away and back (an undo, or
+// the same string retyped) restores equality, and acting on that would slice a
+// spent interim span out of characters that by then belong to the user.
+// Dictation must never delete or displace text it didn't write.
 
 import { type RefObject, useCallback, useLayoutEffect, useRef } from "react";
 
@@ -48,9 +49,17 @@ interface Produced {
   tail: number;
 }
 
-/** Leading whitespace, or punctuation that hugs the word before it. No
- *  separating space is wanted when dictated text lands ahead of these. */
-const HUGS_LEFT = /^[\s,.;:!?)\]}>'"]/;
+/** What follows the insertion point when no separating space belongs after the
+ *  dictated text: whitespace, or punctuation that hugs the word before it.
+ *  Quotes are deliberately absent. They are ambiguous (`"` opens as often as it
+ *  closes) and guessing wrong fuses words, so they get a space like any other
+ *  character. */
+const HUGS_LEFT = /^[\s,.;:!?)\]}>]/;
+
+/** What precedes the insertion point when no separating space belongs before
+ *  the dictated text: start of draft, whitespace, or an opening delimiter the
+ *  text should sit flush against. */
+const HUGS_RIGHT = /[\s([{<]$/;
 
 /**
  * Splice *text* into *base* at *at*, padded with single spaces so dictated
@@ -68,7 +77,7 @@ function splice(
   const start = Math.min(Math.max(at, 0), base.length);
   const before = base.slice(0, start);
   const after = base.slice(start);
-  const lead = text && before && !/\s$/.test(before) ? " " : "";
+  const lead = text && before && !HUGS_RIGHT.test(before) ? " " : "";
   const trail = text && after && !HUGS_LEFT.test(after) ? " " : "";
   const body = lead + text + trail;
   return {
@@ -94,12 +103,23 @@ export function useDictationInsert(
   // win, and written on insert so a second transcript in the same batch
   // doesn't read a pre-render value.
   const draftRef = useRef(draft);
-  draftRef.current = draft;
+  // What this hook last wrote, or null when it doesn't own the draft. Ownership
+  // is tracked rather than inferred by comparing text: an edit away and back
+  // (an undo, or the same string retyped) restores equality, and trusting that
+  // would resurrect a spent region whose characters are by then the user's own
+  // and slice them out of the middle of the draft.
   const producedRef = useRef<Produced | null>(null);
+  if (draftRef.current !== draft) {
+    // The draft changed under us. Released here rather than in an effect so a
+    // transcript arriving before effects flush can't act on a dead region.
+    if (producedRef.current?.value !== draft) producedRef.current = null;
+    draftRef.current = draft;
+  }
   // Whether the textarea has ever held focus. Until it has, its selectionStart
   // is 0 by default rather than a caret the user placed and can see.
   const focusedRef = useRef(false);
-  // Caret to apply once React has rendered the spliced draft.
+  // Caret this hook has asked for but not yet applied, or null when none is
+  // outstanding. Non-null means the DOM caret is stale.
   const wantCaretRef = useRef<number | null>(null);
 
   // Applied in a layout effect because the draft is React state: setting the
@@ -109,16 +129,25 @@ export function useDictationInsert(
     const position = wantCaretRef.current;
     if (position === null) return;
     wantCaretRef.current = null;
+    const ta = textareaRef?.current;
+    if (!ta) return;
     // Deliberately does not focus: a take is usually driven from the mic
     // button, and stealing focus drops its Enter-commit / Esc-cancel keys.
-    textareaRef?.current?.setSelectionRange(position, position);
+    // Some browsers scroll an unfocused element to reveal the new selection,
+    // so the scroll position is restored around the write; a dictating user
+    // watching one part of a long draft shouldn't get yanked elsewhere.
+    const { scrollTop, scrollLeft } = ta;
+    ta.setSelectionRange(position, position);
+    if (ta !== document.activeElement) {
+      ta.scrollTop = scrollTop;
+      ta.scrollLeft = scrollLeft;
+    }
   });
 
   const insert = useCallback(
     (text: string, pin: boolean) => {
       const current = draftRef.current;
-      // Our bookkeeping only holds while the draft is verbatim what we wrote.
-      const mine = producedRef.current?.value === current ? producedRef.current : null;
+      const mine = producedRef.current;
       const region = mine?.region ?? null;
       // Lift a pending interim out so this update replaces it.
       const base = region
@@ -128,19 +157,23 @@ export function useDictationInsert(
       // The live caret, or null while the field has never been focused (where
       // selectionStart's default 0 is not a caret the user placed).
       const live = focusedRef.current && ta ? ta.selectionStart : null;
-      // While a caret write is still pending, the DOM caret is stale: several
-      // transcripts can land in one React batch and the write is a layout
-      // effect that runs only after the batch flushes. The remembered tail is
-      // then the only offset that advances per utterance. A stale caret and a
-      // caret the user just moved are indistinguishable by value, so this
-      // tracks the outstanding write rather than comparing offsets.
-      const stale = wantCaretRef.current !== null;
       // Where this insert goes, most specific first: a pending interim keeps
-      // its start so partials revise in place; then our tail while the caret
-      // is stale; then the user's caret; then the end of the draft, which is
-      // what dictation did before it was positional.
-      const at = region?.start ?? (stale ? (mine?.tail ?? base.length) : (live ?? base.length));
+      // its start so partials revise in place; then our own tail while a caret
+      // write is still outstanding (several transcripts can land in one React
+      // batch, and until it flushes the DOM caret is stale, so the tail is the
+      // only offset that advances per utterance); then the user's caret; then
+      // the end of the draft, dictation's pre-positional behavior.
+      const stale = mine !== null && wantCaretRef.current !== null;
+      const at = region?.start ?? (stale ? mine.tail : (live ?? base.length));
       const spliced = splice(base, at, text);
+
+      // Nothing to write. Reached by the empty-interim clear the mic emits at
+      // the end of a take, once the preceding final has already cleared the
+      // region. setDraft would be a same-value update, which React can bail out
+      // of without committing, so the layout effect would never run to clear a
+      // caret request made here and every later utterance would read the DOM
+      // caret as stale, pinning inserts to the tail and ignoring the user.
+      if (spliced.next === current) return;
 
       draftRef.current = spliced.next;
       producedRef.current = {

--- a/web/src/hooks/useDictationInsert.ts
+++ b/web/src/hooks/useDictationInsert.ts
@@ -1,69 +1,164 @@
 // Shared composer glue for dictation transcripts.
 //
 // The mic button emits two kinds of text (see ComposerMicButton):
-//   - final utterances (onTranscript) — append permanently, and
+//   - final utterances (onTranscript), pinned permanently, and
 //   - interim partials (onInterim, server dictation only) — a revisable
-//     trailing region that forms live while the user speaks and is
-//     rewritten on every update until an utterance finalizes.
+//     region that forms live while the user speaks and is rewritten on
+//     every update until an utterance finalizes.
 //
-// Both composers (ChatPage's Composer and NewChatDialog) hold their draft in
-// a plain useState string, so the revisable region is implemented as a value
-// transform: the hook remembers the exact interim text it last inserted and
-// strips it only when the draft still ends with it verbatim. If it doesn't —
-// the user typed after it, sent the message, or edited the draft — the
-// marker is simply dropped and nothing is removed: dictation must never
-// delete text it didn't write.
+// Text lands at the user's caret, not at the end of the draft: paste a block
+// of context, click above it, dictate, and the words go where the caret is.
+// The caret is read from the textarea itself at insert time: the browser
+// keeps selectionStart on the element across blur, so it survives the mic
+// button taking focus and needs no mirroring here. The composer only has to
+// report that the field has been focused (noteFocus): until then there is no
+// caret on screen to insert at, so text goes to the end of the draft, which
+// is what dictation always did.
 //
-// The marker ref is read before and written after each setDraft call, never
-// inside the updater — updaters must stay pure because React StrictMode
-// double-invokes them.
+// The hook takes the draft as a value rather than reading it inside a setDraft
+// updater. Transcripts arrive off a socket, where React batches and DEFERS the
+// updater, so anything the updater learned (where the text landed, where the
+// caret goes) would be written back too late for the next partial to use, and
+// a streaming interim region would append instead of revise. Taking the draft
+// as a value keeps every offset computable up front and leaves setDraft a
+// plain value assignment, pure by construction under StrictMode.
+//
+// Offsets this hook derives are only meaningful against the draft they were
+// measured in, so they are stored with the exact string it produced and used
+// only while the draft is still verbatim that string. A send, an Esc revert,
+// or the user editing all fail that check, and the hook falls back to the
+// live caret. Dictation must never delete or displace text it didn't write,
+// and string identity is what proves nothing else has landed since.
 
-import { useCallback, useRef } from "react";
+import { type RefObject, useCallback, useLayoutEffect, useRef } from "react";
 
-type SetDraft = (updater: (prev: string) => string) => void;
-
-/** Separator so dictated text never fuses with existing draft words. */
-function joined(base: string, text: string): string {
-  if (!text) return base;
-  if (!base || base.endsWith(" ") || base.endsWith("\n")) return base + text;
-  return `${base} ${text}`;
+/** The draft this hook produced, and how to keep building on it.
+ *
+ *  - ``region`` is the pending interim span (offset + exact text), or null
+ *    once an utterance is pinned; a pending span is replaced in place by the
+ *    next partial rather than walking down the draft.
+ *  - ``tail`` is where that text ended, so a following utterance continues
+ *    after it. Preferred over the DOM caret because several transcripts can
+ *    land in one batch, before the caret this hook requested has been applied.
+ *
+ *  Valid only while the live draft still equals ``value``. */
+interface Produced {
+  value: string;
+  region: { start: number; text: string } | null;
+  tail: number;
 }
+
+/** Leading whitespace, or punctuation that hugs the word before it. No
+ *  separating space is wanted when dictated text lands ahead of these. */
+const HUGS_LEFT = /^[\s,.;:!?)\]}>'"]/;
 
 /**
- * Remove the tracked interim region, but only if the draft still ends
- * with it verbatim; also drop the single space separator we added.
+ * Splice *text* into *base* at *at*, padded with single spaces so dictated
+ * words never fuse with the draft on either side.
+ *
+ * Returns the new draft, the span inserted (padding included, so removing it
+ * restores *base* exactly), and where the caret belongs: directly after the
+ * dictated words, ahead of any trailing space.
  */
-function stripMarker(prev: string, marker: string): string {
-  if (!marker || !prev.endsWith(marker)) return prev;
-  const base = prev.slice(0, prev.length - marker.length);
-  return base.endsWith(" ") ? base.slice(0, -1) : base;
+function splice(
+  base: string,
+  at: number,
+  text: string,
+): { next: string; region: { start: number; text: string }; caret: number } {
+  const start = Math.min(Math.max(at, 0), base.length);
+  const before = base.slice(0, start);
+  const after = base.slice(start);
+  const lead = text && before && !/\s$/.test(before) ? " " : "";
+  const trail = text && after && !HUGS_LEFT.test(after) ? " " : "";
+  const body = lead + text + trail;
+  return {
+    next: before + body + after,
+    region: { start, text: body },
+    caret: start + lead.length + text.length,
+  };
 }
 
-export function useDictationInsert(setDraft: SetDraft): {
-  /** Append a final utterance, replacing any pending interim region. */
+export function useDictationInsert(
+  draft: string,
+  setDraft: (next: string) => void,
+  textareaRef?: RefObject<HTMLTextAreaElement | null>,
+): {
+  /** Pin a final utterance, replacing any pending interim region. */
   appendFinal: (text: string) => void;
   /** Replace the pending interim region ("" clears it). */
   replaceInterim: (text: string) => void;
+  /** Report that the composer has been focused, so its caret is real. */
+  noteFocus: () => void;
 } {
-  const interimRef = useRef("");
+  // The draft as last seen. Refreshed on every render so external changes
+  // win, and written on insert so a second transcript in the same batch
+  // doesn't read a pre-render value.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const producedRef = useRef<Produced | null>(null);
+  // Whether the textarea has ever held focus. Until it has, its selectionStart
+  // is 0 by default rather than a caret the user placed and can see.
+  const focusedRef = useRef(false);
+  // Caret to apply once React has rendered the spliced draft.
+  const wantCaretRef = useRef<number | null>(null);
 
-  const replaceInterim = useCallback(
-    (text: string) => {
-      const marker = interimRef.current;
-      interimRef.current = text;
-      setDraft((prev) => joined(stripMarker(prev, marker), text));
+  // Applied in a layout effect because the draft is React state: setting the
+  // value moves the caret to the end, and the value to select into only
+  // exists in the DOM after the render that carries it.
+  useLayoutEffect(() => {
+    const position = wantCaretRef.current;
+    if (position === null) return;
+    wantCaretRef.current = null;
+    // Deliberately does not focus: a take is usually driven from the mic
+    // button, and stealing focus drops its Enter-commit / Esc-cancel keys.
+    textareaRef?.current?.setSelectionRange(position, position);
+  });
+
+  const insert = useCallback(
+    (text: string, pin: boolean) => {
+      const current = draftRef.current;
+      // Our bookkeeping only holds while the draft is verbatim what we wrote.
+      const mine = producedRef.current?.value === current ? producedRef.current : null;
+      const region = mine?.region ?? null;
+      // Lift a pending interim out so this update replaces it.
+      const base = region
+        ? current.slice(0, region.start) + current.slice(region.start + region.text.length)
+        : current;
+      const ta = textareaRef?.current;
+      // The live caret, or null while the field has never been focused (where
+      // selectionStart's default 0 is not a caret the user placed).
+      const live = focusedRef.current && ta ? ta.selectionStart : null;
+      // While a caret write is still pending, the DOM caret is stale: several
+      // transcripts can land in one React batch and the write is a layout
+      // effect that runs only after the batch flushes. The remembered tail is
+      // then the only offset that advances per utterance. A stale caret and a
+      // caret the user just moved are indistinguishable by value, so this
+      // tracks the outstanding write rather than comparing offsets.
+      const stale = wantCaretRef.current !== null;
+      // Where this insert goes, most specific first: a pending interim keeps
+      // its start so partials revise in place; then our tail while the caret
+      // is stale; then the user's caret; then the end of the draft, which is
+      // what dictation did before it was positional.
+      const at = region?.start ?? (stale ? (mine?.tail ?? base.length) : (live ?? base.length));
+      const spliced = splice(base, at, text);
+
+      draftRef.current = spliced.next;
+      producedRef.current = {
+        value: spliced.next,
+        region: pin || !text ? null : spliced.region,
+        tail: spliced.caret,
+      };
+      wantCaretRef.current = spliced.caret;
+      setDraft(spliced.next);
     },
-    [setDraft],
+    [setDraft, textareaRef],
   );
 
-  const appendFinal = useCallback(
-    (text: string) => {
-      const marker = interimRef.current;
-      interimRef.current = "";
-      setDraft((prev) => joined(stripMarker(prev, marker), text));
-    },
-    [setDraft],
-  );
-
-  return { appendFinal, replaceInterim };
+  return {
+    appendFinal: useCallback((text: string) => insert(text, true), [insert]),
+    replaceInterim: useCallback((text: string) => insert(text, false), [insert]),
+    noteFocus: useCallback(() => {
+      focusedRef.current = true;
+    }, []),
+  };
 }

--- a/web/src/hooks/useDictationInsert.ts
+++ b/web/src/hooks/useDictationInsert.ts
@@ -115,8 +115,10 @@ export function useDictationInsert(
     if (producedRef.current?.value !== draft) producedRef.current = null;
     draftRef.current = draft;
   }
-  // Whether the textarea has ever held focus. Until it has, its selectionStart
-  // is 0 by default rather than a caret the user placed and can see.
+  // Whether the textarea has EVER held focus. Until it has, its selectionStart
+  // is 0 by default rather than a caret the user placed and can see. Never
+  // reset on blur, deliberately: clicking the mic button blurs the composer,
+  // and the caret the user left behind is still the one they can see and mean.
   const focusedRef = useRef(false);
   // Caret this hook has asked for but not yet applied, or null when none is
   // outstanding. Non-null means the DOM caret is stale.
@@ -167,20 +169,28 @@ export function useDictationInsert(
       const at = region?.start ?? (stale ? mine.tail : (live ?? base.length));
       const spliced = splice(base, at, text);
 
-      // Nothing to write. Reached by the empty-interim clear the mic emits at
-      // the end of a take, once the preceding final has already cleared the
-      // region. setDraft would be a same-value update, which React can bail out
-      // of without committing, so the layout effect would never run to clear a
-      // caret request made here and every later utterance would read the DOM
-      // caret as stale, pinning inserts to the tail and ignoring the user.
-      if (spliced.next === current) return;
-
-      draftRef.current = spliced.next;
-      producedRef.current = {
+      const settled: Produced = {
         value: spliced.next,
         region: pin || !text ? null : spliced.region,
         tail: spliced.caret,
       };
+
+      // The draft already reads exactly like this. Two ways to get here: the
+      // empty-interim clear the mic emits at the end of a take, and a final
+      // whose text matches the partial already on screen. Ownership still has
+      // to settle (a final must pin, or the region would stay pending and the
+      // next insert would lift the finalized text back out and delete it), but
+      // no caret may be requested: setDraft would be a same-value update, which
+      // React can bail out of without committing, so the layout effect would
+      // never run to clear the request and every later utterance would read the
+      // DOM caret as stale, pinning inserts to the tail and ignoring the user.
+      if (spliced.next === current) {
+        producedRef.current = mine === null ? null : settled;
+        return;
+      }
+
+      draftRef.current = spliced.next;
+      producedRef.current = settled;
       wantCaretRef.current = spliced.caret;
       setDraft(spliced.next);
     },

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4123,7 +4123,6 @@ export function Composer({
   onGrowthChange,
 }: ComposerProps) {
   const [value, setValue] = useState("");
-  const dictation = useDictationInsert(setValue);
   const [files, setFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);
@@ -4152,6 +4151,9 @@ export function Composer({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Declared after textareaRef so dictation can place the caret after the
+  // text it inserts (and insert at the caret rather than the draft's end).
+  const dictation = useDictationInsert(value, setValue, textareaRef);
   const isComposingRef = useRef(false);
   // Highlight overlay mirroring the textarea; scroll-synced so the tinted
   // `/skill` token stays aligned once the draft grows past the visible rows.
@@ -5070,6 +5072,11 @@ export function Composer({
               // reset for that one tick.
               if (recallingRef.current) recallingRef.current = false;
               else resetCursor();
+            }}
+            onFocus={() => {
+              // From here the textarea's caret is one the user placed, so
+              // dictation inserts there instead of at the end of the draft.
+              dictation.noteFocus();
             }}
             onCompositionStart={() => {
               isComposingRef.current = true;

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1843,10 +1843,12 @@ export function NewChatLandingScreen() {
   useNativeServerSwitcherForMainSurface(landingSurface, true);
 
   const [message, setMessage] = useState<string>(() => landingDraft?.message ?? "");
-  const dictation = useDictationInsert(setMessage);
   // Composer text captured when voice dictation starts, so Esc can revert to it.
   const voiceSnapshotRef = useRef("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Declared after textareaRef so dictation can place the caret after the
+  // text it inserts (and insert at the caret rather than the draft's end).
+  const dictation = useDictationInsert(message, setMessage, textareaRef);
   const isComposingRef = useRef(false);
   // maxRows 9 = 180px of 20px lines, matching the composer's 200px
   // border-box max (180px content + 16px top / 4px bottom padding).
@@ -3701,6 +3703,11 @@ export function NewChatLandingScreen() {
                       )
                     : null,
                 );
+              }}
+              onFocus={() => {
+                // From here the textarea's caret is one the user placed, so
+                // dictation inserts there instead of at the end of the draft.
+                dictation.noteFocus();
               }}
               onBlur={() => {
                 // Dismiss the mention menu when focus leaves the textarea; menu


### PR DESCRIPTION
## Related issue

No filed issue. This came in as direct user feedback on voice dictation
(shipped in 0.7.0):

> Right now, dictated text is always appended to the bottom of the chat cell
> rather than inserted where the cursor is positioned. Often I paste a block of
> context into the cell first and then try to dictate my instructions above it,
> but rn the dictated text still drops to the very bottom instead of at my
> cursor's location.

Happy to file one and link it if the review queue wants the issue-first path.

## Summary

Dictation appended to the end of the draft unconditionally: `useDictationInsert`
built every update as `base + text`, so the caret was never consulted. Paste a
block of context, click above it, dictate, and the words landed underneath the
block instead of where the cursor was.

- **Splice at the caret**, padding with single spaces so dictated words never
  fuse with the draft on either side (and skipping the space before punctuation
  that hugs the previous word: `Ship it|, please.` -> `Ship it today, please.`).
  The caret is left after the inserted text so typing continues naturally.
- **Read the caret off the textarea** at insert time instead of mirroring it in
  React state. My first attempt tracked it with `onSelect`, which was wrong:
  that event fires only ["when some text has been
  selected"](https://developer.mozilla.org/en-US/docs/Web/API/Element/select_event),
  so a plain click that collapses the caret, exactly the reported scenario,
  never fires it. `selectionStart` is preserved on the element across blur, so
  reading it at insert time also survives the mic button taking focus.
- **Require focus before trusting the caret.** An untouched draft reports
  `selectionStart` of 0, indistinguishable from a caret placed at the start, so
  the composers report focus (`noteFocus`) and text still appends until then.
  This preserves the old behavior for restored drafts.

Both composers are fixed, since both route through the hook: `ChatPage`'s
`Composer` and `NewChatDialog`.

### ELI5

The composer is a single string. Dictation used to do "old text + new words",
which always puts the new words last. Now it cuts the string at the cursor and
drops the words into the gap.

```
draft:  "PASTED CONTEXT"
caret:   ^ (start)

before:  PASTED CONTEXT Refactor this:      <- words land at the end
after:   Refactor this: PASTED CONTEXT      <- words land at the caret
                       ^ caret left here, ready to keep typing
```

### Two subtleties worth a reviewer's eye

**Consecutive utterances chain after the previous one** rather than re-reading
the caret. A partial and its final can arrive in a single React batch, where the
caret write (a layout effect) has not run yet, so every insert in that batch
reads the same stale offset and the text interleaves backwards. Two tests cover
this. If you'd rather the caret always win, it's a one-line change, but it
reintroduces the ordering bug.

**The hook now takes the draft as a value** instead of reading it inside a
`setDraft` updater. Transcripts arrive off a socket, where React defers the
updater, so anything the updater computed (where the text landed, where the
caret goes) would be written back too late for the next partial and a streaming
region would append instead of revise. Keeping offsets outside the updater also
keeps it pure, which the original code called out for StrictMode: I confirmed
that reading and writing the marker inside the updater double-inserts on
replay, leaving a stranded partial.

The load-bearing invariant from the original hook is unchanged: **dictation
never deletes text it didn't write.** Ownership of the draft is tracked
explicitly and released as soon as a draft arrives that the hook didn't write,
so a send, an Esc revert, or the user typing all fall back safely.

### Review round 2 (`ecde0bff`)

Polly found two blocking defects. Both were real; I reproduced each with a
failing test before fixing, and both now have permanent regression tests.

**1. A caret request on a no-op update was stranded, which regressed the
headline feature.** The mic ends every take with `onInterim("")`, which lands as
an empty insert once the preceding final has cleared the region. That made
`setDraft` a same-value update, which React can bail out of *without
committing*, so the layout effect never ran to clear the pending caret. Every
later utterance then read the DOM caret as stale and pinned itself to the tail,
ignoring wherever the user clicked. An insert that changes nothing now returns
without requesting a caret (though see round 3: it must still settle ownership
before returning, which this round got wrong).

Worth noting for anyone verifying this: React *does* re-run the component
function on the same-value update (I initially misread a render count of 1 as
proof there was no bailout), but it discards the result without committing, so
effects never fire. The behavioral test is what settled it.

**2. Value-equality ownership could slice out the user's text.** Editing away
and undoing back restores equality with the last produced string while those
characters now belong to the user, so a spent interim span was sliced back out
of the middle of their text: `partial KEEP` became `next KEEP`, dropping the
user's `partial`. That broke this PR's own stated invariant. Ownership is now
released the moment a draft arrives that the hook didn't write, and regained
only by writing again.

Also from the non-blocking notes: fixed a stray space just inside an opening
bracket (`call( the arg)`) and quote handling that fused words when inserting
before an opening quote (`say please"quoted"`); quotes are ambiguous enough that
spacing them like any other character is the safer default. The caret write now
also restores `scrollTop`/`scrollLeft` on an unfocused textarea, since setting a
selection there can scroll the element to reveal it.

### Review round 3 (`3becf852`)

Polly found one more blocking bug, and this one was mine to own: a regression I
introduced in round 2 while fixing #1.

**A final whose text matches the partial already on screen deleted the dictated
word.** The server routinely finalizes exactly what it last streamed, so the
splice is a no-op. My round-2 early return skipped the caret request on that
path (correct) but skipped the *ownership* update with it (wrong), so the interim
region stayed pending and the end-of-take clear lifted the finalized text back
out: `hello PASTED` became `PASTED`. Polly's trace was exact, and the outcome is
worse than a misplacement, it is data loss on a mainline path.

The no-op path now settles ownership before returning (a final still pins, an
empty clear still releases) while still skipping the caret request. Regression
test added for `final == last partial`, plus one for an empty clear arriving with
nothing pending, which covers the other branch of that guard.

Worth stating plainly: my round-2 note claimed the invariant held, and on this
path it did not. The tests I had all used a final that differed from the last
interim, so none of them reached the branch.

Also took the `focusedRef` note: it is deliberately never reset on blur (clicking
the mic blurs the composer, and the caret the user left is still the one they
mean), now said so in the code. The caret-pull-back-during-streaming and
`useLayoutEffect`-every-render notes I left as-is, matching Polly's own read that
neither is a defect.

## Test Plan

`web/src/hooks/useDictationInsert.test.tsx`: 27 tests, all passing. The 7
pre-existing behaviors are kept as-is; 20 new ones cover caret insertion,
mid-draft insertion, punctuation/newline/delimiter boundaries, batched
transcripts, the Esc-discard path, the end-of-take interim clear, the
undo-back-to-produced-text case, a final matching the last partial, focus not
being stolen from the mic button, and the append-when-never-focused fallback.

```
cd web && npx vitest run src/hooks/useDictationInsert.test.tsx   # 27 passed
npx vitest run                                                   # 5359 passed, 0 failed suites
npx tsc --noEmit -p tsconfig.app.json                            # 0 errors
pre-commit run --files <changed files>                           # all passed
```

To confirm the tests pin the behavior rather than just passing:

- Against the original append-to-end logic (adapted to the new signature), the 7
  pre-existing behaviors still passed and all caret assertions failed.
- Against the first round of this PR (`107148ec`), exactly the 4 new tests from
  round 2 fail and the other 21 pass.
- Against round 2 (`53a9213f`), exactly the `final == last partial` test fails
  and the other 26 pass.

`tests/e2e_ui/chat/test_dictation.py` gains a caret test (`53a9213f`), run
against a real browser with the fake mic device and fake ASR engine the other
dictation e2e tests use: paste context, click above it, dictate, assert the
words lead the pasted block; then a second take with the caret moved back to the
top. All 5 tests in that file pass locally, and the new one fails against the
pre-fix append-to-end behavior (transcript lands at the end).

Manual: paste a block of context, click above it, hit the mic (or the dictation
hotkey), dictate. Text lands at the cursor. Worth a look in both composers and
on the server dictation path (Electron / Firefox), where partials revise in
place.

On the build: this branch had no `node_modules` and the npm registry is blocked
from my sandbox, so I borrowed another checkout's tree, which lacked the declared
`@fontsource-variable/hanken-grotesk`. With that one package stubbed locally
(never committed) `vite build` completes cleanly, so the earlier failure was
purely that missing dependency. The e2e run above went through a real build of
this branch.

## Demo

_Screen recording to be attached._

Reproduce in Chrome (Web Speech is the primary dictation path there, so no
server-side model or `[dictation]` extra is needed):

1. Paste a block of text into the composer.
2. Click at the very start, above the pasted block.
3. Hit the mic button (or the dictation hotkey) and speak.

Before: the words landed under the pasted block. After: they land at the cursor,
with the caret left after them so typing continues naturally.

### Note on UI Preview

Worth recording for whoever hits this next: the `ui-preview` label was applied to
this PR (by me and by a second maintainer) and every run skipped, all four jobs
in about a second, across `labeled`, remove-and-re-add, an empty-commit
`synchronize`, and an API re-run of the same payload. Nine attempts. Every gate
in the workflow's `if:` is satisfied (label present, not draft, MEMBER author,
workflow active, same-repo, clean merge), and PR #4288 built from a plain
`labeled` event the same hour with the same label set. Skipped jobs emit no logs,
so the cause is not visible from the API; diagnosing it needs a probe workflow on
`main`, since `pull_request_target` only runs base-branch workflows.

Separately, a preview could not have demonstrated this change anyway: the mic
button only renders when `GET /v1/info` reports `dictation_available`, which
needs the `[dictation]` extra plus downloaded sherpa models. The preview app
installs the three plain wheels and fetches no models, so there would be no mic
to click. Hence the local recording above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The hook's logic is fully unit-tested (25 tests), including the batching,
ownership, and same-value-update edge cases that are hard to hit by hand. Three
things the unit tests cannot reach, which need a human at a real browser:

- Real speech input through the mic, on both the Web Speech path and the
  server-dictation path (streaming partials).
- That the caret write does not fight the composer's auto-grow textarea or the
  `@`-mention menu, which also calls `setSelectionRange`.
- The scroll-preservation guard on an unfocused textarea. jsdom does not lay
  text out, so it cannot scroll; the guard is written from the spec'd behavior
  and wants a check in a long, scrolled draft.

The wiring in the two composers (a one-line `onFocus` each) is not directly
covered; it is exercised through the hook's own component-level tests, which
render a textarea with the same focus wiring.

## Changelog

Voice dictation now inserts text at your cursor instead of appending it to the end of the composer
