### PR TITLE
fix(web): fall back to chat when a terminal-first session loses its terminal

### DIFF
--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -731,6 +731,110 @@ describe("TerminalFirstContext", () => {
     expect(screen.queryByTestId("terminals-panel")).toBeNull();
   });
 
+  it("falls back to chat when an open terminal view loses its terminal", () => {
+    // A runner stop / disconnect empties the terminal list (useTerminals clears
+    // it on the runner-offline edge). Landing while the terminal view is open,
+    // that would strand the user on "No terminals available"; the view must
+    // fall back to chat, where the composer can resume the session.
+    mockConversations([
+      { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    // Stable QueryClient + fresh element per render so the rerender reads the
+    // updated mock (React bails on an identical element reference).
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_native"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    // Open the terminal view (a terminal is present).
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+
+    // The runner stops: the terminal list empties out from under the open view.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    rerender(makeTree());
+
+    // Fell back to chat rather than stranding on "No terminals available".
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+  });
+
+  it("stays in terminal view while the terminal is relaunching", () => {
+    // A relaunch (terminalPending) also empties the list briefly, but the
+    // terminal is coming right back — the startingUp guard must hold the
+    // terminal view so a wake doesn't flip chat/terminal back and forth.
+    mockConversations([
+      { id: "conv_native", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    // terminalPending + a non-failed status makes terminalStartingUp true once
+    // the list empties (see the startup-spinner tests above).
+    useChatStore.setState({ terminalPending: true, sessionStatus: "running" });
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "claude", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_native"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+
+    // Terminal drops but is relaunching (startingUp) — must NOT fall back.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    rerender(makeTree());
+
+    const probe = screen.getByTestId("view-probe");
+    expect(probe).toHaveAttribute("data-terminal-starting-up", "true");
+    expect(probe).toHaveAttribute("data-view", "terminal");
+  });
+
   it("restores the terminal view when re-entering a native session within the same tab", () => {
     // Bug: switching to another chat and back used to drop the user
     // out of terminal view because the conversation-switch effect reset

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1318,6 +1318,25 @@ export function AppShell() {
   // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
   // "open with no target" stays a pill view.
   const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+
+  // A runner stop/disconnect empties the terminal list; if that lands while the
+  // terminal view is open, flip back to chat rather than stranding the user on
+  // "No terminals available" (and chat is where the composer resumes it).
+  // Edge-triggered + startingUp-guarded so a cold boot / relaunch isn't yanked.
+  const hadTerminalRef = useRef(false);
+  useEffect(() => {
+    if (
+      terminalFirst &&
+      panelOpen &&
+      hadTerminalRef.current &&
+      !terminalsAvailable &&
+      !terminalStartingUp
+    ) {
+      setPanelInitialKey(null);
+    }
+    hadTerminalRef.current = terminalsAvailable;
+  }, [terminalFirst, panelOpen, terminalsAvailable, terminalStartingUp, setPanelInitialKey]);
+
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({
       isClaudeNative,


### PR DESCRIPTION
## Related issue

<!-- No existing issue found for this bug; happy to link one if a maintainer points me at it. -->

Closes #

## Summary

- When a terminal-first session's runner **stops or disconnects** while the user is on the **Terminal** view, `useTerminals` clears the terminal list — but the view stayed pinned on the now-empty `MainTerminalView`, stranding the user on **"No terminals available."** with the Terminal toggle greyed out.
- This flips the session back to **chat** on that edge, where the composer lives — which is also where typing resumes a stopped/asleep session. It aligns with the existing "an offline session still needs the terminal page so the user can resume from there" intent (`ChatPage.shouldShowTerminalSurface`), since chat is the better place to resume from.
- The effect is **edge-triggered** (`available → unavailable`) and guarded on `terminalStartingUp`, so a cold-boot or relaunch (where the list is transiently empty but a terminal is coming) is never yanked, and a fresh reload of an already-stopped session still shows the empty terminal page.

## Test Plan

- `web/` vitest: `node_modules/.bin/vitest run src/shell/AppShell.test.tsx src/shell/MainTerminalView.test.tsx` → **103 passed**.
- Added two regression tests to the existing `AppShell.test.tsx` suite:
  - terminal view falls back to chat when the terminal list goes present → empty;
  - it **stays** on terminal while `terminalStartingUp` is true (relaunch guard).
- **Proved the tests catch the bug**: temporarily neutralized the `setPanelInitialKey(null)` line and confirmed the fallback test fails with the exact symptom (`data-view` stuck at `terminal`), then restored the fix and confirmed green.
- `tsc -b`, `oxlint`, and `prettier --check` all clean on the changed files.
- Manually verified end-to-end against a locally-served build of this branch (dedicated server + connected host + vite UI): opened a terminal-first session, switched to Terminal view, stopped the session, and observed the view fall back to chat instead of showing "No terminals available."

## Demo

Reproduction (terminal-first session, e.g. claude-native):
1. Open the session and switch the header toggle to **Terminal**.
2. Stop the session (or drop the runner) while on the terminal view.
3. **Before:** stuck on "No terminals available.", Terminal toggle greyed out. **After:** view falls back to chat, composer ready to resume.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: served this branch locally (dedicated omnigent server + connected host + vite dev UI), opened a terminal-first session, switched to Terminal view, and stopped the session — confirmed the view auto-returns to chat rather than stranding on the empty terminal pane. Automated coverage is the two new `AppShell.test.tsx` cases (fallback on terminal-loss; no-fallback during relaunch), which were confirmed to fail without the fix.

## Changelog

Terminal-first sessions return to chat automatically when the runner stops or disconnects, instead of stranding on an empty "No terminals available" terminal view
