### PR TITLE
fix(cli): teach `omni upgrade` how to upgrade a Homebrew install

### DIFF
--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -95,6 +95,9 @@ _UPGRADE_INDEX_TIMEOUT_SECONDS = 10.0
 # ``direct_url.json`` in place of a URL's userinfo. See
 # ``_unredact_ssh_userinfo`` for why we have to repair it.
 _REDACTED_USERINFO = "****"
+# Homebrew bottles record ``brew`` in ``INSTALLER``; the tap formula is the
+# only upgrade source (pip into the Cellar is clobbered on the next bump).
+_BREW_TAP_FORMULA = "omnigent-ai/tap/omnigent"
 
 
 @dataclass
@@ -1391,12 +1394,13 @@ class _UpgradeSuggestion:
         Always populated.
     :param runnable: ``True`` when ``command`` is a real shell
         invocation we can execute via ``subprocess.run`` —
-        i.e. the installer is one of uv / pip / pipx / poetry
+        i.e. the installer is one of uv / pip / pipx / poetry / brew
         (or pip-as-fallback for an unknown installer with a known
         VCS URL). ``False`` for the unknown-installer prose
-        fallbacks (``"reinstall X from ..."``) which exist to be
-        read, not run; the interactive "run this now?" prompt is
-        suppressed in that case.
+        fallbacks (``"reinstall X from ..."``) and for requests the
+        installer cannot honor (a pinned version or added extras on a
+        Homebrew install), which exist to be read, not run; the
+        interactive "run this now?" prompt is suppressed in that case.
     """
 
     command: str
@@ -1468,7 +1472,7 @@ def _build_upgrade_suggestion(
     """Build the right upgrade command for the user's install shape.
 
     Picks based on ``detected_installer`` (uv / pip / pipx / poetry /
-    unknown) and whether ``direct_url.json`` recorded a VCS URL.
+    brew / unknown) and whether ``direct_url.json`` recorded a VCS URL.
 
     :param info: Metadata from ``_read_installed_wheel_info``.
     :param allow_prerelease: When ``True`` (``omni upgrade --pre``), append
@@ -1529,6 +1533,28 @@ def _build_upgrade_suggestion(
         )
 
     # Registry install — no VCS URL recorded.
+    if installer == "brew":
+        # `brew upgrade` takes neither a version pin nor extras, so refuse
+        # those rather than silently ignoring them.
+        if target_version:
+            return _UpgradeSuggestion(
+                command=(
+                    f"upgrade {_DIST_NAME} with `brew upgrade {_BREW_TAP_FORMULA}` — Homebrew "
+                    f"installs whatever version the tap currently carries and cannot pin "
+                    f"{target_version}"
+                ),
+                runnable=False,
+            )
+        if extras:
+            return _UpgradeSuggestion(
+                command=(
+                    f"upgrade {_DIST_NAME} with `brew upgrade {_BREW_TAP_FORMULA}` — the formula "
+                    f"bundles its own extras and cannot add {_extras_str(extras)}"
+                ),
+                runnable=False,
+            )
+        return _UpgradeSuggestion(command=f"brew upgrade {_BREW_TAP_FORMULA}", runnable=True)
+
     registry_spec = _package_spec(version=target_version, extras=extras)
     if installer == "uv":
         if target_version or extras:

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -880,6 +880,8 @@ def test_read_wheel_info_handles_corrupt_direct_url(
         # poetry path — included for completeness; poetry is rare for
         # CLI tool installs but the format is documented.
         ("poetry", None, "poetry update omnigent", True),
+        # Homebrew bottle — upgrades through the tap, never pip into the keg.
+        ("brew", None, "brew upgrade omnigent-ai/tap/omnigent", True),
         # Unknown installer WITH a VCS URL — we know the source but
         # not the tool, so the suggestion is prose ("reinstall X from
         # <url>"), not a command. Must be runnable=False so the
@@ -1523,6 +1525,48 @@ def test_build_upgrade_suggestion_preserves_uv_tool_extras() -> None:
         _build_upgrade_suggestion(_make_info("uv", extras=("server", "all"))).command
         == "uv tool install --reinstall omnigent[all,server]"
     )
+
+
+def test_build_upgrade_suggestion_brew_is_runnable() -> None:
+    """A Homebrew bottle upgrades through the tap, not through pip.
+
+    The bottle records ``brew`` in ``INSTALLER`` and ships no
+    ``direct_url.json``, so it lands on the registry path. Before this branch
+    existed it fell through to the unknown-installer prose and ``omni
+    upgrade`` dead-ended with "No automatic upgrade command is known".
+    """
+    suggestion = _build_upgrade_suggestion(_make_info("brew"))
+    assert suggestion.command == "brew upgrade omnigent-ai/tap/omnigent"
+    assert suggestion.runnable is True
+    assert "pip" not in suggestion.command
+
+
+def test_build_upgrade_suggestion_brew_prerelease_has_no_flag() -> None:
+    """``--pre`` is a no-op for brew: ``brew upgrade`` takes no such flag."""
+    assert (
+        _build_upgrade_suggestion(_make_info("brew"), allow_prerelease=True).command
+        == "brew upgrade omnigent-ai/tap/omnigent"
+    )
+
+
+def test_build_upgrade_suggestion_brew_refuses_pinned_version() -> None:
+    """A pinned version on brew is refused, not silently dropped.
+
+    ``brew upgrade`` installs whatever the tap carries, so a runnable command
+    here would land on a different version than ``--target-version`` asked for.
+    """
+    suggestion = _build_upgrade_suggestion(_make_info("brew"), target_version="0.2.0")
+    assert suggestion.runnable is False
+    assert "0.2.0" in suggestion.command
+    assert "brew upgrade omnigent-ai/tap/omnigent" in suggestion.command
+
+
+def test_build_upgrade_suggestion_brew_refuses_extras() -> None:
+    """Extras on brew are refused: the formula bundles its own set."""
+    suggestion = _build_upgrade_suggestion(_make_info("brew", extras=("all",)))
+    assert suggestion.runnable is False
+    assert "[all]" in suggestion.command
+    assert "brew upgrade omnigent-ai/tap/omnigent" in suggestion.command
 
 
 def test_build_upgrade_suggestion_uv_target_version() -> None:


### PR DESCRIPTION
## Related issue

Closes #2558

## Summary

`brew install omnigent-ai/tap/omnigent` works today and the tap now tracks releases, but the follow-up ask on #2558 — upgrading a brewed install — still dead-ends:

```
$ omni upgrade --target-version 0.9.0
Error: No automatic upgrade command is known for this install.
       reinstall omnigent from your original source.
```

A Homebrew bottle records `brew` in its dist-info `INSTALLER` and ships no `direct_url.json`, so it reaches the registry branch of `_build_upgrade_suggestion` with an installer name that nothing matched, falling through to the non-runnable prose fallback. Brew users — the audience the tap exists for — had no supported upgrade path.

- Map `brew` → `brew upgrade omnigent-ai/tap/omnigent` (runnable). The formula builds a virtualenv from pinned resources under the Cellar, so pip-ing into that keg would be undone by the next bump; the tap is the only correct source.
- `brew upgrade` accepts neither a version pin nor extras, so `--target-version` and `--extra` return a non-runnable explanation rather than a command that would quietly ignore them.
- `--pre` is a no-op: the tap carries only final releases.

Scoped to the upgrade path. The other two asks on #2558 (`--HEAD`, native `/opt` packaging) are untouched — see the note below.

## Test Plan

Verified against a real Homebrew install on macOS 26.5.2 / arm64, not just unit tests:

```bash
brew tap omnigent-ai/tap
brew install omnigent-ai/tap/omnigent   # → 0.8.2, from the arm64_tahoe bottle
```

Confirmed the real install's metadata is the shape this branch keys on:

```
detected_installer: 'brew'
vcs_url: None
```

Feeding that exact metadata through the patched function:

```
command:  brew upgrade omnigent-ai/tap/omnigent
runnable: True
```

And the generated command is valid Homebrew:

```
$ brew upgrade --dry-run omnigent-ai/tap/omnigent
Warning: omnigent-ai/tap/omnigent 0.8.2 already installed   # exit 0
```

The test install was uninstalled and the tap untapped afterwards.

```bash
python -m pytest tests/cli/test_update_check.py    # 117 passed (5 new brew tests)
pre-commit run --files omnigent/update_check.py tests/cli/test_update_check.py
uvx pyrefly check omnigent/update_check.py         # 0 errors
.venv/bin/mypy omnigent/update_check.py            # Success
```

## Demo

N/A — CLI behaviour, no visual change. Output quoted in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Five unit tests: a `brew` row in the shared `_build_upgrade_suggestion` matrix (asserting `runnable=True`, since a prose fallback flipping to runnable would `subprocess.run` a literal sentence), plus dedicated tests for the `--pre` no-op and the two refusal paths.

Manual verification covers what unit tests can't: that a real bottle actually reports `installer="brew"` with no `direct_url.json`, and that `brew upgrade <tap formula>` is a command Homebrew accepts. Both were run on a live install as quoted above. The one step not exercised end-to-end is `omni upgrade` *executing* the upgrade — that needs a brewed copy genuinely behind a newer tap version, which doesn't exist while the tap is current; the command itself was validated with `--dry-run`.

## Note for reviewers

#2558 also asks for a working `--HEAD` formula and native `/opt`-respecting packaging. Both are out of scope here, and worth knowing where they'd live: the tap's `Formula/omnigent.rb` is **generated** from `.github/scripts/homebrew/omnigent.rb.template` in this repo (I diffed them — the `install`/`test` blocks are byte-identical), so a `head` stanza committed to the tap would be overwritten on the next release bump. It has to go in the template. `--HEAD` is also more than a stanza: the template's `install` pip-installs release-pinned resources, which don't describe a build of a moving `main`. Since the closing keyword above resolves the whole issue, it may be worth opening a narrower follow-up for those two.

## Changelog

`omni upgrade` now upgrades Homebrew installs via `brew upgrade` instead of reporting that no upgrade command is known.

This pull request and its description were written by Isaac.
