### PR TITLE
fix(server): surface a runner's event rejection as failed, not idle

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4375,6 +4375,38 @@ def _publish_routed_model(session_id: str, model: str) -> None:
     session_stream.publish(session_id, event.model_dump())
 
 
+def _runner_reject_detail(response: httpx.Response) -> str:
+    """
+    Describe a runner's refusal of a forwarded event, for the user-visible error.
+
+    The runner's error bodies are ``{"error": <code>, "detail": <text>}``, but a
+    proxy or an unhandled path can return any shape, so this falls back to a
+    body preview and finally to the bare status code — the caller needs a
+    non-empty message either way. Tolerates response fakes that expose only
+    ``status_code``, since those stand in for the runner across the tests.
+
+    :param response: The runner's 4xx/5xx response to the forwarded event.
+    :returns: A one-line detail, e.g.
+        ``"harness_spawn_failed: harness spawn failed (see runner log)"``.
+    """
+    detail: str | None = None
+    code: str | None = None
+    payload: object = None
+    with contextlib.suppress(ValueError, AttributeError):
+        payload = response.json()
+    if isinstance(payload, dict):
+        raw_detail = payload.get("detail")
+        raw_code = payload.get("error")
+        detail = raw_detail.strip() if isinstance(raw_detail, str) and raw_detail.strip() else None
+        code = raw_code.strip() if isinstance(raw_code, str) and raw_code.strip() else None
+    if detail is None and code is not None:
+        return code
+    if detail is None:
+        body = getattr(response, "text", "") or ""
+        return body.strip()[:200] or f"runner returned status {response.status_code}"
+    return f"{code}: {detail}" if code else detail
+
+
 async def _forward_event_to_runner(
     session_id: str,
     conv: Conversation,
@@ -4832,11 +4864,44 @@ async def _forward_event_to_runner(
     # and starts the turn as a background task. No streaming
     # response to drain — events flow through GET /stream.
     try:
-        await runner_client.post(
+        _forward_resp = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json=runner_body,
             timeout=_RUNNER_FORWARD_TIMEOUT,
         )
+        # httpx only raises on transport errors, so a rejection (e.g. a 400 on a
+        # malformed body, or a 501 from a runner with no process manager) would
+        # otherwise read as a started turn: input.consumed would tell the client
+        # the runner has the message and the session would sit "running" until
+        # something else moved it. The turn's own failures do NOT come back here
+        # — the runner accepts with 202 and reports them over the relay — so
+        # this only catches "the runner never took the message". Checked on the
+        # status rather than via ``raise_for_status`` so the runner-client fakes
+        # that only expose ``status_code`` behave as they do in production.
+        if _forward_resp.status_code >= 400:
+            # The live runner took nothing, so ``idle`` would read as a finished
+            # turn that never ran. Persist the reason: the status edge is
+            # SSE-only and would vanish on reload. Not strictly terminal — the
+            # item stays persisted, so a later reconnect can still replay it as
+            # a recovery turn.
+            _reject_detail = _runner_reject_detail(_forward_resp)
+            _logger.warning(
+                "Runner rejected forwarded event for session=%s status=%s detail=%s",
+                session_id,
+                _forward_resp.status_code,
+                _reject_detail,
+            )
+            _reject_error = ErrorDetail(code="runner_rejected_event", message=_reject_detail)
+            # Persist before publishing: a client that reloads on the ``failed``
+            # edge must not race a snapshot that has no ``last_task_error`` yet.
+            await _persist_session_status_error_labels(
+                session_id, _reject_error, conversation_store
+            )
+            _publish_status(session_id, "failed", _reject_error)
+            raise OmnigentError(
+                f"Runner rejected the message: {_reject_detail}",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
         # Publish input.consumed AFTER the forward succeeds —
         # the runner has the message and will start the turn.
         _publish_input_consumed(session_id, persisted_items[0])
@@ -4923,6 +4988,11 @@ async def _forward_event_to_runner(
                     attempted_override=_overridden,
                 )
     except (httpx.HTTPError, ConnectionError) as exc:
+        # Transport failure — the runner never answered. The message is already
+        # persisted (invariant I1), and a trailing user item is what
+        # ``create_session`` replays as a recovery turn when the runner
+        # reconnects, so this really is a queued message rather than a failure.
+        # Keep publishing ``idle`` so the composer is released for a retry.
         _logger.exception(
             "Forward to runner failed for session=%s",
             session_id,
@@ -8958,6 +9028,7 @@ __all__ = [
     "_resolve_elicitation",
     "_run_managed_launch",
     "_run_managed_wake",
+    "_runner_reject_detail",
     "_schedule_deferred_elicitation_clear",
     "_spawn_archive_stop",
     "_spawn_gateway_backed",

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -641,6 +641,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _resolve_elicitation as _resolve_elicitation,
     _run_managed_launch as _run_managed_launch,
     _run_managed_wake as _run_managed_wake,
+    _runner_reject_detail as _runner_reject_detail,
     _schedule_deferred_elicitation_clear as _schedule_deferred_elicitation_clear,
     _spawn_native_approval_popup_forward as _spawn_native_approval_popup_forward,
     _spawn_native_blocked_notice_forward as _spawn_native_blocked_notice_forward,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -8422,3 +8422,69 @@ async def test_message_forward_failure_surfaces_runner_unavailable(
         )
     finally:
         await fake_runner.aclose()
+
+
+async def test_message_forward_rejection_surfaces_failed_with_reason(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A runner that *rejects* the forward fails the session with the reason.
+
+    Distinct from the transport-failure test above. httpx only raises on
+    transport errors, so a runner that answers ``503 harness_spawn_failed``
+    used to read as a started turn: ``input.consumed`` was published and the
+    session settled ``idle``, masking a real failure as a finished turn. The
+    live runner took nothing, so it must surface as ``failed`` carrying the
+    runner's detail, durably enough to survive a reload.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            return httpx.Response(
+                503,
+                json={
+                    "error": "harness_spawn_failed",
+                    "detail": "harness spawn failed (see runner log)",
+                },
+            )
+        return httpx.Response(202, json={})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+
+    async def _fake_get_runner_client(
+        session_id: str,
+        runner_router: object,
+    ) -> httpx.AsyncClient | None:
+        del session_id, runner_router
+        return fake_runner
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(client, agent["id"])
+        sid = session["id"]
+
+        resp = await client.post(
+            f"/v1/sessions/{sid}/events",
+            json={
+                "type": "message",
+                "data": {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+            },
+        )
+        assert resp.status_code == 503, resp.text
+
+        # The rejection is durable: the session reads failed on reload and
+        # last_task_error carries the runner's own reason, not a bare "failed".
+        snap = (await client.get(f"/v1/sessions/{sid}")).json()
+        assert snap["status"] == "failed", snap
+        last_error = snap.get("last_task_error")
+        assert last_error is not None, f"expected a persisted last_task_error, got {snap}"
+        assert last_error["code"] == "runner_rejected_event", last_error
+        assert "harness_spawn_failed" in last_error["message"], last_error
+    finally:
+        await fake_runner.aclose()

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -2287,3 +2287,57 @@ async def test_persist_error_labels_short_message_stored_verbatim() -> None:
         captured["d6e1678fb446a1cf5a892e0df60aaba3"]["omnigent.last_task_error_code"]
         == "runner_error"
     )
+
+
+# ── _runner_reject_detail ────────────────────────────────────────────────────
+
+
+def test_runner_reject_detail_combines_error_code_and_detail() -> None:
+    """The runner's own ``{error, detail}`` shape reads as ``code: detail``."""
+    import httpx
+
+    from omnigent.server.routes.sessions import _runner_reject_detail
+
+    resp = httpx.Response(
+        503,
+        request=httpx.Request("POST", "http://runner/v1/sessions/conv_x/events"),
+        json={"error": "harness_spawn_failed", "detail": "harness spawn failed (see log)"},
+    )
+    assert _runner_reject_detail(resp) == "harness_spawn_failed: harness spawn failed (see log)"
+
+
+def test_runner_reject_detail_falls_back_through_code_body_and_status() -> None:
+    """Each degraded body shape still yields a non-empty reason.
+
+    The reason becomes the user-visible ``last_task_error``, so an
+    error-code-only body, a non-JSON body, and an empty body must each
+    produce something better than a bare "failed".
+    """
+    import httpx
+
+    from omnigent.server.routes.sessions import _runner_reject_detail
+
+    req = httpx.Request("POST", "http://runner/v1/sessions/conv_x/events")
+
+    code_only = httpx.Response(501, request=req, json={"error": "not_implemented"})
+    assert _runner_reject_detail(code_only) == "not_implemented"
+
+    non_json = httpx.Response(400, request=req, text="bad request body")
+    assert _runner_reject_detail(non_json) == "bad request body"
+
+    empty = httpx.Response(503, request=req)
+    assert _runner_reject_detail(empty) == "runner returned status 503"
+
+
+def test_runner_reject_detail_tolerates_status_only_response_fake() -> None:
+    """A fake exposing only ``status_code`` degrades to the status line.
+
+    Runner-client stubs across the server tests return lightweight fakes
+    without ``json()``; the helper must not raise on them.
+    """
+    from omnigent.server.routes.sessions import _runner_reject_detail
+
+    class _Fake:
+        status_code = 503
+
+    assert _runner_reject_detail(_Fake()) == "runner returned status 503"  # type: ignore[arg-type]


### PR DESCRIPTION
## Related issue

Closes #1113

## Summary

Forwarding a message to the runner never checked the HTTP status. httpx only raises on transport errors, so a runner that *answered* with a 4xx/5xx read as a started turn: the server published `input.consumed` — telling the client the runner had the message — and the session settled `idle`, showing a finished turn for work that never ran. This is the "finished badge masking a real failure" case in #1113.

A rejection now surfaces as `failed` carrying the runner's own `error`/`detail`, persisted as labels so the reason survives a reload instead of vanishing with the SSE edge.

**The two failure modes are handled differently, and that's the load-bearing decision here.** The issue suggested treating both as `failed`; that would have broken working recovery. On a *transport* failure the runner never answered, the message is already persisted (invariant I1), and a trailing user item is exactly what `create_session` replays as a recovery turn when the runner reconnects (`_on_runner_connect` → `initialize` without `suppress_recovery_turn`). That really is queued, so it keeps publishing `idle`. On a *rejection* the runner answered and took nothing, so the current connection will never run that turn — only that one becomes `failed`.

**`failed` here is best-effort, not strictly terminal.** The rejected item stays persisted, so the same reconnect machinery can replay it later; `suppress_recovery_turn` only guards the immediate init-before-forward path. That is the intended semantics rather than an accident: for a transient rejection (a `501` from a runner that came up without a process manager) a later replay is exactly the recovery you want, and for a deterministic one (a `400` on a malformed body) the replay just re-rejects and re-publishes `failed`, which is harmless. The alternative — dropping the item to make `failed` durable — would violate invariant I1 and lose the user's message. Pinned by `tests/runner/test_suppress_recovery_turn.py::test_without_suppress_recovery_turn_starts_recovery_turn_from_history`, which asserts the replay directly.

**ELI5:** The server handed the runner a message and assumed it was accepted without reading the reply. When the runner said "no", the server still told the UI "message delivered" and then marked the chat finished — so a turn that never ran looked successful. Now the server reads the reply, and a refusal shows up as a failure with the runner's reason.

```text
                        before                          after
runner answers 503  ──> input.consumed published   ──>  failed + reason, persisted
                        session settles idle            (nothing was queued)
transport drops     ──> session settles idle       ──>  unchanged: idle
                        (recovery turn replays it)      (recovery turn replays it)
```

- Check the forward's status; on >=400 publish `session.status: failed` with `ErrorDetail(code="runner_rejected_event")` and persist it via `_persist_session_status_error_labels` so `last_task_error` survives reload
- Suppress `input.consumed` on a rejection — it previously claimed delivery for a refused message
- New `_runner_reject_detail` extracts the runner's `{error, detail}` shape, degrading through code-only, non-JSON body, and bare status so the reason is never empty

### Scope / notes for reviewers

- **Scoped to Gap 3 of #1113.** Gaps 1 and 2 are already fixed on `main` (#1286 and the `_mark_runner_sessions_offline` rework in #4293), as is the 256-char label truncation from #1467 (`_truncate_label`). The issue body's line numbers all predate the `sessions.py` → `_sessions/` package split.
- **The issue's specific 503 evidence does not apply to this call site.** Both `harness_spawn_failed` returns live inside `_stream_message_to_harness`, reachable only with `stream=true`, which this forward never sets — the runner accepts with 202 and reports turn failures over the relay (already persisted). The real defect is narrower: an unchecked status means *any* rejection (a 400 on a malformed body, a 501 from a runner with no process manager) reads as a started turn.
- **Status is checked directly rather than via `raise_for_status`.** Runner-client fakes across the server tests expose only `status_code`; `runner/app.py:549` documents this same concern ("logging should not make those fakes diverge from production behavior"), and the mid-turn injection path checks status the same way. No test fakes were modified.
- **Out of scope:** `runner/app.py:6175` reduces a spawn error to `"harness returned error response"` on the `stream=true` path, discarding the `detail` it just built (filed as #4358; the background-turn path at `:5441` already decodes the body correctly). Also untouched: the fourth case reported in a #1113 comment (a session marked `failed` while its process is alive and `sys_cancel_task` refuses with "no in-flight task"), which is not one of the issue body's three gaps and needs its own fix — filed as #4357.

## Test Plan

- [x] New integration test `test_message_forward_rejection_surfaces_failed_with_reason`: a runner answering `503 {"error": "harness_spawn_failed"}` leaves the session `failed` with `last_task_error` carrying the reason
- [x] Three unit tests for `_runner_reject_detail` covering each fallback (code-only body, non-JSON, empty body, status-only fake)
- [x] Existing `test_message_forward_failure_surfaces_runner_unavailable` still passes, proving the transport/recovery path is unchanged
- [x] `tests/server/integration/test_sessions_endpoints.py` — 204 passed
- [x] `test_sessions_harness_override.py`, `test_sessions_model_override.py`, `test_routing_integration.py`, `test_sessions_policy_evaluate.py` — 121 passed
- [x] `ruff format` / `ruff check` clean; `pyrefly check` on both changed modules reports 0 errors

Two pre-existing issues worth flagging, both verified as unrelated to this change:

- 9 failures in `test_sessions_snapshot.py` appear when several route test files run in one invocation (test-ordering pollution). Captured the `FAILED` set with and without this diff — byte-identical. All 44 pass in isolation.
- The `pyrefly` pre-commit hook matches zero files when run from a worktree under gitignored `.claude/`, failing identically on stock `main`. Ran `pyrefly check` directly instead (0 errors); please run `pre-commit` from a main checkout to confirm.

## Verification Commands

```bash
# The new rejection test plus the transport test it must not disturb
uv run pytest tests/server/integration/test_sessions_endpoints.py \
  -k "forward_rejection or forward_failure" -v

# Detail-helper fallbacks
uv run pytest tests/server/routes/test_sessions_snapshot.py -k runner_reject -v

# Suites touching the forward path (run snapshot separately — see note above)
uv run pytest tests/server/integration/test_sessions_endpoints.py \
  tests/server/integration/test_sessions_harness_override.py \
  tests/server/integration/test_sessions_model_override.py -q
uv run pytest tests/server/routes/test_sessions_snapshot.py -q
```

## Demo

N/A — server-side status/error plumbing, no UI change. The user-visible effect is that an existing UI path (`chatStore` rendering `session.lastTaskError`) now receives a reason on this edge instead of nothing.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage only. The rejection path is driven end-to-end through the real route with `httpx.MockTransport` standing in for the runner, asserting both the live status and the reload-visible `last_task_error`, so no manual verification was needed.

## Changelog

A session whose message the runner refuses now reports the failure and its reason instead of appearing to finish successfully.

This pull request and its description were written by Isaac.

