### PR TITLE
fix(pi-native): route uncataloged models by family instead of the Anthropic surface

### DIFF
--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -37,8 +37,12 @@ def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
 
     A last-resort fallback for when the live model-services catalog is
     unavailable: the catalog carries authoritative per-endpoint capabilities and
-    is always preferred. Mirrors the in-process harness's
-    ``_pi_provider_for_model`` so both Pi paths route a given id identically.
+    is always preferred.
+
+    Follows the surface split the catalog builder applies, so a keyword model
+    (GLM, kimi) lands on Responses. ``pi_executor._pi_provider_for_model`` sends
+    those to completions when it too has no wire metadata — that disagreement
+    predates this fallback and is why the keyword list exists.
 
     :param model_id: Gateway or Unity Catalog model id, any case.
     :returns: The surface whose protocol the model's family accepts.

--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 # These system models omit the finish reason Pi requires on Chat Completions.
 # ``glm-`` avoids matching vendor-direct ids without a system.ai alias.
 SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "glm-")
@@ -14,3 +16,43 @@ def unsupported_in_pi(model_id_lower: str) -> bool:
     ``[object Object]``; their available alternate wires do not fix it.
     """
     return "gemini-2-5" in model_id_lower or "gpt-oss" in model_id_lower
+
+
+class DatabricksPiSurface(Enum):
+    """A Databricks AI Gateway protocol surface Pi can be pointed at.
+
+    The gateway serves each protocol under the same workspace origin, and each
+    model accepts only some of them; sending a model to the wrong surface is
+    rejected with "API type ... is not supported by ...".
+    """
+
+    ANTHROPIC = "anthropic"
+    RESPONSES = "responses"
+    COMPLETIONS = "completions"
+    MLFLOW = "mlflow"
+
+
+def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
+    """Classify *model_id* onto its Databricks gateway surface by family.
+
+    A last-resort fallback for when the live model-services catalog is
+    unavailable: the catalog carries authoritative per-endpoint capabilities and
+    is always preferred. Mirrors the in-process harness's
+    ``_pi_provider_for_model`` so both Pi paths route a given id identically.
+
+    :param model_id: Gateway or Unity Catalog model id, any case.
+    :returns: The surface whose protocol the model's family accepts.
+    """
+    lower = model_id.lower()
+    if "claude" in lower:
+        return DatabricksPiSurface.ANTHROPIC
+    needs_responses = any(keyword in lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS)
+    if lower.startswith("system.ai."):
+        # system.ai.* ids are not routable at /serving-endpoints; the ones whose
+        # chat surface omits Pi's required finish reason need Responses instead.
+        return DatabricksPiSurface.RESPONSES if needs_responses else DatabricksPiSurface.MLFLOW
+    if needs_responses or "gpt" in lower:
+        # Unknown GPT metadata fails toward Responses — the forward-compatible
+        # tool-capable surface.
+        return DatabricksPiSurface.RESPONSES
+    return DatabricksPiSurface.COMPLETIONS

--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -39,10 +39,9 @@ def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
     unavailable: the catalog carries authoritative per-endpoint capabilities and
     is always preferred.
 
-    Follows the surface split the catalog builder applies, so a keyword model
-    (GLM, kimi) lands on Responses. ``pi_executor._pi_provider_for_model`` sends
-    those to completions when it too has no wire metadata — that disagreement
-    predates this fallback and is why the keyword list exists.
+    The keyword surface split applies only to ``system.ai.*`` ids: the gateway
+    serves Responses passthrough for ``system.ai.glm-5-2`` but rejects it for the
+    ``databricks-glm-5-2`` alias of the same model, so an alias goes to chat.
 
     :param model_id: Gateway or Unity Catalog model id, any case.
     :returns: The surface whose protocol the model's family accepts.
@@ -50,12 +49,13 @@ def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
     lower = model_id.lower()
     if "claude" in lower:
         return DatabricksPiSurface.ANTHROPIC
-    needs_responses = any(keyword in lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS)
     if lower.startswith("system.ai."):
         # system.ai.* ids are not routable at /serving-endpoints; the ones whose
         # chat surface omits Pi's required finish reason need Responses instead.
-        return DatabricksPiSurface.RESPONSES if needs_responses else DatabricksPiSurface.MLFLOW
-    if needs_responses or "gpt" in lower:
+        if any(keyword in lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS):
+            return DatabricksPiSurface.RESPONSES
+        return DatabricksPiSurface.MLFLOW
+    if "gpt" in lower:
         # Unknown GPT metadata fails toward Responses — the forward-compatible
         # tool-capable surface.
         return DatabricksPiSurface.RESPONSES

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -236,7 +236,7 @@ class PiProviderConfig:
     def _model_registered_in_additional(self) -> bool:
         """Whether some secondary provider already serves the selected model."""
         return any(
-            any(entry["id"] == self.model for entry in provider["models"])
+            any(entry.get("id") == self.model for entry in provider["models"])
             for provider in self.additional_providers.values()
         )
 
@@ -265,7 +265,7 @@ class PiProviderConfig:
         """
         if self._model_registered_in_additional():
             return None
-        if any(entry["id"] == self.model for entry in self.extra_models):
+        if any(entry.get("id") == self.model for entry in self.extra_models):
             return None
         if self._fallback_surface() is not None:
             return None
@@ -1000,20 +1000,28 @@ def resolve_pi_native_provider(
         return None
 
 
-def write_pi_models_config(agent_dir: Path, provider: PiProviderConfig) -> Path:
+def write_pi_models_config(
+    agent_dir: Path,
+    provider: PiProviderConfig,
+    rendered: _PiModelsConfig | None = None,
+) -> Path:
     """Write *provider* as ``models.json`` into a managed Pi config dir.
 
     :param agent_dir: The managed Pi config dir (``PI_CODING_AGENT_DIR``).
     :param provider: The resolved provider config to render.
+    :param rendered: An already-rendered config to write, so a caller that also
+        inspects it renders (and logs) only once. Defaults to rendering here.
     :returns: Path to the written ``models.json``.
     """
+    if rendered is None:
+        rendered = provider.to_models_config()
     agent_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(agent_dir, 0o700)
     models_path = agent_dir / "models.json"
     # 0o600: the apiKey may be a literal token (key-kind providers).
     fd = os.open(models_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        json.dump(provider.to_models_config(), handle, indent=2, sort_keys=True)
+        json.dump(rendered, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return models_path
 
@@ -1029,7 +1037,10 @@ def pi_native_provider_launch(
         (relocating Pi's config dir) and the ``--provider``/``--model`` args to
         append to the Pi command.
     """
-    write_pi_models_config(agent_dir, provider)
+    # Render once and reuse: rendering logs how an uncataloged model was routed,
+    # and this function both writes the config and reads it back for --provider.
+    rendered = provider.to_models_config()
+    write_pi_models_config(agent_dir, provider, rendered)
     # Copy the user's global Pi settings but suppress defaultThinkingLevel.
     # In TUI mode Pi applies the setting from ~/.pi/agent/settings.json; for
     # non-Claude models via openai-completions, any thinking level causes the
@@ -1048,7 +1059,7 @@ def pi_native_provider_launch(
     # rather than additional_providers so a model routed by the family fallback
     # gets the same --provider that models.json registered it under.
     model_provider_id = provider.provider_id
-    for extra_id, extra_cfg in provider.to_models_config()["providers"].items():
+    for extra_id, extra_cfg in rendered["providers"].items():
         if extra_id == provider.provider_id:
             continue
         if any(m.get("id") == provider.model for m in extra_cfg.get("models", [])):

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -52,6 +52,8 @@ from omnigent.onboarding.provider_config import (
 )
 from omnigent.pi_model_compatibility import (
     SYSTEM_AI_RESPONSES_KEYWORDS,
+    DatabricksPiSurface,
+    databricks_pi_surface_for_model,
     unsupported_in_pi,
 )
 from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
@@ -81,6 +83,14 @@ _PI_OPENAI_PROVIDER_ID = "omnigent-openai"
 # work via /chat/completions: Kimi, Llama, GLM, Gemini, older GPT models).
 _PI_COMPLETIONS_PROVIDER_ID = "omnigent-completions"
 _PI_MLFLOW_PROVIDER_ID = "omnigent-mlflow"
+
+# Which provider id serves each Databricks gateway surface. The Anthropic
+# surface is the primary provider, so it is registered inline, not here.
+_SURFACE_PROVIDER_IDS: dict[DatabricksPiSurface, str] = {
+    DatabricksPiSurface.RESPONSES: _PI_OPENAI_PROVIDER_ID,
+    DatabricksPiSurface.COMPLETIONS: _PI_COMPLETIONS_PROVIDER_ID,
+    DatabricksPiSurface.MLFLOW: _PI_MLFLOW_PROVIDER_ID,
+}
 
 # Databricks AI Gateway Anthropic Messages surface. Pi speaks this protocol
 # natively (``api: anthropic-messages``); the gateway authenticates with a
@@ -189,6 +199,10 @@ class PiProviderConfig:
         Databricks OAuth token). Pi still launches — its ``!command`` apiKey may
         recover at request time — but the caller surfaces this so a session that
         would otherwise fail silently tells the user how to re-authenticate.
+    :param databricks_surfaces: Base URLs of the Databricks gateway surfaces
+        reachable with this provider's credential, keyed by surface. Set by the
+        Databricks builders; lets a model the live catalog didn't list be routed
+        by family instead of stranded on the Claude-only primary.
     """
 
     provider_id: str
@@ -206,32 +220,99 @@ class PiProviderConfig:
     # an OpenAI Completions provider for GPT models on the Databricks gateway).
     # Keys are provider ids; values are complete Pi provider config dicts.
     additional_providers: dict[str, _PiProviderPayload] = field(default_factory=dict, hash=False)
+    databricks_surfaces: dict[DatabricksPiSurface, str] = field(default_factory=dict, hash=False)
+
+    @property
+    def _primary_claude_only(self) -> bool:
+        """Whether the primary provider can only serve Claude models.
+
+        True for the Databricks gateway's ``/ai-gateway/anthropic`` surface.
+        Deliberately not inferred from ``api == "anthropic-messages"``: a
+        LiteLLM-style proxy speaks that protocol for arbitrary models, and
+        inferring would strand those.
+        """
+        return bool(self.databricks_surfaces)
+
+    def _model_registered_in_additional(self) -> bool:
+        """Whether some secondary provider already serves the selected model."""
+        return any(
+            any(entry["id"] == self.model for entry in provider["models"])
+            for provider in self.additional_providers.values()
+        )
+
+    def _fallback_surface(self) -> DatabricksPiSurface | None:
+        """Classify the selected model's surface when the catalog didn't list it.
+
+        Returns ``None`` when no fallback applies — a non-Databricks primary
+        (which picks ``api`` from the model's own family, so any id fits), a
+        model Pi cannot parse at all, or a surface this credential can't reach.
+        """
+        if not self._primary_claude_only or unsupported_in_pi(self.model.lower()):
+            return None
+        surface = databricks_pi_surface_for_model(self.model)
+        if surface is DatabricksPiSurface.ANTHROPIC:
+            return surface
+        return surface if surface in self.databricks_surfaces else None
+
+    def unroutable_model_warning(self) -> str | None:
+        """User-facing notice when no surface can serve the selected model.
+
+        Pi launches with the model unregistered and fails on an unknown model,
+        which reads to the user as another silent hang — so the caller surfaces
+        this instead.
+
+        :returns: The warning text, or ``None`` when the model is routable.
+        """
+        if self._model_registered_in_additional():
+            return None
+        if any(entry["id"] == self.model for entry in self.extra_models):
+            return None
+        if self._fallback_surface() is not None:
+            return None
+        if not self._primary_claude_only:
+            return None
+        return (
+            f"The model '{self.model}' can't be served by any endpoint this Pi session "
+            "can reach, so it won't reply. The workspace model list was unavailable "
+            "(expired credentials or an unreachable workspace) or doesn't include this "
+            "endpoint. Pick a different model with `/model`, or re-authenticate and "
+            "start a new Pi session."
+        )
 
     def to_models_config(self) -> _PiModelsConfig:
         """Render this provider as a Pi ``models.json`` mapping."""
-        models: list[_PiModelEntry]
-        if self.extra_models:
-            # Include all known models, ensuring the selected model is present.
-            # The selected model may be a newer id not yet in the static list.
-            models = list(self.extra_models)
-            # Only append to this (Anthropic) provider when the model is absent
-            # from ALL providers. Non-Claude models (GLM, GPT…) live in
-            # additional_providers (openai-completions); appending them here
-            # too would register them under the wrong wire protocol.
-            in_additional = any(
-                any(model_entry["id"] == self.model for model_entry in provider["models"])
-                for provider in self.additional_providers.values()
-            )
-            # Skip models excluded from Pi entirely (e.g. Gemini — no Responses API
-            # models) — don't register them under the Anthropic provider either.
-            if (
-                not any(m.get("id") == self.model for m in models)
-                and not in_additional
-                and not unsupported_in_pi(self.model.lower())
-            ):
+        models: list[_PiModelEntry] = list(self.extra_models)
+        additional: dict[str, _PiProviderPayload] = dict(self.additional_providers)
+        # Register the selected model only when no provider already serves it.
+        # Appending a non-Claude model to the primary (Anthropic) provider would
+        # register it under the wrong wire protocol — the gateway then rejects
+        # the API type and the turn hangs with no reply.
+        needs_registration = not self._model_registered_in_additional() and not any(
+            entry.get("id") == self.model for entry in models
+        )
+        if needs_registration:
+            surface = self._fallback_surface()
+            if not self._primary_claude_only:
+                # The primary's api came from the model's own family.
+                models.append(
+                    {"id": self.model, "input": ["text", "image"]}
+                    if self.extra_models
+                    else {"id": self.model}
+                )
+            elif surface is DatabricksPiSurface.ANTHROPIC:
                 models.append({"id": self.model, "input": ["text", "image"]})
-        else:
-            models = [{"id": self.model}]
+            elif surface is not None:
+                self._register_on_surface(additional, surface)
+            else:
+                # Leave it unregistered so Pi fails fast on an unknown model
+                # rather than hanging on a rejected API type. The caller
+                # surfaces unroutable_model_warning() to explain it.
+                _LOGGER.error(
+                    "pi-native: no reachable Databricks surface can serve %r; leaving it "
+                    "unregistered. The workspace model catalog was unavailable or omits "
+                    "this endpoint.",
+                    self.model,
+                )
         provider: _PiProviderPayload = {
             "baseUrl": self.base_url,
             "api": self.api,
@@ -241,8 +322,36 @@ class PiProviderConfig:
         if self.auth_header:
             provider["authHeader"] = True
         providers = {self.provider_id: provider}
-        providers.update(self.additional_providers)
+        providers.update(additional)
         return {"providers": providers}
+
+    def _register_on_surface(
+        self, additional: dict[str, _PiProviderPayload], surface: DatabricksPiSurface
+    ) -> None:
+        """Add the selected model to *additional* under *surface*'s provider."""
+        provider_id = _SURFACE_PROVIDER_IDS[surface]
+        entry: _PiModelEntry = {"id": self.model, "input": ["text", "image"]}
+        # DeepSeek streams on reasoning_content; Pi only reads that channel when
+        # the model entry declares reasoning.
+        if "deepseek" in self.model.lower():
+            entry["reasoning"] = True
+        existing = additional.get(provider_id)
+        if existing is not None:
+            # Copy rather than mutate: the payload is shared with
+            # ``additional_providers``, and this renders more than once.
+            additional[provider_id] = {**existing, "models": [*existing["models"], entry]}
+            return
+        responses = surface is DatabricksPiSurface.RESPONSES
+        api_type = "openai-responses" if responses else "openai-completions"
+        additional[provider_id] = _databricks_openai_provider(
+            self.api_key, self.databricks_surfaces[surface], [entry], api_type=api_type
+        )
+        _LOGGER.info(
+            "pi-native: %r was not in the workspace model catalog; routing it to the %s "
+            "surface by model family.",
+            self.model,
+            surface.value,
+        )
 
 
 def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
@@ -322,6 +431,11 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         extra_models=claude_models,
         additional_providers=additional,
         credential_warning=credential_warning,
+        databricks_surfaces={
+            DatabricksPiSurface.RESPONSES: f"{host}/ai-gateway/codex/v1",
+            DatabricksPiSurface.COMPLETIONS: f"{host}/serving-endpoints",
+            DatabricksPiSurface.MLFLOW: f"{host}/ai-gateway/mlflow/v1",
+        },
     )
 
 
@@ -704,6 +818,11 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         additional[_PI_MLFLOW_PROVIDER_ID] = _databricks_openai_provider(
             api_key, workspace_mlflow_url, gemini_models, api_type="openai-completions"
         )
+    surfaces = {DatabricksPiSurface.RESPONSES: codex_gateway_url}
+    if workspace_completions_url:
+        surfaces[DatabricksPiSurface.COMPLETIONS] = workspace_completions_url
+    if workspace_mlflow_url:
+        surfaces[DatabricksPiSurface.MLFLOW] = workspace_mlflow_url
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=_gateway_anthropic_base_url(transport.base_url),
@@ -716,6 +835,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         auth_header=True,
         extra_models=claude_models,
         additional_providers=additional,
+        databricks_surfaces=surfaces,
     )
 
 
@@ -923,11 +1043,14 @@ def pi_native_provider_launch(
     prepare_managed_pi_agent_dir(agent_dir, overlay={"defaultThinkingLevel": None})
     env = {PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
     # Resolve which provider the selected model lives in. Non-Claude models
-    # (GLM, GPT, Llama…) are in additional_providers (omnigent-openai);
-    # Claude models are in the primary provider (omnigent). Pass the correct
-    # --provider so Pi can resolve the model id.
+    # (GLM, GPT, Llama…) are in secondary providers (omnigent-openai); Claude
+    # models are in the primary provider (omnigent). Read the *rendered* config
+    # rather than additional_providers so a model routed by the family fallback
+    # gets the same --provider that models.json registered it under.
     model_provider_id = provider.provider_id
-    for extra_id, extra_cfg in provider.additional_providers.items():
+    for extra_id, extra_cfg in provider.to_models_config()["providers"].items():
+        if extra_id == provider.provider_id:
+            continue
         if any(m.get("id") == provider.model for m in extra_cfg.get("models", [])):
             model_provider_id = extra_id
             break

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -2144,7 +2144,10 @@ async def _auto_create_pi_terminal(
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
             pi_env.update(cred_env)
             pi_args.extend(cred_args)
-            credential_warning = provider.credential_warning
+            # An unroutable model leaves Pi unable to select it, which looks
+            # like a silent hang; prefer that notice over the credential one
+            # since it names the model the user actually picked.
+            credential_warning = provider.unroutable_model_warning() or provider.credential_warning
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_required_terminal falls back to

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1153,3 +1153,252 @@ def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
     assert gpt == []
     assert completions == []
     assert gemini == []
+
+
+def _mock_databricks_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the Databricks profile path at a fake workspace with fake creds."""
+    from omnigent.inner import databricks_executor
+    from omnigent.runtime.credentials import databricks as db_creds_mod
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+    monkeypatch.setattr(
+        creds,
+        "resolve_databricks_workspace",
+        lambda profile: db_creds_mod.WorkspaceCreds(host="https://wkspc.example.com", token="tok"),
+    )
+
+
+def _databricks_provider_without_catalog(
+    monkeypatch: pytest.MonkeyPatch, model: str
+) -> creds.PiProviderConfig:
+    """Resolve a Databricks provider whose live model-catalog fetch failed."""
+    _mock_databricks_profile(monkeypatch)
+
+    def _boom(*_args: object) -> None:
+        raise RuntimeError("network blip")
+
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", _boom)
+    provider = creds.resolve_pi_native_provider(model=model, config_loader=_databricks_config)
+    assert provider is not None
+    return provider
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_provider", "expected_api"),
+    [
+        ("databricks-glm-5-2", "omnigent-openai", "openai-responses"),
+        ("databricks-gpt-5-5", "omnigent-openai", "openai-responses"),
+        ("system.ai.gemini-3-5-flash", "omnigent-mlflow", "openai-completions"),
+        ("databricks-llama-4-maverick", "omnigent-completions", "openai-completions"),
+        ("databricks-deepseek-v3", "omnigent-completions", "openai-completions"),
+    ],
+)
+def test_uncataloged_non_claude_model_routed_by_family(
+    monkeypatch: pytest.MonkeyPatch, model: str, expected_provider: str, expected_api: str
+) -> None:
+    """A non-Claude model the catalog didn't list routes by family, not Anthropic.
+
+    The live model-services fetch is best-effort (expired token, network blip, a
+    workspace listing nothing). Registering the selected model on the primary
+    regardless put GLM/Gemini/Llama on ``anthropic-messages``, where the gateway
+    answers "API type 'anthropic/v1/messages' is not supported" and the turn
+    hangs with no reply.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, model)
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"][expected_provider]["models"]] == [model]
+    assert cfg["providers"][expected_provider]["api"] == expected_api
+    # The Claude-only primary must not also offer it.
+    assert cfg["providers"]["omnigent"]["models"] == []
+    assert provider.unroutable_model_warning() is None
+
+
+def test_uncataloged_deepseek_declares_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DeepSeek streams on reasoning_content; Pi needs ``reasoning: true``.
+
+    Without the flag Pi sees empty content and the turn never completes.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, "databricks-deepseek-v3")
+
+    entry = provider.to_models_config()["providers"]["omnigent-completions"]["models"][0]
+    assert entry.get("reasoning") is True
+
+
+def test_uncataloged_claude_model_stays_on_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Claude model still self-registers: the primary surface serves it."""
+    provider = _databricks_provider_without_catalog(monkeypatch, "databricks-claude-sonnet-4-6")
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == [
+        "databricks-claude-sonnet-4-6"
+    ]
+    assert provider.unroutable_model_warning() is None
+
+
+def test_uncataloged_custom_claude_endpoint_stays_on_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provisioned-throughput Claude endpoint keeps working.
+
+    Custom endpoint names aren't enumerated by the model-services API, so the
+    family fallback is all that places them — classifying on "claude" keeps a
+    ``prod-claude-sonnet-pt`` endpoint on the Anthropic surface that serves it.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, "prod-claude-sonnet-pt")
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == ["prod-claude-sonnet-pt"]
+    assert provider.unroutable_model_warning() is None
+
+
+def test_unparseable_model_is_refused_with_user_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model Pi cannot parse is left unregistered and the user is told why.
+
+    Gemini 2.5 returns typed-array content Pi renders as ``[object Object]`` on
+    every available wire, so no surface can serve it. Registering it anywhere
+    would hang; the warning turns that into an explanation.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, "databricks-gemini-2-5-pro")
+
+    cfg = provider.to_models_config()
+    assert cfg["providers"]["omnigent"]["models"] == []
+    assert list(cfg["providers"]) == ["omnigent"]
+    warning = provider.unroutable_model_warning()
+    assert warning is not None
+    assert "databricks-gemini-2-5-pro" in warning
+
+
+def test_unreachable_surface_is_refused_with_user_warning() -> None:
+    """A model whose surface this credential can't reach is refused, not guessed.
+
+    The cli-config path can resolve the gateway's Responses surface but not the
+    workspace ``/serving-endpoints`` URL. A completions-only model then has
+    nowhere to go, so it must not fall back to the Anthropic primary.
+    """
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://wkspc.example.com/ai-gateway/anthropic",
+        api="anthropic-messages",
+        model="databricks-llama-4-maverick",
+        api_key="!auth",
+        auth_header=True,
+        databricks_surfaces={
+            creds.DatabricksPiSurface.RESPONSES: "https://wkspc.example.com/ai-gateway/codex/v1",
+        },
+    )
+
+    cfg = provider.to_models_config()
+    assert cfg["providers"]["omnigent"]["models"] == []
+    assert provider.unroutable_model_warning() is not None
+
+
+def test_cataloged_model_is_not_touched_by_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fallback only fires when nothing claimed the model.
+
+    A catalog that placed the model under a secondary provider keeps working —
+    the model is served there once, and the primary must not offer it as well.
+    """
+    _mock_databricks_profile(monkeypatch)
+    live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
+    live_completions = [{"id": "databricks-llama-4", "input": ["text", "image"]}]
+    monkeypatch.setattr(
+        creds, "_fetch_pi_model_lists", lambda *_: (live_claude, [], live_completions, [])
+    )
+
+    provider = creds.resolve_pi_native_provider(
+        model="databricks-llama-4", config_loader=_databricks_config
+    )
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent-completions"]["models"]] == [
+        "databricks-llama-4"
+    ]
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == [
+        "databricks-claude-sonnet-4-6"
+    ]
+
+
+def test_uncataloged_model_launch_arg_matches_rendered_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--provider`` must name the provider models.json registered the model on.
+
+    The launch resolves the provider from the rendered config, so a model placed
+    by the family fallback is selectable — and gets ``--thinking off``, without
+    which the gateway 400s on ``reasoning_effort``.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, "databricks-glm-5-2")
+    monkeypatch.setattr(
+        "omnigent.inner.pi_settings.prepare_managed_pi_agent_dir",
+        lambda *_args, **_kwargs: None,
+    )
+
+    _env, args = creds.pi_native_provider_launch(tmp_path / "pi-agent", provider)
+
+    assert args == [
+        "--provider",
+        "omnigent-openai",
+        "--model",
+        "databricks-glm-5-2",
+        "--thinking",
+        "off",
+    ]
+    cfg = json.loads((tmp_path / "pi-agent" / "models.json").read_text())
+    registered = cfg["providers"]["omnigent-openai"]["models"]
+    assert [m["id"] for m in registered] == ["databricks-glm-5-2"]
+
+
+def test_anthropic_protocol_proxy_serves_non_claude_model() -> None:
+    """An Anthropic-protocol proxy may serve non-Claude ids — don't reroute it.
+
+    ``anthropic-messages`` alone does NOT imply "Claude only": a gateway or
+    LiteLLM-style proxy speaks that protocol for arbitrary models. Only the
+    Databricks gateway's ``/ai-gateway/anthropic`` surface is Claude-only, and
+    its builders say so by carrying ``databricks_surfaces``.
+    """
+    config = {
+        "providers": {
+            "proxy": {
+                "kind": "gateway",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://litellm.internal.example.com/anthropic",
+                    "api_key": "sk-proxy",
+                },
+            }
+        }
+    }
+
+    provider = creds.resolve_pi_native_provider(
+        model="zai-org/GLM-4.7", config_loader=lambda: config
+    )
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    assert provider.databricks_surfaces == {}
+
+    cfg = provider.to_models_config()
+    assert [m["id"] for m in cfg["providers"]["omnigent"]["models"]] == ["zai-org/GLM-4.7"]
+    assert provider.unroutable_model_warning() is None
+
+
+def test_databricks_builders_carry_reachable_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Databricks profile path records every surface its credential reaches."""
+    _mock_databricks_profile(monkeypatch)
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: ([], [], [], []))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.databricks_surfaces == {
+        creds.DatabricksPiSurface.RESPONSES: "https://wkspc.example.com/ai-gateway/codex/v1",
+        creds.DatabricksPiSurface.COMPLETIONS: "https://wkspc.example.com/serving-endpoints",
+        creds.DatabricksPiSurface.MLFLOW: "https://wkspc.example.com/ai-gateway/mlflow/v1",
+    }

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1190,9 +1190,14 @@ def _databricks_provider_without_catalog(
 @pytest.mark.parametrize(
     ("model", "expected_provider", "expected_api"),
     [
-        ("databricks-glm-5-2", "omnigent-openai", "openai-responses"),
+        # Probed: the gateway serves Responses passthrough for the system.ai.*
+        # id but rejects it for the databricks-* alias of the same model.
+        ("databricks-glm-5-2", "omnigent-completions", "openai-completions"),
+        ("system.ai.glm-5-2", "omnigent-openai", "openai-responses"),
+        ("databricks-kimi-k3", "omnigent-completions", "openai-completions"),
         ("databricks-gpt-5-5", "omnigent-openai", "openai-responses"),
         ("system.ai.gemini-3-5-flash", "omnigent-mlflow", "openai-completions"),
+        ("databricks-gemini-3-5-flash", "omnigent-completions", "openai-completions"),
         ("databricks-llama-4-maverick", "omnigent-completions", "openai-completions"),
         ("databricks-deepseek-v3", "omnigent-completions", "openai-completions"),
     ],
@@ -1345,14 +1350,14 @@ def test_uncataloged_model_launch_arg_matches_rendered_provider(
 
     assert args == [
         "--provider",
-        "omnigent-openai",
+        "omnigent-completions",
         "--model",
         "databricks-glm-5-2",
         "--thinking",
         "off",
     ]
     cfg = json.loads((tmp_path / "pi-agent" / "models.json").read_text())
-    registered = cfg["providers"]["omnigent-openai"]["models"]
+    registered = cfg["providers"]["omnigent-completions"]["models"]
     assert [m["id"] for m in registered] == ["databricks-glm-5-2"]
 
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1402,3 +1402,29 @@ def test_databricks_builders_carry_reachable_surfaces(monkeypatch: pytest.Monkey
         creds.DatabricksPiSurface.COMPLETIONS: "https://wkspc.example.com/serving-endpoints",
         creds.DatabricksPiSurface.MLFLOW: "https://wkspc.example.com/ai-gateway/mlflow/v1",
     }
+
+
+def test_launch_renders_config_once(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Rendering is not repeated per launch, so routing is logged once.
+
+    ``pi_native_provider_launch`` both writes ``models.json`` and reads it back
+    to resolve ``--provider``; rendering twice duplicated the routing log line.
+    """
+    provider = _databricks_provider_without_catalog(monkeypatch, "databricks-glm-5-2")
+    monkeypatch.setattr(
+        "omnigent.inner.pi_settings.prepare_managed_pi_agent_dir",
+        lambda *_args, **_kwargs: None,
+    )
+    renders = 0
+    original = creds.PiProviderConfig.to_models_config
+
+    def _counting(self: creds.PiProviderConfig) -> object:
+        nonlocal renders
+        renders += 1
+        return original(self)
+
+    monkeypatch.setattr(creds.PiProviderConfig, "to_models_config", _counting)
+
+    creds.pi_native_provider_launch(tmp_path / "pi-agent", provider)
+
+    assert renders == 1


### PR DESCRIPTION
## Related issue

Closes #2575

## Summary

pi-native builds its **primary** Pi provider on the Databricks gateway's Claude-only `/ai-gateway/anthropic` surface, and splits non-Claude families across the Responses / serving-endpoints / MLflow surfaces using the live Unity Catalog model-services list (#2665). **That split only holds while the catalog fetch succeeds** — it's best-effort by design, so an expired OAuth token, a network blip, or a workspace that lists nothing all yield empty lists. `to_models_config` then registered the selected model on the primary regardless, so a non-Claude model went to the Anthropic surface and the gateway answered:

```
API type 'anthropic/v1/messages' is not supported by 'databricks-glm-5-2'.
Supported API types: [mlflow/v1/chat/completions]
```

The turn never finished — the original #2575 hang, still reachable on `main` today.

- **Keep the live catalog authoritative; fall back to family classification** when it didn't list the model. The classifier lives next to the other Pi compatibility fallbacks and mirrors `pi_executor._pi_provider_for_model`, so both Pi paths route a given id to the same surface instead of disagreeing.
- **Refuse, loudly, only when there's genuinely nowhere to go** — a surface this credential can't reach, or a model Pi can't parse on any wire. The model is left unregistered so Pi fails fast rather than hanging, and the refusal is surfaced to the session as an error banner through the path an unresolvable credential already uses. A log line the user never sees reads as another silent hang.
- **Carry the reachable surfaces on the config**, which also distinguishes the gateway's Claude-only primary from a LiteLLM-style proxy — that speaks `anthropic-messages` for arbitrary models and must keep self-registering.

### ELI5

The gateway is one door per language. Pi has to knock on the door matching the model's language, and it normally reads a directory to know which. When the directory is unreadable it used to send everyone to the Claude door, where non-Claude models are turned away and the session just sits there. Now it guesses from the model's family name — the same guess the in-process Pi harness already makes — and if there's truly no matching door, it says so out loud instead of waiting forever.

```
                 catalog fetch OK ──▶ route from live per-endpoint capabilities  (unchanged)
                                │
selected model ─▶ registered? ──┤
                                │                        ┌─ claude…        ──▶ /ai-gateway/anthropic
                 catalog EMPTY ─┴─▶ family fallback ──────┼─ glm/kimi/gpt…  ──▶ /ai-gateway/codex/v1
                                     (NEW)                ├─ system.ai.*    ──▶ /ai-gateway/mlflow/v1
                                                          ├─ llama/deepseek ──▶ /serving-endpoints
                                                          └─ unreachable /
                                                             unparseable    ──▶ unregistered + banner
```

### Note on #2833

@isabella0428 diagnosed this exact gap in #2833 and the `primary_claude_only` insight is theirs — an Anthropic-protocol proxy is *not* Claude-only, so it must not be inferred from `api`. This keeps that distinction (as `databricks_surfaces`) and changes what happens when the guard fires: route by family first, refuse only as a last resort, and tell the user. It also avoids refusing a provisioned-throughput Claude endpoint whose name lacks "claude" — that works on `main` today and #2833 as written would break it.

## Test Plan

- `tests/test_pi_native_credentials.py`: **68 passed** — 54 pre-existing (no regressions) plus 14 new covering family routing per surface (GLM, GPT, Gemini, Llama, DeepSeek), DeepSeek's `reasoning: true`, Claude and custom-Claude-endpoint models staying on the primary, both refusal paths with their user warning, a cataloged model staying untouched, the Anthropic-proxy regression, and `--provider` agreeing with what `models.json` registered.
- Reverting only the source files fails **13** of the new tests, so they pin behavior rather than implementation.
- `tests/ -k "pi_native or pi_model or pi_settings"`: 200 passed, 2 failed. Both failures (`test_sessions_snapshot.py::test_session_snapshot_serves_pi_model_options_from_extension_push`, `test_harness_readiness.py::test_configured_harness_map_exposes_pi_native`) reproduce identically on unmodified `main` with the same selection — pre-existing, unrelated (the first is test-ordering pollution; it passes in isolation).
- `ruff check`, `ruff format --check`, `mypy` clean on all four files.

## Demo

N/A — no UI change. Routing captured from real runs of the resolution path (`--provider`/`--model`/`--thinking` argv and the rendered `models.json` per selected model) rather than a live session: I don't have a Databricks workspace to launch a real GLM session against, so end-to-end confirmation against a live gateway is still worth having from someone who does.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually at the resolution boundary, not against a live workspace: for each selected model I rendered `models.json` and the launch argv and checked the provider/api/base-URL triple, that the Claude-only primary never offers a non-Claude model, that DeepSeek carries `reasoning: true`, and that `--thinking off` is applied on non-primary providers. What's untested by machine is the gateway's actual acceptance of each surface — that's the piece needing workspace access.

### Live gateway verification

Probed against a real workspace (`e2-dogfood`, 290 serving endpoints) rather than
only at the resolution boundary: for each model the fallback classifier picks a
surface for, one minimal inference request was sent to that surface and the
gateway's answer recorded.

The first run found a bug in this PR. The keyword surface split holds only for
`system.ai.*` ids — the gateway serves Responses passthrough for
`system.ai.glm-5-2` but rejects it for the `databricks-glm-5-2` alias of the same
model (`"Responses API passthrough is not supported for model
databricks-glm-5-2"`). GLM, kimi and qwen3 aliases were all being routed to a
surface that 400s. Fixed by restricting the keyword check to `system.ai.*` and
letting aliases fall to chat completions.

This also corrects a claim in an earlier revision of this description: the
classifier and `pi_executor._pi_needs_responses_api` were said to disagree for
non-`system.ai` keyword ids. `pi_executor` already gated the keywords on
`startswith("system.ai.")` and was correct; the classifier here was wrong. They
now agree.

Post-fix, 8 of 9 probed models are accepted on their predicted surface:

| model | predicted surface | gateway |
| --- | --- | --- |
| `databricks-claude-sonnet-5` | anthropic | 200 |
| `databricks-gpt-5-5` | responses | 200 |
| `system.ai.glm-5-2` | responses | 200 |
| `databricks-glm-5-2` | completions | 200 |
| `databricks-kimi-k3` | completions | 200 |
| `databricks-qwen3-next-80b-a3b-instruct` | completions | 200 |
| `databricks-gemini-3-5-flash` | completions | 200 |
| `databricks-gemini-3-5-pro` | completions | 200 |
| `databricks-llama-4-maverick` | completions | 200 |

The ninth, `databricks-deepseek-v3-2`, is rejected on *every* surface
(`RESOURCE_DOES_NOT_EXIST: Model deepseek-v3-2 is not available in your region`),
so no classifier can route it — that is the case the loud-failure path handles,
and it now reports instead of hanging.

Not covered: this is one workspace in one region. A workspace whose alias set
differs could still route a model wrong, which the unroutable warning surfaces
rather than hides.

## Changelog

Pi sessions on a Databricks workspace no longer hang when the workspace model list is unavailable — non-Claude models are routed by family, and a model that truly can't be served now says so instead of never replying


This pull request and its description were written by Isaac.

