### PR TITLE
feat(examples): add a PinchTab browser agent bundle

### DIFF
--- a/examples/pinchtab_browser/README.md
+++ b/examples/pinchtab_browser/README.md
@@ -1,0 +1,90 @@
+# pinchtab_browser
+
+A single-agent example that **drives a real Chrome** through
+[PinchTab](https://pinchtab.com/), a local browser-control daemon that speaks
+MCP over stdio.
+
+PinchTab reads pages as an accessibility tree with stable element refs
+(`e0`, `e1`, …) rather than screenshots, so page state costs roughly a few
+hundred tokens instead of an image. The agent clicks refs, not CSS selectors or
+pixel coordinates.
+
+## Layout
+
+```
+pinchtab_browser/
+├── config.yaml                    # the agent (claude-sdk brain, no model pinned)
+└── tools/mcp/pinchtab.yaml        # MCP server — auto-discovered, exposes the pinchtab_* tools
+```
+
+No core-engine changes: the server is reached through omnigent's standard
+`tools/mcp/*.yaml` auto-discovery, the sanctioned extension point.
+
+## Operator setup
+
+### 1. Install PinchTab
+
+```bash
+curl -fsSL https://pinchtab.com/install.sh | bash
+# or
+brew install pinchtab/tap/pinchtab
+```
+
+### 2. Generate the local config and token
+
+```bash
+pinchtab config init      # writes the config and mints server.token
+```
+
+The default config binds the daemon to `127.0.0.1` and requires a bearer token.
+**Leave both alone.** PinchTab's dashboard, HTTP API, and MCP bridge are
+explicitly *not* built for untrusted users, multi-tenant use, or public-internet
+exposure — a non-loopback `server.bind` hands whoever can reach the port a
+browser running as you, with your cookies and sessions.
+
+### 3. Start the daemon
+
+```bash
+pinchtab daemon install   # runs it as a background service
+
+# sanity check — the API answers only on loopback, and only with the token
+curl -H "Authorization: Bearer $(pinchtab config token)" http://127.0.0.1:9867/health
+```
+
+### 4. Export the token, then run the agent
+
+```bash
+export PINCHTAB_TOKEN="$(pinchtab config token)"
+omnigent run examples/pinchtab_browser/
+```
+
+`tools/mcp/pinchtab.yaml` reads the token from `PINCHTAB_TOKEN` — the repo never
+holds a credential. If the variable is unset, the bundle fails to load with an
+unresolved-variable error rather than starting up unauthenticated.
+
+Keep the token out of your shell history and out of committed files: prefer the
+command substitution above (or a secret manager) over pasting the literal value.
+
+### Optional: a different daemon target
+
+`PINCHTAB_SERVER` in `tools/mcp/pinchtab.yaml` points at
+`http://127.0.0.1:9867`, PinchTab's default control-plane port. Change it only
+if you moved the local daemon's port. Pointing it at a remote host is out of
+scope for this example and unsupported by PinchTab's security model.
+
+## Tool namespace
+
+PinchTab's tools are all namespaced `pinchtab_*` (`pinchtab_navigate`,
+`pinchtab_snapshot`, `pinchtab_click`, `pinchtab_type`, `pinchtab_get_text`,
+the `pinchtab_wait_for_*` family, …). They sit alongside — and never shadow —
+omnigent's framework-owned `browser_*` built-ins, which drive the desktop app's
+embedded browser instead.
+
+## Safety notes
+
+- The agent gets a browser with your real profile: logged-in sessions, cookies,
+  saved payment methods. Treat a task as you would handing someone your laptop.
+- PinchTab's IDPI defense restricts browsing to a local allowlist by default;
+  widen it deliberately, per site, not globally.
+- The bundle declares no `os_env`, so the agent has no local file or shell
+  tools — the browser is its only reach.

--- a/examples/pinchtab_browser/config.yaml
+++ b/examples/pinchtab_browser/config.yaml
@@ -1,0 +1,56 @@
+# pinchtab_browser — a browser agent driven by the PinchTab MCP server.
+#
+# Usage:
+#   pinchtab daemon install            # start the local daemon (once)
+#   export PINCHTAB_TOKEN="$(pinchtab config token)"
+#   omnigent run examples/pinchtab_browser/
+#
+# See README.md for the full operator setup.
+
+spec_version: 1
+name: pinchtab_browser
+description: >-
+  Single-agent browser operator. Drives a local Chrome through the PinchTab MCP
+  server (accessibility-tree snapshots with stable element refs), so it can
+  navigate, read, fill forms, and complete multi-step web flows without
+  screenshot-sized token costs.
+
+# "Brain": Claude Agent SDK. No model is pinned, so it runs on whatever Claude
+# provider is configured (`omnigent setup`).
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+interaction:
+  conversational: true
+  modalities:
+    input: [text]
+    output: [text]
+
+prompt: |
+  You are a browser operator. You complete web tasks by driving a real Chrome
+  through the PinchTab tools (auto-loaded from tools/mcp/pinchtab.yaml).
+
+  Work from the accessibility tree, not from guesses:
+  - pinchtab_navigate — go to a URL.
+  - pinchtab_snapshot — read the page as a tree of elements with stable refs
+    (e0, e1, …). Take a fresh snapshot after anything that changes the page.
+  - pinchtab_click / pinchtab_type / pinchtab_press — act on a ref from the
+    most recent snapshot, never on a guessed CSS selector or pixel coordinate.
+  - pinchtab_get_text — pull page text when you need to read rather than act.
+  - pinchtab_wait_for_selector / pinchtab_wait_for_load — settle the page
+    before the next snapshot instead of retrying blindly.
+
+  Method:
+  1. Navigate, then snapshot before your first action.
+  2. Act on one element at a time, re-snapshotting after each state change.
+  3. If a ref has gone stale, re-snapshot rather than reusing the old ref.
+  4. Report what you actually observed on the page, quoting the text you read.
+
+  Stop and ask before anything irreversible or authenticated — purchases, sends,
+  deletes, or submitting credentials. Say what you are about to do and act in
+  the same turn otherwise; don't end a turn having only described a plan.
+
+# No `tools:` block is required for MCP — servers under tools/mcp/*.yaml are
+# auto-discovered and their tools exposed to the agent.

--- a/examples/pinchtab_browser/tools/mcp/pinchtab.yaml
+++ b/examples/pinchtab_browser/tools/mcp/pinchtab.yaml
@@ -1,0 +1,26 @@
+# PinchTab MCP server — local Chrome control via accessibility-tree snapshots.
+# Auto-discovered by omnigent (omnigent/spec/parser.py:_discover_mcp_servers);
+# no need to reference it from config.yaml.
+#
+# Exposed tools are namespaced pinchtab_* (pinchtab_navigate, pinchtab_snapshot,
+# pinchtab_click, pinchtab_type, …), so they never shadow omnigent's
+# framework-owned browser_* built-ins.
+name: pinchtab
+description: Local Chrome control (navigate, snapshot, click, type) via the PinchTab MCP server.
+transport: stdio
+
+# `pinchtab mcp` is PinchTab's own stdio MCP bridge. It talks to the PinchTab
+# daemon over HTTP; it does not launch Chrome itself. Start the daemon first —
+# see the bundle README.
+command: pinchtab
+args:
+  - mcp
+
+env:
+  # PinchTab binds to 127.0.0.1 by default and its HTTP API is not built for
+  # untrusted or multi-tenant exposure. Keep this loopback-only.
+  PINCHTAB_SERVER: http://127.0.0.1:9867
+  # Bearer token minted by `pinchtab config init`; read it with
+  # `pinchtab config token`. Sourced from the environment so no credential
+  # lands in the repo. Parsing fails loud if the variable is unset.
+  PINCHTAB_TOKEN: ${PINCHTAB_TOKEN}

--- a/tests/e2e/omnigent/test_example_pinchtab_browser.py
+++ b/tests/e2e/omnigent/test_example_pinchtab_browser.py
@@ -1,0 +1,122 @@
+"""Structural test for the pinchtab_browser example bundle
+(``examples/pinchtab_browser``).
+
+The bundle wires PinchTab — a local browser-control daemon that speaks MCP over
+stdio (``pinchtab mcp``) — through the spec parser's ``tools/mcp/*.yaml``
+auto-discovery, with no ``tools:`` block and no core-engine changes. Pure
+spec-load: no LLM, no live daemon, no real token. Modeled on
+``test_deep_research_example.py``.
+
+What breaks if this fails:
+- the stdio MCP server stops being discovered from ``tools/mcp/*.yaml`` (the
+  agent would load with no browser-control tools at all),
+- the launch command drifts from PinchTab's documented ``pinchtab mcp``,
+- the daemon target stops being loopback-only, or the token stops coming from
+  the ``PINCHTAB_TOKEN`` environment variable (a real token in the YAML would
+  ship a secret in the repo),
+- PinchTab's ``pinchtab_*`` tool namespace starts colliding with the
+  framework-owned ``browser_*`` built-ins,
+- an ``os_env`` block is added, which would hand local file and shell tools to
+  an agent meant to act only through the browser daemon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+from omnigent.tools.builtins.browser import (
+    BrowserClickTool,
+    BrowserNavigateTool,
+    BrowserScreenshotTool,
+    BrowserSnapshotTool,
+    BrowserTypeTool,
+)
+
+# tests/e2e/omnigent/test_example_pinchtab_browser.py -> repo root is 3 parents up.
+_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "pinchtab_browser"
+_MCP_YAML = _BUNDLE / "tools" / "mcp" / "pinchtab.yaml"
+
+# Stand-in for an operator's real token. The bundle must resolve its token from
+# the environment, so parsing it needs *some* value present.
+_TEST_TOKEN = "test-token-not-a-real-credential"
+
+
+@pytest.fixture
+def pinchtab_spec(monkeypatch: pytest.MonkeyPatch) -> AgentSpec:
+    """Load the bundle with a stand-in token in the environment."""
+    monkeypatch.setenv("PINCHTAB_TOKEN", _TEST_TOKEN)
+    return load(_BUNDLE)
+
+
+def test_pinchtab_mcp_server_is_auto_discovered(pinchtab_spec: AgentSpec) -> None:
+    """
+    The bundle loads and its only tool source is the auto-discovered PinchTab
+    stdio MCP server, launched with PinchTab's documented ``pinchtab mcp``.
+
+    There is no ``tools:`` block — the point is that a ``tools/mcp/<name>.yaml``
+    server is discovered and its tools exposed. If discovery regresses, the
+    agent loads with nothing to drive a browser with.
+    """
+    assert pinchtab_spec.name == "pinchtab_browser"
+    assert pinchtab_spec.sub_agents == []
+
+    servers = {s.name: s for s in pinchtab_spec.mcp_servers}
+    assert list(servers) == ["pinchtab"]
+    pinchtab = servers["pinchtab"]
+    assert pinchtab.transport == "stdio"
+    assert pinchtab.command == "pinchtab"
+    assert pinchtab.args == ["mcp"]
+
+
+def test_pinchtab_targets_loopback_only(pinchtab_spec: AgentSpec) -> None:
+    """
+    The MCP client is pointed at a loopback daemon on PinchTab's default port.
+
+    PinchTab's HTTP API is explicitly not built for untrusted or multi-tenant
+    exposure, so the supported configuration never names a non-loopback host.
+    """
+    pinchtab = next(s for s in pinchtab_spec.mcp_servers if s.name == "pinchtab")
+    assert pinchtab.env["PINCHTAB_SERVER"] == "http://127.0.0.1:9867"
+
+
+def test_pinchtab_token_comes_from_the_environment(pinchtab_spec: AgentSpec) -> None:
+    """
+    The token is expanded from ``PINCHTAB_TOKEN`` at parse time, and the YAML
+    on disk carries only the reference — never a literal credential.
+    """
+    pinchtab = next(s for s in pinchtab_spec.mcp_servers if s.name == "pinchtab")
+    assert pinchtab.env["PINCHTAB_TOKEN"] == _TEST_TOKEN
+
+    yaml_text = _MCP_YAML.read_text(encoding="utf-8")
+    assert "${PINCHTAB_TOKEN}" in yaml_text
+    assert _TEST_TOKEN not in yaml_text
+
+
+def test_pinchtab_tools_do_not_collide_with_browser_builtins(
+    pinchtab_spec: AgentSpec,
+) -> None:
+    """
+    PinchTab namespaces every tool it exposes under ``pinchtab_``, so none of
+    them shadow the framework-owned ``browser_*`` built-ins that are registered
+    for every agent regardless of the spec.
+    """
+    builtin_names = {
+        BrowserNavigateTool.name(),
+        BrowserSnapshotTool.name(),
+        BrowserClickTool.name(),
+        BrowserTypeTool.name(),
+        BrowserScreenshotTool.name(),
+    }
+    assert not any(name.startswith("pinchtab_") for name in builtin_names)
+
+    server_names = {s.name for s in pinchtab_spec.mcp_servers}
+    assert server_names.isdisjoint(builtin_names)
+
+
+def test_pinchtab_bundle_has_no_os_environment(pinchtab_spec: AgentSpec) -> None:
+    """The example does not opt into local file or shell tools."""
+    assert pinchtab_spec.os_env is None


### PR DESCRIPTION
## Related issue

Closes #

<!-- Feature with no tracking issue; happy to file one if maintainers prefer. -->

## Summary

- Omnigent had no supported path to [PinchTab](https://pinchtab.com/), a local Chrome-control daemon that speaks MCP over stdio. This wires it through the sanctioned extension point — a `tools/mcp/pinchtab.yaml` server that the spec parser auto-discovers (`omnigent/spec/parser.py:_discover_mcp_servers`) — so there are **no core-engine changes** and no `tools:` block.
- The bundle launches PinchTab's documented `pinchtab mcp` bridge, points `PINCHTAB_SERVER` at the loopback daemon (`http://127.0.0.1:9867`, PinchTab's default), and reads the bearer token from `PINCHTAB_TOKEN`. The repo carries only the `${PINCHTAB_TOKEN}` reference — never a credential — and the bundle fails to load with an unresolved-variable error if an operator forgets to export it.
- PinchTab namespaces every tool it exposes as `pinchtab_*`, so nothing shadows the framework-owned `browser_*` built-ins that `ToolManager._register_browser_tools` registers for every agent.
- `README.md` walks an operator through install, `pinchtab config init`, keeping `server.bind` on `127.0.0.1`, and exporting the token via command substitution rather than pasting it.

Same shape as `examples/deep-research/` (the existing `tools/mcp/*.yaml` precedent), on the stdio branch instead of HTTP.

```
pinchtab_browser/
├── config.yaml                 # claude-sdk brain, no model pinned, no os_env
└── tools/mcp/pinchtab.yaml     # stdio MCP server — auto-discovered
```

## Test Plan

Tests were written first and confirmed red (5 errors, `FileNotFoundError: source not found: .../examples/pinchtab_browser`) before the bundle existed.

```
uv run --no-sync pytest tests/spec \
  tests/e2e/omnigent/test_example_pinchtab_browser.py \
  tests/e2e/omnigent/test_deep_research_example.py \
  tests/e2e/omnigent/test_examples_coverage_sync.py -q
# 562 passed
```

`tests/e2e/omnigent/test_example_pinchtab_browser.py` covers: auto-discovery of the stdio server, the `pinchtab mcp` launch shape, the loopback-only target, token-from-environment (and no literal token in the YAML), no collision with the `browser_*` built-ins, and no `os_env` block. Pure spec-load — no LLM, no live daemon, no real credential.

Also verified by hand that the bundle fails loud without the variable:

```
OmnigentError: Unresolved environment variable '${PINCHTAB_TOKEN}' in config key 'PINCHTAB_TOKEN'.
```

Lint: `pre-commit run --files <changed>` passes every applicable hook, including `ruff-format`, `ruff-check`, and `no-hardcoded-models`.

## Demo

N/A — no UI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the two runtime behaviours a spec-load test can't assert together: loading the bundle with `PINCHTAB_TOKEN` unset raises `OmnigentError` naming the unresolved variable, and loading it with the variable set yields `('pinchtab', 'stdio', 'pinchtab', ['mcp'], {'PINCHTAB_SERVER': 'http://127.0.0.1:9867', 'PINCHTAB_TOKEN': ...})`.

A live round-trip against a running PinchTab daemon was **not** run — it needs the `pinchtab` binary and a real Chrome, neither of which is available in CI. Same posture as `deep-research`, whose test is also spec-load only.

## Changelog

`examples/pinchtab_browser/` drives a local Chrome through the PinchTab MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
