### PR TITLE
feat(android): let organizations preset server URLs via managed configuration

### DIFF
--- a/web/android/README.md
+++ b/web/android/README.md
@@ -55,6 +55,60 @@ when the bridge methods are absent, so the Android shell omits them for now:
 - **Native floating server switcher** and **Chat/Terminal bar.** Rendered
   in-page by the SPA.
 
+## Managed configuration (org-preset servers)
+
+Organizations can preconfigure server URLs so users don't type one. The app
+publishes an [Android managed
+configuration](https://developer.android.com/work/managed-configurations)
+(`app/src/main/res/xml/app_restrictions.xml`) with a single key, which any EMM
+(Intune, Jamf, Workspace ONE, Google Workspace, Android Management API) can push
+to enrolled devices:
+
+| Key          | Type   | Value                                                           |
+| ------------ | ------ | --------------------------------------------------------------- |
+| `serverUrls` | string | Server URLs, comma- or newline-separated, most preferred first. |
+
+```json
+{ "serverUrls": "https://omnigent.corp.example.com" }
+```
+
+Behaviour (`ManagedConfig` + `ServerStore`):
+
+- The URLs are **offered**, listed ahead of the user's recent servers on the
+  connect screen and in the server switcher. The user still taps one to connect —
+  this is true for a single URL as much as for several.
+- The app never auto-connects to a preset and never skips the connect screen, so
+  a policy can't silently move someone onto a different server.
+- Presets are not a lock either: a user can still type any other server, and the
+  one they picked stays current.
+- A preset is never written to the app's prefs, so an admin's later edit is
+  picked up the next time the list is shown.
+- Unparseable entries are dropped; an entry without a scheme gets `https://`;
+  same-origin duplicates collapse; the list is capped at 8.
+
+To test without an EMM, use Google's **Test DPC** on an emulator with no
+accounts (a wiped AVD):
+
+```bash
+adb install -r TestDPC_<ver>.apk      # github.com/googlesamples/android-testdpc releases
+adb shell dpm set-device-owner com.afwsamples.testdpc/.DeviceAdminReceiver
+```
+
+Then Test DPC → _Managed configurations_ → pick Omnigent → **Load manifest
+restrictions** (this renders our schema, confirming the manifest wiring) → set
+`serverUrls` → **Save**. Verify the policy actually landed with:
+
+```bash
+adb shell dumpsys device_policy | grep serverUrls
+```
+
+A physical device that already has a corporate work profile can't be used for
+this: Test DPC can't take over an existing managed profile, and device-owner
+mode requires a device with no accounts.
+
+iOS has no equivalent yet; when it lands it should reuse the `serverUrls` key
+verbatim via Managed App Configuration.
+
 ### Known parity gaps
 
 - **App badge count.** Android has no universal numeric badge API. We set

--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ai.omnigent.android"
         minSdk = 28
         targetSdk = 36
-        versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 2
-        versionName = "0.1.1"
+        versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 7
+        versionName = "0.1.2"
 
         // Instrumented (androidTest) runner — required for UI Automator / Espresso
         // screenshot tests. Mirrors the androidx.test stable line pinned below.

--- a/web/android/app/src/main/AndroidManifest.xml
+++ b/web/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Omnigent">
 
+        <!-- Lets an EMM/MDM preconfigure server URLs; read by ManagedConfig. -->
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/app_restrictions" />
+
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|uiMode|smallestScreenSize|screenLayout|density"

--- a/web/android/app/src/main/java/ai/omnigent/android/ConnectActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ConnectActivity.kt
@@ -13,8 +13,9 @@ import androidx.activity.ComponentActivity
 
 /**
  * Native server-entry screen, the Android counterpart to the iOS `ConnectView`:
- * a URL field plus a tappable recent-servers list. On connect it persists the
- * server via [ServerStore] and hands off to [MainActivity].
+ * a URL field plus a tappable server list (organization presets, then recents).
+ * On connect it persists the server via [ServerStore] and hands off to
+ * [MainActivity].
  *
  * [MainActivity] routes here on launch when no server has been configured yet.
  */
@@ -58,13 +59,13 @@ class ConnectActivity : ComponentActivity() {
     }
 
     private fun renderRecents() {
-        val recents = store.recentServers()
+        val servers = store.offeredServers()
         val container = findViewById<LinearLayout>(R.id.recents)
         findViewById<TextView>(R.id.recents_label).visibility =
-            if (recents.isEmpty()) View.GONE else View.VISIBLE
+            if (servers.isEmpty()) View.GONE else View.VISIBLE
 
         val inflater = LayoutInflater.from(this)
-        for (url in recents) {
+        for (url in servers) {
             val row = inflater.inflate(R.layout.item_recent, container, false) as TextView
             row.text = url
             row.setOnClickListener { connect(url) }

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -545,22 +545,22 @@ class MainActivity : AppCompatActivity() {
 
     /**
      * Show the server-switcher dropdown menu, mirroring the iOS `ServerSwitcher`
-     * `Menu`. Lists the current server (disabled header), other recent servers,
-     * Reload, and Connect to New Server. Tapping a recent server switches
-     * directly without leaving the app; "Connect to New Server" opens
-     * [ConnectActivity] for manual URL entry.
+     * `Menu`. Lists the current server (disabled header), the other servers on
+     * offer (organization presets, then recents), Reload, and Connect to New
+     * Server. Tapping a server switches directly without leaving the app;
+     * "Connect to New Server" opens [ConnectActivity] for manual URL entry.
      */
     private fun showServerSwitcherMenu(anchor: View) {
         val store = ServerStore(this)
         val currentUrl = store.currentServerUrl()
-        val otherServers = store.recentServers().filter { originOf(it) != pinnedOrigin }
+        val otherServers = store.offeredServers().filter { originOf(it) != pinnedOrigin }
 
         val popup = PopupMenu(this, anchor, Gravity.TOP)
         MenuCompat.setGroupDividerEnabled(popup.menu, true)
         popup.menu.apply {
             // Group 0: current server — disabled header.
             add(0, 0, 0, hostLabelOf(currentUrl)).isEnabled = false
-            // Group 1: other recent servers (divider before this group).
+            // Group 1: the other servers on offer (divider before this group).
             otherServers.forEachIndexed { i, url ->
                 add(1, 100 + i, 0, hostLabelOf(url))
             }

--- a/web/android/app/src/main/java/ai/omnigent/android/ManagedConfig.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ManagedConfig.kt
@@ -1,0 +1,61 @@
+package ai.omnigent.android
+
+import android.content.Context
+import android.content.RestrictionsManager
+import android.os.Bundle
+import androidx.core.content.getSystemService
+
+/**
+ * Server URLs an organization preconfigured for this install, read from Android
+ * managed configurations (the schema in `res/xml/app_restrictions.xml`). An
+ * admin sets the `serverUrls` restriction from their EMM/MDM console to a
+ * comma- or newline-separated list, most preferred first.
+ *
+ * Presets are offers only: [ServerStore] lists them ahead of recent servers, but
+ * the user still picks one to connect, and may enter any other server. Nothing
+ * here auto-connects or locks the app to a host.
+ */
+data class ManagedConfig(
+    val serverUrls: List<String>,
+) {
+    /** True when [url] shares an origin with a preset, so it needn't be listed twice. */
+    fun includes(url: String): Boolean {
+        val origin = originOf(url) ?: return false
+        return serverUrls.any { originOf(it) == origin }
+    }
+
+    companion object {
+        /**
+         * Restriction key. Deployed policies reference it by name, so it is a
+         * public contract — never rename it.
+         */
+        const val KEY_SERVER_URLS = "serverUrls"
+
+        val EMPTY = ManagedConfig(emptyList())
+
+        fun from(context: Context): ManagedConfig =
+            from(context.getSystemService<RestrictionsManager>()?.applicationRestrictions)
+
+        /**
+         * Parse a restrictions bundle. Unmanaged installs have no bundle at all,
+         * and a managed one only carries keys the admin actually set — even keys
+         * with an XML default value — so both a null bundle and a missing key are
+         * normal. Unparseable entries are dropped rather than failing the read:
+         * a typo in one URL shouldn't cost the user the whole list.
+         */
+        fun from(restrictions: Bundle?): ManagedConfig {
+            val raw = restrictions?.getString(KEY_SERVER_URLS) ?: return EMPTY
+            val urls =
+                raw
+                    .split('\n', '\r', ',')
+                    .mapNotNull(::normalizeServerUrl)
+                    // The app pins by origin, so same-origin entries are one server.
+                    .distinctBy { originOf(it) ?: it }
+                    .take(MAX_PRESETS)
+            return ManagedConfig(urls)
+        }
+
+        /** Matches the recents cap; keeps a malformed policy from flooding the UI. */
+        private const val MAX_PRESETS = 8
+    }
+}

--- a/web/android/app/src/main/java/ai/omnigent/android/ServerStore.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ServerStore.kt
@@ -6,16 +6,35 @@ import android.content.Context
  * Persistence for the connected server URL plus a recent-servers list, backing
  * [ConnectActivity]. Mirrors the iOS shell's `ConnectView` model (entry +
  * recents); the native UI here is intentionally minimal.
+ *
+ * Organization presets (see [ManagedConfig]) are folded into the offered server
+ * list only. They are never auto-connected and never written to prefs, so the
+ * user always chooses the server and a later policy change is picked up on the
+ * next read.
  */
 class ServerStore(
     context: Context,
+    /** Organization presets; injectable so tests need no restrictions shadow. */
+    val managed: ManagedConfig = ManagedConfig.from(context),
 ) {
     private val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
-    fun hasServer(): Boolean = !prefs.getString(KEY_CURRENT, null).isNullOrBlank()
+    /**
+     * True once the user has picked a server. Presets deliberately don't count:
+     * an admin preconfigures the list, but the user still taps to connect.
+     */
+    fun hasServer(): Boolean = !storedServerUrl().isNullOrBlank()
 
     /** The current server, or the emulator-loopback debug default if unset. */
-    fun currentServerUrl(): String = prefs.getString(KEY_CURRENT, null) ?: DEFAULT_DEBUG_SERVER
+    fun currentServerUrl(): String = storedServerUrl() ?: DEFAULT_DEBUG_SERVER
+
+    /**
+     * The servers to offer in the UI: organization presets first, then recents
+     * they don't already cover. Presets join the one list rather than getting a
+     * section of their own.
+     */
+    fun offeredServers(): List<String> =
+        managed.serverUrls + recentServers().filterNot(managed::includes)
 
     /** Recently-connected servers, most recent first. */
     fun recentServers(): List<String> =
@@ -34,6 +53,8 @@ class ServerStore(
             .putString(KEY_RECENTS, recents.joinToString("\n"))
             .apply()
     }
+
+    private fun storedServerUrl(): String? = prefs.getString(KEY_CURRENT, null)
 
     private companion object {
         const val PREFS = "ai.omnigent.android.servers"

--- a/web/android/app/src/main/res/values/strings.xml
+++ b/web/android/app/src/main/res/values/strings.xml
@@ -17,4 +17,7 @@
     <string name="connect_invalid">Enter a valid http(s) server URL</string>
     <string name="menu_reload">Reload</string>
     <string name="menu_connect_new">Connect to New Server</string>
+    <!-- Shown to IT admins in their EMM console, not to app users. -->
+    <string name="restriction_server_urls_title">Omnigent server URLs</string>
+    <string name="restriction_server_urls_description">Server URLs to offer users, separated by commas or new lines, most preferred first. They are listed in the app for the user to pick from; the app does not connect to one automatically, and users can still enter a different server.</string>
 </resources>

--- a/web/android/app/src/main/res/xml/app_restrictions.xml
+++ b/web/android/app/src/main/res/xml/app_restrictions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Managed configuration schema. An EMM/MDM console renders these entries for the
+  admin; the app reads whatever they push in ManagedConfig. Keys are a contract
+  with already-deployed policies, so never rename one.
+
+  No android:defaultValue: absence of the key is what "unmanaged" means, and the
+  platform doesn't guarantee XML defaults reach the app anyway.
+-->
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+    <restriction
+        android:key="serverUrls"
+        android:description="@string/restriction_server_urls_description"
+        android:restrictionType="string"
+        android:title="@string/restriction_server_urls_title" />
+</restrictions>

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -1,6 +1,9 @@
 package ai.omnigent.android
 
+import android.content.Context
+import android.content.RestrictionsManager
 import android.content.res.Configuration
+import android.os.Bundle
 import android.webkit.WebView
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.core.app.ApplicationProvider
@@ -11,7 +14,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowRestrictionsManager
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
@@ -74,6 +80,24 @@ class MainActivityTest {
         activity.onConfigurationChanged(lightConfiguration)
         assertTrue(insetsController.isAppearanceLightStatusBars)
         assertTrue(insetsController.isAppearanceLightNavigationBars)
+    }
+
+    @Test
+    fun `a managed preset never overrides the server the user picked`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        ServerStore(context).connect("https://example.com")
+        val manager = context.getSystemService(RestrictionsManager::class.java)
+        Shadow
+            .extract<ShadowRestrictionsManager>(manager)
+            .setApplicationRestrictions(
+                Bundle().apply {
+                    putString(ManagedConfig.KEY_SERVER_URLS, "https://managed.example.com")
+                },
+            )
+
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+
+        assertEquals("https://example.com", shadowOf(activity.webView()).lastLoadedUrl)
     }
 
     private fun MainActivity.webView(): WebView =

--- a/web/android/app/src/test/java/ai/omnigent/android/ManagedConfigTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/ManagedConfigTest.kt
@@ -1,0 +1,96 @@
+package ai.omnigent.android
+
+import android.os.Bundle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Parsing of the `serverUrls` managed-configuration value. Robolectric supplies
+ * the real [Bundle] and `Uri` parsing that [ManagedConfig] delegates to.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ManagedConfigTest {
+    private fun configOf(value: String?): ManagedConfig =
+        ManagedConfig.from(
+            Bundle().apply { value?.let { putString(ManagedConfig.KEY_SERVER_URLS, it) } },
+        )
+
+    @Test
+    fun `no restrictions bundle means unmanaged`() {
+        assertEquals(emptyList<String>(), ManagedConfig.from(null as Bundle?).serverUrls)
+    }
+
+    @Test
+    fun `missing key means unmanaged`() {
+        assertEquals(emptyList<String>(), configOf(null).serverUrls)
+    }
+
+    @Test
+    fun `blank value yields no presets`() {
+        assertEquals(emptyList<String>(), configOf("   \n  ").serverUrls)
+    }
+
+    @Test
+    fun `single url is the only preset`() {
+        assertEquals(
+            listOf("https://omnigent.example.com"),
+            configOf("https://omnigent.example.com").serverUrls,
+        )
+    }
+
+    @Test
+    fun `newlines commas and surrounding space all delimit, order preserved`() {
+        assertEquals(
+            listOf("https://a.example.com", "https://b.example.com", "https://c.example.com"),
+            configOf("https://a.example.com,\n https://b.example.com\r\nhttps://c.example.com")
+                .serverUrls,
+        )
+    }
+
+    @Test
+    fun `scheme is defaulted and trailing slash trimmed`() {
+        assertEquals(
+            listOf("https://omnigent.example.com"),
+            configOf("omnigent.example.com/").serverUrls,
+        )
+    }
+
+    @Test
+    fun `unparseable entries are dropped without losing the rest`() {
+        assertEquals(
+            listOf("https://good.example.com"),
+            configOf("ftp://nope.example.com,https://good.example.com,https://").serverUrls,
+        )
+    }
+
+    @Test
+    fun `same-origin entries collapse to one preset`() {
+        assertEquals(
+            listOf("https://omnigent.example.com"),
+            configOf("https://omnigent.example.com,https://omnigent.example.com:443").serverUrls,
+        )
+    }
+
+    @Test
+    fun `preset count is capped`() {
+        val many = (1..20).joinToString(",") { "https://host$it.example.com" }
+
+        assertEquals(8, configOf(many).serverUrls.size)
+    }
+
+    @Test
+    fun `includes matches on origin, not on the literal string`() {
+        val config = configOf("https://omnigent.example.com")
+
+        assertTrue(config.includes("https://omnigent.example.com:443"))
+        assertTrue(config.includes("https://OMNIGENT.example.com"))
+        assertFalse(config.includes("https://other.example.com"))
+        assertFalse(config.includes("not a url"))
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/ServerStoreTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/ServerStoreTest.kt
@@ -1,0 +1,96 @@
+package ai.omnigent.android
+
+import android.content.Context
+import android.content.RestrictionsManager
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowRestrictionsManager
+
+/** Precedence between a user's stored server and organization presets. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ServerStoreTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun storeWithPresets(vararg urls: String) =
+        ServerStore(context, ManagedConfig(urls.toList()))
+
+    @Test
+    fun `unmanaged and unconfigured falls back to the debug default`() {
+        val store = storeWithPresets()
+
+        assertFalse(store.hasServer())
+        assertEquals("http://10.0.2.2:8000", store.currentServerUrl())
+    }
+
+    @Test
+    fun `presets are offered but never connected on the user's behalf`() {
+        val store = storeWithPresets("https://managed.example.com")
+
+        // The connect screen still owns the decision.
+        assertFalse(store.hasServer())
+        assertEquals(listOf("https://managed.example.com"), store.offeredServers())
+        // Nothing was written, so a later policy change is picked up as-is.
+        assertEquals(emptyList<String>(), store.recentServers())
+        assertEquals("http://10.0.2.2:8000", store.currentServerUrl())
+    }
+
+    @Test
+    fun `several presets are all offered`() {
+        val store = storeWithPresets("https://a.example.com", "https://b.example.com")
+
+        assertFalse(store.hasServer())
+        assertEquals(
+            listOf("https://a.example.com", "https://b.example.com"),
+            store.offeredServers(),
+        )
+    }
+
+    @Test
+    fun `connecting to a preset is what makes it current`() {
+        val store = storeWithPresets("https://managed.example.com")
+
+        store.connect("https://managed.example.com")
+
+        assertTrue(store.hasServer())
+        assertEquals("https://managed.example.com", store.currentServerUrl())
+    }
+
+    @Test
+    fun `offered servers lead with presets and drop recents they cover`() {
+        storeWithPresets().connect("https://mine.example.com")
+        // Same origin as the preset below, differently spelled.
+        storeWithPresets().connect("https://managed.example.com:443")
+
+        val store = storeWithPresets("https://managed.example.com")
+
+        assertEquals(
+            listOf("https://managed.example.com", "https://mine.example.com"),
+            store.offeredServers(),
+        )
+    }
+
+    @Test
+    fun `presets are read from managed configuration by default`() {
+        setApplicationRestrictions(
+            Bundle().apply {
+                putString(ManagedConfig.KEY_SERVER_URLS, "https://policy.example.com")
+            },
+        )
+
+        assertEquals(listOf("https://policy.example.com"), ServerStore(context).managed.serverUrls)
+    }
+
+    private fun setApplicationRestrictions(restrictions: Bundle) {
+        val manager = context.getSystemService(RestrictionsManager::class.java)
+        Shadow.extract<ShadowRestrictionsManager>(manager).setApplicationRestrictions(restrictions)
+    }
+}


### PR DESCRIPTION
## Related issue

N/A — no tracking issue.

## Summary

- Managed users had to type a server URL by hand on first launch, with no way
  for IT to hand it to them. The Android shell now publishes an [Android managed
  configuration](https://developer.android.com/work/managed-configurations), so
  any EMM (Intune, Jamf, Workspace ONE, Google Workspace, Android Management
  API) can preconfigure the server URLs an org uses.
- One restriction key, `serverUrls`: a comma- or newline-separated list, most
  preferred first. `ManagedConfig` parses it (defaults a missing scheme to
  `https://`, drops unparseable entries, collapses same-origin duplicates, caps
  at 8) and `ServerStore.offeredServers()` puts the presets ahead of the user's
  recent servers in the one existing list — on the connect screen and in the
  server switcher.
- Presets are offers, not policy enforcement: the app never auto-connects and
  never skips the connect screen, the user can still type any other server, and
  a preset is never written to prefs so an admin's later edit is picked up on the
  next read.

Android offers no plain string-array restriction type, hence the delimited
string: `multi-select` needs the app's own schema to enumerate every possible
host (they are customer-specific), and `bundle_array` renders poorly or not at
all in several EMM consoles.

```
EMM console ──push──> RestrictionsManager ──> ManagedConfig.serverUrls
                                                      │
                        ServerStore.offeredServers() ──┤ presets first
                                                      │ then recents (origin-deduped)
                        ConnectActivity list ◀─────────┴─────▶ server switcher menu
```

## Test Plan

- `cd web/android && ./gradlew :app:testDebugUnitTest` — 50 tests, 49 pass. The
  one failure, `MainActivityTest > configuration change updates system bar icon
  polarity`, is pre-existing: verified failing identically at `HEAD` in a clean
  worktree without these changes. Not touched here.
- `./gradlew :app:assembleDebug` — confirmed the `APP_RESTRICTIONS` meta-data
  lands in the merged manifest and `res/xml/app_restrictions.xml` is packaged in
  the APK.
- On a wiped API 35 emulator with Test DPC 9.0.12 as device owner: Test DPC →
  Managed configurations → Omnigent → **Load manifest restrictions** renders our
  schema and produces the `serverUrls` key, confirming the manifest wiring
  against a real DPC. Setting a value and relaunching shows the preset as a
  tappable row on the connect screen, and the app does not auto-connect.

## Demo

Visible change is additive: preset URLs appear as tappable rows in the existing
server list on the connect screen and in the host-pill switcher menu. Unmanaged
installs are pixel-identical to before — no new views or strings on that screen.

<img width="834" height="1848" alt="image" src="https://github.com/user-attachments/assets/5456081e-7144-492e-bd49-a96e5a527788" />

<img width="523" height="1063" alt="image" src="https://github.com/user-attachments/assets/a40bc233-0930-45bb-9eeb-31ee5f1b7fa5" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`ManagedConfigTest` covers the parse layer (absent bundle, missing key, blank
value, mixed delimiters, scheme defaulting, dropped bad entries, origin dedupe,
the cap, and origin-based `includes`). `ServerStoreTest` covers precedence: a
preset is offered but never becomes current, several presets are all offered,
connecting is what makes one current, and presets lead the offered list while
covering same-origin recents. `MainActivityTest` asserts a preset never
overrides the server the user picked.

Manual verification was needed for the parts no unit test can reach: that a real
DPC renders our restriction schema, and that the key name matches what an EMM
pushes. Done on an emulator with Test DPC as device owner, as described above.

## Changelog

Organizations can preconfigure Omnigent server URLs through Android managed
configuration, and they show up ready to tap in the app's server list.


