### PR TITLE
Fix omnidev restart loop on Linux from non-mutating file access events

### DIFF
--- a/dev/omnidev/src/watcher.rs
+++ b/dev/omnidev/src/watcher.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use notify::RecursiveMode;
+use notify::{EventKind, RecursiveMode};
 use notify_debouncer_full::new_debouncer;
 use tokio::sync::mpsc;
 
@@ -43,6 +43,12 @@ pub fn spawn(
             let mut changed = 0usize;
             for event in &events {
                 for path in &event.paths {
+                    if !is_mutating(&event.kind) {
+                        if debug {
+                            log_watch(&shared, &repo_root, path, "skip (non-mutating event)");
+                        }
+                        continue;
+                    }
                     match classify(path, &ignore) {
                         Ok(()) => {
                             changed += 1;
@@ -70,6 +76,13 @@ pub fn spawn(
         .with_context(|| format!("watching {}", omnigent_dir.display()))?;
 
     Ok(debouncer)
+}
+
+/// Only filesystem mutations should reload the backend. In particular, Python
+/// imports emit access/open events on Linux; treating those as changes creates
+/// a restart loop where each new backend immediately reloads itself.
+fn is_mutating(kind: &EventKind) -> bool {
+    kind.is_create() || kind.is_modify() || kind.is_remove()
 }
 
 /// Build a gitignore matcher from the repo's root `.gitignore` and
@@ -114,6 +127,7 @@ fn log_watch(shared: &Arc<Mutex<Shared>>, repo_root: &Path, path: &Path, what: &
 #[cfg(test)]
 mod tests {
     use super::*;
+    use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
 
     fn ignore_with(line: &str) -> Gitignore {
         let mut b = GitignoreBuilder::new("/repo");
@@ -125,6 +139,18 @@ mod tests {
     fn plain_python_file_triggers_reload() {
         let ig = ignore_with("omnigent/_build_info.py");
         assert_eq!(classify(Path::new("/repo/omnigent/cli.py"), &ig), Ok(()));
+    }
+
+    #[test]
+    fn mutating_events_trigger_reload() {
+        assert!(is_mutating(&EventKind::Create(CreateKind::Any)));
+        assert!(is_mutating(&EventKind::Modify(ModifyKind::Any)));
+        assert!(is_mutating(&EventKind::Remove(RemoveKind::Any)));
+    }
+
+    #[test]
+    fn access_events_do_not_trigger_reload() {
+        assert!(!is_mutating(&EventKind::Access(AccessKind::Any)));
     }
 
     #[test]


### PR DESCRIPTION
## Related issue

Closes #4328

## Summary

- On Linux, `omnidev`'s file watcher treated *every* filesystem event on a watched `.py` path as a source change — including non-mutating **access/open** events. Python imports at backend startup emit access events, so each freshly started backend immediately re-triggered a reload, producing a continuous restart loop (~every 2.6s) with no actual edits.
- Fix: only reload on mutating event kinds (`create` / `modify` / `remove`) in `dev/omnidev/src/watcher.rs`, via a new `is_mutating()` helper; non-mutating events are skipped (and logged in debug mode).

## Test Plan

- `cargo test -p omnidev` (focused binary suite): 38 tests pass, including two new regression tests — `mutating_events_trigger_reload` and `access_events_do_not_trigger_reload`.
- Manually verified on Ubuntu 24.04: after installing the patched binary, `omnidev` no longer restarts the backend/host on startup or on file reads; reloads still fire on real edits.

## Demo

Before

https://github.com/user-attachments/assets/cda7a59c-7053-4a9c-a1cb-b4d6e312fe99



After

https://github.com/user-attachments/assets/88b48a0f-cb07-40d9-9349-fac1bd4159d2



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit tests covering event-kind classification (mutating vs. access). Manually verified on Ubuntu 24.04 that the restart loop is gone and that real edits still trigger a reload.

## Changelog

Fix `omnidev` restart loop on Linux caused by non-mutating file access events