### PR TITLE
feat(session-create): expose terminal_launch_args on sys_session_create

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2241,6 +2241,7 @@ def _build_session_create_body(
     title: object,
     message: object,
     model: object = None,
+    terminal_launch_args: object = None,
 ) -> _JsonObject:
     """
     Build the JSON ``POST /v1/sessions`` body for ``sys_session_create``.
@@ -2269,6 +2270,12 @@ def _build_session_create_body(
         body["title"] = title
     if isinstance(model, str) and model:
         body["model_override"] = model
+    if isinstance(terminal_launch_args, list) and terminal_launch_args:
+        # Forward verbatim; the server bounds-checks via
+        # _validate_terminal_launch_args (flat list, no shell metachars).
+        body["terminal_launch_args"] = [
+            str(a) for a in terminal_launch_args if isinstance(a, str)
+        ]
     if isinstance(message, str) and message:
         body["initial_items"] = [
             {
@@ -2423,6 +2430,7 @@ async def _execute_session_create(
         args.get("title"),
         args.get("message"),
         model=args.get("model"),
+        terminal_launch_args=args.get("terminal_launch_args"),
     )
     try:
         resp = await server_client.post("/v1/sessions", json=body, timeout=30.0)
@@ -2589,6 +2597,14 @@ async def _upload_config_bundle(
     title = args.get("title")
     if isinstance(title, str) and title:
         metadata["title"] = title
+    terminal_launch_args = args.get("terminal_launch_args")
+    if isinstance(terminal_launch_args, list) and terminal_launch_args:
+        # Forward into the multipart metadata JSON; the server parses it
+        # via _parse_session_create_metadata -> SessionCreateMetadata, which
+        # already owns _validate_terminal_launch_args (bounds-checked).
+        metadata["terminal_launch_args"] = [
+            str(a) for a in terminal_launch_args if isinstance(a, str)
+        ]
     try:
         resp = await server_client.post(
             "/v1/sessions",

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -936,6 +936,25 @@ class SysSessionCreateTool(Tool):
                                 "agent's default."
                             ),
                         },
+                        "terminal_launch_args": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional native-terminal pass-through args "
+                                "for the child session, e.g. "
+                                "[\"--yolo\"] for a headless cursor-native "
+                                "worker (cursor-agent's full-bypass flag) so it "
+                                "does not stall on in-terminal approval prompts "
+                                "that no human can answer. Forwarded verbatim "
+                                "into the server request body's "
+                                "terminal_launch_args (already validated and "
+                                "bounds-checked server-side); only meaningful "
+                                "for terminal-native harnesses "
+                                "(cursor/codex/claude-native). Top-level "
+                                "sessions keep these explicit args rather than "
+                                "deriving them from the bundle's yolo flag."
+                            ),
+                        },
                     },
                     # Only the always-optional fields are listed in
                     # ``required`` (none): the agent_id-vs-config_path

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6180,6 +6180,50 @@ async def test_sys_session_create_spawns_child_under_caller() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sys_session_create_forwards_terminal_launch_args() -> None:
+    """
+    ``terminal_launch_args`` reaches the JSON create body verbatim.
+
+    Headless native-terminal workers (cursor/codex/claude-native) stall
+    on in-terminal approval prompts no human can answer; the caller
+    declares the bypass stance (e.g. ``["--yolo"]``) at launch, and the
+    server — which already validates + bounds-checks the list — threads
+    it into the child's terminal_launch_args. If the tool dropped the
+    field, a top-level agent_id/config_path cursor worker would silently
+    run WITHOUT ``--yolo`` and stall on every tool call.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    captured: dict[str, Any] = {}
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            captured.update(json.loads(request.content))
+            return httpx.Response(
+                201,
+                json={"id": "conv_child_tla", "agent_id": "ag_x", "status": "idle"},
+            )
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        await execute_tool(
+            tool_name="sys_session_create",
+            arguments=json.dumps(
+                {"agent_id": "ag_x", "terminal_launch_args": ["--yolo"]}
+            ),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    # Forwarded verbatim into the create body the server validates.
+    assert captured["terminal_launch_args"] == ["--yolo"]
+    assert captured["parent_session_id"] == "conv_caller"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "arguments",
     [


### PR DESCRIPTION
## Problem

`sys_session_create` did not forward `terminal_launch_args`, so **top-level** sessions launched via `agent_id` or `config_path` could not declare a native-terminal bypass stance. A headless `cursor-native` worker uploaded via `config_path` therefore ran **without** `--yolo` even when its bundle declared `executor.config.yolo: true`, and stalled on cursor-agent's in-terminal approval prompts — surfaced as web elicitation cards that no human is present to answer.

## Root cause

The `--yolo` auto-derivation (`_derive_terminal_launch_args_from_spec`) only fires for **named sub-agent** creates (`body.sub_agent_name` set) — not for top-level `config_path`/`agent_id` sessions (`sub_agent_name` is null). Those take the `else` branch (`orchestration.py:5842`) which reads **caller-supplied** `body.terminal_launch_args`. The bundle's `yolo: true` is silently ignored for top-level sessions — by design (a caller cannot inject launch wiring by smuggling args through a spawn body; the flat-list + bounds-check is the security boundary).

So the bypass stance must be declared **at the launch call**, not derived from an uploaded bundle — exactly what the web UI's permission-mode selector already does for top-level sessions.

## Fix (surgical, additive)

The server **already** accepts and validates `terminal_launch_args` on **both** create paths:
- JSON → `SessionCreateRequest.model_validate`
- multipart → `_parse_session_create_metadata` → `SessionCreateMetadata` → `_validate_terminal_launch_args`

The only gap was the **tool surface**. This PR:

- Adds a `terminal_launch_args` param to the `sys_session_create` schema.
- Forwards it verbatim into the JSON body (`_build_session_create_body`) and the multipart metadata (`_upload_config_bundle`).
- The server keeps owning validation/bounds-checking — no security-boundary change.
- Restores **UI ↔ API parity** (the web permission-mode selector already sets `body.terminal_launch_args` for top-level sessions; the programmatic API now can too).

## Why not derive `--yolo` for top-level sessions instead?

That would collapse the security boundary: any uploaded bundle with `yolo: true` would auto-bypass approvals, and it would be a cursor-native special case. Declaring the stance at the (trusted) call site is the correct layer separation and generalizes across cursor/codex/claude-native.

## Tests

- Adds `test_sys_session_create_forwards_terminal_launch_args` — asserts the field reaches the create body verbatim.
- All 8 existing `sys_session_create` tests pass (no regression).