### PR TITLE
fix(pi-native): pick the inline family from the selected model's family

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -839,20 +839,36 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     )
 
 
+def _inline_family_order(model: str | None) -> tuple[str, ...]:
+    """Order the inline families to try, model's own family first.
+
+    Only Claude ids prefer the Anthropic family. Everything else — GPT, and the
+    Gemini/Llama/DeepSeek ids that token as ``"other"`` — is served over an
+    OpenAI-compatible wire by nearly every gateway, so it leads with OpenAI.
+    With no model to go on, Anthropic leads: Pi speaks it natively.
+    """
+    if model and model_catalog.model_family_token(model) != "claude":
+        return ("openai", "anthropic")
+    return ("anthropic", "openai")
+
+
 def _inline_family_pi_provider(
     entry: ProviderEntry, *, model: str | None
 ) -> PiProviderConfig | None:
     """Resolve a key/gateway/local provider into Pi config from its family.
 
-    Prefers the Anthropic family (Pi speaks ``anthropic-messages`` natively),
-    falling back to the OpenAI family via the Responses API.
+    Tries the family matching the selected model first, so a provider offering
+    both surfaces serves a GPT id from its OpenAI family rather than whichever
+    family happens to be configured first. Falls back to the other family, which
+    keeps protocol-translating proxies working: a LiteLLM ``/anthropic``
+    passthrough is the only configured family and still serves any model.
 
     :param entry: The resolved default provider entry.
     :param model: Session model override, or ``None`` to use the family default.
     :returns: The Pi provider config, or ``None`` when no usable family with a
         base URL and credential is configured.
     """
-    for family_name in ("anthropic", "openai"):
+    for family_name in _inline_family_order(model):
         family = entry.family(family_name)
         if family is None or not family.base_url:
             continue

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -847,6 +847,8 @@ def _inline_family_order(model: str | None) -> tuple[str, ...]:
     OpenAI-compatible wire by nearly every gateway, so it leads with OpenAI.
     With no model to go on, Anthropic leads: Pi speaks it natively.
     """
+    # An Anthropic-wire-only non-Claude id would prefer the wrong surface here;
+    # only a dual-surface provider is exposed, since the loop falls through.
     if model and model_catalog.model_family_token(model) != "claude":
         return ("openai", "anthropic")
     return ("anthropic", "openai")

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1394,6 +1394,79 @@ def test_anthropic_protocol_proxy_serves_non_claude_model() -> None:
     assert provider.unroutable_model_warning() is None
 
 
+def _dual_family_config(anthropic: bool = True, openai: bool = True) -> dict[str, object]:
+    """A proxy entry exposing an Anthropic surface, an OpenAI surface, or both."""
+    proxy: dict[str, object] = {"kind": "gateway", "default": True}
+    if anthropic:
+        proxy["anthropic"] = {
+            "base_url": "https://litellm.internal.example.com/anthropic",
+            "api_key": "sk-a",
+        }
+    if openai:
+        proxy["openai"] = {
+            "base_url": "https://litellm.internal.example.com/v1",
+            "api_key": "sk-o",
+        }
+    return {"providers": {"proxy": proxy}}
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_api", "expected_base_url"),
+    [
+        (
+            "claude-sonnet-4-6",
+            "anthropic-messages",
+            "https://litellm.internal.example.com/anthropic",
+        ),
+        ("gpt-5-5", "openai-responses", "https://litellm.internal.example.com/v1"),
+        ("glm-5-2", "openai-responses", "https://litellm.internal.example.com/v1"),
+        # Tokens as "other", but no gateway serves it over Anthropic Messages.
+        ("gemini-3-5-flash", "openai-responses", "https://litellm.internal.example.com/v1"),
+        ("llama-4-maverick", "openai-responses", "https://litellm.internal.example.com/v1"),
+    ],
+)
+def test_dual_family_provider_matches_model_family(
+    model: str, expected_api: str, expected_base_url: str
+) -> None:
+    """A provider offering both surfaces serves each model from its own family.
+
+    The family loop used to return on the first configured family, so a proxy
+    with both surfaces sent every model to Anthropic Messages. A non-translating
+    proxy rejects that and the turn hangs with no reply.
+    """
+    config = _dual_family_config()
+
+    provider = creds.resolve_pi_native_provider(model=model, config_loader=lambda: config)
+
+    assert provider is not None
+    assert provider.api == expected_api
+    assert provider.base_url == expected_base_url
+
+
+@pytest.mark.parametrize(
+    ("model", "anthropic", "openai", "expected_api"),
+    [
+        ("gpt-5-5", True, False, "anthropic-messages"),
+        ("claude-sonnet-4-6", False, True, "openai-responses"),
+    ],
+)
+def test_single_family_provider_serves_any_model(
+    model: str, anthropic: bool, openai: bool, expected_api: str
+) -> None:
+    """One configured family serves every model — it may be protocol-translating.
+
+    Preferring the model's family must not become a requirement: a LiteLLM
+    ``/anthropic`` passthrough serves GPT ids, and an OpenAI-compatible proxy
+    serves Claude ids. Excluding them would strand both.
+    """
+    config = _dual_family_config(anthropic=anthropic, openai=openai)
+
+    provider = creds.resolve_pi_native_provider(model=model, config_loader=lambda: config)
+
+    assert provider is not None
+    assert provider.api == expected_api
+
+
 def test_databricks_builders_carry_reachable_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
     """The Databricks profile path records every surface its credential reaches."""
     _mock_databricks_profile(monkeypatch)


### PR DESCRIPTION
## Related issue

Closes #4343

## Summary

`_inline_family_pi_provider` returned on the **first** family carrying a base URL
and credential, never consulting the selected model. A gateway or proxy exposing
both an Anthropic and an OpenAI surface therefore served every model over
`anthropic-messages` — and a proxy that is not protocol-translating rejects that,
so the turn hangs with no reply. Same failure mode as #2575, different function.

Order the families by the selected model instead: Claude ids prefer the Anthropic
family, everything else leads with OpenAI. The loop still **falls through** to the
other family rather than excluding it, so a single-family translating proxy keeps
working (a LiteLLM `/anthropic` passthrough serving GPT ids, or an
OpenAI-compatible proxy serving Claude).

```
                       before                    after
both families:
  claude-sonnet-4-6    anthropic-messages ✓      anthropic-messages ✓
  gpt-5-5              anthropic-messages ✗      openai-responses   ✓
  gemini-3-5-flash     anthropic-messages ✗      openai-responses   ✓
anthropic only:
  zai-org/GLM-4.7      anthropic-messages ✓      anthropic-messages ✓  (translating proxy)
```

`model_family_token` returns `"other"` for Gemini/Llama/Mistral/Cohere/xAI/Bedrock,
so the check is `!= "claude"` rather than `== "openai"`. That is a deliberate
widening: every non-Claude vendor checked serves an OpenAI-compatible wire and
none serve Anthropic Messages.

## Test Plan

```bash
uv run pytest tests/test_pi_native_credentials.py -q   # 79 passed
uv run ruff check omnigent/pi_native_credentials.py tests/test_pi_native_credentials.py
uv run mypy omnigent/pi_native_credentials.py
```

Ran the issue's tool-free repro before and after; all three reported cases now
route to a surface the family actually serves (table above).

The 7 new tests were checked against `main` with the fix stashed: **4 fail** there
and 3 pass (the already-correct cases), so they are not vacuous. The existing
`test_anthropic_protocol_proxy_serves_non_claude_model` regression test — which
pins the translating-proxy behaviour — stays green.

## Demo

N/A — no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit-tested only. Unlike #4339, which was probed against a live Databricks
workspace, I have no dual-surface third-party proxy to verify against — the
routing decision is asserted at the resolver boundary (`api` + `base_url` per
model) rather than against a real gateway's acceptance. The claim that non-Claude
vendors prefer an OpenAI-compatible wire is reasoned from their published APIs,
not probed.

## Changelog

Pi sessions on a proxy that exposes both Anthropic and OpenAI surfaces now send each model to the surface its family speaks, instead of routing everything through Anthropic and hanging

This pull request and its description were written by Isaac.
