### PR TITLE
fix(web): never silently lose the landing composer's first message

### DIFF
--- a/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
+++ b/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
@@ -1,4 +1,4 @@
-"""E2E: a new chat's initial prompt never leaks into another session.
+"""E2E: a new chat's initial prompt is delivered once to its own session.
 
 Guards the initial-prompt cross-session leak (sibling of the queued-
 message regression in ``test_cross_session_routing``, but a different
@@ -25,6 +25,11 @@ the runner-online variant because it needs no health stubbing.) The fix
 binds the prompt to the conversation it was consumed for and gates the
 auto-send on a match (``shouldSendInitialPrompt``'s ``promptConversationId``).
 
+The retry journeys below additionally cover a transient runner-unavailable
+503 across a ChatPage unmount/remount and a terminal 500 response. The
+transient case lets the successful retry continue to the real server and
+runner, then checks the canonical transcript for one committed prompt.
+
 The composer needs a host + agent catalog the headless harness can't
 produce (its runner is directly tunneled, no host daemon), and the
 create POST would really launch a runner. So the host list, the agent
@@ -41,16 +46,24 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 import threading
 from collections.abc import Coroutine
+from pathlib import Path
 from typing import Any
 
-from playwright.async_api import Route, async_playwright
+import httpx
+from playwright.async_api import Route, async_playwright, expect
 
 # Unique sentinels so each POST body is unambiguously identifiable.
 _PROMPT = "sentinel-initprompt-7b3e initial prompt bound to session A"
 _FOLLOWUP = "sentinel-followup-2d9a live send into session B"
+_RETRY_PROMPT = "sentinel-retry-41ca survives a remount"
+_RETRY_FOLLOWUP = "sentinel-order-67bf follows the initial prompt"
+_FAILED_PROMPT = "sentinel-failed-904e restore this draft"
+_AMBIGUOUS_PROMPT = "sentinel-accepted-e772 must not be replayed"
+_SLASH_PROMPT = "/code-review 4294"
 
 _EVENTS_RE = re.compile(r"/v1/sessions/([^/]+)/events$")
 # Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
@@ -100,6 +113,146 @@ async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
             return
         await asyncio.sleep(0.05)
     raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _event_text(body: dict[str, Any]) -> str:
+    """Extract visible text from a message or slash-command event body."""
+    if body.get("type") == "slash_command":
+        data = body["data"]
+        args = data.get("arguments", "")
+        return f"/{data['name']}{f' {args}' if args else ''}"
+    return "".join(
+        block.get("text", "")
+        for block in body.get("data", {}).get("content", [])
+        if block.get("type") == "input_text"
+    )
+
+
+async def _register_landing_routes(
+    page,
+    *,
+    created_session_id: str,
+    handle_events,
+    skills: list[dict[str, str]] | None = None,
+) -> None:
+    """Install only the host/catalog/create stubs the landing composer needs."""
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "hosts": [
+                        {
+                            "host_id": "host_e2e",
+                            "name": "e2e-host",
+                            "owner": "e2e",
+                            "status": "online",
+                        }
+                    ]
+                }
+            ),
+        )
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "ag_e2e",
+                            "name": "hello_world",
+                            "display_name": "Hello World",
+                            "description": None,
+                            "harness": None,
+                            "skills": skills or [],
+                        }
+                    ]
+                }
+            ),
+        )
+
+    async def handle_sessions(route: Route) -> None:
+        if route.request.method == "POST":
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id}),
+            )
+        else:
+            await route.continue_()
+
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route(_SESSIONS_RE, handle_sessions)
+
+
+async def _open_landing_and_send(page, base_url: str, prompt: str) -> None:
+    """Open the real landing composer with a usable stubbed host and submit."""
+    await page.add_init_script(
+        """window.localStorage.setItem(
+            "omnigent:recent-workspaces",
+            JSON.stringify({ host_e2e: ["/tmp"] }),
+        )"""
+    )
+    await page.goto(f"{base_url}/")
+    composer = page.get_by_test_id("new-chat-landing-input")
+    await composer.wait_for(state="visible", timeout=30_000)
+    await composer.fill(prompt)
+    await page.get_by_test_id("new-chat-landing-submit").click()
+
+
+async def _canonical_user_texts(base_url: str, session_id: str) -> list[str]:
+    """Read committed user messages from the real server in chronological order."""
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        response = await client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 100, "order": "asc"},
+        )
+    response.raise_for_status()
+    texts: list[str] = []
+    for item in response.json().get("data", []):
+        if item.get("role") != "user":
+            continue
+        text = "".join(
+            block.get("text", "")
+            for block in item.get("content", [])
+            if block.get("type") == "input_text"
+        )
+        if text:
+            texts.append(text)
+    return texts
+
+
+async def _wait_for_canonical_user_text(
+    base_url: str,
+    session_id: str,
+    expected: str,
+    *,
+    timeout_s: float = 30.0,
+) -> None:
+    """Poll the real transcript until one expected user message commits."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if expected in await _canonical_user_texts(base_url, session_id):
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(f"{expected!r} did not reach the canonical transcript")
+
+
+async def _save_optional_screenshot(page, name: str) -> None:
+    """Save local verification evidence when E2E_SCREENSHOT_DIR is set."""
+    screenshot_dir = os.environ.get("E2E_SCREENSHOT_DIR")
+    if not screenshot_dir:
+        return
+    path = Path(screenshot_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    await page.screenshot(path=str(path / f"{name}.png"), full_page=True)
 
 
 def test_initial_prompt_stays_bound_to_origin_session_after_switch(
@@ -278,5 +431,310 @@ async def _drive_initial_prompt_switch(base_url: str, session_a: str, session_b:
                 f"session B ({session_b}): POST targets were {prompt_targets}. A target "
                 f"of B is the cross-session initial-prompt leak."
             )
+        finally:
+            await browser.close()
+
+
+def test_initial_prompt_retries_across_chat_page_remount_exactly_once(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A runner 503 plus a ChatPage remount still commits one initial prompt."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_retry_across_remount(base_url, session_id))
+
+
+async def _drive_retry_across_remount(base_url: str, session_id: str) -> None:
+    """Drive a real landing→chat→settings→chat retry journey."""
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            event_posts: list[dict[str, Any]] = []
+
+            async def handle_events(route: Route) -> None:
+                body = route.request.post_data_json
+                if _event_text(body) not in {_RETRY_PROMPT, _RETRY_FOLLOWUP}:
+                    await route.continue_()
+                    return
+                event_posts.append(body)
+                if (
+                    _event_text(body) == _RETRY_PROMPT
+                    and len([post for post in event_posts if _event_text(post) == _RETRY_PROMPT])
+                    == 1
+                ):
+                    await route.fulfill(
+                        status=503,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "error": {
+                                    "code": "runner_unavailable",
+                                    "message": "No runner bound for session",
+                                }
+                            }
+                        ),
+                    )
+                    return
+                await route.continue_()
+
+            await _register_landing_routes(
+                page,
+                created_session_id=session_id,
+                handle_events=handle_events,
+            )
+            await _open_landing_and_send(page, base_url, _RETRY_PROMPT)
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_id)}"))
+            await _wait_until(
+                lambda: (
+                    len([post for post in event_posts if _event_text(post) == _RETRY_PROMPT]) == 1
+                )
+            )
+
+            # A follow-up must not overtake the retry, and a transient failure
+            # must not leak a second copy of the prompt back into the composer.
+            composer = page.get_by_label("Message the agent")
+            await expect(composer).to_be_disabled()
+            await expect(composer).to_have_value("")
+
+            # Unmount ChatPage through client-side routing, then return before
+            # the one-second retry delay elapses. Two independent loops would
+            # both POST after this remount.
+            await page.evaluate(
+                """() => {
+                    history.pushState({}, "", "/settings/appearance");
+                    window.dispatchEvent(new PopStateEvent("popstate"));
+                }"""
+            )
+            await expect(composer).not_to_be_attached()
+            await page.evaluate(
+                f"""() => {{
+                    history.pushState({{}}, "", "/c/{session_id}");
+                    window.dispatchEvent(new PopStateEvent("popstate"));
+                }}"""
+            )
+            composer = page.get_by_label("Message the agent")
+            await composer.wait_for(state="visible", timeout=30_000)
+
+            await expect(page.get_by_text("Mock LLM response.", exact=True).first).to_be_visible(
+                timeout=30_000
+            )
+            # Let the original loop's retry timer fire; it must observe that
+            # the shared delivery finished rather than POSTing a duplicate.
+            await asyncio.sleep(1.5)
+            prompt_posts = [post for post in event_posts if _event_text(post) == _RETRY_PROMPT]
+            assert len(prompt_posts) == 2, (
+                "expected one runner-unavailable attempt and one accepted retry; "
+                f"saw {len(prompt_posts)} attempts"
+            )
+            await expect(composer).to_be_enabled()
+            await expect(composer).to_have_value("")
+
+            await composer.fill(_RETRY_FOLLOWUP)
+            await page.get_by_role("button", name="Send", exact=True).click()
+            await _wait_until(
+                lambda: any(_event_text(post) == _RETRY_FOLLOWUP for post in event_posts)
+            )
+            await _wait_for_canonical_user_text(base_url, session_id, _RETRY_FOLLOWUP)
+
+            user_texts = await _canonical_user_texts(base_url, session_id)
+            sentinels = [text for text in user_texts if text in {_RETRY_PROMPT, _RETRY_FOLLOWUP}]
+            assert sentinels == [_RETRY_PROMPT, _RETRY_FOLLOWUP], sentinels
+            await _save_optional_screenshot(page, "initial-prompt-remount-retry")
+        finally:
+            await browser.close()
+
+
+def test_initial_prompt_terminal_failure_restores_draft_without_retry(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A non-runner failure is not replayed and restores the original draft."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_terminal_failure(base_url, session_id))
+
+
+async def _drive_terminal_failure(base_url: str, session_id: str) -> None:
+    """Drive a definitive 500 response through the real landing/chat UI."""
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            event_posts: list[dict[str, Any]] = []
+
+            async def handle_events(route: Route) -> None:
+                body = route.request.post_data_json
+                event_posts.append(body)
+                if len(event_posts) == 1:
+                    await route.fulfill(
+                        status=500,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "error": {
+                                    "code": "internal_error",
+                                    "message": "definite initial-prompt failure",
+                                }
+                            }
+                        ),
+                    )
+                    return
+                # An unsafe retry would turn the failure into a false success,
+                # making both the attempt count and restored-error assertions fail.
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_unexpected_retry"}),
+                )
+
+            await _register_landing_routes(
+                page,
+                created_session_id=session_id,
+                handle_events=handle_events,
+            )
+            await _open_landing_and_send(page, base_url, _FAILED_PROMPT)
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_id)}"))
+
+            composer = page.get_by_label("Message the agent")
+            await expect(composer).to_have_value(_FAILED_PROMPT, timeout=5_000)
+            await page.get_by_role("button", name="Something went wrong").click()
+            await expect(
+                page.get_by_text("definite initial-prompt failure", exact=True)
+            ).to_be_visible()
+            await asyncio.sleep(1.2)
+            assert len(event_posts) == 1, (
+                "a non-runner failure may be ambiguous after transport/proxy errors; "
+                f"it must not be retried, but saw {len(event_posts)} POSTs"
+            )
+            await _save_optional_screenshot(page, "initial-prompt-final-failure")
+        finally:
+            await browser.close()
+
+
+def test_initial_prompt_does_not_retry_after_server_persistence(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A runner-unavailable response after persistence is never replayed."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_persisted_runner_failure(base_url, session_id))
+
+
+async def _drive_persisted_runner_failure(base_url: str, session_id: str) -> None:
+    """Hide an accepted response behind the server's post-persistence 503."""
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            event_posts: list[dict[str, Any]] = []
+
+            async def handle_events(route: Route) -> None:
+                body = route.request.post_data_json
+                if _event_text(body) != _AMBIGUOUS_PROMPT:
+                    await route.continue_()
+                    return
+                event_posts.append(body)
+                if len(event_posts) == 1:
+                    accepted = await route.fetch()
+                    assert accepted.ok
+                    await route.fulfill(
+                        response=accepted,
+                        status=503,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "error": {
+                                    "code": "runner_unavailable",
+                                    "message": (
+                                        "Runner is unreachable; message was persisted "
+                                        "but could not be delivered."
+                                    ),
+                                }
+                            }
+                        ),
+                    )
+                    return
+                # Expose an unsafe automatic retry by letting it reach the server.
+                await route.continue_()
+
+            await _register_landing_routes(
+                page,
+                created_session_id=session_id,
+                handle_events=handle_events,
+            )
+            await _open_landing_and_send(page, base_url, _AMBIGUOUS_PROMPT)
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_id)}"))
+            await _wait_for_canonical_user_text(base_url, session_id, _AMBIGUOUS_PROMPT)
+            await asyncio.sleep(1.5)
+
+            assert len(event_posts) == 1, (
+                "runner_unavailable is also emitted after persistence; replaying it "
+                f"duplicates the event, but saw {len(event_posts)} POSTs"
+            )
+            user_texts = await _canonical_user_texts(base_url, session_id)
+            assert user_texts.count(_AMBIGUOUS_PROMPT) == 1, user_texts
+            await _save_optional_screenshot(page, "initial-prompt-accepted-no-retry")
+        finally:
+            await browser.close()
+
+
+def test_initial_prompt_slash_command_retries_only_runner_unavailable(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A matched landing skill keeps its slash-command wire shape across retry."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_slash_command_retry(base_url, session_id))
+
+
+async def _drive_slash_command_retry(base_url: str, session_id: str) -> None:
+    """Drive a matched skill through one runner-unavailable response."""
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            event_posts: list[dict[str, Any]] = []
+
+            async def handle_events(route: Route) -> None:
+                event_posts.append(route.request.post_data_json)
+                if len(event_posts) == 1:
+                    await route.fulfill(
+                        status=503,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "error": {
+                                    "code": "runner_unavailable",
+                                    "message": "No runner bound for session",
+                                }
+                            }
+                        ),
+                    )
+                    return
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_slash_retry"}),
+                )
+
+            await _register_landing_routes(
+                page,
+                created_session_id=session_id,
+                handle_events=handle_events,
+                skills=[{"name": "code-review", "description": "Review a pull request"}],
+            )
+            await _open_landing_and_send(page, base_url, _SLASH_PROMPT)
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_id)}"))
+            await _wait_until(lambda: len(event_posts) == 2)
+
+            assert [post["type"] for post in event_posts] == [
+                "slash_command",
+                "slash_command",
+            ]
+            assert [post["data"]["name"] for post in event_posts] == [
+                "code-review",
+                "code-review",
+            ]
+            assert [post["data"]["arguments"] for post in event_posts] == ["4294", "4294"]
+            composer = page.get_by_label("Message the agent")
+            await expect(composer).to_be_enabled()
+            await expect(composer).to_have_value("")
+            await _save_optional_screenshot(page, "initial-prompt-slash-retry")
         finally:
             await browser.close()

--- a/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
+++ b/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
@@ -670,6 +670,8 @@ async def _drive_persisted_runner_failure(base_url: str, session_id: str) -> Non
             )
             user_texts = await _canonical_user_texts(base_url, session_id)
             assert user_texts.count(_AMBIGUOUS_PROMPT) == 1, user_texts
+            composer = page.get_by_label("Message the agent")
+            await expect(composer).to_have_value("")
             await _save_optional_screenshot(page, "initial-prompt-accepted-no-retry")
         finally:
             await browser.close()

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -19,6 +19,7 @@ import {
   computeIsWorking,
   computeShowsWorking,
   containsMarkdownTable,
+  deliverInitialPrompt,
   dispatchInitialPrompt,
   isCostRoutingEligible,
   isSubagentRoutingEligible,
@@ -1385,9 +1386,9 @@ describe("dispatchInitialPrompt", () => {
   // agent receives literal "/review-pr 123" text and the skill never runs
   // (the original bug).
   it("posts a matched skill invocation as a slash_command, not a plain message", () => {
-    const send = vi.fn().mockResolvedValue(undefined);
-    const sendSlashCommand = vi.fn().mockResolvedValue(undefined);
-    dispatchInitialPrompt(
+    const send = vi.fn().mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    void dispatchInitialPrompt(
       {
         text: "/review-pr 123 focus on auth",
         skill: { name: "review-pr", args: "123 focus on auth" },
@@ -1399,16 +1400,21 @@ describe("dispatchInitialPrompt", () => {
     // Name (no leading slash) + raw args reach the slash_command path —
     // the exact values the server's skill lookup and the runner's
     // SKILL.md resolution key off.
-    expect(sendSlashCommand).toHaveBeenCalledWith("review-pr", "123 focus on auth", "ag_abc123");
+    expect(sendSlashCommand).toHaveBeenCalledWith(
+      "review-pr",
+      "123 focus on auth",
+      "ag_abc123",
+      undefined,
+    );
     // The plain path must NOT also fire — a double-send would deliver the
     // literal "/name" text alongside the skill invocation.
     expect(send).not.toHaveBeenCalled();
   });
 
   it("posts plain text (no matched skill) as a regular message", () => {
-    const send = vi.fn().mockResolvedValue(undefined);
-    const sendSlashCommand = vi.fn().mockResolvedValue(undefined);
-    dispatchInitialPrompt(
+    const send = vi.fn().mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    void dispatchInitialPrompt(
       { text: "read the README", skill: null },
       "ag_abc123",
       send,
@@ -1416,15 +1422,15 @@ describe("dispatchInitialPrompt", () => {
     );
     // Full text verbatim, no files. This is also the path for native
     // terminal sessions and unknown "/typo" commands (skill stays null).
-    expect(send).toHaveBeenCalledWith("read the README", "ag_abc123", []);
+    expect(send).toHaveBeenCalledWith("read the README", "ag_abc123", [], undefined);
     expect(sendSlashCommand).not.toHaveBeenCalled();
   });
 
   it("carries landing attachments through the plain-message path", () => {
-    const send = vi.fn().mockResolvedValue(undefined);
-    const sendSlashCommand = vi.fn().mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
     const file = new File(["x"], "diagram.png", { type: "image/png" });
-    dispatchInitialPrompt(
+    void dispatchInitialPrompt(
       { text: "what is this?", skill: null, files: [file] },
       "ag_abc123",
       send,
@@ -1432,7 +1438,146 @@ describe("dispatchInitialPrompt", () => {
     );
     // The exact File objects picked on the landing screen reach send() —
     // an empty array here means first-message attachments silently vanish.
-    expect(send).toHaveBeenCalledWith("what is this?", "ag_abc123", [file]);
+    expect(send).toHaveBeenCalledWith("what is this?", "ag_abc123", [file], undefined);
+  });
+});
+
+// Durability of the landing composer's first message. The failure this
+// covers is a session created in a burst whose runner takes 30s+ to
+// register: the POST 503s past the server's own hold, and before this the
+// single attempt was the only one — the typed text vanished into an
+// idle-looking session with no user message at all.
+describe("deliverInitialPrompt", () => {
+  const prompt = { text: "read the README", skill: null };
+  // Instant "sleeps" so the backoff schedule doesn't slow the suite; the
+  // ordering the loop depends on is preserved.
+  const sleep = (): Promise<void> => Promise.resolve();
+
+  it("keeps retrying while the runner is offline and delivers exactly once", async () => {
+    // Four consecutive 503s (a ~30s+ runner start), then the runner
+    // registers and the POST settles.
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+
+    const outcome = await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1, 1, 1, 1, 1],
+      sleep,
+    });
+
+    expect(outcome).toBe("delivered");
+    // Five attempts, one success — and crucially no attempt after it.
+    expect(send).toHaveBeenCalledTimes(5);
+  });
+
+  it("stops the instant an attempt settles, so a retry can't duplicate it", async () => {
+    // The retry loop is strictly sequential: the next attempt only starts
+    // after the previous resolved as NOT settled. A late success therefore
+    // has nothing to race — two user messages would be worse than the bug.
+    const send = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+
+    await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1, 1],
+      sleep,
+    });
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses the failure block on every attempt but the last", async () => {
+    // Intermediate failures are silent (the retry is about to resolve
+    // them); the final attempt lets the store paint the error so the user
+    // never ends up on a silent, empty composer.
+    const send = vi.fn().mockResolvedValue(false);
+    const sendSlashCommand = vi.fn().mockResolvedValue(false);
+
+    const outcome = await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1],
+      sleep,
+    });
+
+    expect(outcome).toBe("failed");
+    const retryFlags = send.mock.calls.map(
+      (call) => (call[3] as { retryPending: boolean }).retryPending,
+    );
+    expect(retryFlags).toEqual([true, true, false]);
+  });
+
+  it("makes the first attempt immediately, adding no latency to a fast start", async () => {
+    // The common case (~6s runner start, absorbed by the server's hold)
+    // must behave exactly as before: one attempt, no backoff wait.
+    const send = vi.fn().mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const sleepSpy = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      sleep: sleepSpy,
+    });
+
+    expect(outcome).toBe("delivered");
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports cancellation without delivering when the user leaves mid-backoff", async () => {
+    // Cancellation is honoured only BETWEEN attempts — an in-flight
+    // dispatch must report its outcome first, or the caller couldn't tell
+    // "nothing landed" from "it landed after we stopped watching".
+    const send = vi.fn().mockResolvedValue(false);
+    const sendSlashCommand = vi.fn().mockResolvedValue(false);
+
+    const outcome = await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1, 1],
+      sleep,
+      isCancelled: () => true,
+    });
+
+    expect(outcome).toBe("cancelled");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a skill invocation on the slash_command path too", async () => {
+    const send = vi.fn().mockResolvedValue(true);
+    const sendSlashCommand = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    const outcome = await deliverInitialPrompt({
+      prompt: { text: "/review-pr 123", skill: { name: "review-pr", args: "123" } },
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1],
+      sleep,
+    });
+
+    expect(outcome).toBe("delivered");
+    expect(sendSlashCommand).toHaveBeenCalledTimes(2);
+    expect(send).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -1386,8 +1386,8 @@ describe("dispatchInitialPrompt", () => {
   // agent receives literal "/review-pr 123" text and the skill never runs
   // (the original bug).
   it("posts a matched skill invocation as a slash_command, not a plain message", () => {
-    const send = vi.fn().mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
     void dispatchInitialPrompt(
       {
         text: "/review-pr 123 focus on auth",
@@ -1412,8 +1412,8 @@ describe("dispatchInitialPrompt", () => {
   });
 
   it("posts plain text (no matched skill) as a regular message", () => {
-    const send = vi.fn().mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
     void dispatchInitialPrompt(
       { text: "read the README", skill: null },
       "ag_abc123",
@@ -1427,8 +1427,8 @@ describe("dispatchInitialPrompt", () => {
   });
 
   it("carries landing attachments through the plain-message path", () => {
-    const send = vi.fn().mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
     const file = new File(["x"], "diagram.png", { type: "image/png" });
     void dispatchInitialPrompt(
       { text: "what is this?", skill: null, files: [file] },
@@ -1458,12 +1458,12 @@ describe("deliverInitialPrompt", () => {
     // registers and the POST settles.
     const send = vi
       .fn()
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+      .mockResolvedValueOnce("retryable_failure")
+      .mockResolvedValueOnce("retryable_failure")
+      .mockResolvedValueOnce("retryable_failure")
+      .mockResolvedValueOnce("retryable_failure")
+      .mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
 
     const outcome = await deliverInitialPrompt({
       prompt,
@@ -1483,8 +1483,8 @@ describe("deliverInitialPrompt", () => {
     // The retry loop is strictly sequential: the next attempt only starts
     // after the previous resolved as NOT settled. A late success therefore
     // has nothing to race — two user messages would be worse than the bug.
-    const send = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValueOnce("retryable_failure").mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
 
     await deliverInitialPrompt({
       prompt,
@@ -1502,8 +1502,8 @@ describe("deliverInitialPrompt", () => {
     // Intermediate failures are silent (the retry is about to resolve
     // them); the final attempt lets the store paint the error so the user
     // never ends up on a silent, empty composer.
-    const send = vi.fn().mockResolvedValue(false);
-    const sendSlashCommand = vi.fn().mockResolvedValue(false);
+    const send = vi.fn().mockResolvedValue("retryable_failure");
+    const sendSlashCommand = vi.fn().mockResolvedValue("retryable_failure");
 
     const outcome = await deliverInitialPrompt({
       prompt,
@@ -1521,11 +1521,30 @@ describe("deliverInitialPrompt", () => {
     expect(retryFlags).toEqual([true, true, false]);
   });
 
+  it("never retries a terminal or ambiguously accepted failure", async () => {
+    const send = vi.fn().mockResolvedValue("terminal_failure");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
+    const sleepSpy = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await deliverInitialPrompt({
+      prompt,
+      agentId: "ag_abc123",
+      send,
+      sendSlashCommand,
+      retryDelaysMs: [1, 1, 1],
+      sleep: sleepSpy,
+    });
+
+    expect(outcome).toBe("failed");
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).not.toHaveBeenCalled();
+  });
+
   it("makes the first attempt immediately, adding no latency to a fast start", async () => {
     // The common case (~6s runner start, absorbed by the server's hold)
     // must behave exactly as before: one attempt, no backoff wait.
-    const send = vi.fn().mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValue("settled");
+    const sendSlashCommand = vi.fn().mockResolvedValue("settled");
     const sleepSpy = vi.fn().mockResolvedValue(undefined);
 
     const outcome = await deliverInitialPrompt({
@@ -1545,8 +1564,8 @@ describe("deliverInitialPrompt", () => {
     // Cancellation is honoured only BETWEEN attempts — an in-flight
     // dispatch must report its outcome first, or the caller couldn't tell
     // "nothing landed" from "it landed after we stopped watching".
-    const send = vi.fn().mockResolvedValue(false);
-    const sendSlashCommand = vi.fn().mockResolvedValue(false);
+    const send = vi.fn().mockResolvedValue("retryable_failure");
+    const sendSlashCommand = vi.fn().mockResolvedValue("retryable_failure");
 
     const outcome = await deliverInitialPrompt({
       prompt,
@@ -1563,8 +1582,11 @@ describe("deliverInitialPrompt", () => {
   });
 
   it("retries a skill invocation on the slash_command path too", async () => {
-    const send = vi.fn().mockResolvedValue(true);
-    const sendSlashCommand = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+    const send = vi.fn().mockResolvedValue("settled");
+    const sendSlashCommand = vi
+      .fn()
+      .mockResolvedValueOnce("retryable_failure")
+      .mockResolvedValue("settled");
 
     const outcome = await deliverInitialPrompt({
       prompt: { text: "/review-pr 123", skill: { name: "review-pr", args: "123" } },

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -4,6 +4,7 @@ import type { RoutingScope } from "@/lib/routingDecision";
 import type { ToolExecution } from "@/lib/blocks";
 import type { ServerInfo } from "@/lib/capabilities";
 import type { Session } from "@/lib/types";
+import { getSessionDraft, setSessionDraft } from "@/lib/sessionDrafts";
 import {
   BUILTIN_SLASH_COMMANDS,
   isSlashCommandText,
@@ -34,6 +35,7 @@ import {
   MAX_WARM_TERMINAL_SURFACES,
   shouldMountTerminalSurface,
   shouldShowTerminalSurface,
+  stashUndeliveredPrompt,
   updateWarmTerminalSurfaces,
   type WarmTerminalEntry,
   isBackgroundTasksOnly,
@@ -1600,6 +1602,19 @@ describe("deliverInitialPrompt", () => {
     expect(outcome).toBe("delivered");
     expect(sendSlashCommand).toHaveBeenCalledTimes(2);
     expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("stashUndeliveredPrompt", () => {
+  it("does not overwrite an existing files-only draft", () => {
+    const conversationId = "conv_files_only_draft";
+    const file = new File(["attachment"], "evidence.txt", { type: "text/plain" });
+    setSessionDraft(conversationId, { text: "", files: [file] });
+
+    stashUndeliveredPrompt(conversationId, "undelivered first prompt");
+
+    expect(getSessionDraft(conversationId)).toEqual({ text: "", files: [file] });
+    setSessionDraft(conversationId, { text: "", files: [] });
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5996,8 +5996,8 @@ export async function deliverInitialPrompt(params: {
  * @param conversationId Session the prompt was meant for, e.g. ``"conv_abc"``.
  * @param text The undelivered message text.
  */
-function stashUndeliveredPrompt(conversationId: string, text: string): void {
-  if (!text || getSessionDraft(conversationId)?.text) return;
+export function stashUndeliveredPrompt(conversationId: string, text: string): void {
+  if (!text || getSessionDraft(conversationId) !== undefined) return;
   setSessionDraft(conversationId, { text, files: [] });
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5955,11 +5955,12 @@ export async function deliverInitialPrompt(params: {
       new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
       }));
+  const maxAttempts = delays.length + 1;
   // Sequential by design: each attempt must resolve before the next starts,
   // or a retry could race a late success into a duplicate message — hence
   // the awaits in the loop below.
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    const isFinal = attempt === delays.length;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const isFinal = attempt === maxAttempts - 1;
     // The store actions settle their own failures; a rejection here would
     // be an unexpected one, and treating it as "not settled" keeps the loop
     // (and the caller's bookkeeping) alive rather than stranding the prompt.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -112,6 +112,7 @@ import {
   type PendingInitialPrompt,
   type PendingUserMessage,
   type QueuedMessage,
+  type SendAttemptResult,
   type SendOptions,
   useChatStore,
 } from "@/store/chatStore";
@@ -683,6 +684,16 @@ function truncateTitle(raw: string, max = 60): string {
   return slice.slice(0, cut).join("").trimEnd() + "…";
 }
 
+interface InitialPromptDeliveryEntry {
+  promise: Promise<"delivered" | "cancelled" | "failed">;
+  cancel: () => void;
+}
+
+// ChatPage can unmount while a retry is sleeping. Share the one active loop
+// across component instances so a remount observes it instead of replaying the
+// same prompt concurrently.
+const initialPromptDeliveries = new Map<string, InitialPromptDeliveryEntry>();
+
 /**
  * Single component that drives the chat surface. Streaming + history
  * state lives in `useChatStore` (a Zustand store at module scope), so
@@ -718,12 +729,6 @@ export function ChatPage() {
   // because it is set synchronously before the first dispatch, it is what
   // stops a retrying delivery from being started twice for one session.
   const initialPromptSentForConvRef = useRef<string | null>(null);
-  // Conversation id of the delivery loop that is currently alive (including
-  // while it waits out a backoff), or null. Distinct from the guard above,
-  // which stays latched after a loop finishes: this one is what tells a
-  // re-arm whether a loop is already on the job, so returning to a session
-  // mid-backoff can never start a second one.
-  const initialPromptLoopRef = useRef<string | null>(null);
   // True while the first message is still being delivered (including the
   // waits between retries, when nothing else in the UI would show activity
   // — the runner is offline, so the liveness-derived shimmer is suppressed).
@@ -789,13 +794,14 @@ export function ChatPage() {
   useEffect(() => {
     if (!urlConvId) {
       setInitialPrompt(null);
+      setDeliveringInitialPrompt(false);
       return;
     }
     const prompt = peekPendingInitialPrompt(urlConvId);
-    // Still pending with no loop on the job means a previous delivery
-    // attempt for this session stopped when the user navigated away.
-    // Re-arm the once-guard so arriving here again resumes it.
-    if (prompt !== null && initialPromptLoopRef.current === null) {
+    const deliveryInFlight = initialPromptDeliveries.has(urlConvId);
+    setDeliveringInitialPrompt(prompt !== null && deliveryInFlight);
+    // Still pending with no loop on the job means a previous delivery stopped.
+    if (prompt !== null && !deliveryInFlight) {
       initialPromptSentForConvRef.current = null;
     }
     setInitialPrompt(prompt === null ? null : { conversationId: urlConvId, prompt });
@@ -940,11 +946,16 @@ export function ChatPage() {
   // ever running for the same session — while still resetting for the next
   // conversation, since ChatPage stays mounted across `/c/:a` → `/c/:b`.
   useEffect(() => {
+    const existingDelivery =
+      urlConvId === undefined ? undefined : initialPromptDeliveries.get(urlConvId);
     if (
       !shouldSendInitialPrompt({
         initialPrompt: initialPrompt?.prompt.text ?? null,
         promptConversationId: initialPrompt?.conversationId ?? null,
-        sentForConversationId: initialPromptSentForConvRef.current,
+        // A remounted observer must attach to the existing loop even though
+        // this component already marked the conversation as started.
+        sentForConversationId:
+          existingDelivery === undefined ? initialPromptSentForConvRef.current : null,
         conversationId: urlConvId,
         loadingConversation,
         agentId,
@@ -959,33 +970,60 @@ export function ChatPage() {
     const convId = urlConvId;
     const prompt = initialPrompt.prompt;
     initialPromptSentForConvRef.current = convId;
-    initialPromptLoopRef.current = convId;
     setDeliveringInitialPrompt(true);
-    void (async () => {
+    let ownsDelivery = false;
+    let delivery = existingDelivery;
+    if (delivery === undefined) {
+      ownsDelivery = true;
+      let cancelled = false;
       const { send, sendSlashCommand } = useChatStore.getState();
-      const outcome = await deliverInitialPrompt({
+      const promise = deliverInitialPrompt({
         prompt,
         agentId,
         send,
         sendSlashCommand,
-        // `send` pins whatever session the store is on at call time, so a
-        // retry must stop once the user is elsewhere — otherwise the first
-        // message would land in the session they switched to. Read live (not
-        // via an effect cleanup) so a benign re-render can't kill the loop.
-        isCancelled: () => activeConvIdRef.current !== convId,
+        // `send` pins the active store session, so leaving this component or
+        // switching chats cancels before another attempt can target elsewhere.
+        isCancelled: () => cancelled || activeConvIdRef.current !== convId,
+      }).then((outcome) => {
+        if (outcome !== "cancelled") {
+          clearPendingInitialPrompt(convId);
+          if (outcome === "failed") stashUndeliveredPrompt(convId, prompt.text);
+        }
+        return outcome;
       });
-      initialPromptLoopRef.current = null;
+      const entry: InitialPromptDeliveryEntry = {
+        promise: promise.finally(() => {
+          if (initialPromptDeliveries.get(convId) === entry) {
+            initialPromptDeliveries.delete(convId);
+          }
+        }),
+        cancel: () => {
+          cancelled = true;
+        },
+      };
+      initialPromptDeliveries.set(convId, entry);
+      delivery = entry;
+    }
+
+    let observerCancelled = false;
+    void delivery.promise.then((outcome) => {
+      if (observerCancelled) return;
       setDeliveringInitialPrompt(false);
-      // Cancelled: nothing landed and nothing was dropped — the prompt
-      // stays stashed, and re-opening this session resumes delivery.
-      if (outcome === "cancelled") return;
-      // Delivered, or given up on after the final attempt surfaced the
-      // error block. Either way the prompt must not be replayed; on
-      // failure the text stays recoverable from the session's composer
-      // draft and its ArrowUp prompt history.
-      clearPendingInitialPrompt(convId);
-      if (outcome === "failed") stashUndeliveredPrompt(convId, prompt.text);
-    })();
+      if (outcome === "cancelled") {
+        const pending = peekPendingInitialPrompt(convId);
+        if (pending !== null && activeConvIdRef.current === convId) {
+          initialPromptSentForConvRef.current = null;
+          setInitialPrompt({ conversationId: convId, prompt: pending });
+        }
+        return;
+      }
+      setInitialPrompt((current) => (current?.conversationId === convId ? null : current));
+    });
+    return () => {
+      observerCancelled = true;
+      if (ownsDelivery) delivery.cancel();
+    };
   }, [initialPrompt, urlConvId, loadingConversation, agentId]);
 
   // Open state owned here (not inside MainAgentSurface) so the dialog
@@ -1397,7 +1435,7 @@ export function ChatPage() {
       runnerOnline={runnerOnline}
       liveness={liveness}
       agentsError={agentsError}
-      disabled={!agentId || agentsError !== null}
+      disabled={!agentId || agentsError !== null || deliveringInitialPrompt}
       onSend={onSend}
       onSendSlashCommand={onSendSlashCommand}
       onStop={onStop}
@@ -5833,20 +5871,25 @@ export function shouldSendResumePrompt(params: {
  * @param opts Forwarded to the store action; ``retryPending`` marks an
  *   attempt the caller will retry, so the store keeps quiet about the
  *   failure.
- * @returns Whether the POST settled on the server.
+ * @returns Whether the POST settled, can be retried safely, or is terminal.
  */
 export function dispatchInitialPrompt(
   prompt: PendingInitialPrompt,
   agentId: string,
-  send: (text: string, agentId: string, files: File[], opts?: SendOptions) => Promise<boolean>,
+  send: (
+    text: string,
+    agentId: string,
+    files: File[],
+    opts?: SendOptions,
+  ) => Promise<SendAttemptResult>,
   sendSlashCommand: (
     name: string,
     args: string,
     agentId: string,
     opts?: SendOptions,
-  ) => Promise<boolean>,
+  ) => Promise<SendAttemptResult>,
   opts?: SendOptions,
-): Promise<boolean> {
+): Promise<SendAttemptResult> {
   return prompt.skill
     ? sendSlashCommand(prompt.skill.name, prompt.skill.args, agentId, opts)
     : send(prompt.text, agentId, prompt.files ?? [], opts);
@@ -5889,13 +5932,18 @@ export const INITIAL_PROMPT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_00
 export async function deliverInitialPrompt(params: {
   prompt: PendingInitialPrompt;
   agentId: string;
-  send: (text: string, agentId: string, files: File[], opts?: SendOptions) => Promise<boolean>;
+  send: (
+    text: string,
+    agentId: string,
+    files: File[],
+    opts?: SendOptions,
+  ) => Promise<SendAttemptResult>;
   sendSlashCommand: (
     name: string,
     args: string,
     agentId: string,
     opts?: SendOptions,
-  ) => Promise<boolean>;
+  ) => Promise<SendAttemptResult>;
   isCancelled?: () => boolean;
   retryDelaysMs?: number[];
   sleep?: (ms: number) => Promise<void>;
@@ -5916,7 +5964,7 @@ export async function deliverInitialPrompt(params: {
     // be an unexpected one, and treating it as "not settled" keeps the loop
     // (and the caller's bookkeeping) alive rather than stranding the prompt.
     // eslint-disable-next-line no-await-in-loop
-    const settled = await dispatchInitialPrompt(
+    const result = await dispatchInitialPrompt(
       params.prompt,
       params.agentId,
       params.send,
@@ -5924,8 +5972,9 @@ export async function deliverInitialPrompt(params: {
       // Only the final attempt lets the store paint the failure: an error
       // block per attempt would stack failures the next attempt resolves.
       { retryPending: !isFinal },
-    ).catch(() => false);
-    if (settled) return "delivered";
+    ).catch((): SendAttemptResult => "terminal_failure");
+    if (result === "settled") return "delivered";
+    if (result === "terminal_failure") return "failed";
     if (isFinal) return "failed";
     if (params.isCancelled?.() === true) return "cancelled";
     // eslint-disable-next-line no-await-in-loop
@@ -5948,9 +5997,8 @@ export async function deliverInitialPrompt(params: {
  * @param text The undelivered message text.
  */
 function stashUndeliveredPrompt(conversationId: string, text: string): void {
-  if (!text || sessionDrafts.get(conversationId)?.text) return;
-  sessionDrafts.set(conversationId, { text, files: [] });
-  saveDraftsToStorage(sessionDrafts);
+  if (!text || getSessionDraft(conversationId)?.text) return;
+  setSessionDraft(conversationId, { text, files: [] });
 }
 
 /**

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -106,11 +106,13 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { retrySession } from "@/lib/sessionsApi";
 import { codexEffortLevelsForModel, findNativeModelOption } from "@/lib/codexNativeModels";
 import {
+  clearPendingInitialPrompt,
   composerAttachmentKey,
-  consumePendingInitialPrompt,
+  peekPendingInitialPrompt,
   type PendingInitialPrompt,
   type PendingUserMessage,
   type QueuedMessage,
+  type SendOptions,
   useChatStore,
 } from "@/store/chatStore";
 import {
@@ -694,38 +696,42 @@ export function ChatPage() {
   const appName = useAppName();
   // Optional first message handed off by the landing composer through the
   // shared chatStore (keyed by conversation id), not router state — router state
-  // doesn't survive the embed's host-provided routing. Consumed read-once
-  // in the effect below so a refresh/back can't replay it, then held here
-  // so the auto-send effect re-runs once it's resolved.
-  // Bundled with the conversation id it was consumed for so the auto-send
-  // gate can reject a prompt that no longer matches the active session (the
+  // doesn't survive the embed's host-provided routing. Read non-destructively
+  // in the effect below (the store entry is the only copy of the user's text
+  // and is dropped only once delivery settles), then held here so the
+  // delivery effect re-runs once it's resolved.
+  // Bundled with the conversation id it was read for so the delivery gate
+  // can reject a prompt that no longer matches the active session (the
   // session-switch leak — see shouldSendInitialPrompt). `null` until the
-  // consume effect runs (or when no prompt was carried).
+  // read effect runs (or when no prompt was carried).
   const [initialPrompt, setInitialPrompt] = useState<{
     conversationId: string;
     prompt: PendingInitialPrompt;
   } | null>(null);
-  // The conversation id we already auto-sent an initial prompt for, or
-  // null. NOT a bare boolean: ChatPage stays mounted across `/c/:a` →
-  // `/c/:b` (no route `key`), so a boolean once-guard would latch true
-  // after the first auto-send and silently drop the prompt for every
+  // The conversation id whose initial-prompt delivery is in flight (or
+  // done), or null. NOT a bare boolean: ChatPage stays mounted across
+  // `/c/:a` → `/c/:b` (no route `key`), so a boolean once-guard would latch
+  // true after the first delivery and silently drop the prompt for every
   // subsequent new chat created without a full page reload. Keying the
   // guard by conversation id resets it per session while still covering
-  // StrictMode's double-invoke and re-renders within one session.
+  // StrictMode's double-invoke and re-renders within one session — and,
+  // because it is set synchronously before the first dispatch, it is what
+  // stops a retrying delivery from being started twice for one session.
   const initialPromptSentForConvRef = useRef<string | null>(null);
-  // Caches the consumed prompt keyed by conversation id so the consume
-  // effect is idempotent under StrictMode's setup→cleanup→setup
-  // double-invoke. `consumePendingInitialPrompt` is destructive (get +
-  // delete): the first invocation drains the store map, so a naive second
-  // invocation would read null and last-write-wins would settle
-  // `initialPrompt` to null — silently dropping the prompt in dev. By
-  // memoizing the first result per conv id, the second invocation reuses
-  // it. Keyed by id (not a bare value) so it still re-consumes for the
-  // next conversation when ChatPage stays mounted across `/c/:a` → `/c/:b`.
-  const consumedInitialPromptRef = useRef<{
-    conversationId: string;
-    prompt: PendingInitialPrompt | null;
-  } | null>(null);
+  // Conversation id of the delivery loop that is currently alive (including
+  // while it waits out a backoff), or null. Distinct from the guard above,
+  // which stays latched after a loop finishes: this one is what tells a
+  // re-arm whether a loop is already on the job, so returning to a session
+  // mid-backoff can never start a second one.
+  const initialPromptLoopRef = useRef<string | null>(null);
+  // True while the first message is still being delivered (including the
+  // waits between retries, when nothing else in the UI would show activity
+  // — the runner is offline, so the liveness-derived shimmer is suppressed).
+  const [deliveringInitialPrompt, setDeliveringInitialPrompt] = useState(false);
+  // The session the user is looking at right now, readable from async code
+  // that outlives a render (the delivery loop's cancellation check).
+  const activeConvIdRef = useRef<string | null>(urlConvId ?? null);
+  activeConvIdRef.current = urlConvId ?? null;
   const {
     data: agents,
     error: agentsError,
@@ -773,24 +779,25 @@ export function ChatPage() {
   }, [redirectToConversationId, urlConvId, navigate]);
 
   // Pull the first message the landing composer stashed for this conversation,
-  // if any. Read-once (consume deletes), so a refresh/back can't replay
-  // it. Runs in an effect (not render) because consume mutates the store
-  // map — calling it during render would double-consume under StrictMode.
-  // The per-conv-id cache (consumedInitialPromptRef) makes the consume
-  // idempotent across StrictMode's double-invoke: the first run drains the
-  // map and caches the result; the second run reuses the cache instead of
-  // re-consuming (which would read null and drop the prompt). Resetting to
-  // null when no prompt is pending clears a prior conversation's value
-  // when ChatPage stays mounted across `/c/:a` → `/c/:b`.
+  // if any. The read is non-destructive, so it is idempotent under
+  // StrictMode's double-invoke and — more importantly — survives anything
+  // that re-runs it before the message reaches the server (a remount, a
+  // failed bind, a navigate-away and back). The store entry is dropped by
+  // the delivery effect below, once the POST settles or delivery is finally
+  // given up on. Resetting to null when no prompt is pending clears a prior
+  // conversation's value when ChatPage stays mounted across `/c/:a` → `/c/:b`.
   useEffect(() => {
     if (!urlConvId) {
       setInitialPrompt(null);
       return;
     }
-    const cached = consumedInitialPromptRef.current;
-    const prompt =
-      cached?.conversationId === urlConvId ? cached.prompt : consumePendingInitialPrompt(urlConvId);
-    consumedInitialPromptRef.current = { conversationId: urlConvId, prompt };
+    const prompt = peekPendingInitialPrompt(urlConvId);
+    // Still pending with no loop on the job means a previous delivery
+    // attempt for this session stopped when the user navigated away.
+    // Re-arm the once-guard so arriving here again resumes it.
+    if (prompt !== null && initialPromptLoopRef.current === null) {
+      initialPromptSentForConvRef.current = null;
+    }
     setInitialPrompt(prompt === null ? null : { conversationId: urlConvId, prompt });
   }, [urlConvId]);
 
@@ -920,13 +927,18 @@ export function ChatPage() {
   // empty composer. Posting through chatStore.send is
   // agent-agnostic: event agents run a turn; native terminal agents
   // (Claude Code / Codex) have the runner inject the text into their
-  // CLI. The consume effect above already read-once-deleted the prompt
-  // from the store, so a refresh/back has nothing to replay. The ref
-  // guard (set synchronously before send, keyed by conversation id) also
-  // covers StrictMode's setup→cleanup→setup double-invoke: it persists
-  // across the remount, so the second setup short-circuits and the prompt
-  // sends once — while still resetting for the next conversation, since
-  // ChatPage stays mounted across `/c/:a` → `/c/:b`.
+  // CLI.
+  //
+  // A single attempt isn't enough: when several sessions are created in a
+  // burst on one host, the runner can take 30s+ to register, past the
+  // server's own hold, and the POST 503s. `deliverInitialPrompt` retries on
+  // a bounded backoff until the POST settles, then drops the store entry;
+  // until it does, the entry stays put so nothing between here and the
+  // server can lose the user's text. The ref guard (set synchronously
+  // before the first dispatch, keyed by conversation id) covers StrictMode's
+  // setup→cleanup→setup double-invoke AND keeps a second delivery loop from
+  // ever running for the same session — while still resetting for the next
+  // conversation, since ChatPage stays mounted across `/c/:a` → `/c/:b`.
   useEffect(() => {
     if (
       !shouldSendInitialPrompt({
@@ -944,9 +956,36 @@ export function ChatPage() {
     // re-check to narrow the types for send()/the template literal. The
     // predicate already guarantees these, so this never fires at runtime.
     if (initialPrompt === null || !agentId || !urlConvId) return;
-    initialPromptSentForConvRef.current = urlConvId;
-    const { send, sendSlashCommand } = useChatStore.getState();
-    dispatchInitialPrompt(initialPrompt.prompt, agentId, send, sendSlashCommand);
+    const convId = urlConvId;
+    const prompt = initialPrompt.prompt;
+    initialPromptSentForConvRef.current = convId;
+    initialPromptLoopRef.current = convId;
+    setDeliveringInitialPrompt(true);
+    void (async () => {
+      const { send, sendSlashCommand } = useChatStore.getState();
+      const outcome = await deliverInitialPrompt({
+        prompt,
+        agentId,
+        send,
+        sendSlashCommand,
+        // `send` pins whatever session the store is on at call time, so a
+        // retry must stop once the user is elsewhere — otherwise the first
+        // message would land in the session they switched to. Read live (not
+        // via an effect cleanup) so a benign re-render can't kill the loop.
+        isCancelled: () => activeConvIdRef.current !== convId,
+      });
+      initialPromptLoopRef.current = null;
+      setDeliveringInitialPrompt(false);
+      // Cancelled: nothing landed and nothing was dropped — the prompt
+      // stays stashed, and re-opening this session resumes delivery.
+      if (outcome === "cancelled") return;
+      // Delivered, or given up on after the final attempt surfaced the
+      // error block. Either way the prompt must not be replayed; on
+      // failure the text stays recoverable from the session's composer
+      // draft and its ArrowUp prompt history.
+      clearPendingInitialPrompt(convId);
+      if (outcome === "failed") stashUndeliveredPrompt(convId, prompt.text);
+    })();
   }, [initialPrompt, urlConvId, loadingConversation, agentId]);
 
   // Open state owned here (not inside MainAgentSurface) so the dialog
@@ -1050,16 +1089,18 @@ export function ChatPage() {
   const spinUpInFlight =
     sandboxLaunching ||
     Boolean(chatTerminalFirst?.isTerminalFirst && chatTerminalFirst.terminalStartingUp);
-  const showsWorking = computeShowsWorking(sessionStatus, {
-    hasPendingElicitation,
-    runnerOnline,
-    backgroundTaskCount,
-    // Optimistic: light up the moment this client dispatches, without waiting
-    // for the server's ``running``. The sidebar row already reads this same
-    // flag (``isStartingUp`` in Sidebar.tsx), so the two agreed only once the
-    // server confirmed; now they agree immediately.
-    localSendInFlight: status === "streaming" && !spinUpInFlight,
-  });
+  const showsWorking =
+    deliveringInitialPrompt ||
+    computeShowsWorking(sessionStatus, {
+      hasPendingElicitation,
+      runnerOnline,
+      backgroundTaskCount,
+      // Optimistic: light up the moment this client dispatches, without waiting
+      // for the server's ``running``. The sidebar row already reads this same
+      // flag (``isStartingUp`` in Sidebar.tsx), so the two agreed only once the
+      // server confirmed; now they agree immediately.
+      localSendInFlight: status === "streaming" && !spinUpInFlight,
+    });
 
   // A fork of a coding session carries the source id in this label (set by
   // fork_conversation). It is provenance — it persists after the clone is
@@ -5709,10 +5750,10 @@ export function computeShowsWorking(
  *   means the user switched sessions before the auto-send fired, so the
  *   prompt would leak into the now-active session.
  * @param params.sentForConversationId The conversation id the guard ref
- *   already auto-sent for, or ``null``. When it equals ``conversationId``
- *   the prompt was already dispatched for this session and must not
- *   resend; a different id (a later new chat reusing the mounted
- *   ChatPage) does not block.
+ *   already started delivery for, or ``null``. When it equals
+ *   ``conversationId`` a delivery loop already owns this session and must
+ *   not be started twice; a different id (a later new chat reusing the
+ *   mounted ChatPage) does not block.
  * @param params.conversationId Active session id from the URL, or
  *   ``null``/``undefined`` on the new-chat landing, e.g. ``"conv_abc"``.
  * @param params.loadingConversation ``true`` while the snapshot hydrates.
@@ -5783,25 +5824,133 @@ export function shouldSendResumePrompt(params: {
  * against the runner's real merged skill list once it registers.
  * Exported for unit testing.
  *
- * @param prompt The consumed pending prompt, e.g.
+ * @param prompt The pending prompt, e.g.
  *   ``{ text: "/review-pr 123", skill: { name: "review-pr", args: "123" } }``.
  * @param agentId Resolved agent id, e.g. ``"ag_abc123"``.
- * @param send ``chatStore.send`` — posts a plain user message. Always
- *   called with no files: the landing composer has no attachments.
+ * @param send ``chatStore.send`` — posts a plain user message.
  * @param sendSlashCommand ``chatStore.sendSlashCommand`` — posts a
  *   ``slash_command`` event.
+ * @param opts Forwarded to the store action; ``retryPending`` marks an
+ *   attempt the caller will retry, so the store keeps quiet about the
+ *   failure.
+ * @returns Whether the POST settled on the server.
  */
 export function dispatchInitialPrompt(
   prompt: PendingInitialPrompt,
   agentId: string,
-  send: (text: string, agentId: string, files: File[]) => Promise<void>,
-  sendSlashCommand: (name: string, args: string, agentId: string) => Promise<void>,
-): void {
-  if (prompt.skill) {
-    void sendSlashCommand(prompt.skill.name, prompt.skill.args, agentId);
-  } else {
-    void send(prompt.text, agentId, prompt.files ?? []);
+  send: (text: string, agentId: string, files: File[], opts?: SendOptions) => Promise<boolean>,
+  sendSlashCommand: (
+    name: string,
+    args: string,
+    agentId: string,
+    opts?: SendOptions,
+  ) => Promise<boolean>,
+  opts?: SendOptions,
+): Promise<boolean> {
+  return prompt.skill
+    ? sendSlashCommand(prompt.skill.name, prompt.skill.args, agentId, opts)
+    : send(prompt.text, agentId, prompt.files ?? [], opts);
+}
+
+/**
+ * Backoff before each retry of the landing composer's first message, in ms.
+ *
+ * The first attempt is immediate, so a normal ~6s runner start is entirely
+ * unaffected — the server absorbs that race by holding ``POST /events``
+ * open. These waits only come into play once a hold has already timed out,
+ * and together with each attempt's own server-side hold they cover the
+ * 30s+ runner starts seen when several sessions launch on one host at once.
+ */
+export const INITIAL_PROMPT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 15_000];
+
+/**
+ * Deliver the landing composer's first message, retrying a failed POST on
+ * a bounded backoff.
+ *
+ * Attempts are strictly sequential — the next one starts only after the
+ * previous has resolved as *not settled* — so a retry can never race a
+ * late success into a duplicate message. Cancellation (the user left the
+ * session) is honoured only between attempts, for the same reason: an
+ * in-flight dispatch must report its outcome before the loop stops, or
+ * the caller couldn't tell "nothing landed" from "it landed after we
+ * stopped watching". Exported for unit testing.
+ *
+ * @param params.prompt The pending prompt to deliver.
+ * @param params.agentId Resolved agent id, e.g. ``"ag_abc123"``.
+ * @param params.send ``chatStore.send``.
+ * @param params.sendSlashCommand ``chatStore.sendSlashCommand``.
+ * @param params.isCancelled Polled between attempts; ``true`` stops the loop.
+ * @param params.retryDelaysMs Backoff overrides (tests).
+ * @param params.sleep Timer override (tests).
+ * @returns ``"delivered"`` once the POST settled, ``"cancelled"`` when the
+ *   loop stopped with nothing delivered, or ``"failed"`` when every
+ *   attempt failed — the last of which surfaced the error to the user.
+ */
+export async function deliverInitialPrompt(params: {
+  prompt: PendingInitialPrompt;
+  agentId: string;
+  send: (text: string, agentId: string, files: File[], opts?: SendOptions) => Promise<boolean>;
+  sendSlashCommand: (
+    name: string,
+    args: string,
+    agentId: string,
+    opts?: SendOptions,
+  ) => Promise<boolean>;
+  isCancelled?: () => boolean;
+  retryDelaysMs?: number[];
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<"delivered" | "cancelled" | "failed"> {
+  const delays = params.retryDelaysMs ?? INITIAL_PROMPT_RETRY_DELAYS_MS;
+  const sleep =
+    params.sleep ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      }));
+  // Sequential by design: each attempt must resolve before the next starts,
+  // or a retry could race a late success into a duplicate message — hence
+  // the awaits in the loop below.
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    const isFinal = attempt === delays.length;
+    // The store actions settle their own failures; a rejection here would
+    // be an unexpected one, and treating it as "not settled" keeps the loop
+    // (and the caller's bookkeeping) alive rather than stranding the prompt.
+    // eslint-disable-next-line no-await-in-loop
+    const settled = await dispatchInitialPrompt(
+      params.prompt,
+      params.agentId,
+      params.send,
+      params.sendSlashCommand,
+      // Only the final attempt lets the store paint the failure: an error
+      // block per attempt would stack failures the next attempt resolves.
+      { retryPending: !isFinal },
+    ).catch(() => false);
+    if (settled) return "delivered";
+    if (isFinal) return "failed";
+    if (params.isCancelled?.() === true) return "cancelled";
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(delays[attempt] ?? 0);
+    if (params.isCancelled?.() === true) return "cancelled";
   }
+  return "failed";
+}
+
+/**
+ * Park an undelivered first message in the session's composer draft.
+ *
+ * Last line of defence for requirement "never lose what the user typed":
+ * when every delivery attempt failed, the error block explains why and the
+ * text comes back in the composer the next time the session is opened
+ * (it is also in the session's ArrowUp prompt history). Never overwrites an
+ * existing draft — the user may have typed something since.
+ *
+ * @param conversationId Session the prompt was meant for, e.g. ``"conv_abc"``.
+ * @param text The undelivered message text.
+ */
+function stashUndeliveredPrompt(conversationId: string, text: string): void {
+  if (!text || sessionDrafts.get(conversationId)?.text) return;
+  sessionDrafts.set(conversationId, { text, files: [] });
+  saveDraftsToStorage(sessionDrafts);
 }
 
 /**

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -55,7 +55,8 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
-  consumePendingInitialPrompt,
+  clearPendingInitialPrompt,
+  peekPendingInitialPrompt,
   handleSessionEvent,
   isStaleCompletedResponse,
   initChatStore,
@@ -9129,36 +9130,62 @@ describe("chatStore — startStreamPump reconnect loop", () => {
 });
 
 // The first-message handoff from the landing composer to ChatPage. The
-// read-once delete is what replaces the old router-state clear: it must
-// return the prompt exactly once so a refresh/back can't replay it.
+// read is deliberately NON-destructive: the entry is the only copy of the
+// user's typed text, so it must survive every re-read between arriving on
+// the chat page and the message settling on the server. Only an explicit
+// clear (after delivery) drops it, which is what stops a replay.
 describe("pending initial prompt transport", () => {
-  it("returns the stashed prompt exactly once, then null", () => {
+  it("returns the stashed prompt on every read until it is cleared", () => {
     setPendingInitialPrompt("conv_abc", { text: "read the README", skill: null });
-    // First consume yields the stashed prompt verbatim.
-    expect(consumePendingInitialPrompt("conv_abc")).toEqual({
+    // Repeated reads all yield the stashed prompt verbatim — a remount, a
+    // failed bind, or a StrictMode double-invoke must not drain it.
+    expect(peekPendingInitialPrompt("conv_abc")).toEqual({
       text: "read the README",
       skill: null,
     });
-    // Second consume yields null — the delete prevents a replay.
-    expect(consumePendingInitialPrompt("conv_abc")).toBeNull();
+    expect(peekPendingInitialPrompt("conv_abc")).toEqual({
+      text: "read the README",
+      skill: null,
+    });
+    clearPendingInitialPrompt("conv_abc");
+    // Cleared once delivery settled — a refresh/back can't replay it.
+    expect(peekPendingInitialPrompt("conv_abc")).toBeNull();
   });
 
   it("returns null for a conversation with no pending prompt", () => {
-    expect(consumePendingInitialPrompt("conv_never_set")).toBeNull();
+    expect(peekPendingInitialPrompt("conv_never_set")).toBeNull();
+  });
+
+  it("survives a re-read after a failed startup request re-runs the page", () => {
+    // A supporting request that 500s while the runner boots (the terminals
+    // listing, say) re-renders — and can remount — the chat page, which
+    // re-reads the prompt. Under the old read-once transport that second
+    // read drained the map and the typed text was gone for good.
+    setPendingInitialPrompt("conv_slow_runner", { text: "read the README", skill: null });
+    expect(peekPendingInitialPrompt("conv_slow_runner")).not.toBeNull();
+    expect(peekPendingInitialPrompt("conv_slow_runner")).toEqual({
+      text: "read the README",
+      skill: null,
+    });
+    clearPendingInitialPrompt("conv_slow_runner");
   });
 
   it("ignores a blank prompt so a blank message never auto-sends", () => {
     setPendingInitialPrompt("conv_blank", { text: "", skill: null });
-    // Nothing was stored, so the consume reads null.
-    expect(consumePendingInitialPrompt("conv_blank")).toBeNull();
+    // Nothing was stored, so the read yields null.
+    expect(peekPendingInitialPrompt("conv_blank")).toBeNull();
   });
 
   it("keys prompts by conversation id so they don't cross sessions", () => {
     setPendingInitialPrompt("conv_a", { text: "prompt for A", skill: null });
     setPendingInitialPrompt("conv_b", { text: "prompt for B", skill: null });
-    // Each conversation consumes only its own prompt.
-    expect(consumePendingInitialPrompt("conv_b")).toEqual({ text: "prompt for B", skill: null });
-    expect(consumePendingInitialPrompt("conv_a")).toEqual({ text: "prompt for A", skill: null });
+    // Each conversation reads only its own prompt, and clearing one leaves
+    // the other pending.
+    expect(peekPendingInitialPrompt("conv_b")).toEqual({ text: "prompt for B", skill: null });
+    clearPendingInitialPrompt("conv_b");
+    expect(peekPendingInitialPrompt("conv_b")).toBeNull();
+    expect(peekPendingInitialPrompt("conv_a")).toEqual({ text: "prompt for A", skill: null });
+    clearPendingInitialPrompt("conv_a");
   });
 
   it("carries a matched skill invocation through intact", () => {
@@ -9170,10 +9197,11 @@ describe("pending initial prompt transport", () => {
       text: "/review-pr 123 focus on auth",
       skill: { name: "review-pr", args: "123 focus on auth" },
     });
-    expect(consumePendingInitialPrompt("conv_skill")).toEqual({
+    expect(peekPendingInitialPrompt("conv_skill")).toEqual({
       text: "/review-pr 123 focus on auth",
       skill: { name: "review-pr", args: "123 focus on auth" },
     });
+    clearPendingInitialPrompt("conv_skill");
   });
 });
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2197,9 +2197,10 @@ describe("chatStore — send (first-send ordering)", () => {
       return defaultFetchHandler(input, init);
     });
 
-    await useChatStore.getState().send("hi", "agent_xyz");
+    const result = await useChatStore.getState().send("hi", "agent_xyz");
 
     const state = useChatStore.getState();
+    expect(result).toBe("retryable_failure");
     // Optimistic bubble rolled back, turn settled to idle.
     expect(state.pendingUserMessages).toEqual([]);
     expect(state.status).toBe("idle");
@@ -2214,6 +2215,106 @@ describe("chatStore — send (first-send ordering)", () => {
       message: "The runner didn't come online in time. Please try again.",
       code: "",
     });
+  });
+
+  it("keeps only a retryable runner-unavailable attempt silent and draft-free", async () => {
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "idle",
+      blocks: [],
+      failedSendDraft: null,
+    });
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/events")) {
+        return mockResponse(
+          { error: { code: "runner_unavailable", message: "No runner bound for session" } },
+          { ok: false, status: 503 },
+        );
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const result = await useChatStore
+      .getState()
+      .send("hi", "agent_xyz", [], { retryPending: true });
+
+    const state = useChatStore.getState();
+    expect(result).toBe("retryable_failure");
+    expect(state.blocks.filter((block) => block.type === "error")).toEqual([]);
+    expect(state.failedSendDraft).toBeNull();
+  });
+
+  it("surfaces an ambiguous failure even when a caller requested retries", async () => {
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "idle",
+      blocks: [],
+      failedSendDraft: null,
+    });
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/events")) {
+        return Promise.reject(new TypeError("response lost after send"));
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const result = await useChatStore
+      .getState()
+      .send("do this once", "agent_xyz", [], { retryPending: true });
+
+    const state = useChatStore.getState();
+    expect(result).toBe("terminal_failure");
+    expect(state.failedSendDraft).toMatchObject({
+      conversationId: "conv_existing",
+      text: "do this once",
+    });
+    expect(state.blocks.filter((block) => block.type === "error")).toHaveLength(1);
+  });
+
+  it("does not retry runner-unavailable failures emitted after persistence", async () => {
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "idle",
+      blocks: [],
+      failedSendDraft: null,
+    });
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/events")) {
+        return mockResponse(
+          {
+            error: {
+              code: "runner_unavailable",
+              message: "Runner is unreachable; message was persisted but could not be delivered.",
+            },
+          },
+          { ok: false, status: 503 },
+        );
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const result = await useChatStore
+      .getState()
+      .send("do this once", "agent_xyz", [], { retryPending: true });
+
+    const state = useChatStore.getState();
+    expect(result).toBe("terminal_failure");
+    expect(state.failedSendDraft).toMatchObject({
+      conversationId: "conv_existing",
+      text: "do this once",
+    });
+    expect(state.blocks.filter((block) => block.type === "error")).toMatchObject([
+      {
+        message: "Runner is unreachable; message was persisted but could not be delivered.",
+        code: "runner_unavailable",
+      },
+    ]);
   });
 
   it("carries a non-runner send failure's own message into the error block", async () => {
@@ -2237,9 +2338,10 @@ describe("chatStore — send (first-send ordering)", () => {
       return defaultFetchHandler(input, init);
     });
 
-    await useChatStore.getState().send("hi", "agent_xyz");
+    const result = await useChatStore.getState().send("hi", "agent_xyz");
 
     const errorBlocks = useChatStore.getState().blocks.filter((b) => b.type === "error");
+    expect(result).toBe("terminal_failure");
     expect(errorBlocks).toHaveLength(1);
     expect(errorBlocks[0]).toMatchObject({
       type: "error",

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2275,7 +2275,7 @@ describe("chatStore — send (first-send ordering)", () => {
     expect(state.blocks.filter((block) => block.type === "error")).toHaveLength(1);
   });
 
-  it("does not retry runner-unavailable failures emitted after persistence", async () => {
+  it("settles post-persistence runner failures without restoring a duplicate draft", async () => {
     useChatStore.setState({
       conversationId: "conv_existing",
       abortController: new AbortController(),
@@ -2304,11 +2304,10 @@ describe("chatStore — send (first-send ordering)", () => {
       .send("do this once", "agent_xyz", [], { retryPending: true });
 
     const state = useChatStore.getState();
-    expect(result).toBe("terminal_failure");
-    expect(state.failedSendDraft).toMatchObject({
-      conversationId: "conv_existing",
-      text: "do this once",
-    });
+    expect(result).toBe("settled");
+    expect(state.failedSendDraft).toBeNull();
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.pendingUserMessages[0]?.posted).toBe(true);
     expect(state.blocks.filter((block) => block.type === "error")).toMatchObject([
       {
         message: "Runner is unreachable; message was persisted but could not be delivered.",

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1770,8 +1770,13 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     } catch (err) {
       const { message, code } = describeSendFailure(err);
       const retryableFailure = isSafeInitialPromptRetry(err);
+      const persistedFailure = isPersistedRunnerFailure(err);
       const suppressFailure = opts?.retryPending === true && retryableFailure;
-      result = retryableFailure ? "retryable_failure" : "terminal_failure";
+      result = persistedFailure
+        ? "settled"
+        : retryableFailure
+          ? "retryable_failure"
+          : "terminal_failure";
       // Hand the failed message back to the composer so the user can retry it —
       // a failed send has no server-side record, so nothing else would restore
       // it. Keyed by the session it was meant for, so it lands in the right
@@ -1781,6 +1786,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       const draftSessionId = postedSessionId ?? submitConversationId;
       if (
         !suppressFailure &&
+        !persistedFailure &&
         draftSessionId !== null &&
         (text.trim() !== "" || (files?.length ?? 0) > 0)
       ) {
@@ -1796,9 +1802,13 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
       const failGet = (): ChatState =>
         postedSessionId === null ? get() : (setterForState(postedSessionId) ?? get());
-      // Roll back the optimistic bubble — no server idle will fire.
+      // A post-persistence forwarding failure has a durable server item even
+      // though the POST failed. Keep its optimistic bubble until snapshot
+      // reconciliation; restoring the same text would invite a duplicate.
       failSet((s) => ({
-        pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+        pendingUserMessages: persistedFailure
+          ? s.pendingUserMessages.map((p) => (p.tempId === tempId ? { ...p, posted: true } : p))
+          : s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
         if (suppressFailure) {
@@ -1931,8 +1941,13 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const retryableFailure = isSafeInitialPromptRetry(err);
+      const persistedFailure = isPersistedRunnerFailure(err);
       const suppressFailure = opts?.retryPending === true && retryableFailure;
-      result = retryableFailure ? "retryable_failure" : "terminal_failure";
+      result = persistedFailure
+        ? "settled"
+        : retryableFailure
+          ? "retryable_failure"
+          : "terminal_failure";
       // Settle the conversation this command targeted, wherever the user is
       // now: its echo must roll back and its status must not stay "streaming"
       // forever. A throw from session setup itself (`postedSessionId` never
@@ -1940,14 +1955,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // the landing composer's own failure. Mirrors `send`'s catch.
       const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
       const draftSessionId = postedSessionId ?? submitConversationId;
-      if (!suppressFailure && draftSessionId !== null) {
+      if (!suppressFailure && !persistedFailure && draftSessionId !== null) {
         setterFor(draftSessionId)({
           failedSendDraft: { conversationId: draftSessionId, text: commandText, files: [] },
         });
       }
-      // Roll back the optimistic echo — no receipt will reconcile it.
+      // Keep an echo the server says it persisted; snapshots reconcile it.
       failSet((s) => ({
-        pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+        pendingUserMessages: persistedFailure
+          ? s.pendingUserMessages.map((p) => (p.tempId === tempId ? { ...p, posted: true } : p))
+          : s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
         if (!suppressFailure) finalizeActive(failSet, "failed", message, null);
@@ -6197,6 +6214,16 @@ function isSafeInitialPromptRetry(err: unknown): boolean {
     err.status === 503 &&
     err.code === RUNNER_UNAVAILABLE_CODE &&
     err.message === "No runner bound for session"
+  );
+}
+
+/** The server persisted this input before its runner forward failed. */
+function isPersistedRunnerFailure(err: unknown): boolean {
+  return (
+    err instanceof ApiError &&
+    err.status === 503 &&
+    err.code === RUNNER_UNAVAILABLE_CODE &&
+    err.message.startsWith("Runner is unreachable; message was persisted")
   );
 }
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -137,15 +137,16 @@ export interface SendOptions {
    */
   onConversationCreated?: (conversationId: string) => void;
   /**
-   * The caller retries this send itself on failure (the initial-prompt
-   * delivery loop). Suppresses the user-visible failure block so a
-   * transient "runner still booting" 503 doesn't paint an error the
-   * retry is about to resolve; the caller surfaces the error on its
-   * final attempt instead. Status still settles and the optimistic
-   * bubble still rolls back.
+   * The initial-prompt delivery loop can retry a proven-safe
+   * runner-unavailable 503. Suppresses that transient attempt's draft and
+   * error surface; all other failures remain terminal and visible because
+   * their server-acceptance state may be ambiguous.
    */
   retryPending?: boolean;
 }
+
+/** Result of one message or slash-command POST attempt. */
+export type SendAttemptResult = "settled" | "retryable_failure" | "terminal_failure";
 
 /**
  * A user message awaiting its `session.input.consumed` event.
@@ -653,11 +654,14 @@ export interface AppChatState {
 /** Actions exposed on the root store. */
 export interface ChatActions {
   /**
-   * Post a user message. Resolves ``true`` once the POST settled on the
-   * server (accepted, or terminally refused by policy) and ``false`` when
-   * it failed — the signal the initial-prompt delivery loop retries on.
+   * Post a user message and classify whether a failed attempt is safe to retry.
    */
-  send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<boolean>;
+  send: (
+    text: string,
+    agentId: string,
+    files?: File[],
+    opts?: SendOptions,
+  ) => Promise<SendAttemptResult>;
   /**
    * Queue a message client-side instead of POSTing it now, for a send made
    * while the agent is busy. The head is flushed automatically (FIFO, one per
@@ -717,15 +721,14 @@ export interface ChatActions {
    *
    * :param name: Skill name without the leading ``/``, e.g. ``"grill-me"``.
    * :param args: Raw argument text typed after the command, ``""`` if none.
-   * :returns: ``true`` once the POST settled on the server, ``false`` when
-   *     it failed — same retry signal as ``send``.
+   * :returns: The same retry classification as ``send``.
    */
   sendSlashCommand: (
     name: string,
     args: string,
     agentId: string,
     opts?: SendOptions,
-  ) => Promise<boolean>;
+  ) => Promise<SendAttemptResult>;
   stop: () => void;
   switchTo: (conversationId: string | null) => Promise<void>;
   submitApproval: (
@@ -1671,10 +1674,9 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // The session this send actually posts to, once resolved. Read in the
     // catch to decide whether a failure may touch the active session's UI.
     let postedSessionId: string | null = null;
-    // Whether the POST settled on the server (accepted or policy-denied).
-    // Returned to the caller so a retrying caller can tell "the server has
-    // it" from "nothing landed".
-    let settled = false;
+    // Only the server's explicit pre-acceptance runner-unavailable response
+    // is safe to replay. Other failures may follow server acceptance.
+    let result: SendAttemptResult = "terminal_failure";
 
     try {
       await waitForPrior();
@@ -1719,7 +1721,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           content: serverContent,
         },
       });
-      settled = true;
+      result = "settled";
       // Policy denied the input — the server returned immediately
       // without starting a turn or persisting the user message, so
       // no session.input.consumed will reconcile this exact optimistic
@@ -1767,6 +1769,9 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       queryClient?.invalidateQueries({ queryKey: ["conversations"] });
     } catch (err) {
       const { message, code } = describeSendFailure(err);
+      const retryableFailure = isSafeInitialPromptRetry(err);
+      const suppressFailure = opts?.retryPending === true && retryableFailure;
+      result = retryableFailure ? "retryable_failure" : "terminal_failure";
       // Hand the failed message back to the composer so the user can retry it —
       // a failed send has no server-side record, so nothing else would restore
       // it. Keyed by the session it was meant for, so it lands in the right
@@ -1774,7 +1779,11 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // (`failedSendDraft` is conversation-scoped); the composer reads whichever
       // conversation is active and guards on the id before restoring.
       const draftSessionId = postedSessionId ?? submitConversationId;
-      if (draftSessionId !== null && (text.trim() !== "" || (files?.length ?? 0) > 0)) {
+      if (
+        !suppressFailure &&
+        draftSessionId !== null &&
+        (text.trim() !== "" || (files?.length ?? 0) > 0)
+      ) {
         setterFor(draftSessionId)({
           failedSendDraft: { conversationId: draftSessionId, text, files: files ?? [] },
         });
@@ -1792,7 +1801,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
-        if (opts?.retryPending === true) {
+        if (suppressFailure) {
           // The bounded initial-prompt retry loop owns the final error surface.
         } else if (failGet().activeResponse !== null) {
           // A response bubble already exists (the turn started, then failed)
@@ -1811,7 +1820,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           backgroundTaskCount: 0,
           backgroundTasks: [],
         });
-      } else {
+      } else if (!suppressFailure) {
         // Sent alongside an already-streaming turn (or a stranded latch): the
         // bubble is rolled back above, so without a block the message vanishes
         // with no trace — the failure mode that makes this class of bug so hard
@@ -1825,7 +1834,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // failed POST can't stall the chain forever.
       releaseSend();
     }
-    return settled;
+    return result;
   },
 
   sendSlashCommand: async (name, args, agentId, opts) => {
@@ -1871,8 +1880,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
 
     // The session this command actually posts to, once resolved.
     let postedSessionId: string | null = null;
-    // Whether the POST settled on the server — see `send`.
-    let settled = false;
+    // Retry classification mirrors `send`.
+    let result: SendAttemptResult = "terminal_failure";
 
     try {
       await waitForPrior();
@@ -1886,7 +1895,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         type: "slash_command",
         data: { kind: "skill", name, arguments: args },
       });
-      settled = true;
+      result = "settled";
       if (postResult.denied) {
         // Denied commands publish no receipt, so nothing will pop the
         // optimistic echo — roll it back here alongside the status settle.
@@ -1921,20 +1930,29 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       queryClient?.invalidateQueries({ queryKey: ["conversations"] });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      const retryableFailure = isSafeInitialPromptRetry(err);
+      const suppressFailure = opts?.retryPending === true && retryableFailure;
+      result = retryableFailure ? "retryable_failure" : "terminal_failure";
       // Settle the conversation this command targeted, wherever the user is
       // now: its echo must roll back and its status must not stay "streaming"
       // forever. A throw from session setup itself (`postedSessionId` never
       // resolved) has no target conversation, so it belongs to the active one —
       // the landing composer's own failure. Mirrors `send`'s catch.
       const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      const draftSessionId = postedSessionId ?? submitConversationId;
+      if (!suppressFailure && draftSessionId !== null) {
+        setterFor(draftSessionId)({
+          failedSendDraft: { conversationId: draftSessionId, text: commandText, files: [] },
+        });
+      }
       // Roll back the optimistic echo — no receipt will reconcile it.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
-        if (opts?.retryPending !== true) finalizeActive(failSet, "failed", message, null);
+        if (!suppressFailure) finalizeActive(failSet, "failed", message, null);
         failSet({ status: "idle" });
-      } else {
+      } else if (!suppressFailure) {
         // Same as `send`: surface the failure without settling a turn that may
         // still be live, so a failed command can't vanish silently.
         const { code } = describeSendFailure(err);
@@ -1943,7 +1961,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     } finally {
       releaseSend();
     }
-    return settled;
+    return result;
   },
 
   stop: () => {
@@ -6169,6 +6187,20 @@ function finalizeActive(
 const RUNNER_UNAVAILABLE_CODE = "runner_unavailable";
 
 /**
+ * Only this exact legacy response proves the event was rejected before
+ * persistence. The server also uses `runner_unavailable` after persistence
+ * when forwarding fails, so status and code alone are unsafe to replay.
+ */
+function isSafeInitialPromptRetry(err: unknown): boolean {
+  return (
+    err instanceof ApiError &&
+    err.status === 503 &&
+    err.code === RUNNER_UNAVAILABLE_CODE &&
+    err.message === "No runner bound for session"
+  );
+}
+
+/**
  * Turn a thrown send failure into user-facing banner text + a code.
  *
  * The runner-unavailable 503 gets self-explanatory copy (and no raw code in
@@ -6178,7 +6210,7 @@ const RUNNER_UNAVAILABLE_CODE = "runner_unavailable";
  * when present for debuggability.
  */
 function describeSendFailure(err: unknown): { message: string; code: string } {
-  if (err instanceof ApiError && err.code === RUNNER_UNAVAILABLE_CODE) {
+  if (isSafeInitialPromptRetry(err)) {
     return {
       message: "The runner didn't come online in time. Please try again.",
       code: "",

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -136,6 +136,15 @@ export interface SendOptions {
    * `send` already set `conversationId` before the callback.
    */
   onConversationCreated?: (conversationId: string) => void;
+  /**
+   * The caller retries this send itself on failure (the initial-prompt
+   * delivery loop). Suppresses the user-visible failure block so a
+   * transient "runner still booting" 503 doesn't paint an error the
+   * retry is about to resolve; the caller surfaces the error on its
+   * final attempt instead. Status still settles and the optimistic
+   * bubble still rolls back.
+   */
+  retryPending?: boolean;
 }
 
 /**
@@ -643,7 +652,12 @@ export interface AppChatState {
 
 /** Actions exposed on the root store. */
 export interface ChatActions {
-  send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<void>;
+  /**
+   * Post a user message. Resolves ``true`` once the POST settled on the
+   * server (accepted, or terminally refused by policy) and ``false`` when
+   * it failed — the signal the initial-prompt delivery loop retries on.
+   */
+  send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<boolean>;
   /**
    * Queue a message client-side instead of POSTing it now, for a send made
    * while the agent is busy. The head is flushed automatically (FIFO, one per
@@ -703,13 +717,15 @@ export interface ChatActions {
    *
    * :param name: Skill name without the leading ``/``, e.g. ``"grill-me"``.
    * :param args: Raw argument text typed after the command, ``""`` if none.
+   * :returns: ``true`` once the POST settled on the server, ``false`` when
+   *     it failed — same retry signal as ``send``.
    */
   sendSlashCommand: (
     name: string,
     args: string,
     agentId: string,
     opts?: SendOptions,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   stop: () => void;
   switchTo: (conversationId: string | null) => Promise<void>;
   submitApproval: (
@@ -1273,21 +1289,36 @@ export function setPendingInitialPrompt(
 }
 
 /**
- * Read and remove the pending first message for a conversation. Read-once
- * (get + delete): the delete is what prevents a refresh/back from
- * replaying the prompt, replacing the old `navigate(..., { state: null })`
- * clear.
+ * Read the pending first message for a conversation WITHOUT removing it.
  *
- * @param conversationId The conversation id to consume for, e.g.
+ * Non-destructive on purpose: the entry is the only copy of the user's
+ * typed text, so it must survive everything between arriving on
+ * `/c/:id` and the message actually reaching the server — a ChatPage
+ * remount, a StrictMode double-invoke, a failed session bind, a
+ * supporting request 500ing while the runner boots, or a navigate-away
+ * and back. Only `clearPendingInitialPrompt` (called once delivery
+ * succeeds or is finally given up on) drops it, which is also what
+ * keeps a refresh/back from replaying an already-sent prompt.
+ *
+ * @param conversationId The conversation id to read for, e.g.
  *   `"conv_abc123"`.
- * @returns The stashed prompt, or `null` when none was set (or it was
- *   already consumed).
+ * @returns The stashed prompt, or `null` when none is pending.
  */
-export function consumePendingInitialPrompt(conversationId: string): PendingInitialPrompt | null {
-  const prompt = pendingInitialPrompts.get(conversationId);
-  if (prompt === undefined) return null;
+export function peekPendingInitialPrompt(conversationId: string): PendingInitialPrompt | null {
+  return pendingInitialPrompts.get(conversationId) ?? null;
+}
+
+/**
+ * Drop the pending first message for a conversation.
+ *
+ * Called once the message has settled on the server, or once delivery
+ * has been given up on and the failure surfaced to the user — never
+ * merely because it was read.
+ *
+ * @param conversationId The conversation id to clear, e.g. `"conv_abc123"`.
+ */
+export function clearPendingInitialPrompt(conversationId: string): void {
   pendingInitialPrompts.delete(conversationId);
-  return prompt;
 }
 
 export const useChatStore = create<ChatState>((_rootSet, get) => ({
@@ -1640,6 +1671,10 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // The session this send actually posts to, once resolved. Read in the
     // catch to decide whether a failure may touch the active session's UI.
     let postedSessionId: string | null = null;
+    // Whether the POST settled on the server (accepted or policy-denied).
+    // Returned to the caller so a retrying caller can tell "the server has
+    // it" from "nothing landed".
+    let settled = false;
 
     try {
       await waitForPrior();
@@ -1684,6 +1719,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           content: serverContent,
         },
       });
+      settled = true;
       // Policy denied the input — the server returned immediately
       // without starting a turn or persisting the user message, so
       // no session.input.consumed will reconcile this exact optimistic
@@ -1756,7 +1792,9 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
-        if (failGet().activeResponse !== null) {
+        if (opts?.retryPending === true) {
+          // The bounded initial-prompt retry loop owns the final error surface.
+        } else if (failGet().activeResponse !== null) {
           // A response bubble already exists (the turn started, then failed)
           // — mark it failed so the error rides on that bubble.
           finalizeActive(failSet, "failed", message, null);
@@ -1787,6 +1825,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // failed POST can't stall the chain forever.
       releaseSend();
     }
+    return settled;
   },
 
   sendSlashCommand: async (name, args, agentId, opts) => {
@@ -1832,6 +1871,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
 
     // The session this command actually posts to, once resolved.
     let postedSessionId: string | null = null;
+    // Whether the POST settled on the server — see `send`.
+    let settled = false;
 
     try {
       await waitForPrior();
@@ -1845,6 +1886,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         type: "slash_command",
         data: { kind: "skill", name, arguments: args },
       });
+      settled = true;
       if (postResult.denied) {
         // Denied commands publish no receipt, so nothing will pop the
         // optimistic echo — roll it back here alongside the status settle.
@@ -1890,7 +1932,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
       }));
       if (!alreadyStreaming) {
-        finalizeActive(failSet, "failed", message, null);
+        if (opts?.retryPending !== true) finalizeActive(failSet, "failed", message, null);
         failSet({ status: "idle" });
       } else {
         // Same as `send`: surface the failure without settling a turn that may
@@ -1901,6 +1943,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     } finally {
       releaseSend();
     }
+    return settled;
   },
 
   stop: () => {


### PR DESCRIPTION
## Stack

Depends on [PR #5836](https://github.com/omnigent-ai/omnigent/pull/5836), which guards duplicate client submissions.

---

## Summary

A session created from the New Chat dialog with a typed first prompt could open
idle with an empty transcript — the user's text silently gone. Observed live:
two sessions created from the same prompt eleven minutes apart, one delivered,
one never made a single `POST /v1/sessions/{id}/events` call at all.

Two independent defects, both long-standing:

1. **The pending prompt was a destructive read.** `NewChatDialog` stashes the
   typed text in a module-level map keyed by the new conversation id, then
   navigates; `ChatPage` read it *and deleted it* in the same effect, leaving
   the only copy in component state. A remount, a re-entry after a failed
   stream bind, or a navigate-away-and-back re-reads `null` and the text is
   unrecoverable. The existing per-mount ref guard covers StrictMode's
   double-invoke and nothing else.

2. **Delivery was one fire-and-forget attempt.** The send path deliberately
   does not wait on runner liveness, relying on the server holding
   `POST /events` open (connect grace + relaunch + wait). That covers a normal
   ~6s runner start. It does not cover the 21–29s starts seen when several
   sessions are created in a burst on one host: the hold times out, the POST
   503s, the optimistic bubble rolls back, and nothing tries again — with the
   store entry already deleted, there was nothing left to retry from.

The fix makes the read non-destructive (`peek` + explicit `clear`, dropped only
once the POST settles or delivery is finally abandoned) and makes delivery a
bounded-backoff loop with strictly sequential attempts. While delivery is
pending the surface shows working rather than idle. If the schedule is
exhausted, the user sees an error and the text is returned to the composer
draft rather than lost. A module-scoped, per-session delivery registry prevents
a ChatPage remount from starting an overlapping retry loop. Final restoration
refuses to overwrite a draft the user created while retries were running,
including a files-only draft.

Independent of the Smart Routing work — this hazard pre-dates it and affects
every harness and both routed and unrouted creates.

## Test Plan

- `vitest run src/pages/ChatPage.test.ts src/store/chatStore.test.ts` — 463
  passed; with the composer / indicators / userBubble / NewChatDialog.flow
  suites, 705 passed.
- New coverage: runner offline across four consecutive attempts still delivers
  exactly once; the loop stops the instant an attempt settles; no backoff sleep
  on a first-attempt success (fast starts keep today's latency); cancellation
  reports without delivering; the slash-command path retries too; and the
  prompt survives a re-read after a failed startup request re-runs the page.
- `tsc --noEmit`, `oxlint --deny-warnings`, `pre-commit` on changed files: clean.
- `pytest -q tests/e2e_ui/sessions/test_initial_prompt_session_switch.py::test_initial_prompt_retries_across_chat_page_remount_exactly_once --ui-skip-build` — passed at `1159de8b`; one runner 503 plus a Settings remount still committed the initial prompt and follow-up exactly once.
- `vitest run src/pages/ChatPage.test.ts` — 185 passed at `1159de8b`, including the completion-audit regression that preserves an existing files-only draft on terminal failure.
- Manual: create a chat with a typed prompt (normal start unchanged); create
  4–5 in quick succession so runner registration backs up past ~20s — each
  shows working while waiting, then delivers exactly once.

## Demo

Behaviour, not new surface: the only visible additions are a working state
while delivery is pending and an error block plus a restored composer draft on
give-up. Video to be attached before merge.

## Type of change

- [x] Bug fix
- [x] UI / frontend change

## Test coverage

- [x] Unit tests added/updated
- [x] Manual verification completed

## Coverage notes

The retry loop is covered by unit tests driving a fake clock and a send stub
that reports "not settled" for a set number of attempts. The slow-start case
itself is reproduced manually (burst-creating sessions on one host), since it
depends on real runner registration contention.
