### PR TITLE
fix(runner): anchor the build-omnigent skill source on the package root

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -78,6 +78,10 @@ from omnigent.spec.types import AgentSpec
 
 _logger = logging.getLogger("omnigent.runner.app")
 
+#: Root of the installed ``omnigent`` package, for locating packaged assets
+#: (e.g. ``onboarding/agent/skills/``) independently of this module's depth.
+_OMNIGENT_PACKAGE_DIR = Path(__file__).resolve().parent.parent.parent
+
 _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
 _REPL_TERMINAL_NAME = "tui"
 _REPL_TERMINAL_SESSION_KEY = "main"
@@ -5701,10 +5705,14 @@ def _ensure_orchestrator_skills_in_bundle(
     target_dir = bundle_dir / "skills" / skill_name
     if target_dir.exists():
         return
-    source = (
-        Path(__file__).resolve().parent.parent / "onboarding" / "agent" / "skills" / skill_name
-    )
+    # Anchored on the package root, not a ``.parent`` count off this file:
+    # moving this module deeper must not silently break the source path.
+    source = _OMNIGENT_PACKAGE_DIR / "onboarding" / "agent" / "skills" / skill_name
     if not source.is_dir():
+        _logger.debug(
+            "Orchestrator skill source %s is not a directory; skipping injection",
+            source,
+        )
         return
     try:
         target_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/runner/test_orchestrator_skill_injection.py
+++ b/tests/runner/test_orchestrator_skill_injection.py
@@ -1,0 +1,62 @@
+"""Tests for ``build-omnigent`` skill injection into native agent bundles.
+
+The injector resolved its source path by counting ``.parent``s off its own
+module file. Moving the module one package deeper left the count stale, so
+the source directory did not exist and the ``not source.is_dir()`` guard
+returned on every call — silently injecting nothing for every
+``omnigent claude`` / ``omnigent codex`` user.
+
+These tests pin the observable outcome (the skill lands in the bundle and
+the Codex consumer resolves it) rather than the path expression, so the
+next move of the module fails here instead of in the field.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import omnigent
+from omnigent.inner.codex_executor import codex_skill_sources, select_codex_skill_dirs
+from omnigent.runner.native.orchestration import (
+    _ensure_orchestrator_skills_in_bundle,
+)
+
+SKILL_NAME = "build-omnigent"
+
+
+def test_skill_source_lives_in_the_installed_package() -> None:
+    """The canonical source directory ships inside the package."""
+    source = Path(omnigent.__file__).resolve().parent / "onboarding" / "agent" / "skills"
+    assert (source / SKILL_NAME / "SKILL.md").is_file()
+
+
+def test_injects_skill_into_empty_bundle(tmp_path: Path) -> None:
+    """A bare bundle gets a usable ``skills/build-omnigent`` with content."""
+    _ensure_orchestrator_skills_in_bundle(tmp_path, None)
+
+    target = tmp_path / "skills" / SKILL_NAME
+    assert target.is_dir(), f"{SKILL_NAME} was not injected into the bundle"
+    assert (target / "SKILL.md").is_file(), "injected skill has no readable SKILL.md"
+
+
+def test_injection_is_idempotent(tmp_path: Path) -> None:
+    """Re-running on the same bundle neither raises nor duplicates."""
+    _ensure_orchestrator_skills_in_bundle(tmp_path, None)
+    _ensure_orchestrator_skills_in_bundle(tmp_path, None)
+
+    assert (tmp_path / "skills" / SKILL_NAME).is_dir()
+    assert [p.name for p in (tmp_path / "skills").iterdir()] == [SKILL_NAME]
+
+
+def test_codex_resolves_the_injected_skill(tmp_path: Path) -> None:
+    """The injected skill reaches Codex's real skill-source resolution.
+
+    Guards the downstream half: ``codex_skill_sources`` only returns the
+    bundle root when ``<bundle>/skills`` exists, so an injector that links
+    nothing drops the skill even though both sides look correct alone.
+    """
+    _ensure_orchestrator_skills_in_bundle(tmp_path, None)
+
+    sources = codex_skill_sources(tmp_path, tmp_path / "fake-home")
+    assert sources == [tmp_path / "skills"]
+    assert SKILL_NAME in select_codex_skill_dirs("all", sources)


### PR DESCRIPTION
## Related issue

Closes #4389

## Summary

`_ensure_orchestrator_skills_in_bundle` links the `build-omnigent` skill into every agent bundle so that any `omnigent claude` / `omnigent codex` user can author new agents. It has been linking **nothing, on every call**.

The source path was resolved by counting `.parent`s off the module's own file. #3148 extracted native terminal orchestration out of `omnigent/runner/app.py` into `omnigent/runner/native/orchestration.py`, one level deeper, and the `.parent` count came along unchanged, so it began resolving to a directory that does not exist. The `if not source.is_dir(): return` guard then fired every time, without logging.

```
orchestration.py (moved)     -> omnigent/runner/onboarding/agent/skills/build-omnigent   is_dir=False
tool_dispatch.py (not moved) -> omnigent/onboarding/agent/skills/build-omnigent          is_dir=True
```

- **Anchor on the package root** instead of a `.parent` count, so relocating this module cannot silently break the path again. (The issue suggested one more `.parent` as the minimal fix; both resolve identically, but a parent count is precisely what broke here.)
- **Log the missing-source branch**, so the next such regression is visible instead of silent.
- **Add regression coverage.** Nothing under `tests/` referenced this function, which is why the breakage shipped unnoticed.

The MCP `load_skill` path was never affected: it is served by the sibling injector `_inject_orchestrator_skills` in `tool_dispatch.py`, which did not move and is still correct. So this was a partial, not total, loss of the feature.

**ELI5:** a function said "the skill I need is one folder up from me." Then the function got moved into a deeper folder, and nobody updated the directions. It kept looking one folder up, found nothing, and quietly gave up, every single time. Now it navigates from a fixed landmark instead of counting steps from wherever it happens to be standing.

```
                      omnigent/
                      ├── onboarding/agent/skills/build-omnigent   ← the real skill
                      └── runner/
                          ├── tool_dispatch.py   .parent.parent ──> omnigent/  ✅ (never moved)
                          └── native/
                              └── orchestration.py
                                    before: .parent.parent ──> omnigent/runner/  ❌ no such skills dir
                                    after:  package root   ──> omnigent/         ✅
```

Two adjacent things found while investigating, deliberately **not** included to keep this diff scoped:

- `_inject_orchestrator_skills` (`tool_dispatch.py:7104`) is correct today but carries the same fragile `.parent.parent`. Worth the same anchor eventually.
- The two call sites differ: the claude arm (`app.py:2861`) `mkdtemp`s a fallback bundle when `bundle_dir is None`, while the codex arm (`app.py:2917`) guards on `bundle_dir is not None` and skips injection entirely. So codex sessions without a resolved bundle still get no skill even after this fix. That is a behavioural question, not a path bug.

## Test Plan

Verified on latest `main` (`9dab48b46`) using the issue's own reproduction, which fails before and passes after:

```bash
python -c "
import pathlib, tempfile
from omnigent.runner.native.orchestration import _ensure_orchestrator_skills_in_bundle
b = pathlib.Path(tempfile.mkdtemp()); _ensure_orchestrator_skills_in_bundle(b, None)
assert (b/'skills'/'build-omnigent').is_dir(); print('OK')"
```

**A/B on the new tests** — a test that passes on broken code proves nothing, so I restored the buggy path expression and confirmed they go red:

| | `tests/runner/test_orchestrator_skill_injection.py` |
|---|---|
| buggy path restored | **3 failed**, 1 passed |
| fix applied | **4 passed** |

Also verified the **downstream** half, since a path fix that lands a symlink nothing reads would be a fake fix. `codex_skill_sources` only returns the bundle root when `<bundle>/skills` exists, and Claude receives `--plugin-dir <bundle>`; both consume exactly what the injector failed to create. One test pins that Codex resolution chain end to end.

No regressions:

```bash
pytest tests/runner/test_app_sessions_native_terminals_autocreate.py   # 58 passed (the call-site suite)
pytest tests/runner/test_app_scaffold.py tests/runner/test_app_claude_native_launch_args.py \
       tests/runner/test_app_codex_native_model.py tests/runner/test_app_schema_injection.py \
       tests/onboarding/test_onboarding_agent.py                       # 53 passed
pytest tests/runner/test_orchestrator_skill_injection.py               # 4 passed
```

`ruff format` / `ruff check` pass; pyrefly reports 0 errors on both changed files.

## Demo

N/A — non-visual change. The user-visible effect is that `build-omnigent` now appears in the slash-command menu and is discoverable by Claude Code / Codex in native sessions.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Four new unit tests in `tests/runner/test_orchestrator_skill_injection.py`, covering: the packaged source directory exists; the skill lands in a bare bundle with a readable `SKILL.md`; injection is idempotent; and the real `codex_skill_sources` / `select_codex_skill_dirs` resolution finds the injected skill. They assert the observable outcome rather than the path expression, so a future move of this module fails here rather than in the field.

Manual verification: ran the issue's reproduction script on latest `main` before and after the fix, and A/B'd the new tests against the restored buggy path expression (3 red → 4 green) to confirm they actually detect this regression class.

## Changelog

The `build-omnigent` skill is available again in native `omnigent claude` and `omnigent codex` sessions
