### PR TITLE
test: gate Linux-only sandbox tests + isolate ambient model-pin env (#4279 classes 1 & 3)

### DIFF
--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -53,6 +53,15 @@ from omnigent.inner.sandbox import SandboxPolicy, with_denied_unix_sockets
 
 BWRAP_AVAILABLE = shutil.which("bwrap") is not None
 
+# Skip anything that reaches real bwrap resolution/execution when bwrap is not
+# available (macOS, Windows, or a bwrap-less Linux box) — the backend hard-errors
+# off Linux by design. Defined here at module top so it can decorate tests
+# throughout the file, including the resolver tests below (issue #4279: it was
+# previously defined *after* those tests, so it never gated them).
+pytestmark_bwrap = pytest.mark.skipif(
+    not BWRAP_AVAILABLE, reason="bwrap not installed on this host"
+)
+
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -246,6 +255,7 @@ def _repo_root() -> Path:
 # ---------------------------------------------------------------------------
 
 
+@pytestmark_bwrap
 def test_resolve_default_keeps_cwd_read_only() -> None:
     """
     ``write_paths`` omitted (the common case) leaves ``write_roots``
@@ -273,6 +283,7 @@ def test_resolve_default_keeps_cwd_read_only() -> None:
     assert policy.read_roots is None  # No spec-supplied read_paths.
 
 
+@pytestmark_bwrap
 def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     """
     Setting ``write_paths: ["."]`` flips cwd to writable. This is the
@@ -289,6 +300,7 @@ def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     assert policy.write_roots == [Path.cwd().resolve(strict=False)]
 
 
+@pytestmark_bwrap
 def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     """
     ``cwd_allow_hidden=None`` in the spec resolves to the documented
@@ -310,6 +322,7 @@ def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     )
 
 
+@pytestmark_bwrap
 def test_resolve_explicit_cwd_allow_hidden_overrides_default() -> None:
     """
     An explicit ``cwd_allow_hidden`` in the spec replaces the default
@@ -1502,11 +1515,6 @@ def test_s5_read_paths_dedup_skips_paths_under_cwd(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Seccomp profile (real bwrap subprocess required)
 # ---------------------------------------------------------------------------
-
-
-pytestmark_bwrap = pytest.mark.skipif(
-    not BWRAP_AVAILABLE, reason="bwrap not installed on this host"
-)
 
 
 @pytestmark_bwrap

--- a/tests/inner/test_claude_router_hook.py
+++ b/tests/inner/test_claude_router_hook.py
@@ -12,6 +12,27 @@ from omnigent.claude_model_vocabulary import claude_model_alias
 from omnigent.inner.hook_scripts import claude_router_hook, subagent_router
 from tests.inner.conftest import advertise_relay_tools, advertise_router
 
+# Gateway model pins that alias resolution reads from the ambient environment.
+_ANTHROPIC_DEFAULT_MODEL_VARS = (
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_anthropic_default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ambient ``ANTHROPIC_DEFAULT_*_MODEL`` pins for every test here.
+
+    ``alias_pins()`` falls back to ``os.environ`` and ``claude_model_alias``
+    returns ``None`` on a *mismatched* pin, so any developer whose shell pins
+    these vars (anyone driving Claude through a gateway) gets no translation and
+    these tests fail spuriously (issue #4279). Tests that need a specific pin set
+    it explicitly after this autouse fixture has cleared the ambient value.
+    """
+    for var in _ANTHROPIC_DEFAULT_MODEL_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 def _payload(
     *,

--- a/tests/inner/test_seccomp.py
+++ b/tests/inner/test_seccomp.py
@@ -224,6 +224,12 @@ def _run_in_child(probe: str) -> int:
     :param probe: Python source to run in the child.
     :returns: The child's exit code.
     """
+    # seccomp (prctl/seccomp_load) and os.fork() are Linux-only; off Linux the
+    # child dies with "dlsym(prctl): symbol not found" (macOS) or os.fork raises
+    # (Windows). Skip here so every real-filter test that forks a child is gated
+    # in one place (issue #4279), rather than each carrying its own marker.
+    if sys.platform != "linux":
+        pytest.skip("seccomp filter tests require Linux (prctl/seccomp_load + os.fork)")
     pid = os.fork()
     if pid == 0:
         os.execvp(sys.executable, [sys.executable, "-c", probe])
@@ -314,6 +320,10 @@ def test_apply_baseline_denylist_does_not_break_subprocess_basics() -> None:
     )
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="references socket.AF_NETLINK (Linux-only) while building the probe",
+)
 def test_arg_filter_blocks_socket_family_only() -> None:
     """
     ``SCMP_CMP_EQ`` on ``socket(domain, ...)`` returns ``EPERM`` for

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -31,6 +31,22 @@ from tests.runner.conftest import (
 from tests.runner.helpers import NullServerClient
 
 
+@pytest.fixture(autouse=True)
+def _isolate_anthropic_default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ambient ``ANTHROPIC_DEFAULT_*_MODEL`` gateway pins (#4279).
+
+    claude-native model resolution reads these from ``os.environ``; a developer
+    whose shell pins them (anyone driving Claude through a gateway) otherwise
+    gets a different model-change verdict and these tests fail spuriously.
+    """
+    for var in (
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "effort_value",


### PR DESCRIPTION
## Related issue

Addresses #4279 (classes 1 & 3). Does not fully close it — see "Scope" below.

## Summary

Two of the four test-isolation gaps in #4279. I picked the two that also reproduce **off Linux generally** (I verified each on a Windows checkout, not just macOS), so `pytest` stops throwing spurious reds a contributor didn't cause.

### Class 1 — Linux-only tests with no working platform gate

- `tests/inner/test_bwrap_sandbox.py`: the 4 resolver tests call `BwrapSandboxBackend.resolve()`, which hard-errors off Linux by design. A skip marker existed but was defined **below** them (`pytestmark_bwrap`), so it never decorated them. Moved the marker to module top and decorated the 4. The two tests that *assert* the off-Linux raise (`test_resolve_raises_on_non_linux`, `..._when_bwrap_missing`) are deliberately left running.
- `tests/inner/test_seccomp.py`: the filter tests fork a child that loads a real BPF program (`prctl`/`seccomp_load`); off Linux the child dies (`dlsym(prctl)` not found on macOS, `os.fork` missing on Windows). Added the Linux gate once in the shared `_run_in_child` helper, plus a dedicated skip on the one test that references `socket.AF_NETLINK` (Linux-only) while *building* its probe, before the fork.

### Class 3 — ambient `ANTHROPIC_DEFAULT_*_MODEL` alias pins leaked in

`alias_pins()` falls back to `os.environ` and `claude_model_alias` returns `None` on a *mismatched* pin, so any developer whose shell pins those vars (anyone driving Claude through a gateway) gets no translation and the tests fail. Added an autouse fixture clearing all three vars in `test_claude_router_hook.py` and `test_app_sessions_native_events_options.py` — generalizing the isolation one test already did inline.

## Test Plan

Each gap was reproduced then fixed on a Windows checkout:

- Class 1: the 4 bwrap resolver tests and the 6 seccomp filter tests **failed** on `main` (`OSError: only available on Linux`; `os has no attribute 'fork'`); with the change they **skip**.
- Class 3: with `ANTHROPIC_DEFAULT_OPUS_MODEL` (etc.) exported, `test_legacy_task_tool_name_is_routed` and `test_events_model_change_on_native_session_returns_503_when_bridge_not_ready` **failed** on `main`; with the autouse fixture they **pass** regardless of ambient env.

```
OMNIGENT_SKIP_WEB_UI=true uv run pytest \
  tests/inner/test_bwrap_sandbox.py tests/inner/test_seccomp.py \
  tests/inner/test_claude_router_hook.py \
  tests/runner/test_app_sessions_native_events_options.py -q
# 158 passed, 15 skipped (+ 3 unrelated pre-existing Windows-only failures:
#   a symlink-privilege test, a dead-pid test, and a localhost-port test —
#   all fail identically on clean main and are out of scope)
```

`ruff check` + `ruff format --check` clean.

## Scope

Classes 2 (AF_UNIX 104-byte socket-path cap) and 4 (`HOME` / macOS Keychain isolation) from the same issue are genuinely macOS/Linux runtime-specific — on Windows `os.path.expanduser` ignores `HOME` and there is no tmux — so I can't verify them on this box and have left them for a follow-up by someone who can run the macOS suite. I kept this PR to the two classes I could prove end to end.

## Demo

N/A. Test-only change (platform gating + env isolation); no product code touched.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Changelog

Gated the Linux-only bwrap/seccomp tests behind a working skip marker and isolated ambient `ANTHROPIC_DEFAULT_*_MODEL` pins in the model-router tests, so the suite is a usable local signal off Linux.
