### PR TITLE
fix(android): complete login in the WebView on Databricks-hosted servers

### DIFF
--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -602,10 +602,9 @@ class MainActivity : AppCompatActivity() {
         // pendingNavigatePath or push insets into a page that can't consume them.
         if (originOf(url) != pinnedOrigin) return
         // First authenticated app page: drop everything before it from the
-        // back/forward list. Otherwise Back walks into the pre-auth root and the
-        // login-redirect reload (the `loadUrl(origin)` after the cookie injection),
-        // which bounces to login or shows a blank — "back lands on the wrong
-        // screen" / "exits the app". After this the SPA builds clean history.
+        // back/forward list — the pre-auth root, any IdP pages, and the post-login
+        // reload all bounce to login or show a blank if Back reaches them. After
+        // this the SPA builds clean history.
         if (!historyCleared) {
             historyCleared = true
             webView.clearHistory()

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
@@ -8,8 +8,9 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 
 /**
- * Signals [onPageReady] once a pinned-origin page finishes loading and routes
- * the OIDC login flow to the system browser via [onLoginRequired].
+ * Signals [onPageReady] once a pinned-origin page finishes loading and decides
+ * where the login flow runs: inline for servers matching [usesInWebViewAuth],
+ * otherwise handed to the system browser via [onLoginRequired].
  *
  * The facade is normally registered with `addDocumentStartJavaScript` in
  * `MainActivity`. Older WebViews that support the message listener but not
@@ -30,19 +31,20 @@ class OmnigentWebViewClient(
 
         val origin = originOf(url)
         val scheme = url?.let { Uri.parse(it).scheme?.lowercase() }
+        val pinned = pinnedOrigin()
 
         // A real http(s) navigation to a foreign origin means the server bounced
-        // us to the OIDC IdP and shouldOverrideUrlLoading didn't catch the
-        // redirect. Stop and run native system-browser login (RFC 8252: never
-        // authenticate in an embedded WebView; Google blocks it and passkeys don't
-        // work). Idempotent: the login manager ignores a second start while one is
-        // in flight.
+        // us to the IdP and shouldOverrideUrlLoading didn't catch the redirect.
+        // Stop and run native system-browser login (RFC 8252 — required for IdPs
+        // like Google that reject embedded user-agents). Idempotent: the login
+        // manager ignores a second start while one is in flight. Servers that
+        // authenticate in the WebView keep loading instead.
         //
         // A null / about:blank / chrome-error:// URL is a failed or transitional
         // load of the pinned server (e.g. it's offline), NOT an IdP redirect —
         // don't misread it as a bounce and pop the browser. Mirror the http(s)
         // gate in shouldOverrideUrlLoading.
-        if (isHttpScheme(scheme) && origin != pinnedOrigin()) {
+        if (isHttpScheme(scheme) && origin != pinned && !usesInWebViewAuth(pinned)) {
             // Log origin only, never the full URL (carries OAuth state/PKCE).
             authLog("off-origin landing $origin -> login")
             view.stopLoading()
@@ -82,14 +84,27 @@ class OmnigentWebViewClient(
 
         // Same-origin app pages load in the WebView.
         val origin = originOf(url.toString())
-        if (origin == pinnedOrigin()) return false
+        val pinned = pinnedOrigin()
+        if (origin == pinned) return false
 
-        // Off-origin top-level navigation. A server redirect (no user gesture) is
-        // the OIDC flow bouncing to the IdP -> run native system-browser login. A
-        // user gesture is an external link -> hand to the system browser. Either
-        // way the foreign page never loads in this WebView (which holds the
-        // native bridge).
         authLog("off-origin nav $origin gesture=${request.hasGesture()}")
+
+        // In-WebView auth: the IdP flow runs inline — safe because the native
+        // bridge is origin-allowlisted to the pinned origin by WebView itself, so
+        // the IdP page can't reach it. Only a gesture from a pinned-origin page is
+        // an external link; once we're on the IdP's own pages its navigations
+        // (sign-in buttons, form posts, tenant hops) are all gesture-driven and
+        // must stay inline or the flow ejects to the browser mid-login.
+        if (usesInWebViewAuth(pinned)) {
+            if (originOf(view.url) == pinned && request.hasGesture()) {
+                runCatching { view.context.startActivity(Intent(Intent.ACTION_VIEW, url)) }
+                return true
+            }
+            return false
+        }
+
+        // System-browser auth. A user gesture is an external link -> hand to the
+        // system browser. A server redirect is the login flow bouncing to the IdP.
         if (request.hasGesture()) {
             runCatching { view.context.startActivity(Intent(Intent.ACTION_VIEW, url)) }
         } else {

--- a/web/android/app/src/main/java/ai/omnigent/android/Origins.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/Origins.kt
@@ -37,6 +37,24 @@ fun isHttpScheme(scheme: String?): Boolean {
 }
 
 /**
+ * Server domains whose IdP permits embedded user-agents. Their login redirect
+ * chain runs inside the WebView and the server sets the session cookie on its
+ * own domain, so no system-browser hop is needed.
+ */
+private val IN_WEBVIEW_AUTH_DOMAINS =
+    listOf("databricks.com", "azuredatabricks.net", "databricksapps.com")
+
+/**
+ * True when [origin]'s host is, or sits under, a domain that authenticates in
+ * the WebView. Matches on a dot boundary so a lookalike host like
+ * `databricks.com.example.org` does not qualify.
+ */
+fun usesInWebViewAuth(origin: String?): Boolean {
+    val host = origin?.let(Uri::parse)?.host?.lowercase() ?: return false
+    return IN_WEBVIEW_AUTH_DOMAINS.any { host == it || host.endsWith(".$it") }
+}
+
+/**
  * Normalize user-entered server text into a loadable URL, or null if it isn't a
  * usable http(s) address. Adds a default `https://` scheme when omitted and
  * trims a trailing slash.

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
@@ -1,11 +1,15 @@
 package ai.omnigent.android
 
 import android.content.Context
+import android.net.Uri
 import android.webkit.ValueCallback
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -40,21 +44,132 @@ class OmnigentWebViewClientTest {
         assertEquals(PINNED_URL, readyUrl)
     }
 
+    @Test
+    fun `idp redirect loads inline when the server authenticates in the webview`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        var logins = 0
+        val client = client(pinnedOrigin = DATABRICKS_ORIGIN, onLoginRequired = { logins++ })
+
+        val handled = client.shouldOverrideUrlLoading(webView, request(IDP_URL))
+
+        assertFalse(handled) // false = let the WebView load the IdP page
+        assertEquals(0, logins)
+    }
+
+    @Test
+    fun `idp redirect goes to the system browser for other servers`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        var logins = 0
+        val client = client(onLoginRequired = { logins++ })
+
+        val handled = client.shouldOverrideUrlLoading(webView, request(IDP_URL))
+
+        assertTrue(handled)
+        assertEquals(1, logins)
+    }
+
+    @Test
+    fun `tapped external link on the app page leaves the webview`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        webView.currentUrl = "$DATABRICKS_ORIGIN/app"
+        var logins = 0
+        val client = client(pinnedOrigin = DATABRICKS_ORIGIN, onLoginRequired = { logins++ })
+
+        val handled =
+            client.shouldOverrideUrlLoading(
+                webView,
+                request("https://example.org/docs", hasGesture = true),
+            )
+
+        assertTrue(handled)
+        assertEquals(0, logins)
+    }
+
+    @Test
+    fun `tapping sign-in on the idp page stays inline`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        webView.currentUrl = IDP_URL // already mid-login on the IdP
+        var logins = 0
+        val client = client(pinnedOrigin = DATABRICKS_ORIGIN, onLoginRequired = { logins++ })
+
+        // A button press inside the IdP is off-origin AND gesture-driven; it must
+        // not be mistaken for an external link.
+        val handled =
+            client.shouldOverrideUrlLoading(
+                webView,
+                request("https://databricks.okta.com/login/step-up", hasGesture = true),
+            )
+
+        assertFalse(handled)
+        assertEquals(0, logins)
+    }
+
+    @Test
+    fun `off-origin landing keeps loading when the server authenticates in the webview`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        var logins = 0
+        val client = client(pinnedOrigin = DATABRICKS_ORIGIN, onLoginRequired = { logins++ })
+
+        client.onPageStarted(webView, IDP_URL, null)
+
+        assertFalse(webView.stopLoadingCalled)
+        assertEquals(0, logins)
+    }
+
+    @Test
+    fun `off-origin landing is stopped for other servers`() {
+        val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
+        var logins = 0
+        val client = client(onLoginRequired = { logins++ })
+
+        client.onPageStarted(webView, IDP_URL, null)
+
+        assertTrue(webView.stopLoadingCalled)
+        assertEquals(1, logins)
+    }
+
     private fun client(
-        shouldInjectBridgeAtPageReady: Boolean,
+        shouldInjectBridgeAtPageReady: Boolean = false,
+        pinnedOrigin: String = PINNED_ORIGIN,
+        onLoginRequired: () -> Unit = {},
         onPageReady: (String?) -> Unit = {},
     ) = OmnigentWebViewClient(
-        pinnedOrigin = { PINNED_ORIGIN },
+        pinnedOrigin = { pinnedOrigin },
         shouldInjectBridgeAtPageReady = { shouldInjectBridgeAtPageReady },
         onPageReady = onPageReady,
-        onLoginRequired = {},
+        onLoginRequired = onLoginRequired,
     )
+
+    private fun request(
+        url: String,
+        hasGesture: Boolean = false,
+    ) = object : WebResourceRequest {
+        override fun getUrl(): Uri = Uri.parse(url)
+
+        override fun isForMainFrame(): Boolean = true
+
+        override fun isRedirect(): Boolean = !hasGesture
+
+        override fun hasGesture(): Boolean = hasGesture
+
+        override fun getMethod(): String = "GET"
+
+        override fun getRequestHeaders(): Map<String, String> = emptyMap()
+    }
 
     private class RecordingWebView(
         context: Context,
     ) : WebView(context) {
         var evaluatedScript: String? = null
+        var stopLoadingCalled = false
+        var currentUrl: String? = null
         private var callback: ValueCallback<String>? = null
+
+        override fun getUrl(): String? = currentUrl
+
+        override fun stopLoading() {
+            stopLoadingCalled = true
+        }
 
         override fun evaluateJavascript(
             script: String,
@@ -72,5 +187,7 @@ class OmnigentWebViewClientTest {
     private companion object {
         const val PINNED_ORIGIN = "https://example.com"
         const val PINNED_URL = "$PINNED_ORIGIN/app"
+        const val DATABRICKS_ORIGIN = "https://myshard.cloud.databricks.com"
+        const val IDP_URL = "https://databricks.okta.com/authorize?state=abc"
     }
 }

--- a/web/android/app/src/test/java/ai/omnigent/android/OriginsInWebViewAuthTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OriginsInWebViewAuthTest.kt
@@ -1,0 +1,40 @@
+package ai.omnigent.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OriginsInWebViewAuthTest {
+    @Test
+    fun `matches the bare domain and its subdomains`() {
+        assertTrue(usesInWebViewAuth("https://databricks.com"))
+        assertTrue(usesInWebViewAuth("https://foo.cloud.databricks.com"))
+        assertTrue(usesInWebViewAuth("https://adb-123.azuredatabricks.net"))
+        assertTrue(usesInWebViewAuth("https://myapp.databricksapps.com"))
+    }
+
+    @Test
+    fun `matches regardless of host casing`() {
+        assertTrue(usesInWebViewAuth("https://Foo.Databricks.COM"))
+    }
+
+    @Test
+    fun `does not match a lookalike parent domain`() {
+        // The dot boundary is the whole point: a host that merely *contains* the
+        // domain must not authenticate in the WebView.
+        assertFalse(usesInWebViewAuth("https://databricks.com.example.org"))
+        assertFalse(usesInWebViewAuth("https://notdatabricks.com"))
+        assertFalse(usesInWebViewAuth("https://azuredatabricks.net.evil.tld"))
+        assertFalse(usesInWebViewAuth("https://databricksapps.com.evil.tld"))
+    }
+
+    @Test
+    fun `does not match unrelated or unusable origins`() {
+        assertFalse(usesInWebViewAuth("https://example.com"))
+        assertFalse(usesInWebViewAuth(null))
+        assertFalse(usesInWebViewAuth("about:blank"))
+    }
+}


### PR DESCRIPTION
## Related issue

Closes OMNI-2485 — https://linear.app/omnigent/issue/OMNI-2485

## Summary

- The Android shell previously sent *every* login through the system browser:
  it stopped any off-origin navigation, requested a CLI-style ticket, opened
  the browser, polled for the session JWT, then injected it as a cookie
  (`OidcLoginManager`). That detour exists only because Google's OAuth endpoint
  rejects embedded webviews — the browser and WebView have separate cookie
  jars, so the session has to be carried across by hand.
- Databricks-hosted deployments authenticate via Okta, which permits embedded
  user-agents. For those servers the whole detour is unnecessary: the redirect
  chain can run inline and the server sets the session cookie on its own
  domain, so nothing needs bridging.
- Adds `usesInWebViewAuth()` in `Origins.kt`, keyed on the **pinned server**
  (`databricks.com`, `azuredatabricks.net`, `databricksapps.com`). When it
  matches, off-origin navigation loads inline instead of triggering the browser
  hop. `OidcLoginManager` is untouched and still handles every other server.

ELI5: the app used to kick you out to Chrome to log in, then smuggle the
resulting session back in. On Databricks servers it no longer needs to — you
just log in where you already are.

Keying on the pinned server rather than the destination is deliberate: during
login the WebView navigates to `databricks.okta.com`, so a destination
allowlist would have to enumerate IdP domains it can't know up front.

```mermaid
flowchart LR
    A[off-origin nav] --> B{pinned server uses<br/>in-WebView auth}
    B -- no --> C{gesture}
    C -- yes --> D[system browser]
    C -- no --> E[browser hop:<br/>ticket, poll, inject cookie]
    B -- yes --> F{gesture AND<br/>on a pinned-origin page}
    F -- yes --> D
    F -- no --> G[load inline]
```

The gesture check is qualified by "on a pinned-origin page" because once the
WebView is on the IdP's own pages, its sign-in buttons and form posts are both
off-origin *and* gesture-driven — without that qualifier they get mistaken for
external links and ejected to the browser mid-login.

Safe because the native bridge is origin-allowlisted to the pinned origin by
WebView itself (`addWebMessageListener` / `addDocumentStartJavaScript` are both
passed `setOf(origin)`), so an IdP page loaded in this WebView cannot reach it.

Host matching uses a dot boundary (`host == d || host.endsWith(".$d")`) so a
lookalike like `databricks.com.example.org` does not qualify.

## Test Plan

- `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin` — clean.
- `pre-commit run --files <changed>` — ktlint format + check pass.
- New unit tests: 6 cases in `OmnigentWebViewClientTest` (inline IdP redirect,
  browser hop for other servers, external link from the app page, sign-in tap
  on the IdP page, both `onPageStarted` branches) and `OriginsInWebViewAuthTest`
  for the dot-boundary matching.
- On-device against `https://omnigents-<id>.aws.databricksapps.com`: login
  completes entirely in-app through Okta (Okta Verify), no browser launch and
  no "Signed in" notification. `adb logcat -s OmnigentAuth`:

  ```
  off-origin nav https://ai-oss-...cloud.databricks.com gesture=false
  off-origin nav https://ai-oss-...cloud.databricks.com gesture=false
  off-origin nav https://ai-oss-...cloud.databricks.com gesture=true
  off-origin nav https://databricks.okta.com gesture=false
  off-origin nav https://databricks.okta.com gesture=false
  off-origin nav https://ai-oss-...cloud.databricks.com gesture=false
  ```

  Every hop loads inline and `onLoginRequired` never fires. The return to the
  pinned origin logs nothing because same-origin loads short-circuit earlier.

## Demo

N/A — no visual change; the difference is the absence of a browser launch. The
logcat trace above shows the new behaviour.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests could not be executed locally: Robolectric cannot fetch
`org.robolectric:android-all-instrumented` because `repo1.maven.org` is
unreachable from this machine. This is pre-existing and environmental —
untouched tests such as `ThemeTest` fail identically. Compilation of both main
and test sources was verified instead, so CI is the first real run of the new
tests. The end-to-end flow was verified on-device as described above.

Known gaps, both pre-existing and out of scope here:

- Passkey sign-in at the IdP will still fail in the WebView. WebAuthn is off by
  default (`WEB_AUTHENTICATION_SUPPORT_NONE`) and enabling it needs Digital
  Asset Links published at the RP ID (`databricks.okta.com`), a domain this
  repo does not control. Okta Verify and password+MFA are unaffected.
- `shouldOverrideUrlLoading` hands non-http schemes to `Intent(ACTION_VIEW,
  url)`, which is wrong for `intent://…#Intent;…;end` URLs (needs
  `Intent.parseUri`) and fails silently under `runCatching`.

## Changelog

Signing in to Databricks-hosted deployments on Android now happens in the app
instead of bouncing out to the browser




