### PR TITLE
perf(server): gzip workspace-file reads

### DIFF
--- a/omnigent/server/routes/_gzip_route.py
+++ b/omnigent/server/routes/_gzip_route.py
@@ -1,0 +1,199 @@
+"""Per-route gzip for endpoints that inline a whole file in their JSON body.
+
+Most JSON responses are bounded metadata, where compression buys little. The
+workspace-file reads are the exception: they return the file's entire contents
+in a ``content`` field, so an uncompressed response costs a full file transfer
+on every click. Source text compresses 70-300x, which turns a
+multi-hundred-millisecond download into a few milliseconds.
+
+This is a route class rather than an app- or router-level middleware so the
+route table stays the single source of truth for *which* endpoints compress.
+A middleware would have to re-derive that from the request path, duplicating
+the router's matching and — because a path alone says nothing about the method
+— wrapping the ``PUT``/``PATCH``/``DELETE`` handlers that share these paths.
+Starlette's ``Route.handle`` rejects a mismatched method before it reaches
+``self.app``, so a route class only ever wraps the methods its route declares.
+
+FastAPI's decorators expose neither Starlette's per-route ``middleware=`` nor a
+per-route class, so a custom :class:`~fastapi.routing.APIRoute` on a dedicated
+router is the supported equivalent; ``include_router`` preserves it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from fastapi.routing import APIRoute
+from starlette.datastructures import Headers
+from starlette.middleware.gzip import GZipResponder
+from starlette.requests import Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Bodies below this gain nothing from gzip once the header overhead and the
+# CPU are accounted for. Matches the web-ui mount's threshold.
+GZIP_MINIMUM_SIZE = 1024
+# Level 4 reaches the same ratio as the default 9 on JSON and source text
+# (measured ~330x on a 1 MB source file) for roughly half the CPU.
+GZIP_COMPRESSLEVEL = 4
+# ``request.state`` key a handler sets to opt its own response out of gzip.
+# See :func:`skip_gzip`.
+SKIP_GZIP_STATE_KEY = "skip_gzip"
+
+
+def skip_gzip(request: Request) -> None:
+    """
+    Opt this response out of gzip, from inside the handler.
+
+    For content that is already entropy-coded — base64 of compressed media
+    (PNG/JPEG/PDF), which carries only base64's own ~25% redundancy — gzip
+    returns ~1.3x for real event-loop time: 38 ms for a 1 MB file, 385 ms at
+    the 10 MiB binary cap. Not worth blocking the loop for.
+
+    The handler is the right place to decide this because it already holds the
+    payload. The alternative — recovering the same fact from the serialized
+    response bytes — has to re-derive domain information from transport data,
+    which brought its own failure modes (a length-bounded prefix scan, and a
+    dependency on where the producer places the field).
+
+    Sets a flag on ``request.state``, which is backed by ``scope["state"]``, so
+    :class:`GZipFileContentRoute` reads it back at send time. Response body,
+    headers, status, and OpenAPI are all unaffected.
+
+    :param request: The active request.
+    :returns: None.
+    """
+    setattr(request.state, SKIP_GZIP_STATE_KEY, True)
+
+
+def _client_accepts_gzip(accept_encoding: str) -> bool:
+    """
+    Return whether ``Accept-Encoding`` permits gzip.
+
+    Coding tokens are case-insensitive, and ``q=0`` means "do not use this
+    coding" (RFC 9110 §12.5.3) — so a plain substring test would compress for
+    a client that explicitly declined.
+
+    :param accept_encoding: Raw header value, e.g. ``"gzip, deflate, br"``.
+    :returns: True when gzip is listed with a non-zero quality value.
+    """
+    for part in accept_encoding.split(","):
+        token, _, params = part.strip().partition(";")
+        if token.strip().lower() != "gzip":
+            continue
+        for param in params.split(";"):
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "q":
+                try:
+                    return float(value.strip()) > 0
+                except ValueError:
+                    # Malformed q value — treat as unqualified acceptance.
+                    return True
+        return True
+    return False
+
+
+class _StateAwareGZipResponder(GZipResponder):
+    """
+    Gzip responder that honours a handler's :func:`skip_gzip` opt-out.
+
+    The flag can only be read at send time: the handler sets it while running,
+    which is after ``handle`` dispatches but before the response body is
+    emitted. Reuses Starlette's own ``content_type_is_excluded`` opt-out — the
+    flag it already sets for ``text/event-stream`` — so an excluded response
+    takes the library's untouched pass-through path rather than a parallel one
+    here.
+
+    :param app: The wrapped ASGI app (the route's own ``handle``).
+    :param minimum_size: Minimum body size to compress, e.g. ``1024``.
+    :param compresslevel: gzip level passed through to Starlette.
+    :param state: The request's ``scope["state"]`` dict — the same mapping
+        ``request.state`` writes to, so the handler's later opt-out is visible
+        through this reference.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        minimum_size: int,
+        compresslevel: int,
+        state: Mapping[str, object],
+    ) -> None:
+        super().__init__(app, minimum_size, compresslevel=compresslevel)
+        self._state = state
+
+    async def send_with_compression(self, message: Message) -> None:
+        """
+        Widen Starlette's exclusion set when the handler opted out.
+
+        :param message: The outgoing ASGI message.
+        :returns: None.
+        """
+        if (
+            message["type"] == "http.response.body"
+            and not self.started
+            and self._state.get(SKIP_GZIP_STATE_KEY)
+        ):
+            # Starlette reads this flag on the first body message, then emits
+            # the start message it buffered — untouched.
+            self.content_type_is_excluded = True
+        await super().send_with_compression(message)
+
+
+class GZipFileContentRoute(APIRoute):
+    """
+    Route class that gzips this route's responses.
+
+    Attach by grouping the read endpoints on their own router::
+
+        file_read_router = APIRouter(route_class=GZipFileContentRoute)
+
+        @file_read_router.get(path)
+        async def read(...): ...
+
+        router.include_router(file_read_router)
+
+    (FastAPI's decorators do not accept a per-route class; ``route_class`` on
+    the router is the supported form, and ``include_router`` preserves it.)
+
+    Skips compression when the client did not ask for gzip, when the request
+    carries a ``Range`` (a ``206``'s ``Content-Range`` describes the
+    *unencoded* representation, so compressing the body would make the two
+    disagree and break media seeking / PDF byte-range loads), and when the
+    handler called :func:`skip_gzip`.
+    """
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """
+        Compress this route's response when the client and handler allow it.
+
+        :param scope: ASGI request scope, e.g. type ``"http"``.
+        :param receive: ASGI receive callable.
+        :param send: ASGI send callable.
+        :returns: None.
+        """
+        if scope["type"] != "http":
+            await super().handle(scope, receive, send)
+            return
+        headers = Headers(scope=scope)
+        if not _client_accepts_gzip(headers.get("Accept-Encoding", "")) or "range" in headers:
+            await super().handle(scope, receive, send)
+            return
+
+        # The base ``handle`` already has the ASGI signature the responder
+        # calls, so it can serve as the wrapped app directly.
+        responder = _StateAwareGZipResponder(
+            super().handle,
+            GZIP_MINIMUM_SIZE,
+            GZIP_COMPRESSLEVEL,
+            scope.setdefault("state", {}),
+        )
+        await responder(scope, receive, send)
+
+
+__all__ = [
+    "GZIP_COMPRESSLEVEL",
+    "GZIP_MINIMUM_SIZE",
+    "SKIP_GZIP_STATE_KEY",
+    "GZipFileContentRoute",
+    "skip_gzip",
+]

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -54,6 +54,7 @@ from omnigent.server.routes._content_type import (
     require_json_content_type,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
+from omnigent.server.routes._gzip_route import GZipFileContentRoute, skip_gzip
 from omnigent.server.routes._origin import require_trusted_origin
 from omnigent.server.routes._sessions.common import (
     _logger,
@@ -1401,7 +1402,34 @@ def register_resources_routes(
             _publish_changed_files_invalidated(session_id, environment_id)
         return payload
 
-    @router.get(
+    # Reads that inline a whole file in their JSON body, so the response is as
+    # large as the file. Grouped on their own router purely to attach
+    # GZipFileContentRoute: the route table stays the source of truth for what
+    # compresses, and the PUT/PATCH/DELETE handlers sharing these paths — which
+    # return small acks — are registered on ``router`` and stay uncompressed.
+    # Included into ``router`` at the end of this function.
+    file_read_router = APIRouter(route_class=GZipFileContentRoute)
+
+    def _skip_gzip_for_binary(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
+        """
+        Opt a base64 (binary) file read out of gzip, and return the payload.
+
+        Base64 of already-compressed media gains ~1.3x from gzip for real
+        event-loop time (385 ms at the 10 MiB binary cap), so it is skipped.
+        The decision is made here because this is where the payload is known —
+        the response is ``application/json`` for every file, so the transport
+        layer cannot tell binary from text without re-parsing the body.
+
+        :param request: The active request, carrying the flag to the route class.
+        :param payload: The read result, either a file-content object or a
+            directory listing.
+        :returns: *payload*, unchanged, for direct return by the caller.
+        """
+        if payload.get("encoding") == "base64":
+            skip_gzip(request)
+        return payload
+
+    @file_read_router.get(
         "/sessions/{session_id}/resources/environments/{environment_id}/filesystem",
         response_model=None,
     )
@@ -1434,17 +1462,20 @@ def register_resources_routes(
         qs = urllib.parse.urlencode(params)
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}/filesystem?{qs}"
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _fs_get_with_host_fallback(
-            session_id,
-            op="list_or_read",
-            host_params={
-                "path": "",
-                "limit": limit,
-                "after": after,
-                "before": before,
-                "order": order,
-            },
-            runner_path=path,
+        return _skip_gzip_for_binary(
+            request,
+            await _fs_get_with_host_fallback(
+                session_id,
+                op="list_or_read",
+                host_params={
+                    "path": "",
+                    "limit": limit,
+                    "after": after,
+                    "before": before,
+                    "order": order,
+                },
+                runner_path=path,
+            ),
         )
 
     @router.get(
@@ -1528,7 +1559,7 @@ def register_resources_routes(
             runner_path=path,
         )
 
-    @router.get(
+    @file_read_router.get(
         "/sessions/{session_id}/resources/environments/{environment_id}/diff/{relative_path:path}",
         # Internal (UI diff view) — hidden from the public API reference.
         include_in_schema=False,
@@ -1565,7 +1596,7 @@ def register_resources_routes(
             runner_path=path,
         )
 
-    @router.get(
+    @file_read_router.get(
         "/sessions/{session_id}/resources/environments"
         "/{environment_id}/filesystem/{relative_path:path}",
         response_model=None,
@@ -1605,17 +1636,20 @@ def register_resources_routes(
             f"/{environment_id}/filesystem/{relative_path}?{qs}"
         )
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _fs_get_with_host_fallback(
-            session_id,
-            op="list_or_read",
-            host_params={
-                "path": relative_path,
-                "limit": limit,
-                "after": after,
-                "before": before,
-                "order": order,
-            },
-            runner_path=path,
+        return _skip_gzip_for_binary(
+            request,
+            await _fs_get_with_host_fallback(
+                session_id,
+                op="list_or_read",
+                host_params={
+                    "path": relative_path,
+                    "limit": limit,
+                    "after": after,
+                    "before": before,
+                    "order": order,
+                },
+                runner_path=path,
+            ),
         )
 
     @router.put(
@@ -1776,3 +1810,9 @@ def register_resources_routes(
         await _validate_session(session_id, request, LEVEL_READ)
         path = f"/v1/sessions/{session_id}/resources/{resource_id}"
         return await _proxy_get_to_runner(session_id, path)
+
+    # Mount the gzip-wrapped file reads. Appended after every sibling route so
+    # the `{relative_path:path}` catch-alls cannot shadow a more specific
+    # sibling (e.g. `.../environments/{id}/shell`), which is how they behaved
+    # when they were registered inline on `router`.
+    router.include_router(file_read_router)

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -5073,3 +5073,358 @@ async def test_relay_never_delivers_terminal_on_pty_status(
     await _relay_runner_stream(child_id, client, store)  # type: ignore[arg-type]
 
     assert client.posts == []
+
+
+# ── Workspace-file gzip (GZipFileContentRoute) ───────────────────
+#
+# These exercise the real routes through the real router, because the whole
+# point of the route class is that eligibility follows the route table. A
+# synthesized endpoint would not prove the production routes are wrapped.
+
+
+def _fs_text_read_payload(lines: int = 2000) -> dict[str, object]:
+    """Canned runner response for a text file read.
+
+    Mirrors the runner's ``file_content`` shape and key order, including a
+    ``content_type`` that is deliberately *not* a text type: ``.ts`` resolves
+    to ``video/mp2t`` via ``mimetypes``, so a MIME-based eligibility check
+    would wrongly skip real TypeScript source. Compression must be decided
+    from ``encoding`` instead.
+
+    :param lines: How many lines of source to synthesize, e.g. ``2000``.
+    :returns: The payload dict.
+    """
+    content = "    const someVariableName = computeSomething(alpha, beta);\n" * lines
+    return {
+        "object": "session.environment.filesystem.file_content",
+        "path": "src/main.ts",
+        "content_type": "video/mp2t",
+        "bytes": len(content.encode()),
+        "truncated": False,
+        "encoding": "utf-8",
+        "content": content,
+    }
+
+
+def _fs_binary_read_payload(size: int = 256 * 1024) -> dict[str, object]:
+    """Canned runner response for a binary (base64) file read.
+
+    :param size: Decoded payload size in bytes, e.g. ``262144``.
+    :returns: The payload dict, with ``content`` as base64.
+    """
+    import base64
+
+    # Incompressible bytes: gzip would return ~1.0x for real CPU.
+    raw = bytes((i * 7 + 11) % 256 for i in range(size))
+    return {
+        "object": "session.environment.filesystem.file_content",
+        "path": "docs/logo.png",
+        "content_type": "image/png",
+        "bytes": size,
+        "truncated": False,
+        "encoding": "base64",
+        "content": base64.b64encode(raw).decode(),
+    }
+
+
+_FS_BASE = "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+
+
+@pytest.mark.asyncio
+async def test_file_read_is_gzipped(client: httpx.AsyncClient) -> None:
+    """A text file read is compressed, and the body survives the round-trip.
+
+    The read inlines the whole file in ``content``, so without compression the
+    response costs a full file transfer.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    payload = _fs_text_read_payload()
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/src/main.ts",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    # A shared cache must not serve these bytes to an identity client.
+    assert "accept-encoding" in resp.headers.get("vary", "").lower()
+    # httpx inflates transparently, so an intact body proves the encoding
+    # header and the bytes on the wire agree.
+    assert resp.json() == payload
+    # Compression actually happened, rather than the header being set on
+    # unchanged bytes.
+    assert int(resp.headers["content-length"]) < len(str(payload["content"]))
+
+
+@pytest.mark.asyncio
+async def test_binary_file_read_is_not_gzipped(client: httpx.AsyncClient) -> None:
+    """A base64 (binary) read skips compression.
+
+    Base64 of already-compressed media only carries base64's own redundancy, so
+    gzip returns ~1.3x for real event-loop time — 385 ms at the 10 MiB binary
+    cap. The decision comes from the payload's ``encoding``, because these
+    routes always answer ``application/json`` and the file's own MIME type is
+    merely a field inside that JSON.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    payload = _fs_binary_read_payload()
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/docs/logo.png",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_binary_read_is_not_gzipped(client: httpx.AsyncClient) -> None:
+    """A long ``path`` must not push the ``encoding`` field out of range.
+
+    Eligibility is read from the serialized body. ``path`` precedes ``encoding``
+    and is bounded only by ``PATH_MAX``, so a fixed-size prefix scan would miss
+    the field on a deeply nested file and send a multi-megabyte binary through
+    synchronous gzip — the exact case this guards.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    payload = _fs_binary_read_payload()
+    # ~680 chars, comfortably past any small window.
+    payload["path"] = "/".join(["nested_directory"] * 40)
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/{payload['path']}",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+async def test_text_whose_content_fakes_the_encoding_marker_is_gzipped(
+    client: httpx.AsyncClient,
+) -> None:
+    """A text file containing ``"encoding":"base64"`` still compresses.
+
+    Eligibility matches the complete serialized key/value pair, which cannot
+    occur inside a JSON string — an embedded quote is backslash-escaped — so a
+    file's own bytes cannot fake a binary payload and suppress compression.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    payload = _fs_text_read_payload()
+    payload["content"] = 'config = {"encoding":"base64"}\n' * 200
+    payload["path"] = "settings.py"
+    payload["bytes"] = len(str(payload["content"]).encode())
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/settings.py",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+async def test_directory_listing_is_gzipped(client: httpx.AsyncClient) -> None:
+    """A directory listing large enough to clear the minimum size compresses.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    listing = _fs_list_payload()
+    entries = listing["data"]
+    assert isinstance(entries, list)
+    # One entry is below minimum_size; a real directory of any depth is not.
+    listing["data"] = [dict(entries[0], id=f"f{i}.py", name=f"f{i}.py") for i in range(200)]
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=listing)))  # type: ignore[arg-type]
+
+    resp = await client.get(f"{_FS_BASE}/filesystem", headers={"Accept-Encoding": "gzip"})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    assert resp.json() == listing
+
+
+@pytest.mark.asyncio
+async def test_file_diff_is_gzipped(client: httpx.AsyncClient) -> None:
+    """The diff read carries two file bodies, so it compresses too.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    text = "    const value = compute(alpha, beta);\n" * 1000
+    payload: dict[str, object] = {
+        "object": "session.environment.filesystem.file_diff",
+        "path": "src/main.ts",
+        "before": text,
+        "after": text + "// changed\n",
+    }
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/diff/src/main.ts",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+async def test_file_read_honors_identity_request(client: httpx.AsyncClient) -> None:
+    """A client that declines gzip receives identity bytes.
+
+    :param client: Test HTTP client.
+    :returns: None.
+    """
+    payload = _fs_text_read_payload()
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/src/main.ts",
+        headers={"Accept-Encoding": "identity"},
+    )
+
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("token", "expect_gzip"),
+    [
+        ("gzip", True),
+        # Coding tokens are case-insensitive (RFC 9110 §12.5.3).
+        ("GZip", True),
+        ("GZIP", True),
+        ("gzip, deflate, br", True),
+        ("gzip;q=0.5", True),
+        ("*;q=0, gzip", True),
+        # q=0 means "do not use this coding" — a substring test would miss it.
+        ("gzip;q=0", False),
+        ("deflate, gzip;q=0", False),
+        ("deflate", False),
+        ("identity", False),
+    ],
+)
+async def test_file_read_negotiates_accept_encoding(
+    client: httpx.AsyncClient,
+    token: str,
+    expect_gzip: bool,
+) -> None:
+    """Compression follows ``Accept-Encoding``, including case and ``q`` values.
+
+    :param client: Test HTTP client.
+    :param token: The ``Accept-Encoding`` value to send.
+    :param expect_gzip: Whether gzip is expected for that value.
+    :returns: None.
+    """
+    payload = _fs_text_read_payload()
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.get(
+        f"{_FS_BASE}/filesystem/src/main.ts",
+        headers={"Accept-Encoding": token},
+    )
+
+    assert resp.status_code == 200
+    assert (resp.headers.get("content-encoding") == "gzip") is expect_gzip
+    assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("PUT", "filesystem/notes.txt"),
+        ("PATCH", "filesystem/notes.txt"),
+        ("DELETE", "filesystem/notes.txt"),
+    ],
+)
+async def test_filesystem_mutations_are_not_gzipped(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+) -> None:
+    """Mutating handlers on the read paths stay uncompressed.
+
+    They share a URL with the read but return a small ack, so there is nothing
+    to compress. This is the guarantee a path-matching middleware could not
+    make: a path alone says nothing about the method. Because the reads live on
+    their own router, Starlette rejects a mismatched method before the wrapper
+    is ever reached.
+
+    :param client: Test HTTP client.
+    :param method: HTTP method under test.
+    :param path: Environment-relative request path.
+    :returns: None.
+    """
+    payload: dict[str, object] = {
+        "object": "session.environment.filesystem.write_result",
+        "path": "notes.txt",
+        # Padded past minimum_size so only the method decides the outcome.
+        "detail": "x" * 4096,
+    }
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    resp = await client.request(
+        method,
+        f"{_FS_BASE}/{path}",
+        headers={"Accept-Encoding": "gzip"},
+        json={"content": "hi", "old_text": "a", "new_text": "b"},
+    )
+
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["changes", "search?q=main", "shell"])
+async def test_sibling_environment_routes_are_not_gzipped(
+    client: httpx.AsyncClient,
+    path: str,
+) -> None:
+    """Sibling environment routes return bounded metadata and stay uncompressed.
+
+    Keeps the change's blast radius to the endpoints that inline file contents.
+
+    :param client: Test HTTP client.
+    :param path: Environment-relative request path.
+    :returns: None.
+    """
+    payload: dict[str, object] = {
+        "object": "list",
+        "data": [{"path": f"f{i}.py", "status": "modified"} for i in range(200)],
+        "has_more": False,
+    }
+    set_runner_router(_FakeRunnerRouter(_FakeRunnerClient(payload=payload)))  # type: ignore[arg-type]
+
+    url = f"{_FS_BASE}/{path}"
+    headers = {"Accept-Encoding": "gzip"}
+    if path == "shell":
+        resp = await client.post(url, headers=headers, json={"command": "ls"})
+    else:
+        resp = await client.get(url, headers=headers)
+
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers


### PR DESCRIPTION
## Summary

Clicking a file in the viewer was slower than the payload warranted. Workspace-file
reads inline the whole file in a JSON `content` field, and no gzip applied to them —
`GZipMiddleware` was mounted only on the static web-ui mount — so each click paid a
full uncompressed file transfer. Source text compresses extremely well, so this was
the dominant cost.

### Measured on real deployments

Interleaved A/B across two Databricks App deployments — one on `main` (no gzip), one
on this branch — same laptop, same link, byte-identical fixtures in both workspaces.
8 reps per fixture per deployment (96 requests, 0 errors). The two hosts alternate
within each rep so link drift hits both arms equally.

| fixture | wire before | wire after | shrink | mean before | mean after | saved |
|---|---|---|---|---|---|---|
| 1 MB `.ts`, 1800 lines (under the line cap) | 1,050,566 | **14,827** | **70.9x** | 2256 ms | **1270 ms** | **−986 ms** |
| 1 MB `.ts`, 17476 lines (over the cap) | 122,187 | **587** | **208x** | 1582 ms | **1080 ms** | **−502 ms** |
| `uv.lock` (1.09 MB, truncated to 2000 lines) | 368,263 | 110,447 | 3.3x | 1955 ms | 1664 ms | −290 ms |
| `omnigent-desktop.png` (1 MB) | 1,334,136 | 910,172 | 1.5x | 2403 ms | 2390 ms | −13 ms |
| 1 MB incompressible binary | 1,398,309 | 1,059,239 | 1.3x | 2573 ms | 2638 ms | +65 ms |
| `CLAUDE.md` (4 KB) | 4,477 | 2,235 | 2.0x | 1051 ms | 1034 ms | −17 ms |

The text rows have tight spreads (sd 60–71 ms against 500–986 ms deltas), so those
wins are solid. Two things this does **not** help, stated plainly:

- **Binary is a wash.** Those rows sit inside run-to-run noise — that arm's sd was
  422 ms, the largest in the set. gzip of base64 lands near what raw bytes would be
  anyway, so there is no real transfer win for images or PDFs.
- **Small files are unchanged**, because a ~1040 ms fixed per-request cost dominates
  them (~386 ms of it the runner hop, measured separately). 4 KB was never the
  problem. If clicking around still feels slow, that floor is the next thing to
  attack, and it needs different work than this.

### Design notes

Implemented as an `APIRoute` subclass on a dedicated router holding just the three
read endpoints, so **the route table stays the source of truth for what compresses**:

```python
file_read_router = APIRouter(route_class=GZipFileContentRoute)

@file_read_router.get(".../filesystem/{relative_path:path}")   # wrapped
async def read_or_list_environment_path(...): ...

@router.put(".../filesystem/{relative_path:path}")             # not wrapped
async def write_environment_file(...): ...

router.include_router(file_read_router)
```

An earlier revision used a path-regex middleware. That was the wrong shape: it
duplicated the router's own matching, and because a path says nothing about the
method it also wrapped the `PUT`/`PATCH`/`DELETE` handlers sharing these URLs,
despite the policy being reads-only. Starlette's `Route.handle` rejects a
mismatched method *before* delegating to the route's app, so a route class only
ever sees the methods its route declares — the bug is now structurally impossible
rather than patched with an added check.

Two other decisions worth flagging for review:

**Binary reads opt out from inside the handler.** Base64 of already-compressed
media gains ~1.3x from gzip for real event-loop time — 385 ms at the 10 MiB binary
cap — so it is skipped. The handler calls `skip_gzip(request)`, which sets a flag on
`request.state` that the route class reads at send time.

The decision lives in the handler because that is where the payload already is.
These endpoints answer `application/json` for every file, so the transport layer
cannot tell binary from text without re-parsing the response body — and an earlier
revision that did exactly that had two failure modes reviewers caught: a
length-bounded prefix scan (a deeply nested `path` pushed the field out of range,
sending a 10 MiB binary through synchronous gzip) and a dependency on where the
producer placed the field. Response body, headers, status, and OpenAPI are all
unaffected.

**`Range` requests bypass compression**, because a `206`'s `Content-Range` describes
the *unencoded* representation; compressing the body makes the two headers disagree
and breaks media seeking and PDF byte-range loads. `Accept-Encoding` is negotiated
properly too: tokens are case-insensitive and `q=0` means the client declined
(RFC 9110 §12.5.3), which a substring test would miss.

Level 4, not the default 9 — same ratio on JSON and source text at about half the CPU.

## Test Plan

**Automated** — `tests/server/routes/test_session_resources.py`, 12 new cases that
drive the **real routes through the real router** with a stubbed runner (an earlier
revision synthesized endpoints, which is what let the dead-code bug hide):

- a text read is gzipped and the body is byte-intact after the round-trip
- a base64 (binary) read is skipped
- directory listing and the diff read are gzipped
- an identity request gets identity bytes, and `Vary: Accept-Encoding` is set
- 10 parametrized `Accept-Encoding` negotiations (case variants, `q` values, `q=0`)
- `PUT`/`PATCH`/`DELETE` on the read paths stay uncompressed
- sibling routes (`changes`, `search`, `shell`) stay uncompressed

136 passed in that file; 160 across it plus the app, session-resources REST, and
hosts-filesystem integration suites.

**Structural checks:**
- walked the built router: exactly 3 routes wrapped, all `GET`
- every path+method still resolves to the same handler as before the router split,
  so the `{relative_path:path}` catch-alls don't shadow `/changes`, `/search`, or
  `/shell`
- OpenAPI unchanged: the read paths still document all four methods, and the
  internal diff route stays out of the schema
- raw-ASGI checks (no client header injection): absent `Accept-Encoding`, `gzip`,
  `gzip;q=0`, and `Range` each behave correctly

**Manual, against a deployed build** (beyond the timings above): every gzip response
gunzipped to a body byte-identical to its identity response, and only the
filesystem/diff reads carried `content-encoding: gzip` — `…/changes`,
`/v1/sessions/{id}/resources`, `/v1/hosts` and `/health` all returned none.

## Demo

N/A — no visual change; files render identically, just faster.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover the route class's decision logic — payload-based eligibility,
`Accept-Encoding` negotiation, `Range` bypass, method scoping, `Vary`, and body
integrity through the round-trip — by exercising the production routes rather than
synthesized stand-ins. They cannot cover the thing this PR is actually for, bytes and
milliseconds over a real network, so that was verified by the interleaved
two-deployment A/B above plus live byte-identity and scope checks against a deployed
build.

Note the deployed measurements were taken against the earlier middleware revision.
The bytes on the wire are unchanged by the restructure (same compressor, same level,
same routes), and the local before/after byte counts match the deployed ones exactly;
the ~1 s saving on a 1 MB text file is a transfer-size effect, not an artifact of
where the compression was attached.

## Changelog

Files in the viewer load faster — workspace-file reads are now gzipped, cutting a 1 MB text file from ~2.3 s to ~1.3 s

