### PR TITLE
fix(runner): stop warning "sub-agent did not resolve" on healthy child sessions

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5189,7 +5189,10 @@ def create_runner_app(
                     )
 
         _sa_name = await _recover_sub_agent_name(conv)
-        if _sa_name and cached_spec is not None:
+        # The spec in hand may already BE the child: POST /v1/sessions and
+        # earlier turns cache the swapped sub-spec. Searching that for its own
+        # name always misses, which warned "did not resolve" on every turn.
+        if _sa_name and cached_spec is not None and cached_spec.name != _sa_name:
             from omnigent.runtime.workflow import _find_spec_by_name
 
             sub_spec = _find_spec_by_name(cached_spec, _sa_name)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5189,10 +5189,7 @@ def create_runner_app(
                     )
 
         _sa_name = await _recover_sub_agent_name(conv)
-        # The spec in hand may already BE the child: POST /v1/sessions and
-        # earlier turns cache the swapped sub-spec. Searching that for its own
-        # name always misses, which warned "did not resolve" on every turn.
-        if _sa_name and cached_spec is not None and cached_spec.name != _sa_name:
+        if _sa_name and cached_spec is not None:
             from omnigent.runtime.workflow import _find_spec_by_name
 
             sub_spec = _find_spec_by_name(cached_spec, _sa_name)
@@ -5203,7 +5200,10 @@ def create_runner_app(
                     if cached_spec_workdir is not None
                     else cached_spec
                 )
-            else:
+            elif cached_spec.name != _sa_name:
+                # A miss on a spec already named for the sub-agent means the
+                # cache holds the CHILD (POST /v1/sessions and earlier turns
+                # store the swapped sub-spec), not a parent fallback.
                 _warn_unresolved_sub_agent(conv, _sa_name)
 
         cached_spec = _spec_with_workdir_paths(cached_spec, cached_spec_workdir)

--- a/tests/runner/test_subagent_spec_swap_warning.py
+++ b/tests/runner/test_subagent_spec_swap_warning.py
@@ -1,0 +1,222 @@
+"""Regression: the turn path must not re-swap an already-swapped child spec.
+
+Field symptom (polly dispatching a sub-agent): every turn of a healthy child
+session logged
+
+    Sub-agent '<name>' for session <id> did not resolve in the parent spec;
+    falling back to the parent spec (child runs with the parent's prompt,
+    tools and harness).
+
+even though the sub-agent is declared in the bundle. The warning is a false
+positive. Whatever primes ``_session_spec_cache`` first — ``POST
+/v1/sessions``, ``_resolve_session_spec_entry`` behind a resource read, or an
+earlier turn — resolves the PARENT tree, swaps to the named sub-spec, and
+caches the CHILD. The turn path then reads that cached spec and searches it
+*again* for the sub-agent name; ``_find_spec_by_name`` only walks
+``spec.sub_agents``, and the child has no child of its own, so the lookup
+always misses and the warning fires on a session that resolved perfectly.
+
+The warning matters because it names a real, silent failure mode (a child
+booting as a clone of an orchestrator parent), so firing it on healthy
+sessions makes the genuine case unreadable. The fix skips the swap when the
+spec in hand is already the child (its ``name`` is the sub-agent name) and
+keeps warning when a sub-agent name genuinely does not resolve.
+
+The reported bundle was polly's ``pi`` worker; the defect is in the spec-swap
+gate and is independent of the child's harness, so these tests use the
+``claude_code`` / ``claude-native`` child that the rest of the runner suite
+already exercises hermetically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from omnigent.runner import create_runner_app
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+from tests.runner.conftest import (
+    _FakeProcessManager,
+    _runner_client,
+    _ScriptedHarnessClient,
+    _sse,
+)
+from tests.runner.helpers import NullServerClient
+
+PARENT_AGENT_ID = "ag_polly"
+CHILD_SESSION_ID = "conv_child_worker"
+SUB_AGENT_NAME = "claude_code"
+CHILD_HARNESS = "claude-native"
+UNRESOLVABLE_SUB_AGENT_NAME = "renamed_worker"
+_WARNING_FRAGMENT = "did not resolve in the parent spec"
+
+
+def _orchestrator_spec_tree() -> AgentSpec:
+    """Parent orchestrator (``claude-sdk``) with one declared sub-agent."""
+    child = AgentSpec(
+        spec_version=1,
+        name=SUB_AGENT_NAME,
+        executor=ExecutorSpec(type="omnigent", config={"harness": CHILD_HARNESS}),
+    )
+    return AgentSpec(
+        spec_version=1,
+        name="polly",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+        sub_agents=[child],
+    )
+
+
+async def _parent_spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+    """Resolve any agent_id to the parent tree, as the live server does."""
+    del agent_id, session_id
+    return _orchestrator_spec_tree()
+
+
+class _SubAgentSnapshotServer(NullServerClient):
+    """Server client whose session GET carries ``sub_agent_name``.
+
+    :param sub_agent_name: The name the snapshot reports for the child
+        session, e.g. ``"claude_code"``.
+    """
+
+    def __init__(self, sub_agent_name: str) -> None:
+        self._sub_agent_name = sub_agent_name
+
+    class _Resp:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self.status_code = 200
+            self._payload = payload
+            self.text = json.dumps(payload)
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        del kwargs
+        u = url.rstrip("/")
+        if u.endswith(CHILD_SESSION_ID):
+            return self._Resp(
+                {
+                    "agent_id": PARENT_AGENT_ID,
+                    "sub_agent_name": self._sub_agent_name,
+                    "parent_session_id": "conv_parent_polly",
+                    "created_at": 0,
+                    "workspace": None,
+                }
+            )
+        if u.endswith("/items"):
+            return self._Resp({"data": [], "has_more": False})
+        return super()._Response()
+
+
+async def _prime_spec_cache_then_turn(
+    sub_agent_name: str,
+    caplog: pytest.LogCaptureFixture,
+) -> tuple[_FakeProcessManager, list[logging.LogRecord]]:
+    """Prime the session spec cache, then run one turn; return the turn's logs.
+
+    The resource read stands in for every path that populates
+    ``_session_spec_cache`` before the first turn (the live sequence is ``POST
+    /v1/sessions``; the web UI's resource panels hit this one). The log
+    capture is cleared between the phases so the assertions only see what the
+    TURN logged — priming legitimately warns for an unresolvable name, and
+    that warning is not what this module is about.
+
+    :param sub_agent_name: The name the server snapshot reports.
+    :param caplog: pytest log capture, cleared between the phases.
+    :returns: ``(process_manager, records_logged_during_the_turn)``.
+    """
+    pm = _FakeProcessManager(
+        _ScriptedHarnessClient(
+            [
+                _sse({"type": "response.created", "response": {"id": "r1"}}),
+                _sse({"type": "response.completed", "response": {"id": "r1"}}),
+            ]
+        )
+    )
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_parent_spec_resolver,
+        server_client=_SubAgentSnapshotServer(sub_agent_name),  # type: ignore[arg-type]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
+        async with _runner_client(app) as client:
+            primed = await client.get(f"/v1/sessions/{CHILD_SESSION_ID}/resources")
+            assert primed.status_code == 200, f"{primed.status_code} {primed.text}"
+
+            # Everything above is setup; only the turn is under test.
+            caplog.clear()
+
+            turn = await client.post(
+                f"/v1/sessions/{CHILD_SESSION_ID}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": PARENT_AGENT_ID,
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            )
+            assert turn.status_code == 202, f"{turn.status_code} {turn.text}"
+
+            for _ in range(300):
+                if pm.get_client_calls:
+                    break
+                await asyncio.sleep(0.01)
+
+        records = list(caplog.records)
+
+    return pm, records
+
+
+@pytest.mark.asyncio
+async def test_declared_sub_agent_turn_does_not_warn_about_resolution(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A turn for a DECLARED sub-agent must log no "did not resolve" warning.
+
+    The spec cache already holds the swapped child spec, so the turn must
+    recognise it instead of re-searching it for its own name and warning.
+    """
+    pm, records = await _prime_spec_cache_then_turn(SUB_AGENT_NAME, caplog)
+
+    spurious = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
+    assert not spurious, (
+        "turn for a declared sub-agent logged the unresolved-sub-agent "
+        f"warning: {[r.getMessage() for r in spurious]!r}. The cached spec is "
+        "already the child; searching it for its own name always misses."
+    )
+
+    harnesses = [h for (conv, h, _env) in pm.get_client_calls if conv == CHILD_SESSION_ID]
+    assert harnesses, "the turn never asked the process manager for a harness"
+    assert all(h == CHILD_HARNESS for h in harnesses), (
+        f"turn spawned {harnesses!r} for the sub-agent session; expected only "
+        f"{CHILD_HARNESS!r} (the child's own harness)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_sub_agent_turn_still_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A name absent from the tree must still warn — that case is real.
+
+    Guards the fix against over-reach: when the cached spec is the PARENT
+    (the swap missed while priming too), the turn must keep surfacing the
+    fallback that silently boots the child as a parent clone.
+    """
+    _pm, records = await _prime_spec_cache_then_turn(UNRESOLVABLE_SUB_AGENT_NAME, caplog)
+
+    warned = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
+    assert warned, (
+        "a sub-agent name absent from the parent tree produced no "
+        "unresolved-sub-agent warning; the child silently boots with the "
+        "parent's prompt, tools and harness."
+    )

--- a/tests/runner/test_subagent_spec_swap_warning.py
+++ b/tests/runner/test_subagent_spec_swap_warning.py
@@ -1,4 +1,4 @@
-"""Regression: the turn path must not re-swap an already-swapped child spec.
+"""Regression: a sub-agent turn must not warn when it already holds the child.
 
 Field symptom (polly dispatching a sub-agent): every turn of a healthy child
 session logged
@@ -18,11 +18,19 @@ always misses and the warning fires on a session that resolved perfectly.
 
 The warning matters because it names a real, silent failure mode (a child
 booting as a clone of an orchestrator parent), so firing it on healthy
-sessions makes the genuine case unreadable. The fix skips the swap when the
-spec in hand is already the child (its ``name`` is the sub-agent name) and
-keeps warning when a sub-agent name genuinely does not resolve.
+sessions makes the genuine case unreadable. The turn path therefore still
+looks the sub-agent up unconditionally and still swaps whenever it resolves;
+only the warning is gated, suppressed on a miss where the spec in hand
+already carries the sub-agent's name.
 
-The reported bundle was polly's ``pi`` worker; the defect is in the spec-swap
+Gating the LOOKUP on that same name check would be wrong, which is what the
+third test pins. A root may legally share its sub-agent's name — the
+uniqueness check never compares the root's own name — and
+``_find_spec_by_name`` still resolves the child there, so skipping the lookup
+drops a swap that would have succeeded and boots the child as a parent clone
+with no warning at all.
+
+The reported bundle was polly's ``pi`` worker; the defect is in the warning
 gate and is independent of the child's harness, so these tests use the
 ``claude_code`` / ``claude-native`` child that the rest of the runner suite
 already exercises hermetically.
@@ -188,8 +196,9 @@ async def test_declared_sub_agent_turn_does_not_warn_about_resolution(
 ) -> None:
     """A turn for a DECLARED sub-agent must log no "did not resolve" warning.
 
-    The spec cache already holds the swapped child spec, so the turn must
-    recognise it instead of re-searching it for its own name and warning.
+    The spec cache already holds the swapped child spec, so the turn's lookup
+    finds nothing to swap — a miss that means the child is in hand, not that
+    anything fell back to the parent.
     """
     pm, records = await _prime_spec_cache_then_turn(SUB_AGENT_NAME, caplog)
 

--- a/tests/runner/test_subagent_spec_swap_warning.py
+++ b/tests/runner/test_subagent_spec_swap_warning.py
@@ -54,6 +54,12 @@ CHILD_HARNESS = "claude-native"
 UNRESOLVABLE_SUB_AGENT_NAME = "renamed_worker"
 _WARNING_FRAGMENT = "did not resolve in the parent spec"
 
+# A root may legally carry its own sub-agent's name: the uniqueness check
+# (``_check_unique_sub_agent_names``) seeds its ``seen`` set empty and only
+# walks ``spec.sub_agents``, so the root's name is never compared.
+SHADOWED_NAME = "pi"
+SHADOWED_SESSION_ID = "conv_child_shadowed"
+
 
 def _orchestrator_spec_tree() -> AgentSpec:
     """Parent orchestrator (``claude-sdk``) with one declared sub-agent."""
@@ -219,4 +225,121 @@ async def test_unresolvable_sub_agent_turn_still_warns(
         "a sub-agent name absent from the parent tree produced no "
         "unresolved-sub-agent warning; the child silently boots with the "
         "parent's prompt, tools and harness."
+    )
+
+
+def _shadowed_name_spec_tree() -> AgentSpec:
+    """A parent whose OWN name equals its sub-agent's name.
+
+    Legal today: ``_check_unique_sub_agent_names`` never adds the root's name
+    to the ``seen`` set, so this tree validates clean. ``_find_spec_by_name``
+    searches ``spec.sub_agents`` only, so it still resolves the CHILD here —
+    the swap must happen, and any name-equality shortcut would skip it.
+    """
+    child = AgentSpec(
+        spec_version=1,
+        name=SHADOWED_NAME,
+        executor=ExecutorSpec(type="omnigent", config={"harness": CHILD_HARNESS}),
+    )
+    return AgentSpec(
+        spec_version=1,
+        name=SHADOWED_NAME,
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+        sub_agents=[child],
+    )
+
+
+async def _shadowed_spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+    """Resolve any agent_id to the name-shadowing parent tree."""
+    del agent_id, session_id
+    return _shadowed_name_spec_tree()
+
+
+class _ShadowedSnapshotServer(_SubAgentSnapshotServer):
+    """Snapshot server for the name-shadowing session id."""
+
+    def __init__(self) -> None:
+        super().__init__(SHADOWED_NAME)
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        del kwargs
+        u = url.rstrip("/")
+        if u.endswith(SHADOWED_SESSION_ID):
+            return self._Resp(
+                {
+                    "agent_id": PARENT_AGENT_ID,
+                    "sub_agent_name": SHADOWED_NAME,
+                    "parent_session_id": "conv_parent_polly",
+                    "created_at": 0,
+                    "workspace": None,
+                }
+            )
+        if u.endswith("/items"):
+            return self._Resp({"data": [], "has_more": False})
+        return super(_SubAgentSnapshotServer, self)._Response()
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_sharing_the_parent_name_still_swaps_to_the_child(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parent named after its own sub-agent must still hand over the CHILD.
+
+    Guards the quiet-the-warning fix against a shortcut that skips the swap
+    whenever the spec in hand is *named* for the sub-agent: in this legal
+    tree the spec in hand is the PARENT and the swap is still required.
+    Skipping it boots the child with the parent's prompt, tools and harness —
+    the exact silent parent-clone the warning exists to catch, and the child
+    of a coordinator parent then re-dispatches into itself.
+
+    No priming here on purpose: the turn must resolve the parent tree fresh
+    from the bound ``agent_id`` (the state where the spec in hand really is
+    the parent), which is what makes the missing swap observable.
+    """
+    pm = _FakeProcessManager(
+        _ScriptedHarnessClient(
+            [
+                _sse({"type": "response.created", "response": {"id": "r1"}}),
+                _sse({"type": "response.completed", "response": {"id": "r1"}}),
+            ]
+        )
+    )
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_shadowed_spec_resolver,
+        server_client=_ShadowedSnapshotServer(),  # type: ignore[arg-type]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
+        async with _runner_client(app) as client:
+            turn = await client.post(
+                f"/v1/sessions/{SHADOWED_SESSION_ID}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": PARENT_AGENT_ID,
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            )
+            assert turn.status_code == 202, f"{turn.status_code} {turn.text}"
+
+            for _ in range(300):
+                if pm.get_client_calls:
+                    break
+                await asyncio.sleep(0.01)
+
+        records = list(caplog.records)
+
+    harnesses = [h for (conv, h, _env) in pm.get_client_calls if conv == SHADOWED_SESSION_ID]
+    assert harnesses, "the turn never asked the process manager for a harness"
+    assert all(h == CHILD_HARNESS for h in harnesses), (
+        f"turn spawned {harnesses!r} for a sub-agent whose parent shares its "
+        f"name; expected only {CHILD_HARNESS!r}. A 'claude-sdk' spawn means the "
+        "swap was skipped and the child is running as a clone of its parent."
+    )
+
+    spurious = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
+    assert not spurious, (
+        "the name-shadowing tree resolves its sub-agent fine, yet the turn "
+        f"logged: {[r.getMessage() for r in spurious]!r}"
     )


### PR DESCRIPTION
## Related issue

Closes #4430

## Summary

#4430 reported two symptoms when polly dispatched its `pi` sub-agent. They are independent, and only the first is a repo defect.

**Symptom 1 — "did not resolve in the parent spec" (fixed here).** A false positive. The sub-agent spec swap in `_run_turn_bg_setup_and_stream` looks the sub-agent name up in the session's *cached* spec, but by the time a turn runs the cache already holds the **swapped child** spec — `POST /v1/sessions` caches it (`app.py:2723`), as does `_resolve_session_spec_entry` behind any resource read, as does the previous turn. `_find_spec_by_name` only walks `spec.sub_agents`, and the child has no child of its own, so the lookup always misses and the warning fires on a session that resolved perfectly.

This matters because the warning names a real silent failure — a child booting as a clone of an orchestrator parent, which for polly means a worker that inherits "delegate everything to your sub-agents" and has none. Firing it on every healthy child turn buried the genuine case.

```
POST /v1/sessions ─► resolve PARENT (polly) ─► swap to child 'pi' ─► cache CHILD
                                                                       │
turn ──────────────────────────────────────────────────────────────────┘
      cached spec is already 'pi'
        _find_spec_by_name(pi_child, "pi") → None
        before: → warn "did not resolve" (bogus: nothing fell back)
        after:  → spec in hand is already named 'pi', so no fallback happened → quiet
```

The change **gates the warning, not the swap**. The lookup still runs unconditionally and still swaps whenever it resolves, so swap behaviour is identical to before in every tree; the only difference is that a miss stays quiet when the spec in hand already carries the sub-agent's name. The whole production diff against the base commit is one condition plus its comment:

```diff
-            else:
+            elif cached_spec.name != _sa_name:
+                # A miss on a spec already named for the sub-agent means the
+                # cache holds the CHILD (POST /v1/sessions and earlier turns
+                # store the swapped sub-spec), not a parent fallback.
                 _warn_unresolved_sub_agent(conv, _sa_name)
```

That distinction is load-bearing. An earlier revision of this PR instead skipped the *lookup* when the names matched, which is wrong: a parent may legally share its sub-agent's name. `_check_unique_sub_agent_names` (`omnigent/spec/validator.py:593`) seeds `seen` empty and `_collect_sub_agent_names` walks only `spec.sub_agents`, so the root's own name is never compared — `AgentSpec(name="pi", sub_agents=[AgentSpec(name="pi", ...)])` validates with zero errors, and `_find_spec_by_name` still resolves the child. Skipping the lookup there dropped a swap that would have succeeded, booting the child with the parent's prompt/tools/harness *and* suppressing the warning about it. Thanks to the cross-review that caught it; the regression test below pins it.

**Symptom 2 — `harness 'pi' ... exited with 2 during spawn` (not a repo defect; no code change).** The runner log carries the child's own stderr right above the traceback:

```
runner: cannot import harness module 'omnigent.inner.pi_harness': cannot import name
'DatabricksPiSurface' from 'omnigent.pi_model_compatibility'
(/Users/<user>/.local/share/uv/tools/omnigent/lib/python3.14/site-packages/omnigent/pi_model_compatibility.py)
```

`_runner.py` exits 2 exactly when the harness module fails to import. The path is the reporter's **installed** uv-tool copy, not a checkout, and `DatabricksPiSurface` **is** defined (line 21 of `pi_model_compatibility.py`) at the commit the report names, `7ab46cf4` — that module and its consumer landed together in #3572. So the failing install had an old `pi_model_compatibility.py` beside a newer `pi_native_credentials.py`: install skew, not a source defect. Re-verified after the reporter's install was refreshed — `python -c "import omnigent.inner.pi_harness"` against that same interpreter now exits 0. The same log also shows the harness that followed was still `pi`, i.e. the swap had already succeeded — so symptom 1 did not cause symptom 2.

### Follow-up worth a maintainer's call (deliberately NOT in this PR)

Should `_check_unique_sub_agent_names` seed `seen` with the root's own name? A root/child name collision is legal today and resolves deterministically (`_find_spec_by_name` searches only `spec.sub_agents`, so the child always wins), so it is not currently ambiguous — but it is a trap for any code that reasons about spec names, as the earlier revision of this PR demonstrates. Tightening the validator would reject bundles that validate today, so it belongs in its own PR with its own compatibility discussion rather than bundled here.

### Known limitation

The warning is suppressed on a miss whenever the spec in hand is named for the sub-agent. In the doubly-degenerate tree where a parent shares the sub-agent's name **and** that sub-agent has since been removed from the bundle, a genuine parent-fallback would go unwarned. Distinguishing that from "the cache holds the child" needs swap provenance the turn path does not carry. This is warning-only — no swap behaviour changes — and strictly narrower than the every-turn false positive it replaces.

## Test Plan

- **New regression module**, `tests/runner/test_subagent_spec_swap_warning.py` (3 cases). Verified against three versions of the guard, so every case is load-bearing:

  | test | pre-fix `main` | rejected `name != sub_name` shortcut | this PR |
  |---|---|---|---|
  | `test_declared_sub_agent_turn_does_not_warn_about_resolution` | **FAIL** | pass | pass |
  | `test_unresolvable_sub_agent_turn_still_warns` (negative control) | pass | pass | pass |
  | `test_sub_agent_sharing_the_parent_name_still_swaps_to_the_child` | pass | **FAIL** | pass |

  The third case drives a turn with an unprimed spec cache (so the spec in hand really is the parent) against a root/child name collision, and asserts the child's own harness is spawned with no warning. Against the rejected shortcut it fails with `turn spawned ['claude-sdk'] ... expected only 'claude-native'`.
  - `pytest tests/runner/test_subagent_spec_swap_warning.py -q -p no:randomly` → **3 passed**
- **Required neighbouring suites:** `pytest tests/runner/test_subagent_spec_swap_warning.py tests/runner/test_native_subagent_harness_resolution.py tests/runner/test_native_subagent_inbox_delivery.py -q -p no:randomly` → **14 passed**.
- **Full runner suite on the final code:** `pytest tests/runner -q -p no:randomly` → **1432 passed, 16 failed** (1 skipped, 4 xfailed). All 16 reproduce identically on the base commit with this change stashed — `diff` of the two FAILED lists is empty. They are local-environment model-catalog resolutions for `codex-native` / `openai-agents` / `pi`, untouched by this PR.
- **Root/child name collision is legal** — confirmed directly rather than assumed: `validate(AgentSpec(name="pi", sub_agents=[AgentSpec(name="pi", ...)])).errors` → `[]`, and `_find_spec_by_name(parent, "pi") is child` → `True`.
- **Symptom 2 evidence:** read the reporter's `~/.omnigent/logs/runner/runner-*.log` for the stderr line above; checked `git show 7ab46cf4:omnigent/pi_model_compatibility.py` for the symbol; re-ran the import against the installed interpreter from a neutral cwd (exit 0).
- **Gates:** `pre-commit run --files omnigent/runner/app.py tests/runner/test_subagent_spec_swap_warning.py` → `ruff format`, `ruff check`, and every applicable file hook pass. `pyrefly` fails with 81 errors, byte-identical on the base commit with this change stashed (a stale `omnigent_client` in the local venv: `omnigent/chat.py`, `omnigent/repl/_repl.py` — neither touched here). The `web-*` hooks fail only because this worktree has no `node_modules`; this PR contains no JS/TS.

## Demo

N/A — runner-side logging behaviour, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The automated coverage is the new regression module, verified case-by-case against the pre-fix code and against the rejected intermediate guard (table above). "Manual verification" refers to symptom 2 only, which has no code change to cover: it was diagnosed from the reporter's runner log, the symbol's presence at the reported commit, and a direct re-import against the installed interpreter — all listed in the Test Plan.

## Changelog

A sub-agent session no longer logs a spurious "did not resolve in the parent spec" warning on every turn.
