### PR TITLE
feat(ios): let admins preset server URLs via managed app configuration

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		B1000000000000000000000C /* URL+Omnigent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000C /* URL+Omnigent.swift */; };
 		B10000000000000000000011 /* ChatTerminalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* ChatTerminalBar.swift */; };
 		B10000000000000000000012 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* SafariView.swift */; };
+		B10000000000000000000015 /* ManagedConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000015 /* ManagedConfiguration.swift */; };
+		B10000000000000000000016 /* ManagedConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000016 /* ManagedConfigurationProvider.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B10000000000000000000013 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000013 /* PrivacyInfo.xcprivacy */; };
@@ -30,11 +32,13 @@
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
 		B20000000000000000000004 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* DeepLinkTests.swift */; };
 		B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */; };
+		B20000000000000000000007 /* ManagedConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000007 /* ManagedConfigurationTests.swift */; };
 		B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
 		B40000000000000000000004 /* MockHTTPServer.swift in Sources (OmnigentUITests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
 		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
 		B40000000000000000000002 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* SnapshotHelper.swift */; };
 		B40000000000000000000003 /* RedirectConsentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000003 /* RedirectConsentUITests.swift */; };
+		B40000000000000000000005 /* ManagedServersUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000005 /* ManagedServersUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +74,8 @@
 		A1000000000000000000000C /* URL+Omnigent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Omnigent.swift"; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ChatTerminalBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalBar.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		A10000000000000000000015 /* ManagedConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfiguration.swift; sourceTree = "<group>"; };
+		A10000000000000000000016 /* ManagedConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfigurationProvider.swift; sourceTree = "<group>"; };
 		A1000000000000000000000D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1000000000000000000000E /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = AppIcon.icon; path = "../platform-assets/AppIcon.icon"; sourceTree = "<group>"; };
 		A1000000000000000000000F /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
@@ -80,11 +86,13 @@
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000004 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderRedirectTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000007 /* ManagedConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfigurationTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* MockHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPServer.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
 		A40000000000000000000002 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		A40000000000000000000003 /* RedirectConsentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectConsentUITests.swift; sourceTree = "<group>"; };
+		A40000000000000000000005 /* ManagedServersUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedServersUITests.swift; sourceTree = "<group>"; };
 		A30000000000000000000001 /* Omnigent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Omnigent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A30000000000000000000002 /* OmnigentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -153,6 +161,8 @@
 				A1000000000000000000000C /* URL+Omnigent.swift */,
 				A10000000000000000000011 /* ChatTerminalBar.swift */,
 				A10000000000000000000012 /* SafariView.swift */,
+				A10000000000000000000015 /* ManagedConfiguration.swift */,
+				A10000000000000000000016 /* ManagedConfigurationProvider.swift */,
 				A1000000000000000000000D /* Assets.xcassets */,
 				A10000000000000000000013 /* PrivacyInfo.xcprivacy */,
 				A1000000000000000000000F /* Info-Debug.plist */,
@@ -169,6 +179,7 @@
 				A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */,
 				A20000000000000000000004 /* DeepLinkTests.swift */,
 				A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */,
+				A20000000000000000000007 /* ManagedConfigurationTests.swift */,
 				A20000000000000000000006 /* MockHTTPServer.swift */,
 			);
 			path = OmnigentTests;
@@ -180,6 +191,7 @@
 				A40000000000000000000001 /* OmnigentUITests.swift */,
 				A40000000000000000000002 /* SnapshotHelper.swift */,
 				A40000000000000000000003 /* RedirectConsentUITests.swift */,
+				A40000000000000000000005 /* ManagedServersUITests.swift */,
 			);
 			path = OmnigentUITests;
 			sourceTree = "<group>";
@@ -338,6 +350,8 @@
 				B1000000000000000000000C /* URL+Omnigent.swift in Sources */,
 				B10000000000000000000011 /* ChatTerminalBar.swift in Sources */,
 				B10000000000000000000012 /* SafariView.swift in Sources */,
+				B10000000000000000000015 /* ManagedConfiguration.swift in Sources */,
+				B10000000000000000000016 /* ManagedConfigurationProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -350,6 +364,7 @@
 				B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */,
 				B20000000000000000000004 /* DeepLinkTests.swift in Sources */,
 				B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */,
+				B20000000000000000000007 /* ManagedConfigurationTests.swift in Sources */,
 				B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -361,6 +376,7 @@
 				B40000000000000000000001 /* OmnigentUITests.swift in Sources */,
 				B40000000000000000000002 /* SnapshotHelper.swift in Sources */,
 				B40000000000000000000003 /* RedirectConsentUITests.swift in Sources */,
+				B40000000000000000000005 /* ManagedServersUITests.swift in Sources */,
 				B40000000000000000000004 /* MockHTTPServer.swift in Sources (OmnigentUITests) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -432,7 +448,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -487,7 +503,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -511,7 +527,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Omnigent/Info-Debug.plist";
 				VERSIONING_SYSTEM = "apple-generic";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -542,7 +558,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Omnigent/Info-Release.plist";
 				VERSIONING_SYSTEM = "apple-generic";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -566,7 +582,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -590,7 +606,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -613,7 +629,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -636,7 +652,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/web/ios/Omnigent/ConnectView.swift
+++ b/web/ios/Omnigent/ConnectView.swift
@@ -7,6 +7,7 @@ struct ConnectView: View {
 
   @Environment(\.colorScheme) private var colorScheme
   @EnvironmentObject private var settings: SettingsStore
+  @EnvironmentObject private var managedConfiguration: ManagedConfigurationProvider
   @State private var serverURL: String
   @State private var message: String?
   @State private var isConnecting = false
@@ -86,35 +87,23 @@ struct ConnectView: View {
           .frame(maxWidth: .infinity, minHeight: 38, alignment: .leading)
           .padding(.top, 12)
 
-        if !settings.recentServers.isEmpty {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Recent servers")
-              .font(.system(size: 13, weight: .medium))
-              .foregroundStyle(DesignTokens.mutedForeground(colorScheme))
+        // Preset servers sit above recents under their own heading, so an entry
+        // the organization vouches for doesn't read as something the user
+        // happened to type before.
+        if !managedConfiguration.serverURLs.isEmpty {
+          serverSection(
+            title: "Provided by your organization",
+            servers: managedConfiguration.serverURLs.map(\.absoluteString),
+            identifier: "managed-servers"
+          )
+        }
 
-            ForEach(settings.recentServers, id: \.self) { recent in
-              Button {
-                serverURL = recent
-                connect()
-              } label: {
-                Text(recent)
-                  .font(.system(size: 14))
-                  .lineLimit(1)
-                  .truncationMode(.middle)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.horizontal, 12)
-                  .frame(height: 36)
-                  .overlay {
-                    RoundedRectangle(cornerRadius: DesignTokens.radius)
-                      .stroke(DesignTokens.border(colorScheme), lineWidth: 1)
-                  }
-              }
-              .buttonStyle(.plain)
-              .foregroundStyle(DesignTokens.foreground(colorScheme))
-            }
-          }
-          .padding(.top, 12)
-          .disabled(isConnecting)
+        if !visibleRecentServers.isEmpty {
+          serverSection(
+            title: "Recent servers",
+            servers: visibleRecentServers,
+            identifier: "recent-servers"
+          )
         }
       }
       .frame(maxWidth: 384)
@@ -163,6 +152,46 @@ struct ConnectView: View {
         .contentShape(Rectangle())
     }
     .accessibilityLabel("About Omnigent")
+  }
+
+  private var visibleRecentServers: [String] {
+    ManagedServers.recents(
+      settings.recentServers, excludingManaged: managedConfiguration.serverURLs)
+  }
+
+  private func serverSection(title: String, servers: [String], identifier: String) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(title)
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(DesignTokens.mutedForeground(colorScheme))
+
+      ForEach(servers, id: \.self) { server in
+        Button {
+          serverURL = server
+          connect()
+        } label: {
+          Text(server)
+            .font(.system(size: 14))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .frame(height: 36)
+            .overlay {
+              RoundedRectangle(cornerRadius: DesignTokens.radius)
+                .stroke(DesignTokens.border(colorScheme), lineWidth: 1)
+            }
+            // Without this only the URL's glyphs are hit-testable, so a tap on
+            // the empty part of the pill does nothing.
+            .contentShape(RoundedRectangle(cornerRadius: DesignTokens.radius))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(DesignTokens.foreground(colorScheme))
+        .accessibilityIdentifier("\(identifier)-row")
+      }
+    }
+    .padding(.top, 12)
+    .disabled(isConnecting)
   }
 
   private var primary: Color {

--- a/web/ios/Omnigent/ManagedConfiguration.swift
+++ b/web/ios/Omnigent/ManagedConfiguration.swift
@@ -1,0 +1,163 @@
+import Foundation
+import ManagedApp
+
+/// Server URLs an administrator preset for a managed install.
+///
+/// Arrives on either of two channels, both carrying the same flat dictionary:
+/// the `AppConfig` payload of a `com.apple.configuration.app.managed`
+/// declaration, or the classic `com.apple.configuration.managed` defaults key.
+///
+/// Validation lives in `init(from:)` on purpose: the framework reports a thrown
+/// `ManagedAppConfigurationDecodingError` back to the management service and
+/// logs it in the device event log, so a bad value in an admin console becomes
+/// actionable feedback instead of a server that silently never shows up. The
+/// published spec (`web/ios/docs/managed-app-configuration.md`) documents every
+/// code below, so treat them as API.
+struct OmnigentManagedConfiguration: Decodable, Equatable {
+  private(set) var serverURLs: [URL]
+
+  static let empty = OmnigentManagedConfiguration(serverURLs: [])
+
+  /// Bounds the payload so a runaway list can't crowd the user's own servers
+  /// off the connect screen. Apple also asks configurations to stay small.
+  static let maxServerURLs = 10
+
+  enum CodingKeys: String, CodingKey {
+    case serverURLs = "serverUrls"
+  }
+
+  init(serverURLs: [URL]) {
+    self.serverURLs = serverURLs
+  }
+
+  init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    // The key is optional: a configuration that sets nothing is valid and
+    // simply offers no servers.
+    guard values.contains(.serverURLs) else {
+      serverURLs = []
+      return
+    }
+
+    let raw: [String]
+    do {
+      raw = try values.decode([String].self, forKey: .serverURLs)
+    } catch {
+      throw Failure(
+        code: Self.wrongTypeCode,
+        message: "'serverUrls' must be an array of strings.")
+    }
+
+    guard raw.count <= Self.maxServerURLs else {
+      throw Failure(
+        code: Self.tooManyEntriesCode,
+        message:
+          "'serverUrls' has \(raw.count) entries; at most \(Self.maxServerURLs) are allowed.")
+    }
+
+    var origins: Set<String> = []
+    var urls: [URL] = []
+    for entry in raw {
+      let url = try Self.normalize(entry)
+      // Same origin comparison the rest of the shell uses, so a duplicate is
+      // dropped rather than offered twice. Note this does not canonicalize a
+      // redundant `:443`, matching `URL.omnigentOrigin` everywhere else.
+      guard let origin = url.omnigentOrigin else { throw Self.invalidURL(entry) }
+      if origins.insert(origin).inserted {
+        urls.append(url)
+      }
+    }
+    serverURLs = urls
+  }
+
+  /// Reuses the shell's own URL rules so a preset server and a typed one are
+  /// held to exactly the same standard. `allowsInsecureHTTP: false` even in
+  /// debug builds: release builds keep App Transport Security defaults, so an
+  /// `http://` preset would fail at the network layer on a real managed device
+  /// no matter what a debug build accepts. Rejecting it here turns that into a
+  /// console error the admin can act on.
+  private static func normalize(_ entry: String) throws -> URL {
+    do {
+      return try ServerURL.normalize(entry, allowsInsecureHTTP: false)
+    } catch let error as ServerURLError {
+      switch error {
+      case .unsupportedScheme, .insecureHTTPNotAllowed:
+        throw Failure(
+          code: notHTTPSCode,
+          message: "Server URL '\(entry)' must use https://.")
+      case .empty, .invalid:
+        throw invalidURL(entry)
+      }
+    }
+  }
+
+  private static func invalidURL(_ entry: String) -> Failure {
+    Failure(code: invalidURLCode, message: "'\(entry)' is not a valid server URL.")
+  }
+
+  /// The defaults key a management service writes for classic (non-declarative)
+  /// managed app configuration. Read-only from the app's side.
+  static let legacyDefaultsKey = "com.apple.configuration.managed"
+
+  /// Reads the classic managed app configuration, if a service pushed one.
+  ///
+  /// Returns `.empty` for anything unusable. Unlike a declarative
+  /// configuration, this channel has no way to report a decoding error back to
+  /// the administrator, so a bad value can only be ignored — which is why the
+  /// declarative path is preferred when both are present.
+  static func read(legacyFrom defaults: UserDefaults) -> OmnigentManagedConfiguration {
+    guard let dictionary = defaults.dictionary(forKey: legacyDefaultsKey) else { return .empty }
+    do {
+      let data = try PropertyListSerialization.data(
+        fromPropertyList: dictionary, format: .binary, options: 0)
+      return try PropertyListDecoder().decode(Self.self, from: data)
+    } catch {
+      return .empty
+    }
+  }
+
+  struct Failure: ManagedAppConfigurationDecodingError {
+    var code: ManagedAppConfigurationDecodingErrorCode
+    var message: String
+  }
+
+  // Published error codes, part of the spec admins read. `init(rawValue:)`
+  // rejects anything the system reserves, so a value that drifted into the
+  // reserved range would be nil here — `ManagedConfigurationTests` asserts each
+  // one stays below `firstReserved` so that surfaces as a test failure.
+  static let invalidURLCode = ManagedAppConfigurationDecodingErrorCode(rawValue: 100)!
+  static let notHTTPSCode = ManagedAppConfigurationDecodingErrorCode(rawValue: 101)!
+  static let tooManyEntriesCode = ManagedAppConfigurationDecodingErrorCode(rawValue: 102)!
+  static let wrongTypeCode = ManagedAppConfigurationDecodingErrorCode(rawValue: 103)!
+}
+
+/// Merges administrator-preset servers with the user's own recents for display.
+///
+/// Preset servers are combined at read time and never written to
+/// `SettingsStore`, so withdrawing a configuration removes them cleanly and
+/// they never consume the recents cap and evict a server the user chose.
+enum ManagedServers {
+  /// `recents` minus any origin the administrator already presets, so a preset
+  /// server is offered once rather than twice.
+  static func recents(_ recents: [String], excludingManaged managed: [URL]) -> [String] {
+    guard !managed.isEmpty else { return recents }
+    let managedOrigins = Set(managed.compactMap(\.omnigentOrigin))
+    return recents.filter { value in
+      guard let origin = URL(string: value)?.omnigentOrigin else { return true }
+      return !managedOrigins.contains(origin)
+    }
+  }
+
+  /// Every server to offer, administrator-preset ones first.
+  static func merged(managed: [URL], recents: [String]) -> [String] {
+    managed.map(\.absoluteString) + Self.recents(recents, excludingManaged: managed)
+  }
+
+  /// Picks between the two configuration channels. A declarative configuration
+  /// wins because it is validated with feedback to the administrator; the
+  /// classic key is the fallback for services that don't send declarations.
+  static func resolve(declarative: [URL], legacy: [URL]) -> [URL] {
+    declarative.isEmpty ? legacy : declarative
+  }
+}

--- a/web/ios/Omnigent/ManagedConfigurationProvider.swift
+++ b/web/ios/Omnigent/ManagedConfigurationProvider.swift
@@ -1,0 +1,122 @@
+import Foundation
+import ManagedApp
+import UIKit
+
+/// Subscribes to the managed app configuration a management service pushes to
+/// this install and publishes the server URLs it presets.
+///
+/// Watches both channels a service can use — a `com.apple.configuration.app.managed`
+/// declaration via the ManagedApp framework, and the classic
+/// `com.apple.configuration.managed` defaults key — because a service that
+/// doesn't send declarations would otherwise configure nothing. Exposes only
+/// `[URL]`, never a framework type, so views stay unaware of how the list
+/// arrived.
+@MainActor
+final class ManagedConfigurationProvider: ObservableObject {
+  /// Preset server URLs in the order the administrator listed them. Empty when
+  /// the app is unmanaged, no configuration is set, or one failed to decode.
+  @Published private(set) var serverURLs: [URL]
+
+  private let defaults: UserDefaults
+  private var declarativeURLs: [URL] = []
+  private var legacyURLs: [URL] = []
+  private var subscription: Task<Void, Never>?
+  private var legacyObservers: [NSObjectProtocol] = []
+
+  /// Test and preview seam: a fixed list, no subscriptions.
+  init(serverURLs: [URL]) {
+    self.serverURLs = serverURLs
+    defaults = .standard
+  }
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    serverURLs = []
+
+    #if DEBUG
+      // Wins over both channels: this is the local test seam, and neither
+      // channel can be faked in the Simulator's declarative form.
+      if let injected = ProcessInfo.processInfo.omnigentManagedServers {
+        serverURLs = injected
+        return
+      }
+    #endif
+
+    observeLegacyConfiguration()
+    subscribeToDeclarativeConfiguration()
+  }
+
+  deinit {
+    subscription?.cancel()
+    for observer in legacyObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+
+  /// Runs for the lifetime of the app: the sequence re-yields whenever the
+  /// administrator updates the configuration, so the connect screen and the
+  /// server switcher stay current without a relaunch.
+  private func subscribeToDeclarativeConfiguration() {
+    subscription = Task { [weak self] in
+      let provider = ManagedAppConfigurationProvider()
+      for await configuration in await provider.configurations(OmnigentManagedConfiguration.self) {
+        // nil means unmanaged, unset, or a decode failure — in every case the
+        // right answer is to offer nothing rather than a stale list.
+        self?.declarativeURLs = (configuration ?? .empty).serverURLs
+        self?.republish()
+      }
+    }
+  }
+
+  /// A service can rewrite the classic key at any time, and it lands in the
+  /// app's own defaults domain with no callback of its own.
+  ///
+  /// Becoming active is the dependable re-read point:
+  /// `UserDefaults.didChangeNotification` does **not** fire for a write made by
+  /// another process, which is exactly how a configuration arrives, so it is
+  /// only a best-effort fast path here.
+  private func observeLegacyConfiguration() {
+    readLegacyConfiguration()
+    for name in [UIApplication.didBecomeActiveNotification, UserDefaults.didChangeNotification] {
+      legacyObservers.append(
+        NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) {
+          [weak self] _ in
+          Task { @MainActor in self?.readLegacyConfiguration() }
+        }
+      )
+    }
+  }
+
+  private func readLegacyConfiguration() {
+    // Drop the in-process cache first: the value was written by another process,
+    // so a plain read can return the snapshot this process already had.
+    defaults.synchronize()
+    let urls = OmnigentManagedConfiguration.read(legacyFrom: defaults).serverURLs
+    guard urls != legacyURLs else { return }
+    legacyURLs = urls
+    republish()
+  }
+
+  private func republish() {
+    serverURLs = ManagedServers.resolve(declarative: declarativeURLs, legacy: legacyURLs)
+  }
+}
+
+#if DEBUG
+  extension ProcessInfo {
+    /// The `--omnigent-managed-servers <url,url>` DEBUG-only launch argument.
+    /// A declarative configuration can't be delivered to the Simulator at all,
+    /// so this is how UI tests and a local run exercise the preset rows without
+    /// touching the app's defaults. Compiled out of Release, so it can never
+    /// stand in for a real configuration.
+    fileprivate var omnigentManagedServers: [URL]? {
+      guard let value = omnigentArgumentValue(after: "--omnigent-managed-servers") else {
+        return nil
+      }
+      let urls = value.split(separator: ",").compactMap {
+        try? ServerURL.normalize(String($0), allowsInsecureHTTP: true)
+      }
+      return urls.isEmpty ? nil : urls
+    }
+  }
+#endif

--- a/web/ios/Omnigent/OmnigentApp.swift
+++ b/web/ios/Omnigent/OmnigentApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct OmnigentApp: App {
   @StateObject private var settings = SettingsStore()
   @StateObject private var router = AppRouter()
+  @StateObject private var managedConfiguration = ManagedConfigurationProvider()
 
   init() {
     NativeNotificationManager.shared.start()
@@ -14,6 +15,7 @@ struct OmnigentApp: App {
       AppRootView()
         .environmentObject(settings)
         .environmentObject(router)
+        .environmentObject(managedConfiguration)
         .onAppear {
           NativeNotificationManager.shared.setActivationHandler { path in
             router.routeNotification(path)

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -551,13 +551,10 @@ struct OmnigentWebView: UIViewRepresentable {
     }
 
     private func failedURL(from error: NSError) -> URL? {
-      if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
-        return url
-      }
-      if let value = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String {
-        return URL(string: value)
-      }
-      return nil
+      // The string-keyed variant this used to fall back on is deprecated and
+      // redundant on the supported OS versions; callers already fall back to the
+      // web view's own URL when the key is absent.
+      error.userInfo[NSURLErrorFailingURLErrorKey] as? URL
     }
 
     private func injectWorkspaceChromeCSS(_ webView: WKWebView) {

--- a/web/ios/Omnigent/SettingsStore.swift
+++ b/web/ios/Omnigent/SettingsStore.swift
@@ -82,7 +82,7 @@ final class SettingsStore: ObservableObject {
 
 #if DEBUG
   extension ProcessInfo {
-    fileprivate func omnigentArgumentValue(after argumentName: String) -> String? {
+    func omnigentArgumentValue(after argumentName: String) -> String? {
       guard let index = arguments.firstIndex(of: argumentName) else { return nil }
       let valueIndex = arguments.index(after: index)
       guard arguments.indices.contains(valueIndex) else { return nil }

--- a/web/ios/Omnigent/WebShellView.swift
+++ b/web/ios/Omnigent/WebShellView.swift
@@ -10,6 +10,7 @@ struct WebShellView: View {
   @Environment(\.colorScheme) private var colorScheme
   @EnvironmentObject private var settings: SettingsStore
   @EnvironmentObject private var router: AppRouter
+  @EnvironmentObject private var managedConfiguration: ManagedConfigurationProvider
   @StateObject private var model = WebViewModel()
   /// A deep-link path that arrived while the page was still loading — emitted
   /// to the SPA once `isLoading` flips false, so a cold-start / mid-load deep
@@ -31,7 +32,8 @@ struct WebShellView: View {
 
         ServerSwitcher(
           currentURL: model.currentURL ?? initialURL,
-          recents: settings.recentServers,
+          recents: ManagedServers.merged(
+            managed: managedConfiguration.serverURLs, recents: settings.recentServers),
           isLoading: model.isLoading,
           maxWidth: ServerSwitcherMetrics.maxWidth(for: geometry.size.width),
           switchServer: switchServer,

--- a/web/ios/OmnigentTests/ManagedConfigurationTests.swift
+++ b/web/ios/OmnigentTests/ManagedConfigurationTests.swift
@@ -1,0 +1,266 @@
+import ManagedApp
+import XCTest
+
+@testable import Omnigent
+
+/// Decodes the configuration straight from property lists, the exact shape the
+/// ManagedApp framework hands `init(from:)`. No MDM, device management, or
+/// simulator hook is involved, which matters because none of those can be faked
+/// locally — the decoder is the part most likely to be wrong, so it is the part
+/// covered here.
+final class ManagedConfigurationTests: XCTestCase {
+  // MARK: Accepted configurations
+
+  func testAbsentKeyOffersNoServers() throws {
+    XCTAssertEqual(try decode([:]), .empty)
+  }
+
+  func testEmptyListOffersNoServers() throws {
+    XCTAssertEqual(try decode(["serverUrls": []]), .empty)
+  }
+
+  func testAdministratorOrderIsPreserved() throws {
+    let config = try decode([
+      "serverUrls": ["https://b.example.com", "https://a.example.com"]
+    ])
+
+    XCTAssertEqual(
+      config.serverURLs.map(\.absoluteString),
+      ["https://b.example.com", "https://a.example.com"])
+  }
+
+  func testBareHostGetsHTTPS() throws {
+    let config = try decode(["serverUrls": ["omnigent.corp.example.com"]])
+
+    XCTAssertEqual(config.serverURLs.map(\.absoluteString), ["https://omnigent.corp.example.com"])
+  }
+
+  func testWorkspaceMountIsPreserved() throws {
+    // The Databricks mount must survive decoding; discovering it is a network
+    // probe that stays on the connect path, so a preset URL that already names
+    // the mount has to keep it.
+    let config = try decode([
+      "serverUrls": ["https://ws.cloud.databricks.com/ml/omnigents"]
+    ])
+
+    XCTAssertEqual(
+      config.serverURLs.map(\.absoluteString),
+      ["https://ws.cloud.databricks.com/ml/omnigents"])
+  }
+
+  func testDuplicateOriginsAreDroppedKeepingTheFirst() throws {
+    let config = try decode([
+      "serverUrls": [
+        "https://a.example.com", "https://A.Example.com/", "https://b.example.com",
+      ]
+    ])
+
+    XCTAssertEqual(
+      config.serverURLs.map(\.absoluteString),
+      ["https://a.example.com", "https://b.example.com"])
+  }
+
+  func testMaximumEntriesIsAccepted() throws {
+    let entries = (1...OmnigentManagedConfiguration.maxServerURLs).map {
+      "https://s\($0).example.com"
+    }
+
+    XCTAssertEqual(try decode(["serverUrls": entries]).serverURLs.count, entries.count)
+  }
+
+  // MARK: Rejected configurations
+  //
+  // Each case must surface OUR documented code, because that code is what the
+  // administrator sees in the device event log and in our published spec.
+
+  func testInvalidURLIsRejected() {
+    assertFails(
+      ["serverUrls": ["https://"]], with: OmnigentManagedConfiguration.invalidURLCode)
+  }
+
+  func testBlankEntryIsRejected() {
+    assertFails(["serverUrls": ["   "]], with: OmnigentManagedConfiguration.invalidURLCode)
+  }
+
+  func testInsecureHTTPIsRejected() {
+    assertFails(
+      ["serverUrls": ["http://omnigent.corp.example.com"]],
+      with: OmnigentManagedConfiguration.notHTTPSCode)
+  }
+
+  func testNonWebSchemeIsRejected() {
+    assertFails(
+      ["serverUrls": ["ftp://omnigent.corp.example.com"]],
+      with: OmnigentManagedConfiguration.notHTTPSCode)
+  }
+
+  func testTooManyEntriesAreRejected() {
+    let entries = (0...OmnigentManagedConfiguration.maxServerURLs).map {
+      "https://s\($0).example.com"
+    }
+
+    assertFails(
+      ["serverUrls": entries], with: OmnigentManagedConfiguration.tooManyEntriesCode)
+  }
+
+  func testAStringInsteadOfAListIsRejected() {
+    assertFails(
+      ["serverUrls": "https://omnigent.corp.example.com"],
+      with: OmnigentManagedConfiguration.wrongTypeCode)
+  }
+
+  func testOneBadEntryRejectsTheWholeConfiguration() {
+    // Reporting the mistake beats silently offering a partial list the admin
+    // believes is complete.
+    assertFails(
+      ["serverUrls": ["https://good.example.com", "http://bad.example.com"]],
+      with: OmnigentManagedConfiguration.notHTTPSCode)
+  }
+
+  func testOurErrorCodesAreNotSystemReserved() {
+    // Also forces the static codes to be evaluated: they are built with a
+    // force-unwrapped `init(rawValue:)`, so a value that drifted into the
+    // reserved range fails here rather than on a managed device.
+    for code in [
+      OmnigentManagedConfiguration.invalidURLCode,
+      OmnigentManagedConfiguration.notHTTPSCode,
+      OmnigentManagedConfiguration.tooManyEntriesCode,
+      OmnigentManagedConfiguration.wrongTypeCode,
+    ] {
+      XCTAssertLessThan(
+        code.rawValue, ManagedAppConfigurationDecodingErrorCode.firstReserved,
+        "Code \(code.rawValue) is system-reserved and would be reported as generic.")
+    }
+  }
+
+  // MARK: Classic (non-declarative) channel
+  //
+  // Same flat dictionary, delivered through the app's own defaults domain. This
+  // channel cannot report errors to the administrator, so anything unusable
+  // degrades to offering nothing instead of throwing.
+
+  func testLegacyDictionaryIsRead() {
+    let defaults = makeDefaults()
+    defaults.set(
+      ["serverUrls": ["https://corp.example.com"]],
+      forKey: OmnigentManagedConfiguration.legacyDefaultsKey)
+
+    XCTAssertEqual(
+      OmnigentManagedConfiguration.read(legacyFrom: defaults).serverURLs.map(\.absoluteString),
+      ["https://corp.example.com"])
+  }
+
+  func testAbsentLegacyKeyOffersNoServers() {
+    XCTAssertEqual(OmnigentManagedConfiguration.read(legacyFrom: makeDefaults()), .empty)
+  }
+
+  func testInvalidLegacyDictionaryIsIgnoredRatherThanThrowing() {
+    let defaults = makeDefaults()
+    defaults.set(
+      ["serverUrls": ["http://insecure.example.com"]],
+      forKey: OmnigentManagedConfiguration.legacyDefaultsKey)
+
+    XCTAssertEqual(OmnigentManagedConfiguration.read(legacyFrom: defaults), .empty)
+  }
+
+  func testLegacyDictionaryWithUnrelatedKeysIsTolerated() {
+    // A service or other tooling may add keys of its own; they must not stop the
+    // servers from being read.
+    let defaults = makeDefaults()
+    defaults.set(
+      ["serverUrls": ["https://corp.example.com"], "somethingElse": 42],
+      forKey: OmnigentManagedConfiguration.legacyDefaultsKey)
+
+    XCTAssertEqual(OmnigentManagedConfiguration.read(legacyFrom: defaults).serverURLs.count, 1)
+  }
+
+  // MARK: Channel precedence
+
+  func testDeclarativeConfigurationWinsOverLegacy() {
+    let declarative = [URL(string: "https://declarative.example.com")!]
+    let legacy = [URL(string: "https://legacy.example.com")!]
+
+    XCTAssertEqual(ManagedServers.resolve(declarative: declarative, legacy: legacy), declarative)
+  }
+
+  func testLegacyIsUsedWhenNoDeclarativeConfigurationExists() {
+    let legacy = [URL(string: "https://legacy.example.com")!]
+
+    XCTAssertEqual(ManagedServers.resolve(declarative: [], legacy: legacy), legacy)
+  }
+
+  func testNeitherChannelOffersNothing() {
+    XCTAssertEqual(ManagedServers.resolve(declarative: [], legacy: []), [])
+  }
+
+  // MARK: Helpers
+
+  private func makeDefaults() -> UserDefaults {
+    let name = "ManagedConfigurationTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+    return defaults
+  }
+
+  private func decode(_ plist: [String: Any]) throws -> OmnigentManagedConfiguration {
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    return try PropertyListDecoder().decode(OmnigentManagedConfiguration.self, from: data)
+  }
+
+  private func assertFails(
+    _ plist: [String: Any],
+    with expected: ManagedAppConfigurationDecodingErrorCode,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    do {
+      let config = try decode(plist)
+      XCTFail(
+        "Expected code \(expected.rawValue), decoded \(config.serverURLs)", file: file, line: line)
+    } catch let failure as OmnigentManagedConfiguration.Failure {
+      XCTAssertEqual(failure.code, expected, file: file, line: line)
+      XCTAssertFalse(
+        failure.message.isEmpty, "Admins need an actionable message", file: file, line: line)
+    } catch {
+      XCTFail("Expected a reportable failure, got \(error)", file: file, line: line)
+    }
+  }
+}
+
+/// The merge that decides what the connect screen and the server switcher show.
+final class ManagedServersTests: XCTestCase {
+  private let managed = [URL(string: "https://corp.example.com")!]
+
+  func testRecentsDropAServerTheAdministratorAlreadyPresets() {
+    let recents = ManagedServers.recents(
+      ["https://corp.example.com", "https://mine.example.com"], excludingManaged: managed)
+
+    XCTAssertEqual(recents, ["https://mine.example.com"])
+  }
+
+  func testRecentsAreUntouchedWithoutAConfiguration() {
+    let recents = ["https://mine.example.com", "http://localhost:6767"]
+
+    XCTAssertEqual(ManagedServers.recents(recents, excludingManaged: []), recents)
+  }
+
+  func testDifferingPortIsADifferentServer() {
+    let recents = ManagedServers.recents(
+      ["https://corp.example.com:8443"], excludingManaged: managed)
+
+    XCTAssertEqual(recents, ["https://corp.example.com:8443"])
+  }
+
+  func testUnparseableRecentIsKept() {
+    // Dropping an entry we can't parse would silently lose a server the user
+    // connected to; the switcher already tolerates one it can't label.
+    XCTAssertEqual(ManagedServers.recents(["not a url"], excludingManaged: managed), ["not a url"])
+  }
+
+  func testPresetServersComeFirst() {
+    let merged = ManagedServers.merged(
+      managed: managed, recents: ["https://mine.example.com", "https://corp.example.com"])
+
+    XCTAssertEqual(merged, ["https://corp.example.com", "https://mine.example.com"])
+  }
+}

--- a/web/ios/OmnigentUITests/ManagedServersUITests.swift
+++ b/web/ios/OmnigentUITests/ManagedServersUITests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+/// UI smoke test for administrator-preset server URLs, driven through the
+/// DEBUG-only `--omnigent-managed-servers` launch seam.
+///
+/// The seam exists because there is no way to fake a pushed managed app
+/// configuration locally: the real payload arrives over declarative device
+/// management, so a simulator run can never receive one. What this test covers
+/// is everything downstream of the decoder — that preset servers are offered
+/// under their own heading, and that tapping one connects. The decoding and
+/// validation itself is covered by `ManagedConfigurationTests`.
+@MainActor
+final class ManagedServersUITests: XCTestCase {
+  func testPresetServerIsOfferedAndConnects() throws {
+    let marker = "OMNIGENT_MANAGED_SERVER_OK"
+    let server = try MockHTTPServer { _, _ in
+      (
+        200, ["content-type": "text/html"],
+        "<html><body>\(marker)</body></html>".data(using: .utf8)!
+      )
+    }
+    let presetURL = "http://localhost:\(server.port)"
+
+    let app = XCUIApplication(bundleIdentifier: "ai.omnigent.ios")
+    app.launchArguments += [
+      "--omnigent-managed-servers", presetURL,
+      // No saved server, so the connect screen is what we land on.
+      "--omnigent-reset-state",
+    ]
+    app.launch()
+
+    // A preset server must not connect on its own — the user still chooses.
+    XCTAssertTrue(
+      app.staticTexts["Provided by your organization"].waitForExistence(timeout: 15),
+      "Expected preset servers to be offered under their own heading.")
+
+    let row = app.buttons.matching(identifier: "managed-servers-row").firstMatch
+    XCTAssertTrue(row.waitForExistence(timeout: 5), "Expected a row for \(presetURL).")
+    row.tap()
+
+    XCTAssertTrue(
+      app.webViews.staticTexts[marker].waitForExistence(timeout: 30),
+      "Expected tapping a preset server to load it (marker \(marker)).")
+  }
+}

--- a/web/ios/README.md
+++ b/web/ios/README.md
@@ -5,8 +5,8 @@ loads the server-served web UI instead of shipping a duplicate copy of the SPA.
 
 ## Development
 
-Open `Omnigent.xcodeproj` in Xcode 16 or newer and run the `Omnigent` scheme on
-an iOS 18 simulator.
+Open `Omnigent.xcodeproj` in Xcode 26 or newer and run the `Omnigent` scheme on
+an iOS 26 simulator.
 
 Debug builds allow `http://` web content for local development by enabling
 `NSAllowsArbitraryLoadsInWebContent`. Release builds keep App Transport
@@ -19,15 +19,84 @@ loading, foreground local notifications, app badge updates, and notification
 tap routing back into the SPA. It does not implement APNs, background polling,
 or localhost proxy/CORS behavior.
 
+## Managed app configuration
+
+An administrator can preset the server URLs the app offers via a managed app
+configuration, so managed users pick their organization's server from the connect
+screen instead of typing a URL. See
+[`docs/managed-app-configuration.md`](docs/managed-app-configuration.md) for the
+published specification (keys, error codes, sample payload) — that document is
+what administrators read, so keep it in sync with `ManagedConfiguration.swift`.
+
+Two delivery channels are supported: a `com.apple.configuration.app.managed`
+declaration (preferred — validated, with errors reported back to the admin) and
+the classic `com.apple.configuration.managed` defaults key (any MDM, no error
+reporting). The declarative one wins when both are present.
+
+Preset servers are offered, not enforced: nothing connects automatically, the
+user can still type any URL, and preset entries are never persisted into recent
+servers, so withdrawing the configuration withdraws them from the app.
+
+The real payload arrives over declarative device management, which the Simulator
+cannot do at all — it has no MDM enrollment and `simctl` has no profile-install
+command. To exercise the UI, pass the DEBUG-only launch argument:
+
+```
+--omnigent-managed-servers https://one.example.com,https://two.example.com
+```
+
+Set it in the scheme's arguments (Product › Scheme › Edit Scheme › Run ›
+Arguments) for a manual run; `ManagedServersUITests` uses the same seam. To drive
+it from the command line, ask `xcodebuild` where the app is rather than guessing
+a DerivedData path — there are usually several, and installing a stale one looks
+exactly like the feature not working:
+
+````sh
+cd web/ios
+DEVICE='platform=iOS Simulator,name=iPhone 17,OS=26.5'
+xcodebuild build -project Omnigent.xcodeproj -scheme Omnigent -destination "$DEVICE" -quiet
+APP="$(xcodebuild -project Omnigent.xcodeproj -scheme Omnigent -destination "$DEVICE" \
+  -showBuildSettings | awk -F' = ' '/ BUILT_PRODUCTS_DIR/{print $2; exit}')/Omnigent.app"
+
+xcrun simctl boot 'iPhone 17' 2>/dev/null
+xcrun simctl install booted "$APP"
+xcrun simctl launch booted ai.omnigent.ios --omnigent-reset-state \
+  --omnigent-managed-servers 'https://omnigent.corp.example.com,https://my-workspace.cloud.databricks.com/ml/omnigents'
+```
+
+To exercise the real configuration plumbing instead of a test seam, push a classic
+configuration into the app's own defaults — this is the same key an MDM writes, so
+nothing about the app's code path is faked:
+
+```sh
+xcrun simctl spawn booted defaults write ai.omnigent.ios com.apple.configuration.managed \
+  '{ serverUrls = ("https://omnigent.corp.example.com", "https://my-workspace.cloud.databricks.com/ml/omnigents"); }'
+xcrun simctl terminate booted ai.omnigent.ios
+xcrun simctl launch booted ai.omnigent.ios
+
+# Simulate an administrator changing it later: rewrite the key, then leave and
+# re-enter the app. Out-of-process writes don't notify the app, so the list is
+# re-read when it next becomes active.
+xcrun simctl spawn booted defaults delete ai.omnigent.ios com.apple.configuration.managed
+```
+
+The declarative channel cannot be exercised this way; only a real enrolled device
+can deliver a declaration. Decoding and validation are covered without any device management
+by `ManagedConfigurationTests`. Verifying that a real configuration is delivered,
+and that a bad value reports back to the admin console, requires a supervised
+device enrolled in an MDM that supports declarative app configuration.
+
 ## Deep links
 
 An `omnigent://<hostname>/c/<session_id>` URL opens that session on that server
 in the app, mirroring the Electron desktop shell (see
 `designs/desktop-deep-link.md` for the shared design):
 
-```
-omnigent://localhost:8000/c/conv_abc              → http://localhost:8000/c/conv_abc
+````
+
+omnigent://localhost:8000/c/conv_abc → http://localhost:8000/c/conv_abc
 omnigent://my-workspace.cloud.databricks.com/c/x → https://…/ml/omnigents/c/x
+
 ```
 
 The link names a server by **host** (with port if non-default) and carries no
@@ -56,3 +125,4 @@ identity. The scheme is registered via `CFBundleURLSchemes` in both Info plists;
 test from the simulator with `xcrun simctl openurl booted 'omnigent://...'`.
 The web UI must be rebuilt (`pnpm --filter web run build`) for the SPA's `onOpenPath`
 subscriber to be present in the served bundle.
+```

--- a/web/ios/docs/managed-app-configuration.md
+++ b/web/ios/docs/managed-app-configuration.md
@@ -1,0 +1,106 @@
+# Managed app configuration (iOS)
+
+Administrators can preset the server URLs the Omnigent iOS app offers, so people
+in an organization pick their server from a list instead of typing it.
+
+This page is the configuration specification. Apple's guidance is to publish it
+where administrators can reach it, so treat the keys and error codes below as a
+public contract.
+
+## Requirements
+
+The app must be installed as a **managed app** by a device management service.
+Beyond that, either delivery channel works:
+
+| Channel                 | How it is sent                                                             | Requires                                 |
+| ----------------------- | -------------------------------------------------------------------------- | ---------------------------------------- |
+| Declarative (preferred) | `com.apple.configuration.app.managed` declaration with the `AppConfig` key | Declarative device management; iOS 18.4+ |
+| Classic                 | The `com.apple.configuration.managed` app configuration dictionary         | Any MDM that supports app configuration  |
+
+Both carry the same keys. If a service sends both, the declarative configuration
+is used, because it is validated with feedback to the administrator (see
+[Errors](#errors)).
+
+An unmanaged install, or a managed install with no configuration, behaves exactly
+as before: no preset servers, and the person types a URL.
+
+## Keys
+
+| Key          | Type             | Required | Default | Description                                                                      |
+| ------------ | ---------------- | -------- | ------- | -------------------------------------------------------------------------------- |
+| `serverUrls` | Array of strings | No       | `[]`    | Server URLs to offer, most-preferred first. Each must be `https://`. At most 10. |
+
+Notes:
+
+- A bare host is accepted and read as `https://` — `omnigent.corp.example.com`
+  becomes `https://omnigent.corp.example.com`.
+- Include the workspace path if your deployment uses one, for example
+  `https://my-workspace.cloud.databricks.com/ml/omnigents`. The app can discover
+  a Databricks workspace mount on its own, but naming it here skips that lookup.
+- Entries that resolve to the same origin are collapsed, keeping the first.
+- `http://` is rejected. iOS App Transport Security blocks plain HTTP in release
+  builds, so an `http://` server could not load even if it were accepted here.
+  Terminate TLS in front of an on-premises server.
+
+## Behavior
+
+Preset servers appear on the connect screen under **"Provided by your
+organization"**, above the person's own recent servers, and in the in-app server
+switcher.
+
+They are **offered, not enforced**:
+
+- The app does not connect to one automatically. The person still chooses.
+- The person can still type any other server URL.
+- Preset servers are never written to the device's saved-server list, so
+  removing them from the configuration removes them from the app, and they never
+  displace a server the person chose themselves.
+
+Updating the configuration takes effect without reinstalling the app. A
+declarative configuration is applied as soon as the device receives it; a classic
+configuration is picked up the next time the app becomes active, so a change made
+while someone is using the app appears when they next return to it.
+
+## Example
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>configuration</key>
+    <dict>
+        <key>serverUrls</key>
+        <array>
+            <string>https://omnigent.corp.example.com</string>
+            <string>https://my-workspace.cloud.databricks.com/ml/omnigents</string>
+        </array>
+    </dict>
+</dict>
+</plist>
+```
+
+## Errors
+
+An invalid configuration is **rejected as a whole** — no partial list is offered,
+so what the app shows always matches what was configured.
+
+How you find out differs by channel:
+
+- **Declarative:** the device reports the failure to the management service and
+  records the code and message below in its event log, which you can retrieve
+  with a device log request.
+- **Classic:** there is no mechanism to report anything back, so an invalid
+  configuration is silently ignored and no servers are offered. If preset servers
+  don't appear, check the value against the codes below.
+
+| Code  | Meaning                                  | Fix                                                           |
+| ----- | ---------------------------------------- | ------------------------------------------------------------- |
+| `100` | An entry is not a valid server URL.      | Check for typos, stray whitespace, or a missing host.         |
+| `101` | An entry does not use `https://`.        | Use `https://`; see the note on App Transport Security above. |
+| `102` | More than 10 entries.                    | Reduce the list to 10 or fewer.                               |
+| `103` | `serverUrls` is not an array of strings. | Send an array, even for a single URL.                         |
+
+Codes at or above `1879048192` (`0x70000000`) are reserved by the system; the
+codes above are all in the app-specific range.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Someone opening Omnigent on a managed device has to know and type their
  organization's server URL. This lets an administrator preset that list, so the
  connect screen offers the org's servers under a "Provided by your organization"
  heading and in the server switcher.
- Preset servers are **offered, not enforced**: nothing connects automatically,
  the user can still type any URL, and preset entries are never written to the
  saved-server list — so withdrawing the configuration withdraws them from the
  app, and they never consume the 5-entry recents cap and evict a server the user
  chose. `SettingsStore` is untouched, which makes that a structural guarantee
  rather than a rule to remember.
- Two delivery channels, one decoder: a `com.apple.configuration.app.managed`
  declaration read via the `ManagedApp` framework (preferred — validation errors
  are reported back to the admin console and the device event log), and the
  classic `com.apple.configuration.managed` defaults key (works on any MDM, no
  error reporting). Declarative wins when both are present.
- Validation lives in `init(from:)` so a bad value becomes actionable admin
  feedback instead of a server that silently never appears. Four documented error
  codes; `https` only, because release builds keep App Transport Security
  defaults and an `http://` preset could not load anyway.
- `web/ios/docs/managed-app-configuration.md` is the published specification
  (keys, error codes, sample payload) — Apple's guidance is to host this where
  administrators can reach it, so it is a standalone doc.
- Raises `IPHONEOS_DEPLOYMENT_TARGET` to 26.0, which the `ManagedApp` framework
  (iOS 18.4+) no longer needs to be gated behind.

```
declaration (com.apple.configuration.app.managed / AppConfig) ─┐
                                                               ├─► OmnigentManagedConfiguration
defaults key (com.apple.configuration.managed) ────────────────┘      (validate, https, dedupe, cap 10)
                                                                              │
                                    ManagedServers.resolve(declarative:legacy:)│  declarative wins
                                                                              ▼
                                          ConnectView "Provided by your organization" + ServerSwitcher
                                          (merged at read time; never persisted)
```

Two incidental fixes the change forced:

- `ConnectView`'s server rows only hit-tested the URL's glyphs, so a tap on the
  empty part of the pill did nothing. This was pre-existing on the recents rows;
  found by the new UI test, fixed with `.contentShape`.
- The iOS 26 floor surfaced a deprecation warning for
  `NSURLErrorFailingURLStringErrorKey`; the redundant fallback was removed (the
  caller already falls back to the web view's own URL).

## Test Plan

`xcodebuild test -project Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'`

- 65 unit tests pass (+7 for the classic channel and precedence). The decoder is
  covered by decoding property lists directly — the exact shape the framework
  hands `init(from:)` — so no device management is involved: absent key, empty
  list, blank entry, invalid URL, `http://`, non-web scheme, over the cap, a bare
  string instead of a list, duplicate origins, order preservation, and that our
  error codes stay out of the system-reserved range.
- `ManagedServersUITests` drives the whole flow in the simulator through a
  DEBUG-only `--omnigent-managed-servers` launch argument: preset servers appear
  under their own heading, the app does not auto-connect, and tapping a row loads
  it.
- Verified the classic channel end-to-end on a simulator with no launch argument,
  pushing the same key an MDM writes:
  `xcrun simctl spawn booted defaults write ai.omnigent.ios com.apple.configuration.managed '{ serverUrls = ("https://omnigent.corp.example.com", "https://my-workspace.cloud.databricks.com/ml/omnigents"); }'`
- Verified a mid-session configuration change: rewriting the key and returning to
  the app replaces the list. This caught a real bug —
  `UserDefaults.didChangeNotification` does not fire for an out-of-process write,
  which is exactly how a configuration arrives, so the re-read is anchored to
  `didBecomeActive` (plus a `synchronize()` to drop the stale in-process cache).
- `RedirectConsentUITests` and the deep-link UI tests still pass.
  `OmnigentUITests.testLocalServerSnapshot` fails, but identically on a stashed
  clean tree — it needs a live dev server.
- `pre-commit run` clean on all changed files.

Not covered: delivery of a real declaration, and the error codes reaching an
admin console. Nothing can deliver a declaration to a simulator, so that needs a
device enrolled in an MDM with declarative app configuration support.

## Demo

Preset servers on the connect screen, delivered through the classic channel with
no launch argument (`defaults write` of `com.apple.configuration.managed`), and
after an administrator changed the configuration mid-session:

| Two servers preset | Administrator changed it, user returned |
| --- | --- |
| ![Two preset servers under "Provided by your organization"](https://raw.githubusercontent.com/fanzeyi/omnigent/pr-assets/ios-managed-server-url/preset-servers.png) | ![One updated preset server](https://raw.githubusercontent.com/fanzeyi/omnigent/pr-assets/ios-managed-server-url/preset-servers-updated.png) |

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered what automation cannot reach. The DEBUG launch
argument the UI test uses bypasses configuration delivery, so both channels were
exercised by hand on a simulator: the classic key was pushed with `defaults
write` (the same key an MDM writes, hitting the real decoder, validation, merge
and UI), then rewritten mid-session to confirm the app picks up an administrator's
change. Declarative delivery and admin-facing error reporting remain unverified —
they require an enrolled device, and no simulator can receive a declaration.

## Changelog

Administrators can preset the iOS app's server URLs with a managed app configuration, so managed users pick their organization's server instead of typing it

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

