### PR TITLE
fix(host): forward SSH_AUTH_SOCK to runners and harness CLIs

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -433,6 +433,12 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # not match what the host owner configured (e.g. a non-standard
         # kubeconfig location or a colon-separated multi-file list).
         "KUBECONFIG",
+        # ssh-agent socket path. Same class as KUBECONFIG above: a path to a
+        # unix socket, not a bearer secret. Without it every runner-spawned
+        # context (sys_os_shell, terminal panes, coding sub-agents) loses
+        # ssh-agent auth, so git-over-SSH and SSH-cert-authenticated tooling
+        # fail with "dial unix: missing address".
+        "SSH_AUTH_SOCK",
         # Telemetry master opt-in. MUST propagate, or the daemon-spawned runner
         # (and the harness it spawns) never see OMNIGENT_TELEMETRY_ENABLED, so
         # telemetry.init() no-ops there and omni-runner / omni-harness export

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -57,6 +57,12 @@ BASE_ALLOW_EXACT: frozenset[str] = frozenset(
         # without it a corporate-CA user upgrading would hit TLS failures from
         # every harness that does not happen to own a NODE_ prefix of its own.
         "NODE_EXTRA_CA_CERTS",
+        # ssh-agent socket path, so an agent's git-over-SSH and SSH-cert
+        # tooling authenticates. A path to a unix socket, not a bearer token:
+        # reaching the agent still requires the user's own ssh-agent to be
+        # running and to hold the key. Shared here because every harness runs
+        # git, not just the one whose bug surfaced it.
+        "SSH_AUTH_SOCK",
         OMNIGENT_SESSION_ENV_VAR,
     }
 )

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -97,8 +97,13 @@ class _PopenKwargs(TypedDict, total=False):
 #   non-interactive startup.
 # - ``PROMPT_COMMAND``: arbitrary command run by bash before each prompt.
 # - ``CDPATH``: changes the resolution of relative paths in shell ``cd``.
-# - ``SSH_AUTH_SOCK``: the user's running ssh-agent socket — a
-#   credential surface masquerading as a path.
+# - ``SSH_AUTH_SOCK``: the user's ssh-agent socket. Allowed through the
+#   weaker host→runner and harness-CLI boundaries (a socket path, like
+#   ``KUBECONFIG``), but an ACTIVE sandbox is where the agent is being
+#   deliberately confined, and signing with the user's keys is exactly
+#   what that confinement is for. Opt in per-spec, and grant the socket
+#   path too: under seatbelt / bwrap the name alone points at something
+#   unreachable.
 # - ``DBUS_SESSION_BUS_ADDRESS``: lets the helper talk to the user's
 #   D-Bus session.
 # - ``XDG_RUNTIME_DIR``: per-session socket directory (Wayland, ssh-

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -2055,6 +2055,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "SOME_RANDOM_VAR": "x",
         "OMNIGENT_CLAUDE_SDK_NO_SANDBOX": "1",
         "KUBECONFIG": "/home/alice/.kube/config",
+        "SSH_AUTH_SOCK": "/private/tmp/com.apple.launchd.7Qk/Listeners",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
         "OMNIGENT_DATABRICKS_EXTRA_HEADERS": '{"x-databricks-route-hint": "instance-abc"}',
         "OMNIGENT_LOG_LEVEL": "DEBUG",
@@ -2101,6 +2102,10 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # KUBECONFIG is a filesystem path (not a secret) — kubectl, helm, k9s
     # need it to resolve the user's cluster contexts and namespaces.
     assert env["KUBECONFIG"] == "/home/alice/.kube/config"
+    # SSH_AUTH_SOCK is a socket path on the same footing. Dropping it leaves
+    # every runner-spawned context without ssh-agent auth, so git-over-SSH and
+    # SSH-cert tooling fail with "dial unix: missing address".
+    assert env["SSH_AUTH_SOCK"] == "/private/tmp/com.apple.launchd.7Qk/Listeners"
     # CLAUDE_CODE_SKIP_BEDROCK_AUTH disables AWS SigV4 auth for LiteLLM
     # proxies — a non-secret boolean, same rationale as CLAUDE_CODE_USE_BEDROCK.
     assert env["CLAUDE_CODE_SKIP_BEDROCK_AUTH"] == "1"

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -181,6 +181,14 @@ def test_real_builders_pass_node_extra_ca_certs(monkeypatch):
         assert env.get("NODE_EXTRA_CA_CERTS") == "/etc/corp-ca.pem", harness
 
 
+def test_real_builders_pass_ssh_auth_sock(monkeypatch):
+    """ssh-agent must survive filtering, or git-over-SSH breaks in every harness."""
+    sock = "/private/tmp/com.apple.launchd.7Qk/Listeners"
+    monkeypatch.setattr("os.environ", {"SSH_AUTH_SOCK": sock})
+    for harness, build in sorted(SPAWN_ENV_BUILDERS.items()):
+        assert build().get("SSH_AUTH_SOCK") == sock, harness
+
+
 @pytest.mark.parametrize("harness", sorted(HARNESS_PREFIXES))
 def test_no_harness_inherits_unrelated_secrets(harness, hostile_env):
     env = clean_agent_env(allow_prefixes=HARNESS_PREFIXES[harness], source=hostile_env)


### PR DESCRIPTION
## Related issue

Closes #3531

## Summary

Every runner-spawned context lost the ssh-agent socket, so any agent doing git-over-SSH or SSH-cert-authenticated tooling failed with `dial unix: missing address`. In certificate-based auth flows this often surfaces as a confusing `401 Unauthorized` from the endpoint rather than an SSH error, because such tools hard-fail without the socket and have no cached-token fallback.

**ELI5:** your ssh-agent is a doorman holding your keys, and `SSH_AUTH_SOCK` is the intercom number for reaching them. Omnigent was handing agents a blank intercom number, so they'd knock on the door and get turned away, without any hint that the number was the problem.

Two independent gates dropped it:

- **host→runner:** `_build_runner_env` filters the host env through `_RUNNER_ENV_ALLOWLIST`, which omitted `SSH_AUTH_SOCK`. This is also the list *both* host-daemon modes consult, so this one entry fixes the remote-daemon hop too (issue caveat #3).
- **runner→vendor CLI:** `clean_agent_env` is the shared deny-by-default filter, and its safe base omitted it.

```
host (has SSH_AUTH_SOCK)
  └─ _build_runner_env  ─────────── gate 1: allowlist ......... FIXED
       └─ runner
            ├─ clean_agent_env ──── gate 2: shared safe base ... FIXED  (all 7 harnesses)
            │    └─ vendor CLI (codex/goose/acp/kimi/hermes/qwen/pi)
            ├─ sys_os_shell ─────── mirrors parent env ......... inherits the fix
            └─ terminal pane ────── os.environ.copy() ......... inherits the fix
```

Classified as a **path, not a bearer secret**: it names a unix socket, and reaching the agent behind it still requires the user's own ssh-agent to be running and holding the key. Same footing as `KUBECONFIG`, already allowlisted on exactly that reasoning.

An **active OS sandbox deliberately keeps excluding it**: that boundary exists to confine the agent, and signing with the user's keys is what it confines. `os_env.py` previously justified its exclusion by calling the variable "a credential surface masquerading as a path", contradicting the classification above; that rationale is rewritten to rest on the sandbox boundary, so the codebase states one position instead of both.

### Two deliberate divergences from the scope proposed in [this comment](https://github.com/omnigent-ai/omnigent/issues/3531#issuecomment-5150507442)

**Gate 2 is fixed in the shared base, not in codex.** The proposal was to patch codex's `_clean_codex_env`. That function is a thin wrapper over `clean_agent_env`, which is the spawn-env filter for **all seven** harnesses. Patching only codex would have left the other six broken while looking fixed, so the fix lands one level down. Smaller diff, and it's the actual root cause.

**Gate 3 (`shell_environment_policy.inherit="all"`) is intentionally NOT added, because its premise does not reproduce.** On codex-cli 0.144.3 the default already passes `SSH_AUTH_SOCK` through; only an explicit `inherit="core"` drops it. Measured with a clean `CODEX_HOME` to rule out local config:

| `inherit` | `SSH_AUTH_SOCK` present | total vars |
|---|---|---|
| *(default, unset)* | yes | 72 |
| `all` | yes | 72 |
| `core` | **no** | |
| `none` | **no** | |

Since default and `all` are identical, forcing `all` would buy nothing for the common case, and for the one user who *did* set `inherit = "core"` it would silently override a deliberate narrowing of their own env. Omnigent sets no `shell_environment_policy` anywhere and copies the user's `config.toml`, so that setting stays the user's call. If someone reproduces a drop on a codex version where the default differs, that's worth a follow-up issue rather than a pre-emptive override here.

## Test Plan

```bash
pytest tests/test_agent_spawn_env_canary.py \
       tests/host/test_connect.py::test_build_runner_env_allowlists_host_env_and_strips_secrets
```

- New `test_real_builders_pass_ssh_auth_sock` drives **all seven** harnesses' real spawn-env builders, so a future harness that forgets to filter correctly fails here. Sits beside the existing `NODE_EXTRA_CA_CERTS` canary, which guards the same "must survive filtering" property.
- Extended the existing host→runner allowlist test with the socket assertion.
- Suites run green: `test_agent_spawn_env_canary.py` (38), `test_connect.py`, `test_os_env*.py`, plus goose/kimi/hermes/acp/pi executor suites (354).
- Wrote a scratch repro driving all three env builders with a planted host env: both gates print `DROPPED` before the change and the socket path after. Confirmed `sys_os_shell` was innocent (passes through both before and after), matching the issue's analysis.
- Verified in code that `sys_terminal_launch` is a plain `os.environ.copy()` with no name filtering, so it inherits gate 1 rather than needing its own entry.

Two pre-existing failures on this branch, both reproduced on stashed clean `main` and unrelated to this change: `test_connect.py::test_run_host_process_announces_session_log_dir_on_start` and `test_codex_hooks_generation.py::test_router_hook_survives_a_shadowing_workspace`.

## Demo

N/A (no user-visible UI; the change is an env-propagation fix).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage pins both gates: the per-harness canary covers gate 2 for all seven harnesses, and the allowlist test covers gate 1.

Manual verification was the codex `inherit` matrix above (real `codex sandbox` invocations against a clean `CODEX_HOME`) plus the scratch before/after repro of the two gates. The codex matrix is deliberately not a test: it asserts third-party CLI default behaviour that we don't control and would turn into a false alarm on a vendor version bump.

Not covered automatically: a real end-to-end `ssh -T git@github.com` through a live ssh-agent inside a runner-spawned pane, which needs a real agent and network. Reviewers wanting that check can start `omnigent host` **without** the `OMNIGENT_RUNNER_ENV_PASSTHROUGH=SSH_AUTH_SOCK` workaround and run `echo $SSH_AUTH_SOCK && ssh -T git@github.com` in both `sys_os_shell` and a `sys_terminal_launch` pane.

## Changelog

Agents now inherit your ssh-agent, so git-over-SSH and SSH-cert-authenticated tooling work in agent shells and terminals
