### PR TITLE
Split files and changes into two tabs

### DIFF
--- a/tests/e2e_ui/files/test_changed_files_git_status_error.py
+++ b/tests/e2e_ui/files/test_changed_files_git_status_error.py
@@ -67,12 +67,10 @@ def test_git_status_failure_surfaces_in_files_panel(
     open_right_rail(page)
     rail = page.get_by_role("complementary", name="Workspace")
 
-    # Files is the default rail tab; click it explicitly so the assertion does
-    # not depend on the remembered tab from a prior session. The Changed scope
-    # (the flat changed-files list, where the error renders) is the default, but
-    # select it explicitly for the same reason.
-    rail.get_by_role("tab", name=re.compile("^Files")).click()
-    rail.get_by_role("radio", name="Changed").click()
+    # The changed-files list — where the git-status error renders — is now the
+    # Changes rail tab (a peer of Files). Select it explicitly so the assertion
+    # does not depend on the remembered tab from a prior session.
+    rail.get_by_role("tab", name=re.compile("^Changes")).click()
 
     # The panel surfaces the server's reason verbatim, in the destructive style —
     # not a bare status code and not the misleading empty state.

--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -3,7 +3,7 @@
 The desktop Workspace rail renders ``FilesPanel`` in its ``frameless``
 (inline) mode. The working-folder header is a plain label: the file list is
 the whole point of the panel, so there is nothing to collapse to. The header
-must NOT be a button and the file-scope switch (the panel content) must be
+must NOT be a button and the panel content (the file list / search) must be
 visible with no toggle needed.
 
 This is the regression guard against reintroducing the collapse chevron: the
@@ -48,6 +48,7 @@ def test_files_rail_working_folder_header_is_a_static_label(
     expect(rail.get_by_text("Working folder")).to_be_visible(timeout=30_000)
     expect(rail.get_by_role("button", name=re.compile("Working folder"))).to_have_count(0)
 
-    # The content is always shown: the file-scope switch (Changed | All) is
-    # visible with no toggle needed.
-    expect(rail.get_by_role("radiogroup", name="File scope")).to_be_visible()
+    # The content is always shown: the Files (tree) search box is visible with
+    # no toggle needed. Scope is the rail tab now (Files vs Changes), not an
+    # in-panel switch.
+    expect(rail.get_by_role("searchbox", name="Search all files")).to_be_visible()

--- a/tests/e2e_ui/mobile/test_mobile_workflow.py
+++ b/tests/e2e_ui/mobile/test_mobile_workflow.py
@@ -154,8 +154,8 @@ def test_mobile_fab_lists_file_surfaces_and_omits_absent_ones(
     """The FAB menu degrades gracefully to only the available surfaces.
 
     A plain ``hello_world`` session has a workspace (os_env), no child
-    agents, and is not claude-native — so the menu must list Files (the
-    single files surface; its Changed/All scope is an in-panel toggle)
+    agents, and is not claude-native — so the menu must list Files and
+    Changes (the two files surfaces — folder tree and changed-files list)
     and Agents (unconditional — the panel lists at least the main
     agent, badge "1"), and must NOT list Shells or Tasks. The session's
     only terminal is the auto-created embedded Omnigent REPL, which is
@@ -170,6 +170,9 @@ def test_mobile_fab_lists_file_surfaces_and_omits_absent_ones(
     page.get_by_role("button", name="Open session menu").click()
 
     expect(page.get_by_role("menuitem", name="Files", exact=True)).to_be_visible()
+    # Changes is a peer files surface (the changed-files list), listed
+    # alongside Files whenever the workspace is available.
+    expect(page.get_by_role("menuitem", name="Changes", exact=True)).to_be_visible()
     # Agents is always present; "1" = just the main agent. "0" means
     # the main agent was dropped from the count.
     expect(page.get_by_role("menuitem", name=re.compile(r"Agents\s*1"))).to_be_visible()
@@ -177,8 +180,7 @@ def test_mobile_fab_lists_file_surfaces_and_omits_absent_ones(
     # the inventory (reachable via the Chat/Terminal pill instead). An
     # entry here means the REPL leaked back into the FAB gating.
     expect(page.get_by_role("menuitem", name="Shells")).to_have_count(0)
-    # No separate Changes entry (merged into Files) and no todos.
-    expect(page.get_by_role("menuitem", name="Changes")).to_have_count(0)
+    # No todos on a plain hello_world session.
     expect(page.get_by_role("menuitem", name="Tasks")).to_have_count(0)
 
 

--- a/web/src/lib/filesPanelPreferences.test.ts
+++ b/web/src/lib/filesPanelPreferences.test.ts
@@ -12,19 +12,14 @@ afterEach(() => {
 });
 
 describe("filesPanelPreferences", () => {
-  it("defaults to the full tree (All) when nothing is stored", () => {
-    // The whole point: with no saved choice the scope is "All"
-    // (changedOnly false), not "Changed".
+  it("defaults the sort order when nothing is stored", () => {
     expect(readFilesPanelPreferences()).toEqual(DEFAULT_FILES_PANEL_PREFERENCES);
-    expect(DEFAULT_FILES_PANEL_PREFERENCES.changedOnly).toBe(false);
+    expect(DEFAULT_FILES_PANEL_PREFERENCES.sort).toBe("recent");
   });
 
   it("round-trips a written preference", () => {
-    writeFilesPanelPreferences({ changedOnly: true, sort: "alpha" });
-    expect(readFilesPanelPreferences()).toEqual({
-      changedOnly: true,
-      sort: "alpha",
-    });
+    writeFilesPanelPreferences({ sort: "alpha" });
+    expect(readFilesPanelPreferences()).toEqual({ sort: "alpha" });
   });
 
   it("falls back to defaults on malformed JSON", () => {
@@ -40,21 +35,8 @@ describe("filesPanelPreferences", () => {
     expect(readFilesPanelPreferences()).toEqual(DEFAULT_FILES_PANEL_PREFERENCES);
   });
 
-  it("defaults changedOnly when the stored field has the wrong type", () => {
-    // A record present but with a non-boolean changedOnly must default the
-    // field rather than pass a garbage value through to the panel.
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ changedOnly: "yes" }));
-    expect(readFilesPanelPreferences()).toEqual({
-      changedOnly: false,
-      sort: "recent",
-    });
-  });
-
   it("defaults sort when the stored value is invalid", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ changedOnly: true, sort: "bogus" }));
-    expect(readFilesPanelPreferences()).toEqual({
-      changedOnly: true,
-      sort: "recent",
-    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sort: "bogus" }));
+    expect(readFilesPanelPreferences()).toEqual({ sort: "recent" });
   });
 });

--- a/web/src/lib/filesPanelPreferences.ts
+++ b/web/src/lib/filesPanelPreferences.ts
@@ -1,40 +1,33 @@
-// Persisted, app-global preference for the Working folder sidebar scope.
+// Persisted, app-global preference for the Working folder file list.
 //
-// The Files panel toggles between the full folder tree ("All") and the
-// changed-files-only flat list ("Changed"). This is a *preference*, not
-// per-conversation state: the user's choice "carries over" as they switch
-// in and out of sessions and should survive a page refresh, mirroring the
-// global-toggle semantics of fileViewPreferences. It's stored under a
-// single localStorage key with no per-conversation keying.
+// Holds the changed-files sort order. It's a *preference*, not per-conversation
+// state: the user's choice "carries over" as they switch in and out of sessions
+// and should survive a page refresh, mirroring the global-toggle semantics of
+// fileViewPreferences. It's stored under a single localStorage key with no
+// per-conversation keying.
 //
-// AppShell keeps the live React state as the source of truth for the UI;
-// these helpers only seed that state on mount and snapshot it when the user
-// flips the toggle, so a refresh (or a brand-new conversation) starts from
-// the last choice instead of the hardcoded default. A deep-link ?view= URL
-// param overrides the stored preference transiently without mutating it.
+// AppShell keeps the live React state as the source of truth for the UI; these
+// helpers only seed that state on mount and snapshot it when the user changes
+// the sort, so a refresh (or a brand-new conversation) starts from the last
+// choice instead of the hardcoded default.
 
 import { type ChangedSort, isValidSort } from "@/lib/changedSort";
 
 export interface FilesPanelPreferences {
-  /** true = changed-files-only flat list, false = full folder tree ("All"). */
-  changedOnly: boolean;
   /** Sort order for the changed-files flat list. */
   sort: ChangedSort;
 }
 
 const STORAGE_KEY = "omnigent:files-panel-preferences";
 
-// Default to the full folder tree ("All") — the panel opens on every file in
-// the working folder, not just the changed subset.
 export const DEFAULT_FILES_PANEL_PREFERENCES: FilesPanelPreferences = {
-  changedOnly: false,
   sort: "recent",
 };
 
 /**
- * Read the persisted Files-panel scope preference. Returns the default when
- * nothing is stored, on a server render (no `window`), or when the stored
- * value is malformed — never throws, so a corrupt entry can't break the app.
+ * Read the persisted Files-panel preference. Returns the default when nothing
+ * is stored, on a server render (no `window`), or when the stored value is
+ * malformed — never throws, so a corrupt entry can't break the app.
  */
 export function readFilesPanelPreferences(): FilesPanelPreferences {
   if (typeof window === "undefined") return DEFAULT_FILES_PANEL_PREFERENCES;
@@ -47,10 +40,6 @@ export function readFilesPanelPreferences(): FilesPanelPreferences {
     }
     const p = parsed as Record<string, unknown>;
     return {
-      changedOnly:
-        typeof p.changedOnly === "boolean"
-          ? p.changedOnly
-          : DEFAULT_FILES_PANEL_PREFERENCES.changedOnly,
       sort:
         typeof p.sort === "string" && isValidSort(p.sort)
           ? p.sort
@@ -62,8 +51,8 @@ export function readFilesPanelPreferences(): FilesPanelPreferences {
 }
 
 /**
- * Persist the Files-panel scope preference. Swallows quota/access errors so a
- * failed write can't break the panel.
+ * Persist the Files-panel preference. Swallows quota/access errors so a failed
+ * write can't break the panel.
  */
 export function writeFilesPanelPreferences(prefs: FilesPanelPreferences): void {
   if (typeof window === "undefined") return;

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -8,14 +8,21 @@
 
 import type { RightRailTab } from "@/shell/railTabs";
 
-const RAIL_TABS: readonly RightRailTab[] = ["files", "subagents", "terminals", "todos", "browser"];
+const RAIL_TABS: readonly RightRailTab[] = [
+  "files",
+  "changes",
+  "subagents",
+  "terminals",
+  "todos",
+  "browser",
+];
 
 export interface SessionWorkspaceState {
   /** Whether the rail was left open in this session. */
   open?: boolean;
   /** User-chosen rail width (px) for this session. */
   widthPx?: number;
-  /** The selected rail tab (Files / Agents / Shells / Tasks). */
+  /** The selected rail tab (Files / Changes / Agents / Shells / Tasks). */
   rightRailTab?: RightRailTab;
   /** Ordered list of open file tabs. */
   openFiles?: string[];

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -68,18 +68,17 @@ vi.mock("./Sidebar", () => ({
 }));
 vi.mock("./FilesPanel", () => ({
   // Scope-only stand-in matching the real FilesPanel after the open-file tabs
-  // and the FileViewer moved up to WorkspacePanel. It exposes file-select and
-  // scope-toggle buttons only; the inline viewer is now rendered directly by
-  // WorkspacePanel via the FileViewer mock below (data-testid="file-viewer-
-  // inline"), so the desktop file-viewer assertions still hold.
+  // and the FileViewer moved up to WorkspacePanel. It echoes its fixed scope
+  // (data-flat-view) and exposes file-select buttons; the scope is now the
+  // Files vs Changes rail tab (driven by the real WorkspacePanel), not an
+  // in-panel toggle. The inline viewer is rendered directly by WorkspacePanel
+  // via the FileViewer mock below (data-testid="file-viewer-inline").
   FilesPanel: ({
     onFileSelect,
     flatView,
-    onFlatViewChange,
   }: {
     onFileSelect: (path: string) => void;
     flatView: boolean;
-    onFlatViewChange: (v: boolean) => void;
   }) => (
     <div data-testid="files-panel" data-flat-view={String(flatView)}>
       <button
@@ -95,20 +94,6 @@ vi.mock("./FilesPanel", () => ({
         onClick={() => onFileSelect("AGENTS.md")}
       >
         select-agents
-      </button>
-      <button
-        type="button"
-        aria-label="files: switch to explore"
-        onClick={() => onFlatViewChange(false)}
-      >
-        explore
-      </button>
-      <button
-        type="button"
-        aria-label="files: switch to changed"
-        onClick={() => onFlatViewChange(true)}
-      >
-        changed
       </button>
     </div>
   ),
@@ -2357,17 +2342,17 @@ describe("AppShell URL sync — file param", () => {
     expect(screen.getByTestId("files-panel")).toBeInTheDocument();
   });
 
-  it("adds ?file= to the URL when a file is selected while already in explore view", () => {
+  it("adds ?file= to the URL when a file is selected from the Files (tree) tab", () => {
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
     mockConversations([{ id: "conv_abc", permission_level: null }]);
 
-    // Start from the legacy ?view=explore link — resolves to the tree view.
-    renderShell("/c/conv_abc?view=explore");
+    // Files is the default tab — the tree scope.
+    renderShell("/c/conv_abc");
 
-    // Sanity-check: tree (explore) mode active, no file open yet.
+    // Sanity-check: tree mode active, no file open yet.
     expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
 
     fireEvent.click(screen.getByRole("button", { name: /files: select README.md/i }));
@@ -2419,7 +2404,7 @@ describe("AppShell URL sync — file param", () => {
     expect(params).not.toContain("comment=");
   });
 
-  it("clears file/diff/comment/view params from the URL when the rail is collapsed", () => {
+  it("clears file/diff/comment params from the URL when the rail is collapsed", () => {
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -2428,72 +2413,37 @@ describe("AppShell URL sync — file param", () => {
 
     // Deep-link into the workspace with every rail-pointing param. conv_abc is
     // seeded open, so the rail mounts open with the params live.
-    renderShell("/c/conv_abc?file=README.md&diff=1&comment=c1&view=changed");
+    renderShell("/c/conv_abc?file=README.md&diff=1&comment=c1");
 
     // Sanity: the rail is open and the params survived restore.
     expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
     expect(screen.getByTestId("url-params").textContent).toContain("file=README.md");
-    expect(screen.getByTestId("url-params").textContent).toContain("view=changed");
 
     fireEvent.click(screen.getByRole("button", { name: "Collapse right panel" }));
 
     // Collapsing hides the workspace, so every param that points into it is
-    // stripped: file/diff/comment by the toggle's clearFileViewerUrl, and
-    // view= by the scope-sync effect's rightPanelOpen gate. Failure means a
-    // reload would re-open the rail to a file/view the user just dismissed.
+    // stripped by the toggle's clearFileViewerUrl. Failure means a reload would
+    // re-open the rail to a file the user just dismissed.
     const afterCollapse = screen.getByTestId("url-params").textContent ?? "";
     expect(afterCollapse).not.toContain("file=");
     expect(afterCollapse).not.toContain("diff=");
     expect(afterCollapse).not.toContain("comment=");
-    expect(afterCollapse).not.toContain("view=");
 
     fireEvent.click(screen.getByRole("button", { name: "Expand right panel" }));
 
     // Reopening rehydrates the URL from the remembered workspace state: the
-    // file (re-added by the toggle) and the Changed scope (re-added by the
-    // scope-sync effect). diff/comment were URL-only ephemerals, so they stay
-    // gone. Failure means a reopened rail is no longer reflected/shareable in
-    // the URL.
+    // file is re-added by the toggle. diff/comment were URL-only ephemerals, so
+    // they stay gone. Failure means a reopened rail is no longer
+    // reflected/shareable in the URL.
     const afterReopen = screen.getByTestId("url-params").textContent ?? "";
     expect(afterReopen).toContain("file=README.md");
-    expect(afterReopen).toContain("view=changed");
     expect(afterReopen).not.toContain("diff=");
     expect(afterReopen).not.toContain("comment=");
   });
 });
 
-describe("AppShell URL sync — view param", () => {
-  it("restores the tree view from the legacy ?view=explore URL param on load", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-
-    renderShell("/c/conv_abc?view=explore");
-
-    // FilesPanel mock exposes data-flat-view; false means the folder tree.
-    // Failure: the conversationId effect did not read searchParams.get("view")
-    // and call setFilesPanelFlatView(false).
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
-  });
-
-  it("restores Changed-only view from the ?view=changed URL param on load", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-
-    renderShell("/c/conv_abc?view=changed");
-
-    // FilesPanel mock exposes data-flat-view; true means Changed-only.
-    // Failure: the conversationId effect did not read searchParams.get("view")
-    // and call setFilesPanelFlatView(true).
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-  });
-
-  it("writes ?view=changed to the URL when the user enables Changed only", () => {
+describe("Files/Changes tabs drive the panel scope", () => {
+  it("defaults to the Files (tree) tab with no ?view= param in the URL", () => {
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -2502,217 +2452,64 @@ describe("AppShell URL sync — view param", () => {
 
     renderShell("/c/conv_abc");
 
-    // Baseline: Files tab, tree view (flatView=false, no ?view= param).
+    // The Files tab pins the panel to the tree; no scope param is written.
     expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
+    expect(screen.getByRole("tab", { name: /files/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByTestId("url-params").textContent).not.toContain("view=");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /files: switch to changed/i }));
+  it("shows the changed-only list on the Changes tab without touching the URL", () => {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
 
-    // After enabling Changed only: flat list active, ?view=changed in URL.
-    // Failure: the filesPanelFlatView sync useEffect did not call setSearchParams.
+    renderShell("/c/conv_abc");
+
+    // Radix Tabs activate on mouseDown, not click.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /changes/i }));
+
+    // Selecting Changes flips the panel to the changed-only flat list; the
+    // scope is the tab, so no ?view= param is written.
     expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-    expect(screen.getByTestId("url-params").textContent).toContain("view=changed");
+    expect(screen.getByTestId("url-params").textContent).not.toContain("view=");
+  });
+
+  it("restores the Changes tab per session from persisted workspace state", () => {
+    // The selected tab is the scope now: a session left on Changes reopens on
+    // the changed-only list.
+    writeSessionWorkspaceState("conv_changesmem", { open: true, rightRailTab: "changes" });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_changesmem", permission_level: null }]);
+
+    renderShell("/c/conv_changesmem");
+
+    expect(screen.getByRole("tab", { name: /changes/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
   });
 });
 
-describe("Files scope default and persistence", () => {
-  const PREF_KEY = "omnigent:files-panel-preferences";
-
-  function mockChangedFiles(paths: string[]) {
-    useChangedFilesMock.mockReturnValue({
-      data: {
-        available: true,
-        data: paths.map((path) => ({
-          path,
-          name: path.split("/").pop() ?? path,
-          status: "modified" as const,
-          bytes: 1,
-          modified_at: 1,
-        })),
-      },
-      isSuccess: true,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceChangedFiles>);
-  }
-
-  it("defaults to All (tree) even when the conversation loads with changes", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // Changes are present, but with nothing persisted the panel must open on
-    // "All", not "Changed" — the core behavior change. Failure here
-    // means the old auto-default-to-Changed-when-changes-exist logic is back.
-    mockChangedFiles(["src/App.tsx"]);
-
-    renderShell("/c/conv_abc");
-
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
-    expect(screen.getByTestId("url-params").textContent).not.toContain("view=");
-    // And the default must stay unpersisted: merely loading a conversation
-    // with changes must not write a "Changed" preference behind the user's
-    // back. A non-null value here means the removed auto-default crept back
-    // in as a silent localStorage write.
-    expect(localStorage.getItem(PREF_KEY)).toBeNull();
-  });
-
-  it("restores the remembered Changed scope on load from localStorage", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // A previously-saved "Changed" choice must seed the scope on a fresh
-    // mount. Failure means the useState initializer / restore effect isn't
-    // reading the persisted preference.
-    localStorage.setItem(PREF_KEY, JSON.stringify({ changedOnly: true }));
-
-    renderShell("/c/conv_abc");
-
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-  });
-
-  it("persists the toggle choice so it carries into the next session", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([
-      { id: "conv_abc", permission_level: null },
-      { id: "conv_xyz", permission_level: null },
-    ]);
-
-    // Session 1: opens on All, user switches to Changed.
-    renderShell("/c/conv_abc");
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
-    fireEvent.click(screen.getByRole("button", { name: /files: switch to changed/i }));
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-    // The choice was written to localStorage — that's what makes it sticky.
-    expect(localStorage.getItem(PREF_KEY)).toBe(
-      JSON.stringify({ changedOnly: true, sort: "recent" }),
-    );
-
-    // Re-enter a *different* session fresh: it must open on the remembered
-    // "Changed" scope. cleanup() unmounts the shell but does NOT touch
-    // localStorage (only beforeEach clears it, between tests), so the choice
-    // written above survives into this second mount — exactly the cross-
-    // session carry-over the issue asks for. Failure means the choice didn't
-    // carry across sessions.
-    cleanup();
-    renderShell("/c/conv_xyz");
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-  });
-
-  it("keeps the toggled scope on an in-mount session switch when the storage write is blocked", () => {
-    // Simulate blocked storage (Safari private mode): the write is swallowed,
-    // so localStorage stays empty. The remembered scope must come from the
-    // in-memory ref, not a fresh localStorage read — otherwise switching
-    // sessions resets the user's just-made choice back to the default.
-    //
-    // jsdom routes setItem through Storage.prototype (an instance-level spy is
-    // a no-op), so we spy there but throw ONLY for the files-panel preference
-    // key and delegate every other key to the real method. That keeps the
-    // blast radius to this one localStorage write — AppShell's sessionStorage
-    // panel-key writes on mount/navigation still go through untouched.
-    const realSetItem = Storage.prototype.setItem;
-    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (
-      this: Storage,
-      key: string,
-      value: string,
-    ) {
-      if (key === PREF_KEY) throw new Error("storage blocked");
-      realSetItem.call(this, key, value);
-    });
-    try {
-      useEnvironmentMock.mockReturnValue({
-        data: { available: true, root: null },
-        isLoading: false,
-      } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-      mockConversations([
-        { id: "conv_abc", permission_level: null },
-        { id: "conv_xyz", permission_level: null },
-      ]);
-
-      // Stable QueryClient + a fresh element per call so AppShell stays mounted
-      // across the navigation (a fresh client would remount and reset the ref).
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-      render(
-        <QueryClientProvider client={qc}>
-          <TooltipProvider>
-            <MemoryRouter initialEntries={["/c/conv_abc"]}>
-              <Routes>
-                <Route element={<AppShell />}>
-                  <Route
-                    path="c/:conversationId"
-                    element={
-                      <>
-                        <SessionNavButton to="/c/conv_xyz" />
-                        <LocationDisplay />
-                      </>
-                    }
-                  />
-                </Route>
-              </Routes>
-            </MemoryRouter>
-          </TooltipProvider>
-        </QueryClientProvider>,
-      );
-
-      // Opens on All, user switches to Changed. The write throws (swallowed),
-      // so localStorage never records the choice.
-      expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
-      fireEvent.click(screen.getByRole("button", { name: /files: switch to changed/i }));
-      expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-      expect(localStorage.getItem(PREF_KEY)).toBeNull();
-
-      // Switch to another session within the same mount (bare path → no ?view=
-      // param, so the conversation-switch effect hits the remembered-scope
-      // fallback). Failure here means the fallback re-read empty localStorage
-      // and reverted to All instead of using the in-memory ref.
-      fireEvent.click(screen.getByTestId("nav-session"));
-      expect(screen.getByTestId("url-params").textContent).not.toContain("view=");
-      expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
-    } finally {
-      setItemSpy.mockRestore();
-    }
-  });
-
-  it("lets a deep-link ?view=explore param win over the remembered scope", () => {
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // Remembered choice is "Changed", but the explicit deep-link to the tree
-    // must win for this navigation.
-    localStorage.setItem(PREF_KEY, JSON.stringify({ changedOnly: true }));
-
-    renderShell("/c/conv_abc?view=explore");
-
-    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "false");
-    // The deep-link override is transient: it must NOT rewrite the stored
-    // preference. If this flips to changedOnly:false, a shared ?view=explore
-    // link would silently clobber the recipient's remembered choice.
-    expect(localStorage.getItem(PREF_KEY)).toBe(JSON.stringify({ changedOnly: true }));
-  });
-});
-
-describe("AppShell scope switch — conversation redirect (stale-closure regression)", () => {
-  it("keeps the URL on the current conversation when All is clicked after an in-app switch", () => {
-    // Regression for the "click All → jump to a different conversation" bug.
-    // AppShell is a layout route that never remounts across /c/:a → /c/:b, so
-    // when showScopeView was useCallback([]) it stayed frozen to AppShell's
-    // first render: its clearFileViewerUrl closed over react-router's
-    // first-mount navigate, whose relative setSearchParams resolves against the
-    // pathname captured then. Clicking a scope button after switching sessions
-    // therefore yanked the URL back to the conversation open at first mount.
+describe("AppShell scope view — conversation redirect (stale-closure regression)", () => {
+  it("keeps the URL on the current conversation when the scope view is revealed after an in-app switch", () => {
+    // Regression for the "reveal the scope view → jump to a different
+    // conversation" bug. AppShell is a layout route that never remounts across
+    // /c/:a → /c/:b, so when showScopeView was useCallback([]) it stayed frozen
+    // to AppShell's first render: its clearFileViewerUrl closed over
+    // react-router's first-mount navigate, whose relative setSearchParams
+    // resolves against the pathname captured then. Revealing the scope view
+    // after switching sessions therefore yanked the URL back to the
+    // conversation open at first mount.
     //
     // This test reproduces that exact flow: mount on conv_abc, switch in-app to
     // conv_xyz (AppShell stays mounted, carrying the stale closure), open a
-    // file, click All. With the bug the pathname reverts to /c/conv_abc; with
-    // the fix (showScopeView depends on clearFileViewerUrl → setSearchParams →
-    // the live location) it stays on /c/conv_xyz.
+    // file, close it to reveal the scope view. With the bug the pathname
+    // reverts to /c/conv_abc; with the fix (showScopeView depends on
+    // clearFileViewerUrl → setSearchParams → the live location) it stays on
+    // /c/conv_xyz.
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -2757,9 +2554,7 @@ describe("AppShell scope switch — conversation redirect (stale-closure regress
     expect(screen.getByTestId("file-viewer-inline")).toHaveAttribute("data-path", "README.md");
 
     // Close the file via the viewer — this invokes showScopeView, the callback
-    // that regressed. (The Changed/All switch lives in FilesPanel, which is
-    // unmounted while a file is open, so the viewer's close is now the
-    // affordance wired to showScopeView.)
+    // that regressed. The viewer's close is the affordance wired to it.
     fireEvent.click(
       within(screen.getByTestId("file-viewer-inline")).getByRole("button", {
         name: /file-viewer: close/i,
@@ -3018,7 +2813,7 @@ describe("Mobile session menu", () => {
     );
   });
 
-  it("opens the files drawer from the Files entry in the default tree view", () => {
+  it("opens the files drawer in the tree view from the Files entry", () => {
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -3030,12 +2825,30 @@ describe("Mobile session menu", () => {
     openSessionMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /^Files$/i }));
 
-    // Files → drawer open in the default tree view (flatView=false). The
-    // "Changed only" scope is the drawer's own toggle, not forced by the entry.
-    // Failure: openFilesPanel didn't set filesPanelOpen.
+    // Files → drawer open pinned to the full folder tree (flatView=false).
+    // Failure: openFilesPanel didn't set filesPanelOpen / the drawer scope.
     const drawer = screen.getByTestId("files-panel-drawer");
     expect(drawer).toHaveAttribute("data-state", "open");
     expect(drawer).toHaveAttribute("data-flat-view", "false");
+  });
+
+  it("opens the files drawer in the changed-only list from the Changes entry", () => {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+
+    renderShell("/c/conv_abc");
+
+    openSessionMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Changes$/i }));
+
+    // Changes → same drawer, pinned to the changed-files-only list
+    // (flatView=true). Failure: openChangesPanel didn't set the drawer scope.
+    const drawer = screen.getByTestId("files-panel-drawer");
+    expect(drawer).toHaveAttribute("data-state", "open");
+    expect(drawer).toHaveAttribute("data-flat-view", "true");
   });
 
   it("opens the Tasks drawer for a claude-native session with todos", () => {
@@ -3117,6 +2930,7 @@ describe("Mobile session menu", () => {
     });
     expect(screen.getByRole("menuitem", { name: /Agents\s*1/i })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /Files/i })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /Changes/i })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: /Shells/i })).toBeNull();
   });
 });

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -108,30 +108,30 @@ import type { RightRailTab } from "./railTabs";
  *     each panel's width, pushing the main content accordingly. No backdrop —
  *     side panels aren't covering anything.
  *
- * The right slot holds either `FilesPanel` (file tree) or `FileViewer`
- * (code + comments) — never both at once. Selecting a file transitions
- * from the tree view to the code view in the same slot. The "← Back"
- * button in `FileViewer` returns to the file tree.
+ * The right slot holds either `FilesPanel` (file tree / changed list) or
+ * `FileViewer` (code + comments) — never both at once. Selecting a file
+ * transitions from the list to the code view in the same slot. The "← Back"
+ * button in `FileViewer` returns to the list.
  *
  * Default open state is taken from the initial viewport: the left sidebar is
  * open on desktop and closed on mobile. The right files panel starts closed.
  *
  * **Mobile session-rail entry**: the desktop right column has no room on
  * a phone, so the rail's contents are reached via a top-right FAB that
- * opens a dropdown with "Files" and "Terminals" (the latter only when
- * one or more terminals exist). Each entry opens the matching push
- * panel — the FAB and the desktop rail cards route through the same
+ * opens a dropdown with "Files", "Changes" and "Terminals" (the latter
+ * only when one or more terminals exist). Each entry opens the matching
+ * push panel — the FAB and the desktop rail tabs route through the same
  * open*() handlers.
  *
  * **Right rail tabs (desktop)**: the aside is internally tabbed between
- * Files, Terminals and Agents so each can claim the full rail height
- * instead of competing for a vertically-split slot. Files is the default;
- * within it a "Changed only" toggle filters the full folder tree down to
- * just the changed files (flat list). Opening a file (chat link or rail
- * click) forces the rail to the Files tab so the viewer is visible.
- * Terminal-first sessions render the terminal inline in main and therefore
- * hide the rail's Terminals tab. The Agents tab only appears once there's
- * more than one agent (the root has at least one child).
+ * Files, Changes, Terminals and Agents so each can claim the full rail
+ * height instead of competing for a vertically-split slot. Files (full
+ * folder tree) and Changes (changed-files-only flat list) are peer tabs —
+ * the selected tab *is* the scope. Opening a file (chat link or rail click)
+ * forces the rail to a files scope so the viewer is visible. Terminal-first
+ * sessions render the terminal inline in main and therefore hide the rail's
+ * Terminals tab. The Agents tab only appears once there's more than one
+ * agent (the root has at least one child).
  */
 export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
@@ -230,24 +230,11 @@ export function AppShell() {
   // Sidebar open-state captured when entering full screen, so exiting can
   // restore whatever the user had (collapsed stays collapsed; open reopens).
   const sidebarOpenBeforeMaximizeRef = useRef(false);
-  // false = full folder tree ("All"), true = changed-files-only flat list.
-  // Surfaced as the Changed | All toggle inside the Files panel. Seeded from
-  // the persisted, app-global preference (defaults to "All") so the choice
-  // carries over as the user switches in and out of sessions and survives a
-  // refresh. A deep-link ?view= URL param overrides it transiently below.
-  //
-  // The remembered scope is also held in a ref, mirroring FileViewer's
-  // persistedPrefsRef. It's the in-memory source of truth the conversation-
-  // switch effect falls back to — so a toggle is preserved across switches
-  // even if the localStorage write was swallowed (Safari private mode /
-  // blocked storage), rather than re-reading storage and reverting to the
-  // default each switch. The lazy useState initializer reads localStorage
-  // exactly once; the ref seeds from that initial value (useRef ignores its
-  // argument after mount), so we don't re-read storage on every render.
-  const [filesPanelFlatView, setFilesPanelFlatView] = useState(
-    () => readFilesPanelPreferences().changedOnly,
-  );
-  const filesPanelScopePrefRef = useRef(filesPanelFlatView);
+  // Scope of the mobile Files drawer: false = full folder tree, true =
+  // changed-files-only flat list. On desktop the scope is the selected rail
+  // tab (Files vs Changes); on a phone there's no tab strip, so the two FAB
+  // entries open this drawer pinned to their scope.
+  const [filesDrawerFlatView, setFilesDrawerFlatView] = useState(false);
   // Tracks which conversation the current rail tab / open-files state belongs
   // to, so the persist effect targets the right session even before a switch's
   // restore has re-rendered. Set by the conversation-restore effect.
@@ -276,8 +263,8 @@ export function AppShell() {
   // Appearance "Workspace panel" default; reopening a session restores how
   // the user last left it. Toggled via the header's PanelRightIcon, mirroring
   // the sidebar collapse. With no conversation the rail can't render, so the
-  // state stays false — leaving it true would let rail-gated side effects
-  // (the ?view= URL sync) fire on non-session routes like the home page.
+  // state stays false — leaving it true would let rail-gated side effects fire
+  // on non-session routes like the home page.
   const [rightPanelOpen, setRightPanelOpen] = useState(() =>
     conversationId
       ? (readSessionWorkspaceState(conversationId).open ?? readDefaultWorkspacePanelOpen())
@@ -533,6 +520,9 @@ export function AppShell() {
     () =>
       ({
         files: showFilesPanel,
+        // Changes tab shares the Files gate — same on-disk workspace, just the
+        // changed-files scope.
+        changes: showFilesPanel,
         // Browser tab: shown only when the desktop shell hosts the embedded
         // WebContentsView. A plain web build has no embedded browser, and an
         // older desktop build predates the `browser*` bridge — both hide the
@@ -562,12 +552,12 @@ export function AppShell() {
   // Keep the selected tab valid. When the current tab disappears — files
   // panel turns off, or the Shells tab hides (native wrapper / no shell
   // and no shell access) — fall back to the first still-visible tab in
-  // display order (Files · Agents · Shells · Tasks · Browser). Picking the first
-  // available (rather than ping-ponging between two effects) keeps this
-  // convergent even when several tabs vanish at once.
+  // display order (Files · Changes · Agents · Shells · Tasks · Browser). Picking
+  // the first available (rather than ping-ponging between two effects) keeps
+  // this convergent even when several tabs vanish at once.
   useEffect(() => {
     if (railTabsAvailable[rightRailTab]) return;
-    const next = (["files", "subagents", "terminals", "todos", "browser"] as const).find(
+    const next = (["files", "changes", "subagents", "terminals", "todos", "browser"] as const).find(
       (t) => railTabsAvailable[t],
     );
     if (next) setRightRailTab(next);
@@ -727,7 +717,7 @@ export function AppShell() {
     setFilesPanelShowHidden(false);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
-      // effects like the ?view= URL sync stay quiet on non-session routes.
+      // effects stay quiet on non-session routes.
       setRightPanelOpen(false);
       setRightRailTab("files");
       setSelectedFilePath(null);
@@ -743,29 +733,11 @@ export function AppShell() {
     const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
     setPanelInitialKeyState(stored);
 
-    // Restore the Files view scope. A deep-link ?view= param wins and forces
-    // the rail onto the Files tab: ?view=changed → "Changed" (flat list),
-    // ?view=explore is the legacy tree param. With no param, fall back to the
-    // user's remembered choice (defaults to "All") so the scope stays sticky
-    // across session switches.
-    const viewParam = searchParams.get("view");
-    // ``nextTab`` stays null when there's no explicit signal to restore a tab
-    // (no ?view=, no persisted tab, no file to surface). In that case we leave
-    // ``rightRailTab`` untouched so the tab-fallback effect can still land on
-    // the first *available* tab — forcing "files" here would shadow it.
-    let nextTab: RightRailTab | null;
-    if (viewParam === "changed") {
-      setFilesPanelFlatView(true);
-      nextTab = "files";
-    } else if (viewParam === "explore") {
-      setFilesPanelFlatView(false);
-      nextTab = "files";
-    } else {
-      // Fall back to the remembered choice from the in-memory ref (not a
-      // fresh localStorage read) so a swallowed write can't reset the scope.
-      setFilesPanelFlatView(filesPanelScopePrefRef.current);
-      nextTab = persisted.rightRailTab ?? null;
-    }
+    // Restore the selected rail tab (the Files vs Changes scope is now the tab
+    // itself). ``nextTab`` stays null when there's no persisted tab and no file
+    // to surface, so the tab-fallback effect can still land on the first
+    // *available* tab — forcing "files" here would shadow it.
+    let nextTab: RightRailTab | null = persisted.rightRailTab ?? null;
 
     // Restore the open file tabs from the per-session store, then merge the
     // URL ?file= param: a deep-link selects (and, if absent, opens) that file
@@ -791,25 +763,23 @@ export function AppShell() {
       if (wasMaximized) restoreSidebarAfterMaximize();
       return false;
     });
-    // A selected file must be visible in the rail. The Agents/Todos/Terminals
-    // tabs don't render the inline viewer, so pull the rail to Files.
-    if (nextSelected && nextTab !== "files") {
+    // A selected file must be visible in the rail. The Files and Changes tabs
+    // both surface the inline viewer; the Agents/Todos/Terminals tabs don't, so
+    // pull the rail to Files unless it's already on a files scope.
+    if (nextSelected && nextTab !== "files" && nextTab !== "changes") {
       nextTab = "files";
     }
     if (nextTab !== null) setRightRailTab(nextTab);
 
     // Restore the rail open-state for this session. A deep link / reload that
-    // carries a workspace signal — a file to open (?file=), a files-scope view
-    // (?view=changed|explore), or a comment to surface (?comment=) — reveals
-    // the rail even when this session was last left closed; otherwise the
-    // linked file/comment would render into a collapsed, invisible panel. This
-    // is transient: it doesn't rewrite the session's saved open-state.
+    // carries a workspace signal — a file to open (?file=) or a comment to
+    // surface (?comment=) — reveals the rail even when this session was last
+    // left closed; otherwise the linked file/comment would render into a
+    // collapsed, invisible panel. This is transient: it doesn't rewrite the
+    // session's saved open-state.
     const commentParam = searchParams.get("comment");
     const hasWorkspaceUrlSignal =
-      urlFile !== null ||
-      viewParam === "changed" ||
-      viewParam === "explore" ||
-      (commentParam !== null && commentParam !== "");
+      urlFile !== null || (commentParam !== null && commentParam !== "");
     setRightPanelOpen((persisted.open ?? readDefaultWorkspacePanelOpen()) || hasWorkspaceUrlSignal);
 
     stateConvRef.current = conversationId;
@@ -836,41 +806,6 @@ export function AppShell() {
       selectedTerminalKey,
     });
   }, [rightRailTab, openFiles, selectedFilePath, openTerminals, selectedTerminalKey]);
-
-  // Sync the Files-panel scope into the URL. The tree is the default, so we
-  // only write the param for "Changed only" — and only while the rail is open,
-  // since the scope is meaningless (and shouldn't deep-link the rail back open)
-  // once the workspace is collapsed. Collapsing thus drops ?view= here.
-  useEffect(() => {
-    // Skip when the URL already agrees: setSearchParams always navigates, and
-    // a no-op write replays this effect's stale params over whatever another
-    // same-commit effect just wrote (e.g. the one-shot ?sidebar=open strip).
-    const current = new URLSearchParams(window.location.search);
-    const wantChanged = rightPanelOpen && filesPanelFlatView;
-    if (wantChanged ? current.get("view") === "changed" : !current.has("view")) return;
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (wantChanged) {
-          next.set("view", "changed");
-        } else {
-          next.delete("view");
-        }
-        return next;
-      },
-      { replace: true },
-    );
-  }, [filesPanelFlatView, rightPanelOpen]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Manual scope changes (the Changed | All toggle) persist the choice so it
-  // sticks across session switches and page refreshes. Update the in-memory
-  // ref too (the conversation-switch fallback), so the choice survives even if
-  // the localStorage write is swallowed.
-  const handleFilesFlatViewChange = useCallback((v: boolean) => {
-    filesPanelScopePrefRef.current = v;
-    setFilesPanelFlatView(v);
-    writeFilesPanelPreferences({ ...readFilesPanelPreferences(), changedOnly: v });
-  }, []);
 
   const handleFilesSortChange = useCallback((s: ChangedSort) => {
     setFilesPanelSort(s);
@@ -934,22 +869,18 @@ export function AppShell() {
   // ``setSearchParams`` so it always closes over react-router's *current*
   // ``navigate`` — which is bound to the live ``locationPathname`` — rather
   // than a stale one captured at first mount (see ``showScopeView`` below).
-  const clearFileViewerUrl = useCallback(
-    (includeView = false) => {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          next.delete("file");
-          next.delete("diff");
-          next.delete("comment");
-          if (includeView) next.delete("view");
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
+  const clearFileViewerUrl = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("file");
+        next.delete("diff");
+        next.delete("comment");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
 
   // Toggle the right (Workspace) sidebar — shared by the header's collapse
   // button and the ⌘⌥]/Ctrl+Alt+] hotkey so they can't drift. Beyond flipping the
@@ -963,8 +894,7 @@ export function AppShell() {
     if (next) {
       if (selectedFilePath) {
         // Reopening lands back on the file remembered in per-session
-        // state, so re-add ?file= to keep the URL shareable — mirroring
-        // how the scope-sync effect re-adds ?view= on reopen. diff and
+        // state, so re-add ?file= to keep the URL shareable. diff and
         // comment are URL-only ephemerals (not remembered), so they
         // intentionally don't rehydrate. Imperative (not an effect) to
         // avoid the FileViewer diff-sync race documented in that effect.
@@ -982,7 +912,7 @@ export function AppShell() {
       // Collapsing the rail hides the workspace, so strip the deep-
       // link params that point into it; otherwise the URL advertises
       // a workspace view a reload would re-open.
-      clearFileViewerUrl(true);
+      clearFileViewerUrl();
     }
     setRightPanelOpen(next);
   };
@@ -1092,9 +1022,9 @@ export function AppShell() {
   // Switch the workspace rail's tab. The side effect (closing any open
   // file + its comments + URL) lives here, not in WorkspacePanel, so the
   // tab state and the file state can't drift apart — the rail stays a
-  // dumb view. A single Files tab now owns the viewer, so there's no
+  // dumb view. The Files/Changes tabs own the viewer, so there's no
   // per-tab file to stash and restore; switching tabs just closes any
-  // open file.
+  // open file to reveal the picked tab's scope list.
   function handleRightRailTabChange(next: RightRailTab) {
     setRightRailTab(next);
     if (selectedFilePath !== null) {
@@ -1188,10 +1118,9 @@ export function AppShell() {
     setExecutionLogsKey(key);
   }
 
-  // Mobile FAB → "Files" opens the files drawer (mirrors the desktop rail's
-  // Files tab). The "Changed only" scope is the drawer's own toggle, shared
-  // with the desktop rail via ``filesPanelFlatView``, so we don't force it.
-  function openFilesPanel() {
+  // Mobile FAB → "Files" / "Changes" both open the files drawer (mirroring the
+  // desktop rail's two tabs); the entry picks the scope the drawer opens in.
+  function openFilesDrawer(flatView: boolean) {
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
     setPanelInitialKey(null); // close terminals panel
@@ -1199,8 +1128,11 @@ export function AppShell() {
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
+    setFilesDrawerFlatView(flatView);
     setFilesPanelOpen(true);
   }
+  const openFilesPanel = () => openFilesDrawer(false);
+  const openChangesPanel = () => openFilesDrawer(true);
 
   // Mobile FAB → "Agents" opens the subagents list (the desktop rail's
   // Agents tab) as a full-screen drawer.
@@ -1489,6 +1421,7 @@ export function AppShell() {
                     subagentsWorking,
                     agentCount,
                     onOpenFiles: openFilesPanel,
+                    onOpenChanges: openChangesPanel,
                     onOpenShells: openShellsPanel,
                     onOpenSubagents: openSubagentsPanel,
                     onOpenTodos: openTodosPanel,
@@ -1557,8 +1490,6 @@ export function AppShell() {
                     permissionLevel={permissionLevel}
                     filesPanelSort={filesPanelSort}
                     onSortChange={handleFilesSortChange}
-                    filesPanelFlatView={filesPanelFlatView}
-                    onFlatViewChange={handleFilesFlatViewChange}
                     filesPanelShowHidden={filesPanelShowHidden}
                     onShowHiddenChange={setFilesPanelShowHidden}
                     liveness={liveness}
@@ -1596,8 +1527,7 @@ export function AppShell() {
                   open={filesPanelOpen}
                   onClose={() => setFilesPanelOpen(false)}
                   onFileSelect={openFileViewer}
-                  flatView={filesPanelFlatView}
-                  onFlatViewChange={handleFilesFlatViewChange}
+                  flatView={filesDrawerFlatView}
                   showHidden={filesPanelShowHidden}
                   onShowHiddenChange={setFilesPanelShowHidden}
                   sort={filesPanelSort}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -152,11 +152,15 @@ export function AppShell() {
   );
   // The comments panel only contributes to the min width when the rail is
   // actually showing the file viewer — on the Terminals tab the FileViewer
-  // is unmounted, so the 720 floor would just waste horizontal space.
+  // is unmounted, so the 720 floor would just waste horizontal space. Both
+  // the Files and Changes tabs surface the inline viewer, so either qualifies.
   // 240px (CommentsPanel default/min width) + 480px comfortable code viewer
   // width. The panel can be dragged wider, but this floor keeps it usable at
   // its default; widening past it is the user's choice via the inline handle.
-  const inlinePanelMinWidth = rightRailTab === "files" && fileViewerCommentsOpen ? 720 : undefined;
+  const inlinePanelMinWidth =
+    (rightRailTab === "files" || rightRailTab === "changes") && fileViewerCommentsOpen
+      ? 720
+      : undefined;
   const [searchParams, setSearchParams] = useSearchParams();
   const [sidebarOpen, setSidebarOpen] = useState(initialSidebarOpen);
   // Reads the same module-level store Sidebar drives, so the rail's ceiling

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -33,6 +33,7 @@ const mobileMenu = {
   subagentsWorking: 0,
   agentCount: 1,
   onOpenFiles: () => {},
+  onOpenChanges: () => {},
   onOpenShells: () => {},
   onOpenSubagents: () => {},
   onOpenTodos: () => {},

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -3,6 +3,7 @@ import {
   ChevronLeftIcon,
   EllipsisVerticalIcon,
   FileIcon,
+  GitCompareIcon,
   InfoIcon,
   ListIcon,
   ListTodoIcon,
@@ -76,8 +77,10 @@ interface MobileSessionMenuProps {
    * entry badge) — starts at 1 for a lone agent.
    */
   agentCount: number;
-  /** Open the mobile files drawer. */
+  /** Open the mobile files drawer (full folder tree). */
   onOpenFiles: () => void;
+  /** Open the mobile files drawer pinned to the changed-files list. */
+  onOpenChanges: () => void;
   /** Open the mobile shells drawer. */
   onOpenShells: () => void;
   /** Open the mobile agents drawer. */
@@ -443,6 +446,15 @@ export function ChatHeader({
                   >
                     <FileIcon className="size-4" />
                     Files
+                  </DropdownMenuItem>
+                )}
+                {showFilesPanel && (
+                  <DropdownMenuItem
+                    onSelect={mobileMenu.onOpenChanges}
+                    className="gap-2.5 px-2.5 py-2 text-ui"
+                  >
+                    <GitCompareIcon className="size-4" />
+                    Changes
                     {mobileMenu.changedCount > 0 && (
                       <span
                         className={cn(TAB_BADGE_BASE, "ml-auto bg-muted text-muted-foreground")}

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -145,7 +145,6 @@ function renderPanel({
               onSortChange={vi.fn()}
               flatView={flatView}
               onFileSelect={vi.fn()}
-              onFlatViewChange={vi.fn()}
               showHidden={showHidden}
               onShowHiddenChange={vi.fn()}
               onClose={onClose}
@@ -217,8 +216,8 @@ describe("FilesPanel working folder header role", () => {
     renderPanel({ conversationId: "conv_header_card", files: [] });
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
-    // Content is always shown — the scope switch is part of it.
-    expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
+    // Content is always shown — the tree search box is part of it.
+    expect(screen.getByRole("searchbox", { name: "Search all files" })).toBeInTheDocument();
   });
 
   it("renders the header as a static label (no toggle button) in frameless (inline rail) mode", () => {
@@ -240,7 +239,6 @@ describe("FilesPanel working folder header role", () => {
                 frameless
                 flatView={false}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -252,7 +250,7 @@ describe("FilesPanel working folder header role", () => {
 
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
-    expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: "Search all files" })).toBeInTheDocument();
   });
 
   it("renders a static label header with a Close button in the drawer", () => {
@@ -264,7 +262,7 @@ describe("FilesPanel working folder header role", () => {
   });
 });
 
-describe("FilesPanel scope switch (Changed | All) visibility", () => {
+describe("FilesPanel scope (fixed by the caller's Files/Changes tab)", () => {
   it("does not enable the root filesystem listing while showing Changed files", () => {
     renderPanel({
       conversationId: "conv_changed_only",
@@ -300,114 +298,18 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
     });
   });
 
-  it("shows the scope switch in frameless (inline right-rail) mode", () => {
-    // The single Files rail tab owns its scope via this switch, so it must be
-    // present in frameless mode (where the old separate rail tabs used to live).
-    useAllFilesMock.mockReturnValue(allFilesResult([file("src/App.tsx")]));
-    useChangedFilesMock.mockReturnValue(changedFilesResult([changedFile("src/App.tsx")]));
-    useDirectoryMock.mockReturnValue(directoryResult());
-    useEnvironmentMock.mockReturnValue(environmentResult());
-    useSearchMock.mockReturnValue(searchResult());
-
-    render(
-      <MemoryRouter initialEntries={["/c/conv_frameless"]}>
-        <Routes>
-          <Route
-            path="/c/:conversationId"
-            element={
-              <FilesPanel
-                sort="recent"
-                onSortChange={vi.fn()}
-                frameless
-                flatView={false}
-                onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
-                showHidden={false}
-                onShowHiddenChange={vi.fn()}
-              />
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    // Both segments present; All is selected (flatView=false), Changed is not.
-    const changed = screen.getByRole("radio", { name: /^changed$/i });
-    const all = screen.getByRole("radio", { name: /^all$/i });
-    expect(changed).toHaveAttribute("aria-checked", "false");
-    expect(all).toHaveAttribute("aria-checked", "true");
-    expect(changed).not.toHaveClass("bg-muted");
-    expect(all).toHaveClass("bg-muted");
-  });
-
-  it("shows the scope switch in full-screen drawer mode (onClose)", () => {
+  it("does not render an in-panel scope switch (scope is the rail tab now)", () => {
+    // The Changed|All segmented control was replaced by two peer rail tabs;
+    // the panel itself no longer offers a scope toggle.
     renderPanel({
-      conversationId: "conv_drawer_tabs",
+      conversationId: "conv_no_switch",
+      flatView: false,
       files: [file("src/App.tsx")],
-      onClose: vi.fn(),
     });
 
-    expect(screen.getByRole("radio", { name: /^changed$/i })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /^all$/i })).toBeInTheDocument();
-  });
-
-  it("calls onFlatViewChange(true) when the Changed segment is clicked", () => {
-    const onFlatViewChange = vi.fn();
-    useAllFilesMock.mockReturnValue(allFilesResult([file("src/App.tsx")]));
-    useChangedFilesMock.mockReturnValue(changedFilesResult([changedFile("src/App.tsx")]));
-    useDirectoryMock.mockReturnValue(directoryResult());
-    useEnvironmentMock.mockReturnValue(environmentResult());
-    useSearchMock.mockReturnValue(searchResult());
-
-    render(
-      <MemoryRouter initialEntries={["/c/conv_toggle"]}>
-        <Routes>
-          <Route
-            path="/c/:conversationId"
-            element={
-              <FilesPanel
-                sort="recent"
-                onSortChange={vi.fn()}
-                frameless
-                flatView={false}
-                onFileSelect={vi.fn()}
-                onFlatViewChange={onFlatViewChange}
-                showHidden={false}
-                onShowHiddenChange={vi.fn()}
-              />
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /^changed$/i }));
-    // Selecting Changed switches to the changed-files-only flat list.
-    expect(onFlatViewChange).toHaveBeenCalledWith(true);
-  });
-});
-
-describe("FilesPanel Changed pill", () => {
-  // The Changed pill shows the file count only — no +/− line totals.
-  function changedPill() {
-    return screen.getByRole("radio", { name: /^changed$/i });
-  }
-
-  it("shows the file count but no +/− line totals", () => {
-    renderPanel({
-      conversationId: "conv_pill_count",
-      flatView: true,
-      files: [],
-      changedFiles: [
-        changedFile("src/a.ts", "modified", 10, 2),
-        changedFile("src/b.ts", "modified", 5, 1),
-      ],
-    });
-
-    const pill = changedPill();
-    expect(within(pill).getByText("2")).toBeInTheDocument(); // file count
-    expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
-    expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("radiogroup", { name: "File scope" })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /^changed$/i })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /^all$/i })).toBeNull();
   });
 });
 
@@ -430,7 +332,6 @@ describe("FilesPanel changed files search", () => {
                 onSortChange={vi.fn()}
                 flatView={true}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -492,7 +393,6 @@ describe("FilesPanel changed files search", () => {
                 onSortChange={vi.fn()}
                 flatView={false}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -514,7 +414,6 @@ describe("FilesPanel changed files search", () => {
                 onSortChange={vi.fn()}
                 flatView={true}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -588,7 +487,6 @@ describe("FilesPanel changed files search", () => {
                     onClose={() => setDrawerOpen(false)}
                     onFileSelect={vi.fn()}
                     flatView={false}
-                    onFlatViewChange={vi.fn()}
                     showHidden={showHidden}
                     onShowHiddenChange={setShowHidden}
                   />
@@ -602,7 +500,6 @@ describe("FilesPanel changed files search", () => {
                         onSortChange={vi.fn()}
                         flatView={false}
                         onFileSelect={vi.fn()}
-                        onFlatViewChange={vi.fn()}
                         showHidden={showHidden}
                         onShowHiddenChange={setShowHidden}
                       />
@@ -657,7 +554,6 @@ describe("FilesPanel changed files search", () => {
                     onClose={() => setDrawerOpen(false)}
                     onFileSelect={vi.fn()}
                     flatView={false}
-                    onFlatViewChange={vi.fn()}
                     showHidden={showHidden}
                     onShowHiddenChange={setShowHidden}
                   />
@@ -671,7 +567,6 @@ describe("FilesPanel changed files search", () => {
                         onSortChange={vi.fn()}
                         flatView={false}
                         onFileSelect={vi.fn()}
-                        onFlatViewChange={vi.fn()}
                         showHidden={showHidden}
                         onShowHiddenChange={setShowHidden}
                       />
@@ -720,7 +615,6 @@ describe("FilesPanel changed files search", () => {
                   onSortChange={vi.fn()}
                   flatView={true}
                   onFileSelect={vi.fn()}
-                  onFlatViewChange={vi.fn()}
                   showHidden={showHidden}
                   onShowHiddenChange={setShowHidden}
                 />
@@ -773,7 +667,6 @@ describe("FilesPanel tree (Explore) search", () => {
                 onSortChange={vi.fn()}
                 flatView={true}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -964,7 +857,6 @@ describe("FilesPanel tree (Explore) search", () => {
                 onSortChange={vi.fn()}
                 flatView={true}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -986,7 +878,6 @@ describe("FilesPanel tree (Explore) search", () => {
                 onSortChange={vi.fn()}
                 flatView={false}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1194,7 +1085,6 @@ describe("FilesPanel tree (Explore) search", () => {
                 onSortChange={vi.fn()}
                 flatView={true}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1217,7 +1107,6 @@ describe("FilesPanel tree (Explore) search", () => {
                 onSortChange={vi.fn()}
                 flatView={false}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1311,7 +1200,6 @@ describe("FilesPanel scroll position persistence", () => {
                 onSortChange={vi.fn()}
                 flatView={false}
                 onFileSelect={vi.fn()}
-                onFlatViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -5,8 +5,6 @@ import {
   EyeOffIcon,
   FileClockIcon,
   FileTypeIcon,
-  FolderTreeIcon,
-  ListIcon,
   MoonIcon,
   SearchIcon,
   SlidersHorizontalIcon,
@@ -37,8 +35,12 @@ import { useScrollRestore } from "./useScrollRestore";
 
 interface FilesPanelProps {
   onFileSelect: (path: string) => void;
+  /**
+   * Which scope this panel renders: false = full folder tree, true =
+   * changed-files-only flat list. Fixed by the caller (the Files vs Changes
+   * rail tab / mobile drawer) rather than switched inside the panel.
+   */
   flatView: boolean;
-  onFlatViewChange: (flatView: boolean) => void;
   /**
    * Whether hidden files (dot-prefixed paths) are visible. Lifted to
    * the parent so the state survives inline→drawer transitions.
@@ -160,64 +162,6 @@ function SortSelector({
 }
 
 // ---------------------------------------------------------------------------
-// FileScopeSwitch — segmented Changed | All control that flips the whole Files
-// view between the changed-files-only flat list (Changed) and the full folder
-// tree (All). One control replaces the old separate Files / Changes rail tabs.
-// ---------------------------------------------------------------------------
-
-// Leading cell in the search toolbar. Rounded-full pills match the rail tabs;
-// the active scope uses the same theme selection surface as the sidebar.
-function FileScopeSwitch({
-  flatView,
-  onChange,
-  count,
-}: {
-  flatView: boolean;
-  onChange: (flatView: boolean) => void;
-  count: number;
-}) {
-  const changedSelected = flatView;
-  const allSelected = !flatView;
-  const pill =
-    "flex cursor-pointer items-center gap-[6px] rounded-full px-[14px] py-[2px] text-ui font-medium leading-5 transition-colors";
-  const activePill = "bg-muted text-foreground";
-  const idlePill = "text-muted-foreground hover:text-foreground";
-  return (
-    <div role="radiogroup" aria-label="File scope" className="flex shrink-0 items-center gap-1">
-      <button
-        type="button"
-        role="radio"
-        aria-checked={changedSelected}
-        aria-label="Changed"
-        title="Show changed files only"
-        onClick={() => onChange(true)}
-        className={cn(pill, changedSelected ? activePill : idlePill)}
-      >
-        <ListIcon className="size-3.5 shrink-0" />
-        Changed
-        {count > 0 && (
-          <span className="shrink-0 font-normal text-sm text-muted-foreground tabular-nums">
-            {count}
-          </span>
-        )}
-      </button>
-      <button
-        type="button"
-        role="radio"
-        aria-checked={allSelected}
-        aria-label="All"
-        title="Show the full folder tree"
-        onClick={() => onChange(false)}
-        className={cn(pill, allSelected ? activePill : idlePill)}
-      >
-        <FolderTreeIcon className="size-3.5 shrink-0" />
-        All
-      </button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // SearchFilterInput — labeled glob input for "files to include" / "exclude"
 // ---------------------------------------------------------------------------
 
@@ -265,7 +209,6 @@ function SearchFilterInput({
 export function FilesPanel({
   onFileSelect,
   flatView,
-  onFlatViewChange,
   showHidden,
   onShowHiddenChange,
   sort: changedSort,
@@ -321,7 +264,6 @@ export function FilesPanel({
   });
   const workingDir = envQuery.data?.root ?? null;
   const changedFiles = changedQuery.data?.data ?? [];
-  const changedCount = changedFiles.length;
   const hiddenFilesCount = changedFiles.filter((f) =>
     f.path.split("/").some((seg) => seg.startsWith(".")),
   ).length;
@@ -432,7 +374,6 @@ export function FilesPanel({
           className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
           onClick={(e) => e.stopPropagation()}
         >
-          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
               <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -452,7 +393,6 @@ export function FilesPanel({
       {!flatView && (
         <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
                 <SearchIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/web/src/shell/FilesPanelDrawer.tsx
+++ b/web/src/shell/FilesPanelDrawer.tsx
@@ -29,11 +29,11 @@ interface FilesPanelDrawerProps {
    */
   onFileSelect: (path: string) => void;
   /**
-   * Lifted Changed/Explore tab state. Lifted to AppShell so the
-   * choice survives drawer open/close cycles.
+   * Which scope the drawer renders: false = full folder tree, true =
+   * changed-files-only flat list. Fixed by the FAB entry that opened it
+   * (Files vs Changes) — the drawer has no in-panel scope switch.
    */
   flatView: boolean;
-  onFlatViewChange: (flatView: boolean) => void;
   /**
    * Lifted hidden-files toggle state. Lifted to AppShell so the
    * eye-icon choice survives inline→drawer transitions.
@@ -53,7 +53,6 @@ export function FilesPanelDrawer({
   onClose,
   onFileSelect,
   flatView,
-  onFlatViewChange,
   showHidden,
   onShowHiddenChange,
   sort,
@@ -111,7 +110,6 @@ export function FilesPanelDrawer({
         <FilesPanel
           onFileSelect={onFileSelect}
           flatView={flatView}
-          onFlatViewChange={onFlatViewChange}
           showHidden={showHidden}
           onShowHiddenChange={onShowHiddenChange}
           sort={sort}

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -19,7 +19,11 @@ vi.mock("./FileViewer", () => ({
   FileViewer: ({ path }: { path: string }) => <div data-testid="file-viewer-stub">{path}</div>,
 }));
 vi.mock("./FilesPanel", () => ({
-  FilesPanel: () => <div data-testid="files-panel-stub" />,
+  // Echo the fixed scope so tests can prove the Files tab renders the tree
+  // (flatView=false) and the Changes tab the changed-only list (flatView=true).
+  FilesPanel: ({ flatView }: { flatView: boolean }) => (
+    <div data-testid="files-panel-stub" data-flat-view={String(flatView)} />
+  ),
 }));
 vi.mock("./InlineTerminalsSection", () => ({
   InlineTerminalsSection: () => <div data-testid="terminals-stub" />,
@@ -81,6 +85,7 @@ function renderWorkspace(
     rightRailTab?: RightRailTab;
     selectedFilePath?: string | null;
     openFiles?: string[];
+    changedCount?: number;
     showBrowserTab?: boolean;
     showShellsTab?: boolean;
     openTerminals?: string[];
@@ -105,7 +110,7 @@ function renderWorkspace(
         onRightRailTabChange={onRightRailTabChange}
         showFilesPanel
         showBrowserTab={overrides.showBrowserTab ?? false}
-        changedCount={0}
+        changedCount={overrides.changedCount ?? 0}
         showShellsTab={overrides.showShellsTab ?? false}
         terminalsLength={0}
         subagentsWorking={0}
@@ -129,8 +134,6 @@ function renderWorkspace(
         permissionLevel={null}
         filesPanelSort={"recent" as ChangedSort}
         onSortChange={vi.fn()}
-        filesPanelFlatView={false}
-        onFlatViewChange={vi.fn()}
         filesPanelShowHidden={false}
         onShowHiddenChange={vi.fn()}
         liveness={overrides.liveness}
@@ -160,15 +163,27 @@ describe("WorkspacePanel surface presentation", () => {
     renderWorkspace();
 
     const filesTab = screen.getByRole("tab", { name: "Files" });
+    const changesTab = screen.getByRole("tab", { name: "Changes" });
     const agentsTab = screen.getByRole("tab", { name: "Agents 1" });
     expect(filesTab).toHaveClass("size-8", "p-0");
     expect(filesTab).not.toHaveAttribute("title");
+    expect(changesTab).toHaveClass("size-8", "p-0");
     expect(agentsTab).toHaveClass("size-8", "p-0");
     expect(agentsTab).not.toHaveAttribute("title");
   });
 
+  it("badges the Changes tab (not Files) with the changed-file count", () => {
+    renderWorkspace({ changedCount: 3 });
+
+    // The changed-file count moved from the old single Files tab to Changes;
+    // Files carries no count.
+    expect(screen.getByRole("tab", { name: "Changes 3 changed" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Files" })).toBeInTheDocument();
+  });
+
   it.each([
     { tabName: "Files", tooltip: "Files" },
+    { tabName: "Changes", tooltip: "Changes" },
     { tabName: "Agents 1", tooltip: "Agents" },
   ])("explains the $tabName pane icon with a hover tooltip", async ({ tabName, tooltip }) => {
     renderWorkspace();
@@ -268,12 +283,21 @@ describe("WorkspacePanel content area", () => {
     expect(screen.queryByTestId("files-panel-stub")).toBeNull();
   });
 
-  it("renders the FilesPanel scope view when no file is active on the Files tab", () => {
+  it("renders the FilesPanel tree scope when no file is active on the Files tab", () => {
     renderWorkspace({ rightRailTab: "files", selectedFilePath: null });
 
-    // No active file → the scope view (Changed/All list/tree) owns the content
-    // slot and the viewer is unmounted.
-    expect(screen.getByTestId("files-panel-stub")).toBeInTheDocument();
+    // No active file → the scope view owns the content slot and the viewer is
+    // unmounted. The Files tab pins the panel to the full folder tree.
+    const panel = screen.getByTestId("files-panel-stub");
+    expect(panel).toHaveAttribute("data-flat-view", "false");
+    expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
+  });
+
+  it("renders the FilesPanel changed-only scope on the Changes tab", () => {
+    renderWorkspace({ rightRailTab: "changes", selectedFilePath: null });
+
+    // The Changes tab pins the same panel to the changed-files-only flat list.
+    expect(screen.getByTestId("files-panel-stub")).toHaveAttribute("data-flat-view", "true");
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
   });
 });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -3,6 +3,7 @@ import {
   CheckIcon,
   FileIcon,
   FilesIcon,
+  GitCompareIcon,
   GlobeIcon,
   ListTodoIcon,
   Loader2Icon,
@@ -514,12 +515,12 @@ interface WorkspacePanelProps {
    * file + its comments + URL) so they can't drift from the tab state.
    */
   onRightRailTabChange: (next: RightRailTab) => void;
-  /** Whether the Files tab is available (agent spec exposes an os_env). */
+  /** Whether the Files/Changes tabs are available (agent spec exposes an os_env). */
   showFilesPanel: boolean;
   /** Whether the Browser tab is available — Electron shell only (hidden in a
    *  plain web build, which has no embedded WebContentsView). */
   showBrowserTab: boolean;
-  /** Count of changed files, shown as the Files tab badge. */
+  /** Count of changed files, shown as the Changes tab badge. */
   changedCount: number;
   /**
    * Whether the Shells tab is available — AppShell's combined gate
@@ -582,10 +583,6 @@ interface WorkspacePanelProps {
   filesPanelSort: ChangedSort;
   /** Change the changed-files sort order. */
   onSortChange: (sort: ChangedSort) => void;
-  /** Files view scope: false = full tree, true = changed-only flat list. */
-  filesPanelFlatView: boolean;
-  /** Toggle the Files view scope (persisted by AppShell). */
-  onFlatViewChange: (flat: boolean) => void;
   /** Whether the Files panel shows dotfiles/hidden entries. */
   filesPanelShowHidden: boolean;
   /** Toggle hidden-file visibility in the Files panel. */
@@ -599,7 +596,7 @@ interface WorkspacePanelProps {
 /**
  * WorkspacePanel — the desktop right "Workspace" rail, rendered as a
  * floating card (bg-card, rounded, bordered, shadowed) sitting below the
- * full-width chat header band. Internally tabbed between Files,
+ * full-width chat header band. Internally tabbed between Files, Changes,
  * Terminals, Agents and Tasks so each can claim the full rail height
  * instead of competing for a vertically-split slot.
  *
@@ -644,8 +641,6 @@ export function WorkspacePanel({
   permissionLevel,
   filesPanelSort,
   onSortChange,
-  filesPanelFlatView,
-  onFlatViewChange,
   filesPanelShowHidden,
   onShowHiddenChange,
   liveness,
@@ -700,9 +695,11 @@ export function WorkspacePanel({
           className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
         />
       )}
-      {/* Tab strip, in display order Files · Agents · Shells · Tasks.
-          Files and Agents are always present (the Agents panel lists at
-          least the main agent). Shells shows whenever AppShell's gate
+      {/* Tab strip, in display order Files · Changes · Agents · Shells · Tasks.
+          Files (full folder tree) and Changes (changed-files-only list) are
+          two peer tabs — same gate (an on-disk workspace), same FilesPanel,
+          each pinned to one scope. Agents is always present (the Agents panel
+          lists at least the main agent). Shells shows whenever AppShell's gate
           allows it (the agent declares shell access, or a shell already
           exists) — the empty state carries the "+ New shell"
           affordance, so an empty tab is an entry point, not a dead end.
@@ -728,16 +725,28 @@ export function WorkspacePanel({
           }
           onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
         >
-          <TabsList variant="pill" className="gap-0">
+          <TabsList variant="pill" className="gap-1">
             {showFilesPanel && (
               <WorkspaceTabTooltip label="Files">
                 <TabsTrigger
                   value="files"
-                  aria-label={changedCount > 0 ? `Files ${changedCount} changed` : "Files"}
+                  aria-label="Files"
                   className="size-8 shrink-0 rounded-md p-0 hover:bg-muted"
                 >
                   <FilesIcon className="size-4" />
                   <span className="sr-only">Files</span>
+                </TabsTrigger>
+              </WorkspaceTabTooltip>
+            )}
+            {showFilesPanel && (
+              <WorkspaceTabTooltip label="Changes">
+                <TabsTrigger
+                  value="changes"
+                  aria-label={changedCount > 0 ? `Changes ${changedCount} changed` : "Changes"}
+                  className="size-8 shrink-0 rounded-md p-0 hover:bg-muted"
+                >
+                  <GitCompareIcon className="size-4" />
+                  <span className="sr-only">Changes</span>
                   {changedCount > 0 && <span className="sr-only">{changedCount}</span>}
                 </TabsTrigger>
               </WorkspaceTabTooltip>
@@ -882,7 +891,8 @@ export function WorkspacePanel({
         </WorkspaceTabTooltip>
       </div>
       {/* Tab content — single slot. An open shell tab holds its xterm; a
-          file tab holds FileViewer; the Files tab shows FilesPanel; the
+          file tab holds FileViewer; the Files/Changes tabs show FilesPanel
+          (tree vs changed-only list); the
           Shells tab holds the list-only inline section (clicking a row
           opens the shell as a tab above, surfacing its xterm here);
           Subagents lists the root's children + a "main" link back to the
@@ -923,8 +933,7 @@ export function WorkspacePanel({
             <FilesPanel
               frameless
               onFileSelect={openFileViewer}
-              flatView={filesPanelFlatView}
-              onFlatViewChange={onFlatViewChange}
+              flatView={rightRailTab === "changes"}
               showHidden={filesPanelShowHidden}
               onShowHiddenChange={onShowHiddenChange}
               sort={filesPanelSort}

--- a/web/src/shell/railTabs.ts
+++ b/web/src/shell/railTabs.ts
@@ -5,7 +5,7 @@
  */
 
 /** The selectable tabs in the right workspace rail, in display order. */
-export type RightRailTab = "files" | "subagents" | "terminals" | "todos" | "browser";
+export type RightRailTab = "files" | "changes" | "subagents" | "terminals" | "todos" | "browser";
 
 /**
  * Count/status badge geometry. Fixed height with min-width == height keeps a


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-2358/split-files-and-changes-into-separate-tabs

## Summary

The workspace rail used a single **Files** tab whose scope was flipped by an in-panel `Changed | All` segmented switch (backed by a `?view=` query param and an app-global preference).

- Split it into two peer rail tabs — **Files** (full folder tree) and **Changes** (changed-files-only list) — so the scope *is* the selected tab. Both render the same `FilesPanel`, each pinned to one scope; the changed-file count badge now lives on the Changes tab.
- Dropped the `?view=` query param and its URL-sync effect, plus the app-global `changedOnly` preference. The chosen tab is persisted per-session via the existing `rightRailTab` state.
- Mirrored the split on mobile: the session-menu FAB now has both **Files** and **Changes** entries, each opening the drawer pinned to its scope.

Net: ~670 deletions vs ~264 insertions — the in-panel switch, the scope preference, and the URL plumbing all go away.

## Test Plan

- `pnpm test` (web) — updated the affected suites (`FilesPanel`, `WorkspacePanel`, `AppShell`, `ChatHeader`, `filesPanelPreferences`) to drop the removed switch / `?view=` / `changedOnly` assertions and add tab-driven scope + Changes-entry coverage. All touched suites pass (251 tests across the 7 files; full web suite green).
- `tsc --noEmit`, `oxlint`, and `prettier --check` all clean on the changed files.

## Demo

https://github.com/user-attachments/assets/181e6fbb-64b8-4692-a638-04cc8e1aa5ff

https://github.com/user-attachments/assets/8d0e43c0-7064-436e-b125-db42ebb74348

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Scope selection, per-session tab persistence, and the mobile FAB entries are covered by updated unit tests in `AppShell.test.tsx`, `WorkspacePanel.test.tsx`, and `FilesPanel.test.tsx`.

## Changelog

The Files panel is now split into separate **Files** (folder tree) and **Changes** (changed files) tabs
