### PR TITLE
fix(android): floor the server-switcher pill's touch target at 48dp

### DIFF
--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -6,11 +6,13 @@ import android.app.DownloadManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.graphics.Rect
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.view.Gravity
+import android.view.TouchDelegate
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
@@ -185,6 +187,17 @@ class MainActivity : AppCompatActivity() {
                     topMargin = (8 * dp).toInt()
                 }
         container.addView(switchButton)
+        // The pill's visual size (12sp text + 6dp vertical padding) measures to
+        // roughly 27dp tall, well under Android's 48dp minimum interactive
+        // target — and it's the only entry point to the server-switcher menu.
+        // A TouchDelegate on the parent floors the *touch* target without
+        // changing the pill's appearance, growing downward into the free
+        // space below it (growing upward would push the target into the
+        // status bar). Reinstalled on every layout change so it tracks the
+        // pill as the insets listener repositions it.
+        switchButton.addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+            container.touchDelegate = switchButtonTouchDelegate(left, top, right, bottom)
+        }
         setContentView(container)
         applySystemBarContrast()
         installBridge()
@@ -451,6 +464,30 @@ class MainActivity : AppCompatActivity() {
                     c in 'A'..'Z' || c in 'a'..'z' || c in '0'..'9' || c == '-' || c == '_'
                 }
         }
+    }
+
+    /**
+     * Build a [TouchDelegate] that floors the switch button's touch target at
+     * [MIN_TOUCH_TARGET_DP], growing downward from its laid-out bounds.
+     *
+     * @param left the switch button's current laid-out bounds, as reported by
+     *     its [View.OnLayoutChangeListener] — parent-relative (i.e. relative
+     *     to `container`), same as the [TouchDelegate] this builds.
+     * @param top see [left].
+     * @param right see [left].
+     * @param bottom see [left].
+     * @return a delegate to install on the switch button's parent.
+     */
+    private fun switchButtonTouchDelegate(
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+    ): TouchDelegate {
+        val minHeightPx = (MIN_TOUCH_TARGET_DP * resources.displayMetrics.density).toInt()
+        val deficit = minHeightPx - (bottom - top)
+        val expandedBottom = if (deficit > 0) bottom + deficit else bottom
+        return TouchDelegate(Rect(left, top, right, expandedBottom), switchButton)
     }
 
     /**
@@ -780,6 +817,10 @@ class MainActivity : AppCompatActivity() {
 
     private companion object {
         const val MAX_LOGIN_ATTEMPTS = 3
+
+        // Android's recommended minimum interactive target — see
+        // https://developer.android.com/guide/topics/ui/accessibility/apps#large-tap-targets
+        const val MIN_TOUCH_TARGET_DP = 48
 
         // Back-press fallback: long enough that a healthy renderer's JS round-trip
         // (a few ms) always wins the race, short enough to not feel stuck if it

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.TouchDelegate
 import android.view.View
 import android.view.ViewGroup
@@ -159,7 +160,21 @@ class MainActivity : AppCompatActivity() {
         // Wrap the WebView in a FrameLayout so the floating server-switcher
         // pill can sit on top of it. The pill uses the app's brand palette
         // (values/values-night colors.xml) so it adapts to light/dark mode.
-        val container = FrameLayout(this)
+        //
+        // A plain ViewGroup only consults its own touchDelegate as a last
+        // resort, once every child has already failed to claim the touch —
+        // and the full-bleed WebView underneath the pill claims nearly
+        // every touch itself (it tracks all of them for possible scroll/
+        // zoom), so a delegate installed the ordinary way would never run.
+        // Override dispatch to check it first instead.
+        val container =
+            object : FrameLayout(this) {
+                override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+                    val delegate = touchDelegate
+                    if (delegate != null && delegate.onTouchEvent(ev)) return true
+                    return super.dispatchTouchEvent(ev)
+                }
+            }
         container.addView(webView)
         val dp = resources.displayMetrics.density
         switchButton =

--- a/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/MainActivityTest.kt
@@ -4,11 +4,16 @@ import android.content.Context
 import android.content.RestrictionsManager
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.MotionEvent
+import android.view.TouchDelegate
+import android.view.View
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -100,10 +105,105 @@ class MainActivityTest {
         assertEquals("https://example.com", shadowOf(activity.webView()).lastLoadedUrl)
     }
 
+    @Test
+    fun `a tap directly on the switch button still opens the server menu`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val button = activity.switchButton()
+
+        // Original behavior, unaffected by the touch-delegate addition: a tap
+        // that lands inside the pill's own visible bounds still reaches it
+        // directly, with no delegate involved.
+        assertTrue(button.dispatchTouchEvent(motionEventAt(DOWN, x = 1f, y = 1f)))
+        assertTrue(button.dispatchTouchEvent(motionEventAt(UP, x = 1f, y = 1f)))
+    }
+
+    @Test
+    fun `a touch delegate is installed on the switch button's parent`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val container = activity.switchButton().parent as FrameLayout
+
+        // Proves the layout-change hook actually fires and wires a delegate
+        // up in practice, not just that the standalone builder below works.
+        assertNotNull(container.touchDelegate)
+    }
+
+    @Test
+    fun `touch delegate floors the switch button's touch target at 48dp`() {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect("https://example.com")
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val dp = activity.resources.displayMetrics.density
+
+        // Exercise the flooring math directly against #3731's real-device
+        // numbers (a ~27dp-tall pill) rather than this environment's own
+        // text measurement, which — per Robolectric's font-metrics
+        // limitations — doesn't reproduce a real device's ~27dp and would
+        // make this assertion meaningless either way.
+        val delegate =
+            activity.switchButtonTouchDelegate(
+                left = 0,
+                top = 0,
+                right = (100 * dp).toInt(),
+                bottom = (27 * dp).toInt(),
+            )
+
+        // A point a few dp below the visible pill, but within the floored
+        // 48dp target, must still register — this is the bug: before the
+        // fix there was no delegate at all, so this point fell through to
+        // the WebView underneath.
+        assertTrue(
+            "tap just below the visible pill should hit the expanded target",
+            delegate.onTouchEvent(motionEventAt(DOWN, x = 1f, y = (32 * dp))),
+        )
+
+        // A point clearly past the 48dp floor must NOT register — the
+        // expansion is bounded, not an unlimited catch-all over the WebView.
+        assertFalse(
+            "tap well past the floored target should miss",
+            delegate.onTouchEvent(motionEventAt(DOWN, x = 1f, y = (60 * dp))),
+        )
+    }
+
     private fun MainActivity.webView(): WebView =
         MainActivity::class
             .java
             .getDeclaredField("webView")
             .apply { isAccessible = true }
             .get(this) as WebView
+
+    private fun MainActivity.switchButton(): View =
+        MainActivity::class
+            .java
+            .getDeclaredField("switchButton")
+            .apply { isAccessible = true }
+            .get(this) as View
+
+    private fun MainActivity.switchButtonTouchDelegate(
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+    ): TouchDelegate =
+        MainActivity::class
+            .java
+            .getDeclaredMethod(
+                "switchButtonTouchDelegate",
+                Int::class.java,
+                Int::class.java,
+                Int::class.java,
+                Int::class.java,
+            ).apply { isAccessible = true }
+            .invoke(this, left, top, right, bottom) as TouchDelegate
+
+    private fun motionEventAt(
+        action: Int,
+        x: Float,
+        y: Float,
+    ): MotionEvent = MotionEvent.obtain(0, 0, action, x, y, 0)
+
+    private companion object {
+        const val DOWN = MotionEvent.ACTION_DOWN
+        const val UP = MotionEvent.ACTION_UP
+    }
 }


### PR DESCRIPTION
Closes #3731

## Summary

- The Android floating server-switcher pill had no `minHeight` and no `TouchDelegate`, so its touch target came entirely from its visual size: 12sp text plus 6dp top/bottom padding, which measures to roughly 27dp tall on a real device — well under Android's 48dp minimum for interactive targets. This matters more than a typical undersized control because the pill is the only entry point to the server-switcher menu (`showServerSwitcherMenu` has no other caller), and it's documented as the always-available recovery path.
- Added a `TouchDelegate` on the pill's parent `FrameLayout` that floors the touch target at 48dp, expanding downward into the free space below the pill rather than symmetrically — expanding upward would push the target into the status bar, and the horizontal dimension was already unconstrained (`WRAP_CONTENT`), so this is specifically a vertical fix. The pill's own visual size and appearance are untouched.
- The delegate is rebuilt on every layout change (`switchButton.addOnLayoutChangeListener`), so it keeps tracking the pill's position as the existing insets listener repositions it (`topMargin` changes with the status bar inset).
- **The container's `dispatchTouchEvent` is overridden to consult that delegate before its children get a chance to claim the touch.** A plain `ViewGroup` only falls back to its own `touchDelegate` once every child has already failed to claim the event — and the full-bleed `WebView` underneath the pill claims nearly every touch itself (it tracks all of them for possible scroll/zoom), so simply setting `container.touchDelegate = ...` the ordinary way never actually ran in the live app. See "How this was verified" below for how that gap was caught.

## Root cause

`web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt` builds the pill as a plain `TextView` with `setPadding((12*dp).toInt(), (6*dp).toInt(), (12*dp).toInt(), (6*dp).toInt())` and `textSize = 12f`, with no `minHeight` set anywhere and no `TouchDelegate` installed on its parent. Android's default `View.onTouchEvent` only registers a click for a `MotionEvent` that lands within the view's own laid-out bounds, so a tap ~10dp above or below the visible pill fell straight through to the `WebView` underneath.

## Proposed fix

A `TouchDelegate` on the parent, expanding only the *touch* target (not the visual pill) to a 48dp floor, biased downward. This was the shape the issue itself suggested, and it avoids the two alternatives it also called out: a `minHeight` on the `TextView` would change the pill's appearance, and `web/src/index.css`'s `--omnigent-android-switcher-height` (used for a scroll-fade) would then need updating too.

## How this was verified (including a real bug this caught)

The first version of this fix set `container.touchDelegate = ...` the standard way and passed all three unit tests below — but unit tests that call `delegate.onTouchEvent(event)` directly test the delegate's own math, not whether the framework actually reaches it during real touch dispatch. I stood up an actual Android toolchain (JDK 17, SDK, an arm64 system image on a hardware-accelerated emulator) to check, and the first version **did not work in the live app**: `ViewGroup.dispatchTouchEvent` only consults its own `touchDelegate` as a last resort, after every child has failed to claim the touch, and the full-bleed `WebView` sitting under the pill claims nearly every touch itself. The delegate was never reached. Caught this by installing the debug APK, presetting the server via `ServerStore`'s SharedPreferences, reading the pill's exact live bounds via `uiautomator dump` (`[416,84][663,157]`, 73px tall — 27.8dp at this emulator's 2.625x density, which lines up almost exactly with the issue's own ~27dp real-device estimate), and tapping just below it: the menu didn't open.

Fixed by overriding the container's `dispatchTouchEvent` to check the delegate first. Re-verified on the same emulator, at the same pixel coordinates, across three states:

| Build | Tap on the pill itself (y=120) | Tap 5dp below the pill (y=170) | Tap well past the 48dp floor (y=250) |
|---|---|---|---|
| Unfixed (`main`) | Menu opens | **Falls through, no menu** | Falls through, no menu |
| First fix attempt (delegate installed the ordinary way) | Menu opens | **Falls through, no menu** — the bug this caught | Falls through, no menu |
| This PR (dispatch overridden) | Menu opens | **Menu opens** | Falls through, no menu |

That last row is the whole point: the expansion is real (a tap that used to miss now hits), and it's still bounded (a tap well past the floor still correctly reaches the page underneath, not an unlimited catch-all).

## Test Plan

- Added three Robolectric unit tests to `MainActivityTest.kt`:
  - `a tap directly on the switch button still opens the server menu` — the original, correct behavior (a tap on the visible pill itself) is unaffected by the delegate addition.
  - `a touch delegate is installed on the switch button's parent` — proves the layout-change hook actually fires in practice and installs a delegate, not just that the builder function below works in isolation.
  - `touch delegate floors the switch button's touch target at 48dp` — exercises the flooring math directly against a synthetic ~27dp-tall pill (the issue's real-device numbers), asserting a tap just below the visible pill (but within the 48dp floor) is handled, and a tap well past the floor is not. Tested against synthetic bounds rather than this environment's own measured pill height because Robolectric's font metrics for this `TextView` don't reproduce a real device's ~27dp (they measured ~53dp in this harness).
  - These tests exercise the delegate's own math correctly but, as above, don't exercise real touch dispatch order — that gap is why the manual on-emulator pass below exists too.
- `./gradlew testDebugUnitTest --tests "ai.omnigent.android.MainActivityTest"` — 8 passed, 1 pre-existing failure (`configuration change updates system bar icon polarity`) reproduced identically on unmodified `main` in this environment, unrelated to this change.
- `./gradlew compileDebugKotlin` / `compileReleaseKotlin` — both succeed.
- `ktlint` and `pre-commit run` on both changed files — clean.
- Manual on-device (emulator) verification per the table above.

## Demo

No screen recording attached (no straightforward way to attach binary media through this environment's tooling), but the manual verification was real, not simulated: an arm64 Android emulator (Pixel 6 profile, API 35, hardware-accelerated via macOS's Hypervisor.framework), the actual built debug APK, exact pixel coordinates read from `uiautomator dump`, and `adb shell input tap` / `adb exec-out screencap`. The before/after/bounded results are in the table above and are exactly reproducible with those commands against this branch.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was on an emulator, not physical hardware — the touch-dispatch mechanics this fix depends on are standard Android framework behavior, not emulator-specific, but a reviewer with a physical device is still welcome to double-check.

## Changelog

The Android server-switcher pill's touch target is now floored at 48dp, so taps slightly above or below the pill itself now open the server menu instead of falling through to the page
