### PR TITLE
feat(cli): add `omnigent start` as the on switch for hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ plus one `tools/mcp/*.yaml` server, no sub-agents.
 machine as a host:
 
 ```bash
-omnigent host --background   # starts the local server too, then returns
+omnigent start   # starts the local server and registers this machine as a host
 ```
 
 Open the server URL it prints, hit **New Chat**, pick your machine, and go.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1827,6 +1827,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "sandbox",
         "server",
         "setup",
+        "start",
         "stop",
         "uninstall",
         "update",
@@ -4142,6 +4143,47 @@ def server_status(json_output: bool) -> None:
     click.echo(f"  host daemon attached: {'yes' if daemon_attached else 'no'}")
 
 
+@cli.command("start")
+@click.option("--server", default=None, help="Omnigent server URL to host on.")
+@click.option(
+    "--non-interactive",
+    "non_interactive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Never prompt for sign-in. When the server requires auth and you "
+        "are not logged in, fail with the `omnigent login` hint instead of "
+        "launching the browser login flow. Use this in scripts and CI."
+    ),
+)
+def start(server: str | None, non_interactive: bool) -> None:
+    """Start Omnigent on this machine, in the background.
+
+    The on switch, and the counterpart of ``omnigent stop``: brings up the
+    local server (web UI / history) and registers this machine as a host, then
+    returns. With a configured or explicit ``--server`` it hosts on that server
+    instead, and no local server is started.
+
+    An alias of ``omnigent host --background`` — reach for that spelling when
+    a script wants the host lifecycle by name (``omnigent host status`` /
+    ``omnigent host stop``). Sign-in happens here, in your terminal, before the
+    daemon detaches.
+
+    :param server: Omnigent server URL to host on, e.g.
+        ``"https://example.databricksapps.com"``. ``None`` falls back to
+        config; empty string forces local mode.
+    :param non_interactive: When ``True``, never launch the browser login for
+        an un-authed remote server — fail with the ``omnigent login`` hint
+        instead.
+    :returns: None.
+    """
+    _run_background_host(
+        _resolve_host_server(server),
+        stop_command="omnigent stop",
+        non_interactive=non_interactive,
+    )
+
+
 @cli.command("stop")
 @click.option(
     "--force",
@@ -4151,10 +4193,11 @@ def server_status(json_output: bool) -> None:
 def stop(force: bool) -> None:
     """Stop everything Omnigent is running on this machine.
 
-    The off switch: stops every host daemon (local and remote-targeted)
-    and the detached background server. Runners are reaped when their daemon
-    exits. To stop only hosting while keeping the local server (web UI /
-    history) up, use ``omnigent host stop`` instead.
+    The off switch, and the counterpart of ``omnigent start``: stops every host
+    daemon (local and remote-targeted) and the detached background server.
+    Runners are reaped when their daemon exits. To stop only hosting while
+    keeping the local server (web UI / history) up, use ``omnigent host stop``
+    instead.
 
     :param force: Continue past individual failures and SIGKILL daemons that
         do not exit on SIGTERM.
@@ -7674,14 +7717,15 @@ def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
 def _run_background_host(
     server: str | None,
     *,
-    explicit_server: str | None,
+    stop_command: str,
     non_interactive: bool,
 ) -> None:
     """Spawn (or reuse) the detached host daemon and report it.
 
     The background counterpart of the foreground ``omnigent host`` body,
-    selected by ``--background``: the same daemon loop runs detached (see
-    :func:`_ensure_host_daemon`) so the command returns instead of blocking.
+    selected by ``--background`` (and the whole of ``omnigent start``): the
+    same daemon loop runs detached (see :func:`_ensure_host_daemon`) so the
+    command returns instead of blocking.
 
     Sign-in stays in the foreground. The detached daemon has no terminal to
     prompt on, so a Databricks-fronted server is authenticated here, before the
@@ -7691,9 +7735,9 @@ def _run_background_host(
     :param server: Resolved Omnigent server URL, e.g.
         ``"https://example.databricksapps.com"``. ``None`` or ``""`` selects
         local mode (the daemon starts or reuses a local Omnigent server).
-    :param explicit_server: The ``--server`` value as the user spelled it
-        (``""`` for local mode), or ``None`` when the option was omitted.
-        Only used to echo a matching ``host stop`` command.
+    :param stop_command: Command to echo for stopping this daemon, e.g.
+        ``"omnigent stop"`` — each entry point suggests the teardown that
+        matches how it was invoked.
     :param non_interactive: When ``True``, never launch the browser login —
         fail with the ``omnigent login`` hint instead.
     :raises click.ClickException: If the daemon cannot be spawned, exits
@@ -7736,7 +7780,7 @@ def _run_background_host(
         _echo_host_field("log", _display_path(Path(record.log_path)))
     click.echo()
     click.echo(_cli_style("Stop it with:", dim=True))
-    click.echo(f"  {_cli_style(_host_stop_command(explicit_server), bold=True)}")
+    click.echo(f"  {_cli_style(stop_command, bold=True)}")
 
 
 def _echo_host_field(label: str, value: str) -> None:
@@ -7852,7 +7896,7 @@ def host(
     if background:
         _run_background_host(
             server,
-            explicit_server=explicit_server,
+            stop_command=_host_stop_command(explicit_server),
             non_interactive=non_interactive,
         )
         return

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -822,3 +823,76 @@ def test_host_background_signs_in_before_spawning(
     # configured target instead.
     assert "server: https://example.databricksapps.com" in result.output
     assert "omnigent host stop --server https://example.databricksapps.com" in result.output
+
+
+# ── omnigent start ────────────────────────────────────────────────
+
+
+def test_start_spawns_background_host_and_suggests_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``start`` is the friendly spelling of ``host --background``.
+
+    It must spawn the same detached daemon (local mode here, so the daemon
+    brings up the local server too) and suggest the matching off switch —
+    ``omnigent stop``, not the host-specific teardown.
+    """
+    spawned_args, _ = _patch_background_host_spawn(monkeypatch, tmp_path)
+    foreground_runs: list[str] = []
+
+    with patch(
+        "omnigent.host.connect.run_host_process",
+        lambda server_url, **kwargs: foreground_runs.append(server_url),
+    ):
+        result = CliRunner().invoke(cli, ["start"])
+
+    assert result.exit_code == 0, result.output
+    assert foreground_runs == []
+    assert "pid 4242" in result.output
+    assert "server: http://127.0.0.1:6767" in result.output
+    assert "omnigent stop" in result.output
+    assert "host stop" not in result.output
+    assert spawned_args and "--local" in spawned_args[0]
+
+
+def test_start_hosts_on_explicit_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``start --server <url>`` hosts on that server, signing in first.
+
+    The alias must not quietly drop the target or the foreground sign-in
+    pre-flight that a detached daemon cannot perform itself.
+    """
+    spawned_args, _ = _patch_background_host_spawn(monkeypatch, tmp_path)
+    auth_calls: list[tuple[str, bool]] = []
+
+    def _fake_auth(server: str, *, non_interactive: bool = False) -> None:
+        """Record the sign-in pre-flight.
+
+        :param server: Server URL being authenticated.
+        :param non_interactive: Whether prompting is suppressed.
+        """
+        auth_calls.append((server, non_interactive))
+
+    monkeypatch.setattr("omnigent.cli._ensure_databricks_server_auth", _fake_auth)
+
+    result = CliRunner().invoke(
+        cli, ["start", "--server", "https://example.databricksapps.com", "--non-interactive"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert auth_calls == [("https://example.databricksapps.com", True)]
+    assert "server: https://example.databricksapps.com" in result.output
+    assert spawned_args == [
+        [
+            sys.executable,
+            "-m",
+            "omnigent.host._daemon_entry",
+            "--server",
+            "https://example.databricksapps.com",
+        ]
+    ]


### PR DESCRIPTION
## Related issue

Closes OMNI-2524 — https://linear.app/omnigent/issue/OMNI-2524

## Summary

- In local mode `omnigent host --background` (#4317) already starts the local
  server *and* registers this machine as a host, so it is effectively the "turn
  Omnigent on" command — but finding it means knowing the `host` concept and a
  flag. `omnigent start` is that command under the name people look for, and is
  symmetric with the existing `omnigent stop`.
- It is a full alias, not a second implementation: same `--server` /
  `--non-interactive` options, the same CLI → config → local target resolution
  (`_resolve_host_server`), delegating to the same `_run_background_host()`.
  `host --background` keeps working for scripts that want the host lifecycle by
  name (`host status` / `host stop`).
  Registered in `_CLICK_SUBCOMMANDS` too: `main()` consults that allowlist
  before handing argv to click, so a top-level command missing from it can be
  misread as the removed ad-hoc chat (enforced by
  `test_click_subcommands_allowlist_covers_registered_commands`).
- The stop hint each entry point echoes is now passed in, so `start` suggests
  `omnigent stop` while `host --background` keeps mirroring its own invocation.

```
$ omnigent start
Started the host daemon in the background (pid 52359).
  server: http://127.0.0.1:6767
  log:    ~/.omnigent/logs/host/host-20260806-212352-515540.log

Stop it with:
  omnigent stop
```

## Test Plan

- `uv run --extra dev pytest tests/host/test_cli_host.py -q` → 23 passed.
- Manually: `omnigent start` printed the block above in ~4s; `omnigent host
  status` showed `mode=local process=online host=online`; a second `omnigent
  start` reported `already running (pid 52359)` with no second spawn; and
  `omnigent stop` reported `Stopped 1 daemon(s) and the background server`,
  after which `host status` and `server status` were both clear.
- `omnigent --help` lists `start` next to `stop`; `omnigent start --help`
  documents the alias and both options.

## Demo

N/A — CLI-only change; the new output is quoted above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two new tests in `tests/host/test_cli_host.py` cover `start` spawning the same
detached local-mode daemon (with the local server URL reported, the foreground
loop skipped, and `omnigent stop` — not `host stop` — suggested), and
`start --server <url> --non-interactive` passing the target through to both the
sign-in pre-flight and the daemon argv. The daemon spawn and local-server
discovery are stubbed, so no process or log file is created; the detached
daemon itself was covered by the manual run above.

## Changelog

`omnigent start` starts the local server and registers this machine as a host —
the on switch to go with `omnigent stop`.




