### PR TITLE
fix(native-forwarders): don't drop items on pre-flight POST failures

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -146,6 +146,10 @@ def post_may_have_been_delivered(exc: httpx.HTTPError) -> bool:
     - Connection-establishment / pool-acquire failures
       (:data:`_DELIVERY_SAFE_RETRY_ERRORS`): no bytes were sent → not
       delivered → safe to retry, so ``False``.
+    - Errors raised before the request was bound to the transport (no
+      ``.request``, e.g. an auth flow that fails closed instead of
+      yielding the request): nothing was sent → safe to retry, so
+      ``False``.
     - Any other transport error (read/write timeout, read/write error,
       remote protocol error): the request was sent and we never saw a
       response, so the server may have processed it → ambiguous →
@@ -158,6 +162,12 @@ def post_may_have_been_delivered(exc: httpx.HTTPError) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return False
     if isinstance(exc, _DELIVERY_SAFE_RETRY_ERRORS):
+        return False
+    # httpx raises RuntimeError when no request was ever attached, which only
+    # happens if the failure preceded the send.
+    try:
+        _ = exc.request
+    except RuntimeError:
         return False
     return True
 

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -83,6 +83,10 @@ def _read_records(path: Path) -> list[dict[str, object]]:
             False,
         ),
         (httpx.PoolTimeout("no slot", request=httpx.Request("POST", "http://test")), False),
+        # Raised before the request reached the transport, so it carries no
+        # request and nothing was sent. A runner whose auth flow fails closed
+        # raises exactly this. Safe to retry.
+        (httpx.RequestError("token refresh returned no token"), False),
         # Request was sent and no response was seen — the server may have
         # committed it. Ambiguous: a retry could duplicate.
         (httpx.ReadTimeout("no response", request=httpx.Request("POST", "http://test")), True),


### PR DESCRIPTION
## Related issue

Closes #4333

## Summary

`post_may_have_been_delivered` classified any non-`HTTPStatusError` outside the connection-establishment tuple as an **ambiguous** delivery. That swept in errors raised *before the request ever reached the transport* — notably a runner auth flow that fails closed rather than yielding the request, which raises a bare `httpx.RequestError` with no request attached.

The forwarders' ambiguous branch deliberately skips such items without retrying (a re-post would duplicate, since external conversation items aren't deduped server-side) **and** marks the `source_id` permanently seen. So an error that provably never left the process was treated as maybe-committed, and the transcript item — tool calls included — was silently and irrecoverably lost from the server-side session while the local transcript kept it.

This PR treats an error with no bound request as provably undelivered, so it's safe to retry. Genuinely ambiguous mid-flight failures (read/write timeout, write error, remote protocol error) still carry a request and are unchanged.

**ELI5:** the code asked "did my letter maybe get delivered?" and answered "maybe" for a letter it never even put in the envelope — then threw the letter away to avoid sending a duplicate.

```
POST fails
  │
  ├─ HTTPStatusError ─────────────► not committed        → retry (unchanged)
  ├─ Connect/Pool error ──────────► never sent           → retry (unchanged)
  ├─ no .request attached ────────► never sent           → retry  ★ THIS PR
  │      (auth failed closed pre-send)                     was: skip + lose
  └─ Read/Write/Protocol error ───► may be committed     → skip  (unchanged)
```

Observed in the wild as tool calls missing from a session view: one session held **48/48** `function_call`/`function_call_output` server-side against **52/52** locally (12 items lost; 16 in another session). Because the trigger was a persistent auth failure rather than a transient blip, the code comment's assumption — "At worst one item is lost on a flaky POST" — became whole-session loss across hundreds of consecutive failures. Root-cause detail and the upstream auth trigger are in #4333 / #4332.

Note this is narrower than #1594 (server-side idempotency), and complementary: with an idempotency key the ambiguous branch goes away entirely. The point here is that these failures were **never ambiguous to begin with**, so they shouldn't reach that branch even before #1594 lands.

## Test Plan

Added the pre-flight case to the existing `test_post_may_have_been_delivered_classification` parametrization, whose docstring already names this exact hazard ("lost messages (provably-undelivered error marked ambiguous and dropped)").

Verified the test is a genuine regression guard — it fails on unpatched source and passes with the fix, with **no other case changing**:

```text
                                  unfixed   fixed   expected
HTTPStatusError 503               False     False   False
ConnectError                      False     False   False
ConnectTimeout                    False     False   False
PoolTimeout                       False     False   False
RequestError (no request)         True ✗    False   False   ← the fix
ReadTimeout                       True      True    True
WriteError                        True      True    True
RemoteProtocolError               True      True    True
```

Lint/type checks on the changed files:

```console
$ pre-commit run --files omnigent/_native_post_delivery.py tests/test_native_post_delivery.py
ruff format..............................................Passed
ruff check...............................................Passed
pyrefly..................................................Passed
no globally-clobbering asyncio monkeypatch...............Passed
no unconditional `@pytest.mark.skip`.....................Passed
no new hardcoded LLM model ids............................Passed
```

To reproduce the classification directly:

```console
$ python -c "
import httpx
from omnigent._native_post_delivery import post_may_have_been_delivered as f
print(f(httpx.RequestError('token refresh returned no token')))          # False (was True)
print(f(httpx.ReadTimeout('x', request=httpx.Request('POST','http://t'))))  # True
"
```

I could not run the full `pytest` suite locally: the repo pins `uv>=0.11.8` and this machine has 0.10.9, so `uv run --frozen pytest` refuses to start. The classifier is a pure function with no imports beyond `httpx`, so I exercised it via the cases above; CI will cover the full suite.

## Demo

Non-visual change (no UI surface), but it does have a user-visible effect, so here it is as a terminal before/after rather than `N/A`. The script drives the **real** classifier out of the repo with the **real** exception `auth_flow` raises, then replays the forwarder's branch decision for three transcript items.

**Before — `main` today:** the pre-flight auth failure is judged "may have been delivered", so each item is skipped, marked seen, and never retried.

```console
$ python demo_itemloss.py <repo-at-HEAD~1>
auth_flow raised: RequestError: Databricks token refresh returned no token
classifier says may-have-been-delivered = True

  31b66e54:0:function_call           Bash(git status)             DROPPED — marked seen, never retried
  1b04e0b9:0:function_call_output    → 3 files changed            DROPPED — marked seen, never retried
  0d657c03:0:message                 assistant: here's the diff   DROPPED — marked seen, never retried

items permanently lost from the server-side session: 3
seen_source_ids burned (unrecoverable): ['31b66e54:0:function_call', '1b04e0b9:0:function_call_output', '0d657c03:0:message']
```

**After — this PR:** the same failure is correctly judged never-sent, so the items stay queued for the next pass.

```console
$ python demo_itemloss.py <repo-at-HEAD>
auth_flow raised: RequestError: Databricks token refresh returned no token
classifier says may-have-been-delivered = False

  31b66e54:0:function_call           Bash(git status)             retried on next pass — preserved
  1b04e0b9:0:function_call_output    → 3 files changed            retried on next pass — preserved
  0d657c03:0:message                 assistant: here's the diff   retried on next pass — preserved

items permanently lost from the server-side session: 0
seen_source_ids burned (unrecoverable): none
```

What this looks like to a user without the fix: tool calls simply missing from the session view in the web UI, with no error anywhere — the local transcript still has them. See #4333 for the measured counts from a live deployment (48/48 server vs 52/52 local in one session).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage is the added parametrized case in `tests/test_native_post_delivery.py`, verified to fail without the source change and pass with it.

Manual verification: confirmed against a real affected deployment that the dropped `source_id`s were present in the bridge's `transcript_forwarder.json` `seen_source_ids` (so never retried) and that no dead-letter file existed for them (so unrecoverable), and diffed the server's `/v1/sessions/{id}/items` against the local Claude transcript to get the 48-vs-52 counts above.

Not covered here: the end-to-end forwarder path (`_forward_available_items` taking the retry branch instead of the skip branch for a pre-flight failure). That needs a runner with a failing auth flow, which I can't stand up in a unit test without stubbing the auth layer — worth adding if a maintainer prefers it, and I'm happy to extend the PR.

## Changelog

Tool calls and messages are no longer dropped from a session when a runner's credential fails to refresh mid-session.

