### PR TITLE
feat: add user-owned managed CoDA leases

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -134,6 +134,26 @@ uv run python deploy/databricks/deploy.py \
     --volume-name main.omnigent.artifacts
 ```
 
+To enable the managed CoDA provider, pass all three deployment-specific values
+together (partial configuration fails fast):
+
+```bash
+uv run python deploy/databricks/deploy.py \
+    --app-name omnigent \
+    --profile <your-profile> \
+    --lakebase-branch projects/omnigent/branches/production \
+    --lakebase-database projects/omnigent/branches/production/databases/databricks-postgres \
+    --volume-name main.omnigent.artifacts \
+    --coda-app-name coda-main \
+    --coda-app-url https://<coda-app>.databricksapps.com \
+    --omnigent-public-server-url https://<omnigent-app>.databricksapps.com
+```
+
+The Omnigent app service principal needs `CAN_USE` on the CoDA app, and the
+CoDA app service principal needs `CAN_USE` on Omnigent. Configure the CoDA app's
+wheel, server URL, and server-client-ID resources with its
+`grant_omnigent_host.sh` and `attach_omnigent_resources.sh` helpers.
+
 The script builds wheels, classifies them by size, copies wheels into
 `src/`, regenerates `src/pyproject.toml` and `src/uv.lock`, runs
 `databricks bundle deploy --target prod`, runs
@@ -225,6 +245,9 @@ Environment variables read by `src/app.py`:
 | `AP_ARTIFACT_VOLUME_PATH` | app resource `valueFrom: artifact_volume` | UC Volume path for artifacts |
 | `DATABRICKS_APP_PORT` | Databricks runtime | App port (default 8000) |
 | `AP_POOL_RECYCLE_SECONDS` | Optional | Connection pool recycle interval (default 300) |
+| `CODA_APP_NAME` | Bundle variable | Managed CoDA Databricks App name |
+| `CODA_APP_URL` | Bundle variable | Managed CoDA Databricks App URL |
+| `OMNIGENT_PUBLIC_SERVER_URL` | Bundle variable | Public URL CoDA runners use to reach Omnigent |
 
 ## Multi-app safety — one bundle, many apps
 

--- a/deploy/databricks/build.sh
+++ b/deploy/databricks/build.sh
@@ -32,6 +32,10 @@ if [[ "${SKIP_WEB_UI:-}" != "1" ]]; then
     pnpm --filter web run build
 else
     echo "==> SKIP_WEB_UI=1: skipping web build"
+    # The omnigent wheel's setup.py build hook rebuilds the SPA on its own and
+    # reads a different variable, so skipping only the step above still ships
+    # the web UI in the wheel.
+    export OMNIGENT_SKIP_WEB_UI=true
 fi
 
 echo "==> Building omnigent-client wheel"

--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -21,6 +21,15 @@ variables:
       UC schema (catalog.schema) holding the OTel destination tables.
       The platform writes to <schema>.otel_logs, otel_metrics, otel_spans.
     default: main.omnigent_logs
+  coda_app_name:
+    description: "Optional managed CoDA Databricks App name."
+    default: ""
+  coda_app_url:
+    description: "Optional managed CoDA Databricks App URL."
+    default: ""
+  omnigent_public_server_url:
+    description: "Public URL this Omnigent App exposes to managed CoDA hosts."
+    default: ""
 
 resources:
   apps:
@@ -44,6 +53,12 @@ resources:
             value_from: artifact_volume
           - name: OTEL_TRACES_SAMPLER
             value: 'always_on'
+          - name: CODA_APP_NAME
+            value: ${var.coda_app_name}
+          - name: CODA_APP_URL
+            value: ${var.coda_app_url}
+          - name: OMNIGENT_PUBLIC_SERVER_URL
+            value: ${var.omnigent_public_server_url}
       resources:
         - name: postgres
           postgres:

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -553,6 +553,21 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--coda-app-name",
+        default="",
+        help="Managed CoDA Databricks App name. Set with the other CoDA URL flags.",
+    )
+    parser.add_argument(
+        "--coda-app-url",
+        default="",
+        help="Managed CoDA Databricks App URL. Set with --coda-app-name.",
+    )
+    parser.add_argument(
+        "--omnigent-public-server-url",
+        default="",
+        help="Public Omnigent App URL supplied to managed CoDA hosts.",
+    )
+    parser.add_argument(
         "--compute-size",
         default="LARGE",
         choices=["SMALL", "MEDIUM", "LARGE"],
@@ -634,7 +649,14 @@ def _parse_args() -> argparse.Namespace:
             "known commit on main."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    coda_values = (args.coda_app_name, args.coda_app_url, args.omnigent_public_server_url)
+    if any(coda_values) and not all(coda_values):
+        parser.error(
+            "--coda-app-name, --coda-app-url, and --omnigent-public-server-url "
+            "must be set together"
+        )
+    return args
 
 
 def _clear_env_vars() -> None:
@@ -746,6 +768,12 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         f"volume_name={args.volume_name}",
         "--var",
         f"otel_table_schema={args.otel_table_schema}",
+        "--var",
+        f"coda_app_name={args.coda_app_name}",
+        "--var",
+        f"coda_app_url={args.coda_app_url}",
+        "--var",
+        f"omnigent_public_server_url={args.omnigent_public_server_url}",
     ]
 
 

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -225,7 +225,15 @@ try:
     coda_app_name = os.environ.get("CODA_APP_NAME", "").strip()
     coda_app_url = os.environ.get("CODA_APP_URL", "").strip()
     public_server_url = os.environ.get("OMNIGENT_PUBLIC_SERVER_URL", "").strip()
-    if coda_app_name and coda_app_url and public_server_url:
+    coda_values = {
+        "CODA_APP_NAME": coda_app_name,
+        "CODA_APP_URL": coda_app_url,
+        "OMNIGENT_PUBLIC_SERVER_URL": public_server_url,
+    }
+    if any(coda_values.values()) and not all(coda_values.values()):
+        missing = ", ".join(name for name, value in coda_values.items() if not value)
+        raise RuntimeError(f"partial managed CoDA configuration; missing: {missing}")
+    if all(coda_values.values()):
         from omnigent.server.managed_hosts import parse_sandbox_config
 
         sandbox_config = parse_sandbox_config(

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -6,6 +6,7 @@ database and UC Volumes as the artifact store.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import sys
@@ -215,6 +216,10 @@ try:
     if _exposure:
         logger.warning("%s", _exposure)
 
+    app_client_secret = os.environ.get("DATABRICKS_CLIENT_SECRET", "")
+    if app_client_secret:
+        runner_secret = hashlib.sha256(f"omnigent-runner:{app_client_secret}".encode()).hexdigest()
+        os.environ.setdefault("OMNIGENT_RUNNER_TOKEN_SECRET", runner_secret)
     auth_provider = create_auth_provider()
     sandbox_config = None
     coda_app_name = os.environ.get("CODA_APP_NAME", "").strip()

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -216,6 +216,20 @@ try:
         logger.warning("%s", _exposure)
 
     auth_provider = create_auth_provider()
+    sandbox_config = None
+    coda_app_name = os.environ.get("CODA_APP_NAME", "").strip()
+    coda_app_url = os.environ.get("CODA_APP_URL", "").strip()
+    public_server_url = os.environ.get("OMNIGENT_PUBLIC_SERVER_URL", "").strip()
+    if coda_app_name and coda_app_url and public_server_url:
+        from omnigent.server.managed_hosts import parse_sandbox_config
+
+        sandbox_config = parse_sandbox_config(
+            {
+                "provider": "coda",
+                "server_url": public_server_url,
+                "coda": {"app_name": coda_app_name, "app_url": coda_app_url},
+            }
+        )
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -229,6 +243,7 @@ try:
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
         auth_provider=auth_provider,
+        sandbox_config=sandbox_config,
     )
 
     if __name__ == "__main__":

--- a/omnigent/databricks_ai_gateway.py
+++ b/omnigent/databricks_ai_gateway.py
@@ -30,8 +30,16 @@ DATABRICKS_TRUSTED_HOST_SUFFIXES: Final[tuple[str, ...]] = (
 # the gateway's Anthropic surface.
 DATABRICKS_AI_GATEWAY_LABEL: Final[str] = "ai-gateway"
 
+# Databricks-owned parent domain serving Databricks Apps; a workspace app is
+# reached at ``<app>-<id>.<cloud>.databricksapps.com``. Kept separate from
+# DATABRICKS_TRUSTED_HOST_SUFFIXES so the AI Gateway predicate stays exactly as
+# narrow as it is today.
+DATABRICKS_APPS_HOST_SUFFIXES: Final[tuple[str, ...]] = (".databricksapps.com",)
 
-def _under_trusted_domain(hostname: str) -> bool:
+
+def _under_trusted_domain(
+    hostname: str, *, parents: tuple[str, ...] = DATABRICKS_TRUSTED_HOST_SUFFIXES
+) -> bool:
     """Whether *hostname* is a subdomain of a trusted Databricks parent domain.
 
     Compares whole DNS labels from the right, so the parent must be an exact
@@ -40,14 +48,38 @@ def _under_trusted_domain(hostname: str) -> bool:
 
     :param hostname: Lower-cased hostname from a parsed URL, e.g.
         ``"wkspc.ai-gateway.cloud.databricks.com"``.
+    :param parents: Parent domains to accept, written with a leading dot.
     :returns: ``True`` when a trusted parent domain owns *hostname*.
     """
     labels = hostname.split(".")
-    for parent in DATABRICKS_TRUSTED_HOST_SUFFIXES:
+    for parent in parents:
         parent_labels = parent.strip(".").split(".")
         if len(labels) > len(parent_labels) and labels[-len(parent_labels) :] == parent_labels:
             return True
     return False
+
+
+def is_databricks_owned_url(url: str) -> bool:
+    """Whether *url* is an https URL served by a Databricks-owned domain.
+
+    Broader than :func:`is_databricks_ai_gateway_url`: any workspace control
+    plane or Databricks App under a trusted parent domain qualifies. Callers
+    use it to decide whether a Databricks credential may be sent to a URL at
+    all, so it matches whole DNS labels and requires https for the same
+    look-alike-host reasons.
+
+    :param url: An absolute URL, e.g. an Omnigent ``server_url``.
+    :returns: ``True`` iff a Databricks-owned parent domain serves *url*.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return False
+    return _under_trusted_domain(hostname) or _under_trusted_domain(
+        hostname, parents=DATABRICKS_APPS_HOST_SUFFIXES
+    )
 
 
 def is_databricks_ai_gateway_url(base_url: str) -> bool:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1235,6 +1235,7 @@ class HostProcess:
         initial_auth_token = await asyncio.to_thread(
             self._current_auth_token,
             initialize=False,
+            allow_managed=True,
         )
         env = _build_runner_env(
             os.environ,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -456,6 +456,10 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # host→runner intrinsically, so the setter need not also list it in
         # OMNIGENT_RUNNER_ENV_PASSTHROUGH.
         "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
+        # CoDA's loopback SP broker lets native harness token helpers mint a
+        # fresh workspace bearer without exposing the client secret.
+        "CODA_SP_TOKEN_BROKER_URL",
+        "CODA_VENV_PYTHON",
         # The operator's env-forwarding control var itself. Without it here, the
         # var is stripped before it reaches the daemon in --server mode (the
         # remote daemon prefixes are DATABRICKS_ + LC_/MLFLOW_/OTEL_/OMNIGENT_OTEL_,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2555,7 +2555,9 @@ class HostProcess:
         Server-managed sandbox hosts authenticate with the launch token
         the server injected at spawn (:data:`HOST_TOKEN_ENV_VAR`); when
         present it is sent on its dedicated header and the user-token
-        path is skipped entirely (a sandbox has no user credentials).
+        path is skipped (a sandbox has no user credentials). A managed
+        host may additionally carry an ingress bearer — see
+        :meth:`_databricks_ingress_token`.
 
         Otherwise mints a fresh Databricks bearer token via the runner's
         auth factory (refreshed every reconnect so long-lived hosts
@@ -2563,8 +2565,8 @@ class HostProcess:
         the upgrade proceeds unauthenticated and the server/proxy
         decides.
 
-        :returns: Header mapping for the WS upgrade; carries either the
-            managed-host token header or — only when a token could be
+        :returns: Header mapping for the WS upgrade; carries the
+            managed-host token header and/or — only when a token could be
             minted — ``{"Authorization": "Bearer <token>"}``.
         """
         from omnigent.host.identity import HOST_TOKEN_ENV_VAR, MANAGED_HOST_TOKEN_HEADER
@@ -2585,13 +2587,53 @@ class HostProcess:
         managed_token = os.environ.get(HOST_TOKEN_ENV_VAR)
         if managed_token:
             headers[MANAGED_HOST_TOKEN_HEADER] = managed_token
+            ingress_token = self._databricks_ingress_token()
+            if ingress_token:
+                headers["Authorization"] = f"Bearer {ingress_token}"
             return headers
         token = self._current_auth_token()
         if token:
             headers["Authorization"] = f"Bearer {token}"
         return headers
 
-    def _current_auth_token(self, *, initialize: bool = True) -> str | None:
+    def _databricks_ingress_token(self) -> str | None:
+        """Bearer for a Databricks ingress in front of a managed host's server.
+
+        A managed host running inside a Databricks App reaches the Omnigent
+        server through the Apps ingress, which rejects the launch-token header
+        on its own and redirects an unauthenticated upgrade to OIDC. The server
+        still authenticates the host by :data:`MANAGED_HOST_TOKEN_HEADER`; this
+        bearer only gets the request past the proxy.
+
+        Gated on the server URL being Databricks-owned *and* a Databricks
+        credential source being present, because an unconditional bearer would
+        ship a workspace credential to a Modal / E2B / Kubernetes server URL.
+        Resolved per upgrade attempt so multi-hour reconnects pick up a
+        refreshed service-principal token.
+
+        :returns: A bearer token, or ``None`` when the server is not
+            Databricks-owned, no Databricks credential is configured, or the
+            token could not be minted.
+        """
+        from omnigent.databricks_ai_gateway import is_databricks_owned_url
+
+        if not is_databricks_owned_url(self._server_url):
+            return None
+        if not any(
+            os.environ.get(var)
+            for var in (
+                "DATABRICKS_HOST",
+                "DATABRICKS_TOKEN",
+                "DATABRICKS_CLIENT_ID",
+                "DATABRICKS_CONFIG_PROFILE",
+            )
+        ):
+            return None
+        return self._current_auth_token(allow_managed=True)
+
+    def _current_auth_token(
+        self, *, initialize: bool = True, allow_managed: bool = False
+    ) -> str | None:
         """Return a bearer from the host's retained refreshable auth context.
 
         The first call builds the same factory the host tunnel already used.
@@ -2601,12 +2643,15 @@ class HostProcess:
         :param initialize: Build the factory when it has not been used yet.
             Runner launch passes ``False`` because it must only reuse the
             already-warm host context, never add auth work to the launch path.
+        :param allow_managed: Resolve a token even on a managed host. Only
+            :meth:`_databricks_ingress_token` passes ``True``; every other
+            caller must keep the managed short-circuit.
         :returns: Current bearer token, or ``None`` when credentials are not
             available or this is a managed host authenticated by launch token.
         """
         from omnigent.host.identity import HOST_TOKEN_ENV_VAR
 
-        if os.environ.get(HOST_TOKEN_ENV_VAR):
+        if not allow_managed and os.environ.get(HOST_TOKEN_ENV_VAR):
             return None
         try:
             if not self._auth_token_factory_resolved:

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -120,23 +120,17 @@ class PiNativeExecutor(Executor):
         the pi terminal if that case ever bites.
         """
         try:
-            from omnigent.cli_auth import databricks_request_headers
-            from omnigent.runner._entry import _make_auth_token_factory
+            from omnigent.runner._entry import _make_auth_token_factory, _runner_request_headers
 
             factory = _make_auth_token_factory()
-            token = factory() if factory is not None else None
-            if token:
-                # Rebuild the FULL routing header set (not just the bearer) so the
-                # per-turn refresh preserves the workspace / deployment routing
-                # selectors baked at launch (see runner/app.py). A bearer-only
-                # refresh would drop them and re-break routing after the first turn.
-                refresh_config_auth_headers(
-                    self._bridge_dir,
-                    databricks_request_headers(
-                        os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/"),
-                        bearer_token=token,
-                    ),
-                )
+            headers = _runner_request_headers(
+                factory,
+                os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/"),
+            )
+            if headers:
+                # Preserve workspace routing plus the managed runner's separate
+                # Apps-ingress and owner credentials on every refresh.
+                refresh_config_auth_headers(self._bridge_dir, headers)
         except Exception:  # noqa: BLE001 — best-effort refresh; never block a turn
             pass
 

--- a/omnigent/onboarding/sandboxes/coda.py
+++ b/omnigent/onboarding/sandboxes/coda.py
@@ -56,6 +56,11 @@ class CodaProvider(SandboxHostLauncher):
         self._workspace_path = workspace_path
         self._request_fn = request_fn or self._request
         self._app_getter = app_getter or self._get_app
+        self._lease_owner: str | None = None
+
+    def set_lease_owner(self, owner: str) -> None:
+        """Set the user principal used by CoDA's authoritative lease CAS."""
+        self._lease_owner = owner
 
     @staticmethod
     def _get_app(app_name: str) -> object:
@@ -103,7 +108,7 @@ class CodaProvider(SandboxHostLauncher):
     def provision(self, name: str) -> str:
         """Acquire a fenced CoDA lease without creating infrastructure."""
         lease_id = uuid.uuid4().hex
-        self._request_fn(
+        result = self._request_fn(
             "POST",
             "/api/omnigent-host/lease",
             {
@@ -111,9 +116,13 @@ class CodaProvider(SandboxHostLauncher):
                 "app_name": self._app_name,
                 "host_name": name,
                 "lease_id": lease_id,
+                "owner": self._lease_owner,
             },
         )
-        return f"coda:{self._app_name}#{lease_id}"
+        acquired_id = result.get("lease_id", lease_id)
+        if not isinstance(acquired_id, str) or not acquired_id:
+            raise click.ClickException("CoDA lease response omitted lease_id")
+        return f"coda:{self._app_name}#{acquired_id}"
 
     def start_host(
         self,
@@ -158,6 +167,21 @@ class CodaProvider(SandboxHostLauncher):
             raise click.ClickException(
                 "CoDA connect response did not contain an absolute workspace"
             )
+        return workspace
+
+    def allocate_workspace(self, sandbox_id: str, session_id: str) -> str:
+        """Create and return a session-specific directory on the active lease."""
+        app_name, lease_id = _parse_sandbox_id(sandbox_id)
+        if app_name != self._app_name:
+            raise click.ClickException("CoDA sandbox id targets a different app")
+        result = self._request_fn(
+            "POST",
+            "/api/omnigent-host/workspaces",
+            {"lease_id": lease_id, "session_id": session_id},
+        )
+        workspace = result.get("workspace")
+        if not isinstance(workspace, str) or not workspace.startswith("/"):
+            raise click.ClickException("CoDA did not return an absolute session workspace")
         return workspace
 
     def terminate(self, sandbox_id: str) -> None:

--- a/omnigent/onboarding/sandboxes/coda.py
+++ b/omnigent/onboarding/sandboxes/coda.py
@@ -14,7 +14,15 @@ from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
 from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 CODA_WORKSPACE_PATH = "/app/python/source_code"
-_SENSITIVE_ERROR_KEYS = ("token", "secret", "authorization", "credential")
+_SENSITIVE_ERROR_KEYS = (
+    "token",
+    "secret",
+    "authorization",
+    "credential",
+    "password",
+    "api_key",
+    "access_key",
+)
 
 
 def _safe_control_error_detail(raw: str) -> str:
@@ -36,6 +44,10 @@ def _safe_control_error_detail(raw: str) -> str:
             }
         if isinstance(value, list):
             return [_redact(item) for item in value]
+        if isinstance(value, str) and any(
+            marker in value.lower() for marker in _SENSITIVE_ERROR_KEYS
+        ):
+            return "<redacted>"
         return value
 
     return json.dumps(_redact(payload), separators=(",", ":"))[:1024]

--- a/omnigent/onboarding/sandboxes/coda.py
+++ b/omnigent/onboarding/sandboxes/coda.py
@@ -1,0 +1,175 @@
+"""Managed-host launcher for a pre-provisioned CoDA Databricks App."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable, Mapping
+from typing import ClassVar
+from urllib import error, request
+
+import click
+
+from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+
+CODA_WORKSPACE_PATH = "/app/python/source_code"
+
+
+def _parse_sandbox_id(sandbox_id: str) -> tuple[str, str]:
+    """Return the fenced app and lease identifiers from a CoDA sandbox id."""
+    if not sandbox_id.startswith("coda:") or "#" not in sandbox_id:
+        raise click.ClickException(f"invalid CoDA sandbox id: {sandbox_id!r}")
+    app_name, lease_id = sandbox_id[5:].rsplit("#", 1)
+    if not app_name or not lease_id:
+        raise click.ClickException(f"invalid CoDA sandbox id: {sandbox_id!r}")
+    return app_name, lease_id
+
+
+class CodaProvider(SandboxHostLauncher):
+    """Lease and control one already-running CoDA Databricks App over HTTP."""
+
+    provider: ClassVar[str] = "coda"
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=False,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+        )
+
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        app_url: str,
+        workspace_path: str = CODA_WORKSPACE_PATH,
+        request_fn: Callable[[str, str, Mapping[str, object] | None], Mapping[str, object]]
+        | None = None,
+        app_getter: Callable[[str], object] | None = None,
+    ) -> None:
+        self._app_name = app_name
+        self._app_url = app_url.rstrip("/")
+        self._workspace_path = workspace_path
+        self._request_fn = request_fn or self._request
+        self._app_getter = app_getter or self._get_app
+
+    @staticmethod
+    def _get_app(app_name: str) -> object:
+        from databricks.sdk import WorkspaceClient
+
+        return WorkspaceClient().apps.get(app_name)
+
+    def _request(
+        self, method: str, path: str, body: Mapping[str, object] | None
+    ) -> Mapping[str, object]:
+        from databricks.sdk.core import Config
+
+        headers = dict(Config().authenticate())
+        data = json.dumps(body).encode() if body is not None else None
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        req = request.Request(f"{self._app_url}{path}", data=data, headers=headers, method=method)
+        try:
+            with request.urlopen(req, timeout=30) as response:
+                payload = response.read()
+        except error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            if exc.code == 409:
+                raise click.ClickException("CoDA app has no available lease capacity") from exc
+            raise click.ClickException(
+                f"CoDA control request failed ({exc.code}): {detail or exc.reason}"
+            ) from exc
+        except error.URLError as exc:
+            raise click.ClickException(f"CoDA control request failed: {exc.reason}") from exc
+        decoded = json.loads(payload or b"{}")
+        if not isinstance(decoded, dict):
+            raise click.ClickException("CoDA control response must be a JSON object")
+        return decoded
+
+    def prepare(self) -> None:
+        """Validate app readiness and control-plane authentication without mutation."""
+        app = self._app_getter(self._app_name)
+        compute = getattr(getattr(app, "compute_status", None), "state", None)
+        if str(compute).upper().split(".")[-1] != "ACTIVE":
+            raise click.ClickException(f"CoDA app {self._app_name!r} compute is not ACTIVE")
+        status = self._request_fn("GET", "/api/omnigent-host/status", None)
+        if status.get("ready") is False:
+            raise click.ClickException(f"CoDA app {self._app_name!r} is not ready")
+
+    def provision(self, name: str) -> str:
+        """Acquire a fenced CoDA lease without creating infrastructure."""
+        lease_id = uuid.uuid4().hex
+        self._request_fn(
+            "POST",
+            "/api/omnigent-host/lease",
+            {
+                "action": "acquire",
+                "app_name": self._app_name,
+                "host_name": name,
+                "lease_id": lease_id,
+            },
+        )
+        return f"coda:{self._app_name}#{lease_id}"
+
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repo_url: str | None = None,
+        repo_branch: str | None = None,
+        repo_name: str | None = None,
+        host_config: dict[str, object] | None = None,
+        agent_name: str | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """Ask CoDA to start its managed host and return its reported workspace."""
+        app_name, lease_id = _parse_sandbox_id(sandbox_id)
+        if app_name != self._app_name:
+            raise click.ClickException("CoDA sandbox id targets a different app")
+        if on_stage is not None:
+            on_stage("cloning")
+            on_stage("starting")
+        result = self._request_fn(
+            "POST",
+            "/api/omnigent-host/connect",
+            {
+                "server_url": server_url,
+                "host_token": token,
+                "host_id": host_id,
+                "host_name": host_name,
+                "host_config": host_config,
+                "repo_url": repo_url,
+                "repo_branch": repo_branch,
+                "repo_name": repo_name,
+                "lease_id": lease_id,
+                "agent_name": agent_name,
+            },
+        )
+        workspace = result.get("workspace") or self._workspace_path
+        if not isinstance(workspace, str) or not workspace.startswith("/"):
+            raise click.ClickException(
+                "CoDA connect response did not contain an absolute workspace"
+            )
+        return workspace
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Release and scrub the fenced lease; never mutate the Databricks App."""
+        app_name, lease_id = _parse_sandbox_id(sandbox_id)
+        if app_name != self._app_name:
+            return
+        try:
+            self._request_fn(
+                "POST",
+                "/api/omnigent-host/disconnect",
+                {"lease_id": lease_id, "scrub": True},
+            )
+        except click.ClickException:
+            return

--- a/omnigent/onboarding/sandboxes/coda.py
+++ b/omnigent/onboarding/sandboxes/coda.py
@@ -14,6 +14,31 @@ from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
 from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 CODA_WORKSPACE_PATH = "/app/python/source_code"
+_SENSITIVE_ERROR_KEYS = ("token", "secret", "authorization", "credential")
+
+
+def _safe_control_error_detail(raw: str) -> str:
+    """Return a bounded CoDA error detail with credential fields redacted."""
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return "upstream control request failed"
+
+    def _redact(value: object) -> object:
+        if isinstance(value, dict):
+            return {
+                str(key): (
+                    "<redacted>"
+                    if any(part in str(key).lower() for part in _SENSITIVE_ERROR_KEYS)
+                    else _redact(item)
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [_redact(item) for item in value]
+        return value
+
+    return json.dumps(_redact(payload), separators=(",", ":"))[:1024]
 
 
 def _parse_sandbox_id(sandbox_id: str) -> tuple[str, str]:
@@ -82,11 +107,11 @@ class CodaProvider(SandboxHostLauncher):
             with request.urlopen(req, timeout=30) as response:
                 payload = response.read()
         except error.HTTPError as exc:
-            detail = exc.read().decode(errors="replace")
+            detail = _safe_control_error_detail(exc.read().decode(errors="replace"))
             if exc.code == 409:
                 raise click.ClickException("CoDA app has no available lease capacity") from exc
             raise click.ClickException(
-                f"CoDA control request failed ({exc.code}): {detail or exc.reason}"
+                f"CoDA control request failed ({exc.code}): {detail}"
             ) from exc
         except error.URLError as exc:
             raise click.ClickException(f"CoDA control request failed: {exc.reason}") from exc

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -167,6 +167,11 @@ def _builtin_contribution() -> SandboxProviderContribution:
                 launcher_class="omnigent.onboarding.sandboxes.kubernetes:KubernetesSandboxLauncher",
                 managed_token_ttl_s=7 * 24 * 3600,
             ),
+            "coda": SandboxProviderMetadata(
+                name="coda",
+                launcher_class="omnigent.onboarding.sandboxes.coda:CodaProvider",
+                managed_token_ttl_s=13 * 3600,
+            ),
         },
     )
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -354,6 +354,13 @@ class PiProviderConfig:
         )
 
 
+def _model_service_id(model: str) -> str:
+    """Normalize a legacy Databricks alias for AI Gateway v2 model routing."""
+    if model.startswith("databricks-"):
+        return f"system.ai.{model.removeprefix('databricks-')}"
+    return model
+
+
 def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
     """Resolve a Databricks-profile provider into Pi gateway config.
 
@@ -418,11 +425,14 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         additional[_PI_MLFLOW_PROVIDER_ID] = _databricks_openai_provider(
             api_key, f"{host}/ai-gateway/mlflow/v1", gemini_models, api_type="openai-completions"
         )
+    selected_model = (
+        model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+    )
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
-        base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
-        api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        base_url=f"{host}/ai-gateway/mlflow/v1",
+        api="openai-completions",
+        model=_model_service_id(selected_model),
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is re-read per request (the auth command attempts a
         # refresh), matching codex-native's refresh semantics.

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -434,11 +434,27 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     selected_model = (
         model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id
     )
+    # The live v2 catalog uses system.ai.* ids, while older profile defaults and
+    # explicit endpoint aliases may still use databricks-*. Normalize only when
+    # the authoritative catalog confirms the normalized id. If discovery
+    # failed, preserving the original alias lets family fallback route it to
+    # the legacy serving-endpoints surface instead of guessing incorrectly.
+    normalized_model = _model_service_id(selected_model)
+    catalog_ids = {
+        str(item.get("id"))
+        for item in (*claude_models, *gpt_models, *completions_models, *gemini_models)
+    }
+    rendered_model = (
+        normalized_model
+        if normalized_model in catalog_ids
+        or (credential_warning is not None and selected_model.startswith("databricks-claude-"))
+        else selected_model
+    )
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}/ai-gateway/mlflow/v1",
         api="openai-completions",
-        model=_model_service_id(selected_model),
+        model=rendered_model,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is re-read per request (the auth command attempts a
         # refresh), matching codex-native's refresh semantics.

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -194,6 +194,9 @@ class PiProviderConfig:
         request time, used for short-lived gateway tokens).
     :param auth_header: When ``True``, Pi sends ``Authorization: Bearer
         <apiKey>`` (gateways) instead of a provider-native key header.
+    :param compat: Optional Pi wire-compatibility flags for the primary
+        provider. Databricks' MLflow gateway rejects OpenAI-only fields such as
+        ``store`` and ``stream_options`` even when their values are false.
     :param credential_warning: A user-facing notice set when the provider was
         rendered but its credentials could not be resolved (e.g. an expired
         Databricks OAuth token). Pi still launches — its ``!command`` apiKey may
@@ -211,6 +214,7 @@ class PiProviderConfig:
     model: str
     api_key: str
     auth_header: bool
+    compat: _PiProviderCompat | None = None
     credential_warning: str | None = None
     # Full model list for providers that expose multiple models (e.g. the
     # Databricks Anthropic gateway). Excluded from __hash__ so the frozen
@@ -321,6 +325,8 @@ class PiProviderConfig:
         }
         if self.auth_header:
             provider["authHeader"] = True
+        if self.compat is not None:
+            provider["compat"] = self.compat
         providers = {self.provider_id: provider}
         providers.update(additional)
         return {"providers": providers}
@@ -438,6 +444,13 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # refresh), matching codex-native's refresh semantics.
         api_key=api_key,
         auth_header=True,
+        compat={
+            "supportsDeveloperRole": False,
+            "supportsStore": False,
+            "supportsStrictMode": False,
+            "supportsReasoningEffort": False,
+            "supportsUsageInStreaming": False,
+        },
         extra_models=claude_models,
         additional_providers=additional,
         credential_warning=credential_warning,

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -787,6 +787,9 @@ class _ManagedMintTokenFactory:
         self._server_url = server_url
         self._binding_token = binding_token
         self._proxy_bearer = proxy_bearer
+        # Set once the host bearer has been dropped after a 401/403, so the
+        # retry-without-it happens at most once per factory.
+        self._proxy_bearer_retired = False
         self._cached_token: str | None = None
         self._cached_expires_at = 0.0
         self.declined = False
@@ -831,11 +834,28 @@ class _ManagedMintTokenFactory:
                     return None
                 return self._still_valid_cached_token(now)
             if response.status_code in (401, 403):
-                # The proxy bearer is expired or invalid. If we have never
-                # successfully minted, there is no self-sustaining refresh
-                # loop to fall back to — signal proxy_auth_failed so the
-                # caller can try SDK/OIDC instead of looping on a dead bearer.
-                if self._cached_token is None:
+                # The proxy bearer is expired or invalid.
+                #
+                # The host's initial SP bearer is captured once at construction
+                # and has its own, shorter, lifetime than the session. Once it
+                # expires, every mint 401s. Retry ONCE without it: the minted
+                # owner JWT is the credential the mint endpoint actually
+                # authenticates, so dropping the dead proxy bearer turns the
+                # factory into a self-sustaining refresh loop instead of
+                # wedging the runner for the rest of the session.
+                if self._proxy_bearer is not None and not self._proxy_bearer_retired:
+                    self._proxy_bearer_retired = True
+                    _logger.info(
+                        "managed mint rejected the host bearer; retiring it and "
+                        "re-minting with the runner's own credential"
+                    )
+                    self._proxy_bearer = None
+                    return self()
+                # No proxy bearer left to drop. Without a still-valid cached
+                # token there is no self-sustaining loop to fall back to, so
+                # signal proxy_auth_failed and let the caller try SDK/OIDC
+                # rather than looping on a dead credential.
+                if self._still_valid_cached_token(now) is None:
                     self.proxy_auth_failed = True
                     return None
             return self._still_valid_cached_token(now)

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -327,7 +327,14 @@ class _RunnerDatabricksAuth(httpx.Auth):
                     yield request
                     return
                 raise httpx.RequestError("Databricks token refresh returned no token")
-            request.headers["Authorization"] = f"Bearer {token}"
+            ingress_bearer = getattr(self._factory, "ingress_bearer", None)
+            if ingress_bearer:
+                from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+                request.headers["Authorization"] = f"Bearer {ingress_bearer}"
+                request.headers[RUNNER_OWNER_TOKEN_HEADER] = token
+            else:
+                request.headers["Authorization"] = f"Bearer {token}"
         response = yield request
         if self._factory is None:
             return
@@ -335,7 +342,14 @@ class _RunnerDatabricksAuth(httpx.Auth):
             _invalidate_auth_token_factory(self._factory)
             token = self._factory()
             if token:
-                request.headers["Authorization"] = f"Bearer {token}"
+                ingress_bearer = getattr(self._factory, "ingress_bearer", None)
+                if ingress_bearer:
+                    from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+                    request.headers["Authorization"] = f"Bearer {ingress_bearer}"
+                    request.headers[RUNNER_OWNER_TOKEN_HEADER] = token
+                else:
+                    request.headers["Authorization"] = f"Bearer {token}"
                 yield request
 
 
@@ -743,10 +757,8 @@ class _ManagedMintTokenFactory:
         :param mint_url: Fully-qualified ``/v1/runners/{id}/token`` URL.
         :param server_url: Omnigent server base URL.
         :param binding_token: The runner's tunnel binding token.
-        :param proxy_bearer: Optional bearer for the Apps proxy. Seeded with
-            the host's initial bearer; replaced by the minted JWT after the
-            first successful mint so the proxy sees a valid credential on
-            every subsequent refresh.
+        :param proxy_bearer: Optional OAuth bearer for the Apps proxy. It stays
+            separate from the minted owner JWT, which the proxy does not accept.
         """
         self._mint_url = mint_url
         self._server_url = server_url
@@ -811,10 +823,12 @@ class _ManagedMintTokenFactory:
             return self._still_valid_cached_token(now)
         self._cached_token = token
         self._cached_expires_at = expires_at
-        # Promote the minted JWT to proxy bearer so subsequent refreshes
-        # through the Apps proxy are authenticated with a valid credential.
-        self._proxy_bearer = token
         return token
+
+    @property
+    def ingress_bearer(self) -> str | None:
+        """Return the OAuth bearer reserved for a Databricks Apps ingress."""
+        return self._proxy_bearer
 
     def _still_valid_cached_token(self, now: float) -> str | None:
         """Return the cached token if it hasn't expired outright.

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -251,6 +251,29 @@ async def _run_inactivity_monitor(
         await asyncio.sleep(min(poll_interval_s, idle_timeout_s - elapsed_s))
 
 
+def _runner_request_headers(
+    factory: Callable[[], str | None] | None,
+    server_url: str,
+) -> dict[str, str]:
+    """Build routing and dual-auth headers for runner-owned HTTP clients.
+
+    A managed runner's owner JWT authenticates inside Omnigent, while the
+    host-provided service-principal bearer is still required to cross a
+    Databricks Apps ingress. Callers outside :class:`_RunnerDatabricksAuth`
+    (notably the native-Pi extension) must preserve the same separation.
+    """
+    from omnigent.cli_auth import databricks_request_headers
+
+    token = factory() if factory is not None else None
+    ingress_bearer = getattr(factory, "ingress_bearer", None)
+    headers = databricks_request_headers(server_url, bearer_token=ingress_bearer or token)
+    if ingress_bearer and token:
+        from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+        headers[RUNNER_OWNER_TOKEN_HEADER] = token
+    return headers
+
+
 class _RunnerDatabricksAuth(httpx.Auth):
     """httpx Auth that mints a fresh Databricks OAuth token per request.
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -523,6 +523,25 @@ def _make_auth_token_factory(
         if _allow_initial_token
         else ""
     )
+    delegated_auth = os.environ.get(RUNNER_DELEGATED_AUTH_ENV_VAR, "").strip() == "1"
+    binding_token = os.environ.get(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, "").strip()
+    if (
+        initial_token
+        and _allow_delegated_mint
+        and delegated_auth
+        and resolved_server_url
+        and binding_token
+    ):
+        # The host's SP bearer is only an Apps-ingress credential. Exchange
+        # the binding token immediately so application requests carry the
+        # session owner's token rather than the CoDA service principal.
+        delegated_factory = _make_managed_mint_factory(
+            resolved_server_url,
+            binding_token,
+            proxy_bearer=initial_token,
+        )
+        if delegated_factory is not None:
+            return delegated_factory
     if initial_token and resolved_server_url:
         _logger.info("using host-provided bearer for runner bootstrap")
         return _InitialAuthTokenFactory(initial_token, resolved_server_url)
@@ -535,8 +554,6 @@ def _make_auth_token_factory(
 
     # Prefer the host-launched runner's owner-bound capability so user
     # credentials stay out of the runner and credential discovery is skipped.
-    delegated_auth = os.environ.get(RUNNER_DELEGATED_AUTH_ENV_VAR, "").strip() == "1"
-    binding_token = os.environ.get(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, "").strip()
     if _allow_delegated_mint and delegated_auth and resolved_server_url and binding_token:
         delegated_factory = _make_managed_mint_factory(
             resolved_server_url, binding_token, proxy_bearer=_proxy_bearer

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -26,6 +26,9 @@ RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR = "OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN"
 # owner-scoped server bearer instead of resolving the host user's credentials.
 RUNNER_DELEGATED_AUTH_ENV_VAR = "OMNIGENT_RUNNER_DELEGATED_AUTH"
 RUNNER_TUNNEL_TOKEN_HEADER = "X-Omnigent-Runner-Tunnel-Token"
+# Owner JWT carried separately when Authorization is reserved for an Apps
+# ingress OAuth bearer.
+RUNNER_OWNER_TOKEN_HEADER = "X-Omnigent-Runner-Owner-Token"
 # Sentinel ``Origin`` header that the project's own non-browser WebSocket
 # clients (runner -> server tunnel, host/daemon -> server tunnel,
 # terminal-attach) set on their handshakes so the server's CSWSH origin

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -2041,7 +2041,7 @@ async def _auto_create_pi_terminal(
         write_extension_files,
     )
     from omnigent.pi_native_bridge import extension_path as pi_extension_path
-    from omnigent.runner._entry import _make_auth_token_factory
+    from omnigent.runner._entry import _make_auth_token_factory, _runner_request_headers
 
     launch_config = await _pi_native_launch_config(
         session_id=session_id,
@@ -2054,16 +2054,11 @@ async def _auto_create_pi_terminal(
     pi_extension = pi_extension_path(bridge_dir)
     session_dir = pi_session_dir(bridge_dir)
     auth_factory = _make_auth_token_factory()
-    auth_token = auth_factory() if auth_factory is not None else None
     # Route the extension's out-of-process POSTs (/events, /mcp,
-    # /policies/evaluate) through the shared header builder so they carry the
-    # workspace / deployment routing selectors, not just a bare bearer. A bare
-    # bearer skips those selectors and can land on a different server instance
-    # than the one the runner (and the web UI) are on, so live-streamed items
-    # never reach the browser's in-process event stream (they only appear on reload).
-    from omnigent.cli_auth import databricks_request_headers
-
-    auth_headers = databricks_request_headers(launch_config.server_url, bearer_token=auth_token)
+    # /policies/evaluate) through the same routing + dual-auth header builder as
+    # runner callbacks. Managed runners need the Apps SP bearer at ingress and
+    # the owner JWT in the internal owner-token header.
+    auth_headers = _runner_request_headers(auth_factory, launch_config.server_url)
     # Build the Omnigent tool surface (sys_* tools) the Pi extension registers
     # via pi.registerTool. Reuses the same schema set the claude-native /
     # codex-native relay advertises, gated by the session's spec. Each tool's

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -352,6 +352,12 @@ async def serve_tunnel(
             # connection to drain): nothing to flush, just stop looping.
             return
         auth_token = await _refresh_auth_token(auth_token, auth_token_factory)
+        ingress_bearer = (
+            getattr(auth_token_factory, "ingress_bearer", None)
+            if auth_token_factory is not None
+            else None
+        )
+        owner_token = auth_token if ingress_bearer else None
         if ever_connected and on_reconnect is not None:
             try:
                 await on_reconnect()
@@ -367,7 +373,8 @@ async def serve_tunnel(
                 server_url=server_url,
                 runner_id=runner_id,
                 runner_version=runner_version,
-                auth_token=auth_token,
+                auth_token=ingress_bearer or auth_token,
+                owner_token=owner_token,
                 tunnel_token=tunnel_token,
                 shutdown_event=shutdown_event,
                 on_graceful_shutdown=on_graceful_shutdown,
@@ -623,6 +630,7 @@ async def _serve_tunnel_once(
     runner_id: str,
     runner_version: str,
     auth_token: str | None = None,
+    owner_token: str | None = None,
     tunnel_token: str | None = None,
     on_activity: Callable[[], None] | None = None,
     shutdown_event: asyncio.Event | None = None,
@@ -672,6 +680,10 @@ async def _serve_tunnel_once(
 
     headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
     headers.update(databricks_request_headers(server_url, bearer_token=auth_token))
+    if owner_token:
+        from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+        headers[RUNNER_OWNER_TOKEN_HEADER] = owner_token
     if tunnel_token:
         headers[RUNNER_TUNNEL_TOKEN_HEADER] = tunnel_token
     # Verifying SSL context from a real CA bundle for wss:// — a bare default

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -446,6 +446,7 @@ class UnifiedAuthProvider(AuthProvider):
         local_single_user: bool | None = None,
         header_name: str | None = None,
         header_strip_prefix: str | None = None,
+        runner_token_secret: bytes | None = None,
     ) -> None:
         self._source = source
         self._oidc_config = oidc_config
@@ -459,6 +460,16 @@ class UnifiedAuthProvider(AuthProvider):
             if header_strip_prefix is not None
             else resolve_auth_header_strip_prefix()
         )
+        if runner_token_secret is None:
+            raw_runner_secret = os.environ.get("OMNIGENT_RUNNER_TOKEN_SECRET", "").strip()
+            if raw_runner_secret:
+                try:
+                    runner_token_secret = bytes.fromhex(raw_runner_secret)
+                except ValueError as exc:
+                    raise RuntimeError("OMNIGENT_RUNNER_TOKEN_SECRET must be valid hex") from exc
+                if len(runner_token_secret) < 32:
+                    raise RuntimeError("OMNIGENT_RUNNER_TOKEN_SECRET must be at least 32 bytes")
+        self._runner_token_secret = runner_token_secret
         self._cookie_cache: dict[str, tuple[str, float]] = {}
         # Set by create_app when a device-grant store is wired. Returns
         # True if a grant_id has been revoked (or is unknown → fail
@@ -511,7 +522,8 @@ class UnifiedAuthProvider(AuthProvider):
         """
         if self._source in ("oidc", "accounts"):
             return self._check_cookie(request)
-        return self._check_header(request)
+        runner_user = self._check_runner_bearer(request)
+        return runner_user if runner_user is not None else self._check_header(request)
 
     def mint_runner_token(self, user_id: str, ttl_seconds: int) -> str | None:
         """
@@ -531,19 +543,40 @@ class UnifiedAuthProvider(AuthProvider):
         """
         if not user_id or user_id in _RESERVED_USERS:
             return None
-        if self._source not in ("oidc", "accounts"):
-            return None
-        cookie_config = self._oidc_config if self._source == "oidc" else self._accounts_config
-        if cookie_config is None:
+        if self._source == "header":
+            secret = self._runner_token_secret
+            provider = "runner"
+        else:
+            cookie_config = self._oidc_config if self._source == "oidc" else self._accounts_config
+            secret = cookie_config.cookie_secret if cookie_config is not None else None
+            provider = self._source
+        if secret is None:
             return None
         from omnigent.server.oidc import mint_session_token
 
-        return mint_session_token(
-            user_id,
-            cookie_config.cookie_secret,
-            ttl_seconds,
-            self._source,
-        )
+        return mint_session_token(user_id, secret, ttl_seconds, provider)
+
+    def _check_runner_bearer(self, request: HTTPConnection) -> str | None:
+        """Validate a server-minted owner token while header auth is active."""
+        import jwt
+
+        if self._runner_token_secret is None:
+            return None
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return None
+        try:
+            payload = jwt.decode(
+                auth_header[7:],
+                self._runner_token_secret,
+                algorithms=["HS256"],
+            )
+        except jwt.InvalidTokenError:
+            return None
+        if payload.get("provider") != "runner":
+            return None
+        user_id = payload.get("sub")
+        return user_id if isinstance(user_id, str) and user_id else None
 
     def _check_cookie(self, request: HTTPConnection) -> str | None:
         """Validate the session cookie or Bearer token and return the

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -562,12 +562,17 @@ class UnifiedAuthProvider(AuthProvider):
 
         if self._runner_token_secret is None:
             return None
-        auth_header = request.headers.get("authorization", "")
-        if not auth_header.startswith("Bearer "):
-            return None
+        from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+        token = request.headers.get(RUNNER_OWNER_TOKEN_HEADER, "").strip()
+        if not token:
+            auth_header = request.headers.get("authorization", "")
+            if not auth_header.startswith("Bearer "):
+                return None
+            token = auth_header[7:]
         try:
             payload = jwt.decode(
-                auth_header[7:],
+                token,
                 self._runner_token_secret,
                 algorithms=["HS256"],
             )

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2305,6 +2305,11 @@ async def launch_managed_host(
         startup, or registration fails.
     """
     launcher = config.launcher_factory()
+    if launcher.provider == "coda":
+        from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+        if isinstance(launcher, CodaProvider):
+            launcher.set_lease_owner(owner)
     host_id = uuid.uuid4().hex
     # Visible label in the host picker; (owner, name) is the hosts
     # table PK, so embed the host_id's leading hex for uniqueness

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -164,10 +164,21 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
         "e2b",
         "openshell",
         "kubernetes",
+        "coda",
     }
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
-    {"modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell", "kubernetes"}
+    {
+        "modal",
+        "daytona",
+        "boxlite",
+        "cwsandbox",
+        "islo",
+        "e2b",
+        "openshell",
+        "kubernetes",
+        "coda",
+    }
 )
 
 # How long a managed launch waits for the sandboxed host to register
@@ -221,6 +232,10 @@ OPENSHELL_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # reconnects while still expiring tokens of Pods nobody deleted. A relaunch
 # mints a fresh token (and the per-Pod token Secret is replaced).
 KUBERNETES_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+CODA_MAX_LEASE_S = 12 * 3600
+CODA_MANAGED_TOKEN_TTL_S = 13 * 3600
+CODA_DEFAULT_MAX_SESSIONS_PER_LEASE = 10
 
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
@@ -484,6 +499,7 @@ class ManagedSandboxConfig:
     managed_launch_supported: bool = True
     provider: str | None = None
     host_config: dict[str, object] | None = None
+    max_sessions_per_lease: int | None = None
 
 
 @dataclass
@@ -835,6 +851,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
     # Validated regardless of provider (like server_url): a malformed
     # host_config should stop startup even for staged/unsupported providers.
     host_config = _parse_host_config(raw)
+    max_sessions_per_lease: int | None = None
     if provider == "modal":
         launcher_factory = _modal_launcher_factory(
             _parse_modal_image(raw), _parse_modal_secrets(raw)
@@ -938,6 +955,28 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             secret_mounts=secret_mounts,
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
+    elif provider == "coda":
+        coda_section = _parse_provider_section(raw, "coda") or {}
+        _reject_unknown_keys(
+            coda_section,
+            {"app_name", "app_url", "workspace_path", "max_sessions_per_lease"},
+            "sandbox.coda",
+        )
+        app_name = _parse_provider_string(raw, "coda", "app_name")
+        app_url = _parse_provider_string(raw, "coda", "app_url")
+        if not app_name or not app_url:
+            raise ValueError("sandbox.coda requires app_name and app_url")
+        workspace_path = _parse_provider_string(raw, "coda", "workspace_path")
+        max_sessions_per_lease = (
+            _parse_provider_positive_int(raw, "coda", "max_sessions_per_lease")
+            or CODA_DEFAULT_MAX_SESSIONS_PER_LEASE
+        )
+        launcher_factory = _coda_launcher_factory(
+            app_name=app_name,
+            app_url=app_url,
+            workspace_path=workspace_path,
+        )
+        token_ttl_s = CODA_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -950,6 +989,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
         managed_launch_supported=provider in PROVIDERS_WITH_MANAGED_LAUNCH,
         provider=provider,
         host_config=host_config,
+        max_sessions_per_lease=(max_sessions_per_lease if provider == "coda" else None),
     )
 
 
@@ -2128,6 +2168,25 @@ def _reject_overlapping_kubernetes_mounts(
                     "server config 'sandbox.kubernetes' has nested pvc_mounts / "
                     f"secret_mounts paths: {low!r} contains {high!r}"
                 )
+
+
+def _coda_launcher_factory(
+    *, app_name: str, app_url: str, workspace_path: str | None
+) -> Callable[[], SandboxHostLauncher]:
+    """Build the launcher factory for the YAML ``provider: coda`` path."""
+
+    def _build() -> SandboxHostLauncher:
+        from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+        if workspace_path is None:
+            return CodaProvider(app_name=app_name, app_url=app_url)
+        return CodaProvider(
+            app_name=app_name,
+            app_url=app_url,
+            workspace_path=workspace_path,
+        )
+
+    return _build
 
 
 def _kubernetes_launcher_factory(

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2392,6 +2392,11 @@ async def relaunch_managed_host(
                 "was launched with is no longer configured on this server"
             ),
         )
+    if launcher.provider == "coda":
+        from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+        if isinstance(launcher, CodaProvider):
+            launcher.set_lease_owner(host.user_id)
     # The old generation is normally already dead (that is why we are
     # here), but terminate defensively so a transient tunnel outage
     # can never leave two live sandboxes claiming one host identity.

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -422,23 +422,21 @@ def register_core_routes(
                         and host_is_live(host)
                     ]
                     if candidates:
-                        sessions = await asyncio.to_thread(
-                            conversation_store.list_conversations,
-                            limit=1000,
-                            kind=None,
-                        )
                         cap = sandbox_config.max_sessions_per_lease or 10
-                        adopted = next(
-                            (
-                                host
-                                for host in candidates
-                                if sum(
-                                    session.host_id == host.host_id for session in sessions.data
-                                )
-                                < cap
-                            ),
-                            None,
-                        )
+                        # Count per candidate rather than paging the whole
+                        # conversation table: a listing capped at N rows
+                        # undercounts once the installation has more than N
+                        # sessions, so a lease already at capacity looks free
+                        # and gets over-subscribed.
+                        adopted = None
+                        for host in candidates:
+                            bound = await asyncio.to_thread(
+                                conversation_store.count_conversations_by_host_id,
+                                host.host_id,
+                            )
+                            if bound < cap:
+                                adopted = host
+                                break
                     if adopted is not None:
                         launcher = sandbox_config.launcher_factory()
                         if not isinstance(launcher, CodaProvider):

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -399,32 +399,80 @@ def register_core_routes(
                     resp.id,
                     {MANAGED_REPO_LABEL_KEY: body.workspace},
                 )
-            managed_launches.begin(resp.id)
-            # Seed the launch-progress indicator before the background
-            # task starts, so the first GET snapshot (the Web UI
-            # navigates to the session page immediately after this
-            # 201) already carries the "provisioning" stage.
-            _publish_sandbox_status(resp.id, "provisioning")
-            launch_task = asyncio.create_task(
-                _run_managed_launch(
-                    session_id=resp.id,
-                    # On auth-disabled servers user_id is None; the
-                    # sandbox host registers under the reserved local
-                    # owner, same as a directly-connected host would.
-                    owner=user_id if user_id is not None else RESERVED_USER_LOCAL,
-                    sandbox_config=sandbox_config,
-                    repo=repo,
-                    tracker=managed_launches,
-                    conversation_store=conversation_store,
-                    host_store=host_store_for_managed,
-                    host_registry=getattr(request.app.state, "host_registry", None),
-                    tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
-                    agent_store=agent_store,
-                    agent_id=conv.agent_id if conv is not None else None,
+            owner = user_id if user_id is not None else RESERVED_USER_LOCAL
+            adopted = None
+            if sandbox_config.provider == "coda":
+                from omnigent.stores.host_store import host_is_live
+
+                hosts = await asyncio.to_thread(host_store_for_managed.list_hosts, owner)
+                candidates = [
+                    host
+                    for host in hosts
+                    if host.sandbox_provider == "coda"
+                    and host.sandbox_id is not None
+                    and host_is_live(host)
+                ]
+                if candidates:
+                    sessions = await asyncio.to_thread(
+                        conversation_store.list_conversations,
+                        limit=1000,
+                        kind=None,
+                    )
+                    cap = sandbox_config.max_sessions_per_lease or 10
+                    adopted = next(
+                        (
+                            host
+                            for host in candidates
+                            if sum(session.host_id == host.host_id for session in sessions.data)
+                            < cap
+                        ),
+                        None,
+                    )
+            if adopted is not None:
+                from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+                launcher = sandbox_config.launcher_factory()
+                if not isinstance(launcher, CodaProvider):
+                    raise OmnigentError(
+                        "coda sandbox config did not produce a CodaProvider",
+                        code=ErrorCode.INTERNAL_ERROR,
+                    )
+                workspace = await asyncio.to_thread(
+                    launcher.allocate_workspace,
+                    adopted.sandbox_id,
+                    resp.id,
                 )
-            )
-            _managed_launch_tasks.add(launch_task)
-            launch_task.add_done_callback(_managed_launch_tasks.discard)
+                await asyncio.to_thread(
+                    conversation_store.set_host_id,
+                    resp.id,
+                    adopted.host_id,
+                    workspace,
+                )
+                resp.host_id = adopted.host_id
+                resp.workspace = workspace
+                launch_host_id = adopted.host_id
+            else:
+                managed_launches.begin(resp.id)
+                # Seed the launch-progress indicator before the background
+                # task starts, so the first GET snapshot already carries it.
+                _publish_sandbox_status(resp.id, "provisioning")
+                launch_task = asyncio.create_task(
+                    _run_managed_launch(
+                        session_id=resp.id,
+                        owner=owner,
+                        sandbox_config=sandbox_config,
+                        repo=repo,
+                        tracker=managed_launches,
+                        conversation_store=conversation_store,
+                        host_store=host_store_for_managed,
+                        host_registry=getattr(request.app.state, "host_registry", None),
+                        tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
+                        agent_store=agent_store,
+                        agent_id=conv.agent_id if conv is not None else None,
+                    )
+                )
+                _managed_launch_tasks.add(launch_task)
+                launch_task.add_done_callback(_managed_launch_tasks.discard)
 
         # Host launch: if a host is targeted (caller-supplied or
         # managed) and no runner is bound yet, authorize (caller must

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -402,56 +402,72 @@ def register_core_routes(
             owner = user_id if user_id is not None else RESERVED_USER_LOCAL
             adopted = None
             if sandbox_config.provider == "coda":
+                from omnigent.onboarding.sandboxes.coda import CodaProvider
                 from omnigent.stores.host_store import host_is_live
 
-                hosts = await asyncio.to_thread(host_store_for_managed.list_hosts, owner)
-                candidates = [
-                    host
-                    for host in hosts
-                    if host.sandbox_provider == "coda"
-                    and host.sandbox_id is not None
-                    and host_is_live(host)
-                ]
-                if candidates:
-                    sessions = await asyncio.to_thread(
-                        conversation_store.list_conversations,
-                        limit=1000,
-                        kind=None,
-                    )
-                    cap = sandbox_config.max_sessions_per_lease or 10
-                    adopted = next(
-                        (
-                            host
-                            for host in candidates
-                            if sum(session.host_id == host.host_id for session in sessions.data)
-                            < cap
-                        ),
-                        None,
-                    )
-            if adopted is not None:
-                from omnigent.onboarding.sandboxes.coda import CodaProvider
-
-                launcher = sandbox_config.launcher_factory()
-                if not isinstance(launcher, CodaProvider):
-                    raise OmnigentError(
-                        "coda sandbox config did not produce a CodaProvider",
-                        code=ErrorCode.INTERNAL_ERROR,
-                    )
-                workspace = await asyncio.to_thread(
-                    launcher.allocate_workspace,
-                    adopted.sandbox_id,
-                    resp.id,
-                )
-                await asyncio.to_thread(
-                    conversation_store.set_host_id,
-                    resp.id,
-                    adopted.host_id,
-                    workspace,
-                )
-                resp.host_id = adopted.host_id
-                resp.workspace = workspace
-                launch_host_id = adopted.host_id
-            else:
+                # Capacity check + workspace allocation + DB bind are one
+                # critical section. Without it, concurrent creates can both
+                # observe the last free slot on a shared lease.
+                adoption_lock = getattr(request.app.state, "coda_adoption_lock", None)
+                if adoption_lock is None:
+                    adoption_lock = asyncio.Lock()
+                    request.app.state.coda_adoption_lock = adoption_lock
+                async with adoption_lock:
+                    hosts = await asyncio.to_thread(host_store_for_managed.list_hosts, owner)
+                    candidates = [
+                        host
+                        for host in hosts
+                        if host.sandbox_provider == "coda"
+                        and host.sandbox_id is not None
+                        and host_is_live(host)
+                    ]
+                    if candidates:
+                        sessions = await asyncio.to_thread(
+                            conversation_store.list_conversations,
+                            limit=1000,
+                            kind=None,
+                        )
+                        cap = sandbox_config.max_sessions_per_lease or 10
+                        adopted = next(
+                            (
+                                host
+                                for host in candidates
+                                if sum(
+                                    session.host_id == host.host_id for session in sessions.data
+                                )
+                                < cap
+                            ),
+                            None,
+                        )
+                    if adopted is not None:
+                        launcher = sandbox_config.launcher_factory()
+                        if not isinstance(launcher, CodaProvider):
+                            raise OmnigentError(
+                                "coda sandbox config did not produce a CodaProvider",
+                                code=ErrorCode.INTERNAL_ERROR,
+                            )
+                        try:
+                            workspace = await asyncio.to_thread(
+                                launcher.allocate_workspace,
+                                adopted.sandbox_id,
+                                resp.id,
+                            )
+                            await asyncio.to_thread(
+                                conversation_store.set_host_id,
+                                resp.id,
+                                adopted.host_id,
+                                workspace,
+                            )
+                        except Exception:
+                            # Session creation is atomic from the caller's
+                            # perspective: a failed CoDA allocation must not
+                            # leave an unbound durable conversation behind.
+                            await conversation_store.delete_conversation(resp.id)
+                            raise
+                        resp.host_id = adopted.host_id
+                        resp.workspace = workspace
+                        launch_host_id = adopted.host_id
+            if adopted is None:
                 managed_launches.begin(resp.id)
                 # Seed the launch-progress indicator before the background
                 # task starts, so the first GET snapshot already carries it.

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1842,19 +1842,35 @@ def register_events_routes(
         if conv.host_id is not None and host_store_for_managed is not None:
             bound_host = await asyncio.to_thread(host_store_for_managed.get_host, conv.host_id)
             if bound_host is not None and bound_host.sandbox_id is not None:
-                keep_shared_coda_host = False
-                if bound_host.sandbox_provider == "coda":
-                    remaining = await asyncio.to_thread(
-                        conversation_store.list_conversations,
-                        limit=1000,
-                        kind=None,
-                    )
-                    keep_shared_coda_host = any(
-                        session.host_id == bound_host.host_id for session in remaining.data
-                    )
-                if not keep_shared_coda_host:
-                    from omnigent.server.managed_hosts import terminate_managed_host
+                from omnigent.server.managed_hosts import terminate_managed_host
 
+                if bound_host.sandbox_provider == "coda":
+                    # A CoDA host is shared, so "still in use?" and "terminate"
+                    # must be one critical section against session creation's
+                    # adoption. Otherwise: we count 0 -> a concurrent create
+                    # adopts this host -> we terminate it underneath that new
+                    # session. The lock is the same object routes_core.py takes
+                    # around its capacity check and DB bind.
+                    adoption_lock = getattr(request.app.state, "coda_adoption_lock", None)
+                    if adoption_lock is None:
+                        adoption_lock = asyncio.Lock()
+                        request.app.state.coda_adoption_lock = adoption_lock
+                    async with adoption_lock:
+                        # Count by host_id rather than paging the conversation
+                        # table: a listing capped at N rows undercounts once the
+                        # installation has more than N sessions, and the host is
+                        # then terminated while sessions are still bound to it.
+                        remaining = await asyncio.to_thread(
+                            conversation_store.count_conversations_by_host_id,
+                            bound_host.host_id,
+                        )
+                        if remaining == 0:
+                            await terminate_managed_host(
+                                bound_host,
+                                host_store_for_managed,
+                                getattr(request.app.state, "sandbox_config", None),
+                            )
+                else:
                     await terminate_managed_host(
                         bound_host,
                         host_store_for_managed,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1842,16 +1842,27 @@ def register_events_routes(
         if conv.host_id is not None and host_store_for_managed is not None:
             bound_host = await asyncio.to_thread(host_store_for_managed.get_host, conv.host_id)
             if bound_host is not None and bound_host.sandbox_id is not None:
-                from omnigent.server.managed_hosts import terminate_managed_host
+                keep_shared_coda_host = False
+                if bound_host.sandbox_provider == "coda":
+                    remaining = await asyncio.to_thread(
+                        conversation_store.list_conversations,
+                        limit=1000,
+                        kind=None,
+                    )
+                    keep_shared_coda_host = any(
+                        session.host_id == bound_host.host_id for session in remaining.data
+                    )
+                if not keep_shared_coda_host:
+                    from omnigent.server.managed_hosts import terminate_managed_host
 
-                await terminate_managed_host(
-                    bound_host,
-                    host_store_for_managed,
-                    # Supplies the launcher for the provider-side
-                    # terminate; None (config removed since launch)
-                    # still deletes the row and revokes the token.
-                    getattr(request.app.state, "sandbox_config", None),
-                )
+                    await terminate_managed_host(
+                        bound_host,
+                        host_store_for_managed,
+                        # Supplies the launcher for the provider-side
+                        # terminate; None (config removed since launch)
+                        # still deletes the row and revokes the token.
+                        getattr(request.app.state, "sandbox_config", None),
+                    )
         try:
             import hashlib as _hashlib
             import time as _time

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1298,6 +1298,27 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def count_conversations_by_host_id(self, host_id: str) -> int:
+        """
+        Return how many conversations are bound to ``host_id``.
+
+        Used by shared-host lifecycle decisions (capacity checks before
+        adopting a host, and the "is this host still in use?" check before
+        terminating one). Those callers only need a count, so they must not
+        page the whole conversation table: a listing capped at N rows silently
+        undercounts once the installation has more than N sessions, and the
+        host is then torn down while sessions are still bound to it.
+
+        Implementations must be read-after-write consistent with
+        :meth:`set_host_id`, because a host is adopted seconds before this
+        count is consulted again.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4"``.
+        :returns: Number of conversations whose ``host_id`` matches.
+        """
+        ...
+
+    @abstractmethod
     def list_conversations_by_runner_id(
         self,
         runner_id: str,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3005,6 +3005,28 @@ class SqlAlchemyConversationStore(ConversationStore):
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 
+    def count_conversations_by_host_id(self, host_id: str) -> int:
+        """
+        Return how many conversations are bound to ``host_id``.
+
+        One indexed ``COUNT(*)`` on the metadata table, so it stays correct and
+        cheap regardless of how many sessions the installation holds.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4"``.
+        :returns: Number of conversations whose ``host_id`` matches.
+        """
+        with self._session("count_conversations_by_host_id") as session:
+            return int(
+                session.execute(
+                    select(func.count())
+                    .select_from(SqlConversationMetadata)
+                    .where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.host_id == host_id,
+                    )
+                ).scalar_one()
+            )
+
     def list_conversations_by_runner_id(
         self,
         runner_id: str,

--- a/tests/deploy/test_databricks_deploy.py
+++ b/tests/deploy/test_databricks_deploy.py
@@ -1,0 +1,66 @@
+"""Tests for the Databricks Apps deploy orchestrator."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_deploy_module():
+    path = Path(__file__).parents[2] / "deploy" / "databricks" / "deploy.py"
+    spec = importlib.util.spec_from_file_location("omnigent_databricks_deploy_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bundle_vars_include_managed_coda_configuration() -> None:
+    deploy = _load_deploy_module()
+    args = SimpleNamespace(
+        app_name="omnigent",
+        lakebase_branch="projects/omnigent/branches/production",
+        lakebase_database=("projects/omnigent/branches/production/databases/databricks-postgres"),
+        volume_name="main.omnigent.artifacts",
+        otel_table_schema="main.omnigent_logs",
+        coda_app_name="coda-main",
+        coda_app_url="https://coda.example.com",
+        omnigent_public_server_url="https://omnigent.example.com",
+    )
+
+    pairs = deploy._bundle_vars(args)
+
+    assert "coda_app_name=coda-main" in pairs
+    assert "coda_app_url=https://coda.example.com" in pairs
+    assert "omnigent_public_server_url=https://omnigent.example.com" in pairs
+
+
+def test_parse_args_rejects_partial_managed_coda_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deploy = _load_deploy_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "deploy.py",
+            "--app-name",
+            "omnigent",
+            "--lakebase-branch",
+            "projects/omnigent/branches/production",
+            "--lakebase-database",
+            "projects/omnigent/branches/production/databases/databricks-postgres",
+            "--volume-name",
+            "main.omnigent.artifacts",
+            "--coda-app-name",
+            "coda-main",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        deploy._parse_args()

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -573,6 +573,7 @@ def _cleanup_host(host: HostProcess) -> None:
 
 async def test_handle_launch_spawns_subprocess(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     Verify that _handle_launch spawns a subprocess with the correct
@@ -582,6 +583,9 @@ async def test_handle_launch_spawns_subprocess(
     failed or the result frame construction is wrong.
     """
     host = _make_host_process()
+    # Managed hosts still pass their ingress bearer to the runner bootstrap;
+    # delegated owner-token minting cannot cross Apps without it.
+    monkeypatch.setenv("OMNIGENT_HOST_TOKEN", "managed-launch-token")
     host._auth_token_factory = lambda: "host-bootstrap-bearer"
     host._auth_token_factory_resolved = True
     workspace = tmp_path / "project"

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3323,6 +3323,99 @@ def test_build_connect_headers_retains_auth_factory(
     assert token_calls == [1, 1, 1]
 
 
+def test_managed_headers_unchanged_for_non_databricks_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed host on a non-Databricks server URL sends no bearer.
+
+    Regression invariant for the ingress-bearer path: Modal / E2B / Kubernetes
+    server URLs must keep exactly today's headers so no Databricks credential
+    ever leaves the workspace's trust domain.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.runner._entry as entry_mod
+    from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+
+    monkeypatch.setenv("OMNIGENT_HOST_TOKEN", "launch-token")
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
+    # Ambient Databricks creds are present but must not matter off-Databricks.
+    monkeypatch.setenv("DATABRICKS_HOST", "https://acme.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "sp-bearer")
+    monkeypatch.setattr(
+        entry_mod, "_make_auth_token_factory", lambda *, server_url=None: lambda: "sp-bearer"
+    )
+
+    headers = _host("https://omnigent.internal.example.com")._build_connect_headers()
+
+    assert headers == {
+        "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
+        "X-Omnigent-Host-Token": "launch-token",
+    }
+
+
+def test_managed_headers_add_ingress_bearer_on_databricks_apps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed host behind the Apps ingress sends both auth headers.
+
+    The ingress rejects an upgrade that carries only the launch-token header,
+    so ``Authorization`` rides alongside it; the server still authenticates the
+    host by the launch token.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.runner._entry as entry_mod
+
+    minted: list[int] = []
+
+    def _make_factory(*, server_url: str | None = None) -> object:
+        def _factory() -> str:
+            minted.append(1)
+            return f"sp-token-{len(minted)}"
+
+        return _factory
+
+    monkeypatch.setenv("OMNIGENT_HOST_TOKEN", "launch-token")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://acme.cloud.databricks.com")
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", _make_factory)
+
+    host = _host("https://omnigent-1234.aws.databricksapps.com")
+    first = host._build_connect_headers()
+    second = host._build_connect_headers()
+
+    assert first["X-Omnigent-Host-Token"] == "launch-token"
+    assert first["Authorization"] == "Bearer sp-token-1"
+    # Re-resolved per upgrade attempt so a multi-hour reconnect picks up a
+    # refreshed service-principal token.
+    assert second["Authorization"] == "Bearer sp-token-2"
+
+
+def test_managed_headers_skip_bearer_without_databricks_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No Databricks credential source means no bearer, even on Databricks.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setenv("OMNIGENT_HOST_TOKEN", "launch-token")
+    for var in (
+        "DATABRICKS_HOST",
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CONFIG_PROFILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    headers = _host("https://omnigent-1234.aws.databricksapps.com")._build_connect_headers()
+
+    assert "Authorization" not in headers
+    assert headers["X-Omnigent-Host-Token"] == "launch-token"
+
+
 async def test_run_retries_on_login_redirect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -2062,6 +2062,8 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "SSH_AUTH_SOCK": "/private/tmp/com.apple.launchd.7Qk/Listeners",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
         "OMNIGENT_DATABRICKS_EXTRA_HEADERS": '{"x-databricks-route-hint": "instance-abc"}',
+        "CODA_SP_TOKEN_BROKER_URL": "http://127.0.0.1:43210/token",
+        "CODA_VENV_PYTHON": "/app/python/.venv/bin/python",
         "OMNIGENT_LOG_LEVEL": "DEBUG",
         "OMNIGENT_LOG_TO_STDERR": "1",
         "OMNIGENT_LOG_TTY_FD": "9",
@@ -2119,6 +2121,8 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert (
         env["OMNIGENT_DATABRICKS_EXTRA_HEADERS"] == '{"x-databricks-route-hint": "instance-abc"}'
     )
+    assert env["CODA_SP_TOKEN_BROKER_URL"] == "http://127.0.0.1:43210/token"
+    assert env["CODA_VENV_PYTHON"] == "/app/python/.venv/bin/python"
     # Process logging controls forward so host-spawned runners honor --debug
     # and --log-to-stderr.
     assert env["OMNIGENT_LOG_LEVEL"] == "DEBUG"

--- a/tests/onboarding/sandboxes/test_coda.py
+++ b/tests/onboarding/sandboxes/test_coda.py
@@ -45,6 +45,22 @@ def test_control_error_detail_redacts_credentials() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"message":"Authorization: Bearer launch-secret"}',
+        '{"error":"token=launch-secret"}',
+        '{"details":["host token launch-secret"]}',
+        '{"password":"launch-secret"}',
+    ],
+)
+def test_control_error_detail_redacts_credentials_in_values(raw: str) -> None:
+    detail = _safe_control_error_detail(raw)
+
+    assert "launch-secret" not in detail
+    assert "<redacted>" in detail
+
+
 def test_capabilities() -> None:
     caps = launcher(FakeControl()).capabilities
     assert caps.cli_bootstrap is False

--- a/tests/onboarding/sandboxes/test_coda.py
+++ b/tests/onboarding/sandboxes/test_coda.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import click
 import pytest
 
-from omnigent.onboarding.sandboxes.coda import CodaProvider
+from omnigent.onboarding.sandboxes.coda import CodaProvider, _safe_control_error_detail
 
 
 class FakeControl:
@@ -29,6 +29,19 @@ def launcher(control: FakeControl) -> CodaProvider:
         app_url="https://coda-main.example.com",
         request_fn=control,
         app_getter=lambda _: SimpleNamespace(compute_status=SimpleNamespace(state="ACTIVE")),
+    )
+
+
+def test_control_error_detail_redacts_credentials() -> None:
+    detail = _safe_control_error_detail(
+        '{"error":"bad request","host_token":"launch-secret",'
+        '"nested":{"authorization":"Bearer x"}}'
+    )
+
+    assert "launch-secret" not in detail
+    assert "Bearer x" not in detail
+    assert detail == (
+        '{"error":"bad request","host_token":"<redacted>","nested":{"authorization":"<redacted>"}}'
     )
 
 

--- a/tests/onboarding/sandboxes/test_coda.py
+++ b/tests/onboarding/sandboxes/test_coda.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+
+class FakeControl:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, object]] = []
+        self.responses: dict[str, dict[str, object]] = {
+            "/api/omnigent-host/status": {"ready": True},
+            "/api/omnigent-host/lease": {"ok": True},
+            "/api/omnigent-host/connect": {"workspace": "/app/python/source_code/session-a"},
+            "/api/omnigent-host/disconnect": {"ok": True},
+        }
+
+    def __call__(self, method: str, path: str, body: object) -> dict[str, object]:
+        self.calls.append((method, path, body))
+        return self.responses[path]
+
+
+def launcher(control: FakeControl) -> CodaProvider:
+    return CodaProvider(
+        app_name="coda-main",
+        app_url="https://coda-main.example.com",
+        request_fn=control,
+        app_getter=lambda _: SimpleNamespace(compute_status=SimpleNamespace(state="ACTIVE")),
+    )
+
+
+def test_capabilities() -> None:
+    caps = launcher(FakeControl()).capabilities
+    assert caps.cli_bootstrap is False
+    assert caps.managed_launch is True
+    assert caps.local_port_forward is False
+    assert caps.resume_stopped is False
+    assert caps.programmatic_terminate is True
+
+
+def test_prepare_validates_without_mutating() -> None:
+    control = FakeControl()
+    launcher(control).prepare()
+    assert control.calls == [("GET", "/api/omnigent-host/status", None)]
+
+
+def test_prepare_rejects_inactive_app() -> None:
+    provider = CodaProvider(
+        app_name="coda-main",
+        app_url="https://coda-main.example.com",
+        request_fn=FakeControl(),
+        app_getter=lambda _: SimpleNamespace(compute_status=SimpleNamespace(state="STOPPED")),
+    )
+    with pytest.raises(click.ClickException, match="not ACTIVE"):
+        provider.prepare()
+
+
+def test_provision_acquires_fenced_lease() -> None:
+    control = FakeControl()
+    sandbox_id = launcher(control).provision("managed-abcd")
+    assert sandbox_id.startswith("coda:coda-main#")
+    method, path, body = control.calls[-1]
+    assert (method, path) == ("POST", "/api/omnigent-host/lease")
+    assert body["lease_id"] == sandbox_id.rsplit("#", 1)[1]
+
+
+def test_start_host_posts_identity_and_returns_reported_workspace() -> None:
+    control = FakeControl()
+    provider = launcher(control)
+    sandbox_id = provider.provision("managed-abcd")
+    stages: list[str] = []
+    workspace = provider.start_host(
+        sandbox_id,
+        token="launch-token",
+        host_id="host_abcd",
+        host_name="managed-abcd",
+        server_url="https://omnigent.example.com",
+        repo_url=None,
+        host_config={"providers": {}},
+        on_stage=stages.append,
+    )
+    assert workspace == "/app/python/source_code/session-a"
+    assert stages == ["cloning", "starting"]
+    _, path, body = control.calls[-1]
+    assert path == "/api/omnigent-host/connect"
+    assert body["host_token"] == "launch-token"
+    assert body["host_id"] == "host_abcd"
+    assert body["lease_id"] == sandbox_id.rsplit("#", 1)[1]
+
+
+def test_terminate_releases_without_app_lifecycle_calls() -> None:
+    control = FakeControl()
+    provider = launcher(control)
+    sandbox_id = provider.provision("managed-abcd")
+    provider.terminate(sandbox_id)
+    assert control.calls[-1] == (
+        "POST",
+        "/api/omnigent-host/disconnect",
+        {"lease_id": sandbox_id.rsplit("#", 1)[1], "scrub": True},
+    )
+    forbidden = ("stop", "delete", "deploy", "update", "create-update")
+    assert not any(word in path for _, path, _ in control.calls for word in forbidden)
+
+
+def test_terminate_is_best_effort() -> None:
+    def fail(_method: str, _path: str, _body: object) -> dict[str, object]:
+        raise click.ClickException("network down")
+
+    provider = CodaProvider(
+        app_name="coda-main",
+        app_url="https://coda-main.example.com",
+        request_fn=fail,
+        app_getter=lambda _: None,
+    )
+    provider.terminate("coda:coda-main#lease-a")

--- a/tests/runner/test_managed_mint_bearer_expiry.py
+++ b/tests/runner/test_managed_mint_bearer_expiry.py
@@ -1,0 +1,168 @@
+"""An expired host SP bearer must not permanently break the managed mint factory.
+
+Review finding on #4384 (`runner/_entry.py`): *"I think we need to consider when
+the initial SP token expires. this mint factory will be broken from that point
+on."*
+
+The host injects an initial service-principal bearer so the very first mint
+request can pass a Databricks Apps ingress. That bearer is captured once at
+construction and has its own, shorter, lifetime than a long-running session.
+Before this change, once it expired every mint got 401/403 and
+``_ManagedMintTokenFactory`` fell through to ``_still_valid_cached_token``; when
+the cached owner JWT also expired the factory returned ``None`` for the rest of
+the process, leaving the runner unauthenticated with no way back.
+
+The mint endpoint authenticates the *binding token*, not the proxy bearer, so
+dropping the dead bearer and retrying restores a self-sustaining refresh loop.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omnigent.runner import _entry
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://omnigent.example.com/v1/runners/r1/token")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def _factory() -> _entry._ManagedMintTokenFactory:
+    return _entry._ManagedMintTokenFactory(
+        "https://omnigent.example.com/v1/runners/r1/token",
+        "https://omnigent.example.com",
+        "binding-token-1",
+        proxy_bearer="host-sp-bearer",
+    )
+
+
+def test_expired_host_bearer_is_retired_and_the_mint_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 on the host bearer drops it and re-mints, instead of wedging."""
+    factory = _factory()
+    seen_bearers: list[str | None] = []
+
+    def fake_mint(
+        _mint_url: str,
+        _server_url: str,
+        _binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> tuple[str, float]:
+        seen_bearers.append(proxy_bearer)
+        if proxy_bearer is not None:
+            # The Apps ingress rejects the expired SP bearer.
+            raise _http_error(401)
+        return "owner-jwt-1", 1e12
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", fake_mint)
+
+    assert factory() == "owner-jwt-1"
+    # First attempt carried the dead bearer; the retry dropped it.
+    assert seen_bearers == ["host-sp-bearer", None]
+    assert factory.proxy_auth_failed is False
+    assert factory.declined is False
+    assert factory.ingress_bearer is None
+
+
+def test_the_bearer_is_only_retired_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A genuinely unauthorized runner must not retry forever."""
+    factory = _factory()
+    attempts: list[str | None] = []
+
+    def always_401(
+        _mint_url: str,
+        _server_url: str,
+        _binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> tuple[str, float]:
+        attempts.append(proxy_bearer)
+        raise _http_error(403)
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", always_401)
+
+    assert factory() is None
+    # Exactly two network attempts: with the bearer, then without it.
+    assert attempts == ["host-sp-bearer", None]
+    assert factory.proxy_auth_failed is True
+
+
+def test_a_still_valid_cached_token_is_served_rather_than_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-session 401 with a live cached JWT keeps serving it."""
+    factory = _factory()
+    calls: list[str | None] = []
+
+    def mint(
+        _mint_url: str,
+        _server_url: str,
+        _binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> tuple[str, float]:
+        calls.append(proxy_bearer)
+        if len(calls) == 1:
+            return "owner-jwt-1", 1e12
+        raise _http_error(401)
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", mint)
+
+    assert factory() == "owner-jwt-1"
+    # Force a re-mint by expiring the cache, then fail it.
+    factory._cached_expires_at = 1e12
+    factory._cached_token = "owner-jwt-1"
+    factory._cached_expires_at = 0.0
+    assert factory() is None or factory.proxy_auth_failed is True
+
+
+def test_no_proxy_bearer_behaves_as_before(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a host bearer there is nothing to retire; behaviour is unchanged."""
+    factory = _entry._ManagedMintTokenFactory(
+        "https://omnigent.example.com/v1/runners/r1/token",
+        "https://omnigent.example.com",
+        "binding-token-1",
+    )
+    attempts = 0
+
+    def always_401(
+        _mint_url: str,
+        _server_url: str,
+        _binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> tuple[str, float]:
+        nonlocal attempts
+        attempts += 1
+        raise _http_error(401)
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", always_401)
+
+    assert factory() is None
+    assert attempts == 1
+    assert factory.proxy_auth_failed is True
+
+
+def test_definitive_refusal_still_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 400/404 is still a definitive decline, not a bearer problem."""
+    factory = _factory()
+
+    def refuse(
+        _mint_url: str,
+        _server_url: str,
+        _binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> tuple[str, float]:
+        raise _http_error(404)
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", refuse)
+
+    assert factory() is None
+    assert factory.declined is True
+    assert factory.proxy_auth_failed is False

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -34,6 +34,7 @@ from omnigent.runner._entry import (
     _run_inactivity_monitor,
     _run_parent_death_killer,
     _runner_parent_pid_from_env,
+    _runner_request_headers,
     _runner_threadpool_max_workers,
     _runner_tunnel_binding_token_from_env,
     _runner_workspace_from_env,
@@ -840,6 +841,21 @@ def test_runner_databricks_auth_sends_apps_and_owner_headers() -> None:
     )
     assert captured == ["Bearer apps-sp-token"]
     assert request.headers[RUNNER_OWNER_TOKEN_HEADER] == "owner-jwt"
+
+
+def test_runner_request_headers_sends_apps_and_owner_headers() -> None:
+    """Out-of-process clients get the same managed dual-header contract."""
+
+    class _Factory:
+        ingress_bearer = "apps-sp-token"
+
+        def __call__(self) -> str:
+            return "owner-jwt"
+
+    headers = _runner_request_headers(_Factory(), "https://app.databricksapps.com")
+
+    assert headers["Authorization"] == "Bearer apps-sp-token"
+    assert headers[RUNNER_OWNER_TOKEN_HEADER] == "owner-jwt"
 
 
 def test_runner_databricks_auth_injects_fresh_token_per_request() -> None:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -787,7 +787,7 @@ def test_mint_managed_owner_token_includes_proxy_bearer_when_provided(
     assert captured["binding_token"] == "the-binding-token"
 
 
-def test_managed_mint_factory_promotes_minted_jwt_to_proxy_bearer(
+def test_managed_mint_factory_keeps_ingress_bearer_separate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """After the first mint, the factory uses the minted JWT as proxy bearer on re-mints."""
@@ -816,8 +816,28 @@ def test_managed_mint_factory_promotes_minted_jwt_to_proxy_bearer(
     factory._cached_expires_at = 0.0  # expire
     factory()
 
-    assert mint_call_bearers[0] == "Bearer seed-bearer"
-    assert mint_call_bearers[1] == "Bearer minted-jwt"
+    assert mint_call_bearers == ["Bearer seed-bearer", "Bearer seed-bearer"]
+    assert factory.ingress_bearer == "seed-bearer"
+
+
+def test_runner_databricks_auth_sends_apps_and_owner_headers() -> None:
+    """Managed requests separate ingress OAuth from application identity."""
+    from omnigent.runner.identity import RUNNER_OWNER_TOKEN_HEADER
+
+    class _Factory:
+        ingress_bearer = "apps-sp-token"
+
+        def __call__(self) -> str:
+            return "owner-jwt"
+
+    request = httpx.Request("GET", "https://app.databricksapps.com/v1/session")
+    captured = _drive_auth_flow(
+        _RunnerDatabricksAuth(_Factory()),
+        request,
+        httpx.Response(200),
+    )
+    assert captured == ["Bearer apps-sp-token"]
+    assert request.headers[RUNNER_OWNER_TOKEN_HEADER] == "owner-jwt"
 
 
 def test_runner_databricks_auth_injects_fresh_token_per_request() -> None:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -315,14 +315,13 @@ def test_initial_host_token_defers_local_auth_until_rejected(
     assert mint_calls == []
 
 
-def test_initial_host_token_falls_back_to_managed_mint_when_no_sdk_auth(
+def test_initial_host_token_immediately_mints_managed_owner_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """After the host bearer is rejected, a managed runner falls back to managed mint.
+    """A managed runner uses the host bearer only as mint proxy auth.
 
-    When no SDK/OIDC credential is available (managed sandbox with no user
-    credential), the fallback must reach the managed-mint path rather than
-    returning None and bricking all HTTP callbacks.
+    Application requests must carry the owner-bound minted token, never the
+    CoDA service principal bearer that merely crosses the Apps ingress.
     """
     mint_calls: list[int] = []
 
@@ -347,21 +346,18 @@ def test_initial_host_token_falls_back_to_managed_mint_when_no_sdk_auth(
 
     factory = _make_auth_token_factory()
 
-    assert isinstance(factory, _InitialAuthTokenFactory)
-    assert factory() == "host-bootstrap-token"
-    assert mint_calls == []
+    assert factory is not None
+    assert not isinstance(factory, _InitialAuthTokenFactory)
+    assert factory() == "managed-minted-token"
+    assert len(mint_calls) >= 1
 
     request = httpx.Request("GET", "https://app.databricksapps.com/api/version")
-    redirect = httpx.Response(302, headers={"Location": "/oidc/oauth2/v2.0/authorize"})
-    captured = _drive_auth_flow(_RunnerDatabricksAuth(factory), request, redirect)
-
-    # After the initial bearer is rejected, the fallback must mint via the
-    # managed-mint path rather than returning None and bricking callbacks.
-    assert captured == [
-        "Bearer host-bootstrap-token",
-        "Bearer managed-minted-token",
-    ]
-    assert len(mint_calls) >= 1
+    captured = _drive_auth_flow(
+        _RunnerDatabricksAuth(factory),
+        request,
+        httpx.Response(200),
+    )
+    assert captured == ["Bearer managed-minted-token"]
 
 
 def test_delegated_factory_falls_back_when_apps_proxy_redirects_mint(

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -43,6 +43,7 @@ from omnigent.runner._entry import (
 )
 from omnigent.runner.identity import (
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_OWNER_TOKEN_HEADER,
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
@@ -318,10 +319,10 @@ def test_initial_host_token_defers_local_auth_until_rejected(
 def test_initial_host_token_immediately_mints_managed_owner_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A managed runner uses the host bearer only as mint proxy auth.
+    """A managed runner keeps ingress and owner credentials separate.
 
-    Application requests must carry the owner-bound minted token, never the
-    CoDA service principal bearer that merely crosses the Apps ingress.
+    Application requests use the host bearer to cross the Apps ingress and
+    carry the owner-bound minted token in the internal owner-token header.
     """
     mint_calls: list[int] = []
 
@@ -357,7 +358,8 @@ def test_initial_host_token_immediately_mints_managed_owner_token(
         request,
         httpx.Response(200),
     )
-    assert captured == ["Bearer managed-minted-token"]
+    assert captured == ["Bearer host-bootstrap-token"]
+    assert request.headers[RUNNER_OWNER_TOKEN_HEADER] == "managed-minted-token"
 
 
 def test_delegated_factory_falls_back_when_apps_proxy_redirects_mint(

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -492,6 +492,109 @@ async def test_managed_session_create_end_to_end(
     del tunnels
 
 
+async def test_coda_two_sessions_adopt_one_host(
+    managed_session_env: ManagedSessionEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.onboarding.sandboxes.coda import CodaProvider
+    from omnigent.runner.identity import token_bound_runner_id
+
+    env = managed_session_env
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S", 0.2
+    )
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+
+    class FakeCoda(CodaProvider):
+        def __init__(self) -> None:
+            super().__init__(
+                app_name="coda-main",
+                app_url="https://coda.example.com",
+                request_fn=lambda _method, _path, _body: {},
+                app_getter=lambda _: None,
+            )
+
+        def prepare(self) -> None:
+            return None
+
+        def provision(self, _name: str) -> str:
+            return "coda:coda-main#lease-a"
+
+        def start_host(self, sandbox_id: str, **kwargs: object) -> str:
+            future = asyncio.run_coroutine_threadsafe(
+                _fake_sandbox_host(
+                    env.app,
+                    str(kwargs["host_id"]),
+                    str(kwargs["host_name"]),
+                    str(kwargs["token"]),
+                ),
+                loop,
+            )
+            host_futures.append(asyncio.wrap_future(future, loop=loop))
+            return "/app/python/source_code/coda-sessions/first"
+
+        def allocate_workspace(self, _sandbox_id: str, session_id: str) -> str:
+            return f"/app/python/source_code/coda-sessions/{session_id}"
+
+    fake = FakeCoda()
+    env.app.state.sandbox_config = ManagedSandboxConfig(
+        server_url="https://managed-test.example.com",
+        launcher_factory=lambda: fake,
+        token_ttl_s=13 * 3600,
+        provider="coda",
+        max_sessions_per_lease=10,
+    )
+    agent = await create_test_agent(env.client, name="coda-adoption-agent")
+    first_resp = await env.client.post(
+        "/v1/sessions", json={"agent_id": agent["id"], "host_type": "managed"}
+    )
+    first = await _wait_for_managed_binding(env, first_resp.json()["id"])
+    tunnel = await host_futures[0]
+
+    async def answer_next_launch() -> None:
+        for _ in range(50):
+            output = await tunnel.receive_output(timeout=10.0)
+            if output["type"] != "websocket.send":
+                continue
+            try:
+                frame = decode_host_frame(output["text"])
+            except ValueError:
+                continue
+            if isinstance(frame, HostLaunchRunnerFrame):
+                await tunnel.send_input(
+                    {
+                        "type": "websocket.receive",
+                        "text": encode_host_frame(
+                            HostLaunchRunnerResultFrame(
+                                request_id=frame.request_id,
+                                status="launched",
+                                runner_id=token_bound_runner_id(frame.binding_token),
+                            )
+                        ),
+                    }
+                )
+                return
+        raise AssertionError("adopted host did not receive second launch")
+
+    responder = asyncio.create_task(answer_next_launch())
+    second_resp = await env.client.post(
+        "/v1/sessions", json={"agent_id": agent["id"], "host_type": "managed"}
+    )
+    await responder
+    second = env.conv_store.get_conversation(second_resp.json()["id"])
+    assert second is not None
+    assert first.host_id == second.host_id
+    assert first.runner_id != second.runner_id
+    assert first.workspace != second.workspace
+    assert len(env.host_store.list_hosts(RESERVED_USER_LOCAL)) == 1
+    assert (await env.client.delete(f"/v1/sessions/{first.id}")).status_code == 200
+    assert env.host_store.get_host(first.host_id) is not None
+    assert (await env.client.delete(f"/v1/sessions/{second.id}")).status_code == 200
+    assert env.host_store.get_host(first.host_id) is None
+
+
 async def test_managed_session_create_with_repo_workspace_binds_cloned_dir(
     managed_session_env: ManagedSessionEnv,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
+import click
 import pytest
 import pytest_asyncio
 from asgiref.testing import ApplicationCommunicator
@@ -589,6 +590,20 @@ async def test_coda_two_sessions_adopt_one_host(
     assert first.runner_id != second.runner_id
     assert first.workspace != second.workspace
     assert len(env.host_store.list_hosts(RESERVED_USER_LOCAL)) == 1
+
+    before_failure = {session.id for session in env.conv_store.list_conversations(limit=100).data}
+
+    def _allocation_failure(_sandbox_id: str, _session_id: str) -> str:
+        raise click.ClickException("allocation failed")
+
+    monkeypatch.setattr(fake, "allocate_workspace", _allocation_failure)
+    with pytest.raises(click.ClickException, match="allocation failed"):
+        await env.client.post(
+            "/v1/sessions", json={"agent_id": agent["id"], "host_type": "managed"}
+        )
+    after_failure = {session.id for session in env.conv_store.list_conversations(limit=100).data}
+    assert after_failure == before_failure
+
     assert (await env.client.delete(f"/v1/sessions/{first.id}")).status_code == 200
     assert env.host_store.get_host(first.host_id) is not None
     assert (await env.client.delete(f"/v1/sessions/{second.id}")).status_code == 200

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
 from omnigent.server.accounts_bootstrap import (
     bootstrap_admin,
@@ -404,6 +405,22 @@ def test_mint_runner_token_returns_none_for_header_source() -> None:
             return None
 
     assert _Base().mint_runner_token("alice@example.com", 1800) is None
+
+
+def test_header_source_mints_and_validates_internal_runner_token() -> None:
+    """Header auth accepts only its own server-minted runner bearer."""
+    provider = UnifiedAuthProvider(source="header", runner_token_secret=b"r" * 32)
+    token = provider.mint_runner_token("alice@example.com", 1800)
+    assert token is not None
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+    )
+    assert provider.get_user_id(request) == "alice@example.com"
 
 
 def test_mint_runner_token_expired_resolves_to_none() -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -547,6 +547,35 @@ def test_parse_openshell_without_section_defaults(
     assert fake.workspace is None
 
 
+def test_parse_valid_coda_config_builds_parameterized_factory() -> None:
+    from omnigent.onboarding.sandboxes.coda import CodaProvider
+    from omnigent.server.managed_hosts import (
+        CODA_DEFAULT_MAX_SESSIONS_PER_LEASE,
+        CODA_MANAGED_TOKEN_TTL_S,
+        CODA_MAX_LEASE_S,
+        parse_sandbox_config,
+    )
+
+    config = parse_sandbox_config(
+        {
+            "provider": "coda",
+            "server_url": "https://omnigent.example.com",
+            "coda": {
+                "app_name": "coda-main",
+                "app_url": "https://coda-main.example.com",
+            },
+        }
+    )
+
+    assert config is not None
+    assert config.provider == "coda"
+    assert config.managed_launch_supported is True
+    assert config.token_ttl_s == CODA_MANAGED_TOKEN_TTL_S
+    assert config.token_ttl_s > CODA_MAX_LEASE_S
+    assert config.max_sessions_per_lease == CODA_DEFAULT_MAX_SESSIONS_PER_LEASE
+    assert isinstance(config.launcher_factory(), CodaProvider)
+
+
 def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 from omnigent.db.utils import builtin_agent_id, generate_agent_id, now_epoch
 from omnigent.entities.agent import Agent
 from omnigent.onboarding.sandboxes.base import render_host_config_write_command
+from omnigent.onboarding.sandboxes.coda import CodaProvider
 from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
@@ -2289,6 +2291,69 @@ async def test_relaunch_rolls_sandbox_generation_under_same_host(db_uri: str) ->
     resolved = host_store.resolve_launch_token(fake.host_starts[1].host_id, gen2_token)
     assert resolved is not None and resolved.host_id == first.host_id
     assert host_store.resolve_launch_token(fake.host_starts[0].host_id, gen1_token) is None
+
+
+async def test_relaunch_sets_coda_lease_owner_and_keeps_host_identity(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A CoDA relaunch reuses the host owner for its new lease."""
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="cda00000000000000000000000000001",
+        name="managed-coda",
+        user_id=_OWNER,
+        token="old-token",
+        provider="coda",
+        sandbox_id="coda:omnigent#old-lease",
+        token_expires_at=now_epoch() + 3600,
+    )
+    requests: list[tuple[str, Mapping[str, object] | None]] = []
+
+    def request_fn(
+        method: str, path: str, body: Mapping[str, object] | None
+    ) -> Mapping[str, object]:
+        requests.append((method, body))
+        if method == "POST" and path == "/api/omnigent-host/lease":
+            assert body is not None
+            assert body["owner"] == _OWNER
+            assert isinstance(body["lease_id"], str) and body["lease_id"]
+            return {"lease_id": body["lease_id"]}
+        return {"ready": True}
+
+    launcher = CodaProvider(
+        app_name="omnigent",
+        app_url="https://coda.example.com",
+        request_fn=request_fn,
+        app_getter=lambda _name: SimpleNamespace(compute_status=SimpleNamespace(state="ACTIVE")),
+    )
+    monkeypatch.setattr(
+        "omnigent.server.managed_hosts._launcher_for_teardown",
+        lambda _host, _config: launcher,
+    )
+    monkeypatch.setattr(
+        "omnigent.server.managed_hosts._terminate_sandbox_best_effort",
+        lambda *_args, **_kwargs: asyncio.sleep(0),
+    )
+
+    async def _arm(**kwargs: Any) -> str:
+        assert kwargs["host_id"] == host.host_id
+        assert kwargs["owner"] == _OWNER
+        return "/app/python/source_code"
+
+    monkeypatch.setattr("omnigent.server.managed_hosts._arm_and_start_host", _arm)
+    result = await relaunch_managed_host(
+        config=ManagedSandboxConfig(
+            server_url="https://srv.example.com",
+            launcher_factory=lambda: launcher,
+            token_ttl_s=3600,
+        ),
+        host=host,
+        host_store=host_store,
+    )
+
+    assert result.host_id == host.host_id
+    lease_calls = [body for method, body in requests if method == "POST"]
+    assert len(lease_calls) == 1
 
 
 async def test_relaunch_failure_keeps_host_row_and_revokes_token(db_uri: str) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2569,6 +2569,41 @@ def test_create_conversation_git_branch_defaults_none(
     assert fetched.git_branch is None
 
 
+def test_count_conversations_by_host_id(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """Counting by host must be exact and must not depend on a listing page.
+
+    Shared-host lifecycle decisions ask "how many sessions are on this host?"
+    before adopting it (capacity) and before terminating it (still in use?).
+    Deriving that from ``list_conversations(limit=N)`` undercounts once the
+    installation holds more than N sessions, which over-subscribes a full lease
+    and tears down a host that still has sessions bound to it.
+    """
+    host_a = "292dfcdf8a31f1319b469f4fa179ac6b"
+    host_b = "392dfcdf8a31f1319b469f4fa179ac6b"
+    _register_host(db_uri, host_a)
+    _register_host(db_uri, host_b)
+
+    assert conversation_store.count_conversations_by_host_id(host_a) == 0
+
+    for _ in range(3):
+        conv = conversation_store.create_conversation(workspace="/w")
+        conversation_store.set_host_id(conv.id, host_a)
+    on_b = conversation_store.create_conversation(workspace="/w")
+    conversation_store.set_host_id(on_b.id, host_b)
+    # An unbound session must not be attributed to any host.
+    conversation_store.create_conversation(workspace="/w")
+
+    assert conversation_store.count_conversations_by_host_id(host_a) == 3
+    assert conversation_store.count_conversations_by_host_id(host_b) == 1
+    # A well-formed id that no session uses counts zero.
+    assert (
+        conversation_store.count_conversations_by_host_id("492dfcdf8a31f1319b469f4fa179ac6b") == 0
+    )
+
+
 def test_set_host_id(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -31,14 +31,8 @@ def _databricks_config() -> dict[str, object]:
     }
 
 
-def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A Databricks default → Pi anthropic-messages gateway provider.
-
-    The Databricks profile is marked default for the anthropic/openai surfaces
-    (not ``pi`` directly), so the resolver must fall back to the Anthropic
-    surface — which Pi speaks natively — and build a gateway provider with a
-    bearer-token refresh command.
-    """
+def test_resolves_databricks_default_to_gateway_v2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Databricks default renders the AI Gateway v2 MLflow provider."""
     from omnigent.inner import databricks_executor
 
     def _host(profile: str | None) -> str:
@@ -49,8 +43,8 @@ def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.Mo
     provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
 
     assert provider is not None
-    assert provider.api == "anthropic-messages"
-    assert provider.base_url == "https://wkspc.example.com/ai-gateway/anthropic"
+    assert provider.api == "openai-completions"
+    assert provider.base_url == "https://wkspc.example.com/ai-gateway/mlflow/v1"
     assert provider.model == "catalog-databricks-claude-default"
     assert provider.auth_header is True
     # apiKey is a "!command" so Pi refreshes the gateway token per request.
@@ -823,13 +817,13 @@ def test_model_override_beats_databricks_default(monkeypatch: pytest.MonkeyPatch
     )
 
     assert provider is not None
-    assert provider.model == "databricks-claude-opus-4-7"
+    assert provider.model == "system.ai.claude-opus-4-7"
     # The override flows into the rendered models.json. When the live model
     # fetch fails (no real credentials in tests), only the selected model is
     # shown — no stale hardcoded list.
     cfg = provider.to_models_config()
     model_ids = [m["id"] for m in cfg["providers"]["omnigent"]["models"]]
-    assert "databricks-claude-opus-4-7" in model_ids
+    assert "system.ai.claude-opus-4-7" in model_ids
 
 
 def test_model_override_beats_inline_family_default() -> None:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -47,6 +47,14 @@ def test_resolves_databricks_default_to_gateway_v2(monkeypatch: pytest.MonkeyPat
     assert provider.base_url == "https://wkspc.example.com/ai-gateway/mlflow/v1"
     assert provider.model == "catalog-databricks-claude-default"
     assert provider.auth_header is True
+    rendered = provider.to_models_config()["providers"]["omnigent"]
+    assert rendered["compat"] == {
+        "supportsDeveloperRole": False,
+        "supportsStore": False,
+        "supportsStrictMode": False,
+        "supportsReasoningEffort": False,
+        "supportsUsageInStreaming": False,
+    }
     # apiKey is a "!command" so Pi refreshes the gateway token per request.
     assert provider.api_key.startswith("!")
     assert "demo-staging" in provider.api_key


### PR DESCRIPTION
## Related issue

Closes omnigent-ai/omnigent#4386

Beads epic `omnigent-90n` (managed CoDA lease integration).

## Summary

* Add a user-owned CoDA managed-host provider with fenced lease adoption, per-session workspaces, and last-session cleanup.
* Keep Databricks Apps ingress OAuth separate from owner-scoped runner authorization, including native Pi callbacks and token refresh paths.
* Make Databricks deployment wiring explicit and fail fast on partial CoDA configuration.
* Fix Pi AI Gateway v2 compatibility and preserve exact owner/host identity across relaunch.

### ELI5

Omnigent can borrow a ready CoDA app for one user, run multiple isolated sessions there, and release it after the last session. The Apps front door credential opens the building; a separate owner token determines whose session is allowed inside.

```text
Browser user -> Omnigent session -> fenced CoDA lease -> session runner
                 | Apps OAuth |       | owner JWT |
                 +------------+-------+-----------+
```

## Test Plan

* `613 passed` in the focused managed-host/auth suite before final hardening.
* `424 passed` in the final managed CoDA suite after adoption-lock and cleanup fixes.
* `pre-commit run --all-files` passed.
* CoDA companion suite: `600 passed, 1 skipped`.
* Deployed exact Omnigent HEAD `f8f57a8b12effb3322511beebefaf07be8b8cc51` and CoDA HEAD `b30dd5bd591498811bdc3d0c4711df7a5d1e2582` on profile `daveok`.
* Live Pi sessions `fc9b2f7984e6449cb2b90383c56efadf` and `5f88828c30a34581928d33e5d8ac29a1` rendered `AC99_HEAD_ONE_OK` and `AC99_HEAD_TWO_OK` on the same host with distinct runners.
* Final cleanup verified `/health` 200, no sessions, and no hosts.
* Independent requirements, edge-case, security/data, and regression reviews were reproduced and adjudicated PASS.

## Demo

Deployed screenshots captured at:

* `/tmp/managed-coda-evidence/final-f8f57a8b-head-success.png`
* `/tmp/managed-coda-evidence/final-ac99f0cd-two-session-success.png`
* `/tmp/managed-coda-evidence/managed-coda-standby-success.png`

The first two show real assistant items rendered by exact-head managed Pi sessions. Deployment/evidence manifest: `/tmp/managed-coda-evidence/final-deployed-heads.json`.

## Type of change

- [X] Bug fix
- [X] Feature
- [X] UI / frontend change
- [ ] Refactor / chore
- [X] Docs
- [X] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [X] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [X] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used two standing CoDA apps (`coda-main` and `coda`), two sessions sharing one primary lease, an independent standby-host session, exact deployed commit checks, browser-rendered assistant responses, and final lease cleanup.

## Changelog

Omnigent can run user-owned managed sessions on a standing CoDA lease with isolated multi-session runners and automatic cleanup.