### PR TITLE
fix(onboarding): correct the kimi and hermes CLI version floors

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -106,19 +106,22 @@ KIRO_KEY = "kiro"
 #   CLI loses only smart-routing spawn gating, not the ability to launch.
 # - cursor: Cursor's CLI uses ``YYYY.MM.DD[-build]`` date versions. Default
 #   to the day after 2026-06-01 so we don't support stale pre-June builds.
-# - kimi: first ``kimi-cli`` release after 2026-06-01 is 1.47.0
-#   (https://github.com/MoonshotAI/kimi-cli/blob/main/CHANGELOG.md).
-# - hermes: parent_session_id schema was introduced in v0.17.0, but Hermes now
-#   ships date-tagged releases; the first one after 2026-06-01 is 2026.06.05.
+# - kimi: the harness drives Moonshot's ``kimi-code`` CLI (the ``kimi`` binary
+#   this spec installs), whose releases are a 0.x series — NOT the separate
+#   ``kimi-cli`` project, which numbers from 1.x. Its first release after
+#   2026-06-01 is 0.7.0.
+# - hermes: parent_session_id schema introduced in v0.17.0. Hermes reports a
+#   semver version with the build date alongside it
+#   (``Hermes Agent v0.19.1 (2026.7.30)``), so the floor is that semver.
 _CODEX_MIN_VERSION = "0.137.0"
 _PI_MIN_VERSION = "0.79.0"
 _QWEN_MIN_VERSION = "0.18.1"
 _GOOSE_MIN_VERSION = "1.38.0"
-_HERMES_MIN_VERSION = "2026.06.05"
+_HERMES_MIN_VERSION = "0.17.0"
 _KIRO_MIN_VERSION = "2.10.0"
 _CLAUDE_MIN_VERSION = "2.1.161"
 _CURSOR_MIN_VERSION = "2026.06.02"
-_KIMI_MIN_VERSION = "1.47.0"
+_KIMI_MIN_VERSION = "0.7.0"
 
 # OpenCode native harness CLI (``opencode serve`` / ``opencode attach``),
 # installed via the ``opencode-ai`` npm package. No login/logout/status argv
@@ -243,7 +246,7 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         package=None,
         login_args=("login",),
         install_hint="curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
-        # First kimi-cli release after 2026-06-01. Older builds may lack
+        # First kimi-code release after 2026-06-01. Older builds may lack
         # newer TUI/session wiring needed by the native harness.
         min_version=_KIMI_MIN_VERSION,
     ),

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1111,13 +1111,13 @@ def test_ui_setup_steps_generic_for_non_installable() -> None:
     [
         (hi.OPENCODE_KEY, "1.17.7", "1.18.0"),
         (hi.CURSOR_KEY, "2026.06.02", None),
-        (hi.KIMI_KEY, "1.47.0", None),
+        (hi.KIMI_KEY, "0.7.0", None),
         (ANTHROPIC_FAMILY, "2.1.161", None),
         (OPENAI_FAMILY, "0.137.0", None),
         (hi.PI_KEY, "0.79.0", None),
         (hi.QWEN_KEY, "0.18.1", None),
         (hi.GOOSE_KEY, "1.38.0", None),
-        (hi.HERMES_KEY, "2026.06.05", None),
+        (hi.HERMES_KEY, "0.17.0", None),
         (hi.KIRO_KEY, "2.10.0", None),
     ],
 )
@@ -1214,6 +1214,55 @@ def test_the_codex_launch_floor_accepts_the_ci_pinned_cli(
     assert hi.harness_cli_installed(OPENAI_FAMILY) is True
 
 
+def test_the_kimi_floor_accepts_the_cli_this_spec_installs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A current ``kimi-code`` build must read as installed, not too-low.
+
+    The floor tracks Moonshot's ``kimi-code`` CLI (a 0.x series, the binary
+    this spec's installer puts on PATH), not the separately numbered
+    ``kimi-cli`` project. Pinning it to a 1.x version made every shipping
+    ``kimi`` fail the range, so ``harness_is_configured`` stayed false and the
+    host refused every kimi-native launch.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="0.34.0\n", stderr=""
+            )
+        raise AssertionError(f"unexpected subprocess: {argv!r}")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_installed(hi.KIMI_KEY) is True
+
+
+def test_the_hermes_floor_accepts_the_shipping_version_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hermes' semver ``--version`` line must satisfy the floor.
+
+    Hermes prints ``Hermes Agent v0.19.1 (2026.7.30)`` — a semver with the
+    build date beside it — so the parser reads ``0.19.1``. A date-shaped floor
+    could never be met by that string, which left hermes-native unlaunchable.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="Hermes Agent v0.19.1 (2026.7.30)\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected subprocess: {argv!r}")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_installed(hi.HERMES_KEY) is True
+
+
 def test_harness_cli_installed_true_when_version_in_range(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1263,8 +1312,8 @@ def test_parse_harness_cli_version_normalizes_date_versions(raw: str, expected: 
     "key,outdated,satisfying",
     [
         (hi.CURSOR_KEY, "2026.05.24", "2026.06.22"),
-        (hi.KIMI_KEY, "1.46.0", "1.48.0"),
-        (hi.HERMES_KEY, "2026.05.29", "2026.06.19"),
+        (hi.KIMI_KEY, "0.6.0", "0.34.0"),
+        (hi.HERMES_KEY, "0.16.9", "0.19.1"),
     ],
 )
 def test_harness_cli_installed_enforces_default_post_2026_06_01_floors(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two harness version floors are unsatisfiable by the CLI they gate, so
`harness_cli_installed` returns `False` for **every shipping build**. That makes
`harness_is_configured` false, and `HostConnection` then refuses the launch
frame outright (`host/connect.py`, `HARNESS_NOT_CONFIGURED`) — so `kimi-native`
and `hermes-native` cannot start a session on any machine, and the picker shows
a permanent `version-too-low` that upgrading can never clear.

- **kimi** — the harness drives Moonshot's **`kimi-code`** CLI: the `kimi`
  binary this spec's own `install_hint` puts on PATH
  (`code.kimi.com/kimi-code/install.sh`), and the one
  `omnigent/inner/kimi_executor.py` resolves (`~/.kimi-code/bin/kimi`). Its
  releases are a **0.x** series — latest today is `0.34.0`. The floor was taken
  from the separately numbered **`kimi-cli`** project, which starts at 1.x, so
  no `kimi-code` build can ever satisfy `>=1.47.0`. Retargeted at the first
  `kimi-code` release after the same 2026-06-01 cutoff the sibling floors use:
  **0.7.0** (published 2026-06-02).
- **hermes** — the floor assumed date-tagged releases, but Hermes prints a
  semver with the build date beside it, `Hermes Agent v0.19.1 (2026.7.30)`, so
  `_parse_harness_cli_version` reads `0.19.1` — which can never be
  `>=2026.06.05`. Switched to the functional requirement the comment already
  documents: **0.17.0**, where the `parent_session_id` schema landed.

Comments updated to name the right product and the real version scheme, so the
next person doesn't re-derive the floor from the wrong changelog.

ELI5: the "is this CLI new enough?" check was comparing against another
product's version numbers, so a perfectly current CLI always looked too old and
the host refused to launch it.

```
kimi --version -> 0.34.0 ──> parsed 0.34.0 ──> 0.34.0 >= 1.47.0 ?  NO  ─┐
                                                (kimi-cli's series)      │
hermes --version -> "Hermes Agent v0.19.1 (2026.7.30)"                   │
                  └─> parsed 0.19.1 ──> 0.19.1 >= 2026.06.05 ?  NO  ─────┤
                                                                         v
     harness_cli_installed = False -> harness_is_configured = False -> host
     refuses the launch frame: "harness 'kimi-native' is not configured"
```

## Test Plan

- `pytest tests/onboarding/` — 1010 passed.
- Added one regression test per harness, pinned to the CLIs' real `--version`
  output (`0.34.0`; `Hermes Agent v0.19.1 (2026.7.30)`), so a future floor that
  the shipping CLI cannot meet fails here instead of in production.
- Updated the two existing parametrizations that assert the floors
  (`test_versioned_specs_declare_bounds`, and the outdated/satisfying pairs in
  `test_harness_cli_installed_enforces_default_post_2026_06_01_floors`).
- Verified live against the real CLIs on a host running `kimi 0.34.0` +
  `hermes v0.19.1`:

  ```
  before:  kimi ('0.34.0', '>=1.47.0')      kimi-native   -> version-too-low
           hermes ('0.19.1', '>=2026.06.05') hermes-native -> version-too-low
  after:   kimi ('0.34.0', '>=0.7.0')        kimi-native   -> True
           hermes ('0.19.1', '>=0.17.0')     hermes-native -> True
  ```

- `ruff check` / `ruff format --check` clean on both changed files.

## Demo

N/A — no UI change. The user-visible effect is the picker's `version-too-low`
badge clearing for kimi and hermes; the readout is quoted in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the part unit tests can't: running the real
`kimi` and `hermes` binaries through `harness_cli_version` /
`configured_harness_map` on a host that has both installed, confirming the
readiness value flips from `version-too-low` to `True`. Everything else — the
declared floors and the two `--version` shapes — is covered by the unit tests
listed above.

## Changelog

Kimi and Hermes sessions launch again — their version checks compared against
the wrong version series and rejected every current CLI.
