### PR TITLE
feat(sandboxes): add an OSS Databricks Sandbox provider on the public CLI

### DIFF
--- a/omnigent/onboarding/sandboxes/databricks_sandbox.py
+++ b/omnigent/onboarding/sandboxes/databricks_sandbox.py
@@ -1,0 +1,999 @@
+"""
+Databricks Sandbox launcher.
+
+Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
+for `Databricks Sandbox
+<https://docs.databricks.com/aws/en/compute/serverless/sandbox>`_ —
+SSH-accessible, microVM-isolated personal development environments.
+
+Unlike every other provider in this package, the transport is not a
+Python SDK: it is the **public** ``databricks sandbox`` CLI surface
+(``create`` / ``delete`` / ``list`` / ``start`` / ``stop`` / ``status`` /
+``ssh`` / ``config``), which went GA when the Databricks CLI renamed
+``databricks lakebox`` to ``databricks sandbox``
+(https://github.com/databricks/cli/pull/5487). There is therefore no
+optional Python extra to install and no internal dependency — an
+operator who can run ``databricks sandbox ssh`` by hand can run this
+provider. Commands are built as argv lists and executed WITHOUT a shell
+locally, so a sandbox id or path never reaches a local shell.
+
+Platform notes that shape this launcher:
+
+- **Real SSH means real port forwarding.** ``databricks sandbox ssh <id>
+  -- -L <port>:localhost:<port>`` passes flags straight through to
+  ``ssh``, so this is the one exec-model provider in the tree with
+  :attr:`supports_local_port_forward` ``True``. Modal, Daytona, and Islo
+  all lack a local→sandbox path and must skip the in-sandbox App OAuth
+  flow; this provider does not.
+- **But the transport allocates no remote PTY.** ``-- -tt <cmd>`` was
+  verified against CLI v1.11.0 to still run the remote command with
+  ``tty`` reporting "not a tty". :meth:`stream_exec` therefore ignores
+  its ``pty`` argument, and :meth:`exec_foreground` runs without a
+  controlling terminal. CLIs that suppress output when not attached to a
+  terminal — including the ``databricks auth login`` step of the
+  in-sandbox App OAuth flow — may degrade. See the module's open
+  questions in the accompanying issue.
+- **Stop/start with persistent storage.** Sandboxes auto-stop on idle and
+  restart with their disk intact, so a dormant managed host is resumed in
+  place under the SAME sandbox id (:attr:`can_resume` ``True``) rather
+  than reprovisioned. That matters more here than elsewhere: Databricks
+  Sandbox enforces a per-user cap on sandbox count, so a
+  provision-per-session deployment would eventually hit the ceiling.
+- **No image selection and no create-time env injection.** The CLI's
+  ``create`` takes only ``--name``; the sandbox image is Databricks'
+  own (Ubuntu 24.04, user ``sandbox-agent``) and already ships git,
+  tmux, python3, uv, node, and the coding-harness CLIs, so the generic
+  :meth:`~omnigent.onboarding.sandboxes.base.ExecModelHostLauncher.start_host`
+  bootstrap works unmodified. There is deliberately no ``env``
+  passthrough knob: with no create-time env API, the only way to inject
+  credentials would be to prefix them onto the remote argv of every
+  exec, which exposes them in the sandbox's process table.
+- **PEP 668 image.** The sandbox's Python is externally managed
+  (``/usr/lib/python3.12/EXTERNALLY-MANAGED``) and its site-packages are
+  not writable by ``sandbox-agent``, so :meth:`wheel_install_command`
+  passes ``--break-system-packages`` and lets pip fall back to a user
+  install, which precedes ``dist-packages`` on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from pathlib import Path
+from typing import ClassVar
+
+import click
+
+from omnigent.onboarding.sandboxes.base import (
+    RemoteCommandResult,
+    RemoteProcess,
+    SandboxLauncher,
+)
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+
+# ── Constants ──────────────────────────────────────────
+
+DEFAULT_CLI_BINARY: str = "databricks"
+"""Name of the Databricks CLI executable resolved on ``PATH``."""
+
+INSTALL_HINT: str = (
+    "The Databricks CLI is required for the 'databricks' sandbox provider. "
+    "Install it (https://docs.databricks.com/aws/en/dev-tools/cli/install) — "
+    "v0.270.0 or newer, which is where `databricks sandbox` landed — then run "
+    "`databricks auth login --host https://<workspace>` and "
+    "`databricks sandbox register`."
+)
+
+AUTH_HINT: str = (
+    "The Databricks CLI is installed but could not list sandboxes. "
+    "Authenticate with `databricks auth login --host https://<workspace>` "
+    "(or set DATABRICKS_HOST/DATABRICKS_TOKEN), then register this machine "
+    "for sandbox SSH with `databricks sandbox register`."
+)
+
+# `databricks sandbox create` blocks until the microVM reports Running.
+# A cold create takes tens of seconds; the ceiling covers a slow region
+# without hanging a managed launch forever.
+_CREATE_TIMEOUT_S: float = 600.0
+
+# `databricks sandbox start` documents its own 10-minute ceiling for a
+# stopped sandbox to reach Running; match it rather than cutting it short.
+_START_TIMEOUT_S: float = 660.0
+
+# Blocking remote commands (`run`, `put`). The bootstrap's longest single
+# command is the wheel install, which is seconds on a warm sandbox; the
+# ceiling covers a slow git clone of a large repository without letting a
+# wedged SSH session hang a managed launch indefinitely.
+_REMOTE_COMMAND_TIMEOUT_S: float = 1800.0
+
+# Short control-plane calls (list / status / config / delete). Generous
+# enough for a slow workspace round-trip, short enough that a wedged
+# control plane surfaces as an error instead of a stalled launch.
+_CONTROL_TIMEOUT_S: float = 120.0
+
+# How long `forward_local_port` waits for ssh to bind the local port
+# before giving up. Live measurement was ~2 s; the ceiling covers a
+# stopped sandbox that `ssh` auto-starts on connection.
+_FORWARD_BIND_TIMEOUT_S: float = 120.0
+_FORWARD_POLL_INTERVAL_S: float = 0.25
+
+# Grace period for the port-forward child to exit on SIGTERM before it
+# is killed outright.
+_FORWARD_TERMINATE_TIMEOUT_S: float = 5.0
+
+# The line `ssh -v` prints once a `-L` listener is actually bound, e.g.
+# "debug1: Local forwarding listening on 127.0.0.1 port 8022.". Stable
+# across OpenSSH releases and the only non-invasive readiness signal
+# available — see `DatabricksSandboxLauncher._await_forward` for why
+# probing the port instead is wrong in both possible directions. Built
+# per-port so a transcript can never match a different forward.
+_FORWARD_READY_TEMPLATE: str = "Local forwarding listening on 127.0.0.1 port {port}"
+
+# Substrings that mean the forward will never come up, so the wait can
+# fail immediately instead of burning the full readiness timeout.
+#
+# `ExitOnForwardFailure=yes` would be the tidier mechanism, but the
+# Databricks CLI re-quotes the arguments it forwards to ssh and mangles
+# `-o Key=Value` in BOTH spellings — verified live on v1.11.0, where
+# `-o ExitOnForwardFailure=yes` yields "Bad configuration option:
+# 'exitonforwardfailure / invalid quotes" and the single-token
+# `-oExitOnForwardFailure=yes` silently loses `-N`. Watching ssh's own
+# failure lines gets the same fail-fast without an `-o` flag.
+_FORWARD_FAILURE_MARKERS: tuple[str, ...] = (
+    "cannot listen to port",
+    "bind: ",
+    "could not request local forwarding",
+)
+
+# Substrings that mark an `ssh -v` line as explaining a failure, used to
+# lift the useful lines out of verbose handshake chatter.
+_FORWARD_ERROR_MARKERS: tuple[str, ...] = (
+    "address already in use",
+    "bind:",
+    "cannot listen",
+    "permission denied",
+    "connection refused",
+    "connection closed",
+    "could not request local forwarding",
+    "ssh: ",
+)
+
+# Status strings the control plane reports, lower-cased.
+_RUNNING_STATUS: str = "running"
+_STOPPED_STATUSES: frozenset[str] = frozenset({"stopped", "stopping", "starting", "pending"})
+
+# Substrings that mark a control-plane response as "this sandbox does not
+# exist". Matched case-insensitively against combined output so a delete
+# of an already-gone sandbox is idempotent.
+_NOT_FOUND_MARKERS: tuple[str, ...] = ("not found", "does not exist", "no such sandbox")
+
+
+def _drain_forward_output(
+    process: subprocess.Popen[str],
+    transcript: list[str],
+    settled: threading.Event,
+    state: dict[str, bool],
+    port: int,
+) -> None:
+    """
+    Drain an ``ssh -v`` forward child's output for its whole lifetime.
+
+    Runs on a daemon thread. Draining is not optional: ``ssh -v`` keeps
+    logging as channels open and close, and an unread pipe eventually
+    fills and wedges the tunnel. Readiness and hard failure are both
+    recognized here, as a side effect of the drain.
+
+    :param process: The forwarding child, text-mode with stderr merged
+        into ``stdout``.
+    :param transcript: Appended to, so the caller can quote ``ssh``'s
+        own words in an error.
+    :param settled: Set once the outcome is known either way, so the
+        waiter wakes immediately instead of polling to its deadline.
+    :param state: Mutated with ``{"listening": True}`` on success or
+        ``{"failed": True}`` when ssh reports it cannot listen.
+    :param port: The local port whose readiness line to match, so a
+        transcript can never satisfy a different forward.
+    """
+    stream = process.stdout
+    if stream is None:
+        return
+    ready_marker = _FORWARD_READY_TEMPLATE.format(port=port)
+    try:
+        for line in stream:
+            transcript.append(line)
+            if ready_marker in line:
+                state["listening"] = True
+                settled.set()
+            elif any(marker in line.lower() for marker in _FORWARD_FAILURE_MARKERS):
+                state["failed"] = True
+                settled.set()
+    finally:
+        stream.close()
+
+
+def _forward_failure_detail(transcript: list[str]) -> str:
+    """
+    Summarize an ``ssh -v`` transcript for a forward error message.
+
+    Prefers the lines that explain a failure (``ssh``'s own errors and
+    bind complaints) over the verbose handshake chatter, falling back to
+    the tail of the transcript when nothing matches.
+
+    :param transcript: Collected output lines.
+    :returns: A short, single-line explanation.
+    """
+    interesting = [
+        line.strip()
+        for line in transcript
+        if any(marker in line.lower() for marker in _FORWARD_ERROR_MARKERS)
+    ]
+    lines = interesting or [line.strip() for line in transcript[-3:] if line.strip()]
+    return " / ".join(lines) or "<no output>"
+
+
+def _looks_missing(output: str) -> bool:
+    """
+    Return whether CLI output reports the sandbox as nonexistent.
+
+    :param output: Combined stdout/stderr from a failed control-plane call.
+    :returns: ``True`` when the failure is a not-found, e.g. a delete
+        racing another cleanup path.
+    """
+    lowered = output.lower()
+    return any(marker in lowered for marker in _NOT_FOUND_MARKERS)
+
+
+class _DatabricksRemoteProcess(RemoteProcess):
+    """
+    :class:`RemoteProcess` over a ``databricks sandbox ssh`` child.
+
+    stderr is merged into stdout because the caller consumes one line
+    stream; the blocking :meth:`DatabricksSandboxLauncher.run` keeps the
+    two streams separate instead.
+    """
+
+    def __init__(self, process: subprocess.Popen[str], command: str) -> None:
+        """
+        Wrap an already-spawned child.
+
+        :param process: The ``Popen`` handle, text-mode, ``stdout=PIPE``
+            with stderr merged in.
+        :param command: The remote command, for error messages.
+        """
+        self._process = process
+        self._command = command
+        self._lines: Iterator[str] | None = None
+
+    @property
+    def lines(self) -> Iterator[str]:
+        """
+        Line iterator over the child's combined output.
+
+        Cached so a caller can consume a few lines, do other work, and
+        resume where it left off — the contract
+        :class:`~omnigent.onboarding.sandboxes.base.RemoteProcess`
+        requires for the OAuth flow.
+        """
+        if self._lines is None:
+            stream = self._process.stdout
+            self._lines = iter(()) if stream is None else iter(stream)
+        return self._lines
+
+    def wait(self) -> int:
+        """
+        Block until the remote command exits.
+
+        :returns: The remote command's exit code, which
+            ``databricks sandbox ssh`` propagates verbatim.
+        """
+        return self._process.wait()
+
+    def close(self) -> None:
+        """Terminate the child if it is still running, then reap it."""
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=_FORWARD_TERMINATE_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait()
+        if self._process.stdout is not None:
+            self._process.stdout.close()
+
+
+class DatabricksSandboxLauncher(SandboxLauncher):
+    """
+    :class:`SandboxLauncher` for Databricks Sandbox environments.
+
+    Every primitive shells out to the public ``databricks sandbox`` CLI
+    with an argv list (never ``shell=True``): ``create`` / ``delete`` /
+    ``start`` / ``status`` / ``config`` for lifecycle, and ``ssh <id> --
+    <cmd>`` for all transport. The remote command rides as a single argv
+    element, which the CLI hands to ``ssh`` and the sandbox's login shell
+    interprets — so ``run("…", "a; b")`` behaves like a shell line, and
+    callers quote remote paths themselves as the base contract requires.
+    """
+
+    provider: ClassVar[str] = "databricks"
+    # `databricks sandbox ssh <id> -- -L …` forwards flags to ssh, so a
+    # local→sandbox bridge for the App OAuth callback genuinely works.
+    supports_local_port_forward: ClassVar[bool] = True
+    # Sandboxes stop on idle and restart with their disk intact.
+    can_resume: ClassVar[bool] = True
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        """
+        Feature flags, declared against what was verified on CLI v1.11.0.
+
+        ``streaming_exec`` is ``True`` but cannot honor a PTY request —
+        see the module docstring — so the in-sandbox App OAuth flow it
+        backs is the least-proven path in this launcher.
+        """
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=True,
+            resume_stopped=True,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=True,
+            foreground_exec=True,
+        )
+
+    def __init__(
+        self,
+        *,
+        cli_path: str | None = None,
+        profile: str | None = None,
+        idle_timeout: str | None = None,
+        no_autostop: bool = True,
+    ) -> None:
+        """
+        Initialize the launcher.
+
+        :param cli_path: Databricks CLI executable to invoke, e.g.
+            ``"/opt/databricks/bin/databricks"`` — the server's
+            ``sandbox.databricks.cli_path`` config. ``None`` resolves
+            :data:`DEFAULT_CLI_BINARY` on ``PATH``.
+        :param profile: ``~/.databrickscfg`` profile passed as ``-p`` to
+            every call, e.g. ``"sandbox-sp"`` for a service-principal
+            M2M profile. ``None`` uses the CLI's own resolution
+            (``DATABRICKS_*`` env, then the ``DEFAULT`` profile).
+        :param idle_timeout: Per-sandbox idle timeout applied at
+            provision, e.g. ``"4h"``. Ignored while *no_autostop* is
+            ``True``, which is the default.
+        :param no_autostop: Exempt provisioned sandboxes from idle
+            auto-stop. Defaults to ``True`` because a managed host must
+            survive arbitrary idle gaps between turns; set ``False`` to
+            let *idle_timeout* (or the workspace default) apply.
+        """
+        self._cli_path = cli_path or DEFAULT_CLI_BINARY
+        self._profile = profile
+        self._idle_timeout = idle_timeout
+        self._no_autostop = no_autostop
+
+    # ── CLI plumbing ────────────────────────────────────
+
+    def _argv(self, *args: str) -> list[str]:
+        """
+        Build the argv for one ``databricks sandbox`` invocation.
+
+        The profile flag is appended AFTER the subcommand's own
+        arguments but is never allowed past a ``--`` separator, so
+        ``ssh`` remote arguments stay untouched. Callers that need a
+        ``--`` pass it themselves via :meth:`_ssh_argv`.
+
+        :param args: Subcommand and its arguments, e.g.
+            ``("status", "sb-1", "-o", "json")``.
+        :returns: The full argv list, ready for :func:`subprocess.run`.
+        """
+        argv = [self._cli_path, "sandbox", *args]
+        if self._profile is not None:
+            argv += ["-p", self._profile]
+        return argv
+
+    def _ssh_argv(self, sandbox_id: str, *remote: str) -> list[str]:
+        """
+        Build the argv for ``databricks sandbox ssh <id> -- <remote…>``.
+
+        :param sandbox_id: Target sandbox id, e.g.
+            ``"spanking-pitta-1649"``.
+        :param remote: Everything after ``--`` — ssh flags and/or the
+            remote command as a single element.
+        :returns: The full argv list.
+        """
+        return [*self._argv("ssh", sandbox_id), "--", *remote]
+
+    def _cli(
+        self,
+        argv: list[str],
+        *,
+        timeout: float = _CONTROL_TIMEOUT_S,
+        action: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        """
+        Run one CLI invocation and normalize its failures.
+
+        :param argv: Full argv from :meth:`_argv` / :meth:`_ssh_argv`.
+        :param timeout: Seconds to wait before killing the child.
+        :param action: Human phrase for error messages, e.g.
+            ``"create a Databricks Sandbox"``.
+        :param check: When ``True``, raise on a non-zero exit.
+        :returns: The completed process, with text-mode output captured.
+        :raises click.ClickException: When the CLI is missing, times
+            out, or (with *check*) exits non-zero.
+        """
+        try:
+            completed = subprocess.run(  # argv list, no shell
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise click.ClickException(INSTALL_HINT) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise click.ClickException(
+                f"Timed out after {timeout:.0f}s trying to {action}."
+            ) from exc
+        if check and completed.returncode != 0:
+            raise click.ClickException(
+                f"Could not {action} (exit {completed.returncode}): "
+                f"{_combined(completed).strip() or '<no output>'}"
+            )
+        return completed
+
+    def _cli_json(self, argv: list[str], *, timeout: float, action: str) -> dict[str, object]:
+        """
+        Run a CLI invocation whose stdout is a JSON object.
+
+        :param argv: Full argv, which must already request JSON output.
+        :param timeout: Seconds to wait before killing the child.
+        :param action: Human phrase for error messages.
+        :returns: The decoded object.
+        :raises click.ClickException: On CLI failure or unparseable output.
+        """
+        completed = self._cli(argv, timeout=timeout, action=action)
+        try:
+            payload = json.loads(completed.stdout)
+        except ValueError as exc:
+            raise click.ClickException(
+                f"Could not {action}: the Databricks CLI returned "
+                f"unparseable JSON ({completed.stdout.strip()[:200]!r})."
+            ) from exc
+        if not isinstance(payload, dict):
+            raise click.ClickException(
+                f"Could not {action}: expected a JSON object from the "
+                f"Databricks CLI, got {type(payload).__name__}."
+            )
+        return payload
+
+    # ── Lifecycle ───────────────────────────────────────
+
+    def prepare(self) -> None:
+        """
+        Local preflight: the ``databricks`` CLI must be on ``PATH`` and
+        authenticated against a workspace.
+
+        ``databricks sandbox list`` proves both in one call — it is
+        read-only, it fails when no credentials resolve, and it fails
+        when the CLI predates the ``sandbox`` command group.
+
+        :raises click.ClickException: When the CLI is missing (with the
+            install hint) or unauthenticated (with the login hint).
+        """
+        if shutil.which(self._cli_path) is None:
+            raise click.ClickException(INSTALL_HINT)
+        completed = self._cli(
+            self._argv("list", "-o", "json"),
+            action="list Databricks Sandboxes",
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise click.ClickException(
+                f"{AUTH_HINT}\n\nThe CLI reported: {_combined(completed).strip() or '<no output>'}"
+            )
+
+    def provision(self, name: str) -> str:
+        """
+        Create a new Databricks Sandbox and return its id.
+
+        ``create`` blocks until the microVM reports Running, so the id
+        this returns is immediately usable. The auto-stop policy is
+        applied right after creation (see :meth:`keep_alive`) because
+        ``create`` itself exposes no policy flag.
+
+        :param name: Human-readable label, e.g. ``"managed-a1b2c3d4"``.
+            Recorded as the sandbox's display name; the returned id is
+            the canonical reference.
+        :returns: The sandbox id, e.g. ``"spanking-pitta-1649"``.
+        :raises click.ClickException: If provisioning fails or the CLI
+            returns no id.
+        """
+        click.echo(f"▸ Creating Databricks Sandbox '{name}'")
+        payload = self._cli_json(
+            self._argv("create", "--name", name, "--json"),
+            timeout=_CREATE_TIMEOUT_S,
+            action="create a Databricks Sandbox",
+        )
+        sandbox_id = payload.get("sandboxId")
+        if not isinstance(sandbox_id, str) or not sandbox_id:
+            raise click.ClickException(
+                f"Databricks Sandbox creation returned no 'sandboxId' — got {payload!r}."
+            )
+        click.echo(f"  → created {sandbox_id}")
+        self.keep_alive(sandbox_id)
+        return sandbox_id
+
+    def attach(self, sandbox_id: str) -> None:
+        """
+        Validate access to an existing sandbox, starting it if stopped.
+
+        Databricks Sandboxes stop on idle and restart with their disk
+        intact, so — like Daytona and unlike Modal — attach revives a
+        stopped sandbox rather than rejecting it.
+
+        :param sandbox_id: The sandbox to attach to.
+        :raises click.ClickException: When the sandbox does not exist or
+            cannot be started.
+        """
+        click.echo(f"▸ Reusing existing Databricks Sandbox '{sandbox_id}'")
+        if self._status(sandbox_id) != _RUNNING_STATUS:
+            self.resume(sandbox_id)
+
+    def resume(self, sandbox_id: str) -> None:
+        """
+        Start a stopped sandbox in place, keeping its id and disk.
+
+        Starting an already-running sandbox is a documented no-op, so
+        this is safe to call unconditionally.
+
+        :param sandbox_id: The sandbox to start.
+        :raises click.ClickException: If the start fails or times out.
+        """
+        click.echo(f"▸ Starting Databricks Sandbox '{sandbox_id}'")
+        self._cli(
+            self._argv("start", sandbox_id),
+            timeout=_START_TIMEOUT_S,
+            action=f"start Databricks Sandbox '{sandbox_id}'",
+        )
+        click.echo(f"  → running {sandbox_id}")
+
+    def is_running(self, sandbox_id: str) -> bool | None:
+        """
+        Return whether the control plane reports the sandbox as running.
+
+        :param sandbox_id: The sandbox to inspect.
+        :returns: ``True`` when Running, ``False`` for the known
+            not-running states, ``None`` for anything unrecognized (so
+            callers keep their existing liveness behavior).
+        """
+        status = self._status(sandbox_id)
+        if status == _RUNNING_STATUS:
+            return True
+        if status in _STOPPED_STATUSES:
+            return False
+        return None
+
+    def _status(self, sandbox_id: str) -> str:
+        """
+        Return the lower-cased status string for a sandbox.
+
+        :param sandbox_id: The sandbox to inspect.
+        :returns: e.g. ``"running"``, ``"stopped"``, or ``""`` when the
+            control plane reported no status field.
+        :raises click.ClickException: If the status call fails.
+        """
+        payload = self._cli_json(
+            self._argv("status", sandbox_id, "-o", "json"),
+            timeout=_CONTROL_TIMEOUT_S,
+            action=f"read the status of Databricks Sandbox '{sandbox_id}'",
+        )
+        status = payload.get("status")
+        return status.lower() if isinstance(status, str) else ""
+
+    def keep_alive(self, sandbox_id: str) -> None:
+        """
+        Apply the configured auto-stop policy so the host survives idle
+        gaps between turns.
+
+        Soft-fail per the launcher contract: a rejected setting warns
+        rather than aborting the bootstrap — the sandbox is usable, it
+        just may reap itself on idle.
+
+        :param sandbox_id: The sandbox to configure.
+        """
+        if self._no_autostop:
+            flags = ["--no-autostop"]
+            description = "idle auto-stop disabled"
+        elif self._idle_timeout is not None:
+            flags = ["--idle-timeout", self._idle_timeout]
+            description = f"idle timeout set to {self._idle_timeout}"
+        else:
+            return
+        completed = self._cli(
+            self._argv("config", sandbox_id, *flags),
+            action=f"configure Databricks Sandbox '{sandbox_id}'",
+            check=False,
+        )
+        if completed.returncode != 0:
+            click.echo(
+                f"  → warning: could not configure auto-stop on '{sandbox_id}' "
+                f"({_combined(completed).strip() or 'no output'}); the sandbox "
+                "may stop after its idle timeout.",
+                err=True,
+            )
+            return
+        click.echo(f"  → {description}")
+
+    def terminate(self, sandbox_id: str) -> None:
+        """
+        Delete a sandbox, releasing its compute and disk.
+
+        ``--auto-approve`` is mandatory: ``delete`` prompts interactively
+        otherwise, which would hang a server-side teardown. Idempotent
+        from the caller's perspective — a sandbox that is already gone is
+        treated as success, since the desired end state holds.
+
+        :param sandbox_id: The sandbox to delete.
+        :raises click.ClickException: When the delete fails for any
+            reason other than the sandbox not existing.
+        """
+        completed = self._cli(
+            self._argv("delete", sandbox_id, "--auto-approve"),
+            action=f"delete Databricks Sandbox '{sandbox_id}'",
+            check=False,
+        )
+        if completed.returncode != 0 and not _looks_missing(_combined(completed)):
+            raise click.ClickException(
+                f"Could not delete Databricks Sandbox '{sandbox_id}' "
+                f"(exit {completed.returncode}): "
+                f"{_combined(completed).strip() or '<no output>'}"
+            )
+
+    # ── Transport ───────────────────────────────────────
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """
+        Run a shell command in the sandbox and capture its output.
+
+        The remote transport keeps stdout and stderr separate, so both
+        are reported faithfully rather than merged into ``stdout`` the
+        way the SDK-backed providers must.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely; quote remote
+            paths yourself, per the base contract.
+        :param check: When ``True``, raise on non-zero exit.
+        :returns: Exit code plus captured stdout and stderr.
+        :raises click.ClickException: If *check* is ``True`` and the
+            command exits non-zero.
+        """
+        completed = self._cli(
+            self._ssh_argv(sandbox_id, command),
+            timeout=_REMOTE_COMMAND_TIMEOUT_S,
+            action=f"run a command on Databricks Sandbox '{sandbox_id}'",
+            check=False,
+        )
+        for line in completed.stdout.splitlines():
+            if line.strip():
+                click.echo(line)
+        for line in completed.stderr.splitlines():
+            if line.strip():
+                click.echo(line, err=True)
+        if check and completed.returncode != 0:
+            raise click.ClickException(
+                f"Remote command failed on Databricks Sandbox '{sandbox_id}' "
+                f"(exit {completed.returncode}): {command}"
+            )
+        return RemoteCommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        """
+        Copy a local file into the sandbox.
+
+        ``databricks sandbox ssh`` passes local stdin through to the
+        remote process, so the transfer is a plain ``cat > <path>`` fed
+        from the local file — no scp invocation and no dependency on the
+        gateway exposing an sftp subsystem. Verified against CLI v1.11.0.
+
+        :param sandbox_id: Target sandbox.
+        :param local_path: Local file to read.
+        :param remote_path: Absolute destination path on the sandbox,
+            e.g. ``"/tmp/oa-wheels.tgz"``.
+        :raises click.ClickException: If the file cannot be read or the
+            transfer fails.
+        """
+        argv = self._ssh_argv(sandbox_id, f"cat > {shlex.quote(remote_path)}")
+        try:
+            with local_path.open("rb") as handle:
+                completed = subprocess.run(  # argv list, no shell
+                    argv,
+                    stdin=handle,
+                    capture_output=True,
+                    text=True,
+                    timeout=_REMOTE_COMMAND_TIMEOUT_S,
+                    check=False,
+                )
+        except FileNotFoundError as exc:
+            # Either the local file or the CLI itself is missing; the
+            # local file is the likelier caller error, so name it.
+            raise click.ClickException(
+                f"Could not copy '{local_path}' into Databricks Sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        except OSError as exc:
+            raise click.ClickException(
+                f"Could not read '{local_path}' to copy into Databricks "
+                f"Sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise click.ClickException(
+                f"Timed out copying '{local_path}' into Databricks Sandbox '{sandbox_id}'."
+            ) from exc
+        if completed.returncode != 0:
+            raise click.ClickException(
+                f"File upload to Databricks Sandbox '{sandbox_id}' failed "
+                f"(exit {completed.returncode}): "
+                f"{_combined(completed).strip() or '<no output>'}"
+            )
+
+    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
+        """
+        Spawn a command in the sandbox and stream its output line by line.
+
+        ``pty`` is accepted for interface compatibility and **ignored**:
+        passing ``-tt`` through ``databricks sandbox ssh`` was verified
+        not to allocate a remote terminal on CLI v1.11.0. Commands that
+        suppress output when not on a TTY will behave accordingly.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely.
+        :param pty: Ignored — see above.
+        :returns: A handle streaming the process's combined output.
+        :raises click.ClickException: When the CLI is not installed.
+        """
+        del pty
+        argv = self._ssh_argv(sandbox_id, command)
+        try:
+            process = subprocess.Popen(  # argv list, no shell
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError as exc:
+            raise click.ClickException(INSTALL_HINT) from exc
+        return _DatabricksRemoteProcess(process, command)
+
+    def exec_foreground(self, sandbox_id: str, command: str) -> int:
+        """
+        Run *command* in the sandbox with local stdio inherited, blocking
+        until it exits.
+
+        No remote PTY is allocated (see the module docstring), so
+        ``TERM`` is exported explicitly to give tmux-spawning harnesses a
+        usable value rather than an empty one. Ctrl-C propagates to the
+        child ``ssh``, which tears the remote command down.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely, e.g.
+            ``"omnigent host --server https://…"``.
+        :returns: The remote command's exit code.
+        :raises click.ClickException: When the CLI is not installed.
+        """
+        argv = self._ssh_argv(sandbox_id, f"TERM=xterm-256color exec {command}")
+        try:
+            completed = subprocess.run(argv, check=False)  # argv list, no shell
+        except FileNotFoundError as exc:
+            raise click.ClickException(INSTALL_HINT) from exc
+        except KeyboardInterrupt:
+            click.echo("\n  → detaching; the remote command was signalled")
+            raise
+        return completed.returncode
+
+    def forward_local_port(self, sandbox_id: str, port: int) -> AbstractContextManager[None]:
+        """
+        Forward ``127.0.0.1:<port>`` into the sandbox over SSH.
+
+        ``databricks sandbox ssh <id> -- …`` hands the flags straight to
+        ``ssh``. Two details are load-bearing, each fixing a failure seen
+        live against CLI v1.11.0:
+
+        - **Both endpoints are pinned to ``127.0.0.1``**, never
+          ``localhost``. Unpinned, ``ssh`` binds the local port on BOTH
+          ``::1`` and ``127.0.0.1``, and the sandbox side resolves
+          ``localhost`` to whichever family it prefers — so a callback
+          server bound only to IPv4 loopback can be missed entirely.
+        - **Readiness comes from ``ssh -v`` itself**, not from probing the
+          port. See :meth:`_await_forward`.
+
+        Only bare flags are passed: the Databricks CLI re-quotes what it
+        forwards to ``ssh`` and mangles ``-o Key=Value`` (see
+        :data:`_FORWARD_FAILURE_MARKERS`), so the equivalent of
+        ``ExitOnForwardFailure`` is done by watching ``ssh``'s own
+        "cannot listen to port" output instead of setting the option.
+
+        The context manager does not yield until ``ssh`` reports the
+        forward listening, so a caller that immediately opens a browser
+        at it cannot race the bind.
+
+        :param sandbox_id: Target sandbox.
+        :param port: Local + remote loopback port to bridge, e.g. ``8022``.
+        :returns: Context manager holding the forward open.
+        :raises click.ClickException: When the CLI is missing, the child
+            exits early, or the forward is not established in time.
+        """
+        return self._forward_local_port(sandbox_id, port)
+
+    @contextmanager
+    def _forward_local_port(self, sandbox_id: str, port: int) -> Iterator[None]:
+        """
+        Implement :meth:`forward_local_port`.
+
+        Split out so the public method can carry the documented
+        ``AbstractContextManager`` return type rather than a generator.
+        """
+        argv = self._ssh_argv(
+            sandbox_id,
+            "-v",
+            "-N",
+            "-L",
+            f"127.0.0.1:{port}:127.0.0.1:{port}",
+        )
+        try:
+            process = subprocess.Popen(  # argv list, no shell
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError as exc:
+            raise click.ClickException(INSTALL_HINT) from exc
+        # ssh keeps logging for the life of the session; an unread pipe
+        # would fill and wedge it, so one daemon thread drains stdout
+        # for the whole lifetime and the readiness wait just watches
+        # what it collects.
+        transcript: list[str] = []
+        settled = threading.Event()
+        state: dict[str, bool] = {}
+        reader = threading.Thread(
+            target=_drain_forward_output,
+            args=(process, transcript, settled, state, port),
+            name="databricks-forward-reader",
+            daemon=True,
+        )
+        reader.start()
+        try:
+            self._await_forward(process, settled, state, transcript, port, sandbox_id)
+            yield
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=_FORWARD_TERMINATE_TIMEOUT_S)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+            reader.join(timeout=_FORWARD_TERMINATE_TIMEOUT_S)
+
+    @staticmethod
+    def _await_forward(
+        process: subprocess.Popen[str],
+        settled: threading.Event,
+        state: dict[str, bool],
+        transcript: list[str],
+        port: int,
+        sandbox_id: str,
+    ) -> None:
+        """
+        Block until ``ssh`` reports the local forward listening.
+
+        Readiness is taken from ``ssh -v``'s own
+        ``"Local forwarding listening on …"`` line rather than from
+        probing the port, because BOTH probe styles are wrong here:
+
+        - A **connect** probe traverses the tunnel and opens a real TCP
+          session against whatever listens on the sandbox side. The
+          in-sandbox App OAuth callback server accepts exactly one
+          connection, so the probe consumes the very request the caller
+          is waiting for. Observed live: the forward reported healthy and
+          the caller's own connection then hung until timeout.
+        - A **bind** probe races ``ssh`` for the port. When the probe
+          happens to hold it at the moment ``ssh`` binds, ``ssh`` loses
+          and the tunnel is dead while the port still looks taken.
+          Observed live at roughly one run in three.
+
+        Watching ``ssh``'s own output has neither failure mode: it
+        touches nothing, and it reports the state ``ssh`` actually
+        reached.
+
+        :param process: The forwarding child, polled so an early exit is
+            reported as itself rather than as a readiness timeout.
+        :param settled: Set by the reader thread once the outcome is known.
+        :param state: Carries ``listening`` / ``failed`` from the reader.
+        :param transcript: Lines collected so far, for error messages.
+        :param port: Local loopback port expected to bind.
+        :param sandbox_id: Target sandbox, for error messages.
+        :raises click.ClickException: When ``ssh`` reports it cannot
+            listen, the child exits early, or the forward is not reported
+            within :data:`_FORWARD_BIND_TIMEOUT_S`.
+        """
+        deadline = time.monotonic() + _FORWARD_BIND_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if settled.wait(timeout=_FORWARD_POLL_INTERVAL_S):
+                if state.get("listening"):
+                    return
+                raise click.ClickException(
+                    f"Port forward to Databricks Sandbox '{sandbox_id}' could not "
+                    f"listen on 127.0.0.1:{port}: {_forward_failure_detail(transcript)}"
+                )
+            if process.poll() is not None:
+                raise click.ClickException(
+                    f"Port forward to Databricks Sandbox '{sandbox_id}' exited "
+                    f"before listening on 127.0.0.1:{port} "
+                    f"(exit {process.returncode}): "
+                    f"{_forward_failure_detail(transcript)}"
+                )
+        raise click.ClickException(
+            f"Port forward to Databricks Sandbox '{sandbox_id}' did not report "
+            f"listening on 127.0.0.1:{port} within "
+            f"{_FORWARD_BIND_TIMEOUT_S:.0f}s: {_forward_failure_detail(transcript)}"
+        )
+
+    def wheel_install_command(self, remote_tgz_path: str) -> str:
+        """
+        Remote command that installs locally-built wheels over the
+        sandbox's preinstalled omnigent.
+
+        Diverges from
+        :func:`~omnigent.onboarding.sandboxes.base.host_image_wheel_install_command`
+        because the Databricks Sandbox image is not the Omnigent host
+        image: its interpreter is PEP 668 externally-managed and its
+        ``dist-packages`` are root-owned, so ``pip`` needs
+        ``--break-system-packages`` and falls back to a user install.
+        User site precedes ``dist-packages`` on ``sys.path``, so the
+        overlay wins at import time.
+
+        ``--force-reinstall`` is required for the same reason as the host
+        image: the baked omnigent shares a version with the local build,
+        so pip would otherwise consider it satisfied and silently skip.
+        ``--no-deps`` keeps the overlay to the local wheels alone.
+
+        :param remote_tgz_path: Sandbox path of the shipped tarball, e.g.
+            ``"/tmp/oa-wheels.tgz"``.
+        :returns: Shell command string for :meth:`run`.
+        """
+        quoted = shlex.quote(remote_tgz_path)
+        return (
+            "cd /tmp && rm -rf oa-wheels && mkdir oa-wheels && "
+            f"tar xzf {quoted} -C oa-wheels --warning=no-unknown-keyword && "
+            "pip install --quiet --break-system-packages --force-reinstall "
+            "--no-deps --no-warn-script-location oa-wheels/*.whl"
+        )
+
+
+def _combined(completed: subprocess.CompletedProcess[str]) -> str:
+    """
+    Join a completed process's captured streams for error reporting.
+
+    :param completed: The finished process.
+    :returns: stdout and stderr concatenated, in that order.
+    """
+    return f"{completed.stdout or ''}{completed.stderr or ''}"

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -134,6 +134,18 @@ def _builtin_contribution() -> SandboxProviderContribution:
                 name="lakebox",
                 launcher_class="omnigent.onboarding.sandboxes.lakebox:LakeboxLauncher",
             ),
+            # OSS Databricks Sandbox provider, built entirely on the public
+            # `databricks sandbox` CLI. Distinct from `lakebox`, whose
+            # launcher module ships only in the internal build and is
+            # therefore filtered out of this table by
+            # `_provider_module_available` in an OSS install.
+            "databricks": SandboxProviderMetadata(
+                name="databricks",
+                launcher_class=(
+                    "omnigent.onboarding.sandboxes.databricks_sandbox:DatabricksSandboxLauncher"
+                ),
+                managed_token_ttl_s=7 * 24 * 3600,
+            ),
             "modal": SandboxProviderMetadata(
                 name="modal",
                 launcher_class="omnigent.onboarding.sandboxes.modal:ModalSandboxLauncher",

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -32,8 +32,9 @@ stores into ``create_app``):
    ``<data_dir>/config.yaml``)::
 
        sandbox:
-         # lakebox|modal|daytona|blaxel|boxlite|cwsandbox|islo|e2b|openshell|kubernetes
-         provider: modal
+         provider: modal          # databricks|lakebox|modal|daytona|blaxel
+                                  # |boxlite|cwsandbox|islo|e2b|openshell
+                                  # |kubernetes
          server_url: https://omnigent.example.com
          # For SEVERAL providers, replace `provider:` with a `providers:`
          # list (mutually exclusive); a create picks one by name via
@@ -116,9 +117,15 @@ stores into ``create_app``):
    it connects to the gateway made active with ``openshell gateway
    select`` (``$OPENSHELL_GATEWAY`` / ``~/.config/openshell/active_gateway``,
    or ``sandbox.openshell.cluster``), so the server process needs
-   OpenShell gateway access. ``modal``, ``daytona``, ``blaxel``, ``cwsandbox``,
-   ``islo``, and ``openshell`` have managed-launch support; ``lakebox``
-   parses but rejects at launch.
+   OpenShell gateway access. The ``databricks`` launcher needs no API
+   key either: it shells out to the public ``databricks sandbox`` CLI,
+   so the server process needs that CLI on ``PATH`` and an authenticated
+   profile (``sandbox.databricks.profile`` selects one). ``databricks``,
+   ``modal``, ``daytona``, ``blaxel``, ``cwsandbox``, ``islo``, and
+   ``openshell`` have managed-launch support; ``lakebox`` parses but
+   rejects at launch — its launcher module ships only in the internal
+   build, so an OSS deployment wanting Databricks Sandbox should name
+   ``databricks``.
 
 2. **Direct construction** (embedding deployments): build
    :class:`ManagedSandboxConfig` with a custom
@@ -171,6 +178,7 @@ _logger = logging.getLogger(__name__)
 SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
     {
         "lakebox",
+        "databricks",
         "modal",
         "daytona",
         "blaxel",
@@ -184,6 +192,7 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
     {
+        "databricks",
         "modal",
         "daytona",
         "blaxel",
@@ -233,6 +242,14 @@ DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # re-authenticate its tunnel across reconnects while still expiring tokens of
 # boxes nobody removed. A relaunch mints a fresh token.
 BOXLITE_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Launch-token lifetime for the YAML databricks path. Databricks
+# Sandboxes have no platform lifetime cap — they auto-stop on idle (which
+# the launcher disables by default) and restart with their disk intact —
+# so the bound is policy, not platform: 7 days mirrors Daytona. A stopped
+# sandbox that the wake path resumes keeps its id, so the token must
+# outlive an idle weekend.
+DATABRICKS_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
 # Launch-token lifetime for the YAML islo path. Islo sandboxes are
 # deleted by managed-session teardown; use the same 7-day policy bound
@@ -1205,6 +1222,22 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
         # Derived from OMNIGENT_CWSANDBOX_MAX_LIFETIME_S so the token always
         # outlives the (operator-overridable) sandbox lifetime.
         token_ttl_s = managed_token_ttl_s()
+    elif provider == "databricks":
+        databricks_section = _parse_provider_section(raw, "databricks")
+        if databricks_section is not None:
+            _reject_unknown_keys(
+                databricks_section,
+                {"cli_path", "profile", "idle_timeout", "no_autostop"},
+                "sandbox.databricks",
+            )
+        no_autostop = _parse_provider_bool(raw, "databricks", "no_autostop")
+        launcher_factory = _databricks_launcher_factory(
+            cli_path=_parse_provider_string(raw, "databricks", "cli_path"),
+            profile=_parse_provider_string(raw, "databricks", "profile"),
+            idle_timeout=_parse_provider_string(raw, "databricks", "idle_timeout"),
+            no_autostop=True if no_autostop is None else no_autostop,
+        )
+        token_ttl_s = DATABRICKS_MANAGED_TOKEN_TTL_S
     elif provider == "islo":
         launcher_factory = _islo_launcher_factory(
             image=_parse_provider_image(raw, "islo"),
@@ -1963,6 +1996,45 @@ def _islo_launcher_factory(
             memory_mb=memory_mb,
             disk_gb=disk_gb,
             idle_pause_after_s=idle_pause_after_s,
+        )
+
+    return _build
+
+
+def _databricks_launcher_factory(
+    *,
+    cli_path: str | None,
+    profile: str | None,
+    idle_timeout: str | None,
+    no_autostop: bool,
+) -> Callable[[], SandboxHostLauncher]:
+    """
+    Build the launcher factory for the YAML ``provider: databricks`` path.
+
+    :param cli_path: Databricks CLI executable to invoke, e.g.
+        ``"/opt/databricks/bin/databricks"``, or ``None`` to resolve
+        ``databricks`` on ``PATH``.
+    :param profile: ``~/.databrickscfg`` profile passed to every CLI
+        call, e.g. ``"sandbox-sp"`` for a service-principal M2M profile,
+        or ``None`` to use the CLI's own credential resolution.
+    :param idle_timeout: Per-sandbox idle timeout applied at provision,
+        e.g. ``"4h"``, or ``None`` for the workspace default. Ignored
+        while *no_autostop* is ``True``.
+    :param no_autostop: Whether provisioned sandboxes are exempt from
+        idle auto-stop. Defaults to ``True`` at the parse site, since a
+        managed host must survive idle gaps between turns.
+    :returns: A factory producing parameterized Databricks launchers.
+    """
+
+    def _build() -> SandboxHostLauncher:
+        """Construct the Databricks Sandbox launcher."""
+        from omnigent.onboarding.sandboxes.databricks_sandbox import DatabricksSandboxLauncher
+
+        return DatabricksSandboxLauncher(
+            cli_path=cli_path,
+            profile=profile,
+            idle_timeout=idle_timeout,
+            no_autostop=no_autostop,
         )
 
     return _build

--- a/tests/onboarding/sandboxes/test_databricks_sandbox.py
+++ b/tests/onboarding/sandboxes/test_databricks_sandbox.py
@@ -1,0 +1,739 @@
+"""Tests for :mod:`omnigent.onboarding.sandboxes.databricks_sandbox`."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes import databricks_sandbox as dbx
+from omnigent.onboarding.sandboxes.databricks_sandbox import (
+    AUTH_HINT,
+    INSTALL_HINT,
+    DatabricksSandboxLauncher,
+)
+
+# ── Fake `databricks` CLI ───────────────────────────────────
+#
+# The launcher's whole transport is `subprocess.run` / `subprocess.Popen`
+# against the real Databricks CLI, which the test environment neither has
+# nor should reach. These are hand-rolled recorders (never MagicMock: the
+# launcher's argv must hit an explicit stub, not silently succeed), swapped
+# in with `monkeypatch.setattr(dbx.subprocess, …)` — the same pattern
+# tests/onboarding/sandboxes/test_bootstrap.py uses.
+
+
+@dataclass
+class _Reply:
+    """
+    One canned CLI response.
+
+    :param returncode: Exit code the fake CLI reports.
+    :param stdout: Captured standard output.
+    :param stderr: Captured standard error.
+    """
+
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _Call:
+    """
+    One recorded ``subprocess.run`` invocation.
+
+    :param argv: The argv list the launcher built.
+    :param stdin: Whatever was passed as ``stdin``, or ``None``.
+    """
+
+    argv: list[str]
+    stdin: Any = None
+
+
+@dataclass
+class _FakeCLI:
+    """
+    Recorder + canned-reply table for the fake Databricks CLI.
+
+    :param replies: Reply queue keyed by subcommand (``"create"``,
+        ``"ssh"``, …). Each call pops the next reply for its subcommand,
+        falling back to a bare success once the queue empties, so a test
+        only has to script the responses it cares about.
+    :param calls: Every invocation, in order.
+    """
+
+    replies: dict[str, list[_Reply]] = field(default_factory=dict)
+    calls: list[_Call] = field(default_factory=list)
+
+    def reply_with(self, subcommand: str, *replies: _Reply) -> None:
+        """
+        Queue responses for one subcommand.
+
+        :param subcommand: e.g. ``"status"``.
+        :param replies: Responses, returned in order.
+        """
+        self.replies.setdefault(subcommand, []).extend(replies)
+
+    def argvs(self, subcommand: str) -> list[list[str]]:
+        """
+        Return every recorded argv for one subcommand.
+
+        :param subcommand: e.g. ``"config"``.
+        :returns: The matching argv lists, in call order.
+        """
+        return [call.argv for call in self.calls if _subcommand(call.argv) == subcommand]
+
+    def run(self, argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Stand in for ``subprocess.run``, recording and replying."""
+        self.calls.append(_Call(argv=list(argv), stdin=kwargs.get("stdin")))
+        queue = self.replies.get(_subcommand(argv), [])
+        reply = queue.pop(0) if queue else _Reply()
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=reply.returncode,
+            stdout=reply.stdout,
+            stderr=reply.stderr,
+        )
+
+
+def _subcommand(argv: list[str]) -> str:
+    """
+    Extract the ``databricks sandbox <sub>`` subcommand from an argv.
+
+    :param argv: The full argv list.
+    :returns: The subcommand, or ``""`` when the argv is not shaped like
+        a sandbox call.
+    """
+    if "sandbox" not in argv:
+        return ""
+    index = argv.index("sandbox") + 1
+    return argv[index] if index < len(argv) else ""
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, cli: _FakeCLI | None = None) -> _FakeCLI:
+    """
+    Swap in the fake CLI and make ``shutil.which`` resolve the binary.
+
+    :param monkeypatch: pytest's patcher.
+    :param cli: An existing recorder to reuse, or ``None`` for a fresh one.
+    :returns: The recorder now backing ``subprocess.run``.
+    """
+    fake = cli if cli is not None else _FakeCLI()
+    monkeypatch.setattr(dbx.subprocess, "run", fake.run)
+    monkeypatch.setattr(dbx.shutil, "which", lambda name: f"/fake/{name}")
+    return fake
+
+
+def _remote_command(argv: list[str]) -> str:
+    """
+    Return the remote command an ``ssh`` argv carries after ``--``.
+
+    :param argv: A recorded ``ssh`` argv.
+    :returns: The single remote-command element.
+    """
+    return argv[argv.index("--") + 1]
+
+
+# ── capabilities ────────────────────────────────────────────
+
+
+def test_capabilities_declare_port_forward_and_resume() -> None:
+    """
+    The two flags that distinguish this provider from every other
+    exec-model launcher must be True: `databricks sandbox ssh` is real
+    SSH (so `-L` forwarding works) and sandboxes restart with their disk
+    intact (so a dormant host resumes under the same id). Both were
+    verified live; if either regresses to False the bootstrap silently
+    routes around a capability the platform actually has.
+    """
+    capabilities = DatabricksSandboxLauncher().capabilities
+    assert capabilities.local_port_forward is True
+    assert capabilities.resume_stopped is True
+    assert capabilities.managed_launch is True
+    assert capabilities.programmatic_terminate is True
+    assert capabilities.file_copy is True
+
+
+# ── prepare ─────────────────────────────────────────────────
+
+
+def test_prepare_raises_install_hint_when_cli_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    No `databricks` on PATH must fail with the install remediation, not
+    a bare FileNotFoundError from the first subprocess call.
+    """
+    monkeypatch.setattr(dbx.shutil, "which", lambda name: None)
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().prepare()
+    assert str(exc.value) == INSTALL_HINT
+
+
+def test_prepare_raises_auth_hint_when_list_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    An installed-but-unauthenticated CLI must point at `databricks auth
+    login`, and must surface the CLI's own reason verbatim so an
+    operator can tell "wrong workspace" from "key not registered".
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("list", _Reply(returncode=1, stderr="cannot resolve credentials"))
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().prepare()
+    assert AUTH_HINT in str(exc.value)
+    assert "cannot resolve credentials" in str(exc.value)
+
+
+def test_prepare_accepts_authenticated_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful `sandbox list` is the whole preflight."""
+    cli = _install(monkeypatch)
+    cli.reply_with("list", _Reply(stdout="[]"))
+    DatabricksSandboxLauncher().prepare()
+    assert cli.argvs("list") == [["databricks", "sandbox", "list", "-o", "json"]]
+
+
+# ── provision ───────────────────────────────────────────────
+
+
+def test_provision_creates_and_returns_sandbox_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `create --json` is the id source. The label rides as `--name`, and
+    the returned id (not the label) is what every later primitive uses.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"sandboxId": "spanking-pitta-1649"})))
+    sandbox_id = DatabricksSandboxLauncher().provision("managed-a1b2c3d4")
+    assert sandbox_id == "spanking-pitta-1649"
+    assert cli.argvs("create") == [
+        ["databricks", "sandbox", "create", "--name", "managed-a1b2c3d4", "--json"]
+    ]
+
+
+def test_provision_disables_autostop_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A managed host sits idle between turns, so provision must follow
+    `create` with `config --no-autostop`. Without it the sandbox reaps
+    itself on the workspace's default idle timeout and the session dies.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"sandboxId": "sb-1"})))
+    DatabricksSandboxLauncher().provision("managed-a1b2c3d4")
+    assert cli.argvs("config") == [["databricks", "sandbox", "config", "sb-1", "--no-autostop"]]
+
+
+def test_provision_applies_idle_timeout_when_autostop_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With `no_autostop=False`, a configured idle timeout is applied
+    instead — the two knobs are mutually exclusive on the CLI.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"sandboxId": "sb-1"})))
+    DatabricksSandboxLauncher(no_autostop=False, idle_timeout="4h").provision("label")
+    assert cli.argvs("config") == [
+        ["databricks", "sandbox", "config", "sb-1", "--idle-timeout", "4h"]
+    ]
+
+
+def test_provision_skips_config_when_no_policy_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No policy configured → no `config` call at all."""
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"sandboxId": "sb-1"})))
+    DatabricksSandboxLauncher(no_autostop=False).provision("label")
+    assert cli.argvs("config") == []
+
+
+def test_provision_raises_when_create_returns_no_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A create that succeeds but reports no `sandboxId` must fail loud —
+    returning an empty id would strand every later primitive on a
+    sandbox that does not exist.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"status": "Running"})))
+    with pytest.raises(click.ClickException, match="no 'sandboxId'"):
+        DatabricksSandboxLauncher().provision("label")
+
+
+def test_provision_raises_on_unparseable_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-JSON stdout must surface as a clear error, not a ValueError."""
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout="Creating sandbox…"))
+    with pytest.raises(click.ClickException, match="unparseable JSON"):
+        DatabricksSandboxLauncher().provision("label")
+
+
+def test_profile_is_threaded_through_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A configured profile must reach every CLI invocation. A server
+    running under a service-principal profile that leaked a single
+    unprofiled call would silently fall back to the DEFAULT profile —
+    i.e. a different workspace.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("create", _Reply(stdout=json.dumps({"sandboxId": "sb-1"})))
+    launcher = DatabricksSandboxLauncher(profile="sandbox-sp")
+    launcher.provision("label")
+    launcher.run("sb-1", "true")
+    launcher.terminate("sb-1")
+    for call in cli.calls:
+        assert "-p" in call.argv, call.argv
+        assert call.argv[call.argv.index("-p") + 1] == "sandbox-sp"
+
+
+def test_profile_flag_never_crosses_the_ssh_separator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `-p` is a CLI flag, not an ssh flag: it must appear BEFORE `--`.
+    Past the separator the Databricks CLI hands arguments straight to
+    ssh, where `-p` means "port" and would silently redirect the
+    connection.
+    """
+    cli = _install(monkeypatch)
+    DatabricksSandboxLauncher(profile="sandbox-sp").run("sb-1", "echo hi")
+    argv = cli.argvs("ssh")[0]
+    assert argv.index("-p") < argv.index("--")
+
+
+def test_cli_path_override_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit executable path replaces the bare `databricks` name."""
+    cli = _install(monkeypatch)
+    DatabricksSandboxLauncher(cli_path="/opt/databricks/bin/databricks").run("sb-1", "true")
+    assert cli.argvs("ssh")[0][0] == "/opt/databricks/bin/databricks"
+
+
+# ── run ─────────────────────────────────────────────────────
+
+
+def test_run_passes_command_as_one_argument_after_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The remote command must ride as a SINGLE argv element after `--`.
+    Splitting it on whitespace would let the sandbox's login shell see
+    `echo` and `hi` as separate ssh arguments and break every command
+    containing shell syntax.
+    """
+    cli = _install(monkeypatch)
+    DatabricksSandboxLauncher().run("sb-1", "echo hi; exit 0")
+    argv = cli.argvs("ssh")[0]
+    assert argv[:4] == ["databricks", "sandbox", "ssh", "sb-1"]
+    assert _remote_command(argv) == "echo hi; exit 0"
+
+
+def test_run_reports_stdout_and_stderr_separately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Unlike the SDK-backed providers, this transport keeps the two
+    streams apart — the launcher must not merge them into `stdout`.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("ssh", _Reply(stdout="out\n", stderr="err\n"))
+    result = DatabricksSandboxLauncher().run("sb-1", "true")
+    assert result.stdout == "out\n"
+    assert result.stderr == "err\n"
+    assert result.returncode == 0
+
+
+def test_run_raises_on_nonzero_when_checked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A checked failure names the sandbox, the exit code, and the command."""
+    cli = _install(monkeypatch)
+    cli.reply_with("ssh", _Reply(returncode=7, stderr="boom\n"))
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().run("sb-1", "false")
+    assert "sb-1" in str(exc.value)
+    assert "exit 7" in str(exc.value)
+    assert "false" in str(exc.value)
+
+
+def test_run_returns_failure_when_unchecked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`check=False` reports the exit code instead of raising."""
+    cli = _install(monkeypatch)
+    cli.reply_with("ssh", _Reply(returncode=7))
+    result = DatabricksSandboxLauncher().run("sb-1", "false", check=False)
+    assert result.returncode == 7
+
+
+def test_run_raises_install_hint_when_cli_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A missing binary surfacing mid-bootstrap (not just at `prepare`)
+    must still carry the install remediation.
+    """
+
+    def _missing(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Stand in for an absent executable."""
+        raise FileNotFoundError(argv[0])
+
+    monkeypatch.setattr(dbx.subprocess, "run", _missing)
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().run("sb-1", "true")
+    assert str(exc.value) == INSTALL_HINT
+
+
+def test_run_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged SSH session must time out with a named action, not hang."""
+
+    def _hang(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Stand in for a command that never returns."""
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=float(kwargs["timeout"]))
+
+    monkeypatch.setattr(dbx.subprocess, "run", _hang)
+    with pytest.raises(click.ClickException, match="Timed out"):
+        DatabricksSandboxLauncher().run("sb-1", "true")
+
+
+# ── put ─────────────────────────────────────────────────────
+
+
+def test_put_streams_the_file_over_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    File shipping is `cat > <path>` fed from local stdin — verified as
+    the working transport, since the CLI passes stdin through. The
+    remote path must be shell-quoted: it lands in the sandbox's login
+    shell, where an unquoted space or `;` would truncate or inject.
+    """
+    cli = _install(monkeypatch)
+    local = tmp_path / "oa-wheels.tgz"
+    local.write_bytes(b"wheel-bytes")
+    DatabricksSandboxLauncher().put("sb-1", local, "/tmp/dir with space/oa-wheels.tgz")
+    argv = cli.argvs("ssh")[0]
+    assert _remote_command(argv) == "cat > '/tmp/dir with space/oa-wheels.tgz'"
+    # The local file handle — not its bytes, not a path string — is what
+    # the CLI child reads from.
+    stdin = cli.calls[0].stdin
+    assert stdin is not None
+    assert stdin.name == str(local)
+
+
+def test_put_raises_when_local_file_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unreadable local file must name the path, not the CLI."""
+    _install(monkeypatch)
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().put("sb-1", tmp_path / "absent.tgz", "/tmp/x")
+    assert "absent.tgz" in str(exc.value)
+
+
+def test_put_raises_when_transfer_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A non-zero `cat` (e.g. a read-only destination) must fail loud."""
+    cli = _install(monkeypatch)
+    cli.reply_with("ssh", _Reply(returncode=1, stderr="Permission denied"))
+    local = tmp_path / "f.tgz"
+    local.write_bytes(b"x")
+    with pytest.raises(click.ClickException) as exc:
+        DatabricksSandboxLauncher().put("sb-1", local, "/root/f.tgz")
+    assert "Permission denied" in str(exc.value)
+
+
+# ── lifecycle ───────────────────────────────────────────────
+
+
+def test_terminate_passes_auto_approve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `delete` prompts interactively without `--auto-approve`, which would
+    hang a server-side teardown forever. The flag is not optional.
+    """
+    cli = _install(monkeypatch)
+    DatabricksSandboxLauncher().terminate("sb-1")
+    assert cli.argvs("delete") == [["databricks", "sandbox", "delete", "sb-1", "--auto-approve"]]
+
+
+def test_terminate_is_idempotent_for_a_missing_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Deleting an already-gone sandbox is success: the desired end state
+    holds, and managed teardown races another cleanup path routinely.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("delete", _Reply(returncode=1, stderr="sandbox sb-1 not found"))
+    DatabricksSandboxLauncher().terminate("sb-1")
+
+
+def test_terminate_raises_on_other_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A delete that fails for any other reason must NOT be swallowed."""
+    cli = _install(monkeypatch)
+    cli.reply_with("delete", _Reply(returncode=1, stderr="permission denied"))
+    with pytest.raises(click.ClickException, match="permission denied"):
+        DatabricksSandboxLauncher().terminate("sb-1")
+
+
+def test_resume_starts_the_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resume is `start <id>`, which blocks until the microVM is Running."""
+    cli = _install(monkeypatch)
+    DatabricksSandboxLauncher().resume("sb-1")
+    assert cli.argvs("start") == [["databricks", "sandbox", "start", "sb-1"]]
+
+
+def test_attach_starts_a_stopped_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A stopped sandbox retains its disk, so attaching revives it rather
+    than rejecting it — the Daytona posture, not the Modal one.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("status", _Reply(stdout=json.dumps({"status": "Stopped"})))
+    DatabricksSandboxLauncher().attach("sb-1")
+    assert cli.argvs("start") == [["databricks", "sandbox", "start", "sb-1"]]
+
+
+def test_attach_leaves_a_running_sandbox_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An already-running sandbox must not be restarted."""
+    cli = _install(monkeypatch)
+    cli.reply_with("status", _Reply(stdout=json.dumps({"status": "Running"})))
+    DatabricksSandboxLauncher().attach("sb-1")
+    assert cli.argvs("start") == []
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [("Running", True), ("Stopped", False), ("Stopping", False), ("Wedged", None)],
+)
+def test_is_running_maps_control_plane_status(
+    monkeypatch: pytest.MonkeyPatch, status: str, expected: bool | None
+) -> None:
+    """
+    Known states map to True/False; anything unrecognized maps to None
+    so callers keep their existing liveness behavior instead of acting
+    on a guess.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("status", _Reply(stdout=json.dumps({"status": status})))
+    assert DatabricksSandboxLauncher().is_running("sb-1") is expected
+
+
+def test_keep_alive_warns_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Keep-alive is soft-fail per the launcher contract: a rejected policy
+    leaves a usable sandbox that may reap itself, which is worth a
+    warning but not an aborted bootstrap.
+    """
+    cli = _install(monkeypatch)
+    cli.reply_with("config", _Reply(returncode=1, stderr="policy rejected"))
+    DatabricksSandboxLauncher().keep_alive("sb-1")
+
+
+# ── forward_local_port ──────────────────────────────────────
+
+
+class _FakeSshForward:
+    """
+    Stand-in for the ``ssh -v -N -L`` child.
+
+    Emits a scripted ``ssh -v`` transcript on stdout — readiness is read
+    from that transcript, so the fake reproduces the real signal without
+    binding a port or reaching a network.
+
+    :param transcript: Lines the fake ssh prints, in order.
+    :param returncode: Exit status once the transcript is exhausted, or
+        ``None`` to stay alive like a healthy forward.
+    """
+
+    def __init__(self, transcript: list[str], returncode: int | None = None) -> None:
+        self.stdout = io.StringIO("".join(transcript))
+        self._returncode = returncode
+        self.terminated = False
+
+    @property
+    def returncode(self) -> int | None:
+        """Exit status, read by the launcher's error path."""
+        return self._returncode
+
+    def poll(self) -> int | None:
+        """Report the child's exit status, if it has one."""
+        return self._returncode
+
+    def terminate(self) -> None:
+        """Record the teardown signal."""
+        self.terminated = True
+        self._returncode = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Reap the fake child."""
+        del timeout
+        self._returncode = 0 if self._returncode is None else self._returncode
+        return self._returncode
+
+    def kill(self) -> None:
+        """Nothing to kill — the fake never blocks on terminate."""
+
+
+_READY_TRANSCRIPT = [
+    "debug1: Authentication succeeded (publickey).\n",
+    "debug1: Local forwarding listening on 127.0.0.1 port 8022.\n",
+    "debug1: Entering interactive session.\n",
+]
+
+
+def test_forward_pins_both_endpoints_to_ipv4_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Both ends of the `-L` spec must be literal 127.0.0.1, never
+    `localhost`.
+
+    Unpinned, ssh binds the local port on BOTH ::1 and 127.0.0.1 while
+    the sandbox side resolves `localhost` to whichever family it
+    prefers — so a callback server bound only to IPv4 loopback can be
+    missed entirely.
+
+    The argv must also carry no `-o` option: the Databricks CLI
+    re-quotes what it forwards to ssh, and `-o ExitOnForwardFailure=yes`
+    was verified live to produce "Bad configuration option" while the
+    single-token spelling silently dropped `-N`.
+    """
+    _install(monkeypatch)
+    seen: list[list[str]] = []
+
+    def _fake_popen(argv: list[str], **kwargs: Any) -> _FakeSshForward:
+        """Record the argv and hand back a ready forward."""
+        seen.append(argv)
+        return _FakeSshForward(_READY_TRANSCRIPT)
+
+    monkeypatch.setattr(dbx.subprocess, "Popen", _fake_popen)
+    with DatabricksSandboxLauncher().forward_local_port("sb-1", 8022):
+        pass
+    argv = seen[0]
+    assert "-L" in argv
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:8022:127.0.0.1:8022"
+    assert "localhost" not in " ".join(argv)
+    assert "-N" in argv
+    # -v is what produces the readiness line the wait depends on.
+    assert "-v" in argv
+    # No `-o` options: the Databricks CLI re-quotes forwarded arguments
+    # and mangles `-o Key=Value`, which cost a live debugging cycle when
+    # `ExitOnForwardFailure` silently broke `-N`.
+    assert "-o" not in argv
+    assert not any(token.startswith("-o") and len(token) > 2 for token in argv)
+
+
+def test_forward_waits_for_ssh_to_report_listening(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Readiness comes from ssh's own transcript, and NOT from probing the
+    port — both probe styles were observed to fail live.
+
+    A *connect* probe traverses the tunnel and opens a real session
+    against whatever listens in the sandbox; the App OAuth callback
+    server accepts exactly ONE connection, so the probe consumed the very
+    request the caller was waiting for. A *bind* probe races ssh for the
+    port and, about one run in three, won — leaving ssh's own bind to
+    fail and the tunnel dead while the port still looked taken.
+
+    A transcript that never reports listening must therefore time out
+    rather than be declared ready by a probe that touched the port.
+    """
+    _install(monkeypatch)
+    monkeypatch.setattr(dbx, "_FORWARD_BIND_TIMEOUT_S", 0.5)
+    monkeypatch.setattr(dbx, "_FORWARD_POLL_INTERVAL_S", 0.05)
+    silent = ["debug1: Authentication succeeded (publickey).\n"]
+    monkeypatch.setattr(dbx.subprocess, "Popen", lambda argv, **kwargs: _FakeSshForward(silent))
+    with pytest.raises(click.ClickException, match="did not report listening"):
+        with DatabricksSandboxLauncher().forward_local_port("sb-1", 8022):
+            pass
+
+
+def test_forward_fails_fast_when_ssh_cannot_listen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ssh reporting "cannot listen to port" must abort immediately rather
+    than burn the full readiness timeout.
+
+    This is the stand-in for `ExitOnForwardFailure=yes`, which the
+    Databricks CLI cannot pass through intact. Without it, a port
+    collision costs the caller the entire bind timeout before it learns
+    anything.
+    """
+    _install(monkeypatch)
+    # Deliberately generous: a slow path here would mean the failure was
+    # detected by the deadline rather than by the transcript.
+    monkeypatch.setattr(dbx, "_FORWARD_BIND_TIMEOUT_S", 30.0)
+    monkeypatch.setattr(dbx, "_FORWARD_POLL_INTERVAL_S", 0.05)
+    refused = [
+        "debug1: Authentication succeeded (publickey).\n",
+        "bind [127.0.0.1]:8022: Address already in use\n",
+        "channel_setup_fwd_listener_tcpip: cannot listen to port: 8022\n",
+    ]
+    # Still alive — exactly the case ExitOnForwardFailure would have
+    # turned into an exit, and the reason the transcript is watched.
+    monkeypatch.setattr(dbx.subprocess, "Popen", lambda argv, **kwargs: _FakeSshForward(refused))
+    started = time.monotonic()
+    with pytest.raises(click.ClickException, match="could not listen"):
+        with DatabricksSandboxLauncher().forward_local_port("sb-1", 8022):
+            pass
+    assert time.monotonic() - started < 10.0
+
+
+def test_forward_reports_ssh_own_error_when_child_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An ssh that dies before listening for a reason OTHER than a bind
+    failure (bad key, deleted sandbox, gateway refusal) must be reported
+    with ssh's own words and exit code, not as a generic timeout the
+    operator has to wait out.
+
+    Distinct from the bind-failure path above: there the child is still
+    alive and only the transcript reveals the problem; here the child is
+    gone and its exit status is the evidence.
+    """
+    _install(monkeypatch)
+    monkeypatch.setattr(dbx, "_FORWARD_BIND_TIMEOUT_S", 2.0)
+    monkeypatch.setattr(dbx, "_FORWARD_POLL_INTERVAL_S", 0.05)
+    failed = [
+        "debug1: Offering public key: /home/me/.ssh/sandbox_ed25519\n",
+        "ssh: Permission denied (publickey).\n",
+    ]
+    monkeypatch.setattr(
+        dbx.subprocess, "Popen", lambda argv, **kwargs: _FakeSshForward(failed, returncode=255)
+    )
+    with pytest.raises(click.ClickException) as exc:
+        with DatabricksSandboxLauncher().forward_local_port("sb-1", 8022):
+            pass
+    assert "Permission denied" in str(exc.value)
+    assert "exit 255" in str(exc.value)
+
+
+def test_forward_tears_down_the_child_on_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Leaving the block must stop ssh — a leaked forward holds the local
+    port and keeps a billable SSH session open against the sandbox.
+    """
+    _install(monkeypatch)
+    child = _FakeSshForward(_READY_TRANSCRIPT)
+    monkeypatch.setattr(dbx.subprocess, "Popen", lambda argv, **kwargs: child)
+    with DatabricksSandboxLauncher().forward_local_port("sb-1", 8022):
+        pass
+    assert child.terminated is True
+
+
+# ── wheel install ───────────────────────────────────────────
+
+
+def test_wheel_install_command_breaks_system_packages() -> None:
+    """
+    The sandbox image's interpreter is PEP 668 externally-managed, so a
+    plain `pip install` refuses outright. `--force-reinstall` is equally
+    load-bearing: the baked omnigent shares a version with the local
+    build, so pip would otherwise report success and change nothing.
+    """
+    command = DatabricksSandboxLauncher().wheel_install_command("/tmp/oa-wheels.tgz")
+    assert "--break-system-packages" in command
+    assert "--force-reinstall" in command
+    assert "--no-deps" in command
+    assert "/tmp/oa-wheels.tgz" in command
+
+
+def test_wheel_install_command_quotes_the_tarball_path() -> None:
+    """The tarball path is interpolated into a shell command; quote it."""
+    command = DatabricksSandboxLauncher().wheel_install_command("/tmp/a b.tgz")
+    assert "'/tmp/a b.tgz'" in command

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -68,6 +68,7 @@ def test_plugin_state_loads_builtins() -> None:
     assert isinstance(state, SandboxProviderPluginState)
     assert "modal" in state
     assert "blaxel" in state
+    assert "databricks" in state
     assert "kubernetes" in state
 
 
@@ -94,6 +95,7 @@ def test_available_providers_returns_builtins() -> None:
     names = available_providers()
     assert "modal" in names
     assert "blaxel" in names
+    assert "databricks" in names
     assert "kubernetes" in names
 
 
@@ -124,6 +126,13 @@ def test_instantiate_loads_blaxel_without_optional_sdk() -> None:
     reset_plugin_state_for_tests()
     launcher = instantiate("blaxel")
     assert launcher.provider == "blaxel"
+
+
+def test_instantiate_loads_databricks_without_optional_sdk() -> None:
+    """The Databricks launcher uses only the public CLI and core dependencies."""
+    reset_plugin_state_for_tests()
+    launcher = instantiate("databricks")
+    assert launcher.provider == "databricks"
 
 
 def test_instantiate_unknown_raises() -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -26,6 +26,7 @@ from omnigent.onboarding.sandboxes.base import (
     render_host_config_write_command,
 )
 from omnigent.onboarding.sandboxes.blaxel import managed_token_ttl_s as blaxel_managed_token_ttl_s
+from omnigent.onboarding.sandboxes.databricks_sandbox import DatabricksSandboxLauncher
 from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
 from omnigent.onboarding.sandboxes.registry import (
     COMMUNITY_MODULE_PREFIX,
@@ -37,6 +38,7 @@ from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.managed_hosts import (
     BOXLITE_MANAGED_TOKEN_TTL_S,
+    DATABRICKS_MANAGED_TOKEN_TTL_S,
     DAYTONA_MANAGED_TOKEN_TTL_S,
     ISLO_MANAGED_TOKEN_TTL_S,
     KUBERNETES_MANAGED_TOKEN_TTL_S,
@@ -278,6 +280,60 @@ def test_parse_daytona_without_section_defaults(
     assert cfg.launcher_factory() is fake
     assert fake.image is None
     assert fake.env is None
+
+
+def test_parse_valid_databricks_config_builds_parameterized_factory() -> None:
+    """Databricks YAML settings reach the public-CLI launcher unchanged."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "databricks",
+            "server_url": "https://srv.example.com/",
+            "databricks": {
+                "cli_path": "/opt/databricks/bin/databricks",
+                "profile": "sandbox-sp",
+                "idle_timeout": "4h",
+                "no_autostop": False,
+            },
+        }
+    )
+    assert cfg is not None
+    cfg = cfg.default
+    assert cfg.server_url == "https://srv.example.com"
+    assert cfg.token_ttl_s == DATABRICKS_MANAGED_TOKEN_TTL_S
+    assert cfg.managed_launch_supported is True
+    assert cfg.provider == "databricks"
+
+    launcher = cfg.launcher_factory()
+    assert isinstance(launcher, DatabricksSandboxLauncher)
+    assert launcher.provider == "databricks"
+    assert launcher._cli_path == "/opt/databricks/bin/databricks"
+    assert launcher._profile == "sandbox-sp"
+    assert launcher._idle_timeout == "4h"
+    assert launcher._no_autostop is False
+
+
+def test_parse_databricks_without_section_uses_launcher_defaults() -> None:
+    """Provider plus server URL is a complete Databricks configuration."""
+    cfg = parse_sandbox_config({"provider": "databricks", "server_url": "https://srv.example.com"})
+    assert cfg is not None
+    launcher = cfg.default.launcher_factory()
+    assert isinstance(launcher, DatabricksSandboxLauncher)
+    assert launcher._cli_path == "databricks"
+    assert launcher._profile is None
+    assert launcher._idle_timeout is None
+    assert launcher._no_autostop is True
+
+
+def test_parse_databricks_rejects_unknown_settings() -> None:
+    """Typos in the provider block fail instead of being silently ignored."""
+    with pytest.raises(ValueError, match="unknown key"):
+        parse_sandbox_config(
+            {
+                "provider": "databricks",
+                "server_url": "https://srv.example.com",
+                "databricks": {"workspace": "wrong-layer"},
+            }
+        )
 
 
 def test_parse_valid_blaxel_config_builds_parameterized_factory(


### PR DESCRIPTION
## Related issue

Closes #4427

## Summary

Databricks Sandbox is public, but OSS Omnigent still has no usable managed-host provider for it. This adds a `databricks` provider backed only by the public `databricks sandbox` CLI; the internal-only `lakebox` provider remains unchanged.

**ELI5:** Omnigent can now ask the Databricks CLI to create a sandbox, start its host, reconnect after an idle stop, and delete it when finished.

```mermaid
flowchart LR
    O[Omnigent server] -->|public CLI| D[databricks sandbox]
    D --> S[Sandbox]
    S -->|managed host tunnel| O
```

The launcher supports lifecycle operations, SSH command/file transport, persistent resume, and local port forwarding. Server YAML accepts `cli_path`, `profile`, `idle_timeout`, and `no_autostop` under `sandbox.databricks`.

## Test Plan

- `uv run pytest tests/onboarding/sandboxes/test_registry.py tests/onboarding/sandboxes/test_databricks_sandbox.py tests/server/test_managed_hosts.py -q` → 310 passed.
- `uv run pytest tests/onboarding/sandboxes/test_databricks_sandbox.py tests/onboarding/sandboxes tests/server/test_managed_hosts.py -q` → 729 passed before the additional registry/config tests were added.
- Ruff format/check and Pyrefly pre-commit hooks passed.
- Against Databricks CLI v1.13.0, confirmed `list`/`status` JSON includes `sandboxId` and `status`, `status <id> -o json -p DEFAULT` accepts the launcher's profile placement, and `ssh <id> -p DEFAULT -- <command>` executes the command.
- The full repository pre-commit run reached all hooks; web and VS Code type checks could not resolve existing JavaScript dependencies in this worktree. No UI or VS Code files are changed.

## Demo

![Databricks Sandbox provider configuration and managed-host lifecycle commands](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-4434-review-evidence.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover provider discovery, YAML parsing, lifecycle calls, JSON failures, profile placement, SSH transport, file copy, resume, keep-alive, port-forward readiness/cleanup, and wheel installation. Manual verification checks the exact public CLI argv and JSON contracts that mocked subprocesses cannot prove.

## Changelog

Run managed hosts on Databricks Sandbox through the public Databricks CLI

