### PR TITLE
fix(cli): select local mode for `--server local` and `--server ""`

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6970,7 +6970,10 @@ def _dispatch_run(
         )
 
     if target is None:
-        if server_from_cli and server is not None and harness is None:
+        # Truthiness, not ``is not None``: an empty ``--server ""`` selects local
+        # mode (see ``_ensure_backend``), so it must not be treated as a direct
+        # server URL and normalized into the bare scheme ``"https:"``.
+        if server_from_cli and server and harness is None:
             # Normalize like every other entry point: expand a bare workspace
             # URL to its /api/2.0/omnigent mount and strip any ?o= query. Else
             # a direct ``--server`` request hits the root and bounces to /login.
@@ -7484,6 +7487,17 @@ def run(
     # global config, which provides user-level defaults.
     server_source = click.get_current_context().get_parameter_source("server")
     server_from_cli = server_source is not None and server_source.name == "COMMANDLINE"
+    # ``--server ""`` is the documented "ignore any configured remote and target
+    # a local server" request. Collapse it to the ``None`` local-mode sentinel
+    # every downstream consumer already understands, and remember that it was
+    # explicit so the config fallback below cannot put the remote back. Without
+    # this, the empty string flowed on as a real server value and normalized to
+    # the bare scheme ``"https:"``, which then landed in the AGENT slot and
+    # failed as "Agent path not found: https:".
+    local_server_requested = server_from_cli and server == ""
+    if local_server_requested:
+        server = None
+        server_from_cli = False
     model_source = click.get_current_context().get_parameter_source("model")
     model_from_cli = model_source is click.core.ParameterSource.COMMANDLINE
     harness_source = click.get_current_context().get_parameter_source("harness")
@@ -7500,7 +7514,7 @@ def run(
     direct_server_cli = (
         target is None
         and server_from_cli
-        and server is not None
+        and bool(server)
         and not harness_from_cli
         and acp_agent is None
     )
@@ -7513,7 +7527,7 @@ def run(
         # it — but fall back to a built-in launcher when an explicit --harness
         # doesn't match the default agent's harness.
         target = _resolve_default_agent_target(_global_cfg.get("default_agent"), harness)
-    if server is None:
+    if server is None and not local_server_requested:
         server = _global_cfg.get("server")
     if model is None and not direct_server_cli:
         model = _global_cfg.get("model")
@@ -10380,8 +10394,18 @@ def _resolve_server_url(server: str) -> str:
         ``"example.cloud.databricks.com/omnigent"``.
     :returns: The normalized API base URL without a trailing slash, e.g.
         ``"https://example.cloud.databricks.com/api/2.0/omnigent"``.
+    :raises click.ClickException: If *server* is empty or whitespace-only.
+        Callers select local mode with a falsy value instead (see
+        ``_ensure_backend``); normalizing it here would yield the bare scheme
+        ``"https:"`` and strand the caller on a nonsense URL.
     """
     from omnigent.conversation_browser import display_server_url, strip_conversation_path
+
+    if not server.strip():
+        raise click.ClickException(
+            "--server was given an empty value where a URL is required. "
+            'Omit --server (or pass --server "") to use a local server.'
+        )
 
     # A URL copied from the browser while a conversation is open carries the
     # SPA's ``/c/<id>`` route. The SPA catch-all answers any GET under it with

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2182,6 +2182,27 @@ _HOST_PID_PATH = Path.home() / ".omnigent" / "host.pid"
 # target (real URLs never collide with the marker).
 _LOCAL_DAEMON_MARKER = "local"
 
+# ``--server`` values that mean "run against a local server" rather than naming a
+# remote one. ``""`` is the historical spelling; ``"local"`` is the readable alias
+# and matches ``_LOCAL_DAEMON_MARKER`` above, the marker local mode already
+# records in host.pid. Neither can be a real target: an empty value has no host,
+# and a bare ``local`` would normalize to the unroutable ``https://local``.
+_LOCAL_SERVER_ALIASES = frozenset({"", _LOCAL_DAEMON_MARKER})
+
+
+def _is_local_server_request(server: str | None) -> bool:
+    """
+    Whether a ``--server`` value asks for a local server.
+
+    :param server: Raw ``--server`` value, e.g. ``""``, ``"local"``, or
+        ``"https://example.databricksapps.com"``. ``None`` (flag absent) is
+        not a request — it leaves the config default free to apply.
+    :returns: ``True`` for a local-server alias, else ``False``.
+    """
+    if server is None:
+        return False
+    return server.strip().casefold() in _LOCAL_SERVER_ALIASES
+
 
 @dataclass(frozen=True)
 class _HostDaemonRecord:
@@ -7390,8 +7411,9 @@ def attach(
         "Remote omnigent URL. Uploads the local YAML as an ephemeral "
         "agent, spawns a LOCAL runner that tunnels to this server (so "
         "terminals/MCPs run on your laptop), and connects the REPL to it. "
-        'Pass --server "" to auto-spawn a persistent local server in the '
-        "background and target that instead of a remote one."
+        "Pass --server local to auto-spawn a persistent local server in the "
+        "background and target that instead of a remote one, overriding any "
+        'configured server default (--server "" does the same).'
     ),
 )
 @click.option(
@@ -7467,6 +7489,7 @@ def run(
       omnigent run examples/hello_world.yaml
       omnigent run examples/hello_world.yaml --harness codex --model gpt-5.4-mini
       omnigent run --server http://localhost:6767
+      omnigent run --server local  # local server, ignoring any configured default
       omnigent run examples/databricks_coding_agent.yaml --server https://<app>.databricksapps.com
       omnigent run --server https://<app>.databricksapps.com --profile my-sp -p "hi"
     """
@@ -7487,14 +7510,14 @@ def run(
     # global config, which provides user-level defaults.
     server_source = click.get_current_context().get_parameter_source("server")
     server_from_cli = server_source is not None and server_source.name == "COMMANDLINE"
-    # ``--server ""`` is the documented "ignore any configured remote and target
-    # a local server" request. Collapse it to the ``None`` local-mode sentinel
-    # every downstream consumer already understands, and remember that it was
-    # explicit so the config fallback below cannot put the remote back. Without
-    # this, the empty string flowed on as a real server value and normalized to
-    # the bare scheme ``"https:"``, which then landed in the AGENT slot and
-    # failed as "Agent path not found: https:".
-    local_server_requested = server_from_cli and server == ""
+    # ``--server local`` (or ``--server ""``) is the documented "ignore any
+    # configured remote and target a local server" request. Collapse it to the
+    # ``None`` local-mode sentinel every downstream consumer already understands,
+    # and remember that it was explicit so the config fallback below cannot put
+    # the remote back. Without this, the value flowed on as a real server and
+    # normalized to a bogus URL — ``""`` became the bare scheme ``"https:"``,
+    # which then landed in the AGENT slot as "Agent path not found: https:".
+    local_server_requested = server_from_cli and _is_local_server_request(server)
     if local_server_requested:
         server = None
         server_from_cli = False
@@ -10394,17 +10417,19 @@ def _resolve_server_url(server: str) -> str:
         ``"example.cloud.databricks.com/omnigent"``.
     :returns: The normalized API base URL without a trailing slash, e.g.
         ``"https://example.cloud.databricks.com/api/2.0/omnigent"``.
-    :raises click.ClickException: If *server* is empty or whitespace-only.
-        Callers select local mode with a falsy value instead (see
-        ``_ensure_backend``); normalizing it here would yield the bare scheme
-        ``"https:"`` and strand the caller on a nonsense URL.
+    :raises click.ClickException: If *server* is a local-server alias (empty or
+        ``"local"``) rather than a URL. Callers route those to local mode before
+        reaching here (see ``_is_local_server_request`` / ``_ensure_backend``);
+        normalizing one would yield a nonsense target — the bare scheme
+        ``"https:"`` for an empty value, or the unroutable ``https://local``.
     """
     from omnigent.conversation_browser import display_server_url, strip_conversation_path
 
-    if not server.strip():
+    if _is_local_server_request(server):
         raise click.ClickException(
-            "--server was given an empty value where a URL is required. "
-            'Omit --server (or pass --server "") to use a local server.'
+            f"--server was given {server!r}, which selects a local server, where "
+            "a remote URL is required. Pass `--server local` to the command you "
+            "meant to run locally, or give this one a URL."
         )
 
     # A URL copied from the browser while a conversation is open carries the

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -43,6 +43,7 @@ from omnigent.cli import (
     _resolve_bundle_env_vars,
     _resolve_default_agent_target,
     _resolve_first_run_plan,
+    _resolve_server_url,
     _save_global_config,
     _save_local_config,
     _server_uvicorn_log_config,
@@ -3751,6 +3752,78 @@ def test_run_server_without_agent_dispatches_direct_server(
         # including for remote servers.
         auto_open_conversation=True,
     )
+
+
+def test_run_empty_server_uses_local_mode_over_configured_remote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run AGENT --server ""`` targets a local server, not the configured one.
+
+    An empty ``--server`` is the documented way to ask for a local server
+    ("auto-spawn a persistent local server ... instead of a remote one"), so it
+    has to beat the ``server`` config default rather than fall back to it.
+    ``run_chat`` gets ``server_url=None``, the sentinel ``_ensure_backend``
+    reads as local mode.
+    """
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda *_a, **_kw: {"server": "https://configured.example.com"},
+    )
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli, ["run", "tests/resources/examples/hello_world.yaml", "--server", ""]
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = run_chat.call_args.kwargs
+    assert kwargs["target"] == "tests/resources/examples/hello_world.yaml"
+    assert kwargs["server_url"] is None
+
+
+def test_run_empty_server_without_agent_is_not_a_direct_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run --server ""`` (no AGENT) resolves the default agent locally.
+
+    Regression: the no-AGENT direct-server branch gated on ``server is not
+    None``, so an empty ``--server`` was misread as a direct server URL and
+    normalized to the bare scheme ``"https:"``. That string is not
+    ``_is_url``-shaped, so it was then taken for an agent path and the run died
+    with "Agent path not found: https:" — while a configured remote silently
+    replaced the local server the user asked for.
+    """
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda *_a, **_kw: {
+            "server": "https://configured.example.com",
+            "default_agent": "tests/resources/examples/hello_world.yaml",
+        },
+    )
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(cli, ["run", "--server", ""])
+
+    assert result.exit_code == 0, result.output
+    kwargs = run_chat.call_args.kwargs
+    # The bug put the bogus normalized URL in the AGENT slot.
+    assert kwargs["target"] == "tests/resources/examples/hello_world.yaml"
+    assert kwargs["server_url"] is None
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_resolve_server_url_rejects_empty_value(value: str) -> None:
+    """An empty ``--server`` value fails loud instead of yielding ``"https:"``.
+
+    Normalizing an empty string used to produce the bare scheme ``"https:"``
+    (``https://`` from the default-scheme step, then trailing-slash-trimmed),
+    which every caller then treated as a real URL. Callers select local mode
+    with a falsy value and must never route it here.
+    """
+    with pytest.raises(ClickException, match="empty value"):
+        _resolve_server_url(value)
 
 
 def test_run_server_resume_by_id_forwards_to_run_attach(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -32,6 +32,7 @@ from omnigent.cli import (
     _expand_config_env_vars,
     _extract_global_logging_flags,
     _HostHttpResult,
+    _is_local_server_request,
     _is_removed_ad_hoc_invocation,
     _is_run_shorthand,
     _load_global_config,
@@ -3754,16 +3755,18 @@ def test_run_server_without_agent_dispatches_direct_server(
     )
 
 
-def test_run_empty_server_uses_local_mode_over_configured_remote(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("alias", ["", "local", "LOCAL", " local "])
+def test_run_local_server_alias_beats_configured_remote(
+    alias: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``run AGENT --server ""`` targets a local server, not the configured one.
+    """``run AGENT --server local`` targets a local server, not the configured one.
 
-    An empty ``--server`` is the documented way to ask for a local server
-    ("auto-spawn a persistent local server ... instead of a remote one"), so it
-    has to beat the ``server`` config default rather than fall back to it.
-    ``run_chat`` gets ``server_url=None``, the sentinel ``_ensure_backend``
-    reads as local mode.
+    ``--server local`` (and the older ``--server ""``) is the documented way to
+    ask for a local server "instead of a remote one", so it has to beat the
+    ``server`` config default rather than fall back to it. ``run_chat`` gets
+    ``server_url=None``, the sentinel ``_ensure_backend`` reads as local mode.
+    Matching ignores case and surrounding space, so a shell-quoted
+    ``--server " local "`` behaves the same.
     """
     monkeypatch.setattr(
         "omnigent.cli._load_effective_config",
@@ -3773,7 +3776,7 @@ def test_run_empty_server_uses_local_mode_over_configured_remote(
     monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
 
     result = CliRunner().invoke(
-        cli, ["run", "tests/resources/examples/hello_world.yaml", "--server", ""]
+        cli, ["run", "tests/resources/examples/hello_world.yaml", "--server", alias]
     )
 
     assert result.exit_code == 0, result.output
@@ -3782,10 +3785,31 @@ def test_run_empty_server_uses_local_mode_over_configured_remote(
     assert kwargs["server_url"] is None
 
 
-def test_run_empty_server_without_agent_is_not_a_direct_server(
-    monkeypatch: pytest.MonkeyPatch,
+def test_run_localhost_server_is_still_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``localhost`` URL stays an explicit server — only bare ``local`` is the alias.
+
+    The local-mode aliases match the whole value, so hosts that merely *start*
+    with "local" keep their normal explicit-server behavior instead of being
+    swallowed by the alias.
+    """
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "tests/resources/examples/hello_world.yaml", "--server", "localhost:8000"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert run_chat.call_args.kwargs["server_url"] == "localhost:8000"
+
+
+@pytest.mark.parametrize("alias", ["", "local"])
+def test_run_local_server_alias_without_agent_is_not_a_direct_server(
+    alias: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``run --server ""`` (no AGENT) resolves the default agent locally.
+    """``run --server local`` (no AGENT) resolves the default agent locally.
 
     Regression: the no-AGENT direct-server branch gated on ``server is not
     None``, so an empty ``--server`` was misread as a direct server URL and
@@ -3804,7 +3828,7 @@ def test_run_empty_server_without_agent_is_not_a_direct_server(
     run_chat = Mock()
     monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
 
-    result = CliRunner().invoke(cli, ["run", "--server", ""])
+    result = CliRunner().invoke(cli, ["run", "--server", alias])
 
     assert result.exit_code == 0, result.output
     kwargs = run_chat.call_args.kwargs
@@ -3813,17 +3837,42 @@ def test_run_empty_server_without_agent_is_not_a_direct_server(
     assert kwargs["server_url"] is None
 
 
-@pytest.mark.parametrize("value", ["", "   "])
-def test_resolve_server_url_rejects_empty_value(value: str) -> None:
-    """An empty ``--server`` value fails loud instead of yielding ``"https:"``.
+@pytest.mark.parametrize("value", ["", "   ", "local", "LOCAL"])
+def test_resolve_server_url_rejects_local_server_aliases(value: str) -> None:
+    """A local-server alias fails loud instead of normalizing to a bogus URL.
 
     Normalizing an empty string used to produce the bare scheme ``"https:"``
     (``https://`` from the default-scheme step, then trailing-slash-trimmed),
-    which every caller then treated as a real URL. Callers select local mode
-    with a falsy value and must never route it here.
+    which every caller then treated as a real URL; ``"local"`` would likewise
+    become the unroutable ``https://local``. Callers route local mode before
+    reaching here and must never pass an alias in.
     """
-    with pytest.raises(ClickException, match="empty value"):
+    with pytest.raises(ClickException, match="selects a local server"):
         _resolve_server_url(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", True),
+        ("   ", True),
+        ("local", True),
+        ("LOCAL", True),
+        (" local ", True),
+        (None, False),
+        ("localhost", False),
+        ("localhost:8000", False),
+        ("http://localhost:6767", False),
+        ("https://example.databricksapps.com", False),
+    ],
+)
+def test_is_local_server_request(value: str | None, expected: bool) -> None:
+    """Only a whole-value ``""``/``local`` selects local mode.
+
+    ``None`` means the flag was absent (the config default still applies), and a
+    host that merely starts with "local" is a real server, so neither counts.
+    """
+    assert _is_local_server_request(value) is expected
 
 
 def test_run_server_resume_by_id_forwards_to_run_attach(


### PR DESCRIPTION
## Related issue

Closes #

<!-- No existing issue found for this bug; the root cause and regression origin are documented below. -->

## Summary

`omnigent run --server ""` — documented as the way to target a local server instead of a remote one — failed with:

```
Error: Agent path not found: https:
```

Specifically the **no-AGENT** form. With an AGENT (`run agent.yaml --server ""`) it worked fine. With no AGENT, `target is None`, so `_dispatch_run` enters the no-AGENT direct-server branch — and that branch gated on `server is not None` rather than truthiness. So `""` was classified as a direct server URL and normalized into a bare scheme:

```
_with_default_scheme("")  ->  f"https://{''}"  ->  "https://"
trailing-slash trim       ->  "https://".rstrip("/")  ->  "https:"
```

`"https:"` has no `//`, so it fails `_is_url()` — it was handed to `run_chat(target=...)`, which took it for a local **agent path** and died looking for a file named `https:`. With an AGENT that branch is skipped entirely and `""` flows to `_ensure_backend`, which already reads it as local mode via a truthy `if server:`.

### Regression origin

This worked for ~6 weeks and broke in **436b2d8c** (#1324, 2026-06-26, *"route every Databricks surface with the `?o=` workspace selector"*), which replaced one line in that branch:

```python
base_url = server.rstrip("/")            # before: "" -> ""  (falsy -> local mode)
base_url = _resolve_server_url(server)   # after:  "" -> "https:"
```

The old line was accidentally safe — `"".rstrip("/")` is still `""`, still falsy, so `_ensure_backend` read it as local. Centralizing normalization through `_resolve_server_url` was right for real URLs, but it also introduced scheme-defaulting, which turns `""` into a URL-shaped nonsense value. Verified by running the CLI on either side of that commit:

| Commit | `run --server ""` |
| --- | --- |
| `921524ae` (parent) | `target=''` → local mode, worked |
| `436b2d8c` | `target='https:'` → broken |

### And a readable alias: `--server local`

The empty string is hard to discover and easy to mistake for a missing value. `local` is already this codebase's name for the mode — `_LOCAL_DAEMON_MARKER = "local"` is the marker local mode records in `host.pid`, where *"real URLs never collide with the marker"*. Neither spelling can be a genuine target: an empty value has no host, and a bare `local` previously normalized to the unroutable `https://local`.

### ELI5

`--server local` means "never mind any remote, just run locally". The code asked *"did you pass a server?"* instead of *"did you pass a **non-empty** server?"* — an empty string counts as "yes" to the first question. So it built a URL out of nothing, got the useless fragment `https:`, and then mistook that for a filename.

### Flow

```mermaid
graph TD
    A["run --server '' (no AGENT)"] --> B{"server is not None?"}
    B -->|"before: TRUE for ''"| C["_resolve_server_url('')"]
    C --> D["'https://' -> rstrip('/') -> 'https:'"]
    D --> E{"_is_url('https:')?"}
    E -->|"False (no //)"| F["treated as AGENT path"]
    F --> G["Error: Agent path not found: https:"]
    B -->|"after: _is_local_server_request()"| H["server = None (local sentinel)"]
    H --> I["_ensure_backend(None) -> local server"]
```

### Changes (`omnigent/cli.py`)

- New `_is_local_server_request` helper + `_LOCAL_SERVER_ALIASES` (`{"", "local"}`), so the rule lives in one place. Matched case-insensitively on the whole trimmed value, so `localhost:8000` and `http://localhost:6767` keep their normal explicit-server behavior.
- Both gates (`direct_server_cli`, `_dispatch_run`) test truthiness instead of `is not None`.
- An explicit local-mode request collapses to the `None` sentinel `_ensure_backend` already understands. Note the `local_server_requested` guard on the config fallback is **behavior-preserving, not a fix**: `""` previously escaped `if server is None:` by not being `None`, and collapsing it to `None` would newly expose it to the configured `server` default. The guard keeps `--server local`/`""` beating the config default, as before.
- `_resolve_server_url` rejects a local-mode alias outright rather than inventing a nonsense URL — no caller can reproduce the `"https:"` shape again.
- `--server` help text and a `run` usage example document the alias.

Unrelated to #4303 / PR #4374 (the `/c/<id>` stripping fix); that path works.

## Test Plan

Regression tests **fail on the pre-fix code and pass after** — the pre-fix failure reproduces the bug exactly:

```
E  AssertionError: assert 'https:' == 'tests/resources/examples/hello_world.yaml'
```

```bash
uv run --extra dev pytest tests/cli/test_cli.py \
  -k "local_server or localhost_server or resolve_server_url_rejects" -v
```

Behavior verified across the matrix (with a remote `server` in config, to confirm the alias beats the configured default):

| Invocation | Result |
| --- | --- |
| `run --server local` (no AGENT) | local mode — **was broken** |
| `run --server ""` (no AGENT) | local mode — **was broken** |
| `run AGENT --server local` | local mode (`server_url=None`), config remote ignored |
| `run AGENT --server ""` | local mode — worked before, still works |
| `run AGENT --server LOCAL` / `" local "` | local mode (case- and space-insensitive) |
| `run --server local --harness codex` | local mode, materialized launcher |
| `run --server local -p hi` | local mode, one-shot |
| `run --server "   "` | fails loud with a clear message (previously silent `https:`) |
| `run AGENT --server localhost:8000` | **remote** — alias must not swallow `localhost` |
| `run --server URL` | direct server — unchanged |
| `run AGENT` (remote from config) | config remote still honored — unchanged |

Full suite and gates:

- `tests/cli/test_cli.py` + `tests/cli/test_login_databricks.py` — **326 passed**
- `ruff format` / `ruff check` — clean
- `pyrefly check` — 0 errors
- `no-skipped-tests`, `no-global-asyncio-patch`, `no-hardcoded-models` — clean

## Demo

N/A — CLI behaviour change, no UI surface. Before/after on the reported command:

```console
$ omnigent run --server ""          # before
omnigent: Starting the local server…
Error: Agent path not found: https:

$ omnigent run --server local       # after (and --server "" too)
omnigent: Starting the local server…   (starts and connects normally)
```

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed each row of the matrix above through `CliRunner`, asserting on the `target` / `server_url` kwargs `run_chat` actually receives — which is where the bogus `"https:"` landed. Asserting only on `server_url` is misleading here: it is `None` in both the working and broken cases, so the bug is visible solely in `target`. The regression origin was pinned by checking out `omnigent/cli.py` at `436b2d8c` and its parent and running the CLI at each. Regression tests were also run against the unpatched file to confirm they fail without the fix rather than passing vacuously. `run --help` was rendered to check the new option text and example.

## Changelog

`omnigent run --server local` runs against a local server, overriding any configured server default — and the no-AGENT `omnigent run --server ""` no longer fails with `Agent path not found: https:`
