### PR TITLE
fix(web): don't redirect into a new session the user navigated away from

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -863,6 +863,262 @@ async def _drive_open_before_create_responds(base_url: str, session_id: str) -> 
             await browser.close()
 
 
+def test_start_session_no_redirect_after_navigating_away(
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """A create that lands after the user left must not yank them into it.
+
+    The create POST is slow (session bootstrap + runner launch), so the
+    user often opens another session while it is still in flight. When
+    the response finally arrives, following it would tear the user out
+    of the session they deliberately navigated to — a hijacked view,
+    seconds after the fact. The redirect belongs to the landing screen:
+    it may only fire while the user is still sitting on it.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _run_in_fresh_loop(_drive_no_redirect_after_navigating_away(base_url, session_a, session_b))
+
+
+async def _drive_no_redirect_after_navigating_away(
+    base_url: str, session_a: str, session_b: str
+) -> None:
+    """Async body of the late-create redirect test.
+
+    :param base_url: Spawned server base URL.
+    :param session_a: Pre-seeded session the faked create returns — the
+        one the late redirect would wrongly jump to.
+    :param session_b: Pre-seeded session the user opens mid-create, and
+        must still be on once the create lands.
+    """
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            # Holds the create POST open so the navigate-away happens
+            # strictly inside the in-flight window, as it does for a real
+            # multi-second create.
+            release_create = asyncio.Event()
+            # Set when the browser receives the create response, so the
+            # settle window below starts only once the redirect could fire.
+            create_answered = asyncio.Event()
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    await release_create.wait()
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_a}),
+                    )
+                else:
+                    await route.continue_()
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+
+            # Keep the agent-discovery scan empty so only the stubbed Claude
+            # agent feeds the picker (see _drive_permission_mode for why).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            def note_create_response(response) -> None:
+                if response.request.method == "POST" and _SESSIONS_RE.search(response.url):
+                    create_answered.set()
+
+            page.on("response", note_create_response)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+            # The create is in flight and parked on the gate.
+            await _wait_until(lambda: len(create_bodies) == 1)
+
+            # Leave for another session via the sidebar — a client-side
+            # navigation, so the create fetch keeps running (a reload would
+            # abort it and the race would never happen).
+            await page.locator(f'a[href="/c/{session_b}"]').click()
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_b)}$"))
+
+            # Let the create land. Waiting on the response (rather than a
+            # bare sleep) keeps the assertion honest: a create that never
+            # completed would fail here instead of passing vacuously.
+            release_create.set()
+            await asyncio.wait_for(create_answered.wait(), timeout=30.0)
+
+            # Watch the URL for a while: the regression navigates within a
+            # tick of the response, but `expect` would happily pass on the
+            # pre-redirect URL, so sample instead of retrying-until-true.
+            visited: list[str] = []
+            for _ in range(50):
+                url = page.url
+                if not visited or visited[-1] != url:
+                    visited.append(url)
+                await asyncio.sleep(0.05)
+
+            assert all(f"/c/{session_a}" not in url for url in visited), visited
+            assert page.url.endswith(f"/c/{session_b}"), page.url
+        finally:
+            await browser.close()
+
+
+def test_start_session_landing_clears_after_navigating_away(
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Coming back to the landing screen mid-create must not restore the draft.
+
+    The composer stashes its half-composed draft on unmount so a detour
+    into another session doesn't lose a half-typed thought. But a draft
+    that has already been *submitted* is spent: it belongs to the session
+    now being created. Restoring it hands the user a composer pre-filled
+    with the message they just sent — and a second Send would create a
+    duplicate session.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _run_in_fresh_loop(_drive_landing_clears_after_navigating_away(base_url, session_a, session_b))
+
+
+async def _drive_landing_clears_after_navigating_away(
+    base_url: str, session_a: str, session_b: str
+) -> None:
+    """Async body of the spent-draft test.
+
+    :param base_url: Spawned server base URL.
+    :param session_a: Pre-seeded session the faked create returns.
+    :param session_b: Pre-seeded session the user detours through before
+        returning to the landing screen.
+    """
+    message = "set up the project"
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            release_create = asyncio.Event()
+            create_answered = asyncio.Event()
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    await release_create.wait()
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_a}),
+                    )
+                else:
+                    await route.continue_()
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+
+            # Keep the agent-discovery scan empty so only the stubbed Claude
+            # agent feeds the picker (see _drive_permission_mode for why).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            def note_create_response(response) -> None:
+                if response.request.method == "POST" and _SESSIONS_RE.search(response.url):
+                    create_answered.set()
+
+            page.on("response", note_create_response)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            landing_input = page.get_by_test_id("new-chat-landing-input")
+            await landing_input.wait_for(state="visible", timeout=30_000)
+
+            await landing_input.fill(message)
+            await page.get_by_test_id("new-chat-landing-submit").click()
+            await _wait_until(lambda: len(create_bodies) == 1)
+
+            # Detour through another session and come straight back, all
+            # while the create is still bootstrapping.
+            await page.locator(f'a[href="/c/{session_b}"]').click()
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_b)}$"))
+            await page.get_by_test_id("new-chat-button").click()
+            await landing_input.wait_for(state="visible", timeout=30_000)
+
+            # A spent draft must not come back — not while the create is
+            # still running, nor once it lands.
+            await expect(landing_input).to_have_value("")
+            release_create.set()
+            await asyncio.wait_for(create_answered.wait(), timeout=30.0)
+            for _ in range(20):
+                assert await landing_input.input_value() == "", "submitted draft was restored"
+                await asyncio.sleep(0.05)
+        finally:
+            await browser.close()
+
+
 def test_start_session_remembers_last_picked_host(seeded_session: tuple[str, str]) -> None:
     """The host chip restores the last explicitly-picked host after a reload.
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3,7 +3,7 @@ import type * as UseConversationsModule from "@/hooks/useConversations";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
 import type * as ChatStoreModule from "@/store/chatStore";
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -939,6 +939,47 @@ describe("NewChatLandingScreen", () => {
     );
     // The attachment chip re-renders from the restored draft.
     expect(screen.getByText("diagram.png")).toBeTruthy();
+  });
+
+  it("hands the draft back when a create the user walked away from is rejected", async () => {
+    // A submitted draft is dropped on unmount — it belongs to the session
+    // being created. But a create the server rejects makes no session, so
+    // the message is the user's again and must survive the round-trip
+    // instead of vanishing with the failed attempt.
+    let rejectCreate: (() => void) | null = null;
+    authenticatedFetchMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          rejectCreate = () =>
+            resolve({
+              ok: false,
+              status: 400,
+              json: async () => ({ detail: "workspace already in use" }),
+              text: async () => "workspace already in use",
+            } as unknown as Response);
+        }),
+    );
+    const first = renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "rebuild the parser" },
+    });
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(rejectCreate).not.toBeNull());
+
+    // The user gives up waiting and opens another session, then the create
+    // comes back rejected.
+    first.unmount();
+    await act(async () => {
+      rejectCreate!();
+    });
+
+    renderLanding();
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "rebuild the parser",
+    );
   });
 
   it("enables submit only once a message, host, agent and valid workspace are set", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2139,9 +2139,13 @@ export function NewChatLandingScreen() {
 
   // Mirror the current draft fields into a ref every render so the unmount
   // cleanup below can snapshot the latest values without re-subscribing.
-  // `submittedRef` is flipped just before we navigate to a freshly-created
-  // session so the snapshot is dropped instead of resurrected.
+  // `submittedRef` is flipped once the draft is sent to a create, so the
+  // snapshot is dropped instead of resurrected.
   const submittedRef = useRef(false);
+  // Whether this composer is still on screen. The create POST can outlive
+  // it — the user opens another session while the session bootstraps — and
+  // the post-create navigation must not follow them there.
+  const onScreenRef = useRef(true);
   const draftRef = useRef<LandingDraft>(null as unknown as LandingDraft);
   draftRef.current = {
     message,
@@ -2164,7 +2168,11 @@ export function NewChatLandingScreen() {
     costControlMode,
   };
   useEffect(() => {
+    // Re-set on setup so StrictMode's setup→cleanup→setup double-invoke
+    // doesn't leave the screen marked gone.
+    onScreenRef.current = true;
     return () => {
+      onScreenRef.current = false;
       landingDraft = submittedRef.current ? null : draftRef.current;
     };
   }, []);
@@ -3325,6 +3333,14 @@ export function NewChatLandingScreen() {
     }
   }
 
+  // No session was created after all, so the draft is the user's again —
+  // including when they navigated away and the unmount cleanup already
+  // dropped it on the strength of the submit.
+  function returnDraftToUser() {
+    submittedRef.current = false;
+    if (!onScreenRef.current) landingDraft = draftRef.current;
+  }
+
   async function handleCreate() {
     // Mirror the Send button's disabled condition (canSubmit) so the Enter-key
     // and form-submit paths that call this directly can't create a session with
@@ -3332,6 +3348,12 @@ export function NewChatLandingScreen() {
     if (!canSubmit) return;
     setCreating(true);
     setCreateError(null);
+    // The draft is spent from the moment it is submitted: it belongs to the
+    // session now being created, so a detour back to this screen must not
+    // hand it back pre-filled. Flipped here rather than on the response
+    // because the create outlives an unmount; a create that fails hands the
+    // draft back via returnDraftToUser.
+    submittedRef.current = true;
     try {
       const trimmedBranch = branchName.trim();
       // `shouldCreateWorktree` (component scope): true only when a branch is
@@ -3569,6 +3591,7 @@ export function NewChatLandingScreen() {
         // the workspace and agent, so winning on the push can't skip past an
         // error the user needed to see on this screen.
         if ("error" in created) {
+          returnDraftToUser();
           setCreateError(created.error);
           return;
         }
@@ -3626,13 +3649,17 @@ export function NewChatLandingScreen() {
       // the freshly-opened chat (whose composer reads the same per-conversation
       // key). Sanitized text so recall reproduces exactly what was sent.
       appendPromptHistoryEntry(initialPrompt, data.id);
-      // The session was created — drop the preserved draft so the next visit
-      // to the landing screen starts clean (and the unmount cleanup below
-      // doesn't resurrect what we just sent).
-      submittedRef.current = true;
+      // The session was created — drop any draft a detour back to this
+      // screen stashed, so the next visit starts clean.
       landingDraft = null;
-      navigate(`/c/${data.id}`);
+      // Only follow the create while the user is still on the landing
+      // screen. A create that outlived it means they moved on to another
+      // session; jumping them into this one now would hijack that. The
+      // session is created either way and its first message stays held
+      // for whenever they open it.
+      if (onScreenRef.current) navigate(`/c/${data.id}`);
     } catch {
+      returnDraftToUser();
       setCreateError("Couldn't reach the server. Check your connection and try again.");
     } finally {
       setCreating(false);


### PR DESCRIPTION
## Related issue

N/A — reported directly rather than filed as an issue. (I attempted to open one to link here but issue creation was not permitted from this environment.)

## Summary

Start a new session from the web UI, then click a different session in the sidebar before the new one opens. Seconds later the view jumps into the new session anyway, tearing you out of the session you deliberately navigated to.

`NewChatLandingScreen`'s create handler awaits `POST /v1/sessions` — which doesn't answer until the host has spawned a runner, so seconds — and then calls `navigate(...)` unconditionally. That closure outlives the composer's unmount, so a create that lands after the user has moved on still redirects them.

- **Gate the post-create navigation on the composer still being on screen.** The session is created either way and its first message stays held, so opening it later still dispatches the prompt.
- **Flip the "this draft is spent" flag at submit, not on the response.** Same root cause: the unmount cleanup now runs while the create is still in flight, so returning to the landing screen mid-create handed the user back a composer pre-filled with the message they had already sent (and a second Send would create a duplicate session).
- **Hand the draft back when a create fails or is rejected**, from both the `catch` and the `!res.ok`-style early return — otherwise a failed send would silently eat the user's message.

ELI5: the "go to the new chat" instruction was a note the composer left for itself. It kept honouring that note even after the user had walked to a different room. Now it checks whether it's still standing where it wrote it.

```mermaid
sequenceDiagram
    participant U as User
    participant L as Landing composer
    participant S as Server
    U->>L: type prompt + Send
    L->>S: POST /v1/sessions
    U->>L: click session B in sidebar (composer unmounts)
    S-->>L: {id: A}  (seconds later)
    Note over L: before — navigate(/c/A), hijacking the view
    Note over L: after  — still on screen? no → stay on B
```

## Test Plan

- `tests/e2e_ui/start_session/test_start_session.py::test_start_session_no_redirect_after_navigating_away` — holds the create POST on a gate, navigates to another session via the sidebar (client-side, so the fetch keeps running), releases the create, waits for the browser to *receive* the response, then samples the URL for 2.5s. Sampling rather than `expect()` matters: `expect` retries until pass, so it would never catch a redirect that arrives a tick later. Fails without the fix with `AssertionError: ['…/c/3c4e05e0…', '…/c/1810512565…']`.
- `tests/e2e_ui/start_session/test_start_session.py::test_start_session_landing_clears_after_navigating_away` — submits, detours through another session, returns to the landing screen mid-create, asserts the composer is empty both while the create runs and after it lands. Fails without the fix with `Actual value: set up the project`.
- `web/src/shell/NewChatDialog.test.tsx` — "hands the draft back when a create the user walked away from is rejected" covers the failure path. A/B verified: removing the restore makes it fail.
- Full suites: `tests/e2e_ui/start_session` + `tests/e2e_ui/sessions/test_initial_prompt_session_switch.py`, and all of `NewChatDialog.test.tsx`.
- Manual, against a local server with a real connected host and a real Claude Code runner launch (no stubs): navigated away mid-create and watched 45s — stayed put; the new session appeared in the sidebar and its held first message dispatched on open; the composer was empty on return in both timing cases (mid-create and after the create landed).

## Demo

N/A — the change is the *absence* of a navigation, which a screenshot can't show. The two e2e tests above capture the before/after directly: the URL trace `['…/c/A', '…/c/B']` (redirect fires) versus `['…/c/B']` (stays put), and the composer value `"set up the project"` versus `""`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both new e2e tests were confirmed to fail on the unfixed code and pass after, with no test modification in between. The unit test was A/B'd the same way (removing the restore makes it fail).

Manual verification used a real host and a real runner launch rather than the stubbed create the e2e tests use, to confirm the fix holds when the in-flight window is a genuine multi-second runner boot: navigated away mid-create, watched 45s (no redirect), confirmed the new session still appears in the sidebar and its held first message dispatches when opened, and confirmed the composer is empty on return both mid-create and post-create.

Note on behaviour: because the redirect is what triggers the held first message, a session the user walks away from mid-create now sits idle until they open it — the agent doesn't start working in the background. Dispatching it eagerly needs a send path that targets a non-active session, which is a separate change.

## Changelog

Navigating to another session while a new one is still being created no longer yanks you into the new session when it finishes
