### PR TITLE
feat(web): make the header Chat/Terminal switcher a segmented toggle

### DIFF
--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -66,37 +66,19 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
-# The header Chat/Terminal switcher is a Radix dropdown whose trigger *toggles*
-# on pointer-down. On a busy page (a live terminal stream plus the trigger's own
-# hover-driven tooltip re-rendering onto the same node) a lone click can net back
-# to closed, leaving the menu shut. Reopen until the target item is on screen
-# instead of asserting a single click landed.
-_VIEW_MENU_OPEN_ATTEMPTS = 5
-_VIEW_MENU_OPEN_TIMEOUT_MS = 5_000
-
-
 def _select_view_mode(page: Page, option: str) -> None:
-    """Open the header Chat/Terminal switcher and select *option*.
+    """Click the header Chat/Terminal switcher's *option* segment.
 
-    Clicks the ``view-mode-toggle`` trigger and waits for the ``option`` radio
-    item; a Radix toggle-trigger click can be swallowed on a busy page, so retry
-    the open before selecting rather than trusting one click.
+    Both destinations are always on screen (a segmented control, not a menu),
+    so this is a single click with no menu to open first.
 
     :param page: The Playwright page, on the session's chat surface.
-    :param option: The menu item label, e.g. ``"Chat"`` or ``"Terminal"``.
+    :param option: The segment to activate, ``"Chat"`` or ``"Terminal"``.
     """
-    toggle = page.get_by_test_id("view-mode-toggle")
-    expect(toggle).to_be_visible(timeout=30_000)
-    item = page.get_by_role("menuitemradio", name=option)
-    for attempt in range(_VIEW_MENU_OPEN_ATTEMPTS):
-        toggle.click()
-        try:
-            expect(item).to_be_visible(timeout=_VIEW_MENU_OPEN_TIMEOUT_MS)
-            break
-        except AssertionError:
-            if attempt == _VIEW_MENU_OPEN_ATTEMPTS - 1:
-                raise
-    item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(timeout=30_000)
+    segment = page.get_by_test_id(f"view-mode-{option.lower()}")
+    expect(segment).to_be_enabled(timeout=30_000)
+    segment.click()
 
 
 def _ensure_chat_view(page: Page) -> None:

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -291,17 +291,17 @@ describe("ChatHeader — Chat/Terminal switcher wiring", () => {
   it("mounts the ViewModeToggle for a terminal-first session", () => {
     renderHeaderWithSession(makeTerminalFirstCtx());
     expect(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+      screen.getByRole("group", { name: /switch between chat and terminal/i }),
     ).toBeInTheDocument();
   });
 
   it("omits the toggle for a non-terminal-first session", () => {
     renderHeaderWithSession(makeTerminalFirstCtx({ isTerminalFirst: false }));
-    expect(screen.queryByRole("button", { name: /switch between chat and terminal/i })).toBeNull();
+    expect(screen.queryByRole("group", { name: /switch between chat and terminal/i })).toBeNull();
   });
 
   it("omits the toggle when there is no TerminalFirst context", () => {
     renderHeaderWithSession(null);
-    expect(screen.queryByRole("button", { name: /switch between chat and terminal/i })).toBeNull();
+    expect(screen.queryByRole("group", { name: /switch between chat and terminal/i })).toBeNull();
   });
 });

--- a/web/src/shell/ViewModeToggle.test.tsx
+++ b/web/src/shell/ViewModeToggle.test.tsx
@@ -43,6 +43,16 @@ function renderToggle(ctx: TerminalFirstContextValue | null) {
   );
 }
 
+/** The Chat segment — icon-only, so it's addressed by its accessible name. */
+function chatSegment() {
+  return screen.getByRole("button", { name: /^chat view$/i });
+}
+
+/** The Terminal segment. Its name doubles as the starting-up explanation. */
+function terminalSegment() {
+  return screen.getByRole("button", { name: /^terminal (view|is starting up…)$/i });
+}
+
 beforeEach(() => {
   isIOSShellMock.mockReturnValue(false);
 });
@@ -53,44 +63,16 @@ afterEach(() => {
 });
 
 describe("ViewModeToggle", () => {
-  it("renders the MessagesSquare trigger for terminal-first sessions", () => {
+  it("renders both segments for terminal-first sessions", () => {
     renderToggle(makeCtx());
-    expect(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /switch between chat and terminal/i })).toBeVisible();
+    expect(chatSegment()).toBeVisible();
+    expect(terminalSegment()).toBeVisible();
   });
 
   it("renders nothing for a non-terminal-first session", () => {
     const { container } = renderToggle(makeCtx({ isTerminalFirst: false }));
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it("labels the trigger 'Terminal view' on hover in the terminal view", async () => {
-    renderToggle(makeCtx({ view: "terminal" }));
-    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
-    fireEvent.pointerEnter(trigger);
-    // The tooltip content mirrors the active view (portalled, so it appears
-    // in addition to the menu item's own label).
-    await screen.findByRole("tooltip", { name: /^terminal view$/i });
-  });
-
-  it("labels the trigger 'Chat view' on hover in the chat view", async () => {
-    renderToggle(makeCtx({ view: "chat" }));
-    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
-    fireEvent.pointerEnter(trigger);
-    await screen.findByRole("tooltip", { name: /^chat view$/i });
-  });
-
-  it("suppresses the tooltip while the menu is open", async () => {
-    renderToggle(makeCtx({ view: "chat" }));
-    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
-    // Hover shows the tooltip…
-    fireEvent.pointerEnter(trigger);
-    await screen.findByRole("tooltip", { name: /^chat view$/i });
-    // …but opening the menu must hide it so it doesn't overlap the dropdown.
-    fireEvent.pointerDown(trigger, { button: 0 });
-    await screen.findByRole("menuitemradio", { name: /^chat$/i });
-    expect(screen.queryByRole("tooltip", { name: /^chat view$/i })).toBeNull();
   });
 
   it("renders nothing outside a provider", () => {
@@ -109,52 +91,60 @@ describe("ViewModeToggle", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("marks the current view as checked in the menu", async () => {
-    renderToggle(makeCtx({ view: "terminal" }));
-    // Radix menus open on pointerdown, not click.
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
-      { button: 0 },
-    );
-    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
-    expect(terminalItem).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByRole("menuitemradio", { name: /^chat$/i })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
+  it("presses only the active segment in the chat view", () => {
+    renderToggle(makeCtx({ view: "chat" }));
+    expect(chatSegment()).toHaveAttribute("aria-pressed", "true");
+    expect(terminalSegment()).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("invokes setView when a menu option is selected", async () => {
+  it("presses only the active segment in the terminal view", () => {
+    renderToggle(makeCtx({ view: "terminal" }));
+    expect(terminalSegment()).toHaveAttribute("aria-pressed", "true");
+    expect(chatSegment()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("switches to the terminal view in one click — no menu to open", () => {
     const setView = vi.fn();
-    renderToggle(makeCtx({ setView }));
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
-      { button: 0 },
-    );
-    fireEvent.click(await screen.findByRole("menuitemradio", { name: /^terminal$/i }));
+    renderToggle(makeCtx({ setView, view: "chat" }));
+    fireEvent.click(terminalSegment());
     expect(setView).toHaveBeenCalledWith("terminal");
   });
 
-  it("disables the Terminal option and shows a spinner while the terminal is coming up", async () => {
-    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: true }));
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
-      { button: 0 },
-    );
-    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
-    expect(terminalItem).toHaveAttribute("aria-disabled", "true");
-    expect(terminalItem.querySelector(".animate-spin")).not.toBeNull();
-    expect(terminalItem).toHaveAttribute("title", expect.stringMatching(/starting up/i));
+  it("switches back to the chat view in one click", () => {
+    const setView = vi.fn();
+    renderToggle(makeCtx({ setView, view: "terminal" }));
+    fireEvent.click(chatSegment());
+    expect(setView).toHaveBeenCalledWith("chat");
   });
 
-  it("disables the Terminal option WITHOUT a spinner when no terminal exists and none is coming up", async () => {
+  it("names each segment on hover so the icon-only control is legible", async () => {
+    renderToggle(makeCtx({ view: "chat" }));
+    // Radix opens on a real pointer move over the trigger (the wrapper span),
+    // so a bare pointerEnter on the button wouldn't surface the tooltip.
+    fireEvent.pointerMove(chatSegment().parentElement!, { pointerType: "mouse" });
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Chat view");
+  });
+
+  it("disables the Terminal segment and shows a spinner while the terminal is coming up", () => {
+    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: true }));
+    const terminal = terminalSegment();
+    expect(terminal).toBeDisabled();
+    // The name carries the reason, so the disabled state explains itself.
+    expect(terminal).toHaveAccessibleName(/starting up/i);
+    expect(terminal.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("disables the Terminal segment WITHOUT a spinner when no terminal exists and none is coming up", () => {
     renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: false }));
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: /switch between chat and terminal/i }),
-      { button: 0 },
-    );
-    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
-    expect(terminalItem).toHaveAttribute("aria-disabled", "true");
-    expect(terminalItem.querySelector(".animate-spin")).toBeNull();
+    const terminal = terminalSegment();
+    expect(terminal).toBeDisabled();
+    expect(terminal.querySelector(".animate-spin")).toBeNull();
+  });
+
+  it("leaves the Chat segment usable while the terminal is unavailable", () => {
+    const setView = vi.fn();
+    renderToggle(makeCtx({ setView, terminalsAvailable: false, view: "terminal" }));
+    fireEvent.click(chatSegment());
+    expect(setView).toHaveBeenCalledWith("chat");
   });
 });

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -1,23 +1,16 @@
-import { useRef, useState } from "react";
-import { ChevronDownIcon, Loader2Icon, MessagesSquareIcon, TerminalIcon } from "lucide-react";
+import { Loader2Icon, MessagesSquareIcon, TerminalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isIOSShell } from "@/lib/nativeBridge";
-import { type TerminalFirstView, useTerminalFirst } from "./TerminalFirstContext";
+import { cn } from "@/lib/utils";
+import { useTerminalFirst } from "./TerminalFirstContext";
 
 /**
- * Header Chat/Terminal switcher for terminal-first sessions. A
- * MessagesSquare + chevron trigger opens a small menu with Chat and
- * Terminal options (the current view is checked), replacing the old
- * in-page pill above the composer. Status lives in the sidebar — this is
- * purely a view toggle.
+ * Header Chat/Terminal switcher for terminal-first sessions. Two icon
+ * segments in a shared track show both destinations at once, so the
+ * active view is readable at a glance and switching is one click — no
+ * menu to open. Status lives in the sidebar; this is purely a view
+ * toggle.
  *
  * Self-gates to null when there's nothing to toggle:
  *   - non-terminal-first sessions,
@@ -27,99 +20,98 @@ import { type TerminalFirstView, useTerminalFirst } from "./TerminalFirstContext
  */
 export function ViewModeToggle() {
   const ctx = useTerminalFirst();
-  const [open, setOpen] = useState(false);
-  // Drive the tooltip from the trigger's own hover/focus rather than a nested
-  // TooltipTrigger: stacking TooltipTrigger + DropdownMenuTrigger asChild onto
-  // one Button merges two Slots and the tooltip's listeners can get dropped.
-  // Suppress it while the menu is open so it never overlaps the dropdown.
-  const [hovered, setHovered] = useState(false);
-  // Tracks how the last menu interaction ended so close-focus handling can tell
-  // a pointer close (suppress refocus — a restored ghost-button focus ring reads
-  // as a stuck highlight) from a keyboard close (restore focus so keyboard/AT
-  // users keep their place).
-  const closedByPointerRef = useRef(false);
   if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return null;
 
   const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
+  const terminalLabel = terminalStartingUp ? "Terminal is starting up…" : "Terminal view";
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      {/* Tooltip anchors to a wrapper span (a single clean Slot) rather than
-          stacking TooltipTrigger + DropdownMenuTrigger onto the same Button —
-          two merged Slots on one node drop the tooltip's hover listeners. The
-          span carries the hover/focus that drives the controlled tooltip; the
-          DropdownMenuTrigger keeps anchoring the menu to the Button. Suppressed
-          while the menu is open so it never overlaps the dropdown. */}
-      <Tooltip open={hovered && !open}>
-        <TooltipTrigger asChild>
-          <span
-            className="inline-flex"
-            onPointerEnter={() => setHovered(true)}
-            onPointerLeave={() => setHovered(false)}
-            onFocus={() => setHovered(true)}
-            onBlur={() => setHovered(false)}
-          >
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Switch between chat and terminal"
-                data-testid="view-mode-toggle"
-                className="w-11 gap-1 px-0 text-muted-foreground hover:text-foreground border-none"
-              >
-                <MessagesSquareIcon className="size-4" />
-                <ChevronDownIcon className="size-3 opacity-60" />
-              </Button>
-            </DropdownMenuTrigger>
-          </span>
-        </TooltipTrigger>
-        {/* Bottom placement: the header sits at top-0, so a top-side tooltip
-            would render above the viewport edge and get clipped. */}
-        <TooltipContent side="bottom">
-          {view === "terminal" ? "Terminal view" : "Chat view"}
-        </TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent
-        align="end"
-        className="min-w-40"
-        // On a pointer close, don't snap focus back to the trigger: a ghost
-        // button keeps its focus ring lit until the next click, reading as a
-        // stuck "selected" state. On a keyboard close, let focus return so
-        // keyboard/AT users keep their place.
-        onCloseAutoFocus={(e) => {
-          if (closedByPointerRef.current) e.preventDefault();
-          closedByPointerRef.current = false;
-        }}
-        onPointerDownCapture={() => {
-          closedByPointerRef.current = true;
-        }}
+    <div
+      role="group"
+      aria-label="Switch between chat and terminal"
+      data-testid="view-mode-toggle"
+      // Inset track: p-0.5 around two size-6 segments lands the control at
+      // 32px tall, matching the header's other controls.
+      className="flex items-center gap-0.5 rounded-[var(--radius-lg)] bg-muted/60 p-0.5"
+    >
+      <ViewModeSegment
+        label="Chat view"
+        active={view === "chat"}
+        onClick={() => setView("chat")}
+        testId="view-mode-chat"
       >
-        <DropdownMenuRadioGroup
-          value={view}
-          onValueChange={(next) => setView(next as TerminalFirstView)}
-        >
-          <DropdownMenuRadioItem value="chat" className="gap-2">
-            <MessagesSquareIcon className="size-4" />
-            Chat
-          </DropdownMenuRadioItem>
-          {/* Terminal disabled until a PTY is reachable; a spinner while it's
-              coming up reads as "loading" rather than a dead option. */}
-          <DropdownMenuRadioItem
-            value="terminal"
-            className="gap-2"
-            disabled={!terminalsAvailable}
-            title={terminalStartingUp ? "Terminal is starting up…" : undefined}
-          >
-            {terminalStartingUp ? (
-              <Loader2Icon className="size-4 animate-spin" aria-hidden />
-            ) : (
-              <TerminalIcon className="size-4" />
+        <MessagesSquareIcon className="size-3.5" />
+      </ViewModeSegment>
+      {/* Terminal stays disabled until a PTY is reachable; the spinner while
+          it's coming up reads as "loading" rather than a dead segment. */}
+      <ViewModeSegment
+        label={terminalLabel}
+        active={view === "terminal"}
+        disabled={!terminalsAvailable}
+        onClick={() => setView("terminal")}
+        testId="view-mode-terminal"
+      >
+        {terminalStartingUp ? (
+          <Loader2Icon className="size-3.5 animate-spin" aria-hidden />
+        ) : (
+          <TerminalIcon className="size-3.5" />
+        )}
+      </ViewModeSegment>
+    </div>
+  );
+}
+
+/**
+ * One segment of the switcher: an icon-only button whose name lives in a
+ * tooltip. `aria-pressed` (not a radio) so each segment reads as an
+ * independent toggle to AT, matching how it behaves — clicking the active
+ * segment is a no-op rather than a selection change.
+ */
+function ViewModeSegment({
+  label,
+  active,
+  disabled = false,
+  onClick,
+  testId,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      {/* Wrapper span owns hover/focus: a disabled button gets no pointer
+          events, so the tooltip explaining *why* it's disabled would never
+          open if it anchored to the button itself. */}
+      <TooltipTrigger asChild>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant={active ? "secondary" : "ghost"}
+            size="icon-xs"
+            aria-label={label}
+            aria-pressed={active}
+            disabled={disabled}
+            onClick={onClick}
+            data-testid={testId}
+            className={cn(
+              "border-none",
+              active
+                ? "bg-background text-foreground shadow-sm hover:bg-background"
+                : "text-muted-foreground hover:bg-transparent hover:text-foreground",
             )}
-            Terminal
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          >
+            {children}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      {/* Bottom placement: the header sits at top-0, so a top-side tooltip
+          would render above the viewport edge and get clipped. */}
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Related issue

Closes #

<!-- No existing issue covers this redesign (#4253 is a hotkey request; #1157 is a
separate antigravity-native bug). Happy to file one if maintainers want it tracked. -->

## Summary

The header Chat/Terminal switcher for terminal-first sessions hid both destinations behind a dropdown: a `MessagesSquare` + chevron trigger you had to open before you could see which view you were in or switch to the other. Reading the current view took a hover (the tooltip); switching took two clicks. The trigger icon was identical in both views.

This makes it a **two-segment icon toggle** in a shared track — both destinations always visible, active one filled, one click to switch. Same header slot, immediately left of Share.

- Sized to the header's existing controls (`size-6` segments in a `p-0.5` track = 32px tall), so it sits flush with Share (`h-6`) and the right-panel toggle (`icon-xs`).
- **Behavior unchanged**: same `TerminalFirstContext`, same three self-gates (non-terminal-first sessions · iOS shell, where the native Liquid Glass bar owns the switcher · rail-opened shell views), and Terminal stays disabled — with a spinner while a PTY is coming up — until one is reachable.
- Each segment carries `aria-pressed` and a tooltip naming it, so the icon-only control stays legible to pointer and AT users. The Terminal tooltip doubles as the "starting up" explanation.

Net **−36 lines**: collapsing the menu removed the machinery it needed — the controlled tooltip (two merged Slots on one node dropped its hover listeners), the pointer-vs-keyboard close-refocus ref, and the e2e open-retry loop that existed because a toggle-trigger click could net back to closed.

Follow-up to #3931, which moved the switcher into the header and introduced the dropdown form. Placement is unchanged; only its presentation.

```
before                          after
┌──────────────┐                ┌───────────────┐
│  [💬 ▾]      │  hover to      │ ┌────┬────┐   │  active view
│      │       │  learn view,   │ │ 💬 │ >_ │   │  visible at rest,
│      └─ menu │  2 clicks to   │ └────┴────┘   │  1 click to switch
│         opens│  switch        │   ^filled     │
└──────────────┘                └───────────────┘
```

## Test Plan

- `pnpm run type-check` — clean (`tsc -b`)
- `pnpm run lint` (oxlint, `--deny-warnings`) — clean
- `pnpm prettier --check` on changed files — clean
- `ruff format --check` + `ruff check` on the changed e2e helper — clean
- `pnpm vitest run src/shell/ViewModeToggle.test.tsx src/shell/ChatHeader.test.tsx src/shell/AppShell.test.tsx src/shell/MainTerminalView.test.tsx` — **126/126 pass**

Manual: `cd web && pnpm dev`, open a terminal-first (`claude-native`) session, and check the top-right — the toggle sits immediately left of Share. Clicking either segment switches the main view; the active segment is filled; the choice survives a refresh in the same tab.

Pre-existing failures unrelated to this change: 3 in `NewChatDialog.test.tsx` (host picker / "This machine"). Confirmed by stashing this diff and reproducing them on untouched `main` — that file has zero references to `ViewModeToggle` / `TerminalFirstContext`.

## Demo

https://github.com/user-attachments/assets/2a9bc886-e902-400a-b122-dc428bb9d187

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`ViewModeToggle.test.tsx` was rewritten for the new contract — the old cases asserted dropdown internals (`menuitemradio`, open-on-pointerdown, tooltip-suppressed-while-menu-open) that no longer exist. 13 cases now cover: both segments rendering, all three self-gates (non-terminal-first / outside a provider / `isShellView` / iOS shell), `aria-pressed` on exactly the active segment in each view, one-click `setView` in both directions, the hover tooltip, and Terminal disabled with/without the spinner — plus that Chat stays usable while the terminal is unavailable.

E2E: `_select_view_mode` in `tests/e2e_ui/messages/test_message_render_parity.py` now clicks the segment testid directly instead of opening a menu and clicking a `menuitemradio`. This drops the 5-attempt open-retry loop (a segmented control has nothing to open, so the flake it guarded against is gone). The `view-mode-toggle` testid is preserved on the group, so the 7 native render-parity suites that assert its visibility are unaffected.

Manual verification covered the parts unit tests can't: that the control's 32px height lines up with Share and the panel toggle in the real header, and that the view survives a refresh.

## Changelog

The Chat/Terminal switcher is now a segmented toggle — both views are visible at a glance and switching takes one click

