### PR TITLE
fix(sandbox): skip escaping-symlink masks that abort the bwrap namespace

### DIFF
--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -278,11 +278,11 @@ def scan_cwd_mask_entries(
                     continue
                 seen.add(key)
                 # ``is_dir`` follows symlinks by default — matches what
-                # the agent would observe through the bind. For broken
-                # symlinks it returns False; the backend's "file"
-                # emitter handles both (``--bind /dev/null`` works on
-                # a broken symlink; SBPL ``(literal ...)`` denies the
-                # path regardless of what it points at).
+                # the agent would observe through the bind. Backends decide
+                # how to act on a symlink entry: SBPL ``(literal ...)``
+                # denies the path itself, while bwrap cannot mount onto a
+                # symlink at all and skips it (the mount namespace already
+                # confines where the link resolves).
                 kind: MaskKind = "dir" if child.is_dir() else "file"
                 entries.append(MaskedEntry(path=child_path, kind=kind))
                 # Prune: don't descend into a masked dir.

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1142,6 +1142,15 @@ def _dotfile_and_symlink_mask_args(
         # still masked.
         if not _path_exists_lstat(entry.path):
             continue
+        # Symlinks are skipped: bwrap resolves a mount destination through
+        # the final symlink, so both mask shapes abort the whole namespace
+        # ("Can't create file at <link>" / "Can't mount tmpfs on <link>")
+        # and kill the launcher at spawn. Skipping is safe because the mount
+        # namespace already confines symlink resolution — the link is
+        # followed inside the sandbox view, where an escaping target is
+        # either unmounted or independently masked.
+        if entry.path.is_symlink():
+            continue
         if entry.kind == "dir":
             args.extend(["--tmpfs", str(entry.path)])
         else:

--- a/tests/inner/test_bwrap_symlink_mask_3265.py
+++ b/tests/inner/test_bwrap_symlink_mask_3265.py
@@ -1,0 +1,135 @@
+"""Escaping-symlink masks must not emit a mount onto the symlink path.
+
+bwrap resolves a mount destination *through* a final symlink, so masking a
+symlink aborts the whole namespace (``Can't create file at <link>`` for the
+file shape, ``Can't mount tmpfs on <link>`` for the dir shape) and kills the
+launcher at spawn. Skipping symlink entries is safe: the mount namespace
+already confines symlink resolution, so the link is followed inside the
+sandbox view where an escaping target is unmounted or separately masked.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+from omnigent.inner.bwrap_sandbox import _dotfile_and_symlink_mask_args
+from omnigent.inner.sandbox import SandboxPolicy
+
+_BWRAP = shutil.which("bwrap")
+
+
+def _mask_args_for(tmp_path: pathlib.Path) -> list[str]:
+    """Ask the real bwrap emitter for the mask args covering *tmp_path*."""
+    policy = SandboxPolicy(
+        backend_type="linux_bwrap",
+        active=True,
+        read_roots=[tmp_path],
+        write_roots=[tmp_path],
+        write_files=[],
+        allow_network=True,
+        cwd_hidden_scan_overflow="warn",
+    )
+    return _dotfile_and_symlink_mask_args(tmp_path, [], policy)
+
+
+def test_no_mask_targets_a_symlink(tmp_path: pathlib.Path) -> None:
+    """No emitted mount may point at a symlink, for either mask shape."""
+    tasks = tmp_path / "proj" / "sess" / "tasks"
+    tasks.mkdir(parents=True)
+    # Escape to $HOME: /tmp is itself a safe root, so a tmp-to-tmp link never
+    # counts as escaping. This mirrors production, where the claude CLI links
+    # /tmp/claude-<uid>/.../tasks/<id>.output into ~/.claude/projects/.
+    escaping_file = pathlib.Path.home() / ".claude" / "nonexistent-3265.jsonl"
+    escaping_dir = pathlib.Path.home() / ".claude"
+    # A symlink to a file (the `tasks/<id>.output` shape) and one to a
+    # directory — the dir shape aborts too, via `--tmpfs <link>`.
+    (tasks / "abc.output").symlink_to(escaping_file)
+    (tasks / "dirlink").symlink_to(escaping_dir)
+
+    args = _mask_args_for(tmp_path)
+    destinations = [
+        args[i + 2] if args[i] != "--tmpfs" else args[i + 1]
+        for i in range(len(args))
+        if args[i] in ("--tmpfs", "--bind-try")
+    ]
+    offenders = [d for d in destinations if pathlib.Path(d).is_symlink()]
+    assert not offenders, f"mask targets a symlink, which aborts bwrap: {offenders}"
+
+
+@pytest.mark.skipif(_BWRAP is None, reason="bwrap not installed")
+def test_skipping_symlink_masks_does_not_leak_the_target(tmp_path: pathlib.Path) -> None:
+    """Skipping the symlink mask must not expose a masked target's content."""
+    secret = tmp_path / ".env"
+    secret.write_text("DOTSECRET", encoding="utf-8")
+    dotdir = tmp_path / ".aws"
+    dotdir.mkdir()
+    (dotdir / "credentials").write_text("AWSKEY", encoding="utf-8")
+
+    # Absolute links to the masked paths: the mask must still win when the
+    # sandbox follows them, even though no mount is emitted on the links.
+    (tmp_path / "link_to_dotfile").symlink_to(secret.resolve())
+    (tmp_path / "link_into_dotdir").symlink_to((dotdir / "credentials").resolve())
+
+    argv = [_BWRAP, "--ro-bind", "/usr", "/usr"]
+    for path in ("/bin", "/lib", "/lib64"):
+        if pathlib.Path(path).exists():
+            argv += ["--ro-bind-try", path, path]
+    argv += ["--dev", "/dev", "--tmpfs", "/tmp"]
+    argv += ["--bind-try", str(tmp_path), str(tmp_path)]
+    # Exactly what the emitter now produces: masks on the real dotfile and
+    # dotdir, and nothing at all on the two symlinks.
+    argv += _mask_args_for(tmp_path)
+    argv += [
+        shutil.which("sh") or "/bin/sh",
+        "-c",
+        f"cat {tmp_path / 'link_to_dotfile'} {tmp_path / 'link_into_dotdir'} {secret} "
+        "2>/dev/null; exit 0",
+    ]
+
+    done = subprocess.run(argv, capture_output=True, text=True)
+    assert done.returncode == 0, f"namespace must assemble: {done.stderr}"
+    assert "DOTSECRET" not in done.stdout
+    assert "AWSKEY" not in done.stdout
+
+
+@pytest.mark.skipif(_BWRAP is None, reason="bwrap not installed")
+def test_bwrap_rejects_a_bind_onto_a_symlink(tmp_path: pathlib.Path) -> None:
+    """Pin the bwrap behavior the emitter has to respect."""
+    plain = tmp_path / "plain"
+    plain.write_text("x", encoding="utf-8")
+    link = tmp_path / "link"
+    link.symlink_to(plain)
+
+    base = [_BWRAP, "--ro-bind", "/usr", "/usr"]
+    for path in ("/bin", "/lib", "/lib64"):
+        if pathlib.Path(path).exists():
+            base += ["--ro-bind-try", path, path]
+    base += [
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+        "--bind-try",
+        str(tmp_path),
+        str(tmp_path),
+    ]
+    true_bin = shutil.which("true") or "/bin/true"
+
+    ok = subprocess.run(
+        [*base, "--bind-try", "/dev/null", str(plain), true_bin],
+        capture_output=True,
+        text=True,
+    )
+    assert ok.returncode == 0, f"regular-file mask should work: {ok.stderr}"
+
+    bad = subprocess.run(
+        [*base, "--bind-try", "/dev/null", str(link), true_bin],
+        capture_output=True,
+        text=True,
+    )
+    assert bad.returncode != 0
+    assert "Can't create file at" in bad.stderr


### PR DESCRIPTION
## Related issue

Closes #3265

## Summary

A `claude-sdk` agent with `sandbox.type: linux_bwrap` died at **every** session spawn with an opaque Claude SDK connect timeout, the real error being:

```
bwrap: Can't create file at /tmp/claude-<uid>/<proj>/<sess>/tasks/<id>.output: No such file or directory
```

- **Root cause:** the dotfile / escaping-symlink masker emitted `--bind-try /dev/null <path>` for every non-directory entry. bwrap resolves a mount destination *through* a final symlink, so when the entry is a **symlink** the mount aborts the whole namespace and the launcher exits non-zero. The claude CLI links `tasks/<id>.output` into `~/.claude/projects/...`, which escapes the safe-root set, so the walker flagged it and the emitter aimed a mount at the link.
- **Fix:** skip symlink entries in the bwrap emitter. Safe because the mount namespace already confines symlink resolution: the link is followed *inside* the sandbox view, where an escaping target is either not mounted or independently masked.
- Also corrects a comment in `_cwd_scan.py` asserting `--bind /dev/null` "works on a broken symlink". It does not on bwrap, and that claim is what licensed the bug.

**Both mask shapes were affected**, not just the file one:

| mask target | emitted | bwrap result |
|---|---|---|
| regular file | `--bind-try /dev/null <path>` | ok |
| symlink → file | `--bind-try /dev/null <link>` | `Can't create file at <link>` |
| symlink → dir | `--tmpfs <link>` | `Can't mount tmpfs on <link>` |

Depth is irrelevant: a symlink and a regular file in the *same* bound directory differ only by kind. So pre-creating the nested `tasks/` subtree (one of the fixes floated on the issue) would not have helped, since the bind is still aimed at a symlink.

**Not `claude-sdk` specific.** The cwd pass always runs and `linux_bwrap` is the Linux default, so any escaping symlink in an agent workspace hit this. `darwin_seatbelt` shares the walker but emits path-based SBPL literals and is unaffected.

**Why #2749's degrade could not catch it:** `wrap_launcher_argv` only *builds* argv and never executes bwrap, so a mount-time failure is structurally invisible to a dry run of the builder. Worth noting `run_launcher` also uses `os.execvp`, which replaces the process, so its `except BaseException` cannot observe bwrap's non-zero exit either. That degrade gap is left alone here: it converts a hard crash into a silent de-sandbox, so it deserves its own PR rather than riding along with a security-path fix.

### ELI5

The sandbox hides secret-looking files by pasting an empty file over them. That works on a real file, but a symlink is a signpost, not a place, so there's nothing to paste onto and the whole sandbox refuses to start. Turns out we never needed to cover signposts: the sandbox only shows the agent a small set of directories, and a signpost pointing outside that set already leads nowhere.

## Test Plan

New `tests/inner/test_bwrap_symlink_mask_3265.py` (3 tests), all exercising the real emitter:

1. `test_no_mask_targets_a_symlink` — no emitted mount may point at a symlink, covering both the file and dir shapes.
2. `test_skipping_symlink_masks_does_not_leak_the_target` — **the security check.** Boots a real bwrap namespace and confirms reads *through* symlinks to a masked dotfile and into a masked dotdir return nothing, so skipping the mask is not a hole.
3. `test_bwrap_rejects_a_bind_onto_a_symlink` — pins the bwrap behavior the emitter must respect, so a future change that reinstates the mount fails loudly.

A/B verified the tests are load-bearing (not vacuous):

```bash
git checkout HEAD~1 -- omnigent/inner/bwrap_sandbox.py   # drop the fix
pytest tests/inner/test_bwrap_symlink_mask_3265.py -q    # 1 failed, 2 passed
git checkout HEAD -- omnigent/inner/bwrap_sandbox.py     # restore
pytest tests/inner/test_bwrap_symlink_mask_3265.py -q    # 3 passed
```

Regression suites (`bwrap`, `cwd_scan`, `sandbox`, `seatbelt`, `claude_sdk_executor`): **183 passed, 12 skipped, 0 failures**. `pre-commit` clean on the range.

Reproduced end-to-end first: instrumenting the walker against my own `/tmp/claude-1000` returned 5 flagged entries, all `→ ~/.claude/projects/.../subagents/*.jsonl`, matching the reported path shape exactly. Local `bwrap` is 0.4.0; the reporter saw 0.11.1, and the constraint predates both.

## Demo

N/A — non-visual sandbox fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two bwrap-executing tests are `skipif`-guarded on `shutil.which("bwrap")`, so they run on Linux CI and skip cleanly elsewhere; test 1 is pure argv assembly and runs everywhere.

Manual verification: isolated the failure to the symlink destination by masking a regular file and a symlink in the same bound directory (file `RC=0`, symlink aborts), and confirmed no bwrap mount shape can target a symlink (`--bind-try`, `--ro-bind-try`, `--symlink`, `--tmpfs` all fail). Confirmed the security question empirically in both directions: a symlink whose target is unmounted already reads empty (mask redundant), while a symlink to `/etc/hostname` under a default bind *does* resolve, which is why the dotfile/dotdir masks on real targets must stay and only the symlink emission is dropped.

Not covered: a live `claude-sdk` spawn on bwrap 0.11.1. I reproduced the mount failure directly at the bwrap layer instead, which is the layer the fix changes.
