### PR TITLE
chore(android): bump app versionName to 0.1.1

### DIFF
--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         minSdk = 28
         targetSdk = 36
         versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 2
-        versionName = "0.1.0"
+        versionName = "0.1.1"
 
         // Instrumented (androidTest) runner — required for UI Automator / Espresso
         // screenshot tests. Mirrors the androidx.test stable line pinned below.


### PR DESCRIPTION
## Related issue

N/A — chore, no issue required.

## Summary

- Bumps the Android shell's `versionName` from `0.1.0` to `0.1.1`.
- `versionCode` is intentionally untouched: it is supplied per release by CI
  (`android-bundle.yml` passes `-PversionCode=<input>`, documented as "must be
  higher than the last uploaded to Play; starts at 3"). The `?: 2` in
  `build.gradle.kts` is only a local-build fallback, so changing it would have
  no effect on what ships to Play.

## Test Plan

- `./gradlew :app:processDebugMainManifest` and inspected the merged manifest:

  ```
  app/build/intermediates/merged_manifest/debug/processDebugMainManifest/AndroidManifest.xml
    android:versionCode="2"
    android:versionName="0.1.1"
  ```

- `pre-commit run --files web/android/app/build.gradle.kts` — passes.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

A version-string constant has no behaviour to unit test. Verified by building
the merged manifest and confirming `android:versionName="0.1.1"` is what the
build actually emits, rather than only reading back the source line.


