### PR TITLE
fix(cli): accept a copied conversation URL as a server, and stop the SPA mislabeling missing API routes

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1448,16 +1448,22 @@ async def _prepare_chat_session_via_daemon(
     from omnigent.native_terminal import bind_session_runner
 
     async with OmnigentClient(base_url=base_url, headers=headers, auth=auth) as sdk:
-        if fork_session_id is not None:
-            fork_result = await sdk.sessions.fork(fork_session_id)
-            session_id = fork_result["id"]
-        elif resume_conversation_id is not None:
-            session_id = resume_conversation_id
-        else:
-            created = await sdk.sessions.create(
-                bundle, filename="agent.tar.gz", workspace=workspace
-            )
-            session_id = created.id
+        try:
+            if fork_session_id is not None:
+                fork_result = await sdk.sessions.fork(fork_session_id)
+                session_id = fork_result["id"]
+            elif resume_conversation_id is not None:
+                session_id = resume_conversation_id
+            else:
+                created = await sdk.sessions.create(
+                    bundle, filename="agent.tar.gz", workspace=workspace
+                )
+                session_id = created.id
+        except ClientOmnigentError as exc:
+            # A server that answers /health but has no session API is the
+            # wrong base URL (e.g. one carrying the web-UI path), not a bug
+            # worth a traceback. Name the URL so the fix is obvious.
+            raise click.ClickException(f"Could not start a session on {base_url}: {exc}") from exc
 
     # A separate raw httpx client for the host-runner protocol (the daemon
     # launch helpers operate on httpx, not the SDK).

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1460,9 +1460,11 @@ async def _prepare_chat_session_via_daemon(
                 )
                 session_id = created.id
         except ClientOmnigentError as exc:
-            # A server that answers /health but has no session API is the
-            # wrong base URL (e.g. one carrying the web-UI path), not a bug
-            # worth a traceback. Name the URL so the fix is obvious.
+            # Any create/fork/resume rejection here is a server-side answer, not
+            # a client bug worth a traceback: a wrong base URL that answers
+            # /health but has no session API, a fork of a session that is gone,
+            # a permission refusal. Name the URL, since a wrong one is the case
+            # that looks least like itself, and pass the server's message through.
             raise click.ClickException(f"Could not start a session on {base_url}: {exc}") from exc
 
     # A separate raw httpx client for the host-runner protocol (the daemon

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10381,9 +10381,13 @@ def _resolve_server_url(server: str) -> str:
     :returns: The normalized API base URL without a trailing slash, e.g.
         ``"https://example.cloud.databricks.com/api/2.0/omnigent"``.
     """
-    from omnigent.conversation_browser import display_server_url
+    from omnigent.conversation_browser import display_server_url, strip_conversation_path
 
-    normalized = _with_default_scheme(server.rstrip("/"))
+    # A URL copied from the browser while a conversation is open carries the
+    # SPA's ``/c/<id>`` route. The SPA catch-all answers any GET under it with
+    # its HTML shell, so it probes as a healthy server and is accepted, then
+    # every API call 404s. Trim it back to the base before anything probes it.
+    normalized = _with_default_scheme(strip_conversation_path(server.rstrip("/")))
     expanded = _workspace_api_server_url(normalized)
     candidate = _canonical_azure_databricks_url(normalized)
     if candidate is None:

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import urllib.parse
@@ -14,6 +15,37 @@ from collections.abc import Callable
 # instead of the JSON API.
 WORKSPACE_API_PATH = "/api/2.0/omnigent"
 WORKSPACE_UI_PATH = "/omnigent"
+
+# Client-side SPA route for one conversation (see web/src/App.tsx's
+# ``c/:conversationId``). ``conversation_url`` appends it; ``strip_conversation_path``
+# is the inverse, for a URL copied out of the browser's address bar.
+_CONVERSATION_PATH_RE = re.compile(r"/c/[^/]+/?$")
+
+
+def strip_conversation_path(url: str) -> str:
+    """
+    Drop a trailing ``/c/<conversation_id>`` from a server URL.
+
+    The web UI's address bar shows ``<base>/c/<id>`` for an open
+    conversation, so that is what a user copies when asked for "the
+    omnigent URL". It is a client-side route, not a server mount: the SPA
+    catch-all answers ``GET <base>/c/<id>/v1/me`` with a ``200`` HTML shell,
+    so such a URL passes an auth probe and is accepted as a server, then
+    every real API call 404s because no router owns that prefix. Trimming
+    the route recovers the base the API actually lives on.
+
+    :param url: A server URL, possibly a copied conversation link, e.g.
+        ``"https://app.databricksapps.com/c/9bed9ec6"``.
+    :returns: The URL without the conversation route, e.g.
+        ``"https://app.databricksapps.com"``.
+    """
+    parsed = urllib.parse.urlsplit(url.rstrip("/"))
+    trimmed = _CONVERSATION_PATH_RE.sub("", parsed.path)
+    if trimmed == parsed.path:
+        return url
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, trimmed, parsed.query, parsed.fragment)
+    )
 
 
 def is_workspace_hosted_url(base_url: str) -> bool:

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -39,10 +39,11 @@ def strip_conversation_path(url: str) -> str:
     :returns: The URL without the conversation route, e.g.
         ``"https://app.databricksapps.com"``.
     """
-    parsed = urllib.parse.urlsplit(url.rstrip("/"))
+    stripped = url.rstrip("/")
+    parsed = urllib.parse.urlsplit(stripped)
     trimmed = _CONVERSATION_PATH_RE.sub("", parsed.path)
     if trimmed == parsed.path:
-        return url
+        return stripped
     return urllib.parse.urlunsplit(
         (parsed.scheme, parsed.netloc, trimmed, parsed.query, parsed.fragment)
     )

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2541,7 +2541,15 @@ class _SPAStaticFiles(StaticFiles):
         try:
             response = await super().get_response(path, scope)
         except StarletteHTTPException as exc:
-            if exc.status_code == 404 and _is_web_ui_api_fallback_path(path):
+            # StaticFiles only serves GET/HEAD, so it answers every other
+            # method with 405, which reads as "this endpoint exists, wrong
+            # method" and sends a client pointed at the wrong base URL
+            # hunting a server bug instead. Nothing reaching this catch-all
+            # exists, and a non-GET is never an SPA navigation, so answer
+            # 404 whatever the path looks like.
+            if exc.status_code == 405 or (
+                exc.status_code == 404 and _is_web_ui_api_fallback_path(path)
+            ):
                 return JSONResponse(
                     status_code=404,
                     content={

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1444,6 +1444,44 @@ def test_prepare_chat_session_via_daemon_fork_wins_over_resume(
     assert launch["session_id"] == "conv_forked"
 
 
+def test_prepare_chat_session_via_daemon_reports_create_failure_as_click_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed session create is a ``ClickException`` naming the server URL.
+
+    A base URL that answers ``/health`` but exposes no session API (e.g. one
+    carrying the workspace web-UI path) fails here. Letting the SDK's
+    ``OmnigentError`` escape turns that wrong-URL case into a crash-handler
+    traceback, which hides the one detail that identifies it: the URL.
+    """
+    captured: dict[str, object] = {}
+    _patch_daemon_launch(monkeypatch, captured)
+
+    async def _boom(_self: object, _bundle: bytes, *, filename: str, workspace: str) -> object:
+        raise ClientOmnigentError({"detail": "Method Not Allowed"}, 405, "")
+
+    monkeypatch.setattr(_FakeSessionsApi, "create", _boom)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        asyncio.run(
+            _prepare_chat_session_via_daemon(
+                base_url="https://example.databricks.com/omnigent",
+                headers={},
+                auth=None,
+                host_id="host_x",
+                bundle=b"bundle-bytes",
+                resume_conversation_id=None,
+                fork_session_id=None,
+                workspace="/tmp/proj",
+            )
+        )
+
+    # The URL is what tells the user their server target is wrong.
+    assert "https://example.databricks.com/omnigent" in str(excinfo.value)
+    # No runner is launched for a session that was never created.
+    assert "launch" not in captured
+
+
 # ── OMNIGENT_MODEL env-var fallback ───────────────────
 #
 # These tests pin explicit-environment and discovered-default precedence on

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -486,10 +486,14 @@ async def test_unmatched_api_path_404s_for_every_method(
         )
         unmatched_post = await client.post("/v1/nope", json={})
         unmatched_get = await client.get("/v1/nope")
+        # OPTIONS is covered too. No CORS middleware is installed, so a
+        # preflight reaching this mount was already a 405 that no browser
+        # could use; 404 is the more accurate answer, not a lost capability.
+        unmatched_options = await client.request("OPTIONS", "/v1/nope")
         # An extensionless non-API path still gets the SPA shell.
         spa = await client.get("/c/conv_abc123")
 
-    for resp in (prefixed, unmatched_post, unmatched_get):
+    for resp in (prefixed, unmatched_post, unmatched_get, unmatched_options):
         assert resp.status_code == 404, resp.text
         assert resp.json()["error"]["code"] == "not_found"
     assert spa.status_code == 200

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -436,3 +436,61 @@ async def test_web_ui_serves_pwa_service_worker_and_manifest(
     # is no-cache for the same reason as sw.js — a stale sentinel must not linger.
     assert version.status_code == 200
     assert version.headers["cache-control"] == app_module._WEB_UI_HTML_CACHE_CONTROL
+
+
+async def test_unmatched_api_path_404s_for_every_method(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An unmatched ``/v1`` path 404s regardless of HTTP method.
+
+    The web UI is mounted at ``/`` and sees every unmatched request.
+    Starlette's ``StaticFiles`` answers any non-GET with 405, which reads as
+    "the endpoint exists, wrong method", so a client pointed at the wrong
+    base URL (e.g. one carrying the workspace web-UI path) sees
+    ``405 Method Not Allowed`` from ``POST /v1/sessions`` and blames the
+    server instead of its own URL.
+
+    :param runtime_init: Fixture that initializes the runtime with a mock LLM.
+    :param db_uri: Test database URI.
+    :param tmp_path: Pytest temporary directory fixture.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    web_ui_dist = tmp_path / "web-ui"
+    web_ui_dist.mkdir(parents=True)
+    (web_ui_dist / "index.html").write_text("<!doctype html><div id='root'></div>")
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", web_ui_dist)
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    app = app_module.create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # The reported crash: a base URL carrying the web-UI path, so the
+        # bundled-create route never matches.
+        prefixed = await client.post(
+            "/omnigent/v1/sessions",
+            data={"metadata": "{}"},
+            files={"bundle": ("agent.tar.gz", b"x", "application/gzip")},
+        )
+        unmatched_post = await client.post("/v1/nope", json={})
+        unmatched_get = await client.get("/v1/nope")
+        # An extensionless non-API path still gets the SPA shell.
+        spa = await client.get("/c/conv_abc123")
+
+    for resp in (prefixed, unmatched_post, unmatched_get):
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["error"]["code"] == "not_found"
+    assert spa.status_code == 200
+    assert "<div id='root'>" in spa.text

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -290,3 +290,59 @@ def test_conversation_url_plain_server_unchanged(tmp_path, monkeypatch) -> None:
         conversation_url("http://127.0.0.1:6767", "conv_abc123")
         == "http://127.0.0.1:6767/c/conv_abc123"
     )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # The URL a user copies from the address bar with a conversation open.
+        (
+            "https://app.databricksapps.com/c/9bed9ec6fd244725b60e159dc0052fea",
+            "https://app.databricksapps.com",
+        ),
+        ("https://app.databricksapps.com/c/conv_abc/", "https://app.databricksapps.com"),
+        ("http://127.0.0.1:6767/c/conv_abc", "http://127.0.0.1:6767"),
+        # Workspace web-UI mount keeps its prefix; only the route is trimmed.
+        ("https://ws.databricks.com/omnigent/c/conv_abc", "https://ws.databricks.com/omnigent"),
+        # Real server bases must survive untouched.
+        (
+            "https://ws.databricks.com/api/2.0/omnigent",
+            "https://ws.databricks.com/api/2.0/omnigent",
+        ),
+        ("http://127.0.0.1:6767", "http://127.0.0.1:6767"),
+        # A path that merely contains /c/ elsewhere is not a conversation route.
+        ("https://host.example/c/conv_abc/extra", "https://host.example/c/conv_abc/extra"),
+    ],
+)
+def test_strip_conversation_path(url: str, expected: str) -> None:
+    """A copied conversation link resolves back to the server base.
+
+    The SPA catch-all serves its HTML shell for any GET under ``/c/<id>``, so a
+    pasted conversation URL answers an auth probe with ``200`` and is accepted
+    as a server; every later API call then 404s because no router owns that
+    prefix. Trimming the client-side route is what keeps that URL usable.
+
+    :param url: Input URL.
+    :param expected: Expected server base.
+    :returns: None.
+    """
+    assert browser.strip_conversation_path(url) == expected
+
+
+def test_strip_conversation_path_inverts_conversation_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``strip_conversation_path`` undoes what ``conversation_url`` builds.
+
+    These two must stay inverses: the CLI prints a conversation link with one
+    and has to accept that same link back through the other. If either changes
+    shape independently, a pasted link silently becomes an unusable server URL.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
+    base = "https://app.databricksapps.com"
+    link = browser.conversation_url(base, "conv_abc123")
+    assert link == f"{base}/c/conv_abc123"
+    assert browser.strip_conversation_path(link) == base


### PR DESCRIPTION
## Related issue

Closes #4303

## Summary

A bare `omni` crashed at session-create with `OmnigentError: {'detail': 'Method Not Allowed'}`, on a machine that was never pointed at a remote by hand. Three separate defects stack up:

- **A copied conversation URL was stored as the server.** The config held `https://<host>/c/9bed9ec6...` — `/c/<id>` is the web UI's *client-side* chat route (`web/src/App.tsx`), i.e. what's in the address bar with a conversation open, so it's what a user pastes when asked for their omnigent URL. `omnigent login` stored it verbatim, and bare `omni` (which rewrites to `run`, which falls back to the config `server` key) then addressed every API call under that route, where no router matches.
- **Nothing caught the bad URL earlier, because the SPA answers any GET with its shell.** The web UI is mounted at `/` and receives every unmatched request, so `GET <base>/c/<id>/v1/me` returns `200 text/html`. The login probe reads that 200 as "header-auth mode, no login needed" and persists the URL; `/health` passes too. The first request needing a real route is the session create.
- **That failure then reported the wrong thing.** `StaticFiles` serves only GET/HEAD and raises 405 otherwise. Its body is byte-identical to FastAPI's path-matched-wrong-method response, so `POST /v1/sessions` → `405 Method Not Allowed` reads as *"this endpoint exists, wrong verb"* and points at server routing rather than at the URL. (`POST /v1/sessions` **is** registered unconditionally; a healthy server 400s a bogus bundle.)

Each fix sits at the single chokepoint for its defect:

1. `strip_conversation_path` (the inverse of the existing `conversation_url`) is applied in `_resolve_server_url`, which every entry point — including `_ensure_backend` — already normalizes through. An **already-stored** bad link is therefore repaired on the next run, with no hand-edited config.
2. The SPA catch-all answers **404, not 405**, for anything that reaches it: nothing there exists, and a non-GET is never an SPA navigation.
3. A failed session create raises `ClickException` naming the URL — which the function's docstring already promised. The raw client error was reaching the crash handler as a traceback.

```
before:  POST <host>/c/<id>/v1/sessions  ->  405 {"detail":"Method Not Allowed"}   (traceback)
after:   POST <host>/v1/sessions         ->  route matches; the /c/<id> route is trimmed
         a genuinely wrong URL           ->  404 not_found  ->  "Could not start a session on <url>"
```

<details>
<summary>ELI5 + request flow</summary>

You copied the link to a chat out of your browser and gave it to the CLI as the address of the server. Those look the same but aren't: the chat link points at a *page inside* the app, not the app's front door. The server's web UI is friendly enough to answer "hello" at any address, so nothing noticed until the CLI tried to actually do something. Then the error message said "wrong knock" instead of "wrong door".

```mermaid
flowchart TD
    A["bare omni (TTY)"] --> B["rewritten to: run"]
    B --> C["no --server, so read config server key"]
    C --> D["https://host/c/9bed9ec6..."]
    D --> E{"POST base + /v1/sessions"}
    E -->|"path is /c/id/v1/sessions"| F["no router owns this prefix"]
    F --> G["falls through to SPA mount at /"]
    G -->|"before: non-GET"| H["405 Method Not Allowed<br/>(reads as 'endpoint exists')"]
    H --> I["escapes as traceback"]
    G -->|"after"| J["404 not_found"]
    D -.->|"after: trimmed in _resolve_server_url"| K["https://host"]
    K --> L["POST /v1/sessions matches"]
```
</details>

## Test Plan

```bash
# the three new/changed test files
pytest tests/test_conversation_browser.py tests/cli/test_chat.py \
       tests/server/integration/test_app.py -q          # 150 passed

# full server integration suite, against the final commit
pytest tests/server/integration/ -q                     # 1109 passed, 3 xfailed
```

New coverage:

- `test_strip_conversation_path` — 7 cases, including the exact URL from the crash report, and asserting real API bases (`/api/2.0/omnigent`, loopback) are left untouched.
- `test_strip_conversation_path_inverts_conversation_url` — pins the two helpers as inverses, since the CLI prints a link with one and must accept it back through the other.
- `test_unmatched_api_path_404s_for_every_method` — 404 across POST/GET/OPTIONS incl. the reported `/omnigent/v1/sessions` shape, while `/c/<id>` still serves the SPA shell.
- `test_prepare_chat_session_via_daemon_reports_create_failure_as_click_error` — `ClickException` naming the URL, and no runner launched for a session that was never created.

Both server-side and client-side tests fail without the fix (405 vs 404; traceback vs `ClickException`).

Also verified manually: the stored URL from the crash report now resolves to `https://<host>`, so `POST` lands on `/v1/sessions`; and SPA routes, `HEAD`, real assets, and missing assets are all unchanged — only non-GET-on-unmatched flips 405→404.

CI's `Pytest (server-integration)` job is green on the final commit. Its first attempt
failed on `test_on_runner_disconnect_spares_idle_sessions_and_labels_interrupted_ones`,
which is unrelated to this diff and flaky under sharding: it passes locally both with
this change and with these four source files reverted to `main`, the same job fails on
`main` itself (414f1f55, with 20 failures including a different test in that same file),
and it passed on re-run here with no code change.

Two notes on this environment, both confirmed pre-existing by stashing the change and re-running:

- `tests/cli/` reports 96 failures from missing optional deps (`json5`, `respx`); the failure set is byte-identical to clean `main` (96/873 there vs 96/**874** here, the +1 being the new test).
- The `pyrefly` pre-commit hook reports 97 errors on a clean tree in this worktree (it resolves site-packages through another checkout). Run directly against the changed files with the right interpreter it reports **0 errors**.

## Demo

Not a UI change, so no screenshot. The user-visible surface is the CLI's behavior on a
stored bad URL, driven here through the real code paths (`_resolve_server_url` and the
real `_SPAStaticFiles` mounted at `/`), with the exact URL from the crash report:

```console
~/.omnigent/config.yaml:38
  server: https://omnigents-3272836215725701.aws.databricksapps.com/c/9bed9ec6fd244725b60e159dc0052fea

  ^ this is the web UI's /c/<id> chat route, not a server base

==============================================================================
WHY NOTHING CAUGHT IT: the SPA at / answers any GET with its shell
==============================================================================
  GET   /c/9bed9ec6fd244725b60e159dc0052fea/v1/me  -> 200 text/html; charset=utf-8
  GET   /c/9bed9ec6fd244725b60e159dc0052fea        -> 200 text/html; charset=utf-8
  => omnigent login reads 200 as 'header-auth mode' and stores the URL

==============================================================================
BEFORE: first real API call, and what the user saw
==============================================================================
  POST /c/9bed9ec6fd244725b60e159dc0052fea/v1/sessions
  -> 405 {'detail': 'Method Not Allowed'}   (pre-fix behavior)

  $ omni
  Traceback (most recent call last):
    File ".../omnigent/cli.py", line 7740, in run
    File ".../omnigent/chat.py", line 1464, in _prepare_chat_session_via_daemon
    File ".../omnigent_client/_sessions.py", line 399, in create
  omnigent_client._errors.OmnigentError: {'detail': 'Method Not Allowed'}

  ^ 405 reads as "endpoint exists, wrong verb" -> points at the server,
    not at the URL. Nothing names the real problem.

==============================================================================
AFTER (1): the stored URL is repaired at the resolve chokepoint
==============================================================================
  stored   : https://omnigents-3272836215725701.aws.databricksapps.com/c/9bed9ec6fd244725b60e159dc0052fea
  resolved : https://omnigents-3272836215725701.aws.databricksapps.com
  POST to  : https://omnigents-3272836215725701.aws.databricksapps.com/v1/sessions        <- matches the API route

  $ omni
  (starts normally; no config edit needed)

==============================================================================
AFTER (2): a genuinely wrong URL now says so
==============================================================================
  POST /c/9bed9ec6fd244725b60e159dc0052fea/v1/sessions
  -> 404 {'error': {'code': 'not_found', 'message': 'Not found'}}

  $ omni
  Error: Could not start a session on https://<host>/c/9bed9ec6...: Not found

  ^ names the URL, exits clean, no traceback.
```

<sub>The `$ omni` blocks are the CLI-level effect of the HTTP results above them; the
status codes, the resolved URL, and the response bodies are all live output. Reproducing
the traceback verbatim needs the pre-fix build, so that block is quoted from the crash
report in #4303.</sub>

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts the tests can't assert directly: that the URL from the crash report resolves to a working API base through `_resolve_server_url` (the path a real `omni` takes), and that the 405→404 change doesn't disturb the SPA's own behaviour (client-side routes, `HEAD`, real vs missing static assets). Automated tests cover the resolver cases, the round-trip invariant, the server response codes, and the client error type.

Not covered: an end-to-end run against a live Databricks Apps deployment. Reproducing the exact deployment shape needs a hosted app, so the SPA catch-all was exercised via its real `_SPAStaticFiles` class mounted on the real app factory instead.

## Changelog

A conversation link copied from your browser now works wherever a server URL is expected, instead of failing later with an opaque "Method Not Allowed" crash
