### PR TITLE
fix(ci): avoid noisy issue-triage runs

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -13,9 +13,9 @@ name: Issue Triage
 # exfiltrate secrets. All GitHub mutations happen in steps the LLM
 # cannot influence.
 #
-# Runs on issue open, and again when someone removes the `needs-info` label —
-# the re-triage path reads the reporter's follow-up comments and classifies +
-# assigns the issue (re-adding `needs-info` only if it is still too vague).
+# Runs on issue open, and is called by needs-info-response.yml after an issue
+# author supplies follow-up details. The re-triage path reads those comments and
+# classifies + assigns the issue (re-adding `needs-info` if it is still vague).
 #
 # What the bot does:
 #   1. Removes `needs-triage`, adds `triaged`
@@ -30,10 +30,17 @@ name: Issue Triage
 
 on:
   issues:
-    # `unlabeled` re-runs triage when someone removes `needs-info` (see the job
-    # `if:` below) — that removal is the signal the issue now has enough detail
-    # to classify and assign.
-    types: [opened, unlabeled]
+    types: [opened]
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Issue to re-triage
+        required: true
+        type: number
+      retriage:
+        description: Treat this invocation as a needs-info re-triage
+        required: true
+        type: boolean
   # Manual dry run against any issue: classify and log the decision. Both
   # inputs default off, and with them off nothing is written — no label,
   # comment, assignment, or closure.
@@ -76,25 +83,15 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Run on:
-    #   - a newly opened issue by a non-bot author (initial triage), OR
-    #   - the `needs-info` label being REMOVED from an open issue (re-triage:
-    #     the removal signals the issue now has enough detail to classify).
-    # The `unlabeled` path intentionally allows a bot actor: the removal is made
-    # by the omnigent-ci App (see needs-info-response.yml) whose login ends in
-    # `[bot]`, and only an App-token/human removal re-triggers at all — this
-    # workflow's own label edits use the default GITHUB_TOKEN, which never emits
-    # re-triggering events, so there is no loop to guard against here.
+    # Initial triage ignores bot-authored issues. Re-triage is an explicit call
+    # from needs-info-response.yml after the issue author supplies more detail.
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      inputs.retriage ||
       (
+        github.event_name == 'issues' &&
         github.event.action == 'opened' &&
         !endsWith(github.event.issue.user.login, '[bot]')
-      ) ||
-      (
-        github.event.action == 'unlabeled' &&
-        github.event.label.name == 'needs-info' &&
-        github.event.issue.state == 'open'
       )
     steps:
       - name: Check LLM credentials available
@@ -454,6 +451,7 @@ jobs:
           # into the repo default.
           EVENT_ACTION: ${{ github.event.action }}
           IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          IS_RETRIAGE: ${{ inputs.retriage }}
           DISPATCH_APPLY_LABELS: ${{ inputs.apply_labels }}
           DISPATCH_POST_COMMENT: ${{ inputs.post_comment }}
           ISSUE_PRIORITIZATION_V2_ENABLED: ${{ vars.ISSUE_PRIORITIZATION_V2_ENABLED }}
@@ -508,7 +506,10 @@ jobs:
           # duplicate path runs, but every write is opt-in: each dispatch input
           # decides on its own, never falling back to the repo default.
           is_dispatch = flag("IS_DISPATCH")
-          is_open_event = is_dispatch or os.environ.get("EVENT_ACTION") == "opened"
+          is_retriage = flag("IS_RETRIAGE")
+          is_open_event = not is_retriage and (
+              is_dispatch or os.environ.get("EVENT_ACTION") == "opened"
+          )
           apply_labels = flag("DISPATCH_APPLY_LABELS") if is_dispatch else True
           post_comment_enabled = (
               flag("DISPATCH_POST_COMMENT") if is_dispatch else flag("POST_DUPLICATE_COMMENTS")

--- a/.github/workflows/needs-info-response.yml
+++ b/.github/workflows/needs-info-response.yml
@@ -20,7 +20,9 @@ permissions:
 
 concurrency:
   group: needs-info-response-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  # An in-flight run may already have removed needs-info and started re-triage.
+  # Cancelling it could leave the issue unlabeled without completing triage.
+  cancel-in-progress: false
 
 jobs:
   clear-needs-info:

--- a/.github/workflows/needs-info-response.yml
+++ b/.github/workflows/needs-info-response.yml
@@ -1,27 +1,21 @@
 name: Clear needs-info on author response
 
 # When the issue AUTHOR comments on an issue that carries `needs-info`, remove
-# the label — the reporter has (presumably) supplied the missing detail. That
-# removal is the signal the rest of the pipeline is built around:
+# the label — the reporter has (presumably) supplied the missing detail — then
+# call the triage workflow directly:
 #
 #   author comments  ->  this workflow removes `needs-info`
-#                     ->  issue-triage.yml's `unlabeled` trigger re-triages
+#                     ->  this workflow calls issue-triage.yml to re-triage
 #                         (reads the follow-up comments, classifies + assigns,
 #                          or re-adds `needs-info` if it is still too vague)
 #   author never responds  ->  stale.yml closes the issue after inactivity
-#
-# CRITICAL: the label MUST be removed with the omnigent-ci App token, not the
-# default GITHUB_TOKEN. GitHub does not re-trigger workflows from events made
-# by GITHUB_TOKEN, so a default-token removal would NOT fire issue-triage's
-# `unlabeled` re-triage. The App token is a distinct actor, so its `unlabeled`
-# event does re-trigger. If the App isn't configured, we skip (fail-closed):
-# leaving the label is safer than removing it and stranding the issue.
 
 on:
   issue_comment:
     types: [created]
 
 permissions:
+  contents: read
   issues: write
 
 concurrency:
@@ -31,6 +25,8 @@ concurrency:
 jobs:
   clear-needs-info:
     runs-on: ubuntu-latest
+    outputs:
+      removed: ${{ steps.remove-label.outputs.removed }}
     # Only when a NON-bot commenter who IS the issue author comments on an OPEN
     # issue (not a PR — issue_comment fires for PRs too) that still carries
     # `needs-info`.
@@ -41,26 +37,10 @@ jobs:
       github.event.comment.user.login == github.event.issue.user.login &&
       contains(github.event.issue.labels.*.name, 'needs-info')
     steps:
-      - name: Mint omnigent-ci App token
-        id: app-token
-        if: vars.OMNIGENT_BOT_APP_ID != ''
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
-          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
-
-      - name: Warn when the omnigent-ci App is unconfigured
-        # The feature no-ops without the App (see above). Surface it so a dormant
-        # setup is distinguishable from a broken one.
-        if: steps.app-token.outputs.token == ''
-        run: echo "::notice::omnigent-ci App not configured; needs-info re-triage is dormant (label left in place)."
-
       - name: Remove needs-info label
-        # Skip when the App isn't configured: removing with GITHUB_TOKEN would
-        # not re-trigger re-triage, so the label would just silently vanish.
-        if: steps.app-token.outputs.token != ''
+        id: remove-label
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
@@ -73,6 +53,17 @@ jobs:
                --jq '.labels[].name' | grep -qx needs-info; then
             echo "Author responded on #$ISSUE_NUMBER; removing needs-info to re-triage."
             gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label needs-info
+            echo "removed=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs-info already cleared on #$ISSUE_NUMBER; nothing to do."
+            echo "removed=false" >> "$GITHUB_OUTPUT"
           fi
+
+  retriage:
+    needs: clear-needs-info
+    if: needs.clear-needs-info.outputs.removed == 'true'
+    uses: ./.github/workflows/issue-triage.yml
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      retriage: true
+    secrets: inherit


### PR DESCRIPTION
## Related issue

N/A — Test / CI change.

## Summary

- Stop subscribing issue triage to every `unlabeled` event; expose the workflow through `workflow_call` instead.
- After an issue author responds, remove `needs-info` with the normal workflow token and call triage directly only when the label was actually removed.
- Preserve initial issue triage and manual dispatch. A maintainer manually removing `needs-info` must now use manual dispatch if re-triage is desired.

ELI5: instead of waking triage for every removed label and immediately going back to sleep, the author-response workflow now calls triage only when it has relevant work.

```text
Before: any label removed -> Issue Triage run -> usually skipped
After:  author response -> remove needs-info -> call Issue Triage
```

## Test Plan

- `pre-commit run --files .github/workflows/issue-triage.yml .github/workflows/needs-info-response.yml`
- `uvx --from actionlint-py actionlint .github/workflows/issue-triage.yml .github/workflows/needs-info-response.yml`
- `git diff --check`
- After merge, comment as the author on an open issue carrying `needs-info`; confirm the response workflow removes the label and runs its reusable `retriage` job.
- Remove an unrelated label (for example `validating`); confirm no Issue Triage run is created.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This changes GitHub Actions orchestration only. Static workflow syntax and expression validation are covered by pre-commit and `actionlint`; end-to-end event delivery requires the workflow to run from the default branch.
