### PR TITLE
fix(web): use opaque background for maximized workspace panel

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -587,12 +587,20 @@ html:not(.dark) .conversations-sidebar {
 /* Right rail (workspace panel) in dark: blends into the canvas, keeping only
  * its left divider. Excluded from the glass rule above, so this just clears
  * the rail's md:bg-card fill and the bg-card fills its panel contents paint
- * (FilesPanel/TerminalsPanel/SubagentsPanel + the graph surface). */
-.dark aside[aria-label="Workspace"],
+ * (FilesPanel/TerminalsPanel/SubagentsPanel + the graph surface).
+ * Skip when maximized — the panel covers the full content area and needs an
+ * opaque background so the chat beneath doesn't bleed through. */
+.dark aside[aria-label="Workspace"]:not([data-maximized]),
 .dark
-  aside[aria-label="Workspace"]
+  aside[aria-label="Workspace"]:not([data-maximized])
   :is([data-workspace-panel-content] > *, [data-workspace-panel-surface]) {
   background: transparent !important;
+}
+
+/* When maximized the workspace panel covers the full content area; use an
+ * opaque background so the chat underneath doesn't bleed through. */
+aside[aria-label="Workspace"][data-maximized] {
+  background: var(--card-solid) !important;
 }
 
 /* Popovers/menus — same glass treatment */
@@ -1776,17 +1784,17 @@ html:not(.dark) .conversations-sidebar {
 }
 @media (min-width: 48rem) {
   :root:not(.dark)[data-theme="custom"][data-custom-translucent-sidebar]
-    :is(.conversations-sidebar, aside[aria-label="Workspace"]) {
+    :is(.conversations-sidebar, aside[aria-label="Workspace"]:not([data-maximized])) {
     background-color: var(--custom-light-sidebar);
     backdrop-filter: blur(20px) saturate(1.12);
   }
   .dark[data-theme="custom"][data-custom-translucent-sidebar]
-    :is(.conversations-sidebar, aside[aria-label="Workspace"]) {
+    :is(.conversations-sidebar, aside[aria-label="Workspace"]:not([data-maximized])) {
     background-color: var(--custom-dark-sidebar);
     backdrop-filter: blur(20px) saturate(1.12);
   }
   :root[data-theme="custom"][data-custom-translucent-sidebar]
-    aside[aria-label="Workspace"]
+    aside[aria-label="Workspace"]:not([data-maximized])
     :is([data-workspace-panel-content] > *, [data-workspace-panel-surface]) {
     background-color: transparent;
   }

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -685,6 +685,7 @@ export function WorkspacePanel({
       // same flush/bordered styling — only the width changes. The resize
       // handle is suppressed in that state — there's no neighbor to resize
       // against.
+      data-maximized={maximized || undefined}
       className={cn(
         "@container/rail relative z-40 hidden md:flex md:min-h-0 md:flex-col md:overflow-hidden md:border-l md:border-border md:bg-card",
         maximized ? "md:absolute md:inset-0" : "md:shrink-0",


### PR DESCRIPTION
## Related issue

N/A

## Summary

In dark mode, the workspace panel's background is set to `transparent` so it blends into the canvas when docked. When the panel is maximized (fullscreen mode for viewing code changes), it uses `absolute inset-0` to cover the full content area — but the transparent background lets the chat content underneath bleed through.

This fix:
- Adds a `data-maximized` attribute to the workspace panel `<aside>` when maximized.
- Gates the dark-mode transparent background rule with `:not([data-maximized])` so it only applies when docked.
- Applies `var(--card-solid)` as an opaque background when maximized, covering all themes (default, custom translucent sidebar, and built-in themes with semi-transparent `--card` values).

## Test Plan

1. Open the app in dark mode.
2. Open a file or diff in the workspace panel.
3. Click the maximize button to enter fullscreen.
4. Verify the background is solid — no chat content visible behind the code.
5. Click minimize to return to docked mode and verify the panel still blends into the canvas as before.
6. Repeat with a custom theme that uses translucent sidebar.

## Demo

Before (chat bleeds through maximized workspace panel):

<img width="1540" height="846" alt="Screenshot From 2026-08-07 15-38-29" src="https://github.com/user-attachments/assets/07abf483-986b-451d-b9dc-fbe555865d50" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CSS-only fix plus one data attribute. Verified manually by maximizing the workspace panel in dark mode and confirming the background is opaque. No automated test covers glassmorphism rendering.

## Changelog

Maximized workspace panel no longer shows chat content through a transparent background in dark mode.