### PR TITLE
fix(pyrefly): include editable workspace packages

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -6,6 +6,9 @@ project-includes = [
 
 project-excludes = []
 
+# Editable workspace packages are project sources, not third-party site packages.
+disable-project-excludes-heuristics = true
+
 python-version = "3.12"
 
 search-path = ["."]


### PR DESCRIPTION
## Related issue

Related to #3644.

## Summary

Pyrefly automatically treats editable workspace packages discovered through the virtual environment as third-party site-packages and excludes them from project mode. That caused the newly-added Python SDK include to be skipped even though the check reported zero errors.

Disable Pyrefly's default project-exclude heuristics so the explicit project-includes list remains authoritative and the Python client SDK is actually checked.

## Test Plan

- uv run --no-sync pyrefly check — 0 errors with no skipped-SDK warning.
- uv run --no-sync pyrefly dump-config --max-files all — 25 SDK Python files configured.
- uv run --no-sync pre-commit run --all-files — all hooks pass.

## Demo

N/A — non-visual type-checker configuration fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified both Pyrefly's configured file list and the complete pre-commit gate against the updated configuration.