### PR TITLE
Modal styling

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -622,7 +622,7 @@ function AddPolicyDialog({
             </div>
           )}
           <div className="flex justify-end gap-2 pt-1">
-            <button
+            <Button
               type="button"
               onClick={() => {
                 // With a policy selected, Cancel steps back to the list so the
@@ -635,18 +635,13 @@ function AddPolicyDialog({
                   onOpenChange(false);
                 }
               }}
-              className="rounded px-3 py-1.5 text-sm hover:bg-muted"
+              variant="outline"
             >
               Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleAdd}
-              disabled={!selected || addPolicy.isPending}
-              className="rounded bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
-            >
+            </Button>
+            <Button type="button" onClick={handleAdd} disabled={!selected || addPolicy.isPending}>
               {addPolicy.isPending ? "Adding..." : "Add"}
-            </button>
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -79,7 +79,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-ui text-popover-foreground ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-[30px] bg-popover p-6 text-ui text-popover-foreground duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-dialog",
           className,
         )}
         style={{ ...iosViewportStyle, ...style }}
@@ -88,8 +88,8 @@ function DialogContent({
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
-              <XIcon />
+            <Button variant="ghost" className="absolute top-5 right-6" size="icon-lg">
+              <XIcon className="size-5 text-muted-foreground" data-icon-size />
               <span className="sr-only">Close</span>
             </Button>
           </DialogPrimitive.Close>
@@ -117,7 +117,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-6 -mb-6 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-6 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -136,7 +136,10 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("font-heading text-ui leading-none font-medium", className)}
+      className={cn(
+        "font-heading min-h-8 leading-[32px] text-ui text-[1.25em] pr-10 font-[600]",
+        className,
+      )}
       {...props}
     />
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -112,6 +112,7 @@
     0 4px 16px -2px rgb(var(--ui-shadow-warm-rgb) / 0.1),
     0 1px 0 rgb(var(--ui-shadow-neutral-rgb) / 0.02);
   --shadow-tooltip: 0 3px 6px rgb(var(--ui-shadow-neutral-rgb) / 0.05);
+  --shadow-dialog: 0 16px 48px rgb(var(--ui-shadow-neutral-rgb) / 0.2);
 }
 
 /* The two body text steps. Keep these non-inline: `@theme inline` bakes the

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1785,13 +1785,14 @@ function HarnessConfigModal({
         <DialogFooter className="border-t-0 bg-transparent">
           <Button
             type="button"
+            size="lg"
             variant="outline"
             onClick={() => onOpenChange(false)}
             data-testid="new-chat-landing-config-cancel"
           >
             Cancel
           </Button>
-          <Button type="button" onClick={save} data-testid="new-chat-landing-config-save">
+          <Button type="button" onClick={save} data-testid="new-chat-landing-config-save" size="lg">
             Save
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Related issue

OMNI-2354

## Summary

Match dialogs to the base modal design:

- `DialogContent` now uses a larger corner radius (`rounded-[30px]`), roomier `p-6` padding, and a soft drop shadow (`--shadow-dialog`) instead of the thin `ring-1` outline.
- The close button is larger (`icon-lg`, `top-5 right-6`) with a muted-foreground X; the title is bigger/bolder with clearance for the close button, and `DialogFooter` padding tracks the new `p-6` content padding.
- Cleaned up footer actions to use the `<Button>` component instead of raw `<button>` markup: `AddPolicyDialog` (AgentInfo) now uses `outline` Cancel + default Add, and `HarnessConfigModal` (NewChatDialog) footer buttons are `size="lg"`.

## Test Plan

Manual verification in the web app — opened dialogs (New Chat harness config, Add Policy, and other modals sharing `DialogContent`) and confirmed the new radius, padding, shadow, close button, and title styling render correctly and footers align.

## Demo

<img width="1900" height="1032" alt="Screenshot 2026-08-07 at 14 56 32" src="https://github.com/user-attachments/assets/f87411b2-f932-4ab4-86bd-e7efef72d738" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Styling-only change with no behavioral logic; verified visually across dialogs that share `DialogContent`. The footer markup change (raw `<button>` → `<Button>`) preserves existing `onClick`/`disabled`/`data-testid` wiring.

## Changelog

Refreshed modal styling — larger rounded corners, softer drop shadow, and roomier padding
