### PR TITLE
fix(runner): stop idle shutdown deadlocking on a stopped delta worker

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -87,6 +87,11 @@ _REPLAY_POST_TIMEOUT_SECONDS = 5.0
 _REPLAY_DEADLINE_SECONDS = 30.0
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
 _DELTA_FLUSH_CHAR_THRESHOLD = 64
+# Upper bound on how long a flush/close barrier waits for the delta worker to
+# acknowledge it. The worker only has to drain its buffer over an already-open
+# HTTP client, so this is generous; it exists so a worker that died without
+# draining its queue can never wedge a teardown path forever.
+_DELTA_BARRIER_TIMEOUT_SECONDS = 10.0
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
 # Context-compaction progress edge. Publishes the same
 # ``response.compaction.in_progress`` / ``response.compaction.completed`` SSE
@@ -1151,10 +1156,7 @@ class _OutputTextDeltaCoalescer:
         """
         if self._worker_task is None:
             return
-        loop = asyncio.get_running_loop()
-        done: asyncio.Future[None] = loop.create_future()
-        self._queue.put_nowait(_DeltaFlushBarrier(done=done))
-        await done
+        await self._await_barrier(_DeltaFlushBarrier, "flush")
 
     async def close(self) -> None:
         """
@@ -1162,14 +1164,57 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None after the worker has stopped.
         """
-        if self._worker_task is None:
+        worker_task = self._worker_task
+        if worker_task is None:
+            return
+        self._worker_task = None
+        await self._await_barrier(_DeltaFlushStop, "close", worker_task=worker_task)
+        # The barrier may have timed out or the worker may already be gone;
+        # either way stop waiting on it once it can no longer make progress.
+        if not worker_task.done():
+            worker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+            await asyncio.wait_for(worker_task, timeout=_DELTA_BARRIER_TIMEOUT_SECONDS)
+
+    async def _await_barrier(
+        self,
+        barrier: type[_DeltaFlushBarrier] | type[_DeltaFlushStop],
+        operation: str,
+        worker_task: asyncio.Task[None] | None = None,
+    ) -> None:
+        """
+        Queue a barrier and wait, bounded, for the worker to acknowledge it.
+
+        The barrier's future is resolved only by the worker. On a teardown
+        where the worker is already cancelled nothing will ever resolve it,
+        so the wait is bounded rather than indefinite — an unbounded await
+        here wedges ``asyncio.run``'s final task sweep and the runner never
+        exits.
+
+        :param barrier: Queue marker class to enqueue, e.g.
+            :class:`_DeltaFlushStop`.
+        :param operation: Name used in the timeout warning, e.g. ``"close"``.
+        :param worker_task: Worker to probe for liveness; defaults to the
+            live worker. :meth:`close` passes the task it detached.
+        :returns: None once the worker acknowledges or the wait times out.
+        """
+        worker_task = worker_task or self._worker_task
+        if worker_task is not None and worker_task.done():
+            # Nothing will drain the queue, so skip the barrier entirely
+            # instead of paying the full timeout for a known-dead worker.
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
-        self._queue.put_nowait(_DeltaFlushStop(done=done))
-        await done
-        await self._worker_task
-        self._worker_task = None
+        self._queue.put_nowait(barrier(done=done))
+        try:
+            await asyncio.wait_for(done, timeout=_DELTA_BARRIER_TIMEOUT_SECONDS)
+        except TimeoutError:
+            _logger.warning(
+                "Codex forwarder delta %s timed out after %.1fs waiting for the "
+                "delta worker; abandoning buffered deltas",
+                operation,
+                _DELTA_BARRIER_TIMEOUT_SECONDS,
+            )
 
     def _ensure_worker(self) -> None:
         """
@@ -1184,6 +1229,37 @@ class _OutputTextDeltaCoalescer:
             )
 
     async def _run(self) -> None:
+        """
+        Run the drain loop, releasing queued barriers on the way out.
+
+        :returns: None after a stop marker is processed or the worker is
+            cancelled.
+        """
+        try:
+            await self._drain()
+        finally:
+            # A cancelled/failed worker must release every queued barrier, or
+            # the flush/close awaiting it blocks forever on a future nothing
+            # will resolve.
+            self._abandon_queued_barriers()
+
+    def _abandon_queued_barriers(self) -> None:
+        """
+        Resolve every queued flush/stop barrier so no waiter is left parked.
+
+        :returns: None.
+        """
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            if isinstance(item, _DeltaChunk):
+                continue
+            if not item.done.done():
+                item.done.set_result(None)
+
+    async def _drain(self) -> None:
         """
         Drain queued deltas and flush barriers in FIFO order.
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -55,6 +55,13 @@ _RUNNER_THREADPOOL_MAX_WORKERS_ENV_VAR = "OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS
 # finishes cleanly; a tunnel wedged past this is cancelled so shutdown can't
 # hang forever.
 _GRACEFUL_SHUTDOWN_TUNNEL_TIMEOUT_S = 15.0
+# Backstop on the whole shutdown sequence: the teardown awaits plus
+# ``asyncio.run``'s final cancel-and-gather sweep. A leftover task that parks on
+# a future nothing will resolve makes that sweep wait forever, leaving an
+# immortal runner holding a half-open tunnel (the server then logs a steady
+# stream of "runner ... is offline" errors when routing to it). Comfortably above
+# the tunnel drain budget so a healthy shutdown always wins the race.
+_SHUTDOWN_WATCHDOG_GRACE_S = 60.0
 # Re-mint a delegated runner's owner JWT this many seconds before it
 # expires, so a live session's HTTP callbacks never present an expired
 # token. Well under the server-side token TTL.
@@ -1000,6 +1007,54 @@ def _run_parent_death_killer(
     exit_fn(0)
 
 
+def _arm_shutdown_watchdog(
+    *,
+    grace_s: float = _SHUTDOWN_WATCHDOG_GRACE_S,
+    exit_fn: Callable[[int], None] = os._exit,
+) -> threading.Thread:
+    """Hard-exit the runner if graceful shutdown does not finish in time.
+
+    Runs on a daemon thread, NOT the event loop: the wedge this guards
+    against is the loop itself. ``asyncio.run`` ends by cancelling leftover
+    tasks and gathering them, and a task parked on a future nothing will
+    resolve makes that gather wait forever — no event-loop watchdog could
+    fire, and the runner would keep a half-open tunnel and its RAM
+    indefinitely. There is nothing to disarm: the sweep this covers runs
+    after the runner's own teardown, so on a healthy exit the process is
+    already gone and the hard exit never runs.
+
+    :param grace_s: Seconds to allow graceful shutdown before the hard exit,
+        e.g. ``60.0``.
+    :param exit_fn: Hard-exit function, defaults to :func:`os._exit`;
+        injectable so tests can observe it without killing the runner.
+    :returns: The started watchdog thread, so tests can join it.
+    """
+
+    def _watch() -> None:
+        """Hard-exit unless the process exits within the grace window.
+
+        :returns: None.
+        """
+        time.sleep(grace_s)
+        # os._exit skips the exit-reason logging and buffer flushing, so record
+        # the reason and flush first. The file handler flushes per record.
+        _logger.warning(
+            "runner exiting: graceful shutdown did not complete within %.1fs; forcing hard exit",
+            grace_s,
+        )
+        with contextlib.suppress(Exception):
+            sys.stderr.flush()
+        exit_fn(0)
+
+    thread = threading.Thread(
+        target=_watch,
+        name="runner-shutdown-watchdog",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
 def _runner_workspace_from_env() -> Path | None:
     """Return the optional CLI launch workspace from runner process wiring.
 
@@ -1580,6 +1635,12 @@ async def _run_tunnel_from_env() -> None:
             # cancelled by the finally as a backstop.
             await asyncio.wait({tunnel_task}, timeout=_GRACEFUL_SHUTDOWN_TUNNEL_TIMEOUT_S)
     finally:
+        # Arm the hard-exit backstop before tearing anything down: from here on
+        # a wedged teardown await — or a leftover task that never finishes
+        # asyncio.run's final sweep — must not strand the process forever.
+        # Deliberately never disarmed: the sweep runs after this coroutine
+        # returns, so the watchdog has to outlive it and dies with the process.
+        _arm_shutdown_watchdog()
         # Log why the runner is stopping so the runner log explains the exit.
         # A crash unwinding through here is attributed by sys.excepthook with
         # its traceback, so only record the reason for an orderly shutdown.

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -21,6 +21,7 @@ from omnigent.runner._entry import (
     _DEFAULT_RUNNER_IDLE_TIMEOUT_S,
     _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS,
     _agent_cache_dest,
+    _arm_shutdown_watchdog,
     _InitialAuthTokenFactory,
     _install_crash_logging,
     _load_runner_idle_timeout_s_from_config,
@@ -2210,3 +2211,37 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
 
     assert dest == cache_root / "ag_abc123-v3"
+
+
+def test_arm_shutdown_watchdog_hard_exits_when_teardown_wedges(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A shutdown that never finishes is forced out by the watchdog.
+
+    Without this backstop a leftover task parked on a future nothing will
+    resolve makes ``asyncio.run``'s final cancel-and-gather sweep wait
+    forever: the runner becomes immortal, holding a half-open tunnel (so the
+    server logs a stream of "runner ... is offline" errors) plus all its RAM.
+    The watchdog runs off the event loop precisely because the loop is what
+    wedges. Uses a tiny grace and an injected exit function so the real
+    ``os._exit`` never fires.
+
+    :param caplog: Pytest log capture fixture.
+    :returns: None.
+    """
+    exit_calls: list[int] = []
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.runner._entry"):
+        thread = _arm_shutdown_watchdog(grace_s=0.01, exit_fn=exit_calls.append)
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert exit_calls == [0], (
+        "a wedged shutdown must be forced out, otherwise the runner never exits"
+    )
+    # os._exit skips the tunnel loop's exit-reason logging, so the watchdog
+    # must explain itself or the wedge leaves no trace in the runner log.
+    assert any(
+        "runner exiting" in record.message and "forcing hard exit" in record.message
+        for record in caplog.records
+    ), f"expected a hard-exit log line, got {[r.message for r in caplog.records]}"

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -15,6 +15,8 @@ only an already-mirrored value is not re-posted.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2538,3 +2540,99 @@ def test_settle_timeout_tracks_slowest_configured_server(tmp_path: Path) -> None
         '[mcp_servers.off]\ncommand = "y"\nenabled = false\nstartup_timeout_sec = 120\n',
     )
     assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 25.0
+
+
+# ── delta coalescer teardown: never park on a future the worker won't resolve ──
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_close_returns_when_worker_is_already_gone() -> None:
+    """``close()`` must not park forever when the delta worker is dead.
+
+    ``close()`` enqueues a stop barrier whose future only the worker
+    resolves. On a runner shutdown the worker is already cancelled, so an
+    unbounded ``await`` there never returns — and because the forwarder's
+    cleanup runs under cancellation, ``asyncio.run``'s final task sweep
+    waits on it forever and the runner never exits.
+
+    :returns: None.
+    """
+    coalescer = fwd._OutputTextDeltaCoalescer(_RecordingClient(), "conv_x")  # type: ignore[arg-type]
+    await coalescer.append("hello")
+    worker = coalescer._worker_task
+    assert worker is not None
+    worker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker
+
+    # A dead worker is detected up front, so this resolves promptly rather
+    # than burning the full barrier timeout.
+    await asyncio.wait_for(coalescer.close(), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_flush_returns_when_worker_is_already_gone() -> None:
+    """``flush()`` is bounded too — the same dead-worker barrier applies.
+
+    ``flush()`` is awaited on the session-rotation and turn-boundary paths,
+    so a stopped worker must not wedge those either.
+
+    :returns: None.
+    """
+    coalescer = fwd._OutputTextDeltaCoalescer(_RecordingClient(), "conv_x")  # type: ignore[arg-type]
+    await coalescer.append("hello")
+    worker = coalescer._worker_task
+    assert worker is not None
+    worker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker
+
+    await asyncio.wait_for(coalescer.flush(), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_worker_release_barriers_when_cancelled() -> None:
+    """A cancelled worker releases queued barriers so no waiter is stranded.
+
+    This covers the race the timeout alone cannot: a barrier already queued
+    when the worker is cancelled. Its future must be resolved on the way out
+    or the waiter blocks on something nothing will ever complete.
+
+    :returns: None.
+    """
+    coalescer = fwd._OutputTextDeltaCoalescer(_RecordingClient(), "conv_x")  # type: ignore[arg-type]
+    await coalescer.append("hello")
+    worker = coalescer._worker_task
+    assert worker is not None
+
+    # Queue the barrier, then kill the worker before it can drain it — the
+    # ordering a real teardown hits.
+    flush_task = asyncio.create_task(coalescer.flush())
+    await asyncio.sleep(0)
+    worker.cancel()
+
+    await asyncio.wait_for(flush_task, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_close_still_flushes_on_a_healthy_shutdown() -> None:
+    """A live worker still drains buffered deltas before ``close()`` returns.
+
+    The teardown bounds must not cost the ordinary case its flush: text
+    buffered when the session ends still has to reach AP.
+
+    :returns: None.
+    """
+    client = _RecordingClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(client, "conv_x")  # type: ignore[arg-type]
+    await coalescer.append("hello")
+
+    await asyncio.wait_for(coalescer.close(), timeout=5)
+
+    deltas = [
+        payload["data"]["delta"]
+        for _url, payload in client.posts
+        if payload.get("data", {}).get("delta")
+    ]
+    assert "hello" in deltas, f"buffered delta was dropped on close; posted {deltas}"
+    assert coalescer._worker_task is None


### PR DESCRIPTION
## Related issue

Closes #2748

## Summary

A runner that hit its idle timeout could **hang forever in `asyncio.run` teardown instead of exiting**. The idle monitor fired correctly, but the codex-forwarder tasks never finished cancelling, so `asyncio.run`'s final cancel-and-gather sweep waited indefinitely. The process stayed alive holding a half-open tunnel — the server then logs a steady stream of `runner … is offline for conversation …` errors when routing to it — plus all its RAM and idle codex subagents. Over a night of autonomous sessions these zombie runners accumulate.

**ELI5:** shutdown asked the mail-sorter to "finish the last batch and tell me when you're done," but the sorter had already gone home. So shutdown waited for a reply that would never come — forever, holding the door open behind it.

The delta coalescer's `flush()`/`close()` enqueue a barrier whose `done` future is resolved *only* by the background delta worker. On shutdown that worker is already cancelled, so the barrier is never processed and the cleanup parks on a future nothing will ever complete. Because the cleanup itself runs under cancellation, cancelling again cannot break it — hence the reported `cancelling=1` tasks making no progress.

```
asyncio.run
 └─ _cancel_all_tasks → gather(...)          ← waits forever
     └─ codex-forwarder-<session>  (cancelling=1)
         └─ supervise_forwarder finally:
             └─ delta_coalescer.close()
                 └─ await done               ← worker is gone; never resolved
```

Fixed on three levels, so no single failure can wedge the exit again:

- **Bound the barrier waits** — `flush()`/`close()` wait with a timeout, and skip the barrier outright when the worker is already known dead, so an ordinary teardown pays no timeout at all.
- **Release queued barriers on worker teardown** — the worker's `finally` resolves any barrier already in flight, unblocking its waiter instead of stranding it. This covers the race a timeout alone cannot.
- **Hard-exit backstop** — a watchdog armed on a daemon thread at the start of shutdown. The wedge is the event loop itself, so an event-loop watchdog could never fire; the thread covers both the teardown awaits *and* the task sweep that runs after them. This bounds the whole shutdown sequence regardless of which task wedges, so a future variant of this bug degrades to a logged hard exit rather than an immortal runner.

## Test Plan

Reproduced first, using a script that mimics `asyncio.run`'s teardown (cancel every task once, then gather) around a forwarder whose cleanup calls `close()`:

- **Before:** `RESULT: DEADLOCK — teardown never completed`, with the two tasks left parked exactly as the issue describes (`codex-forwarder-x`, `codex-native-delta-coalescer`).
- **After:** `RESULT: exited cleanly`.

Regression tests added (`tests/test_codex_native_forwarder.py`, `tests/runner/test_runner_entry.py`):

- `close()` / `flush()` return promptly when the worker is already gone.
- A barrier queued *before* the worker is cancelled still unblocks its waiter.
- A healthy shutdown still flushes buffered deltas to AP — the bounds must not cost the ordinary path its flush.
- The shutdown watchdog hard-exits on a wedge and logs why (`os._exit` skips the tunnel loop's exit-reason logging, so it has to explain itself).

Verified the three deadlock tests **fail on the unpatched tree** (`TimeoutError`) and pass with the fix, so they pin the actual bug rather than passing vacuously.

Suites run: `tests/test_codex_native_forwarder.py` + `tests/runner/test_runner_entry.py` → **180 passed**; full `tests/runner/` → 1427 passed, 16 failed. All 16 failures reproduce identically on a clean tree (codex-native lifecycle, pi cwd threading, nimble dispatch) — pre-existing and unrelated. `pre-commit`: ruff format/check pass; pyrefly reports the same 13 pre-existing errors as the clean tree, none in the changed files.

## Demo

N/A — non-visual runner lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the before/after deadlock repro described above, driving the real coalescer through a simulated `asyncio.run` teardown — the wedge only appears during interpreter-level task-sweep teardown, which a unit test cannot enter directly. The unit tests cover the reachable halves: the bounded barrier waits, the queued-barrier release race, and the watchdog's hard exit.

## Changelog

Runners no longer hang instead of exiting after an idle timeout, which left zombie processes holding half-open tunnels.
