### PR TITLE
fix(ci): don't ask reporters to self-close onto a closed issue

### DIFF
--- a/.github/scripts/issue_duplicates.py
+++ b/.github/scripts/issue_duplicates.py
@@ -260,6 +260,22 @@ def _cosine(left: dict[str, float], right: dict[str, float]) -> float:
     return dot / (left_norm * right_norm)
 
 
+def reference_disposition(candidate: dict[str, Any]) -> str:
+    """How a referenced issue's state changes what we can ask the reporter for.
+
+    `open` — the discussion is live, so the reporter can move their report there.
+    `fixed` — closed as completed, so hitting it again is a regression or an old
+    build, and the new report has to stay open to capture that.
+    `declined` — closed as not planned, so there is nothing to move a report into.
+    """
+    if candidate.get("state") != "CLOSED":
+        return "open"
+    labels = {label.casefold() for label in _label_names(candidate.get("labels"))}
+    if candidate.get("stateReason") == "NOT_PLANNED" or "wontfix" in labels:
+        return "declined"
+    return "fixed"
+
+
 def validate_duplicate_decision(
     result: dict[str, Any],
     issue: dict[str, Any],
@@ -327,13 +343,37 @@ def validate_duplicate_decision(
         duplicate_of = None
         similar_issues = []
 
+    # The referenced issues' own state decides what the comment can ask for, so
+    # carry it alongside the numbers rather than re-fetching at comment time.
+    referenced = [duplicate_of] if duplicate_of is not None else similar_issues
+    dispositions = {
+        str(number): reference_disposition(candidates_by_number[number])
+        for number in referenced
+        if number in candidates_by_number
+    }
+
     return {
         "duplicate_decision": decision,
         "duplicate_of": duplicate_of,
         "similar_issues": similar_issues,
         "duplicate_confidence": confidence,
         "duplicate_reasoning": _duplicate_reason(decision),
+        "reference_dispositions": dispositions,
     }
+
+
+def _disposition_for(decision: dict[str, Any], number: int | None) -> str:
+    """Look up a reference's disposition, treating anything unknown as open.
+
+    Defaulting to `open` keeps the wording that assumes a live discussion, which
+    is the safe direction: it asks the reporter to check rather than telling them
+    a fix shipped.
+    """
+    dispositions = decision.get("reference_dispositions")
+    if not isinstance(dispositions, dict):
+        return "open"
+    value = dispositions.get(str(number))
+    return value if value in {"open", "fixed", "declined"} else "open"
 
 
 def build_duplicate_comment(
@@ -362,6 +402,23 @@ def build_duplicate_comment(
                 f"place.{explanation}\n\n"
                 "If it isn't the same, say so here and a maintainer will reopen it."
             )
+        elif _disposition_for(decision, issue_number) == "fixed":
+            message = (
+                f"Thanks for reporting this. This looks like the same problem as "
+                f"#{issue_number}, which has already been fixed — so the fix may "
+                f"have shipped after the build you're on.\n\n"
+                "Could you check whether you're on a version that includes it? If "
+                "you are and this still happens, say so here — that makes it a "
+                "regression rather than a duplicate, and we'll keep this open."
+            )
+        elif _disposition_for(decision, issue_number) == "declined":
+            message = (
+                f"Thanks for reporting this. This looks like the same problem as "
+                f"#{issue_number}, which was closed as not planned — worth reading "
+                f"for the reasoning.\n\n"
+                "If your case is different from what was decided there, say what's "
+                "different and we'll pick it up here."
+            )
         else:
             # The reporter can settle this faster than a maintainer can: they know
             # whether the other issue covers their case. Ask them to close it
@@ -374,18 +431,55 @@ def build_duplicate_comment(
                 "If it doesn't, say what's different and we'll pick it up here."
             )
     elif decision["duplicate_decision"] == "similar":
-        references = ", ".join(f"#{number}" for number in decision["similar_issues"])
-        covers = (
-            "they already cover" if len(decision["similar_issues"]) > 1 else "it already covers"
-        )
-        # Softer than the duplicate case — a loose match is a weaker basis for
-        # asking someone to close their own report — but still theirs to settle.
-        message = (
-            f"Thanks for reporting this. {references} may be related — could you "
-            f"take a look in case {covers} this?\n\n"
-            "If it turns out to be the same problem, please close this one and add "
-            "your details there. Otherwise leave a note and we'll pick it up here."
-        )
+        numbers = decision["similar_issues"]
+        references = ", ".join(f"#{number}" for number in numbers)
+        plural = len(numbers) > 1
+        dispositions = {_disposition_for(decision, number) for number in numbers}
+        # A closed match cannot absorb the report: asking for a self-close would
+        # send the reporter's detail somewhere nobody is reading. Mixed sets keep
+        # the open ask, since at least one live issue can take it.
+        if "open" in dispositions:
+            covers = "they already cover" if plural else "it already covers"
+            message = (
+                f"Thanks for reporting this. {references} may be related — could you "
+                f"take a look in case {covers} this?\n\n"
+                "If it turns out to be the same problem, please close this one and add "
+                "your details there. Otherwise leave a note and we'll pick it up here."
+            )
+        elif dispositions == {"declined"}:
+            was = "were" if plural else "was"
+            message = (
+                f"Thanks for reporting this. {references} may be related, and {was} "
+                f"closed as not planned — worth reading for the reasoning.\n\n"
+                "If your case is different from what was decided there, say what's "
+                "different and we'll pick it up here."
+            )
+        else:
+            # At least one fixed match, possibly beside a declined one. Name each
+            # group separately: claiming a declined issue was fixed is worse than
+            # the extra clause costs.
+            fixed = [n for n in numbers if _disposition_for(decision, n) == "fixed"]
+            declined = [n for n in numbers if _disposition_for(decision, n) == "declined"]
+            fixed_refs = ", ".join(f"#{number}" for number in fixed)
+            many = len(fixed) > 1
+            also = (
+                " ({} {} closed as not planned, for context.)".format(
+                    ", ".join(f"#{number}" for number in declined),
+                    "were" if len(declined) > 1 else "was",
+                )
+                if declined
+                else ""
+            )
+            message = (
+                f"Thanks for reporting this. {fixed_refs} may be related, and "
+                f"{'have' if many else 'has'} already been fixed — so the "
+                f"{'fixes' if many else 'fix'} may have shipped after the build "
+                f"you're on.{also}\n\n"
+                "Could you check whether you're on a version that includes "
+                f"{'them' if many else 'it'}? If you are and this still happens, "
+                "say so here — that makes it a regression rather than a duplicate, "
+                "and we'll keep this open."
+            )
     else:
         return ""
 
@@ -479,6 +573,7 @@ def _normalize_candidate(issue_number: int, candidate: dict[str, Any]) -> dict[s
         "title": str(candidate.get("title") or "")[:500],
         "body": str(candidate.get("body") or "")[:2000],
         "state": state,
+        "stateReason": str(candidate.get("stateReason") or "").upper(),
         "url": str(candidate.get("url") or ""),
         "createdAt": candidate.get("createdAt"),
         "updatedAt": candidate.get("updatedAt"),

--- a/.github/scripts/issue_duplicates_test.py
+++ b/.github/scripts/issue_duplicates_test.py
@@ -11,6 +11,7 @@ from issue_duplicates import (
     extract_issue_references,
     parse_triage_output,
     rank_candidates,
+    reference_disposition,
     similarity_scores,
     validate_duplicate_decision,
 )
@@ -210,6 +211,151 @@ class IssueDuplicatesTest(unittest.TestCase):
 
         self.assertIn("it already covers", comment_for([12]))
         self.assertIn("they already cover", comment_for([12, 34]))
+
+    def test_reference_disposition_splits_closed_by_reason(self):
+        self.assertEqual(reference_disposition({"state": "OPEN"}), "open")
+        self.assertEqual(
+            reference_disposition({"state": "CLOSED", "stateReason": "COMPLETED"}), "fixed"
+        )
+        self.assertEqual(
+            reference_disposition({"state": "CLOSED", "stateReason": "NOT_PLANNED"}), "declined"
+        )
+        # `wontfix` carries the same meaning as NOT_PLANNED on older closures,
+        # which predate the state reason.
+        self.assertEqual(
+            reference_disposition(
+                {"state": "CLOSED", "stateReason": "", "labels": [{"name": "wontfix"}]}
+            ),
+            "declined",
+        )
+        # An unset reason on a closed issue is treated as fixed: completed is by
+        # far the common case, and the wording still asks rather than asserts.
+        self.assertEqual(reference_disposition({"state": "CLOSED", "stateReason": ""}), "fixed")
+
+    def test_comment_does_not_ask_a_reporter_to_close_onto_a_fixed_issue(self):
+        """A shipped fix makes this a version question, not a duplicate to merge into.
+
+        Reproduces the real #4245 comment, which pointed at #1977 — closed as
+        completed — and still asked the reporter to close their own report and add
+        details there, where nobody would read them.
+        """
+        issue = {
+            "title": "SOCKS proxy ImportError on local daemon health check",
+            "body": "Using a SOCKS proxy, the local daemon health check raises ImportError.",
+        }
+        decision = validate_duplicate_decision(
+            {
+                "duplicate_decision": "similar",
+                "similar_issues": [1977],
+                "duplicate_confidence": 0.8,
+            },
+            issue,
+            [{"number": 1977, "state": "CLOSED", "stateReason": "COMPLETED", **issue}],
+        )
+
+        comment = build_duplicate_comment(decision, close_issue=False)
+
+        self.assertEqual(decision["reference_dispositions"], {"1977": "fixed"})
+        self.assertIn("#1977", comment)
+        self.assertIn("already been fixed", comment)
+        self.assertIn("regression rather than a duplicate", comment)
+        # The two asks that made no sense against a closed issue.
+        self.assertNotIn("please close this one", comment)
+        self.assertNotIn("add your details there", comment)
+
+    def test_comment_on_a_declined_issue_never_asks_for_a_self_close(self):
+        """Nothing was planned there, so there is no discussion to move a report into."""
+        issue = {
+            "title": "Support running the daemon as a Windows service",
+            "body": "The daemon should install itself as a Windows service.",
+        }
+        decision = validate_duplicate_decision(
+            {
+                "duplicate_decision": "similar",
+                "similar_issues": [1500],
+                "duplicate_confidence": 0.8,
+            },
+            issue,
+            [{"number": 1500, "state": "CLOSED", "stateReason": "NOT_PLANNED", **issue}],
+        )
+
+        comment = build_duplicate_comment(decision, close_issue=False)
+
+        self.assertIn("closed as not planned", comment)
+        self.assertIn("was closed", comment)
+        self.assertNotIn("please close this one", comment)
+        self.assertNotIn("already been fixed", comment)
+
+    def test_a_live_reference_still_gets_the_self_close_ask(self):
+        """One open match among closed ones can still absorb the report."""
+        issue = {
+            "title": "Session sidebar loses scroll position on rename",
+            "body": "Renaming a session resets the sidebar scroll position to the top.",
+        }
+        decision = validate_duplicate_decision(
+            {
+                "duplicate_decision": "similar",
+                "similar_issues": [900, 950],
+                "duplicate_confidence": 0.8,
+            },
+            issue,
+            [
+                {"number": 900, "state": "CLOSED", "stateReason": "COMPLETED", **issue},
+                {"number": 950, "state": "OPEN", **issue},
+            ],
+        )
+
+        comment = build_duplicate_comment(decision, close_issue=False)
+
+        self.assertEqual(decision["reference_dispositions"], {"900": "fixed", "950": "open"})
+        self.assertIn("please close this one", comment)
+
+    def test_a_declined_reference_is_not_described_as_fixed(self):
+        """Mixed closures name each group: "fixed" must not absorb the declined one."""
+        comment = build_duplicate_comment(
+            {
+                "duplicate_decision": "similar",
+                "duplicate_of": None,
+                "similar_issues": [12, 34],
+                "duplicate_confidence": 0.8,
+                "reference_dispositions": {"12": "fixed", "34": "declined"},
+            },
+            close_issue=False,
+        )
+
+        self.assertIn("#12 may be related, and has already been fixed", comment)
+        self.assertIn("#34 was closed as not planned", comment)
+
+    def test_a_fixed_duplicate_is_not_asked_to_close_either(self):
+        """The `duplicate` verdict has the same closed-reference problem."""
+        decision = {
+            "duplicate_decision": "duplicate",
+            "duplicate_of": 12,
+            "similar_issues": [],
+            "duplicate_confidence": 1.0,
+            "duplicate_reasoning": "The reports describe the same behavior.",
+            "reference_dispositions": {"12": "fixed"},
+        }
+
+        comment = build_duplicate_comment(decision, close_issue=False)
+
+        self.assertIn("already been fixed", comment)
+        self.assertNotIn("please close this one", comment)
+
+    def test_a_missing_disposition_keeps_the_open_wording(self):
+        """Absent state defaults to the ask-don't-assert copy rather than crashing."""
+        comment = build_duplicate_comment(
+            {
+                "duplicate_decision": "similar",
+                "duplicate_of": None,
+                "similar_issues": [12],
+                "duplicate_confidence": 0.8,
+            },
+            close_issue=False,
+        )
+
+        self.assertIn("please close this one", comment)
+        self.assertNotIn("already been fixed", comment)
 
     def test_duplicate_comment_reflects_closure_flag(self):
         decision = {

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -176,7 +176,7 @@ jobs:
           # a query-dependent candidate set makes IDF — and so the closure
           # threshold — depend on what search happened to return.
           gh issue list --repo "$REPO" --state all --limit "$CORPUS_LIMIT" \
-            --json number,title,body,state,url,createdAt,updatedAt,labels \
+            --json number,title,body,state,stateReason,url,createdAt,updatedAt,labels \
             > /tmp/corpus.json
 
           PYTHONPATH=.github/scripts python3 <<'PYEOF'


### PR DESCRIPTION
## Related issue

Relates to #4198 (duplicate-detector rollout — comments are live at Stage 2).
Follow-up to #4223, which introduced the self-close ask.

## Summary

The duplicate-check comment asks reporters to close their own issue and add
details to the match — but never checked whether the match was **still open**.

On #4245 it pointed at #1977, closed as completed a month earlier, and still
said *"please close this one and add your details there."* Both asks were wrong:
if a reporter hits a bug whose fix already shipped, that's a **regression, an
incomplete fix, or an older build** — all of which need the new issue to stay
open — and details added to a closed issue go nowhere.

This is the common case, not an edge case. The corpus is deliberately
`--state all` (*"Every issue ever filed, so long-closed reports stay
discoverable"*), and measuring against the real corpus:

- **65% of top-ranked candidates** over the last 40 issues are already-fixed
  issues (25 fixed / 14 open / 1 declined).
- 405 of 770 issues in the repo are closed; of the last 100 closures, 92 are
  `COMPLETED`, 7 `NOT_PLANNED`, 1 `DUPLICATE`.

So the old copy was wrong more often than it was right.

### Comments now branch on the reference's own state

| Disposition | Ask |
|---|---|
| `open` | unchanged — reporter can move their report there |
| closed as `COMPLETED` | leads with the shipped fix, asks which build they're on, keeps the issue open as a regression if it still reproduces |
| closed as `NOT_PLANNED` / `wontfix` | points at the reasoning, **no** self-close ask |

The #4245 case now renders as:

> Thanks for reporting this. #1977 may be related, and has already been fixed — so the fix may have shipped after the build you're on.
>
> Could you check whether you're on a version that includes it? If you are and this still happens, say so here — that makes it a regression rather than a duplicate, and we'll keep this open.

Declined:

> Thanks for reporting this. #1500 may be related, and was closed as not planned — worth reading for the reasoning.
>
> If your case is different from what was decided there, say what's different and we'll pick it up here.

### Implementation notes

- `stateReason` is plumbed through the corpus fetch (`gh issue list --json …`)
  and `_normalize_candidate`; `reference_disposition()` maps state → `open` /
  `fixed` / `declined`, treating the legacy `wontfix` label as declined.
- Dispositions ride along on the decision dict, so the comment builder doesn't
  re-fetch. A **missing** disposition falls back to the open wording, which asks
  rather than asserts — safe for any caller that doesn't supply state.
- **Mixed sets name each group separately** (`#12 … has already been fixed
  (#34 was closed as not planned, for context.)`) — an earlier draft described
  a declined issue as fixed, which is a worse error than the extra clause costs.
- The non-closing `duplicate` verdict had the same flaw and gets the same
  treatment.

Worth noting for Stage 3: with `ISSUE_TRIAGE_CLOSE_DUPLICATES=true`, a
`duplicate` verdict pointing at a *closed* issue would auto-close a possible
regression report. That path is still dark, so there's time to look at it
separately.

## Test Plan

```bash
python3 -m unittest discover -s .github/scripts -p 'issue_duplicates_test.py'
# Ran 34 tests — OK  (27 before this change)
pre-commit run --files .github/scripts/issue_duplicates.py \
  .github/scripts/issue_duplicates_test.py .github/workflows/issue-triage.yml
```

New tests cover the disposition mapping (including `wontfix` and an unset
reason), the `fixed` / `declined` / mixed comment paths, the missing-disposition
fallback, and the `duplicate` verdict equivalent.

Also **replayed #4245 against the live corpus** (2000 issues fetched with
`stateReason`) to confirm #1977 ranks as a candidate, resolves to `fixed`, and
produces the corrected comment rather than the self-close ask.

## Demo

N/A — bot comment copy; every rendered variant is quoted above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was twofold: rendering all seven similar-branch variants to
check number agreement and factual accuracy (this is how the "declined
described as fixed" bug surfaced), and replaying the real #4245 / #1977 pair
through `rank_candidates` → `validate_duplicate_decision` →
`build_duplicate_comment` against the live 2000-issue corpus. The corpus-fetch
`--json` change can only be verified in CI, since it depends on `gh issue list`
output shape — `gh` was confirmed to populate `stateReason` for closed issues
locally.

## Changelog

Duplicate-detection comments no longer ask you to close your issue when the
matching issue is already closed — an already-fixed match now asks whether
you're on a build with the fix, and treats a still-reproducing report as a
regression.

---

This pull request and its description were written by Isaac.