### PR TITLE
fix(web): stop a stalled POST from blocking every send in the tab

### DIFF
--- a/tests/e2e_ui/sessions/test_cross_session_routing.py
+++ b/tests/e2e_ui/sessions/test_cross_session_routing.py
@@ -18,6 +18,12 @@ never-to-A — once for a plain-text follow-up, and once for a follow-up carryin
 an image (upload → ``input_image`` post, both addressed to B). (The FIFO/idle
 unit behavior is covered by the ``chatStore`` tests.)
 
+A third test pins the other side of that isolation: a send whose POST never
+settles must not wedge a DIFFERENT session. POSTs are serialized through a
+client-side ordering chain, and while that chain was one per tab a single
+stalled POST blocked every later send in every conversation — silently, with
+a page reload as the only recovery.
+
 Why async Playwright (not the sync ``page`` fixture): the test inspects the
 body of every ``/events`` POST via a route handler and asserts on which
 session each was addressed to, across interleaved UI actions (send, switch
@@ -46,6 +52,7 @@ _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 # Unique sentinels so each POST body is unambiguously identifiable.
 _MSG1 = "sentinel-xsess-msg1-3a7f first message into B"
 _MSG2 = "sentinel-xsess-msg2-9c2e second message into B"
+_MSG3 = "sentinel-xsess-msg3-5d1b message into A while B is stalled"
 
 _EVENTS_RE = re.compile(r"/v1/sessions/([^/]+)/events$")
 
@@ -125,6 +132,100 @@ def test_queued_message_with_image_flushes_to_origin(
     """
     base_url, session_a, session_b = seeded_session_pair
     _run_in_fresh_loop(_drive_cross_session_image_flush(base_url, session_a, session_b))
+
+
+def test_stalled_send_does_not_block_another_session(
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """A send whose POST never settles must not wedge a different session.
+
+    POSTs are serialized through a client-side chain so they reach the
+    server in submission order. That chain used to be one per tab, and a
+    POST whose connection dies mid-flight never settles — so its link was
+    never released and EVERY later send, in every conversation, parked on
+    it forever. The composer just kept queueing with no error, and only a
+    page reload cleared it.
+
+    Failure mode this catches: B's stalled POST blocks the send in A, so
+    ``_MSG3`` never reaches the server at all.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _run_in_fresh_loop(_drive_stalled_send_isolation(base_url, session_a, session_b))
+
+
+async def _drive_stalled_send_isolation(base_url: str, session_a: str, session_b: str) -> None:
+    """Async body of the stalled-send isolation test.
+
+    :param base_url: Spawned server base URL.
+    :param session_a: The healthy session, sent to while B is stalled.
+    :param session_b: The session whose POST is held open for good.
+    """
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        # Never set during the test body: B's POST models a connection that
+        # died in flight, so it stays pending until teardown releases the
+        # handler (leaving it awaiting a browser close would strand the task).
+        release_b = asyncio.Event()
+        try:
+            event_posts: list[tuple[str, str]] = []
+            b_post_held = False
+
+            async def handle_events(route: Route) -> None:
+                nonlocal b_post_held
+                request = route.request
+                match = _EVENTS_RE.search(request.url)
+                assert match is not None, f"unexpected /events url: {request.url}"
+                session_id = match.group(1)
+                text = request.post_data_json["data"]["content"][0]["text"]
+                event_posts.append((session_id, text))
+                if session_id == session_b and not b_post_held:
+                    b_post_held = True
+                    await release_b.wait()
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            await page.route("**/v1/sessions/*/events", handle_events)
+
+            await page.goto(f"{base_url}/c/{session_b}")
+            composer = page.get_by_label("Message the agent")
+            await page.get_by_placeholder(_COMPOSER_PLACEHOLDER).wait_for(
+                state="visible", timeout=15_000
+            )
+            send_button = page.get_by_role("button", name="Send", exact=True)
+
+            # B's POST goes out and is never answered — the stalled send.
+            await composer.fill(_MSG1)
+            await send_button.click()
+            await _wait_until(lambda: b_post_held)
+
+            # Switch to A via the sidebar (client-side nav — a reload would
+            # reset the JS module state holding the chain, dissolving the bug).
+            await page.locator(f'a[href="/c/{session_a}"]').click()
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
+            # A is its own session and idle, so this send dispatches rather
+            # than queueing — the placeholder proves it before we type.
+            await page.get_by_placeholder(_COMPOSER_PLACEHOLDER).wait_for(
+                state="visible", timeout=15_000
+            )
+
+            # The assertion: A's send reaches the server while B is still
+            # stalled. Before the fix it never POSTed at all.
+            await page.get_by_label("Message the agent").fill(_MSG3)
+            await page.get_by_role("button", name="Send", exact=True).click()
+            await _wait_until(lambda: any(text == _MSG3 for _, text in event_posts))
+            assert [sid for sid, text in event_posts if text == _MSG3] == [session_a], (
+                f"msg3 must be delivered to the active session A, got {event_posts}"
+            )
+            # B's POST is still in flight — the isolation is what let A through,
+            # not B's send having quietly resolved.
+            assert not release_b.is_set()
+        finally:
+            release_b.set()
+            await browser.close()
 
 
 async def _drive_cross_session_image_flush(base_url: str, session_a: str, session_b: str) -> None:

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2403,6 +2403,46 @@ describe("chatStore — send while streaming (queueing)", () => {
     expect(useChatStore.getState().activeResponse?.state).toBe("cancelled");
   });
 
+  it("surfaces a failed send without settling the live turn", async () => {
+    // A send that fails while a turn is streaming used to roll its optimistic
+    // bubble back and stop there — no error block, no status change. That
+    // silence is why a message that never reaches the agent looks like it was
+    // never typed. The error must show; the live turn must not be touched.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      abortController: new AbortController(),
+      status: "streaming",
+      sessionStatus: "running",
+      activeResponse: { responseId: "resp_in_flight", state: "streaming", error: null },
+      blocks: [],
+      pendingUserMessages: [],
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_abc/events" && init?.method === "POST") {
+        return Promise.reject(new Error("network down"));
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().send("does this vanish?", "agent_xyz");
+
+    const state = useChatStore.getState();
+    const errorBlocks = state.blocks.filter((b) => b.type === "error");
+    expect(errorBlocks).toHaveLength(1);
+    expect(errorBlocks[0]).toMatchObject({ type: "error", message: "network down" });
+    // The optimistic bubble rolls back — no server record will reconcile it.
+    expect(state.pendingUserMessages).toHaveLength(0);
+    // The in-flight turn keeps its lifecycle: not failed, not settled.
+    expect(state.activeResponse).toEqual({
+      responseId: "resp_in_flight",
+      state: "streaming",
+      error: null,
+    });
+    expect(state.status).toBe("streaming");
+  });
+
   it("revive is a no-op for failed and absent responses", () => {
     useChatStore.setState({
       conversationId: "conv_abc",
@@ -9049,6 +9089,97 @@ describe("chatStore — client-side message queue", () => {
     expect(sendSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["stranded?", "agent_xyz"]);
   });
+
+  /**
+   * Drive a send whose POST never settles, leaving `status` latched to
+   * "streaming", then queue a message behind it.
+   *
+   * @param rowStatus - the session's status in the sidebar cache, i.e. the
+   *   server's own view of whether a turn is running.
+   * @returns the texts delivered to /events, appended to as the test advances.
+   */
+  async function wedgeOnHungSend(rowStatus: Conversation["status"]): Promise<string[]> {
+    seedConversationsCache([conv("conv_abc", rowStatus)]);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+      queuedMessages: [],
+    });
+
+    const delivered: string[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_abc/events" && init?.method === "POST") {
+        const text = JSON.parse(init.body as string).data.content[0].text;
+        delivered.push(text);
+        if (text === "hung") return new Promise<Response>(() => {});
+        return mockResponse({ queued: true, item_id: "ci_ok" });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    void useChatStore.getState().send("hung", "agent_xyz");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(delivered).toEqual(["hung"]);
+    expect(useChatStore.getState().status).toBe("streaming");
+
+    // enqueueMessage flushes eagerly; the latch must hold it back.
+    useChatStore.getState().enqueueMessage("queued", undefined);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(delivered).toEqual(["hung"]);
+    return delivered;
+  }
+
+  it("drains the queue once a stranded send latch outlives any plausible POST", async () => {
+    // The wedge: postEvent has no timeout, so a POST whose connection dies
+    // mid-flight never settles. `status` stays "streaming" forever and that
+    // same flag gates the queue — every later message queues with no error and
+    // no recovery short of a page reload.
+    vi.useFakeTimers();
+    try {
+      const delivered = await wedgeOnHungSend("idle");
+
+      // Still within the window a real POST could take: the latch is honored.
+      await vi.advanceTimersByTimeAsync(120_000);
+      useChatStore.getState().maybeFlushQueuedHead();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual(["hung"]);
+
+      // Past it, with the session's own row reading idle, the latch is
+      // stranded: it clears and the queue drains.
+      await vi.advanceTimersByTimeAsync(60_000);
+      useChatStore.getState().maybeFlushQueuedHead();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual(["hung", "queued"]);
+      expect(useChatStore.getState().queuedMessages).toEqual([]);
+      // The stale latch was cleared — the drain's own send owns this one, and
+      // its clock restarts, so it can't inherit the stranded send's staleness.
+      expect(useChatStore.getState().status).toBe("streaming");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the queue parked when the session is genuinely running", async () => {
+    // Same elapsed time, different server truth. Overriding the latch here
+    // would double-send into a live turn, so only the server's own idle row
+    // may override it.
+    vi.useFakeTimers();
+    try {
+      const delivered = await wedgeOnHungSend("running");
+
+      await vi.advanceTimersByTimeAsync(300_000);
+      useChatStore.getState().maybeFlushQueuedHead();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual(["hung"]);
+      expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["queued"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("chatStore — background cross-session flush", () => {
@@ -9340,59 +9471,151 @@ describe("chatStore — background cross-session flush", () => {
     });
   });
 
-  it("serializes a background flush behind an in-flight foreground send (FIFO across paths)", async () => {
-    // The navigate-away race: a foreground send() for the active conversation is
-    // still in flight (its /events POST held open) when the background flush
-    // fires for another conversation. Both POSTs must go through the one send
-    // chain, so the background POST cannot overtake the foreground one — it
-    // waits until the foreground POST resolves.
-    seedConversationsCache([conv("conv_active", "idle"), conv("conv_bg", "idle")]);
+  it("serializes a background flush behind an in-flight foreground send to the same conversation", async () => {
+    // The navigate-away race: a foreground send() for conv_a is still in flight
+    // (its /events POST held open) when the user switches away, so conv_a's
+    // queue now drains via the background path. Both take a slot on conv_a's
+    // chain, so the background POST cannot overtake the foreground one.
+    seedConversationsCache([conv("conv_a", "idle"), conv("conv_other", "idle")]);
     useChatStore.setState({
-      conversationId: "conv_active",
+      conversationId: "conv_a",
       boundAgentId: "agent_xyz",
       abortController: new AbortController(),
       status: "idle",
       sessionStatus: "idle",
-      queuedMessages: [{ queueId: "q_1", text: "bg-msg", conversationId: "conv_bg" }],
+      queuedMessages: [],
     });
 
-    // Hold conv_active's foreground POST open; conv_bg's background POST resolves
-    // immediately. Records delivery order across both endpoints.
+    // Both POSTs hit the same endpoint, so order is recorded by message text.
     const delivered: string[] = [];
     let releaseForeground: () => void = () => {};
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url === "/v1/sessions/conv_active/events" && init?.method === "POST") {
-        delivered.push("foreground");
-        return new Promise<Response>((resolve) => {
-          releaseForeground = () => resolve(mockResponse({ queued: true, item_id: "ci_fg" }));
-        });
-      }
-      if (url === "/v1/sessions/conv_bg/events" && init?.method === "POST") {
-        delivered.push("background");
+      if (url === "/v1/sessions/conv_a/events" && init?.method === "POST") {
+        const text = JSON.parse(init.body as string).data.content[0].text;
+        delivered.push(text);
+        if (text === "fg-msg") {
+          return new Promise<Response>((resolve) => {
+            releaseForeground = () => resolve(mockResponse({ queued: true, item_id: "ci_fg" }));
+          });
+        }
         return mockResponse({ queued: true, item_id: "ci_bg" });
       }
       return defaultFetchHandler(input, init);
     });
 
-    // Foreground send() takes the first chain slot and its POST is held open.
+    // Foreground send() takes conv_a's first chain slot; its POST is held open.
     const fg = useChatStore.getState().send("fg-msg", "agent_xyz");
     await tick();
-    expect(delivered).toEqual(["foreground"]);
+    expect(delivered).toEqual(["fg-msg"]);
 
-    // Background flush fires while the foreground POST is still in flight. It
-    // must NOT deliver yet — it's queued behind the foreground POST on the chain.
+    // User navigates away, handing conv_a's queue to the background path.
+    useChatStore.setState({
+      conversationId: "conv_other",
+      queuedMessages: [{ queueId: "q_1", text: "bg-msg", conversationId: "conv_a" }],
+    });
     useChatStore.getState().flushBackgroundQueues();
     await tick();
     await tick();
-    expect(delivered).toEqual(["foreground"]);
+    expect(delivered).toEqual(["fg-msg"]);
 
     // Release the foreground POST → the background POST is now free to deliver.
     releaseForeground();
     await fg;
     await tick();
     await tick();
-    expect(delivered).toEqual(["foreground", "background"]);
+    expect(delivered).toEqual(["fg-msg", "bg-msg"]);
+  });
+
+  it("does not serialize sends across different conversations", async () => {
+    // Ordering only means anything WITHIN a conversation. A single global chain
+    // let one stalled POST wedge every session in the tab, so a POST held open
+    // for conv_a must not delay a send to conv_b.
+    seedConversationsCache([conv("conv_a", "idle"), conv("conv_b", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_a",
+      boundAgentId: "agent_xyz",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+      queuedMessages: [],
+    });
+
+    const delivered: string[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_a/events" && init?.method === "POST") {
+        delivered.push("conv_a");
+        // Never settles — conv_a's chain stays occupied for the whole test.
+        return new Promise<Response>(() => {});
+      }
+      if (url === "/v1/sessions/conv_b/events" && init?.method === "POST") {
+        delivered.push("conv_b");
+        return mockResponse({ queued: true, item_id: "ci_b" });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    void useChatStore.getState().send("a-msg", "agent_xyz");
+    await tick();
+    expect(delivered).toEqual(["conv_a"]);
+
+    useChatStore.setState({ conversationId: "conv_b" });
+    void useChatStore.getState().send("b-msg", "agent_xyz");
+    await tick();
+    await tick();
+    expect(delivered).toEqual(["conv_a", "conv_b"]);
+  });
+
+  it("releases the chain when a prior send's POST never settles", async () => {
+    // postEvent issues its fetch with no timeout, so a connection that dies
+    // mid-flight never settles and that send's `finally` never runs. The wait on
+    // the prior send is bounded so the next send to the SAME conversation still
+    // goes out — otherwise the composer queues forever with no error and no
+    // recovery short of a page reload.
+    vi.useFakeTimers();
+    try {
+      seedConversationsCache([conv("conv_a", "idle")]);
+      useChatStore.setState({
+        conversationId: "conv_a",
+        boundAgentId: "agent_xyz",
+        abortController: new AbortController(),
+        status: "idle",
+        sessionStatus: "idle",
+        queuedMessages: [],
+      });
+
+      const delivered: string[] = [];
+      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "/v1/sessions/conv_a/events" && init?.method === "POST") {
+          const text = JSON.parse(init.body as string).data.content[0].text;
+          delivered.push(text);
+          if (text === "hung") return new Promise<Response>(() => {});
+          return mockResponse({ queued: true, item_id: "ci_ok" });
+        }
+        return defaultFetchHandler(input, init);
+      });
+
+      void useChatStore.getState().send("hung", "agent_xyz");
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual(["hung"]);
+
+      // Second send parks behind the hung one until the bounded wait expires.
+      void useChatStore.getState().send("after", "agent_xyz");
+      await vi.advanceTimersByTimeAsync(1);
+      expect(delivered).toEqual(["hung"]);
+
+      // A legitimately slow POST (runner session-init, sandbox-host wake) must
+      // still keep its ordering — the bound sits above those, not under them.
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(delivered).toEqual(["hung"]);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(delivered).toEqual(["hung", "after"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -707,12 +707,116 @@ let queryClient: QueryClient | null = null;
 const racedNativeModelOptions = new Map<string, NativeModelOption[]>();
 let pendingSeq = 0;
 let queueSeq = 0;
-// Tail of the send chain. Each `send` waits on the previous send's network
-// work before issuing its own POST, so rapid-fire messages reach the server
-// in submission order. Concurrent `fetch` POSTs have no ordering guarantee,
-// which otherwise lets the server accept messages out of order. Module-level
-// (one active chat at a time); the chain only ever resolves, never rejects.
-let sendChain: Promise<void> = Promise.resolve();
+// Tail of each conversation's send chain. A send waits on the previous send
+// TO THE SAME CONVERSATION before issuing its own POST, so rapid-fire messages
+// reach the server in submission order. Concurrent `fetch` POSTs have no
+// ordering guarantee, which otherwise lets the server accept messages out of
+// order. Keyed by the conversation pinned at submit time; `null` is the
+// not-yet-created session, of which a tab can only have one in flight. Order
+// only means anything WITHIN a conversation, so keying per conversation stops
+// a stalled POST in one from delaying every other conversation in the tab.
+const sendChains = new Map<string | null, Promise<void>>();
+
+// A chain link must never be able to deadlock its successors. `postEvent`
+// issues its fetch with no timeout, so a connection that dies mid-flight never
+// settles and the send's `finally` never releases its link. Waiting on the
+// prior send is therefore bounded: past this the successor proceeds anyway and
+// only ordering degrades, which beats a composer that queues forever with no
+// error and no recovery short of a page reload. Set well above any legitimate
+// POST — a message can block on runner session-init or a sandbox-host wake,
+// which take minutes — so this only ever fires on a send that is truly stuck,
+// never reordering a slow one.
+const SEND_CHAIN_MAX_WAIT_MS = 180_000;
+
+// When a send last latched local `status` to "streaming". Stamped on the way in
+// and never cleared on the way out: after a normal turn `status` settles to
+// "idle" on its own, so a leftover value is inert — only a `status` still
+// reading "streaming" long afterwards makes it meaningful.
+let sendLatchedAt: number | null = null;
+
+/**
+ * Read one conversation's server-side status from the sidebar cache.
+ *
+ * The `["conversations"]` cache is kept live by the WS `/v1/sessions/updates`
+ * overlay and the poll, so it is the one view of a session's real status that
+ * does not depend on this tab's own send lifecycle.
+ *
+ * @returns the row's status, or `undefined` when no loaded page holds the row.
+ */
+function cachedConversationStatus(conversationId: string): string | undefined {
+  if (queryClient === null) return undefined;
+  for (const [, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    for (const page of data?.pages ?? []) {
+      for (const row of page.data) {
+        if (row.id === conversationId) return row.status;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether local `status: "streaming"` is a stranded latch rather than a live send.
+ *
+ * `postEvent` issues its fetch with no timeout, so a POST whose connection dies
+ * mid-flight never settles: `send`'s `finally` never runs and `status` stays
+ * "streaming" forever. That flag gates both the composer and the queue, so every
+ * later message queues with no error and no recovery short of a page reload. A
+ * turn whose terminal SSE edge was lost strands it the same way.
+ *
+ * Nothing separates a stuck send from a slow one except elapsed time, so the
+ * latch is overridden only once it has outlived any plausible POST AND the
+ * session's own row disagrees with it. A live streaming response is never stale.
+ */
+function sendLatchIsStranded(s: ChatState): boolean {
+  if (sendLatchedAt === null || Date.now() - sendLatchedAt < SEND_CHAIN_MAX_WAIT_MS) return false;
+  if (s.activeResponse?.state === "streaming") return false;
+  return s.conversationId !== null && cachedConversationStatus(s.conversationId) === "idle";
+}
+
+/**
+ * Take this send's place in its conversation's POST-ordering chain.
+ *
+ * @param conversationId - Conversation pinned at submit time (`null` for a
+ *   session the send is about to create).
+ * @returns `waitForPrior`, awaited before any network work, and `release`,
+ *   which MUST be called from a `finally` to hand off to the next send.
+ */
+function takeSendChainLink(conversationId: string | null): {
+  waitForPrior: () => Promise<void>;
+  release: () => void;
+} {
+  const prior = sendChains.get(conversationId) ?? Promise.resolve();
+  let resolveLink: () => void = () => {};
+  const link = new Promise<void>((resolve) => {
+    resolveLink = resolve;
+  });
+  sendChains.set(conversationId, link);
+  return {
+    waitForPrior: async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          prior,
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, SEND_CHAIN_MAX_WAIT_MS);
+          }),
+        ]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    },
+    release: () => {
+      resolveLink();
+      // Drop the bucket once this link is still the tail, so the map doesn't
+      // accumulate an entry per conversation the user ever sends to. A
+      // successor that already took a link owns the tail, so this no-ops.
+      if (sendChains.get(conversationId) === link) sendChains.delete(conversationId);
+    },
+  };
+}
 let flashTimer: ReturnType<typeof setTimeout> | null = null;
 const workspaceInvalidationTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -823,9 +927,10 @@ export function initChatStore(client: QueryClient): void {
   workspaceInvalidationTimers.clear();
   backgroundFlushInFlight.clear();
   backgroundFlushCooldownUntil.clear();
-  // Reset the POST-ordering chain so a prior run's unresolved send can't block
+  // Reset the POST-ordering chains so a prior run's unresolved send can't block
   // the next one (production calls this once at boot; tests call it per case).
-  sendChain = Promise.resolve();
+  sendChains.clear();
+  sendLatchedAt = null;
   queryClient = client;
 }
 
@@ -1061,13 +1166,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // sub-agents) outlives it, so the server accepts a new turn immediately —
     // mirror `shouldQueueSend`. Only the local send lifecycle (`streaming`) and
     // an actively `running` turn gate the flush. No agent → nothing to send to.
-    if (
-      s.conversationId === null ||
-      s.boundAgentId === null ||
-      s.status === "streaming" ||
-      s.sessionStatus === "running"
-    ) {
+    if (s.conversationId === null || s.boundAgentId === null || s.sessionStatus === "running") {
       return;
+    }
+    if (s.status === "streaming") {
+      // A send owns the latch, so the queue waits for it — that is the
+      // one-message-per-turn contract. Unless the latch is stranded, in which
+      // case waiting is forever: clear it so the composer also stops queueing
+      // (`shouldQueueSend` reads the same flag) and drain below. Only the
+      // ACTIVE conversation can wedge like this; `flushBackgroundQueues`
+      // already drives every other queue off the server's own status.
+      if (!sendLatchIsStranded(s)) return;
+      sendLatchedAt = null;
+      // The stranded send still holds this conversation's chain link, so the
+      // drain below would park on it for another SEND_CHAIN_MAX_WAIT_MS. Same
+      // evidence, same conclusion: drop the link too. If that send ever does
+      // settle, its `release` only clears an entry it still owns, so a fresh
+      // chain started here is safe.
+      sendChains.delete(s.conversationId);
+      set({ status: "idle" });
     }
     // Flush the FIRST message OF THE BOUND CONVERSATION (FIFO within it), not
     // the global array head. The queue is one flat array across conversations,
@@ -1129,17 +1246,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
         queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
       }));
       // Join the SAME send chain the foreground path uses. A queued message can
-      // hand off from the foreground flush (send() → sendChain) to here the
+      // hand off from the foreground flush (send() → sendChains) to here the
       // moment the user navigates away, and the two POST paths would otherwise
       // race — a background postEvent could overtake a foreground send() still
-      // awaiting its chain slot, delivering out of FIFO order. Taking a slot
-      // here (await priorSend before the upload/post, release in finally)
-      // serializes every POST across both paths through one ordering primitive.
-      const priorSend = sendChain;
-      let releaseSend: () => void = () => {};
-      sendChain = new Promise<void>((resolve) => {
-        releaseSend = resolve;
-      });
+      // awaiting its chain slot, delivering out of FIFO order. Both paths take
+      // a slot on THIS conversation's chain (wait before the upload/post,
+      // release in finally), so they share one ordering primitive per session.
+      const { waitForPrior, release: releaseSend } = takeSendChainLink(conversationId);
       // Upload any attachments, then post the message referencing their
       // server-assigned file_ids — the same two-phase sequence send() runs
       // (no combined endpoint exists: /resources/files stores the blob and
@@ -1152,7 +1265,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // head (preserving this conversation's FIFO order) and set a cooldown so
       // the next trigger backs off instead of hammering a failing runner.
       void (async () => {
-        await priorSend;
+        await waitForPrior();
         // Reuse prior successful uploads so cooldown-paced retries do not
         // orphan blobs that already landed.
         const fileBlocks = await uploadFileBlocks(conversationId, head.files ?? []);
@@ -1202,6 +1315,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // until its own `response.completed` arrives.
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
+      sendLatchedAt = Date.now();
       set({ status: "streaming", activeResponse: null });
     }
 
@@ -1243,22 +1357,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // target afterward would leak the message into the now-active session.
     const submitConversationId = get().conversationId;
 
-    // Take our place in the send chain: wait for the prior send's network
-    // work, then hand off to the next via `releaseSend` in the finally
-    // below. This serializes POSTs in submission order without delaying the
-    // optimistic bubble rendered above. `priorSend` only ever resolves.
-    const priorSend = sendChain;
-    let releaseSend: () => void = () => {};
-    sendChain = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
+    // Take our place in this conversation's send chain: wait for its prior
+    // send's network work, then hand off to the next via `releaseSend` in the
+    // finally below. This serializes POSTs in submission order without delaying
+    // the optimistic bubble rendered above.
+    const { waitForPrior, release: releaseSend } = takeSendChainLink(submitConversationId);
 
     // The session this send actually posts to, once resolved. Read in the
     // catch to decide whether a failure may touch the active session's UI.
     let postedSessionId: string | null = null;
 
     try {
-      await priorSend;
+      await waitForPrior();
       const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
       postedSessionId = sessionId;
 
@@ -1385,6 +1495,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
             set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
           }
           set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0, blockedOn: null });
+        } else {
+          // Sent alongside an already-streaming turn (or a stranded latch). The
+          // bubble is rolled back above, so without a block the message vanishes
+          // with no trace — the failure mode that makes this class of bug so
+          // hard to see. Surface it WITHOUT touching the turn lifecycle:
+          // `finalizeActive` would mark a live response failed, and settling
+          // `status` would end a turn that is still running.
+          set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
         }
       }
     } finally {
@@ -1402,6 +1520,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // serialization) so a skill invocation behaves like any other turn.
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
+      sendLatchedAt = Date.now();
       set({ status: "streaming", activeResponse: null });
     }
     // Optimistic echo of the typed command, mirroring `send`. Without it
@@ -1431,17 +1550,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // resolve mis-routes to the session the user has since switched to.
     const submitConversationId = get().conversationId;
 
-    const priorSend = sendChain;
-    let releaseSend: () => void = () => {};
-    sendChain = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
+    const { waitForPrior, release: releaseSend } = takeSendChainLink(submitConversationId);
 
     // The session this command actually posts to, once resolved.
     let postedSessionId: string | null = null;
 
     try {
-      await priorSend;
+      await waitForPrior();
       const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
       postedSessionId = sessionId;
       // Same wire shape the REPL sends (repl/_repl.py). The server resolves
@@ -1517,6 +1632,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (stillActive && !alreadyStreaming) {
         finalizeActive(set, "failed", message, null);
         set({ status: "idle" });
+      } else if (stillActive) {
+        // Same reasoning as `send`: surface the failure without settling a turn
+        // that may still be live, so a failed command can't vanish silently.
+        const { code } = describeSendFailure(err);
+        set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
       }
     } finally {
       releaseSend();


### PR DESCRIPTION
## Related issue

N/A

## Summary

Messages typed in the chat UI stopped reaching the terminal in a live claude-native session. The composer sat on "Send a follow-up (queued)", nothing arrived, and **steer** — which bypasses the queue gate entirely — was swallowed just as silently.

The runner never received them. Its inbound-event log for that session ends at 20:54:33 and stays empty for the next 75 minutes while the runner keeps posting events normally, and the bridge hook journal shows Claude ending its turn cleanly at 20:57:57 with the server forwarding that edge back. Server and runner were healthy the whole time; the messages never left the browser.

`chatStore` keeps a module-level `sendChain` so POSTs reach the server in submission order. Each `send` awaits the previous one's network work and releases its link in a `finally`. But `postEvent` issues its fetch with **no timeout**, so a POST whose connection dies mid-flight never settles — the `finally` never runs, and the chain is blocked forever. Because the chain is module-level, that wedged *every* conversation in the tab, not just the one. Nothing surfaced an error, and the only reset was a page reload.

```
send A ──POST──▶ ✗ connection dies, promise never settles
                 └── finally never runs, link never released
send B ──await priorSend──▶ ⧗ forever   ← steer lands here too
send C ──await priorSend──▶ ⧗ forever   ← different conversation, same chain
```

Four changes:

- **Key the chain per conversation.** Ordering only means anything *within* a conversation; serializing across them was accidental coupling. Both call sites already pin `submitConversationId` before taking a link, so the key was there. `flushBackgroundQueues` joins the same per-conversation chain, keeping the FIFO guarantee it relies on.
- **Bound the wait on the prior send** (180s). Past it the successor proceeds and only ordering degrades, which beats a chain that can deadlock. Set well above any legitimate POST — a message can block on runner session-init or a sandbox-host wake — so it only fires on a send that is genuinely stuck.
- **Surface a send that fails alongside a streaming turn.** The error block was behind `!alreadyStreaming`, so a failure while a turn was live (or while the latch was stranded) rolled the bubble back and stopped there. The lifecycle mutations stay gated — `finalizeActive` would mark a live response failed — but the error block is now unconditional.
- **Let the active conversation's queue reconcile against the server.** `maybeFlushQueuedHead` trusted only client-local state, so a stranded `streaming` latch gated the queue forever. It now drains once that latch outlives any plausible POST *and* the session's own row reads idle — the same server-truth source `flushBackgroundQueues` already uses for every other conversation.

## Test Plan

```
cd web
npx vitest run src/store/chatStore.test.ts     # 310 passed
npm run type-check && npm run lint             # clean
npx prettier --check src/store/chatStore.ts src/store/chatStore.test.ts
```

Full web suite: 5382 passed / 3 expected-fail / 1 skipped. The 3 failures in `src/shell/NewChatDialog.test.tsx` are **pre-existing on `origin/main`** — verified by stashing this change and re-running that file on a clean tree (same 3 failures).

Each new test was checked against a deliberately neutered fix to confirm it actually guards the behavior rather than passing vacuously:

| Test | Neutered by |
|---|---|
| chain releases when a prior POST never settles | removing the `Promise.race` bound |
| queue drains once a stranded latch outlives a POST | forcing `sendLatchIsStranded` to `false` |
| failed send surfaces without settling the live turn | disabling the new `else` branch |

`tests/e2e_ui/sessions/test_cross_session_routing.py::test_stalled_send_does_not_block_another_session` drives the regression through the real UI: session B's `/events` POST is held open by a route handler, the user switches to session A via the sidebar (client-side nav, so the JS module state holding the chain survives — a reload would dissolve the bug), and A's send must still reach the server. Before the fix it never POSTs at all.

## Demo

N/A — no visual change to record. The user-visible effect is the *absence* of a wedge (and an error block where there was silence); reproducing it live requires killing a TCP connection mid-POST, which the unit tests simulate with a promise that never resolves.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Five unit tests cover the four changes: same-conversation FIFO across the foreground/background paths (rewritten — the previous version asserted cross-conversation serialization, which is exactly the coupling being removed, and never exercised the navigate-away hand-off its own comment described), cross-conversation independence under a hung POST, the bounded release, the stranded-latch drain, and the safety case that the drain does **not** fire when the server's row says `running` (which would double-send into a live turn).

Disclosure: the new e2e_ui test could not be run locally — spawning the fixture's runner from this environment dies in `asyncio.add_signal_handler` with `RuntimeError: the fd 6 must be in non-blocking mode`, before any test body executes. Pre-existing tests in the same file fail identically on the same fixture, so the blocker is environmental rather than something this test introduces; CI's `e2e-ui.yml` (which runs on every PR) is the first real execution.

The fix has also not been exercised in a live browser against a genuinely dead connection — that failure mode is not reproducible on demand. The root-cause diagnosis behind it *was* verified against live data (runner logs, the bridge hook journal, the session API correlated against the real tmux pane), and the unit tests reproduce the wedge deterministically.

## Changelog

Messages sent from the chat UI no longer stop reaching the agent after a dropped network request
