### PR TITLE
fix(server): stop a runner drop from failing finished sub-agents

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2066,22 +2066,22 @@ def create_app(
 
     # ── Tunnel lifecycle callbacks (Step 8.5 crash recovery) ───
     async def _on_runner_disconnect(runner_id: str) -> None:
-        """Mark sessions pinned to *this* runner as offline.
+        """Mark the turns *this* runner interrupted as offline.
 
         Filters by ``runner_id`` against ``conversation_store`` so a
         disconnect on one runner does not flip every cached session
         (e.g. sessions owned by other runners on the same server, or
         sessions left in the module-level cache by earlier tests on
-        the same xdist worker) to ``"failed"``. The cache is updated
-        in lockstep with the publish so the list endpoint stays
-        coherent.
+        the same xdist worker) to ``"failed"``.
+        :func:`_mark_runner_sessions_offline` then narrows that set to
+        the sessions actually mid-turn and stamps the disconnect cause
+        on them, so idle sub-agents keep their finished state and the
+        interrupted ones read as a recoverable disconnect.
 
         :param runner_id: The disconnected runner's id.
         """
-        from omnigent.server.routes.sessions import (
-            _publish_status,
-            _session_status_cache,
-        )
+        from omnigent.server.routes.sessions import _mark_runner_sessions_offline
+        from omnigent.server.schemas import ErrorDetail
 
         # Newest-wins guard: a superseded tunnel's teardown fires this
         # hook after a fresh tunnel for the same ``runner_id`` already
@@ -2113,20 +2113,22 @@ def create_app(
         # Archived sessions are included by construction — an archived
         # session can still be runner-bound, and skipping it here would
         # leave it stuck "running" forever.
-        affected = [
-            c.id
-            for c in await asyncio.to_thread(
-                conversation_store.list_conversations_by_runner_id, runner_id
-            )
-        ]
+        affected = await asyncio.to_thread(
+            conversation_store.list_conversations_by_runner_id, runner_id
+        )
         _logger.warning(
-            "Runner %s disconnected; marking %d session(s) offline",
+            "Runner %s disconnected; reconciling %d bound session(s)",
             runner_id,
             len(affected),
         )
-        for session_id in affected:
-            _session_status_cache[session_id] = "failed"
-            _publish_status(session_id, "failed")
+        await _mark_runner_sessions_offline(
+            affected,
+            ErrorDetail(
+                code="runner_disconnected",
+                message="Runner disconnected unexpectedly.",
+            ),
+            conversation_store,
+        )
 
     async def _on_runner_exited(runner_id: str, error: str) -> None:
         """Mark a crashed runner's session(s) failed and push the cause.
@@ -2137,34 +2139,33 @@ def create_app(
         never fires for it). Mirrors that callback's by-runner lookup,
         but carries the daemon-composed error onto the ``session.status:
         failed`` event so the open view surfaces the cause immediately
-        instead of spinning on "starting" until a timeout.
+        instead of spinning on "starting" until a timeout. An idle
+        top-level session is included for exactly that reason; an idle
+        sub-agent is not, since its work finished on a runner that was
+        already live.
 
         :param runner_id: The crashed runner's id.
         :param error: Human-readable cause from the daemon (exit code +
             log tail), e.g. ``"runner process exited with code 1 ..."``.
         """
-        from omnigent.server.routes.sessions import (
-            _publish_status,
-            _session_status_cache,
-        )
+        from omnigent.server.routes.sessions import _mark_runner_sessions_offline
         from omnigent.server.schemas import ErrorDetail
 
-        affected = [
-            c.id
-            for c in await asyncio.to_thread(
-                conversation_store.list_conversations_by_runner_id, runner_id
-            )
-        ]
+        affected = await asyncio.to_thread(
+            conversation_store.list_conversations_by_runner_id, runner_id
+        )
         _logger.warning(
-            "Runner %s reported crashed; marking %d session(s) failed: %s",
+            "Runner %s reported crashed; reconciling %d bound session(s): %s",
             runner_id,
             len(affected),
             error,
         )
-        detail = ErrorDetail(code="runner_failed_to_start", message=error)
-        for session_id in affected:
-            _session_status_cache[session_id] = "failed"
-            _publish_status(session_id, "failed", error=detail)
+        await _mark_runner_sessions_offline(
+            affected,
+            ErrorDetail(code="runner_failed_to_start", message=error),
+            conversation_store,
+            fail_idle_top_level=True,
+        )
 
     async def _on_runner_connect(runner_id: str) -> None:
         """Re-assign sessions and restart SSE relays on reconnect.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2402,6 +2402,63 @@ async def _publish_runner_recovered_status_impl(
     await _persist_session_status_error_labels(session_id, None, conversation_store)
 
 
+async def _mark_runner_sessions_offline_impl(
+    convs: list[Conversation],
+    error: ErrorDetail,
+    conversation_store: ConversationStore,
+    *,
+    fail_idle_top_level: bool = False,
+) -> None:
+    """
+    Fail the sessions a departed runner actually interrupted, with the cause.
+
+    A runner going away ends in-flight turns; it does not retroactively
+    fail work that already finished. Sub-agents ride their parent's runner,
+    so the departure reaches every child bound to it — marking the idle
+    ones ``failed`` painted a whole Agents rail red for sub-agents that had
+    completed successfully. The runner's absence is already carried by
+    liveness (``clear_runner_liveness``), which is what drives the
+    reconnect affordances, so a session that was not mid-turn needs no
+    status edge at all.
+
+    The sessions that DO get failed carry the cause, persisted as durable
+    labels. The cause is what lets the client render a benign
+    "Disconnected" instead of a red "Failed", and what lets
+    :func:`_publish_runner_recovered_status` clear the state when the
+    runner comes back — that helper only clears a failure it can identify
+    as a disconnect.
+
+    :param convs: Conversations bound to the departed runner, from
+        :meth:`ConversationStore.list_conversations_by_runner_id`.
+    :param error: The cause to publish and persist, e.g.
+        ``ErrorDetail(code="runner_disconnected", message="...")``.
+    :param conversation_store: Store used to persist the error labels.
+    :param fail_idle_top_level: When ``True``, also fail an idle top-level
+        session. A crash report covers the runner that died *before* it
+        could run anything, so its session never reached ``running`` and
+        would otherwise sit silent; a sub-agent is spawned by an
+        already-live runner and can never be in that state, so idle
+        children are skipped either way.
+    :returns: None.
+    """
+    for conv in convs:
+        # An intentional teardown (Stop / archive) drops the tunnel on
+        # purpose. The relay owns that path — it publishes a quiet idle and
+        # consumes the marker — so peek without discarding here.
+        if conv.id in _intentional_stop_sessions:
+            continue
+        # Cache first (this replica holds the runner's tunnel, so it saw the
+        # turn edges), falling back to the row for a session whose live state
+        # was published before a restart.
+        live = _session_status_cache.get(conv.id, conv.live_status)
+        interrupted = live in ("running", "waiting")
+        dead_on_arrival = fail_idle_top_level and conv.kind != "sub_agent"
+        if not interrupted and not dead_on_arrival:
+            continue
+        _publish_status(conv.id, "failed", error)
+        await _persist_session_status_error_labels(conv.id, error, conversation_store)
+
+
 async def _wait_for_host_bound_runner_client(
     session_id: str,
     runner_router: RunnerRouter | None,

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -662,6 +662,9 @@ from omnigent.server.routes._sessions.orchestration import (
     _kick_managed_wake_impl as _kick_managed_wake,
 )
 from omnigent.server.routes._sessions.orchestration import (
+    _mark_runner_sessions_offline_impl as _mark_runner_sessions_offline,
+)
+from omnigent.server.routes._sessions.orchestration import (
     _publish_runner_recovered_status_impl as _publish_runner_recovered_status,
 )
 
@@ -744,6 +747,7 @@ if TYPE_CHECKING:
         "_kick_managed_wake",
         "_launch_runner_on_host",
         "_load_agent_spec_for_session",
+        "_mark_runner_sessions_offline",
         "_poll_request_disconnect",
         "_presentation_labels_for_agent",
         "_publish_runner_recovered_status",

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -1326,3 +1326,90 @@ async def test_on_runner_connect_preserves_genuine_failure_on_reconnect(
 # out of ``test_sessions_three_layer.py`` + this file into a shared
 # ``_three_layer_helpers.py`` module once a third caller arrives. Kept
 # duplicated for now to keep this PR scoped to fixture + tests only.
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_on_runner_disconnect_spares_idle_sessions_and_labels_interrupted_ones(
+    tunnel_three_layer_stack: _TunnelStack,
+) -> None:
+    """A real tunnel drop fails only the mid-turn session, with its cause.
+
+    Sub-agents ride their parent's runner, so ``_on_runner_disconnect``
+    sees every session bound to it. It used to mark them all ``failed``
+    with no ``ErrorDetail``, which painted finished sub-agents red and
+    left a failure the UI could not tell from a real one (and that
+    ``_publish_runner_recovered_status`` could not clear, since it
+    matches on the disconnect code). Drives a genuine WS close on a
+    dedicated runner and asserts the idle session is untouched while the
+    running one carries ``runner_disconnected``.
+    """
+    from omnigent.runtime import get_conversation_store
+    from omnigent.server.routes import sessions as sessions_module
+
+    ap_client = tunnel_three_layer_stack.ap_client
+    ap_app = tunnel_three_layer_stack.ap_app
+    runner_id = "runner-offline-reconcile-test"
+
+    communicator = await _connect_runner_tunnel(ap_app, runner_id)
+    await _send_hello_and_wait(
+        communicator,
+        ap_app,
+        runner_id,
+        harnesses=[_TEST_HARNESS_NAME],
+    )
+
+    store = get_conversation_store()
+    session_ids: list[str] = []
+    for _ in range(2):
+        create_resp = await ap_client.post(
+            "/v1/sessions",
+            data={"metadata": json.dumps({})},
+            files={
+                "bundle": (
+                    "agent.tar.gz",
+                    _build_harness_agent_bundle(),
+                    "application/gzip",
+                ),
+            },
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        session_id = create_resp.json()["session_id"]
+        # Bind through the store (not a PATCH) so no relay spawns: this test
+        # is about the app-level fan-out, and a relay would also react to the
+        # close, making the assertion ambiguous about which path ran.
+        store.replace_runner_id(session_id, runner_id)
+        session_ids.append(session_id)
+
+    running_id, idle_id = session_ids
+    sessions_module._session_status_cache[running_id] = "running"
+    sessions_module._session_status_cache[idle_id] = "idle"
+
+    try:
+        await communicator.send_input({"type": "websocket.disconnect", "code": 1006})
+
+        async def _hook_ran() -> None:
+            while sessions_module._session_status_cache.get(running_id) != "failed":
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(_hook_ran(), timeout=5.0)
+
+        # The interrupted turn is failed AND carries the cause, so the client
+        # renders a recoverable "Disconnected" and recovery can clear it.
+        running_conv = store.get_conversation(running_id)
+        assert running_conv is not None
+        assert sessions_module._last_task_error_from_labels(running_conv.labels) == {
+            "code": "runner_disconnected",
+            "message": "Runner disconnected unexpectedly.",
+        }
+
+        # The idle session had no turn to fail: status and labels untouched.
+        assert sessions_module._session_status_cache.get(idle_id) == "idle"
+        idle_conv = store.get_conversation(idle_id)
+        assert idle_conv is not None
+        assert sessions_module._last_task_error_from_labels(idle_conv.labels) is None
+    finally:
+        with contextlib.suppress(asyncio.TimeoutError, Exception):
+            await communicator.wait(timeout=2.0)
+        for session_id in session_ids:
+            sessions_module._session_status_cache.pop(session_id, None)

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -833,3 +833,108 @@ async def test_relay_running_edge_clears_stale_intentional_stop_marker() -> None
         sessions_module._runner_relay_tasks.clear()
         sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
+
+
+def _bound_conv(
+    session_id: str,
+    *,
+    kind: str = "default",
+    live_status: str | None = None,
+) -> Any:
+    """
+    Build a conversation-shaped row for the offline-reconciliation helper.
+
+    ``_mark_runner_sessions_offline`` reads only ``id``, ``kind`` and
+    ``live_status`` off each row, so a namespace is enough.
+
+    :param session_id: Conversation identifier.
+    :param kind: ``"default"`` (top-level) or ``"sub_agent"``.
+    :param live_status: Persisted live status, read only on a cache miss.
+    :returns: A conversation-shaped namespace.
+    """
+    return SimpleNamespace(id=session_id, kind=kind, live_status=live_status)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "cached", "live_status", "intentional_stop", "fail_idle_top_level", "expect_failed"),
+    [
+        # A turn was in flight when the runner went away — fail it, with cause.
+        ("default", "running", None, False, False, True),
+        ("sub_agent", "running", None, False, False, True),
+        ("sub_agent", "waiting", None, False, False, True),
+        # A sub-agent that finished its work keeps that outcome: the runner
+        # leaving does not retroactively fail completed work (this is the
+        # whole Agents-rail-goes-red bug).
+        ("sub_agent", "idle", None, False, False, False),
+        ("default", "idle", None, False, False, False),
+        # Cache miss falls back to the persisted row value.
+        ("default", None, "running", False, False, True),
+        ("default", None, "idle", False, False, False),
+        ("default", None, None, False, False, False),
+        # Stop / archive drop the tunnel on purpose; the relay owns that path.
+        ("default", "running", None, True, False, False),
+        # A crash report also covers the runner that died before it could run
+        # anything, so an idle TOP-LEVEL session is failed — but an idle
+        # sub-agent (spawned by an already-live runner) still is not.
+        ("default", "idle", None, False, True, True),
+        ("sub_agent", "idle", None, False, True, False),
+    ],
+)
+async def test_mark_runner_sessions_offline_only_fails_interrupted_turns(
+    kind: str,
+    cached: str | None,
+    live_status: str | None,
+    intentional_stop: bool,
+    fail_idle_top_level: bool,
+    expect_failed: bool,
+) -> None:
+    """
+    Only the sessions a departed runner interrupted are failed, with cause.
+
+    Sub-agents ride their parent's runner, so a drop reaches every child
+    bound to it. Marking them all ``failed`` painted the whole Agents rail
+    red for sub-agents that had completed successfully, and — because the
+    fan-out carried no ``ErrorDetail`` — left a failure the UI could not
+    tell from a real one and the reconnect recovery could not clear.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+    from omnigent.server.schemas import ErrorDetail
+
+    session_id = "b04d1f3c9a5e4f7a8c2b6d0e1f3a5c79"
+    store = _RecordingLabelStore()
+    error = ErrorDetail(code="runner_disconnected", message="Runner disconnected unexpectedly.")
+    if cached is not None:
+        sessions_module._session_status_cache[session_id] = cached
+    if intentional_stop:
+        sessions_module._intentional_stop_sessions.add(session_id)
+
+    try:
+        await sessions_module._mark_runner_sessions_offline(
+            [_bound_conv(session_id, kind=kind, live_status=live_status)],
+            error,
+            store,  # type: ignore[arg-type]
+            fail_idle_top_level=fail_idle_top_level,
+        )
+
+        status = sessions_module._session_status_cache.get(session_id)
+        persisted = store.labels.get(session_id)
+        if expect_failed:
+            assert status == "failed"
+            # The cause must be durable: it is what lets the UI render a
+            # benign "Disconnected" and what
+            # ``_publish_runner_recovered_status`` matches on to clear the
+            # failure when the runner comes back.
+            assert persisted is not None
+            assert sessions_module._last_task_error_from_labels(persisted) == {
+                "code": "runner_disconnected",
+                "message": "Runner disconnected unexpectedly.",
+            }
+        else:
+            assert status == cached
+            assert persisted is None
+    finally:
+        sessions_module._intentional_stop_sessions.discard(session_id)
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -879,6 +879,11 @@ def _bound_conv(
         # sub-agent (spawned by an already-live runner) still is not.
         ("default", "idle", None, False, True, True),
         ("sub_agent", "idle", None, False, True, False),
+        # A crash report never downgrades an interrupted turn: a mid-turn
+        # sub-agent is failed under either flag.
+        ("sub_agent", "waiting", None, False, True, True),
+        # An intentional teardown still wins over the crash-report flag.
+        ("default", "idle", None, True, True, False),
     ],
 )
 async def test_mark_runner_sessions_offline_only_fails_interrupted_turns(


### PR DESCRIPTION
## Related issue

Addresses **Gap 2** of #1113 (partial — Gaps 1 and 3 remain, so this does not auto-close it).

Closes #

## Summary

Sub-agents ride their parent's runner (`child.runner_id == parent.runner_id`), so a tunnel drop reaches every child bound to it. `_on_runner_disconnect` marked **all** of them `failed` regardless of whether they were mid-turn, and published the edge with **no `ErrorDetail`**. Result: an Agents rail full of sub-agents that had completed successfully turns red, with nothing recording why.

The missing cause is what makes it stick. `_publish_runner_recovered_status(require_disconnect_code=True)` only clears a failure it can *identify* as a disconnect, so the fan-out's unlabelled `failed` survives a reconnect until the next real `running` edge. Only the per-session relay wrote the cause — and a session whose runner stream already ended on `[DONE]` has no relay left to write it, which is exactly the finished-sub-agent case.

```
runner tunnel drops
   ├── per-session relay (only if still streaming) → failed + "runner_disconnected"  ✅ has cause
   └── _on_runner_disconnect (every bound session) → failed, no cause                ❌ red "Failed"
                                                     └── finished sub-agents included
```

Both callbacks now go through one helper, `_mark_runner_sessions_offline`, which:

- **skips sessions that were not mid-turn** — cache first, the persisted `live_status` as fallback. A disconnect ends in-flight turns; it does not retroactively fail finished work. The runner's absence is already carried by liveness (`clear_runner_liveness`), which is what drives the reconnect affordances.
- **stamps the cause** on the ones it does fail, persisted as durable labels.
- **skips an intentional Stop/archive teardown** (peeks at `_intentional_stop_sessions` without consuming the marker — the relay owns that).

`_on_runner_exited` passes `fail_idle_top_level=True` so a runner that died *before* it could run anything still surfaces on its top-level session; an idle sub-agent is skipped either way, since its runner was already live.

**No frontend change.** `subagentStatus.ts` already maps a `runner_disconnected` / `runner_failed_to_start` cause to a quiet grey "Disconnected" instead of the red "Failed" — it was simply never given the data.

## Test Plan

**Automated** — an integration test in `tests/server/integration/test_sessions_tunnel_three_layer.py` drives a genuine WS close on a dedicated runner with two bound sessions (one mid-turn, one idle) and asserts the idle one is untouched while the interrupted one carries `runner_disconnected`. Plus `tests/server/routes/test_sessions_runner_relay.py`, 11 new parametrized cases over the decision matrix (mid-turn vs idle, `default` vs `sub_agent`, cache-hit vs `live_status` fallback, intentional-stop, `fail_idle_top_level`), asserting both the status edge and the persisted cause:

```
uv run pytest tests/server/routes/test_sessions_runner_relay.py -q          # 18 passed
uv run pytest tests/server/integration/test_sessions_tunnel_three_layer.py \
              tests/server/test_session_live_state.py -q                     # green
```

**Manual, against a live runner** — dedicated server + host + a real claude-native session that spawned 3 parallel `general-purpose` sub-agents, let them finish, started a new turn, then `kill -9` on the runner (which fires *both* `_on_runner_disconnect` and the host's `host.runner_exited`):

| | before | after |
|---|---|---|
| root, interrupted mid-turn | red `Failed` | grey dot, "Disconnected" |
| 3 sub-agents, finished earlier | red `Failed` ×3 | blue dots, "Done" — untouched |

Verified through the API and the SQLite rows: root `status=failed` with `last_task_error.code=runner_failed_to_start`; all three children still `current_task_status=completed` with empty error labels.

`test_sessions_snapshot.py` contributes 9 failures when run alongside the other server suites — A/B'd with this change reverted and the result is identical (9 failed / 59 passed), so it is pre-existing cross-suite pollution, not from this PR.

## Demo

No frontend change in this PR, so nothing new to show in the UI itself — the rail
already knew how to render this state. The server-side behaviour change, observed
live in the Agents rail after killing a real runner:

```
BEFORE                              AFTER
● Claude Code          Failed       ○ Claude Code        (grey — Disconnected)
  ↳ ● general-purpose  Failed         ↳ ● general-purpose  (blue — Done)
  ↳ ● general-purpose  Failed         ↳ ● general-purpose  (blue — Done)
  ↳ ● general-purpose  Failed         ↳ ● general-purpose  (blue — Done)
    (● = red destructive dot)
```

Backing data from that run, straight off the API:

```
ROOT   status=failed  cause=runner_failed_to_start   → renders "Disconnected"
CHILD  task_status=completed  err=None               → renders "Done"
CHILD  task_status=completed  err=None               → renders "Done"
CHILD  task_status=completed  err=None               → renders "Done"
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the reconciliation decision itself (11 cases); the integration test covers the `_on_runner_disconnect` wiring through a real tunnel close. `_on_runner_exited`'s wiring is exercised only manually (it needs a host daemon reporting `host.runner_exited`) — that path was verified against a live host + runner as described in the Test Plan, killing a real runner under a real claude-native session with completed sub-agents. Existing tunnel/relay suites cover the paths this touches from the other side (the relay's own disconnect labelling and the reconnect recovery that consumes them).

## Changelog

A runner disconnecting no longer marks finished sub-agents as failed — the Agents tab keeps their "Done" state and shows an interrupted session as a recoverable "Disconnected" instead of a red "Failed".
