### PR TITLE
feat(web): add configurable chat view width

### DIFF
--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -42,11 +42,14 @@ import {
   reactRouterRouting,
 } from "./lib/routing";
 import { initChatStore } from "./store/chatStore";
+import { applyChatViewWidth, readChatViewWidth } from "./lib/chatViewWidthPreferences";
 import "katex/dist/katex.min.css";
 import "streamdown/styles.css";
 import "./index.css";
 import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
+
+applyChatViewWidth(readChatViewWidth());
 
 export type { OmnigentHostConfig } from "./lib/host";
 export type { RoutingApi } from "./lib/routing";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -14,6 +14,10 @@
  * app theme customization in this file. */
 @source "../node_modules/streamdown/dist/*.js";
 
+.chat-column-width {
+  max-width: var(--chat-column-max-width, 48rem);
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/web/src/lib/chatViewWidthPreferences.test.ts
+++ b/web/src/lib/chatViewWidthPreferences.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyChatViewWidth,
+  CHAT_VIEW_WIDTH_DEFAULT,
+  normalizeChatViewWidth,
+  readChatViewWidth,
+  writeChatViewWidth,
+} from "./chatViewWidthPreferences";
+
+const STORAGE_KEY = "omnigent:chat-view-width";
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.style.removeProperty("--chat-column-max-width");
+});
+
+describe("chatViewWidthPreferences", () => {
+  it("defaults to normal and clears the default value", () => {
+    expect(readChatViewWidth()).toBe(CHAT_VIEW_WIDTH_DEFAULT);
+    writeChatViewWidth("wide");
+    expect(readChatViewWidth()).toBe("wide");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("wide");
+
+    writeChatViewWidth("normal");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(document.documentElement.style.getPropertyValue("--chat-column-max-width")).toBe(
+      "48rem",
+    );
+  });
+
+  it("normalizes unknown values", () => {
+    expect(normalizeChatViewWidth("wide")).toBe("wide");
+    expect(normalizeChatViewWidth("bogus")).toBe("normal");
+    expect(normalizeChatViewWidth(null)).toBe("normal");
+  });
+
+  it("applies the extra-wide CSS value", () => {
+    applyChatViewWidth("extra-wide");
+    expect(document.documentElement.style.getPropertyValue("--chat-column-max-width")).toBe(
+      "64rem",
+    );
+  });
+});

--- a/web/src/lib/chatViewWidthPreferences.ts
+++ b/web/src/lib/chatViewWidthPreferences.ts
@@ -1,0 +1,52 @@
+// Persisted, app-global preference for the maximum width of the chat column.
+
+const STORAGE_KEY = "omnigent:chat-view-width";
+const CSS_VARIABLE = "--chat-column-max-width";
+
+export const chatViewWidths = ["normal", "wide", "extra-wide"] as const;
+export type ChatViewWidth = (typeof chatViewWidths)[number];
+
+export const CHAT_VIEW_WIDTH_DEFAULT: ChatViewWidth = "normal";
+
+const CHAT_VIEW_WIDTH_MAX: Record<ChatViewWidth, string> = {
+  normal: "48rem",
+  wide: "56rem",
+  "extra-wide": "64rem",
+};
+
+export function isChatViewWidth(value: string | null | undefined): value is ChatViewWidth {
+  return value === "normal" || value === "wide" || value === "extra-wide";
+}
+
+export function normalizeChatViewWidth(value: string | null | undefined): ChatViewWidth {
+  return isChatViewWidth(value) ? value : CHAT_VIEW_WIDTH_DEFAULT;
+}
+
+export function readChatViewWidth(): ChatViewWidth {
+  if (typeof window === "undefined") return CHAT_VIEW_WIDTH_DEFAULT;
+  try {
+    return normalizeChatViewWidth(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return CHAT_VIEW_WIDTH_DEFAULT;
+  }
+}
+
+export function applyChatViewWidth(value: ChatViewWidth): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(CSS_VARIABLE, CHAT_VIEW_WIDTH_MAX[value]);
+}
+
+export function writeChatViewWidth(value: ChatViewWidth): void {
+  if (typeof window === "undefined") return;
+  const normalized = normalizeChatViewWidth(value);
+  applyChatViewWidth(normalized);
+  try {
+    if (normalized === CHAT_VIEW_WIDTH_DEFAULT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, normalized);
+    }
+  } catch {
+    // localStorage access errors shouldn't break settings.
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,7 @@ import {
 } from "./lib/uiFontPreferences";
 import { applyThemePalette, readThemePalette } from "./lib/themePalette";
 import { applyCustomTheme, readCustomTheme } from "./lib/customTheme";
+import { applyChatViewWidth, readChatViewWidth } from "./lib/chatViewWidthPreferences";
 import { initChatStore } from "./store/chatStore";
 import "katex/dist/katex.min.css";
 import "streamdown/styles.css";
@@ -62,6 +63,7 @@ initNativeInsets();
 // Apply the saved desktop UI font size and family before first paint so there's no flash.
 applyDesktopUiFontSize(readUiFontSizePx());
 applyUiFontFamily(readUiFontFamily());
+applyChatViewWidth(readChatViewWidth());
 
 // The standalone sidebar font size control was removed. Clear its legacy value
 // so sidebar items follow the shared desktop interface size.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -346,7 +346,7 @@ export function collectBubbleMarkdown(items: RenderItem[]): string {
 }
 
 // All chat-column elements must share this width to stay aligned.
-const CHAT_COLUMN_WIDTH = "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-5xl";
+const CHAT_COLUMN_WIDTH = "chat-column-width";
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
 const DISPLAY_MATH_RE = /(^|\n)\s*(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\])/;
@@ -3666,9 +3666,9 @@ function AssistantBubble({
         from="assistant"
         data-testid="message-bubble"
         data-role="assistant"
-        className={isWide ? "max-w-full" : "max-w-3xl"}
+        className={isWide ? "max-w-full" : CHAT_COLUMN_WIDTH}
       >
-        {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap
+        {/* A fold-only bubble takes w-full at the ordinary chat-column cap
             rather than shrink-wrapping to the summary row's ~110px, which
             collapsed the row's trailing hairline (a flex-1 span) to zero
             and stopped its click target short of the column. Keeping the

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -213,6 +213,7 @@ afterEach(() => {
   // selected in one test doesn't leak into the next.
   document.documentElement.removeAttribute("data-theme");
   document.documentElement.removeAttribute("data-custom-translucent-sidebar");
+  document.documentElement.style.removeProperty("--chat-column-max-width");
   for (const property of Array.from(document.documentElement.style)) {
     if (property.startsWith("--custom-")) document.documentElement.style.removeProperty(property);
   }
@@ -275,6 +276,22 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("terminal-theme-light")).toHaveAttribute("aria-checked", "false");
     expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "false");
     expect(localStorage.getItem("omnigent:terminal-theme")).toBeNull();
+  });
+
+  it("persists the selected chat width", () => {
+    renderPage("/settings/appearance");
+    expect(screen.getByTestId("chat-view-width-normal")).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByTestId("chat-view-width-extra-wide"));
+
+    expect(localStorage.getItem("omnigent:chat-view-width")).toBe("extra-wide");
+    expect(screen.getByTestId("chat-view-width-extra-wide")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(document.documentElement.style.getPropertyValue("--chat-column-max-width")).toBe(
+      "64rem",
+    );
   });
 
   it("renders Terminal theme before Color theme", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -137,6 +137,14 @@ import {
   writeWorkspacePanelDefault,
   type WorkspacePanelDefault,
 } from "@/lib/workspacePanelPreferences";
+import {
+  applyChatViewWidth,
+  chatViewWidths,
+  CHAT_VIEW_WIDTH_DEFAULT,
+  readChatViewWidth,
+  writeChatViewWidth,
+  type ChatViewWidth,
+} from "@/lib/chatViewWidthPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
@@ -572,6 +580,40 @@ function WorkspacePanelDefaultControl() {
   );
 }
 
+function ChatViewWidthControl() {
+  const [value, setValue] = useState(() => readChatViewWidth());
+  const labelId = useId();
+  const choose = useCallback((next: ChatViewWidth) => {
+    setValue(next);
+    writeChatViewWidth(next);
+  }, []);
+  const labels: Record<ChatViewWidth, string> = {
+    normal: "Normal",
+    wide: "Wide",
+    "extra-wide": "Extra-wide",
+  };
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Chat width"
+      helper="Choose how much horizontal space the conversation and composer use."
+    >
+      <CardRadioGroup<ChatViewWidth>
+        labelledBy={labelId}
+        value={value}
+        onSelect={choose}
+        className="grid grid-cols-3 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={chatViewWidths.map((width) => ({
+          value: width,
+          testId: `chat-view-width-${width}`,
+          body: <span className="text-center text-ui font-medium">{labels[width]}</span>,
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
 function ColorThemeControl() {
   // Render each chip in the currently-resolved mode so it matches the app now.
   const { resolvedTheme } = useTheme();
@@ -845,6 +887,8 @@ function AppearanceSection() {
     applyCustomTheme(DEFAULT_CUSTOM_THEME);
 
     writeWorkspacePanelDefault(WORKSPACE_PANEL_DEFAULT);
+    writeChatViewWidth(CHAT_VIEW_WIDTH_DEFAULT);
+    applyChatViewWidth(CHAT_VIEW_WIDTH_DEFAULT);
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
 
@@ -869,6 +913,7 @@ function AppearanceSection() {
           "omnigent:ui-theme-palette",
           "omnigent:custom-theme",
           "omnigent:default-workspace-panel",
+          "omnigent:chat-view-width",
           "omnigent:hide-unconfigured-harnesses",
         ]) {
           window.localStorage.removeItem(key);
@@ -911,6 +956,8 @@ function AppearanceSection() {
         {!isEmbedded && <ColorThemeControl />}
 
         <WorkspacePanelDefaultControl />
+
+        <ChatViewWidthControl />
 
         <HideUnconfiguredHarnessesControl />
 


### PR DESCRIPTION
## Related issue

N/A — no issue number was provided.

## Summary

- Adds a persisted Chat width setting under Settings → Appearance with Normal, Wide, and Extra-wide options.
- Applies the selected width consistently to the transcript, assistant messages, status rows, composer, and related chat surfaces.
- Resets the preference with the rest of Appearance settings and initializes it for standalone and embedded app entry points.

ELI5: The chat column was fixed to a narrow size. This adds three simple width choices so users can give the conversation more room without manually resizing anything.

```text
Settings → Appearance → Chat width
             ↓
      localStorage preference
             ↓
  --chat-column-max-width CSS variable
             ↓
 transcript + composer + chat surfaces
```

## Test Plan

- Added unit coverage for preference normalization, persistence, CSS application, and default reset behavior.
- Added SettingsPage coverage for selecting and persisting Extra-wide.
- Prettier check passed for all changed files.
- `git diff --check` passed.
- Full pre-commit could not complete because the checkout lacks `.venv` and web dependencies; the affected hooks reported missing executables (`.venv/bin/python`, web Prettier/Oxlint/TypeScript tooling).

## Demo

Settings control:

![Appearance settings showing Normal, Wide, and Extra-wide chat width options](https://gist.githubusercontent.com/PattaraS/3ea1bb718c1fcf1768e4017704706c60/raw/appearance-chat-width-full.svg)

Chat view comparison at a wide desktop viewport (2560px):

**Normal**

![Normal chat width](https://gist.githubusercontent.com/PattaraS/ac567d6b36a1a1e8b99189babe484d14/raw/chat-normal-wide.svg)

**Wide**

![Wide chat width](https://gist.githubusercontent.com/PattaraS/ac567d6b36a1a1e8b99189babe484d14/raw/chat-wide-wide.svg)

**Extra-wide**

![Extra-wide chat width](https://gist.githubusercontent.com/PattaraS/ac567d6b36a1a1e8b99189babe484d14/raw/chat-extra-wide-wide.svg)

The comparison uses the same conversation and viewport; only the selected chat width changes. The PR review deployment can be used to verify the live behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover the preference helpers and Appearance selection. Manual browser verification is deferred to the PR review deployment because local frontend dependencies are unavailable in this checkout.

## Changelog

Users can choose Normal, Wide, or Extra-wide chat content from Appearance settings.
