### PR TITLE
fix(routing): confine spawns only for pinned Smart Routing parents

### DIFF
--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -488,12 +488,23 @@ def out_of_parent_family(
     from omnigent.runner.subagent_routing import (
         auto_harness_session,
         harness_family,
+        routing_class_from_snapshot,
         subagent_routing_enabled,
     )
 
     if parent is None or conv is None:
         return False
     if not subagent_routing_enabled(getattr(parent, "subagent_routing_override", None)):
+        return False
+    # Same predicate as the child-create gate: confinement belongs to a
+    # pinned Smart Routing parent, so a parent that merely has the subagent
+    # switch on routes a cross-family pane like any other.
+    parent_class = routing_class_from_snapshot(
+        cost_control_mode=getattr(parent, "cost_control_mode_override", None),
+        harness_override=getattr(parent, "harness_override", None),
+        labels=getattr(parent, "labels", None),
+    )
+    if not parent_class.routing_enabled or parent_class.auto_harness:
         return False
     if auto_harness_session(conv, parent):
         return False

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -68,6 +68,7 @@ from omnigent.runner.subagent_routing import (
     ROUTING_DECISION_LABEL_KEY,
     auto_harness_session,
     harness_family,
+    routing_class_from_snapshot,
     subagent_routing_enabled,
 )
 from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
@@ -4217,6 +4218,11 @@ def _pinned_spawn_family(parent: Conversation | None) -> str | None:
     the family choice to the router, and a parent that routes no spawns at
     all confines nothing.
 
+    The switch alone is not enough: the runner hides out-of-family agents
+    only from a parent whose routing class is routed and pinned, so a
+    session that flipped the subagent switch with Smart Routing off is
+    listed the whole agent surface and must be able to create from it too.
+
     :param parent: The parent session's row, or ``None`` for a top-level
         create (nothing to stay in family with).
     :returns: ``"claude"`` / ``"gpt"`` / ``"pi"``, or ``None`` when the
@@ -4224,7 +4230,12 @@ def _pinned_spawn_family(parent: Conversation | None) -> str | None:
     """
     if parent is None or not subagent_routing_enabled(parent.subagent_routing_override):
         return None
-    if auto_harness_session(parent):
+    routing_class = routing_class_from_snapshot(
+        cost_control_mode=parent.cost_control_mode_override,
+        harness_override=parent.harness_override,
+        labels=parent.labels,
+    )
+    if not routing_class.routing_enabled or routing_class.auto_harness:
         return None
     return harness_family(_resolve_harness(parent))
 
@@ -4287,11 +4298,13 @@ def _out_of_family_spawn_notice(
     """
     if parent is None or auto_harness_session(conv, parent):
         return None
-    parent_harness = _resolve_harness(parent)
-    parent_family = harness_family(parent_harness)
+    # Through the create gate's own answer, so a pane is declined here only
+    # when its create would have been refused too.
+    parent_family = _pinned_spawn_family(parent)
     child_family = harness_family(harness)
     if parent_family is None or child_family is None or parent_family == child_family:
         return None
+    parent_harness = _resolve_harness(parent)
     return (
         f"Not routed: a {parent_harness} session's spawns stay in its own model "
         f"family, and this sub-agent runs on {harness}."

--- a/tests/runner/test_agent_list_spawn_family.py
+++ b/tests/runner/test_agent_list_spawn_family.py
@@ -158,6 +158,26 @@ async def test_routed_session_with_subagent_routing_off_sees_every_family() -> N
 
 
 @pytest.mark.asyncio
+async def test_subagent_switch_without_smart_routing_sees_every_family() -> None:
+    # A bundle session may route its spawns with Smart Routing off; those
+    # spawns go through session-create, which serves any family. The create
+    # gate answers the same, so the listing must not hide anything here.
+    remember_session_routing_class("conv_parent", SessionRoutingClass())
+    seen: list[str] = []
+    listing = await _agent_list(
+        {
+            "id": "conv_parent",
+            "harness": "codex-native",
+            "subagent_routing_override": "on",
+            "labels": {},
+        },
+        seen,
+    )
+    assert _names(listing) == ["claude-code", "codex", "pi", "mystery"]
+    assert "/v1/sessions/conv_parent" not in seen
+
+
+@pytest.mark.asyncio
 async def test_unreadable_session_leaves_the_listing_alone() -> None:
     remember_session_routing_class("conv_parent", _PINNED)
     seen: list[str] = []

--- a/tests/server/routes/test_spawn_family_gate.py
+++ b/tests/server/routes/test_spawn_family_gate.py
@@ -1,0 +1,138 @@
+"""The child-create family gate reads the parent's routing class.
+
+Confinement is a pinned-Smart-Routing feature: the runner's ``sys_agent_list``
+only hides out-of-family agents from a parent whose routing class is routed and
+pinned. The create gate has to answer the same question, or a session with only
+the subagent-routing switch flipped is listed a codex agent and then refused a
+400 when it tries to spawn it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.entities.conversation import Conversation
+from omnigent.errors import OmnigentError
+from omnigent.runner.subagent_routing import (
+    AUTO_HARNESS_LABEL_KEY,
+    routing_class_from_snapshot,
+)
+from omnigent.runner.turn_routing import out_of_parent_family
+from omnigent.server.routes._sessions.orchestration import (
+    _pinned_spawn_family,
+    _reject_out_of_family_child,
+)
+
+
+def _conv(
+    *,
+    cost_control_mode_override: str | None = None,
+    subagent_routing_override: str | None = None,
+    harness_override: str | None = "codex-native",
+    labels: dict[str, str] | None = None,
+) -> Conversation:
+    return Conversation(
+        id="conv_parent",
+        created_at=0,
+        updated_at=0,
+        root_conversation_id="conv_parent",
+        labels=labels or {},
+        cost_control_mode_override=cost_control_mode_override,
+        subagent_routing_override=subagent_routing_override,
+        harness_override=harness_override,
+    )
+
+
+_PLAIN = _conv()
+_TOGGLE_ONLY = _conv(subagent_routing_override="on")
+_PINNED_ROUTED = _conv(cost_control_mode_override="on", subagent_routing_override="on")
+_PINNED_ROUTED_SWITCH_OFF = _conv(cost_control_mode_override="on")
+_AUTO_ROUTED = _conv(
+    cost_control_mode_override="on",
+    subagent_routing_override="on",
+    harness_override="auto",
+    labels={AUTO_HARNESS_LABEL_KEY: "1"},
+)
+
+
+@pytest.mark.parametrize(
+    ("parent", "expected"),
+    [
+        (None, None),
+        (_PLAIN, None),
+        (_TOGGLE_ONLY, None),
+        (_PINNED_ROUTED, "gpt"),
+        (_PINNED_ROUTED_SWITCH_OFF, None),
+        (_AUTO_ROUTED, None),
+    ],
+)
+def test_confinement_matches_the_routing_class(
+    parent: Conversation | None, expected: str | None
+) -> None:
+    assert _pinned_spawn_family(parent) == expected
+
+
+@pytest.mark.parametrize(
+    "parent", [None, _PLAIN, _TOGGLE_ONLY, _PINNED_ROUTED_SWITCH_OFF, _AUTO_ROUTED]
+)
+def test_unconfined_parent_creates_across_families(parent: Conversation | None) -> None:
+    _reject_out_of_family_child(parent, "claude-native")
+
+
+def test_pinned_routed_parent_refuses_an_out_of_family_child() -> None:
+    with pytest.raises(OmnigentError, match="own model family"):
+        _reject_out_of_family_child(_PINNED_ROUTED, "claude-native")
+
+
+def test_pinned_routed_parent_allows_an_in_family_child() -> None:
+    _reject_out_of_family_child(_PINNED_ROUTED, "codex-native")
+
+
+def test_unresolvable_child_harness_is_allowed() -> None:
+    _reject_out_of_family_child(_PINNED_ROUTED, None)
+
+
+@pytest.mark.parametrize(
+    ("parent", "confined"),
+    [
+        (_PLAIN, False),
+        (_TOGGLE_ONLY, False),
+        (_PINNED_ROUTED, True),
+        (_PINNED_ROUTED_SWITCH_OFF, False),
+        (_AUTO_ROUTED, False),
+    ],
+)
+def test_create_gate_agrees_with_the_listing_predicate(
+    parent: Conversation, confined: bool
+) -> None:
+    # The runner hides out-of-family agents on exactly this predicate, so the
+    # two halves have to answer alike for every parent.
+    routing_class = routing_class_from_snapshot(
+        cost_control_mode=parent.cost_control_mode_override,
+        harness_override=parent.harness_override,
+        labels=parent.labels,
+    )
+    listing_confines = (
+        routing_class.routing_enabled
+        and not routing_class.auto_harness
+        and parent.subagent_routing_override == "on"
+    )
+    assert listing_confines is confined
+    assert (_pinned_spawn_family(parent) is not None) is confined
+
+
+@pytest.mark.parametrize(
+    ("parent", "expected"),
+    [
+        (_PLAIN, False),
+        (_TOGGLE_ONLY, False),
+        (_PINNED_ROUTED, True),
+        (_PINNED_ROUTED_SWITCH_OFF, False),
+        (_AUTO_ROUTED, False),
+    ],
+)
+def test_turn_family_guard_follows_the_same_predicate(
+    parent: Conversation, expected: bool
+) -> None:
+    child = _conv(harness_override="claude-native")
+    assert out_of_parent_family(child, parent, "codex-native", "claude-native") is expected


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The two halves of spawn-family confinement disagreed. `sys_agent_list` (runner)
short-circuits on the caller's routing class — it confines only a session that
is routed **and** pinned — so a session with just the subagent-routing switch on
(Smart Routing off) sees the full agent roster. The child-create gate
(`_pinned_spawn_family`) confined on that switch alone, so the very agents the
listing advertised came back as a 400 `out of family` from `sys_session_create`.
A plain Polly / SDK / bundle session that routes its spawns could not spawn a
codex child at all.

- `_pinned_spawn_family` now reads `routing_class_from_snapshot` (the canonical
  reader of routing state) in addition to the switch, so the create gate and the
  listing answer the same question. `_reject_out_of_family_child` follows.
- The route-turn guard `out_of_parent_family` and the native-spawn decline
  notice `_out_of_family_spawn_notice` shared the toggle-only predicate; both
  now read the same routing class, so no pane is declined routing after a create
  the gate allowed.

Behaviour matrix (unchanged rows marked):

| parent | listing | cross-family create |
| --- | --- | --- |
| plain | full (unchanged) | allowed (unchanged) |
| subagent switch on, Smart Routing off | full (unchanged) | **allowed (the fix)** |
| pinned Smart Routing | confined (unchanged) | 400 (unchanged) |
| auto-harness Smart Routing | full (unchanged) | allowed (unchanged) |

## Test Plan

```
uv run pytest tests/server/routes/test_spawn_family_gate.py \
  tests/runner/test_agent_list_spawn_family.py \
  tests/server/test_turn_routing.py tests/server/test_subagent_routing.py \
  tests/server/routes/test_native_smart_routing_create.py \
  tests/server/integration/test_routing_integration.py
```

404 passed. New `tests/server/routes/test_spawn_family_gate.py` pins the matrix
above on both gates and asserts the create gate agrees with the listing
predicate for every parent shape; `tests/runner/test_agent_list_spawn_family.py`
gains the explicit toggle-only listing case.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

A session that routes its subagent spawns without Smart Routing can spawn agents from any model family again, instead of being offered agents its create then refused.

This pull request and its description were written by Isaac.
