### PR TITLE
chore(ios): bump app MARKETING_VERSION to 0.1.1

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -532,7 +532,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -563,7 +563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Bumps the iOS app's marketing version (`CFBundleShortVersionString`) from
  `0.1.0` to `0.1.1` ahead of cutting a TestFlight build, so the release is not
  published under the same user-facing version as the previous one.
- Only the **Omnigent** app target's Debug and Release configurations change, as
  `web/ios/RELEASE.md` prescribes. The `.tests` / `.uitests` bundle versions are
  left at `0.1.0`; they are never shipped, and Android's equivalent bump (#4309)
  likewise touched only the app's version.
- The build number is deliberately untouched: it is computed per upload as
  `latest_testflight_build_number + 1` and injected by fastlane at archive time,
  so it must not be bumped by hand.

## Test Plan

- `xcodebuild build -project Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'`
  succeeds, and the built app's `Info.plist` reports the new version:
  `plutil -extract CFBundleShortVersionString raw .../Omnigent.app/Info.plist` → `0.1.1`.
- `plutil -lint web/ios/Omnigent.xcodeproj/project.pbxproj` passes, confirming the
  hand-edited project file is still well-formed.
- Verified the two changed entries belong to the `ai.omnigent.ios` target (Debug
  and Release) and that no other target's version moved.

## Demo

N/A — no user-visible interface change; only the reported version string.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A version string has no behaviour to unit test. Verified by building the app and
reading `CFBundleShortVersionString` back out of the built `Info.plist`, plus a
`plutil -lint` on the edited project file to catch a malformed hand edit. The
existing iOS suites continue to cover app behaviour.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

