### PR TITLE
fix(web): remember the sidebar's session filter across reloads

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_session_filter_persistence.py
+++ b/tests/e2e_ui/sessions/test_sidebar_session_filter_persistence.py
@@ -1,0 +1,241 @@
+"""Browser e2e: the sidebar's session filter survives a page reload.
+
+The sidebar's session filter (the funnel: All / My sessions / Shared /
+Archived) used to live only in React state, so every reload snapped the list
+back to "All sessions" — a viewer who works out of "My sessions" had to
+re-pick it after each refresh. The pick is now persisted per-device
+(``omnigent:session-filter`` in ``localStorage``) and seeded back on mount.
+
+These drive the real chain the ``Sidebar`` unit tests mock out, end-to-end
+against a live server: seed an owned session and a shared one over the REST
+API, pick a filter through the live funnel, reload the browser, and assert
+the list is still scoped and the radio item still reads checked.
+
+Also covered is the read-side guard. "Shared sessions" is dropped from the
+menu on a loopback-only server (one user, so the slice is meaningless), so a
+value stored against a multi-user server must not be honored there — it would
+scope the list to a slice with no menu entry to leave it by. That half runs
+against the single-user ``live_server``; the persistence halves need the
+multi-user server, since the shared filter is what makes a reload's scoping
+observable (rows drop *out*, rather than merely staying put).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Locator, Page, expect
+
+from tests.e2e_ui.collaboration._multi_user_server import (
+    ADMIN_EMAIL,
+    MultiUserServer,
+    spawn_multi_user_server,
+)
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+# Edit access (2): enough to share a session with a non-owner. Mirrors
+# LEVEL_EDIT in omnigent/server/auth.py.
+_LEVEL_EDIT = 2
+
+_FILTER = '[data-testid="session-filter"]'
+
+# Where the sidebar persists the pick (see web/src/lib/sessionFilterPreferences.ts).
+_STORAGE_KEY = "omnigent:session-filter"
+
+
+def _create_session(server: MultiUserServer, *, owner_email: str, title: str) -> str:
+    """Create a session owned by *owner_email* and give it a unique *title*.
+
+    A multi-user header-auth server 401s headerless writes, so both the create
+    and the title PATCH carry the owner's ``X-Forwarded-Email``. The title makes
+    the row easy to spot among other tests' sessions on the shared server.
+    """
+    headers = {"X-Forwarded-Email": owner_email}
+    create = httpx.post(
+        f"{server.base_url}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", _build_hello_world_bundle(), "application/gzip")},
+        headers=headers,
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = create.json()["session_id"]
+    resp = httpx.patch(
+        f"{server.base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        headers=headers,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return session_id
+
+
+def _grant(server: MultiUserServer, session_id: str, user_id: str, level: int) -> None:
+    """Grant *user_id* *level* on *session_id* (the admin owner acts)."""
+    resp = httpx.put(
+        f"{server.base_url}/v1/sessions/{session_id}/permissions",
+        json={"user_id": user_id, "level": level},
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """The sidebar row (``<li>``) for *session_id*, located by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _set_filter(page: Page, value: str) -> None:
+    """Open the filter funnel and pick *value* (all/mine/shared/archived)."""
+    page.locator(_FILTER).click()
+    page.locator(f'[data-testid="session-filter-{value}"]').click()
+
+
+def _expect_checked_filter(page: Page, value: str) -> None:
+    """Open the funnel and assert *value* is the checked radio item."""
+    page.locator(_FILTER).click()
+    expect(page.locator(f'[data-testid="session-filter-{value}"]')).to_have_attribute(
+        "aria-checked", "true", timeout=15_000
+    )
+    # Close the menu so a follow-up assertion isn't blocked by Radix's
+    # aria-hidden on the rest of the tree.
+    page.keyboard.press("Escape")
+
+
+@pytest.fixture(scope="module")
+def multi_user_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[MultiUserServer]:
+    """A NON-single-user server so the Shared filter renders."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_session_filter_persistence")
+    yield from spawn_multi_user_server(mock_llm_server_url, server_tmp)
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_my_sessions_filter_survives_a_reload(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """Picking "My sessions" still scopes the list after a full page reload.
+
+    Seeds a session the viewer owns and one the admin shared with them, picks
+    "My sessions" (dropping the shared row), then reloads. Before the fix the
+    filter reset to "All sessions" on load, so the shared row came back and the
+    viewer had to re-pick after every refresh.
+
+    Asserts both the visible effect (shared row stays out, owned row stays in)
+    and the menu state (the radio item reads checked), so a list that happened
+    to look right for another reason can't pass.
+    """
+    server = multi_user_server
+    uniq = uuid.uuid4().hex[:6]
+    viewer_email = f"viewer-filter-{uniq}@ui.test"
+
+    owned = _create_session(server, owner_email=viewer_email, title=f"e2e-filter-owned-{uniq}")
+    shared = _create_session(server, owner_email=ADMIN_EMAIL, title=f"e2e-filter-shared-{uniq}")
+    _grant(server, shared, viewer_email, _LEVEL_EDIT)
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{owned}")
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+
+        # Default "All sessions": both rows visible, so the scoping below is a
+        # real change rather than a row that was never there.
+        expect(_row(page, owned)).to_be_visible(timeout=30_000)
+        expect(_row(page, shared)).to_be_visible(timeout=30_000)
+
+        _set_filter(page, "mine")
+        expect(_row(page, shared)).to_have_count(0, timeout=15_000)
+        expect(_row(page, owned)).to_be_visible()
+
+        # The reload the fix is about: a fresh document, so the sidebar must
+        # re-seed the filter from storage rather than default to "All sessions".
+        page.reload()
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+        expect(_row(page, owned)).to_be_visible(timeout=30_000)
+        expect(_row(page, shared)).to_have_count(0)
+        _expect_checked_filter(page, "mine")
+    finally:
+        ctx.close()
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_shared_sessions_filter_survives_a_reload(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """The Shared filter also persists — the write isn't special-cased to "mine".
+
+    The persistence hangs off the sidebar's single tab-change funnel, so every
+    option should round-trip. This picks the opposite slice from the test above
+    and reloads: the shared row stays, the owned one stays out.
+    """
+    server = multi_user_server
+    uniq = uuid.uuid4().hex[:6]
+    viewer_email = f"viewer-shared-{uniq}@ui.test"
+
+    owned = _create_session(server, owner_email=viewer_email, title=f"e2e-shared-owned-{uniq}")
+    shared = _create_session(server, owner_email=ADMIN_EMAIL, title=f"e2e-shared-shared-{uniq}")
+    _grant(server, shared, viewer_email, _LEVEL_EDIT)
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{owned}")
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+        expect(_row(page, shared)).to_be_visible(timeout=30_000)
+
+        _set_filter(page, "shared")
+        expect(_row(page, shared)).to_be_visible(timeout=15_000)
+        expect(_row(page, owned)).to_have_count(0, timeout=15_000)
+
+        page.reload()
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+        expect(_row(page, shared)).to_be_visible(timeout=30_000)
+        expect(_row(page, owned)).to_have_count(0)
+        _expect_checked_filter(page, "shared")
+    finally:
+        ctx.close()
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_stored_shared_filter_is_dropped_on_a_single_user_server(
+    page: Page,
+    live_server: str,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A persisted "shared" doesn't strand the viewer on a single-user server.
+
+    ``live_server`` is loopback-only, so the funnel drops "Shared sessions" —
+    there's one user and the slice is meaningless. Seeding the stored value
+    that a multi-user server would have written (or a hand-edited entry) must
+    therefore fall back to "All sessions": honoring it would scope the list to
+    a slice with no menu entry to leave it by, i.e. an empty list the viewer
+    can't escape.
+
+    Uses ``add_init_script`` so the value is in storage *before* any app script
+    runs, which is what a returning viewer's first paint actually sees.
+    """
+    _base_url, session_id = seeded_session
+    page.add_init_script(f"localStorage.setItem({_STORAGE_KEY!r}, 'shared');")
+
+    page.goto(f"{live_server}/c/{session_id}")
+    expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+
+    # The viewer's own session renders (an honored "shared" would hide it), and
+    # the menu shows All checked with no Shared option to have selected.
+    expect(_row(page, session_id)).to_be_visible(timeout=30_000)
+    page.locator(_FILTER).click()
+    expect(page.locator('[data-testid="session-filter-all"]')).to_have_attribute(
+        "aria-checked", "true", timeout=15_000
+    )
+    expect(page.locator('[data-testid="session-filter-shared"]')).to_have_count(0)

--- a/web/src/lib/sessionFilterPreferences.test.ts
+++ b/web/src/lib/sessionFilterPreferences.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SESSION_FILTER,
+  readSessionFilter,
+  writeSessionFilter,
+} from "./sessionFilterPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("sessionFilterPreferences", () => {
+  it('defaults to "all" when nothing is stored', () => {
+    // A first-time viewer sees the whole list, as before persistence existed.
+    expect(DEFAULT_SESSION_FILTER).toBe("all");
+    expect(readSessionFilter(true)).toBe("all");
+  });
+
+  it("round-trips every filter value", () => {
+    for (const filter of ["all", "mine", "shared", "archived"] as const) {
+      writeSessionFilter(filter);
+      expect(readSessionFilter(true)).toBe(filter);
+    }
+  });
+
+  it("falls back to the default for an unknown stored value", () => {
+    // Guards against a hand-edited entry or a filter this build dropped:
+    // scoping the list to a slice with no menu entry would strand the viewer.
+    localStorage.setItem("omnigent:session-filter", "starred");
+    expect(readSessionFilter(true)).toBe("all");
+
+    localStorage.setItem("omnigent:session-filter", "");
+    expect(readSessionFilter(true)).toBe("all");
+  });
+
+  it('ignores a stored "shared" on a single-user server', () => {
+    // A loopback-only server drops "Shared sessions" from the menu, so honoring
+    // it would show an empty list the viewer has no control to leave.
+    writeSessionFilter("shared");
+    expect(readSessionFilter(false)).toBe("all");
+    // Still honored where the option exists.
+    expect(readSessionFilter(true)).toBe("shared");
+  });
+
+  it("keeps the other filters on a single-user server", () => {
+    writeSessionFilter("archived");
+    expect(readSessionFilter(false)).toBe("archived");
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API.
+    // Both helpers must swallow them — a broken preference must not break the
+    // sidebar.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeSessionFilter("mine")).not.toThrow();
+    expect(readSessionFilter(true)).toBe("all");
+  });
+});

--- a/web/src/lib/sessionFilterPreferences.ts
+++ b/web/src/lib/sessionFilterPreferences.ts
@@ -1,0 +1,60 @@
+// Persisted, per-device preference for which slice the sidebar's session list
+// shows ("All sessions" / "My sessions" / "Shared sessions" / "Archived
+// sessions").
+//
+// The sidebar keeps its live React state as the source of truth; these helpers
+// only seed that state on mount and snapshot it when the visible tab changes,
+// so a reload lands on the slice the viewer was last looking at instead of
+// snapping back to "All sessions". It's a device-local view preference — no
+// account or session state is changed — so it lives in localStorage like the
+// other `*Preferences` helpers.
+
+const STORAGE_KEY = "omnigent:session-filter";
+
+/**
+ * Which slice of sessions the sidebar shows. Mirrors the sidebar's tab
+ * vocabulary; kept here so validation and the stored format live together.
+ */
+export type SessionFilter = "all" | "mine" | "shared" | "archived";
+
+export const DEFAULT_SESSION_FILTER: SessionFilter = "all";
+
+const SESSION_FILTERS = new Set<string>(["all", "mine", "shared", "archived"]);
+
+/**
+ * Read the persisted session filter. Returns {@link DEFAULT_SESSION_FILTER}
+ * when nothing is stored, on a server render (no `window`), when storage is
+ * inaccessible, or when the stored value isn't a filter this build knows —
+ * never throws, so a corrupt or stale entry can't strand the viewer on a slice
+ * the menu can't show.
+ *
+ * `multiUser` mirrors the sidebar's own gate: a loopback-only server has one
+ * user, so "Shared sessions" is dropped from the menu there. A "shared" value
+ * stored against a multi-user server therefore falls back to the default
+ * rather than scoping the list to a slice with no menu entry to leave it by.
+ */
+export function readSessionFilter(multiUser: boolean): SessionFilter {
+  if (typeof window === "undefined") return DEFAULT_SESSION_FILTER;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return DEFAULT_SESSION_FILTER;
+  }
+  if (raw === null || !SESSION_FILTERS.has(raw)) return DEFAULT_SESSION_FILTER;
+  if (raw === "shared" && !multiUser) return DEFAULT_SESSION_FILTER;
+  return raw as SessionFilter;
+}
+
+/**
+ * Persist the session filter. Swallows quota/access errors so a failed write
+ * can't break the sidebar.
+ */
+export function writeSessionFilter(value: SessionFilter): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // The filter is a local view preference; losing it is harmless.
+  }
+}

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -339,6 +339,50 @@ describe("Sidebar session list", () => {
     expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "false");
   });
 
+  it("keeps the picked filter across a remount", () => {
+    mockConversations([
+      conv("conv_mine", "Claude Code"),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
+    ]);
+    renderSidebar();
+
+    selectSessionFilter("mine");
+    expect(screen.queryByText("conv_shared")).toBeNull();
+
+    // Fresh mount re-reads localStorage: still scoped to the viewer's own
+    // sessions. If this fails, the pick lived only in memory and a reload
+    // silently snapped the list back to "All sessions".
+    cleanup();
+    renderSidebar();
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
+    fireEvent.pointerDown(screen.getByTestId("session-filter"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    expect(screen.getByTestId("session-filter-mine")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("drops a persisted Shared filter on a single-user server", () => {
+    // "Shared sessions" isn't in the menu on a loopback-only server, so honoring
+    // a value stored against a multi-user one would scope the list to a slice
+    // the viewer has no option to leave.
+    localStorage.setItem("omnigent:session-filter", "shared");
+    isServerLocalMock.mockReturnValue(true);
+    mockConversations([conv("conv_mine", "Claude Code")]);
+    renderSidebar();
+
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByTestId("session-filter"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    expect(screen.getByTestId("session-filter-all")).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByTestId("session-filter-shared")).toBeNull();
+  });
+
   it("shows archived sessions only under the Archived filter", () => {
     mockConversations([
       conv("conv_live", "Claude Code"),

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -154,6 +154,11 @@ import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
+import {
+  type SessionFilter,
+  readSessionFilter,
+  writeSessionFilter,
+} from "@/lib/sessionFilterPreferences";
 import { NewProjectButton } from "./NewProjectButton";
 import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
@@ -220,9 +225,10 @@ function SidebarRowDataProvider({
 /**
  * Which slice of sessions the sidebar shows. ``"mine"``/``"shared"`` split by
  * ownership (see :func:`isOwnedByViewer`); ``"archived"`` is the only slice
- * that includes archived sessions.
+ * that includes archived sessions. The vocabulary lives with the persistence
+ * helpers, which validate a stored value against it.
  */
-type SidebarTab = "all" | "mine" | "shared" | "archived";
+type SidebarTab = SessionFilter;
 
 const SIDEBAR_FILTERS: { value: SidebarTab; label: string }[] = [
   { value: "all", label: "All sessions" },
@@ -452,11 +458,13 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   // (from the Sessions header or the Projects header kebab, respectively).
   const [selectionScope, setSelectionScope] = useState<SelectionScope>("sessions");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  // Active filter from the Sessions heading's menu.
-  const [activeTab, setActiveTab] = useState<SidebarTab>("all");
   // A loopback-only server has one user, so "Shared" is meaningless there —
   // the filter menu drops that option. Mirrors AppShell's `shareDisabled`.
+  // Read before the filter state, which validates a stored "shared" against it.
   const multiUser = !isCurrentServerLocal();
+  // Active filter from the Sessions heading's menu, seeded from the persisted
+  // preference so a reload keeps the slice the viewer was last on.
+  const [activeTab, setActiveTab] = useState<SidebarTab>(() => readSessionFilter(multiUser));
 
   const lastSelectedIdRef = useRef<string | null>(null);
   const getVisibleIdsRef = useRef<() => string[]>(() => []);
@@ -507,11 +515,13 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   // switch keeps the bulk-action count honest with the visible tab (the viewer
   // re-enters per tab) instead of carrying stale rows across. Every path that
   // changes the tab must go through here — not a bare setActiveTab — or the
-  // selection cleanup is skipped (e.g. the "New session" snap-back below).
+  // selection cleanup and the persisted preference are skipped (e.g. the
+  // "New session" snap-back below).
   const switchTab = useCallback(
     (tab: SidebarTab) => {
       if (selectionMode) exitSelectionMode();
       setActiveTab(tab);
+      writeSessionFilter(tab);
     },
     [selectionMode, exitSelectionMode],
   );


### PR DESCRIPTION
## Related issue

Closes #4380

## Summary

The sidebar's Sessions filter ("All sessions" / "My sessions" / "Shared
sessions" / "Archived sessions") kept its pick only in React state, so every
reload snapped the list back to "All sessions". Anyone working out of one slice
had to re-pick it after each refresh.

- Persist the pick to `localStorage` and seed the sidebar's state from it, in a
  new `web/src/lib/sessionFilterPreferences.ts` following the existing
  `*Preferences` helpers (and the sidebar's own collapsed-section /
  expanded-project state).
- Write it inside `switchTab`, the documented single funnel for tab changes, so
  the "New session" snap-back to "My sessions" is remembered too.
- Validate on read: an unknown filter, or `"shared"` on a loopback-only server
  where the menu drops that option, falls back to "All sessions" rather than
  scoping the list to a slice the viewer has no menu entry to leave.

`SidebarTab` is now an alias of the exported `SessionFilter` so the vocabulary
lives next to the validation that depends on it.

## Test Plan

Automated (from `web/`):

- `npx vitest run src/lib/sessionFilterPreferences.test.ts` — 6 pass.
- `npx vitest run src/shell/Sidebar.test.tsx src/shell/Sidebar.selectionTabs.test.tsx src/shell/Sidebar.shiftSelect.test.tsx` — 89 pass.
- Full suite: 5413 pass, 1 skipped, 3 expected-fail — no regressions.
- `pnpm run type-check`, `oxlint --deny-warnings`, `prettier --check .` — clean.
- `pre-commit run web-prettier web-oxlint web-tsc` — all Passed. The three
  remote file-hygiene hooks (trailing-whitespace / end-of-file-fixer /
  check-yaml) couldn't install in this sandbox (no pypi.org access); verified
  by hand instead — no trailing whitespace, all files newline-terminated, no
  YAML touched.

New tests:

- `sessionFilterPreferences.test.ts` — default, round-trip of all four values,
  unknown-value fallback, the single-user `"shared"` guard, and that neither
  helper throws when `localStorage` is inaccessible (private mode / quota).
- `Sidebar.test.tsx` — picking "My sessions" survives a remount (the real
  round trip through the UI: shared session stays hidden and the radio item
  reads `aria-checked`), and a persisted `"shared"` is dropped on a
  single-user server.

E2E (`tests/e2e_ui/sessions/test_sidebar_session_filter_persistence.py`, 3 tests,
real browser against a live server):

- "My sessions" still scopes the list after a full `page.reload()` — asserted
  both by the shared row staying out and by the radio item reading
  `aria-checked`, so a list that happens to look right can't pass.
- The Shared filter round-trips too, proving the write isn't special-cased to
  `"mine"` (it hangs off the sidebar's single tab-change funnel).
- A stored `"shared"` is dropped on the loopback-only `live_server`, whose menu
  omits that option — seeded via `add_init_script` so the value is in storage
  before any app script runs, as a returning viewer's first paint would see it.

Proved the e2e tests actually catch the bug rather than just describing it:
reverted the seed to `useState<SidebarTab>("all")`, rebuilt the SPA, and the two
persistence tests failed at the post-reload assertion with the filtered-out row
back at count 1; restoring the seed turned them green again. The third passes
either way by design — it guards the read-side fallback, which is independent of
the seed. Neighbouring filter suites (`test_sidebar_pinned_projects_filter_independence.py`,
`test_sidebar_ownership_gating.py`, `test_archived_project_filter.py`) — 7 pass.
`ruff format --check` / `ruff check` clean on the new file.

Manual: pick "My sessions", reload, list stays scoped; repeat for "Archived
sessions".

## Demo

Before:

https://github.com/user-attachments/assets/9b9f6a32-e07b-40d4-a144-e03742779f80


After:

https://github.com/user-attachments/assets/94723e37-c1f1-4efb-bd63-8837c47e8e45



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behaviour is covered by the unit tests above plus the three e2e tests — the
Sidebar unit test asserts the persistence round trip through the real component,
and the e2e tests assert it across a real browser reload, so it fails if the pick
ever goes back to memory-only. The e2e pair was verified to fail without the fix
(see Test Plan). Manually confirmed the reload behaviour in the browser
for "My sessions" and "Archived sessions", since no automated test exercises a
real page reload.

## Changelog

The sidebar remembers your session filter across reloads instead of resetting to "All sessions"
