### PR TITLE
fix(copilot): honour the gh CLI login and support a GitHub Enterprise host

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2701,9 +2701,11 @@ def _manage_copilot_harness() -> None:
     from omnigent.onboarding.copilot_auth import (
         COPILOT_CONFIG_KEY,
         COPILOT_SECRET_NAME,
+        copilot_github_host,
         copilot_github_token_configured,
         copilot_github_token_ref,
         copilot_sdk_installed,
+        gh_cli_github_token,
     )
     from omnigent.onboarding.interactive import select
 
@@ -2727,11 +2729,26 @@ def _manage_copilot_harness() -> None:
         ]
         if token_set:
             rows.append(_HarnessMenuRow("Remove GitHub token", action="remove_key"))
+        host = copilot_github_host(config)
+        rows.append(
+            _HarnessMenuRow(
+                f"Change GitHub Enterprise host ({host})"
+                if host
+                else "Set GitHub Enterprise host",
+                action="set_host",
+            )
+        )
+        if host:
+            rows.append(_HarnessMenuRow("Clear GitHub Enterprise host", action="clear_host"))
         rows.append(_HarnessMenuRow("← Back", action="back"))
 
-        header = (
-            "Copilot — GitHub token configured" if token_set else "Copilot — no GitHub token yet"
-        )
+        if token_set:
+            header = "Copilot — GitHub token configured"
+        elif gh_cli_github_token(host) is not None:
+            # No stored token, but a ``gh auth login`` session works as one.
+            header = "Copilot — using your GitHub CLI login"
+        else:
+            header = "Copilot — no GitHub token yet"
         idx = select(header, [r.label for r in rows], clear_on_exit=True, status=status)
         if idx < 0:  # Esc / q
             return
@@ -2740,6 +2757,13 @@ def _manage_copilot_harness() -> None:
             return
         if action == "set_key":
             status = _set_copilot_github_token()
+        elif action == "set_host":
+            status = _set_copilot_github_host()
+        elif action == "clear_host":
+            from omnigent.onboarding.copilot_auth import copilot_github_host_settings
+
+            _save_global_config(copilot_github_host_settings(None))
+            status = "✓ Cleared Copilot GitHub Enterprise host"
         elif action == "remove_key":
             ref = copilot_github_token_ref(config)
             # Only the secret we own (``keychain:copilot``) is ours to delete: a
@@ -2750,6 +2774,28 @@ def _manage_copilot_harness() -> None:
                 secret_store.delete_secret(COPILOT_SECRET_NAME)
             _save_global_config({}, unset_keys=(COPILOT_CONFIG_KEY,))
             status = "✓ Removed Copilot GitHub token"
+
+
+def _set_copilot_github_host() -> str | None:
+    """Prompt for and store the Copilot GitHub Enterprise host; return a status line.
+
+    Organizations reaching Copilot through a GHE (data-residency) instance need
+    auth and API calls pointed at their own hostname. Stored as
+    ``copilot.github_host`` and forwarded to the Copilot CLI as
+    ``COPILOT_GH_HOST``.
+
+    :returns: A status string for the menu, or ``None`` if the user aborted.
+    """
+    from omnigent.onboarding.copilot_auth import copilot_github_host_settings
+    from omnigent.onboarding.interactive import prompt_text
+
+    entered = prompt_text("GitHub Enterprise hostname (e.g. acme.ghe.com)").strip()
+    if not entered:
+        return None
+    _save_global_config(copilot_github_host_settings(entered))
+    from omnigent.onboarding.copilot_auth import copilot_github_host
+
+    return f"✓ Copilot GitHub Enterprise host set ({copilot_github_host()})"
 
 
 def _set_copilot_github_token() -> str | None:

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2705,6 +2705,7 @@ def _manage_copilot_harness() -> None:
         copilot_github_token_configured,
         copilot_github_token_ref,
         copilot_sdk_installed,
+        copilot_token_removal_settings,
         gh_cli_github_token,
     )
     from omnigent.onboarding.interactive import select
@@ -2772,7 +2773,12 @@ def _manage_copilot_harness() -> None:
             # those cases just drop the config block and leave the secret.
             if ref == f"keychain:{COPILOT_SECRET_NAME}":
                 secret_store.delete_secret(COPILOT_SECRET_NAME)
-            _save_global_config({}, unset_keys=(COPILOT_CONFIG_KEY,))
+            # Keep a configured GHE host: the saver replaces the whole block, so
+            # unsetting it wholesale would discard the host along with the token.
+            if (remaining := copilot_token_removal_settings()) is not None:
+                _save_global_config(remaining)
+            else:
+                _save_global_config({}, unset_keys=(COPILOT_CONFIG_KEY,))
             status = "✓ Removed Copilot GitHub token"
 
 

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -104,6 +104,9 @@ GITHUB_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # pins the two spellings equal.
 COPILOT_HOST_ENV_VAR = "COPILOT_GH_HOST"
 
+# The user's ambient host, captured before we ever write the var ourselves.
+_AMBIENT_HOST = os.environ.get(COPILOT_HOST_ENV_VAR) or None
+
 # Upper bound (seconds) on one ``send_and_wait``. The SDK default is 60s, far
 # too short for an agentic turn (sub-agent dispatches, long tool calls), so we
 # pass a generous finite bound: a wedged turn surfaces a timeout error instead
@@ -535,8 +538,12 @@ class CopilotExecutor(Executor):
         # no host parameter. Set it in our own environment rather than passing
         # ``env=`` — the SDK inherits ``os.environ`` only when ``env`` is None,
         # so handing it a dict would strip everything else from the subprocess.
+        # Assign both ways so a hostless executor can't inherit a host another
+        # one left behind.
         if self._github_host:
             os.environ[COPILOT_HOST_ENV_VAR] = self._github_host
+        else:
+            os.environ.pop(COPILOT_HOST_ENV_VAR, None)
         client = CopilotClient(
             github_token=self._github_token,
             working_directory=cwd,
@@ -886,10 +893,16 @@ def _ambient_github_token(host: str | None = None) -> str | None:
 
 
 def _configured_github_host() -> str | None:
-    """Return the configured GHE hostname: env var first, then the config block."""
+    """Return the configured GHE hostname: env var first, then the config block.
+
+    Reads the *ambient* env var captured at import, not the live one — the
+    executor writes ``COPILOT_HOST_ENV_VAR`` to hand the host to the bundled CLI,
+    and reading that back would let one executor's host leak into a later
+    hostless one.
+    """
     from omnigent.onboarding.copilot_auth import copilot_github_host
 
-    return os.environ.get(COPILOT_HOST_ENV_VAR) or copilot_github_host()
+    return _AMBIENT_HOST or copilot_github_host()
 
 
 def _coerce_args(raw: Any) -> dict[str, Any]:  # type: ignore[explicit-any]

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -98,6 +98,12 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 # Requests" permission, or an OAuth token from the gh / Copilot CLI app.
 GITHUB_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 
+# The Copilot CLI's GHE hostname override (``copilot help environment``). Spelled
+# here rather than imported from ``omnigent.onboarding.copilot_auth``: onboarding
+# pulls in the secret store / keyring, which this path imports lazily. A test
+# pins the two spellings equal.
+COPILOT_HOST_ENV_VAR = "COPILOT_GH_HOST"
+
 # Upper bound (seconds) on one ``send_and_wait``. The SDK default is 60s, far
 # too short for an agentic turn (sub-agent dispatches, long tool calls), so we
 # pass a generous finite bound: a wedged turn surfaces a timeout error instead
@@ -300,6 +306,7 @@ class CopilotExecutor(Executor):
         os_env: OSEnvSpec | None = None,
         model: str | None = None,
         github_token: str | None = None,
+        github_host: str | None = None,
         bundle_dir: Path | None = None,
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
@@ -314,7 +321,10 @@ class CopilotExecutor(Executor):
             gateway-routed id or ``None`` falls back to Copilot's auto-select.
         :param github_token: GitHub token carrying Copilot access. ``None``
             falls back to ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
-            ``GITHUB_TOKEN`` in the environment.
+            ``GITHUB_TOKEN`` in the environment, then the ``gh`` CLI login.
+        :param github_host: GitHub Enterprise hostname (e.g. ``"acme.ghe.com"``)
+            to authenticate against. ``None`` falls back to the configured
+            ``copilot.github_host``, then Copilot's default ``github.com``.
         :param bundle_dir: Reserved for future skill wiring; unused in v1.
         :param agent_name: Optional agent name (reserved for parity).
         :param skills_filter: Accepted for parity; copilot has no skill
@@ -323,7 +333,9 @@ class CopilotExecutor(Executor):
         self._cwd = cwd or (os_env.cwd if os_env is not None else None)
         self._os_env_spec = os_env
         self._model_override = model
-        self._github_token = github_token or _ambient_github_token()
+        # Resolved before the token: a GHE user's token must come from that host.
+        self._github_host = github_host or _configured_github_host()
+        self._github_token = github_token or _ambient_github_token(self._github_host)
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter
@@ -519,6 +531,12 @@ class CopilotExecutor(Executor):
         # must be absolute"), and a spec / os_env can hand us a relative cwd
         # (e.g. ``.``), so always resolve to an absolute path.
         cwd = os.path.abspath(self._cwd or os.getcwd())
+        # A GHE hostname reaches the bundled CLI only as an env var; the SDK has
+        # no host parameter. Set it in our own environment rather than passing
+        # ``env=`` — the SDK inherits ``os.environ`` only when ``env`` is None,
+        # so handing it a dict would strip everything else from the subprocess.
+        if self._github_host:
+            os.environ[COPILOT_HOST_ENV_VAR] = self._github_host
         client = CopilotClient(
             github_token=self._github_token,
             working_directory=cwd,
@@ -846,13 +864,32 @@ class CopilotExecutor(Executor):
 # ---------------------------------------------------------------------------
 
 
-def _ambient_github_token() -> str | None:
-    """Return the first set ambient GitHub token, in CLI precedence order."""
+def _ambient_github_token(host: str | None = None) -> str | None:
+    """Return an ambient GitHub token: env vars first, then the ``gh`` CLI login.
+
+    The env vars come first because the Copilot CLI honors them in this same
+    precedence. The ``gh`` fallback covers the common "I ran ``gh auth login``"
+    case: Copilot only picks a ``gh`` login up by reading ``oauth_token`` from
+    ``~/.config/gh/hosts.yml``, which is absent whenever ``gh`` stores the token
+    in an OS keychain instead (the default on macOS).
+
+    :param host: GHE hostname whose ``gh`` token to fetch; ``None`` resolves the
+        configured host, so a GHE user's token comes from their own instance.
+    """
     for var in GITHUB_TOKEN_ENV_VARS:
         value = os.environ.get(var)
         if value:
             return value
-    return None
+    from omnigent.onboarding.copilot_auth import gh_cli_github_token
+
+    return gh_cli_github_token(host if host is not None else _configured_github_host())
+
+
+def _configured_github_host() -> str | None:
+    """Return the configured GHE hostname: env var first, then the config block."""
+    from omnigent.onboarding.copilot_auth import copilot_github_host
+
+    return os.environ.get(COPILOT_HOST_ENV_VAR) or copilot_github_host()
 
 
 def _coerce_args(raw: Any) -> dict[str, Any]:  # type: ignore[explicit-any]

--- a/omnigent/inner/copilot_harness.py
+++ b/omnigent/inner/copilot_harness.py
@@ -24,7 +24,11 @@ Env vars read at startup:
   ``None`` falls back to ``os_env.cwd`` then the process cwd.
 - ``HARNESS_COPILOT_GITHUB_TOKEN``: GitHub token carrying Copilot access, used
   as the SDK ``github_token``. ``None`` falls back to an inherited
-  ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``.
+  ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``, then the ``gh``
+  CLI's stored login.
+- ``HARNESS_COPILOT_GITHUB_HOST``: GitHub Enterprise hostname (e.g.
+  ``"acme.ghe.com"``) to authenticate against. ``None`` falls back to the
+  configured ``copilot.github_host``, then Copilot's default ``github.com``.
 - ``HARNESS_COPILOT_OS_ENV``: JSON-encoded :class:`OSEnvSpec` (its ``cwd`` is
   used when ``HARNESS_COPILOT_CWD`` is unset). Defaults to
   ``caller_process + sandbox=none``.
@@ -53,6 +57,7 @@ _logger = logging.getLogger(__name__)
 _ENV_MODEL = "HARNESS_COPILOT_MODEL"
 _ENV_CWD = "HARNESS_COPILOT_CWD"
 _ENV_GITHUB_TOKEN = "HARNESS_COPILOT_GITHUB_TOKEN"
+_ENV_GITHUB_HOST = "HARNESS_COPILOT_GITHUB_HOST"
 _ENV_OS_ENV = "HARNESS_COPILOT_OS_ENV"
 _ENV_SKILLS_FILTER = "HARNESS_COPILOT_SKILLS_FILTER"
 _ENV_BUNDLE_DIR = "HARNESS_COPILOT_BUNDLE_DIR"
@@ -133,6 +138,7 @@ def _build_copilot_executor() -> Executor:
         os_env=_resolve_os_env(),
         model=os.environ.get(_ENV_MODEL) or None,
         github_token=os.environ.get(_ENV_GITHUB_TOKEN) or None,
+        github_host=os.environ.get(_ENV_GITHUB_HOST) or None,
         bundle_dir=bundle_dir,
         agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
         skills_filter=_resolve_skills_filter(),

--- a/omnigent/onboarding/copilot_auth.py
+++ b/omnigent/onboarding/copilot_auth.py
@@ -45,6 +45,11 @@ COPILOT_SECRET_NAME = "copilot"
 COPILOT_CONFIG_KEY = "copilot"
 _TOKEN_REF_FIELD = "github_token_ref"
 _TOKEN_FIELD = "github_token"
+_HOST_FIELD = "github_host"
+
+# The Copilot CLI's own GHE hostname override (``copilot help environment``). It
+# wins over ``GH_HOST``, so setting only this leaves a user's ``gh`` host alone.
+COPILOT_HOST_ENV_VAR = "COPILOT_GH_HOST"
 
 # Ambient GitHub-token env vars, in the precedence the Copilot CLI/SDK honors.
 COPILOT_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
@@ -54,6 +59,30 @@ COPILOT_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # never lock anyone out of their own token. Classic ``ghp_`` PATs are excluded
 # because Copilot rejects them.
 _GITHUB_TOKEN_PREFIXES = ("github_pat_", "gho_", "ghu_", "ghs_")
+
+
+def gh_cli_github_token(host: str | None = None) -> str | None:
+    """Return the ``gh`` CLI's stored OAuth token, or ``None`` if unavailable.
+
+    The Copilot CLI honors a ``gh`` login only by reading ``oauth_token`` out of
+    ``~/.config/gh/hosts.yml``. On macOS (and any host with a working credential
+    helper) ``gh`` keeps the token in the OS keychain and omits it from that
+    file, so a logged-in user still looks credential-less to Copilot. Asking
+    ``gh`` itself works on every platform.
+
+    :param host: GitHub hostname to fetch the token for, e.g. ``"acme.ghe.com"``;
+        ``None`` lets ``gh`` pick its default host.
+    :returns: The token, or ``None`` when ``gh`` is absent, logged out, or fails.
+    """
+    argv = ["gh", "auth", "token"]
+    if host:
+        argv += ["--hostname", host]
+    try:
+        completed = subprocess.run(argv, capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    token = completed.stdout.strip()
+    return token if completed.returncode == 0 and token else None
 
 
 def looks_like_github_copilot_token(value: str) -> bool:
@@ -189,14 +218,60 @@ def copilot_github_token_configured(config: dict[str, object] | None = None) -> 
     return resolve_copilot_github_token(config) is not None
 
 
+def copilot_github_host(config: dict[str, object] | None = None) -> str | None:
+    """Return the configured GitHub Enterprise hostname, if any.
+
+    Reads ``copilot.github_host`` from the global config. Organizations reaching
+    Copilot through a GHE (data-residency) instance need auth and API calls
+    pointed at their own host rather than ``github.com``.
+
+    :param config: A pre-loaded config mapping; ``None`` loads the global config.
+    :returns: The hostname (e.g. ``"acme.ghe.com"``), or ``None`` when unset.
+        A scheme, if pasted, is stripped — the CLI wants a bare hostname.
+    """
+    cfg = load_config() if config is None else config
+    block = cfg.get(COPILOT_CONFIG_KEY)
+    if not isinstance(block, dict):
+        return None
+    host = block.get(_HOST_FIELD)
+    if not isinstance(host, str) or not host.strip():
+        return None
+    return host.strip().removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def copilot_github_host_settings(host: str | None) -> dict[str, object]:
+    """Build the ``{"copilot": {...}}`` settings dict recording *host*.
+
+    Preserves the existing token reference: the saver replaces the whole
+    ``copilot:`` block, so dropping the token here would unset it.
+
+    :param host: The GHE hostname to record; ``None`` / empty clears the field.
+    :returns: The ``copilot:`` block to persist.
+    """
+    block: dict[str, object] = {}
+    ref = copilot_github_token_ref()
+    if ref is not None:
+        block[_TOKEN_REF_FIELD] = ref
+    if host and host.strip():
+        block[_HOST_FIELD] = host.strip()
+    return {COPILOT_CONFIG_KEY: block}
+
+
 def copilot_github_token_settings(ref: str) -> dict[str, object]:
     """Build the ``{"copilot": {...}}`` settings dict that records *ref*.
 
     Handed to :func:`omnigent.cli._save_global_config` (a shallow update, so it
     replaces the whole ``copilot:`` block) to persist the reference.
 
+    Preserves any configured ``github_host`` — the saver replaces the whole
+    ``copilot:`` block, so omitting it here would silently unset the GHE host.
+
     :param ref: The secret reference to record, e.g. ``"keychain:copilot"`` or
         ``"env:GH_TOKEN"``.
-    :returns: ``{"copilot": {"github_token_ref": ref}}``.
+    :returns: ``{"copilot": {"github_token_ref": ref, ...}}``.
     """
-    return {COPILOT_CONFIG_KEY: {_TOKEN_REF_FIELD: ref}}
+    block: dict[str, object] = {_TOKEN_REF_FIELD: ref}
+    host = copilot_github_host()
+    if host is not None:
+        block[_HOST_FIELD] = host
+    return {COPILOT_CONFIG_KEY: block}

--- a/omnigent/onboarding/copilot_auth.py
+++ b/omnigent/onboarding/copilot_auth.py
@@ -257,6 +257,19 @@ def copilot_github_host_settings(host: str | None) -> dict[str, object]:
     return {COPILOT_CONFIG_KEY: block}
 
 
+def copilot_token_removal_settings() -> dict[str, object] | None:
+    """Return the ``copilot:`` block that must remain after removing the token.
+
+    Preserves ``github_host``: the saver replaces the whole block, so unsetting
+    it wholesale would silently discard a configured GHE host.
+
+    :returns: The block to persist, or ``None`` when nothing is left to keep and
+        the whole ``copilot:`` key can be unset.
+    """
+    host = copilot_github_host()
+    return {COPILOT_CONFIG_KEY: {_HOST_FIELD: host}} if host else None
+
+
 def copilot_github_token_settings(ref: str) -> dict[str, object]:
     """Build the ``{"copilot": {...}}`` settings dict that records *ref*.
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -256,12 +256,18 @@ def _harness_availability_core(harness: str) -> HarnessAvailability:
         # the environment. A bad / Copilot-less token surfaces at run time.
         from omnigent.onboarding.copilot_auth import (
             COPILOT_TOKEN_ENV_VARS,
+            copilot_github_host,
             copilot_github_token_configured,
+            gh_cli_github_token,
         )
 
-        return copilot_github_token_configured() or any(
+        if copilot_github_token_configured() or any(
             os.environ.get(var) for var in COPILOT_TOKEN_ENV_VARS
-        )
+        ):
+            return True
+        # A ``gh auth login`` session is a usable Copilot credential, so a
+        # logged-in user is ready without pasting a token into setup.
+        return gh_cli_github_token(copilot_github_host()) is not None
     if (
         canonical not in _HARNESS_FAMILY
         and canonical not in _PI_HARNESSES

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2119,6 +2119,16 @@ def _build_copilot_spawn_env(
                 if os.environ.get(_env_var):
                     env["HARNESS_COPILOT_GITHUB_TOKEN"] = os.environ[_env_var]
                     break
+            # No token anywhere: leave it unset so the harness falls back to the
+            # ``gh`` CLI login itself (it may run on a different host than the
+            # runner, where a different ``gh`` session applies).
+    # GitHub Enterprise hostname, when configured — auth and API calls must
+    # target the user's own host rather than github.com.
+    from omnigent.onboarding.copilot_auth import copilot_github_host
+
+    copilot_host = copilot_github_host()
+    if copilot_host is not None:
+        env["HARNESS_COPILOT_GITHUB_HOST"] = copilot_host
     # Always set so the wrap doesn't fall back to ``"all"`` and override an
     # explicit ``skills: none`` from the spec (parity with the peer builders).
     env["HARNESS_COPILOT_SKILLS_FILTER"] = json.dumps(spec.skills_filter)

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -13,6 +13,7 @@ gated e2e test.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import types
 from typing import Any
@@ -20,6 +21,7 @@ from typing import Any
 import pytest
 
 from omnigent.inner.copilot_executor import (
+    COPILOT_HOST_ENV_VAR,
     CopilotExecutor,
     _accumulate_usage,
     _ambient_github_token,
@@ -44,6 +46,7 @@ from omnigent.inner.executor import (
     ToolCallStatus,
     TurnComplete,
 )
+from omnigent.onboarding import copilot_auth
 
 
 def _user(content: str, session_id: str = "conv1") -> Message:
@@ -335,11 +338,68 @@ def test_usage_without_copilot_cost_omits_cost_usd() -> None:
 def test_ambient_github_token_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
         monkeypatch.delenv(var, raising=False)
+    # Stub the gh-CLI fallback: this test pins env-var precedence, and the dev
+    # machine running it may well have a real ``gh`` login.
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", lambda host=None: None)
     assert _ambient_github_token() is None
     monkeypatch.setenv("GITHUB_TOKEN", "gho_c")
     monkeypatch.setenv("GH_TOKEN", "gho_b")
     monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_a")
     assert _ambient_github_token() == "gho_a"
+
+
+def test_ambient_github_token_falls_back_to_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No token env var but a ``gh auth login`` session: use the gh token.
+
+    Copilot only picks a ``gh`` login up by reading ``oauth_token`` out of
+    ``~/.config/gh/hosts.yml``, which is absent when ``gh`` keeps the token in an
+    OS keychain (the default on macOS) — so a logged-in user looks
+    credential-less and the session fails to authenticate.
+    """
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", lambda host=None: "gho_from_gh")
+    assert _ambient_github_token() == "gho_from_gh"
+
+
+def test_ambient_github_token_prefers_env_over_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_env")
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", lambda host=None: "gho_from_gh")
+    assert _ambient_github_token() == "gho_env"
+
+
+def test_gh_cli_token_requested_for_configured_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GHE user's gh token must be fetched for their host, not github.com."""
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(COPILOT_HOST_ENV_VAR, "acme.ghe.com")
+    seen: list[str | None] = []
+
+    def _fake(host: str | None = None) -> str:
+        seen.append(host)
+        return "gho_ghe"
+
+    monkeypatch.setattr(copilot_auth, "gh_cli_github_token", _fake)
+    assert _ambient_github_token() == "gho_ghe"
+    assert seen == ["acme.ghe.com"]
+
+
+def test_host_env_var_spelling_matches_onboarding() -> None:
+    """The executor spells the CLI's host env var itself (onboarding is lazy-imported)."""
+    assert COPILOT_HOST_ENV_VAR == copilot_auth.COPILOT_HOST_ENV_VAR
+
+
+async def test_github_host_exported_for_bundled_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK has no host parameter, so the GHE host only reaches the bundled
+    CLI as an env var it inherits from us."""
+    _install_fake_copilot(monkeypatch, [[]])
+    monkeypatch.delenv(COPILOT_HOST_ENV_VAR, raising=False)
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_x")
+    ex = CopilotExecutor(github_host="acme.ghe.com")
+    assert ex._github_host == "acme.ghe.com"
+    async for _ in ex.run_turn([_user("hi")], tools=[], system_prompt=""):
+        pass
+    assert os.environ[COPILOT_HOST_ENV_VAR] == "acme.ghe.com"
 
 
 def test_capabilities() -> None:

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pytest
 
+from omnigent.inner import copilot_executor
 from omnigent.inner.copilot_executor import (
     COPILOT_HOST_ENV_VAR,
     CopilotExecutor,
@@ -372,7 +373,7 @@ def test_gh_cli_token_requested_for_configured_host(monkeypatch: pytest.MonkeyPa
     """A GHE user's gh token must be fetched for their host, not github.com."""
     for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv(COPILOT_HOST_ENV_VAR, "acme.ghe.com")
+    monkeypatch.setattr(copilot_executor, "_AMBIENT_HOST", "acme.ghe.com")
     seen: list[str | None] = []
 
     def _fake(host: str | None = None) -> str:
@@ -397,9 +398,24 @@ async def test_github_host_exported_for_bundled_cli(monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_x")
     ex = CopilotExecutor(github_host="acme.ghe.com")
     assert ex._github_host == "acme.ghe.com"
+    assert COPILOT_HOST_ENV_VAR not in os.environ, "set at session start, not construction"
     async for _ in ex.run_turn([_user("hi")], tools=[], system_prompt=""):
         pass
     assert os.environ[COPILOT_HOST_ENV_VAR] == "acme.ghe.com"
+
+
+async def test_hostless_executor_clears_a_leftover_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hostless executor must not inherit a host another one left in the env."""
+    _install_fake_copilot(monkeypatch, [[]])
+    monkeypatch.setenv(COPILOT_HOST_ENV_VAR, "stale.ghe.com")
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_x")
+    monkeypatch.setattr(copilot_executor, "_AMBIENT_HOST", None)
+    monkeypatch.setattr(copilot_auth, "copilot_github_host", lambda config=None: None)
+    ex = CopilotExecutor()
+    assert ex._github_host is None
+    async for _ in ex.run_turn([_user("hi")], tools=[], system_prompt=""):
+        pass
+    assert COPILOT_HOST_ENV_VAR not in os.environ
 
 
 def test_capabilities() -> None:

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -181,6 +181,22 @@ def test_host_settings_clears_field_when_none(tmp_path: Path) -> None:
     }
 
 
+def test_token_removal_keeps_configured_host(tmp_path: Path) -> None:
+    """Removing the token must not take a configured GHE host with it."""
+    _write_config(
+        tmp_path, {"copilot": {"github_token_ref": "keychain:copilot", "github_host": "a.ghe.com"}}
+    )
+    assert copilot_auth.copilot_token_removal_settings() == {
+        "copilot": {"github_host": "a.ghe.com"}
+    }
+
+
+def test_token_removal_none_when_no_host(tmp_path: Path) -> None:
+    """With no host to keep, the caller unsets the whole block."""
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "keychain:copilot"}})
+    assert copilot_auth.copilot_token_removal_settings() is None
+
+
 def test_gh_cli_github_token_returns_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
     """A ``gh auth login`` session is a usable Copilot credential."""
     calls: list[list[str]] = []

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -12,6 +12,7 @@ a run / setup readout falls back rather than crashing. Mirrors
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -131,10 +132,91 @@ def test_dangling_keychain_reference_is_soft_none(tmp_path: Path) -> None:
     assert copilot_github_token_configured() is False
 
 
-def test_settings_shape() -> None:
+def test_settings_shape(tmp_path: Path) -> None:
     assert copilot_github_token_settings("keychain:copilot") == {
         "copilot": {"github_token_ref": "keychain:copilot"}
     }
+
+
+# ---------------------------------------------------------------------------
+# GitHub Enterprise host + gh-CLI login fallback
+# ---------------------------------------------------------------------------
+
+
+def test_github_host_none_when_unset(tmp_path: Path) -> None:
+    assert copilot_auth.copilot_github_host() is None
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "keychain:copilot"}})
+    assert copilot_auth.copilot_github_host() is None
+
+
+@pytest.mark.parametrize(
+    "stored",
+    ["acme.ghe.com", "https://acme.ghe.com", "http://acme.ghe.com/", "  acme.ghe.com  "],
+)
+def test_github_host_normalized_to_bare_hostname(tmp_path: Path, stored: str) -> None:
+    """A pasted URL is reduced to the bare hostname the Copilot CLI expects."""
+    _write_config(tmp_path, {"copilot": {"github_host": stored}})
+    assert copilot_auth.copilot_github_host() == "acme.ghe.com"
+
+
+def test_host_and_token_settings_preserve_each_other(tmp_path: Path) -> None:
+    """Each saver replaces the whole ``copilot:`` block, so neither may drop the other."""
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "keychain:copilot"}})
+    assert copilot_auth.copilot_github_host_settings("acme.ghe.com") == {
+        "copilot": {"github_token_ref": "keychain:copilot", "github_host": "acme.ghe.com"}
+    }
+
+    _write_config(tmp_path, {"copilot": {"github_host": "acme.ghe.com"}})
+    assert copilot_github_token_settings("env:GH_TOKEN") == {
+        "copilot": {"github_token_ref": "env:GH_TOKEN", "github_host": "acme.ghe.com"}
+    }
+
+
+def test_host_settings_clears_field_when_none(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path, {"copilot": {"github_token_ref": "keychain:copilot", "github_host": "a.ghe.com"}}
+    )
+    assert copilot_auth.copilot_github_host_settings(None) == {
+        "copilot": {"github_token_ref": "keychain:copilot"}
+    }
+
+
+def test_gh_cli_github_token_returns_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``gh auth login`` session is a usable Copilot credential."""
+    calls: list[list[str]] = []
+
+    def _fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="gho_abc\n", stderr="")
+
+    monkeypatch.setattr(copilot_auth.subprocess, "run", _fake_run)
+    assert copilot_auth.gh_cli_github_token() == "gho_abc"
+    assert calls == [["gh", "auth", "token"]]
+
+    calls.clear()
+    assert copilot_auth.gh_cli_github_token("acme.ghe.com") == "gho_abc"
+    assert calls == [["gh", "auth", "token", "--hostname", "acme.ghe.com"]]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        subprocess.CompletedProcess(["gh"], 1, stdout="", stderr="not logged in"),
+        subprocess.CompletedProcess(["gh"], 0, stdout="   \n", stderr=""),
+        FileNotFoundError("gh"),
+        subprocess.TimeoutExpired("gh", 10),
+    ],
+)
+def test_gh_cli_github_token_soft_none(monkeypatch: pytest.MonkeyPatch, outcome: object) -> None:
+    """Logged out, gh absent, or hung — never raise into a run or setup readout."""
+
+    def _fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome  # type: ignore[return-value]
+
+    monkeypatch.setattr(copilot_auth.subprocess, "run", _fake_run)
+    assert copilot_auth.gh_cli_github_token() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -32,6 +32,11 @@ def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     monkeypatch.delenv("CURSOR_API_KEY", raising=False)
     for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
         monkeypatch.delenv(var, raising=False)
+    # Copilot also accepts a ``gh auth login`` session as a token, so a developer's
+    # real gh login would otherwise flip their verdict here too.
+    import omnigent.onboarding.copilot_auth as _ca
+
+    monkeypatch.setattr(_ca, "gh_cli_github_token", lambda host=None: None)
     # Codex readiness resolves the binary via resolve_cli_binary, which honors
     # an OMNIGENT_CODEX_PATH override and probes on-disk global install dirs.
     # Clear the override and stub the fallback dirs so a developer's real codex
@@ -66,6 +71,11 @@ def _all_clis_installed(monkeypatch: pytest.MonkeyPatch) -> None:
             else:
                 version = "9.9.9\n"
             return subprocess.CompletedProcess(args=argv, returncode=0, stdout=version, stderr="")
+        if argv[:3] == ["gh", "auth", "token"]:
+            # Copilot readiness falls back to the ``gh`` CLI login when no token
+            # is configured. Report "logged out" so these tests stay about CLI
+            # presence; the fallback itself is covered in test_copilot_auth.py.
+            return subprocess.CompletedProcess(args=argv, returncode=1, stdout="", stderr="")
         raise AssertionError(f"unexpected subprocess during readiness tests: {argv!r}")
 
     monkeypatch.setattr(hi.subprocess, "run", _stub_run)
@@ -422,6 +432,24 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "pi-native",
     ):
         assert result[missing] == "binary-missing", f"{missing} should name the missing CLI binary"
+
+
+def test_copilot_ready_via_gh_cli_login_without_stored_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``gh auth login`` session alone makes copilot ready.
+
+    Without this, a logged-in user is told to paste a token that ``gh`` already
+    holds — and on macOS ``gh`` keeps it in the keychain, where the Copilot CLI
+    (which only reads ``oauth_token`` out of ``hosts.yml``) can't see it.
+    """
+    import omnigent.onboarding.copilot_auth as _ca
+
+    _all_clis_installed(monkeypatch)
+    assert configured_harness_map()["copilot"] is False
+
+    monkeypatch.setattr(_ca, "gh_cli_github_token", lambda host=None: "gho_from_gh")
+    assert configured_harness_map()["copilot"] is True
 
 
 def test_configured_harness_map_all_true_with_clis(

--- a/tests/runtime/test_copilot_spawn_env.py
+++ b/tests/runtime/test_copilot_spawn_env.py
@@ -104,6 +104,25 @@ def test_no_auth_prefers_stored_block_over_ambient(
     assert env["HARNESS_COPILOT_GITHUB_TOKEN"] == "gho_stored"
 
 
+def test_github_host_threaded_when_configured(tmp_path: Path) -> None:
+    """A configured GHE host must survive the spawn-env → wrap → executor hop."""
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"copilot": {"github_host": "acme.ghe.com"}})
+    )
+    env = _build_copilot_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_COPILOT_GITHUB_HOST"] == "acme.ghe.com"
+
+
+def test_github_host_absent_when_unconfigured() -> None:
+    assert "HARNESS_COPILOT_GITHUB_HOST" not in _build_copilot_spawn_env(_make_spec())
+
+
+def test_no_token_anywhere_leaves_token_unset() -> None:
+    """With no token, the wrap must be free to fall back to the harness host's
+    own ``gh`` login rather than receiving an empty value."""
+    assert "HARNESS_COPILOT_GITHUB_TOKEN" not in _build_copilot_spawn_env(_make_spec(auth=None))
+
+
 def test_bundle_dir_threaded(tmp_path: Path) -> None:
     env = _build_copilot_spawn_env(_make_spec(), workdir=tmp_path)
     assert env["HARNESS_COPILOT_BUNDLE_DIR"] == str(tmp_path)


### PR DESCRIPTION
## Related issue

Closes #1936

## Summary

Two Copilot auth gaps, both reported in #1936:

- **`gh auth login` was not honoured.** The Copilot CLI *does* accept a `gh` login, but only by reading `oauth_token` straight out of `~/.config/gh/hosts.yml`. When `gh` stores the token in an OS keychain instead (the default on macOS) that field is absent, so a logged-in user looks credential-less and session creation 401s. `gh auth token` works on every platform, so it becomes the last fallback in the executor's ambient-token lookup — the single chokepoint both the in-process executor and the harness wrap route through. Readiness gained the same fallback, so `omnigent setup` stops asking for a token `gh` already holds.
- **No GitHub Enterprise host.** A new `copilot.github_host` config field (settable from `omnigent setup`) is threaded through the spawn env to the executor and exported as `COPILOT_GH_HOST` for the bundled CLI to inherit.

Worth flagging for reviewers: **the root cause named in the issue is not the actual one.** The issue reports that `CopilotClient` is built without `use_logged_in_user=True`. On `github-copilot-sdk` 1.0.8 the SDK already derives it as `not bool(github_token)` on every connection path, so a `None` token resolves to `True` — verified directly:

```python
CopilotClient(github_token=None)._options.use_logged_in_user  # True
```

So nothing in the SDK call needed changing; the credential simply wasn't reachable.

<details>
<summary>ELI5 + flow</summary>

You told GitHub's `gh` tool who you are. On a Mac, `gh` puts your key in the system safe. Copilot only ever looks in `gh`'s text file, never the safe, so it thinks you never logged in. Now we just ask `gh` for the key directly.

```mermaid
flowchart TD
    A[need a GitHub token] --> B{COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN?}
    B -->|set| T[use it]
    B -->|none| C{gh auth token}
    C -->|prints token| T
    C -->|absent / logged out| N[no token: CLI reads hosts.yml as before]
    T --> D[CopilotClient github_token=...]
    N --> D
    H[copilot.github_host] -.->|COPILOT_GH_HOST| CLI[bundled Copilot CLI]
    H -.->|--hostname| C
```

The host is resolved *before* the token so a GHE user's `gh` token is fetched from their own instance.
</details>

Three implementation notes, all downstream of two constraints: `_save_global_config` replaces the whole `copilot:` block, and the SDK exposes no host parameter.

- Both `copilot:` settings savers preserve each other's field, so storing a token can't clear the host or vice versa. **`Remove GitHub token` likewise keeps a configured host**, and only unsets the whole key when there is nothing left to preserve. Caught in review; confirmed as real data loss before fixing.
- `COPILOT_GH_HOST` is set on our own environment rather than passed as `env=`, because the SDK inherits `os.environ` **only** when that argument is `None` — handing it a dict strips everything else from the subprocess.
- Because we write that var, host resolution reads the *ambient* value captured at import rather than the live var, and a hostless session clears it. Otherwise a hostless executor could inherit a host an earlier one left behind.

## Test Plan

Reproduced and fixed against the real SDK + bundled CLI (`github-copilot-sdk==1.0.8`), with a fresh `COPILOT_HOME` per run — the CLI caches credentials after a success, so without that isolation the "before" state falsely passes.

Isolating the failure to the missing `oauth_token` (each run is a token-less env, no `COPILOT_*` / `GH_TOKEN` / `GITHUB_TOKEN`):

| `HOME` contents | Result |
| --- | --- |
| real `HOME` | turn succeeds |
| only `gh` `hosts.yml` copied in | turn succeeds (so a `gh` login *is* honoured on Linux) |
| `hosts.yml` with `oauth_token` removed, users entry kept (the macOS shape) | **`Session was not created with authentication info or custom provider`** |
| `hosts.yml` with a bogus token | `Failed to fetch GitHub CLI user login (401): Bad credentials` |

Clean A/B on the macOS-shape config, identical env, fresh `COPILOT_HOME` both times:

- **before:** `Session was not created with authentication info or custom provider`
- **after:** real turn completes — `TurnComplete(response='Hi.', ...)`, token sourced from `gh`

GHE plumbing verified to actually reach the CLI: `COPILOT_GH_HOST=bogus.ghe.com` flips a previously-succeeding turn to a failure, confirming the var is honoured (the SDK has no host parameter, and `strings` on the 160 MB stripped CLI binary shows neither `GH_HOST` nor `hosts.yml`, so this behavioural check is the reliable signal).

Automated:

```bash
pytest tests/inner/test_copilot_executor.py tests/inner/test_copilot_harness.py \
       tests/onboarding/test_copilot_auth.py tests/onboarding/test_harness_readiness.py \
       tests/runtime/test_copilot_spawn_env.py
# 145 passed
```

Also ran `tests/inner` + `tests/runtime` in full (3452 passed). Seven failures there are **pre-existing on `main`** and unrelated — confirmed by re-running the same selections and the same combined ordering on a clean tree, where all seven fail identically (five are order-dependent: `test_claude_router_hook`, `test_codex_hooks_generation`, `test_executor_adapter`; two fail standalone: `test_openai_agents_sdk_spawn_env`, `test_provider_spawn_env`).

`ruff check` / `ruff format` clean. `pyrefly` reports the same 4 pre-existing SDK-stub errors as an unmodified copy of the file (baseline verified equal).

## Demo

N/A — no UI surface. The `omnigent setup` → Copilot menu gains "Set GitHub Enterprise host" and shows `Copilot — using your GitHub CLI login` when no token is stored but `gh` is logged in.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the `gh` fallback and its precedence (env vars still win), the soft-`None` paths (logged out, `gh` absent, timeout), per-host token fetching, host normalization (a pasted `https://…/` reduces to a bare hostname), the two savers preserving each other's field, token removal keeping a configured host, a hostless executor clearing a leftover host, spawn-env threading, and readiness via a `gh` login alone.

Manual verification covers what unit tests can't: the real bundled CLI's credential discovery. The failure is entirely about which file the CLI reads, so the fix is only meaningful against the real binary — hence the isolation table and clean A/B above.

Two test-only notes for reviewers: `test_harness_readiness.py::_all_clis_installed` patches `subprocess.run` on the shared stdlib module and asserts on any unexpected argv, so the new `gh auth token` probe needed teaching there (it reports "logged out" to keep those tests about CLI presence). That file's autouse isolation fixture also now stubs `gh_cli_github_token`, so a developer's real `gh` login can't flip a readiness verdict.

## Changelog

The Copilot harness now authenticates with your existing `gh auth login` session, and a GitHub Enterprise host can be set via `omnigent setup`

