### PR TITLE
fix(terminals): bound the terminal output pipeline against TUI floods

### DIFF
--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -53,11 +53,14 @@ from omnigent.runner.transports.ws_tunnel.frames import (
 
 _logger = logging.getLogger(__name__)
 
-# Cap on frames queued for a runner's sender task. Protocol frames are never
-# dropped or coalesced — a lost frame strands its RPC silently — so past the
-# cap ``send_text`` fails loudly with ConnectionError instead: a backlog this
-# deep means the tunnel socket has stopped draining.
+# Cap on frames queued for a runner's sender task (a count cap: individual
+# frames stay small because request/response bodies cross the tunnel as
+# chunked body frames). Protocol frames are never dropped or coalesced — a
+# lost frame strands its RPC silently — so a full queue makes ``send_text``
+# WAIT for the sender to drain, and only a sender that frees no room within
+# the stall deadline fails the send loudly with ConnectionError.
 _OUTBOUND_QUEUE_MAX_FRAMES = 1024
+_OUTBOUND_SEND_STALL_S = 10.0
 
 
 class WebSocketLike(Protocol):
@@ -700,39 +703,49 @@ class TunnelRegistry:
         :returns: None after the frame has been accepted into the
             route-loop outbound queue.
         :raises ConnectionError: If ``session`` is no longer the
-            registry's current generation for its runner id.
+            registry's current generation for its runner id, or its
+            sender freed no queue room within the stall deadline.
         """
         ack: concurrent.futures.Future[None] = concurrent.futures.Future()
 
-        def _enqueue() -> None:
-            """Run on ``session.loop`` and enqueue the outbound frame."""
-            error: ConnectionError | None = None
+        async def _enqueue() -> None:
+            """Run on ``session.loop``: bounded-wait enqueue of the frame."""
             with self._lock:
-                if self._sessions.get(session.runner_id) is not session:
-                    error = ConnectionError(f"runner {session.runner_id!r} tunnel was replaced")
-                else:
-                    try:
-                        session.outbound_queue.put_nowait(data)
-                    except asyncio.QueueFull:
-                        # The sender task has stopped draining the socket.
-                        # Frames must not be dropped silently (a lost frame
-                        # strands its RPC), so fail the send loudly.
-                        _logger.warning(
-                            "runner %s outbound queue saturated at %d frames; failing send",
-                            session.runner_id,
-                            session.outbound_queue.maxsize,
-                        )
-                        error = ConnectionError(
-                            f"runner {session.runner_id!r} outbound tunnel queue is full"
-                        )
-            if error is not None:
+                stale = self._sessions.get(session.runner_id) is not session
+            if stale:
                 if not ack.done():
-                    ack.set_exception(error)
-            else:
+                    ack.set_exception(
+                        ConnectionError(f"runner {session.runner_id!r} tunnel was replaced")
+                    )
+                return
+            try:
+                # A full queue is backpressure, not failure: a burst can fill
+                # it faster than the sender wakes, so wait for drain and only
+                # treat a sender that frees no room in the deadline as stalled.
+                await asyncio.wait_for(
+                    session.outbound_queue.put(data), timeout=_OUTBOUND_SEND_STALL_S
+                )
+            except TimeoutError:
+                _logger.warning(
+                    "runner %s outbound queue freed no room in %.0fs (%d frames); failing send",
+                    session.runner_id,
+                    _OUTBOUND_SEND_STALL_S,
+                    session.outbound_queue.qsize(),
+                )
                 if not ack.done():
-                    ack.set_result(None)
+                    ack.set_exception(
+                        ConnectionError(f"runner {session.runner_id!r} outbound tunnel stalled")
+                    )
+                return
+            if not ack.done():
+                ack.set_result(None)
 
-        _call_session_soon_threadsafe(session, _enqueue)
+        def _start_enqueue() -> None:
+            """Run on the owner loop; task-ify the bounded-wait put."""
+            task = asyncio.get_running_loop().create_task(_enqueue())
+            task.add_done_callback(_discard_task_exception)
+
+        _call_session_soon_threadsafe(session, _start_enqueue)
         await asyncio.wrap_future(ack)
 
     # ── Routing incoming frames ──────────────────────────

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -61,6 +61,11 @@ _logger = logging.getLogger(__name__)
 # the stall deadline fails the send loudly with ConnectionError.
 _OUTBOUND_QUEUE_MAX_FRAMES = 1024
 _OUTBOUND_SEND_STALL_S = 10.0
+# Drain-poll interval while a send waits out a full queue. Polling (instead of
+# parking in ``Queue.put``) keeps the stale-check + enqueue atomic under the
+# registry lock and lets a session replacement release waiting senders within
+# one interval instead of the full stall deadline.
+_OUTBOUND_SEND_POLL_S = 0.05
 
 
 class WebSocketLike(Protocol):
@@ -727,39 +732,46 @@ class TunnelRegistry:
         async def _enqueue() -> None:
             """Run on ``session.loop``: bounded-wait enqueue of the frame."""
             try:
-                if _stale():
-                    _resolve(_replaced_error())
-                    return
-                try:
+                deadline = time.monotonic() + _OUTBOUND_SEND_STALL_S
+                while True:
+                    # Stale-check + enqueue in one locked step: ``register``
+                    # swaps sessions under the same lock, so a frame can never
+                    # land in a queue that was already retired (whose sender
+                    # may still transmit on the dying connection).
+                    with self._lock:
+                        if self._sessions.get(session.runner_id) is not session:
+                            _resolve(_replaced_error())
+                            return
+                        try:
+                            session.outbound_queue.put_nowait(data)
+                        except asyncio.QueueFull:
+                            pass
+                        else:
+                            _resolve(None)
+                            return
                     # A full queue is backpressure, not failure: a burst can
-                    # fill it faster than the sender wakes, so wait for drain
-                    # and only treat no room freed in the deadline as failure.
-                    await asyncio.wait_for(
-                        session.outbound_queue.put(data), timeout=_OUTBOUND_SEND_STALL_S
-                    )
-                except TimeoutError:
-                    if _stale():
-                        _resolve(_replaced_error())
-                        return
-                    _logger.warning(
-                        "runner %s outbound queue freed no room in %.0fs (%d frames); "
-                        "failing send (sender stalled, or outpaced by concurrent senders)",
-                        session.runner_id,
-                        _OUTBOUND_SEND_STALL_S,
-                        session.outbound_queue.qsize(),
-                    )
-                    _resolve(
-                        ConnectionError(
-                            f"runner {session.runner_id!r} outbound tunnel stalled "
-                            "(sender dead, or saturated by concurrent sends)"
+                    # fill it faster than the sender wakes, so poll for drain
+                    # (re-validating the generation each pass) and only treat
+                    # no room freed within the deadline as failure.
+                    if time.monotonic() >= deadline:
+                        if _stale():
+                            _resolve(_replaced_error())
+                            return
+                        _logger.warning(
+                            "runner %s outbound queue freed no room in %.0fs (%d frames); "
+                            "failing send (sender stalled, or outpaced by concurrent senders)",
+                            session.runner_id,
+                            _OUTBOUND_SEND_STALL_S,
+                            session.outbound_queue.qsize(),
                         )
-                    )
-                    return
-                if _stale():
-                    # The frame landed in a retired queue no sender drains.
-                    _resolve(_replaced_error())
-                    return
-                _resolve(None)
+                        _resolve(
+                            ConnectionError(
+                                f"runner {session.runner_id!r} outbound tunnel stalled "
+                                "(sender dead, or saturated by concurrent sends)"
+                            )
+                        )
+                        return
+                    await asyncio.sleep(_OUTBOUND_SEND_POLL_S)
             finally:
                 # Route teardown can cancel this task mid-wait; the caller
                 # must never be left awaiting an ack nothing will settle.

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -708,37 +708,62 @@ class TunnelRegistry:
         """
         ack: concurrent.futures.Future[None] = concurrent.futures.Future()
 
+        def _resolve(error: BaseException | None) -> None:
+            """Settle ``ack`` once; later resolutions are no-ops."""
+            if ack.done():
+                return
+            if error is None:
+                ack.set_result(None)
+            else:
+                ack.set_exception(error)
+
+        def _stale() -> bool:
+            with self._lock:
+                return self._sessions.get(session.runner_id) is not session
+
+        def _replaced_error() -> ConnectionError:
+            return ConnectionError(f"runner {session.runner_id!r} tunnel was replaced")
+
         async def _enqueue() -> None:
             """Run on ``session.loop``: bounded-wait enqueue of the frame."""
-            with self._lock:
-                stale = self._sessions.get(session.runner_id) is not session
-            if stale:
-                if not ack.done():
-                    ack.set_exception(
-                        ConnectionError(f"runner {session.runner_id!r} tunnel was replaced")
-                    )
-                return
             try:
-                # A full queue is backpressure, not failure: a burst can fill
-                # it faster than the sender wakes, so wait for drain and only
-                # treat a sender that frees no room in the deadline as stalled.
-                await asyncio.wait_for(
-                    session.outbound_queue.put(data), timeout=_OUTBOUND_SEND_STALL_S
-                )
-            except TimeoutError:
-                _logger.warning(
-                    "runner %s outbound queue freed no room in %.0fs (%d frames); failing send",
-                    session.runner_id,
-                    _OUTBOUND_SEND_STALL_S,
-                    session.outbound_queue.qsize(),
-                )
-                if not ack.done():
-                    ack.set_exception(
-                        ConnectionError(f"runner {session.runner_id!r} outbound tunnel stalled")
+                if _stale():
+                    _resolve(_replaced_error())
+                    return
+                try:
+                    # A full queue is backpressure, not failure: a burst can
+                    # fill it faster than the sender wakes, so wait for drain
+                    # and only treat no room freed in the deadline as failure.
+                    await asyncio.wait_for(
+                        session.outbound_queue.put(data), timeout=_OUTBOUND_SEND_STALL_S
                     )
-                return
-            if not ack.done():
-                ack.set_result(None)
+                except TimeoutError:
+                    if _stale():
+                        _resolve(_replaced_error())
+                        return
+                    _logger.warning(
+                        "runner %s outbound queue freed no room in %.0fs (%d frames); "
+                        "failing send (sender stalled, or outpaced by concurrent senders)",
+                        session.runner_id,
+                        _OUTBOUND_SEND_STALL_S,
+                        session.outbound_queue.qsize(),
+                    )
+                    _resolve(
+                        ConnectionError(
+                            f"runner {session.runner_id!r} outbound tunnel stalled "
+                            "(sender dead, or saturated by concurrent sends)"
+                        )
+                    )
+                    return
+                if _stale():
+                    # The frame landed in a retired queue no sender drains.
+                    _resolve(_replaced_error())
+                    return
+                _resolve(None)
+            finally:
+                # Route teardown can cancel this task mid-wait; the caller
+                # must never be left awaiting an ack nothing will settle.
+                _resolve(_replaced_error())
 
         def _start_enqueue() -> None:
             """Run on the owner loop; task-ify the bounded-wait put."""

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -53,6 +53,12 @@ from omnigent.runner.transports.ws_tunnel.frames import (
 
 _logger = logging.getLogger(__name__)
 
+# Cap on frames queued for a runner's sender task. Protocol frames are never
+# dropped or coalesced — a lost frame strands its RPC silently — so past the
+# cap ``send_text`` fails loudly with ConnectionError instead: a backlog this
+# deep means the tunnel socket has stopped draining.
+_OUTBOUND_QUEUE_MAX_FRAMES = 1024
+
 
 class WebSocketLike(Protocol):
     """Minimal WebSocket protocol used by the registry + transport.
@@ -273,7 +279,7 @@ class TunnelRegistry:
             ws=ws,
             hello=hello,
             loop=loop,
-            outbound_queue=asyncio.Queue(),
+            outbound_queue=asyncio.Queue(maxsize=_OUTBOUND_QUEUE_MAX_FRAMES),
             connected_at=now,
             last_frame_at=now,
             owner=owner,
@@ -705,7 +711,20 @@ class TunnelRegistry:
                 if self._sessions.get(session.runner_id) is not session:
                     error = ConnectionError(f"runner {session.runner_id!r} tunnel was replaced")
                 else:
-                    session.outbound_queue.put_nowait(data)
+                    try:
+                        session.outbound_queue.put_nowait(data)
+                    except asyncio.QueueFull:
+                        # The sender task has stopped draining the socket.
+                        # Frames must not be dropped silently (a lost frame
+                        # strands its RPC), so fail the send loudly.
+                        _logger.warning(
+                            "runner %s outbound queue saturated at %d frames; failing send",
+                            session.runner_id,
+                            session.outbound_queue.maxsize,
+                        )
+                        error = ConnectionError(
+                            f"runner {session.runner_id!r} outbound tunnel queue is full"
+                        )
             if error is not None:
                 if not ack.done():
                     ack.set_exception(error)
@@ -787,7 +806,14 @@ def _retire_session_writer(session: RunnerSession, *, code: int, reason: str) ->
 
     def _retire() -> None:
         """Run on the WebSocket owner loop."""
-        session.outbound_queue.put_nowait(None)
+        try:
+            session.outbound_queue.put_nowait(None)
+        except asyncio.QueueFull:
+            # A retired session's pending frames are already dead (in-flight
+            # requests were aborted) — make room so the stop sentinel lands.
+            with contextlib.suppress(asyncio.QueueEmpty):
+                session.outbound_queue.get_nowait()
+            session.outbound_queue.put_nowait(None)
         close = getattr(session.ws, "close", None)
         if close is not None:
             with contextlib.suppress(Exception):

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -811,8 +811,7 @@ def _retire_session_writer(session: RunnerSession, *, code: int, reason: str) ->
         except asyncio.QueueFull:
             # A retired session's pending frames are already dead (in-flight
             # requests were aborted) — make room so the stop sentinel lands.
-            with contextlib.suppress(asyncio.QueueEmpty):
-                session.outbound_queue.get_nowait()
+            session.outbound_queue.get_nowait()
             session.outbound_queue.put_nowait(None)
         close = getattr(session.ws, "close", None)
         if close is not None:

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -765,12 +765,27 @@ class TunnelRegistry:
                 # must never be left awaiting an ack nothing will settle.
                 _resolve(_replaced_error())
 
+        def _finalize_enqueue(task: asyncio.Task[None]) -> None:
+            """Backstop: a task cancelled before its coroutine's first step
+            never enters the try/finally, so settle the ack from done()."""
+            if not task.cancelled():
+                _ = task.exception()
+            _resolve(_replaced_error())
+
         def _start_enqueue() -> None:
             """Run on the owner loop; task-ify the bounded-wait put."""
             task = asyncio.get_running_loop().create_task(_enqueue())
-            task.add_done_callback(_discard_task_exception)
+            task.add_done_callback(_finalize_enqueue)
 
-        _call_session_soon_threadsafe(session, _start_enqueue)
+        if not session.loop.is_running():
+            # A stopped owner loop never runs the scheduled callback (only
+            # expected at process shutdown) — fail loud, don't await forever.
+            raise ConnectionError(f"runner {session.runner_id!r} tunnel loop is not running")
+        try:
+            _call_session_soon_threadsafe(session, _start_enqueue)
+        except RuntimeError as exc:
+            # Loop closed between the check above and the schedule call.
+            raise ConnectionError(f"runner {session.runner_id!r} tunnel loop is closed") from exc
         await asyncio.wrap_future(ack)
 
     # ── Routing incoming frames ──────────────────────────

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -114,6 +114,11 @@ _CONTROL_READ_CHUNK: Final[int] = 256 * 1024
 # single read; raise it so a large burst can be pulled in one wakeup.
 _CONTROL_STDOUT_BUFFER_LIMIT: Final[int] = 16 * 1024 * 1024
 
+# Bound on one buffered partial control line; a line that outgrows it is
+# discarded whole (%output records are lossy-safe and the queue's gap
+# handling repaints) instead of accumulating without limit across reads.
+_CONTROL_MAX_LINE_BYTES: Final[int] = _CONTROL_STDOUT_BUFFER_LIMIT
+
 # When the control reader ends with a send backlog still queued (a
 # burst-then-exit program), how long to let the forwarder finish draining that
 # sentinel-terminated backlog before teardown cancels it. Bounds teardown so a
@@ -134,6 +139,56 @@ _CLIPBOARD_READ_TIMEOUT_S: Final[float] = 2.0
 # Correlating the notification with this client's recent input prevents one
 # attached browser from overwriting every other viewer's local clipboard.
 _CLIPBOARD_RECENT_INPUT_WINDOW_S: Final[float] = 5.0
+
+
+async def _parse_control_stream(
+    stdout: asyncio.StreamReader,
+    handle_line: Callable[[bytes], bool],
+) -> None:
+    """Parse raw control-stream reads into lines routed via *handle_line*.
+
+    Reads with ``read()`` rather than ``readline()`` so one wakeup can pull
+    many buffered ``%output`` lines at once and an oversized line can't raise
+    ``LimitOverrunError``. ``read`` returns buffered data without suspending,
+    so the loop yields explicitly after each parsed batch to keep the event
+    loop live under a flood; a partial line that outgrows
+    :data:`_CONTROL_MAX_LINE_BYTES` is discarded whole rather than buffered
+    without bound.
+
+    :param stdout: The control client's stdout stream.
+    :param handle_line: Per-line router; returns ``False`` to stop reading.
+    :returns: None on stream EOF or when *handle_line* stops the read.
+    """
+    buffer = b""
+    discarding = False
+    while True:
+        data = await stdout.read(_CONTROL_READ_CHUNK)
+        if not data:
+            # tmux control client closed its stdout — server/session gone.
+            return
+        buffer += data
+        if discarding:
+            # Skip the tail of an oversized line through its newline; fall
+            # through either way so every batch reaches the yield below.
+            _, newline, buffer = buffer.partition(b"\n")
+            if newline:
+                discarding = False
+            else:
+                buffer = b""
+        # Parse all COMPLETE lines; keep any trailing partial for next read.
+        *lines, buffer = buffer.split(b"\n")
+        for raw_line in lines:
+            if not handle_line(raw_line.rstrip(b"\r")):
+                return
+        if len(buffer) > _CONTROL_MAX_LINE_BYTES:
+            _logger.warning(
+                "control line exceeded %d bytes; discarding it whole",
+                _CONTROL_MAX_LINE_BYTES,
+            )
+            buffer = b""
+            discarding = True
+        # Give the event loop a turn after each parsed batch.
+        await asyncio.sleep(0)
 
 
 def unescape_control_output(value: bytes) -> bytes:
@@ -570,9 +625,10 @@ async def bridge_tmux_control_to_websocket(
     # (``None`` = EOF sentinel). The forwarder coalesces everything queued into
     # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
     # a backlog of tiny per-line payloads collapses into a few large frames.
-    # Byte-bounded: past the cap the oldest chunks are dropped (lossy-safe —
-    # the next repaint restores the screen) instead of growing without bound.
-    output_chunks: asyncio.Queue[bytes | None] = _ByteBoundedOutputQueue()
+    # Byte/item-bounded: saturation drops whole incoming %output records (never
+    # already-queued ones contiguous with sent bytes); on gap close the queue
+    # injects parser-resync bytes and the hook below forces a full repaint.
+    output_chunks = _ByteBoundedOutputQueue()
     # Keep at most the newest pending clipboard buffer plus the EOF sentinel.
     # A noisy pane cannot build an unbounded queue of names/subprocess reads.
     clipboard_buffers: asyncio.Queue[str | None] = asyncio.Queue(maxsize=2)
@@ -614,6 +670,16 @@ async def bridge_tmux_control_to_websocket(
         except (ConnectionResetError, BrokenPipeError, OSError):
             return
 
+    repaint_tasks: set[asyncio.Task[None]] = set()
+
+    def _repaint_after_gap() -> None:
+        """Drop gap closed: have tmux re-emit the screen as fresh %output."""
+        task = asyncio.create_task(_send_command(b"refresh-client\n"))
+        repaint_tasks.add(task)
+        task.add_done_callback(repaint_tasks.discard)
+
+    output_chunks.on_gap_end = _repaint_after_gap
+
     def _handle_control_line(line: bytes) -> bool:
         """Route one protocol line; return ``True`` to keep reading.
 
@@ -654,31 +720,9 @@ async def bridge_tmux_control_to_websocket(
         return True
 
     async def _read_control() -> None:
-        """Read raw control-stream chunks, parse lines, queue %output.
-
-        Reads with ``stdout.read()`` rather than ``readline()`` so one wakeup
-        can pull many buffered ``%output`` lines at once — letting the
-        forwarder coalesce them — and so an oversized line can't raise
-        ``LimitOverrunError``. Always enqueues the ``None`` EOF sentinel on exit
-        so the forwarder terminates.
-        """
-        buffer = b""
+        """Parse the control stream, queueing %output; EOF sentinel on exit."""
         try:
-            while True:
-                data = await stdout.read(_CONTROL_READ_CHUNK)
-                if not data:
-                    # tmux control client closed its stdout — server/session gone.
-                    return
-                buffer += data
-                # Parse all COMPLETE lines; keep any trailing partial for next read.
-                *lines, buffer = buffer.split(b"\n")
-                for raw_line in lines:
-                    if not _handle_control_line(raw_line.rstrip(b"\r")):
-                        return
-                # ``stdout.read`` returns buffered data without suspending, so
-                # under a flood this loop never yields on its own — give the
-                # event loop a turn after each parsed batch.
-                await asyncio.sleep(0)
+            await _parse_control_stream(stdout, _handle_control_line)
         finally:
             output_chunks.put_nowait(None)
             clipboard_buffers.put_nowait(None)

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -738,7 +738,7 @@ async def bridge_tmux_control_to_websocket(
             return
 
     async def _emit_pane_snapshot() -> None:
-        """Drop gap closed: repaint from a pane snapshot, as synthetic output."""
+        """Output was dropped: repaint from a pane snapshot, as synthetic output."""
         snapshot = await _capture_pane_snapshot(socket_path, tmux_target)
         if snapshot is not None:
             output_chunks.put_nowait(snapshot)

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -74,9 +74,11 @@ from omnigent.terminals.ws_bridge import (
     WS_CLOSE_INTERNAL_ERROR,
     WS_CLOSE_TERMINAL_DETACHED,
     WS_CLOSE_TERMINAL_NOT_FOUND,
+    _ByteBoundedOutputQueue,
     _coalesce_limit_after_input,
     _forward_pty_to_ws,
     _monotonic,
+    _put_output_chunk,
 )
 
 _logger = logging.getLogger(__name__)
@@ -569,7 +571,9 @@ async def bridge_tmux_control_to_websocket(
     # (``None`` = EOF sentinel). The forwarder coalesces everything queued into
     # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
     # a backlog of tiny per-line payloads collapses into a few large frames.
-    output_chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
+    # Byte-bounded: past the cap the oldest chunks are dropped (lossy-safe —
+    # the next repaint restores the screen) instead of growing without bound.
+    output_chunks: asyncio.Queue[bytes | None] = _ByteBoundedOutputQueue()
     # Keep at most the newest pending clipboard buffer plus the EOF sentinel.
     # A noisy pane cannot build an unbounded queue of names/subprocess reads.
     clipboard_buffers: asyncio.Queue[str | None] = asyncio.Queue(maxsize=2)
@@ -626,7 +630,7 @@ async def bridge_tmux_control_to_websocket(
             # %output %<pane-id> <escaped-bytes>
             parts = line.split(b" ", 2)
             if len(parts) == 3:
-                output_chunks.put_nowait(unescape_control_output(parts[2]))
+                _put_output_chunk(output_chunks, unescape_control_output(parts[2]))
             return True
         buffer_name = _clipboard_buffer_name(line)
         if buffer_name is not None:
@@ -672,8 +676,12 @@ async def bridge_tmux_control_to_websocket(
                 for raw_line in lines:
                     if not _handle_control_line(raw_line.rstrip(b"\r")):
                         return
+                # ``stdout.read`` returns buffered data without suspending, so
+                # under a flood this loop never yields on its own — give the
+                # event loop a turn after each parsed batch.
+                await asyncio.sleep(0)
         finally:
-            output_chunks.put_nowait(None)
+            _put_output_chunk(output_chunks, None)
             clipboard_buffers.put_nowait(None)
             if reader_done is not None:
                 reader_done.set()

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -116,8 +116,9 @@ _CONTROL_READ_CHUNK: Final[int] = 256 * 1024
 _CONTROL_STDOUT_BUFFER_LIMIT: Final[int] = 16 * 1024 * 1024
 
 # Bound on one buffered partial control line; a line that outgrows it is
-# discarded whole (%output records are lossy-safe and the queue's gap
-# handling repaints) instead of accumulating without limit across reads.
+# discarded whole instead of accumulating without limit across reads. Each
+# discard is reported via ``on_discard`` so the output queue's gap handling
+# (drop counters, resync bytes, snapshot repaint) recovers the lost screen.
 _CONTROL_MAX_LINE_BYTES: Final[int] = _CONTROL_STDOUT_BUFFER_LIMIT
 
 # When the control reader ends with a send backlog still queued (a
@@ -145,6 +146,7 @@ _CLIPBOARD_RECENT_INPUT_WINDOW_S: Final[float] = 5.0
 async def _parse_control_stream(
     stdout: asyncio.StreamReader,
     handle_line: Callable[[bytes], bool],
+    on_discard: Callable[[int], None] | None = None,
 ) -> None:
     """Parse raw control-stream reads into lines routed via *handle_line*.
 
@@ -154,10 +156,13 @@ async def _parse_control_stream(
     so the loop yields explicitly after each parsed batch to keep the event
     loop live under a flood; a partial line that outgrows
     :data:`_CONTROL_MAX_LINE_BYTES` is discarded whole rather than buffered
-    without bound.
+    without bound, and each discarded line is reported via *on_discard*.
 
     :param stdout: The control client's stdout stream.
     :param handle_line: Per-line router; returns ``False`` to stop reading.
+    :param on_discard: Called once per discarded oversized line with its
+        byte count so far, so the caller can run its drop/repaint recovery
+        (a discarded ``%output`` line is lost screen content).
     :returns: None on stream EOF or when *handle_line* stops the read.
     """
     buffer = b""
@@ -186,6 +191,8 @@ async def _parse_control_stream(
                     "control line exceeded %d bytes; discarding it whole",
                     _CONTROL_MAX_LINE_BYTES,
                 )
+                if on_discard is not None:
+                    on_discard(len(raw_line))
                 continue
             if not handle_line(raw_line.rstrip(b"\r")):
                 return
@@ -194,6 +201,8 @@ async def _parse_control_stream(
                 "control line exceeded %d bytes; discarding it whole",
                 _CONTROL_MAX_LINE_BYTES,
             )
+            if on_discard is not None:
+                on_discard(len(buffer))
             buffer = b""
             discarding = True
         # Give the event loop a turn after each parsed batch.
@@ -788,7 +797,18 @@ async def bridge_tmux_control_to_websocket(
     async def _read_control() -> None:
         """Parse the control stream, queueing %output; EOF sentinel on exit."""
         try:
-            await _parse_control_stream(stdout, _handle_control_line)
+            await _parse_control_stream(
+                stdout,
+                _handle_control_line,
+                # An oversized discarded line is lost screen content: open the
+                # drop gap so resync bytes + a snapshot repaint recover it.
+                on_discard=output_chunks.record_dropped_output,
+            )
+            # A drop just before EOF can leave the snapshot capture in flight;
+            # land it ahead of the sentinel or the forwarder never sends it.
+            # Skipped on cancellation so route teardown stays prompt.
+            with contextlib.suppress(Exception):
+                await repainter.flush(_FORWARD_DRAIN_TIMEOUT_S)
         finally:
             output_chunks.put_nowait(None)
             clipboard_buffers.put_nowait(None)

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -77,6 +77,7 @@ from omnigent.terminals.ws_bridge import (
     _ByteBoundedOutputQueue,
     _coalesce_limit_after_input,
     _forward_pty_to_ws,
+    _GapRepainter,
     _monotonic,
 )
 
@@ -178,6 +179,14 @@ async def _parse_control_stream(
         # Parse all COMPLETE lines; keep any trailing partial for next read.
         *lines, buffer = buffer.split(b"\n")
         for raw_line in lines:
+            if len(raw_line) > _CONTROL_MAX_LINE_BYTES:
+                # A near-cap partial completed by this read can exceed the
+                # cap as a whole line without ever tripping the partial check.
+                _logger.warning(
+                    "control line exceeded %d bytes; discarding it whole",
+                    _CONTROL_MAX_LINE_BYTES,
+                )
+                continue
             if not handle_line(raw_line.rstrip(b"\r")):
                 return
         if len(buffer) > _CONTROL_MAX_LINE_BYTES:
@@ -189,6 +198,54 @@ async def _parse_control_stream(
             discarding = True
         # Give the event loop a turn after each parsed batch.
         await asyncio.sleep(0)
+
+
+async def _capture_pane_snapshot(socket_path: str, tmux_target: str) -> bytes | None:
+    """Capture the pane's screen as bytes that repaint a client terminal.
+
+    Gap recovery for control mode: ``refresh-client`` re-emits nothing to a
+    control client, so screen content lost to a drop gap is restored by
+    re-painting from a ``capture-pane`` snapshot — clear+home, the pane rows
+    with their escape sequences, then the cursor put back where tmux
+    reports it.
+
+    :param socket_path: Private tmux server socket path.
+    :param tmux_target: Pane target, e.g. a session name.
+    :returns: Snapshot bytes, or None when tmux is missing or the
+        capture fails (pane gone, server down).
+    """
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        return None
+
+    async def _run(*args: str) -> bytes | None:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                tmux,
+                "-S",
+                socket_path,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            out, _ = await proc.communicate()
+        except OSError:
+            return None
+        return out if proc.returncode == 0 else None
+
+    screen = await _run("capture-pane", "-p", "-e", "-t", tmux_target)
+    if screen is None:
+        return None
+    body = screen.rstrip(b"\n").replace(b"\n", b"\r\n")
+    cursor_home = b""
+    cursor = await _run("display-message", "-p", "-t", tmux_target, "#{cursor_y} #{cursor_x}")
+    if cursor is not None:
+        try:
+            row, col = (int(v) for v in cursor.split())
+            cursor_home = f"\x1b[{row + 1};{col + 1}H".encode()
+        except ValueError:
+            pass
+    return b"\x1b[H\x1b[2J" + body + cursor_home
 
 
 def unescape_control_output(value: bytes) -> bytes:
@@ -627,7 +684,8 @@ async def bridge_tmux_control_to_websocket(
     # a backlog of tiny per-line payloads collapses into a few large frames.
     # Byte/item-bounded: saturation drops whole incoming %output records (never
     # already-queued ones contiguous with sent bytes); on gap close the queue
-    # injects parser-resync bytes and the hook below forces a full repaint.
+    # injects parser-resync bytes and the hook below re-emits a captured pane
+    # snapshot (refresh-client is a no-op toward a control-mode client).
     output_chunks = _ByteBoundedOutputQueue()
     # Keep at most the newest pending clipboard buffer plus the EOF sentinel.
     # A noisy pane cannot build an unbounded queue of names/subprocess reads.
@@ -670,15 +728,14 @@ async def bridge_tmux_control_to_websocket(
         except (ConnectionResetError, BrokenPipeError, OSError):
             return
 
-    repaint_tasks: set[asyncio.Task[None]] = set()
+    async def _emit_pane_snapshot() -> None:
+        """Drop gap closed: repaint from a pane snapshot, as synthetic output."""
+        snapshot = await _capture_pane_snapshot(socket_path, tmux_target)
+        if snapshot is not None:
+            output_chunks.put_nowait(snapshot)
 
-    def _repaint_after_gap() -> None:
-        """Drop gap closed: have tmux re-emit the screen as fresh %output."""
-        task = asyncio.create_task(_send_command(b"refresh-client\n"))
-        repaint_tasks.add(task)
-        task.add_done_callback(repaint_tasks.discard)
-
-    output_chunks.on_gap_end = _repaint_after_gap
+    repainter = _GapRepainter(_emit_pane_snapshot)
+    output_chunks.on_gap_end = repainter.request
 
     def _handle_control_line(line: bytes) -> bool:
         """Route one protocol line; return ``True`` to keep reading.
@@ -891,6 +948,7 @@ async def bridge_tmux_control_to_websocket(
         # Detach reflows the pane back to remaining clients — stamp it.
         if on_client_interaction is not None:
             on_client_interaction()
+        repainter.cancel()
         # Detach the control client: an empty command line detaches cleanly.
         await _send_command(b"\n")
         with contextlib.suppress(ProcessLookupError):

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -78,7 +78,6 @@ from omnigent.terminals.ws_bridge import (
     _coalesce_limit_after_input,
     _forward_pty_to_ws,
     _monotonic,
-    _put_output_chunk,
 )
 
 _logger = logging.getLogger(__name__)
@@ -630,7 +629,7 @@ async def bridge_tmux_control_to_websocket(
             # %output %<pane-id> <escaped-bytes>
             parts = line.split(b" ", 2)
             if len(parts) == 3:
-                _put_output_chunk(output_chunks, unescape_control_output(parts[2]))
+                output_chunks.put_nowait(unescape_control_output(parts[2]))
             return True
         buffer_name = _clipboard_buffer_name(line)
         if buffer_name is not None:
@@ -681,7 +680,7 @@ async def bridge_tmux_control_to_websocket(
                 # event loop a turn after each parsed batch.
                 await asyncio.sleep(0)
         finally:
-            _put_output_chunk(output_chunks, None)
+            output_chunks.put_nowait(None)
             clipboard_buffers.put_nowait(None)
             if reader_done is not None:
                 reader_done.set()

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -209,6 +209,15 @@ async def _capture_pane_snapshot(socket_path: str, tmux_target: str) -> bytes | 
     with their escape sequences, then the cursor put back where tmux
     reports it.
 
+    Ordering vs interleaved %output: records the reader enqueues before the
+    snapshot almost always predate the capture (tmux emits before we parse),
+    so the snapshot repainting over them is a no-op; anything emitted after
+    the capture lands behind it in FIFO order and re-renders on top. The
+    screen capture runs LAST (after the cursor query) to keep the window in
+    which output can both postdate the capture and precede it in the queue
+    to single milliseconds. Mode state flipped inside the gap (alt-screen,
+    cursor visibility) is not recaptured — capture-pane reports content only.
+
     :param socket_path: Private tmux server socket path.
     :param tmux_target: Pane target, e.g. a session name.
     :returns: Snapshot bytes, or None when tmux is missing or the
@@ -233,10 +242,6 @@ async def _capture_pane_snapshot(socket_path: str, tmux_target: str) -> bytes | 
             return None
         return out if proc.returncode == 0 else None
 
-    screen = await _run("capture-pane", "-p", "-e", "-t", tmux_target)
-    if screen is None:
-        return None
-    body = screen.rstrip(b"\n").replace(b"\n", b"\r\n")
     cursor_home = b""
     cursor = await _run("display-message", "-p", "-t", tmux_target, "#{cursor_y} #{cursor_x}")
     if cursor is not None:
@@ -245,6 +250,10 @@ async def _capture_pane_snapshot(socket_path: str, tmux_target: str) -> bytes | 
             cursor_home = f"\x1b[{row + 1};{col + 1}H".encode()
         except ValueError:
             pass
+    screen = await _run("capture-pane", "-p", "-e", "-t", tmux_target)
+    if screen is None:
+        return None
+    body = screen.rstrip(b"\n").replace(b"\n", b"\r\n")
     return b"\x1b[H\x1b[2J" + body + cursor_home
 
 
@@ -683,9 +692,9 @@ async def bridge_tmux_control_to_websocket(
     # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
     # a backlog of tiny per-line payloads collapses into a few large frames.
     # Byte/item-bounded: saturation drops whole incoming %output records (never
-    # already-queued ones contiguous with sent bytes); on gap close the queue
-    # injects parser-resync bytes and the hook below re-emits a captured pane
-    # snapshot (refresh-client is a no-op toward a control-mode client).
+    # already-queued ones contiguous with sent bytes); each drop requests a
+    # captured-pane re-emit via the hook below (refresh-client is a no-op
+    # toward a control-mode client) and gap close injects parser-resync bytes.
     output_chunks = _ByteBoundedOutputQueue()
     # Keep at most the newest pending clipboard buffer plus the EOF sentinel.
     # A noisy pane cannot build an unbounded queue of names/subprocess reads.
@@ -735,7 +744,7 @@ async def bridge_tmux_control_to_websocket(
             output_chunks.put_nowait(snapshot)
 
     repainter = _GapRepainter(_emit_pane_snapshot)
-    output_chunks.on_gap_end = repainter.request
+    output_chunks.on_drop = repainter.request
 
     def _handle_control_line(line: bytes) -> bool:
         """Route one protocol line; return ``True`` to keep reading.

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -426,12 +426,14 @@ async def _write_all_nonblocking(
 
 
 class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
-    """Terminal-output queue that tracks queued bytes for the drop policy.
+    """Terminal-output queue whose ``put_nowait`` sheds backlog past a byte cap.
 
-    ``_put``/``_get`` are asyncio.Queue's documented subclass hooks (the
-    same ones ``PriorityQueue`` overrides); the item count stays unbounded
-    so ``put_nowait`` never raises — bounding happens by bytes in
-    :func:`_put_output_chunk`.
+    Drop policy: terminal bytes are lossy-safe — the pane's next repaint
+    restores the screen — so when the browser send is wedged and the backlog
+    exceeds the cap, the OLDEST chunks go (the freshest output wins). The
+    ``None`` EOF sentinel is never dropped. Item count stays unbounded, so
+    ``put_nowait`` never raises; ``_put``/``_get`` are asyncio.Queue's
+    subclass hooks (the same ones ``PriorityQueue`` overrides).
     """
 
     def __init__(self, max_bytes: int = _OUTPUT_QUEUE_MAX_BYTES) -> None:
@@ -450,31 +452,20 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
             self.queued_bytes -= len(item)
         return item
 
-
-def _put_output_chunk(queue: asyncio.Queue[bytes | None], chunk: bytes | None) -> None:
-    """Enqueue terminal output, dropping the oldest backlog past the byte cap.
-
-    Drop policy: terminal bytes are lossy-safe — the pane's next repaint
-    restores the screen — so when the browser send is wedged and the backlog
-    exceeds the cap, the OLDEST chunks go (the freshest output wins). The
-    ``None`` EOF sentinel is never dropped. Plain (unbounded) queues pass
-    through untouched, keeping the policy opt-in per bridge.
-    """
-    queue.put_nowait(chunk)
-    if not isinstance(queue, _ByteBoundedOutputQueue):
-        return
-    while queue.queued_bytes > queue.max_bytes and queue.qsize() > 1:
-        dropped = queue.get_nowait()
-        if dropped is None:
-            # EOF sentinel must survive; re-queue it behind the remaining
-            # data (the consumer stops at None wherever it sits).
-            queue.put_nowait(None)
-            return
-        _logger.debug(
-            "terminal output queue saturated (%d queued bytes); dropped %d-byte chunk",
-            queue.queued_bytes,
-            len(dropped),
-        )
+    def put_nowait(self, item: bytes | None) -> None:
+        super().put_nowait(item)
+        while self.queued_bytes > self.max_bytes and self.qsize() > 1:
+            dropped = self.get_nowait()
+            if dropped is None:
+                # EOF sentinel must survive; re-queue it behind the remaining
+                # data (the consumer stops at None wherever it sits).
+                super().put_nowait(None)
+                return
+            _logger.debug(
+                "terminal output queue saturated (%d queued bytes); dropped %d-byte chunk",
+                self.queued_bytes,
+                len(dropped),
+            )
 
 
 def _pump_pty_chunks(
@@ -494,15 +485,15 @@ def _pump_pty_chunks(
             chunk = os.read(fd, _PTY_READ_CHUNK)
             if not chunk:
                 loop.remove_reader(fd)
-                _put_output_chunk(queue, None)
+                queue.put_nowait(None)
                 return
-            _put_output_chunk(queue, chunk)
+            queue.put_nowait(chunk)
     except BlockingIOError:
         return
     except OSError:
         with contextlib.suppress(ValueError):
             loop.remove_reader(fd)
-        _put_output_chunk(queue, None)
+        queue.put_nowait(None)
 
 
 async def _forward_pty_to_ws(

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -482,28 +482,38 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
             self.queued_bytes -= len(item)
         return item
 
+    def record_dropped_output(self, num_bytes: int) -> None:
+        """Account one lost output chunk: open the gap and fire ``on_drop``.
+
+        Shared by the saturation drop below and by producers that must shed
+        output before it can ever be queued (an oversized control line), so
+        every loss opens the resync gap and requests a repaint instead of
+        leaving the client terminal silently inconsistent.
+        """
+        self.dropped_chunks += 1
+        self.dropped_bytes += num_bytes
+        self._in_gap = True
+        now = _monotonic()
+        if self._warned_at is None or now - self._warned_at >= _OUTPUT_DROP_WARN_INTERVAL_S:
+            self._warned_at = now
+            _logger.warning(
+                "terminal output queue saturated or producer shed output "
+                "(%d bytes / %d chunks queued); %d chunks (%d bytes) dropped so far",
+                self.queued_bytes,
+                self.qsize(),
+                self.dropped_chunks,
+                self.dropped_bytes,
+            )
+        if self.on_drop is not None:
+            self.on_drop()
+
     def put_nowait(self, item: bytes | None) -> None:
         if (
             item is not None
             and self.qsize() > 0
             and (self.queued_bytes + len(item) > self.max_bytes or self.qsize() >= self.max_items)
         ):
-            self.dropped_chunks += 1
-            self.dropped_bytes += len(item)
-            self._in_gap = True
-            now = _monotonic()
-            if self._warned_at is None or now - self._warned_at >= _OUTPUT_DROP_WARN_INTERVAL_S:
-                self._warned_at = now
-                _logger.warning(
-                    "terminal output queue saturated (%d bytes / %d chunks queued); "
-                    "%d chunks (%d bytes) dropped so far",
-                    self.queued_bytes,
-                    self.qsize(),
-                    self.dropped_chunks,
-                    self.dropped_bytes,
-                )
-            if self.on_drop is not None:
-                self.on_drop()
+            self.record_dropped_output(len(item))
             return
         if self._in_gap and item is not None:
             self._in_gap = False
@@ -561,6 +571,30 @@ class _GapRepainter:
         if self._trailing:
             self._trailing = False
             self._task = asyncio.create_task(self._run(self._cooldown()))
+
+    async def flush(self, timeout_s: float) -> None:
+        """Bounded wait for a pending repaint (and its trailing rerun) to land.
+
+        EOF-time helper: a drop right before stream EOF leaves the snapshot
+        task in flight, and output enqueued behind the EOF sentinel is never
+        read — so the reader flushes before queueing the sentinel. Returns
+        immediately when nothing is pending; gives up at *timeout_s* so a
+        wedged capture can't hang teardown.
+        """
+        deadline = _monotonic() + timeout_s
+        while True:
+            task = self._task
+            if task is None or task.done():
+                return
+            remaining = deadline - _monotonic()
+            if remaining <= 0:
+                return
+            # Shielded: a flush timeout must not cancel the repaint itself.
+            # A repaint error is already logged by _run; swallow it here.
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(asyncio.shield(task), timeout=remaining)
+            if self._task is task:
+                return  # no trailing rerun was spawned
 
     def cancel(self) -> None:
         """Teardown: drop any pending or in-flight repaint."""
@@ -859,7 +893,10 @@ async def bridge_tmux_pty_to_websocket(
     pty_chunks = _ByteBoundedOutputQueue()
     last_client_input_at: float | None = None
     last_pane_check_at: float | None = None
-    # Every drop requests a (throttled) repaint of the content it lost.
+    # Every drop requests a (throttled) repaint of the content it lost. The
+    # repaint rides the PTY itself (refresh-client re-emits through the attach
+    # client), so a drop-then-EOF needs no flush here: PTY EOF means the attach
+    # client is gone and no repaint could reach the browser through it.
     repainter = _GapRepainter(lambda: _refresh_attach_client(socket_path, pid))
     pty_chunks.on_drop = repainter.request
 

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -65,6 +65,16 @@ _logger = logging.getLogger(__name__)
 # measurable interactivity gains.
 _PTY_READ_CHUNK: Final[int] = 4096
 
+# Per-``add_reader`` wakeup read cap. The callback is level-triggered, so it
+# re-fires while the fd stays readable; capping the drain keeps the event
+# loop live (heartbeats, other bridges) under a sustained TUI output flood.
+_PTY_READS_PER_WAKEUP: Final[int] = 16
+
+# Byte cap on queued-but-unsent terminal output. Generous so normal bursts
+# (multi-MB build logs behind a slow browser send) still deliver in full;
+# only a pathological flood against a stuck consumer trips the drop path.
+_OUTPUT_QUEUE_MAX_BYTES: Final[int] = 16 * 1024 * 1024
+
 # Default per-frame cap: merge queued PTY chunks into bounded sends so
 # huge bursts stream.
 _WS_COALESCE_MAX_BYTES: Final[int] = 64 * 1024
@@ -415,6 +425,86 @@ async def _write_all_nonblocking(
             return
 
 
+class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
+    """Terminal-output queue that tracks queued bytes for the drop policy.
+
+    ``_put``/``_get`` are asyncio.Queue's documented subclass hooks (the
+    same ones ``PriorityQueue`` overrides); the item count stays unbounded
+    so ``put_nowait`` never raises — bounding happens by bytes in
+    :func:`_put_output_chunk`.
+    """
+
+    def __init__(self, max_bytes: int = _OUTPUT_QUEUE_MAX_BYTES) -> None:
+        super().__init__()
+        self.max_bytes = max_bytes
+        self.queued_bytes = 0
+
+    def _put(self, item: bytes | None) -> None:
+        super()._put(item)
+        if item is not None:
+            self.queued_bytes += len(item)
+
+    def _get(self) -> bytes | None:
+        item = super()._get()
+        if item is not None:
+            self.queued_bytes -= len(item)
+        return item
+
+
+def _put_output_chunk(queue: asyncio.Queue[bytes | None], chunk: bytes | None) -> None:
+    """Enqueue terminal output, dropping the oldest backlog past the byte cap.
+
+    Drop policy: terminal bytes are lossy-safe — the pane's next repaint
+    restores the screen — so when the browser send is wedged and the backlog
+    exceeds the cap, the OLDEST chunks go (the freshest output wins). The
+    ``None`` EOF sentinel is never dropped. Plain (unbounded) queues pass
+    through untouched, keeping the policy opt-in per bridge.
+    """
+    queue.put_nowait(chunk)
+    if not isinstance(queue, _ByteBoundedOutputQueue):
+        return
+    while queue.queued_bytes > queue.max_bytes and queue.qsize() > 1:
+        dropped = queue.get_nowait()
+        if dropped is None:
+            # EOF sentinel must survive; re-queue it behind the remaining
+            # data (the consumer stops at None wherever it sits).
+            queue.put_nowait(None)
+            return
+        _logger.debug(
+            "terminal output queue saturated (%d queued bytes); dropped %d-byte chunk",
+            queue.queued_bytes,
+            len(dropped),
+        )
+
+
+def _pump_pty_chunks(
+    loop: asyncio.AbstractEventLoop,
+    fd: int,
+    queue: asyncio.Queue[bytes | None],
+) -> None:
+    """``add_reader`` callback: read a bounded batch of PTY output into *queue*.
+
+    The read cap matters under a flood: ``add_reader`` is level-triggered, so
+    returning with data still buffered just re-fires the callback on the next
+    loop pass — after other ready callbacks (tunnel heartbeats, other bridges)
+    get their turn. Enqueues the ``None`` EOF sentinel on PTY EOF/error.
+    """
+    try:
+        for _ in range(_PTY_READS_PER_WAKEUP):
+            chunk = os.read(fd, _PTY_READ_CHUNK)
+            if not chunk:
+                loop.remove_reader(fd)
+                _put_output_chunk(queue, None)
+                return
+            _put_output_chunk(queue, chunk)
+    except BlockingIOError:
+        return
+    except OSError:
+        with contextlib.suppress(ValueError):
+            loop.remove_reader(fd)
+        _put_output_chunk(queue, None)
+
+
 async def _forward_pty_to_ws(
     websocket: WebSocket,
     pty_chunks: asyncio.Queue[bytes | None],
@@ -632,7 +722,7 @@ async def bridge_tmux_pty_to_websocket(
     fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     loop = asyncio.get_running_loop()
-    pty_chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
+    pty_chunks: asyncio.Queue[bytes | None] = _ByteBoundedOutputQueue()
     last_client_input_at: float | None = None
     last_pane_check_at: float | None = None
 
@@ -644,23 +734,7 @@ async def bridge_tmux_pty_to_websocket(
         """
         return _coalesce_limit_after_input(last_client_input_at)
 
-    def _on_pty_readable() -> None:
-        try:
-            while True:
-                chunk = os.read(master_fd, _PTY_READ_CHUNK)
-                if not chunk:
-                    loop.remove_reader(master_fd)
-                    pty_chunks.put_nowait(None)
-                    return
-                pty_chunks.put_nowait(chunk)
-        except BlockingIOError:
-            return
-        except OSError:
-            with contextlib.suppress(ValueError):
-                loop.remove_reader(master_fd)
-            pty_chunks.put_nowait(None)
-
-    loop.add_reader(master_fd, _on_pty_readable)
+    loop.add_reader(master_fd, _pump_pty_chunks, loop, master_fd, pty_chunks)
 
     async def _ws_to_pty() -> None:
         nonlocal last_client_input_at, last_pane_check_at

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -41,7 +41,7 @@ import struct
 import sys
 import time
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
@@ -84,6 +84,9 @@ _OUTPUT_DROP_WARN_INTERVAL_S: Final[float] = 30.0
 # ST terminates a dangling OSC/DCS string, so a drop gap can never wedge the
 # client terminal parser mid-sequence.
 _OUTPUT_GAP_RESYNC: Final[bytes] = b"\x18\x1b\\"
+# Floor between gap-recovery repaints: a slow-but-live consumer can cycle
+# drop gaps at WebSocket send rate, and each repaint amplifies the flood.
+_REPAINT_MIN_INTERVAL_S: Final[float] = 2.0
 
 # Default per-frame cap: merge queued PTY chunks into bounded sends so
 # huge bursts stream.
@@ -442,8 +445,10 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
     whose prefix was already sent, wedging the client terminal parser — so a
     saturated queue drops the INCOMING chunk whole instead, keeping delivered
     bytes contiguous up to a single gap. When the gap closes, parser-resync
-    bytes precede the resuming output and ``on_gap_end`` (bridge-wired) forces
-    a full repaint so screen content recovers too. The ``None`` EOF sentinel
+    bytes precede the resuming output and ``on_gap_end`` (bridge-wired,
+    throttled) restores the lost screen content — an attach-client refresh for
+    the PTY bridge, a re-emitted capture-pane snapshot for the control bridge
+    (where ``refresh-client`` re-emits nothing). The ``None`` EOF sentinel
     is always accepted. A lone chunk is accepted even above the byte budget —
     producers bound single-chunk size — so the backlog never exceeds the
     budget by more than one chunk.
@@ -502,6 +507,51 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
             if self.on_gap_end is not None:
                 self.on_gap_end()
         super().put_nowait(item)
+
+
+class _GapRepainter:
+    """Throttled gap recovery: one outstanding repaint, min-interval paced.
+
+    A slow-but-live consumer can cycle drop gaps at WebSocket send rate;
+    running a repaint per gap would spawn a subprocess each time and every
+    redraw amplifies the very flood that opened the gap. ``request`` is
+    trailing-edge: a gap closing inside the cooldown still gets exactly one
+    repaint once the cooldown expires, so the final gap is never left stale.
+    """
+
+    def __init__(
+        self,
+        repaint: Callable[[], Coroutine[object, object, None]],
+        min_interval_s: float = _REPAINT_MIN_INTERVAL_S,
+    ) -> None:
+        self._repaint = repaint
+        self._min_interval_s = min_interval_s
+        self._task: asyncio.Task[None] | None = None
+        self._last_started_at: float | None = None
+
+    def request(self) -> None:
+        """Schedule a repaint unless one is already pending or running."""
+        if self._task is not None and not self._task.done():
+            return
+        delay = 0.0
+        if self._last_started_at is not None:
+            delay = max(0.0, self._last_started_at + self._min_interval_s - _monotonic())
+        self._task = asyncio.create_task(self._run(delay))
+
+    async def _run(self, delay: float) -> None:
+        if delay > 0:
+            await asyncio.sleep(delay)
+        self._last_started_at = _monotonic()
+        try:
+            await self._repaint()
+        except Exception:
+            _logger.debug("gap repaint failed", exc_info=True)
+
+    def cancel(self) -> None:
+        """Teardown: drop any pending or in-flight repaint."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
 
 
 async def _refresh_attach_client(socket_path: str, client_pid: int) -> None:
@@ -793,15 +843,9 @@ async def bridge_tmux_pty_to_websocket(
     pty_chunks = _ByteBoundedOutputQueue()
     last_client_input_at: float | None = None
     last_pane_check_at: float | None = None
-    repaint_tasks: set[asyncio.Task[None]] = set()
-
-    def _repaint_after_gap() -> None:
-        """Drop gap closed: restore the screen content the gap lost."""
-        task = asyncio.create_task(_refresh_attach_client(socket_path, pid))
-        repaint_tasks.add(task)
-        task.add_done_callback(repaint_tasks.discard)
-
-    pty_chunks.on_gap_end = _repaint_after_gap
+    # Drop gap closed: restore the screen content the gap lost (throttled).
+    repainter = _GapRepainter(lambda: _refresh_attach_client(socket_path, pid))
+    pty_chunks.on_gap_end = repainter.request
 
     def _current_ws_coalesce_limit() -> int:
         """
@@ -900,6 +944,7 @@ async def bridge_tmux_pty_to_websocket(
         # so that detach reflow is discounted rather than read as activity.
         if on_client_interaction is not None:
             on_client_interaction()
+        repainter.cancel()
         with contextlib.suppress(ValueError):
             loop.remove_reader(master_fd)
         with contextlib.suppress(ProcessLookupError):

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -444,10 +444,12 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
     Drop policy: evicting already-queued output could sever an escape sequence
     whose prefix was already sent, wedging the client terminal parser — so a
     saturated queue drops the INCOMING chunk whole instead, keeping delivered
-    bytes contiguous up to a single gap. When the gap closes, parser-resync
-    bytes precede the resuming output and ``on_gap_end`` (bridge-wired,
-    throttled) restores the lost screen content — an attach-client refresh for
-    the PTY bridge, a re-emitted capture-pane snapshot for the control bridge
+    bytes contiguous up to a single gap. Every drop fires ``on_drop``
+    (bridge-wired, throttled by :class:`_GapRepainter`) so recovery never
+    waits on a future accepted chunk that may not arrive (a flood tail can be
+    the last output for a while); when the gap closes, parser-resync bytes
+    precede the resuming output. Recovery is an attach-client refresh for the
+    PTY bridge and a re-emitted capture-pane snapshot for the control bridge
     (where ``refresh-client`` re-emits nothing). The ``None`` EOF sentinel
     is always accepted. A lone chunk is accepted even above the byte budget —
     producers bound single-chunk size — so the backlog never exceeds the
@@ -465,7 +467,7 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
         self.queued_bytes = 0
         self.dropped_chunks = 0
         self.dropped_bytes = 0
-        self.on_gap_end: Callable[[], None] | None = None
+        self.on_drop: Callable[[], None] | None = None
         self._in_gap = False
         self._warned_at: float | None = None
 
@@ -500,12 +502,12 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
                     self.dropped_chunks,
                     self.dropped_bytes,
                 )
+            if self.on_drop is not None:
+                self.on_drop()
             return
         if self._in_gap and item is not None:
             self._in_gap = False
             super().put_nowait(_OUTPUT_GAP_RESYNC)
-            if self.on_gap_end is not None:
-                self.on_gap_end()
         super().put_nowait(item)
 
 
@@ -515,8 +517,9 @@ class _GapRepainter:
     A slow-but-live consumer can cycle drop gaps at WebSocket send rate;
     running a repaint per gap would spawn a subprocess each time and every
     redraw amplifies the very flood that opened the gap. ``request`` is
-    trailing-edge: a gap closing inside the cooldown still gets exactly one
-    repaint once the cooldown expires, so the final gap is never left stale.
+    trailing-edge: a request inside the cooldown coalesces into the parked
+    run, and a request while a capture is IN FLIGHT parks one trailing run
+    (that capture may predate the event), so the final gap is never stale.
     """
 
     def __init__(
@@ -528,27 +531,40 @@ class _GapRepainter:
         self._min_interval_s = min_interval_s
         self._task: asyncio.Task[None] | None = None
         self._last_started_at: float | None = None
+        self._capturing = False
+        self._trailing = False
 
     def request(self) -> None:
-        """Schedule a repaint unless one is already pending or running."""
+        """Schedule a repaint; never lose a request, never stack more than one."""
         if self._task is not None and not self._task.done():
+            if self._capturing:
+                self._trailing = True
             return
-        delay = 0.0
-        if self._last_started_at is not None:
-            delay = max(0.0, self._last_started_at + self._min_interval_s - _monotonic())
-        self._task = asyncio.create_task(self._run(delay))
+        self._task = asyncio.create_task(self._run(self._cooldown()))
+
+    def _cooldown(self) -> float:
+        if self._last_started_at is None:
+            return 0.0
+        return max(0.0, self._last_started_at + self._min_interval_s - _monotonic())
 
     async def _run(self, delay: float) -> None:
         if delay > 0:
             await asyncio.sleep(delay)
+        self._capturing = True
         self._last_started_at = _monotonic()
         try:
             await self._repaint()
         except Exception:
             _logger.debug("gap repaint failed", exc_info=True)
+        finally:
+            self._capturing = False
+        if self._trailing:
+            self._trailing = False
+            self._task = asyncio.create_task(self._run(self._cooldown()))
 
     def cancel(self) -> None:
         """Teardown: drop any pending or in-flight repaint."""
+        self._trailing = False
         if self._task is not None:
             self._task.cancel()
             self._task = None
@@ -843,9 +859,9 @@ async def bridge_tmux_pty_to_websocket(
     pty_chunks = _ByteBoundedOutputQueue()
     last_client_input_at: float | None = None
     last_pane_check_at: float | None = None
-    # Drop gap closed: restore the screen content the gap lost (throttled).
+    # Every drop requests a (throttled) repaint of the content it lost.
     repainter = _GapRepainter(lambda: _refresh_attach_client(socket_path, pid))
-    pty_chunks.on_gap_end = repainter.request
+    pty_chunks.on_drop = repainter.request
 
     def _current_ws_coalesce_limit() -> int:
         """

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -74,6 +74,16 @@ _PTY_READS_PER_WAKEUP: Final[int] = 16
 # (multi-MB build logs behind a slow browser send) still deliver in full;
 # only a pathological flood against a stuck consumer trips the drop path.
 _OUTPUT_QUEUE_MAX_BYTES: Final[int] = 16 * 1024 * 1024
+# Companion item cap: a flood of tiny chunks costs per-object memory long
+# before the byte budget trips.
+_OUTPUT_QUEUE_MAX_ITEMS: Final[int] = 32768
+# Minimum interval between saturation WARNINGs from one queue; each warning
+# carries cumulative drop counters, so repeats double as periodic summaries.
+_OUTPUT_DROP_WARN_INTERVAL_S: Final[float] = 30.0
+# Injected where dropped output resumes: CAN aborts a partial CSI/escape and
+# ST terminates a dangling OSC/DCS string, so a drop gap can never wedge the
+# client terminal parser mid-sequence.
+_OUTPUT_GAP_RESYNC: Final[bytes] = b"\x18\x1b\\"
 
 # Default per-frame cap: merge queued PTY chunks into bounded sends so
 # huge bursts stream.
@@ -426,20 +436,33 @@ async def _write_all_nonblocking(
 
 
 class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
-    """Terminal-output queue whose ``put_nowait`` sheds backlog past a byte cap.
+    """Terminal-output queue that rejects NEW chunks past its byte/item budget.
 
-    Drop policy: terminal bytes are lossy-safe — the pane's next repaint
-    restores the screen — so when the browser send is wedged and the backlog
-    exceeds the cap, the OLDEST chunks go (the freshest output wins). The
-    ``None`` EOF sentinel is never dropped. Item count stays unbounded, so
-    ``put_nowait`` never raises; ``_put``/``_get`` are asyncio.Queue's
-    subclass hooks (the same ones ``PriorityQueue`` overrides).
+    Drop policy: evicting already-queued output could sever an escape sequence
+    whose prefix was already sent, wedging the client terminal parser — so a
+    saturated queue drops the INCOMING chunk whole instead, keeping delivered
+    bytes contiguous up to a single gap. When the gap closes, parser-resync
+    bytes precede the resuming output and ``on_gap_end`` (bridge-wired) forces
+    a full repaint so screen content recovers too. The ``None`` EOF sentinel
+    is always accepted. A lone chunk is accepted even above the byte budget —
+    producers bound single-chunk size — so the backlog never exceeds the
+    budget by more than one chunk.
     """
 
-    def __init__(self, max_bytes: int = _OUTPUT_QUEUE_MAX_BYTES) -> None:
+    def __init__(
+        self,
+        max_bytes: int = _OUTPUT_QUEUE_MAX_BYTES,
+        max_items: int = _OUTPUT_QUEUE_MAX_ITEMS,
+    ) -> None:
         super().__init__()
         self.max_bytes = max_bytes
+        self.max_items = max_items
         self.queued_bytes = 0
+        self.dropped_chunks = 0
+        self.dropped_bytes = 0
+        self.on_gap_end: Callable[[], None] | None = None
+        self._in_gap = False
+        self._warned_at: float | None = None
 
     def _put(self, item: bytes | None) -> None:
         super()._put(item)
@@ -453,19 +476,73 @@ class _ByteBoundedOutputQueue(asyncio.Queue["bytes | None"]):
         return item
 
     def put_nowait(self, item: bytes | None) -> None:
+        if (
+            item is not None
+            and self.qsize() > 0
+            and (self.queued_bytes + len(item) > self.max_bytes or self.qsize() >= self.max_items)
+        ):
+            self.dropped_chunks += 1
+            self.dropped_bytes += len(item)
+            self._in_gap = True
+            now = _monotonic()
+            if self._warned_at is None or now - self._warned_at >= _OUTPUT_DROP_WARN_INTERVAL_S:
+                self._warned_at = now
+                _logger.warning(
+                    "terminal output queue saturated (%d bytes / %d chunks queued); "
+                    "%d chunks (%d bytes) dropped so far",
+                    self.queued_bytes,
+                    self.qsize(),
+                    self.dropped_chunks,
+                    self.dropped_bytes,
+                )
+            return
+        if self._in_gap and item is not None:
+            self._in_gap = False
+            super().put_nowait(_OUTPUT_GAP_RESYNC)
+            if self.on_gap_end is not None:
+                self.on_gap_end()
         super().put_nowait(item)
-        while self.queued_bytes > self.max_bytes and self.qsize() > 1:
-            dropped = self.get_nowait()
-            if dropped is None:
-                # EOF sentinel must survive; re-queue it behind the remaining
-                # data (the consumer stops at None wherever it sits).
-                super().put_nowait(None)
+
+
+async def _refresh_attach_client(socket_path: str, client_pid: int) -> None:
+    """Force a full redraw of one tmux attach client after a drop gap.
+
+    Best-effort recovery for screen content the drop lost: resolve the client
+    by pid (each bridge owns exactly one attach child), then ``refresh-client``
+    makes tmux repaint it end to end.
+    """
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        return
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            socket_path,
+            "list-clients",
+            "-F",
+            "#{client_pid} #{client_tty}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await proc.communicate()
+        for line in out.decode(errors="replace").splitlines():
+            pid_str, _, tty = line.partition(" ")
+            if pid_str == str(client_pid) and tty:
+                refresh = await asyncio.create_subprocess_exec(
+                    tmux,
+                    "-S",
+                    socket_path,
+                    "refresh-client",
+                    "-t",
+                    tty,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await refresh.wait()
                 return
-            _logger.debug(
-                "terminal output queue saturated (%d queued bytes); dropped %d-byte chunk",
-                self.queued_bytes,
-                len(dropped),
-            )
+    except OSError:
+        return
 
 
 def _pump_pty_chunks(
@@ -713,9 +790,18 @@ async def bridge_tmux_pty_to_websocket(
     fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     loop = asyncio.get_running_loop()
-    pty_chunks: asyncio.Queue[bytes | None] = _ByteBoundedOutputQueue()
+    pty_chunks = _ByteBoundedOutputQueue()
     last_client_input_at: float | None = None
     last_pane_check_at: float | None = None
+    repaint_tasks: set[asyncio.Task[None]] = set()
+
+    def _repaint_after_gap() -> None:
+        """Drop gap closed: restore the screen content the gap lost."""
+        task = asyncio.create_task(_refresh_attach_client(socket_path, pid))
+        repaint_tasks.add(task)
+        task.add_done_callback(repaint_tasks.discard)
+
+    pty_chunks.on_gap_end = _repaint_after_gap
 
     def _current_ws_coalesce_limit() -> int:
         """

--- a/tests/runner/transports/ws_tunnel/test_registry_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_registry_extended.py
@@ -387,12 +387,12 @@ async def test_wait_for_runner_zero_timeout_just_checks() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_text_fails_loud_when_outbound_queue_saturated() -> None:
-    """A saturated outbound queue fails the send instead of dropping the frame.
+async def test_send_text_waits_out_a_full_queue_instead_of_failing() -> None:
+    """A momentarily full outbound queue is backpressure, not an error.
 
-    Protocol frames must never be dropped silently — a lost frame strands its
-    RPC — so when the sender task stops draining the socket and the bounded
-    queue fills, send_text surfaces a ConnectionError to the caller.
+    A burst can fill the queue before the sender task wakes; the send must
+    wait for drain (never dropping or failing the frame) and complete once
+    the sender frees a slot.
     """
     from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
 
@@ -401,8 +401,34 @@ async def test_send_text_fails_loud_when_outbound_queue_saturated() -> None:
     for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
         session.outbound_queue.put_nowait("frame")
 
-    with pytest.raises(ConnectionError, match="queue is full"):
-        await reg.send_text(session, "one-too-many")
+    send = asyncio.create_task(reg.send_text(session, "tail-frame"))
+    await asyncio.sleep(0.01)
+    assert not send.done(), "send failed instead of waiting for the sender to drain"
+
+    session.outbound_queue.get_nowait()  # the sender drains one slot
+    await asyncio.wait_for(send, timeout=2.0)  # frame accepted, never dropped
+
+
+@pytest.mark.asyncio
+async def test_send_text_fails_loud_when_sender_stalled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender that frees no room within the deadline fails the send loudly.
+
+    Protocol frames must never be dropped silently — a lost frame strands its
+    RPC — so a truly stalled socket surfaces ConnectionError to the caller.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 0.05)
+    reg = TunnelRegistry()
+    session = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        session.outbound_queue.put_nowait("frame")
+
+    with pytest.raises(ConnectionError, match="stalled"):
+        await reg.send_text(session, "frame-behind-stalled-sender")
 
 
 @pytest.mark.asyncio

--- a/tests/runner/transports/ws_tunnel/test_registry_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_registry_extended.py
@@ -381,3 +381,48 @@ async def test_wait_for_runner_zero_timeout_just_checks() -> None:
     assert await reg.wait_for_runner("r1", timeout_s=0) is None
     session = reg.register("r1", _NoopWS(), _hello())
     assert await reg.wait_for_runner("r1", timeout_s=-1) is session
+
+
+# ── Outbound queue backpressure ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_text_fails_loud_when_outbound_queue_saturated() -> None:
+    """A saturated outbound queue fails the send instead of dropping the frame.
+
+    Protocol frames must never be dropped silently — a lost frame strands its
+    RPC — so when the sender task stops draining the socket and the bounded
+    queue fills, send_text surfaces a ConnectionError to the caller.
+    """
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    reg = TunnelRegistry()
+    session = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        session.outbound_queue.put_nowait("frame")
+
+    with pytest.raises(ConnectionError, match="queue is full"):
+        await reg.send_text(session, "one-too-many")
+
+
+@pytest.mark.asyncio
+async def test_retire_delivers_stop_sentinel_through_full_queue() -> None:
+    """Retiring a session with a full outbound queue still stops its sender.
+
+    The stop sentinel makes room by evicting one dead frame (the session's
+    in-flight requests are already aborted) instead of overflowing — so the
+    queue stays at its bound and the sender task still sees None and exits.
+    """
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    reg = TunnelRegistry()
+    old = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        old.outbound_queue.put_nowait("frame")
+
+    reg.register("r1", _NoopWS(), _hello())  # newest-wins triggers retire of old
+    await asyncio.sleep(0)  # let the retire callback run on this loop
+
+    assert old.outbound_queue.qsize() == _OUTBOUND_QUEUE_MAX_FRAMES
+    drained = [old.outbound_queue.get_nowait() for _ in range(old.outbound_queue.qsize())]
+    assert drained[-1] is None

--- a/tests/runner/transports/ws_tunnel/test_registry_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_registry_extended.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import threading
 
 import pytest
 
@@ -488,6 +489,69 @@ async def test_send_text_resolves_when_enqueue_task_cancelled(
 
     with pytest.raises(ConnectionError):
         await asyncio.wait_for(send, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_send_text_resolves_when_enqueue_task_cancelled_before_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A task cancelled before its coroutine's FIRST step must settle the ack.
+
+    Such a cancel never enters the coroutine body, so its try/finally cannot
+    run — only the task-done backstop keeps the caller from hanging forever.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 30.0)
+    reg = TunnelRegistry()
+    session = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        session.outbound_queue.put_nowait("frame")
+
+    before = asyncio.all_tasks()
+    send = asyncio.create_task(reg.send_text(session, "parked-frame"))
+    # ONE bare yield: send_text has created the enqueue task, but the loop
+    # has not stepped it yet — the cancel below lands pre-start.
+    await asyncio.sleep(0)
+    enqueue_tasks = asyncio.all_tasks() - before - {send}
+    assert enqueue_tasks, "expected the enqueue task to exist before its first step"
+    for task in enqueue_tasks:
+        task.cancel()
+
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(send, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_send_text_fails_loud_when_owner_loop_stopped() -> None:
+    """A stopped owner loop never runs the enqueue callback — fail loud.
+
+    In-process the owner loop is the server loop and stops only at shutdown
+    (the stopped-loop hang is not reachable in normal operation), but the
+    guard is cheap and turns a would-be forever-await into ConnectionError.
+    """
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        reg = TunnelRegistry()
+
+        async def _register() -> object:
+            return reg.register("r1", _NoopWS(), _hello())
+
+        session = asyncio.run_coroutine_threadsafe(_register(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        assert not loop.is_running()
+
+        with pytest.raises(ConnectionError, match="not running"):
+            await asyncio.wait_for(reg.send_text(session, "frame"), timeout=2.0)  # type: ignore[arg-type]
+    finally:
+        if loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=5)
+        loop.close()
 
 
 @pytest.mark.asyncio

--- a/tests/runner/transports/ws_tunnel/test_registry_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_registry_extended.py
@@ -432,6 +432,65 @@ async def test_send_text_fails_loud_when_sender_stalled(
 
 
 @pytest.mark.asyncio
+async def test_send_text_reports_replaced_when_session_swapped_mid_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A send parked on a full queue resolves as 'replaced' after a swap.
+
+    Replacing the session retires the old queue (stop sentinel keeps it
+    full), so the parked put can't complete — the send must still resolve
+    within the stall deadline and name the replacement, not a stall.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 0.2)
+    reg = TunnelRegistry()
+    session = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        session.outbound_queue.put_nowait("frame")
+
+    send = asyncio.create_task(reg.send_text(session, "parked-frame"))
+    await asyncio.sleep(0.01)
+    assert not send.done(), "send resolved before the sender freed any room"
+
+    reg.register("r1", _NoopWS(), _hello())  # replaces + retires the old session
+    with pytest.raises(ConnectionError, match="replaced"):
+        await asyncio.wait_for(send, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_send_text_resolves_when_enqueue_task_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the owner-loop enqueue task must never orphan the caller.
+
+    Route teardown cancels pending tasks on the session loop; a send parked
+    in the bounded-wait put must surface ConnectionError, not hang forever
+    on an ack nothing will ever settle.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 30.0)
+    reg = TunnelRegistry()
+    session = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        session.outbound_queue.put_nowait("frame")
+
+    before = asyncio.all_tasks()
+    send = asyncio.create_task(reg.send_text(session, "parked-frame"))
+    await asyncio.sleep(0.01)
+    enqueue_tasks = asyncio.all_tasks() - before - {send}
+    assert enqueue_tasks, "expected the owner-loop enqueue task to be running"
+    for task in enqueue_tasks:
+        task.cancel()
+
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(send, timeout=2.0)
+
+
+@pytest.mark.asyncio
 async def test_retire_delivers_stop_sentinel_through_full_queue() -> None:
     """Retiring a session with a full outbound queue still stops its sender.
 

--- a/tests/runner/transports/ws_tunnel/test_registry_extended.py
+++ b/tests/runner/transports/ws_tunnel/test_registry_extended.py
@@ -461,6 +461,75 @@ async def test_send_text_reports_replaced_when_session_swapped_mid_wait(
 
 
 @pytest.mark.asyncio
+async def test_send_text_swap_mid_wait_never_lands_frame_in_retired_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A send waiting out a full queue must not enqueue after a session swap.
+
+    The retired session's sender can still be transmitting on the dying
+    connection; a frame that lands in its queue after the swap may be sent
+    there even while the caller is told 'replaced' — a duplicate-operation
+    risk when the caller retries. Stale-check + enqueue must be atomic with
+    respect to ``register``.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 30.0)
+    reg = TunnelRegistry()
+    old = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        old.outbound_queue.put_nowait("frame")
+
+    send = asyncio.create_task(reg.send_text(old, "sneaky-frame"))
+    await asyncio.sleep(0.05)
+    assert not send.done(), "send resolved before the sender freed any room"
+
+    reg.register("r1", _NoopWS(), _hello())  # swap; old session is retired
+    await asyncio.sleep(0)
+    # The old (dying) sender drains one more dead frame, freeing a slot the
+    # parked frame could sneak into.
+    old.outbound_queue.get_nowait()
+
+    with pytest.raises(ConnectionError, match="replaced"):
+        await asyncio.wait_for(send, timeout=2.0)
+    drained = [old.outbound_queue.get_nowait() for _ in range(old.outbound_queue.qsize())]
+    assert "sneaky-frame" not in drained, (
+        "frame landed in the retired queue after the swap — it could still "
+        "transmit on the dying connection while the caller was told 'replaced'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_text_replacement_releases_parked_sender_promptly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retirement must release a full-queue waiter well before the stall deadline.
+
+    The retirement sentinel keeps the retired queue full, so a putter parked
+    inside ``Queue.put`` would only discover the replacement at the 10s stall
+    timeout. The waiter must instead observe the swap and fail 'replaced'
+    promptly.
+    """
+    import omnigent.runner.transports.ws_tunnel.registry as registry_mod
+    from omnigent.runner.transports.ws_tunnel.registry import _OUTBOUND_QUEUE_MAX_FRAMES
+
+    monkeypatch.setattr(registry_mod, "_OUTBOUND_SEND_STALL_S", 30.0)
+    reg = TunnelRegistry()
+    old = reg.register("r1", _NoopWS(), _hello())
+    for _ in range(_OUTBOUND_QUEUE_MAX_FRAMES):
+        old.outbound_queue.put_nowait("frame")
+
+    send = asyncio.create_task(reg.send_text(old, "parked-frame"))
+    await asyncio.sleep(0.05)
+    assert not send.done(), "send resolved before the sender freed any room"
+
+    reg.register("r1", _NoopWS(), _hello())  # swap; nothing drains the old queue
+    with pytest.raises(ConnectionError, match="replaced"):
+        await asyncio.wait_for(send, timeout=2.0)
+
+
+@pytest.mark.asyncio
 async def test_send_text_resolves_when_enqueue_task_cancelled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -854,6 +854,30 @@ async def test_parse_control_stream_bounds_partial_line_buffer(
 
 
 @pytest.mark.asyncio
+async def test_parse_control_stream_discards_oversized_complete_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A near-cap partial completed by the next read can't bypass the cap.
+
+    The partial-buffer check only sees line tails still awaiting a newline;
+    a read that completes the line must not hand the over-cap whole to the
+    handler.
+    """
+    monkeypatch.setattr(control_bridge, "_CONTROL_MAX_LINE_BYTES", 64)
+
+    seen: list[bytes] = []
+
+    def _handle(line: bytes) -> bool:
+        seen.append(line)
+        return True
+
+    stdout = _ScriptedStdout([b"x" * 60, b"x" * 20 + b"\nok\n"])
+    await control_bridge._parse_control_stream(stdout, _handle)  # type: ignore[arg-type]
+
+    assert seen == [b"ok"], f"oversized complete line leaked through: {seen!r}"
+
+
+@pytest.mark.asyncio
 async def test_parse_control_stream_yields_while_discarding_oversized_line(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -893,11 +917,13 @@ async def test_parse_control_stream_yields_while_discarding_oversized_line(
 async def test_control_bridge_wires_bounded_output_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The %output queue is the bounded one, with the repaint hook attached.
+    """The %output queue is the bounded one, and a gap close truly repaints.
 
     Guards the saturation policy end to end: the bridge must instantiate the
-    byte/item-bounded queue (not a plain asyncio.Queue) and wire its
-    on_gap_end hook so a drop gap forces a tmux repaint.
+    byte/item-bounded queue (not a plain asyncio.Queue) and wire on_gap_end
+    so a drop gap re-emits a pane snapshot the browser actually receives —
+    a control-mode ``refresh-client`` re-emits nothing, so only snapshot
+    bytes on the WebSocket prove recovery.
     """
     created: list[ws_bridge._ByteBoundedOutputQueue] = []
 
@@ -921,4 +947,32 @@ async def test_control_bridge_wires_bounded_output_queue(
     assert created, "bridge did not use the bounded output queue"
     assert created[0].on_gap_end is not None, "repaint hook not wired to the queue"
 
+    # The attach seed may itself contain clear+home bytes, so require NEW
+    # snapshot bytes to arrive after the simulated gap close.
+    baseline = b"".join(ws.sent).count(b"\x1b[H\x1b[2J")
+    created[0].on_gap_end()  # simulate a drop gap closing
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while asyncio.get_running_loop().time() < deadline:
+        if b"".join(ws.sent).count(b"\x1b[H\x1b[2J") > baseline:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("gap close never delivered a repaint snapshot to the websocket")
+
     await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_capture_pane_snapshot_repaints_screen_content() -> None:
+    """The snapshot starts with clear+home and carries the pane's content."""
+    sock, target = await _new_private_tmux("printf 'SNAPMARK\\n'; sleep 30")
+    await asyncio.sleep(0.5)
+    try:
+        snapshot = await control_bridge._capture_pane_snapshot(str(sock), target)
+    finally:
+        await _kill_tmux(sock)
+
+    assert snapshot is not None
+    assert snapshot.startswith(b"\x1b[H\x1b[2J"), "snapshot must clear before repainting"
+    assert b"SNAPMARK" in snapshot

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -878,6 +878,143 @@ async def test_parse_control_stream_discards_oversized_complete_line(
 
 
 @pytest.mark.asyncio
+async def test_parse_control_stream_oversized_discards_open_drop_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both oversized-discard branches run the queue's drop recovery.
+
+    A discarded ``%output`` line is lost screen content. If the discard
+    bypasses the queue's drop machinery, no repaint is requested and no
+    resync bytes precede the resuming output — the client terminal stays
+    permanently inconsistent. Wire the parser's discard hook to the bounded
+    queue exactly like the bridge does and assert a complete oversized line
+    AND an oversized partial each open the gap.
+    """
+    monkeypatch.setattr(control_bridge, "_CONTROL_MAX_LINE_BYTES", 64)
+    queue = ws_bridge._ByteBoundedOutputQueue()
+    drops: list[int] = []
+    queue.on_drop = lambda: drops.append(1)
+
+    def _handle(line: bytes) -> bool:
+        if line.startswith(b"%output "):
+            parts = line.split(b" ", 2)
+            queue.put_nowait(unescape_control_output(parts[2]))
+        return True
+
+    stdout = _ScriptedStdout(
+        [
+            b"%output %0 " + b"a" * 100 + b"\n",  # oversized COMPLETE line
+            b"%output %0 " + b"b" * 100,  # oversized PARTIAL, no newline yet
+            b"tail\n%output %0 after-gap\n",  # tail skipped; output resumes
+        ]
+    )
+    await control_bridge._parse_control_stream(
+        stdout,  # type: ignore[arg-type]
+        _handle,
+        on_discard=queue.record_dropped_output,
+    )
+
+    assert drops == [1, 1], "each oversized discard must fire the drop/repaint hook"
+    assert queue.dropped_chunks == 2
+    drained = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert drained == [ws_bridge._OUTPUT_GAP_RESYNC, b"after-gap"], (
+        f"resync bytes must precede output resuming after a discard gap: {drained!r}"
+    )
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_oversized_line_discard_repaints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversized control line's discard delivers a repaint to the browser.
+
+    The reader sheds a line that outgrows the cap, losing its %output bytes
+    upstream of the bounded queue — so the queue's own saturation path never
+    sees the loss. The bridge must still route the discard into gap recovery
+    or the screen silently diverges with no repaint ever scheduled.
+    """
+    monkeypatch.setattr(control_bridge, "_CONTROL_MAX_LINE_BYTES", 256)
+    sock, target = await _new_private_tmux(
+        'python3 -c \'import sys,time; time.sleep(1.0); sys.stdout.write("Z"*8192); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    # Attach completes while the pane is still quiet; the seed (sent before
+    # the burst) is the only clear+home on the wire at baseline time.
+    await asyncio.sleep(0.5)
+    baseline = b"".join(ws.sent).count(b"\x1b[H\x1b[2J")
+
+    # The 8 KiB burst arrives as %output lines far above the shrunken cap and
+    # is discarded whole — only a snapshot repaint can restore the screen.
+    deadline = asyncio.get_running_loop().time() + 8.0
+    while asyncio.get_running_loop().time() < deadline:
+        if b"".join(ws.sent).count(b"\x1b[H\x1b[2J") > baseline:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("oversized-line discard never delivered a repaint snapshot")
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_drop_right_before_eof_still_repaints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repaint in flight when the control stream hits EOF still reaches the ws.
+
+    The reader enqueues the EOF sentinel from its exit path while the snapshot
+    capture runs as a separate task; without flushing the repaint first, the
+    snapshot lands behind the sentinel (never read) or is cancelled at
+    teardown — the drop's recovery silently vanishes.
+    """
+    created: list[ws_bridge._ByteBoundedOutputQueue] = []
+
+    class _Recording(ws_bridge._ByteBoundedOutputQueue):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            created.append(self)
+
+    monkeypatch.setattr(control_bridge, "_ByteBoundedOutputQueue", _Recording)
+
+    marker = b"\x1b[H\x1b[2JEOF-REPAINT-MARKER"
+
+    async def _slow_snapshot(_socket_path: str, _tmux_target: str) -> bytes | None:
+        # Long enough that the EOF below reliably races the in-flight capture.
+        await asyncio.sleep(0.3)
+        return marker
+
+    monkeypatch.setattr(control_bridge, "_capture_pane_snapshot", _slow_snapshot)
+
+    sock, target = await _new_private_tmux("sleep 30")
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    await asyncio.sleep(0.5)
+    assert created and created[0].on_drop is not None, "repaint hook not wired"
+
+    created[0].on_drop()  # a drop right before EOF: capture goes in flight
+    await asyncio.sleep(0.05)  # let the repaint task enter the slow capture
+    await _kill_and_join(sock, task)  # EOF races the capture; bridge drains
+
+    assert any(b"EOF-REPAINT-MARKER" in frame for frame in ws.sent), (
+        "repaint requested before EOF was lost behind the sentinel"
+    )
+
+
+@pytest.mark.asyncio
 async def test_parse_control_stream_yields_while_discarding_oversized_line(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -917,11 +917,11 @@ async def test_parse_control_stream_yields_while_discarding_oversized_line(
 async def test_control_bridge_wires_bounded_output_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The %output queue is the bounded one, and a gap close truly repaints.
+    """The %output queue is the bounded one, and a drop truly repaints.
 
     Guards the saturation policy end to end: the bridge must instantiate the
-    byte/item-bounded queue (not a plain asyncio.Queue) and wire on_gap_end
-    so a drop gap re-emits a pane snapshot the browser actually receives —
+    byte/item-bounded queue (not a plain asyncio.Queue) and wire on_drop
+    so a DROP re-emits a pane snapshot the browser actually receives —
     a control-mode ``refresh-client`` re-emits nothing, so only snapshot
     bytes on the WebSocket prove recovery.
     """
@@ -945,19 +945,19 @@ async def test_control_bridge_wires_bounded_output_queue(
     await asyncio.sleep(1.0)
 
     assert created, "bridge did not use the bounded output queue"
-    assert created[0].on_gap_end is not None, "repaint hook not wired to the queue"
+    assert created[0].on_drop is not None, "repaint hook not wired to the queue"
 
     # The attach seed may itself contain clear+home bytes, so require NEW
-    # snapshot bytes to arrive after the simulated gap close.
+    # snapshot bytes to arrive after the simulated drop.
     baseline = b"".join(ws.sent).count(b"\x1b[H\x1b[2J")
-    created[0].on_gap_end()  # simulate a drop gap closing
+    created[0].on_drop()  # simulate a dropped chunk
     deadline = asyncio.get_running_loop().time() + 5.0
     while asyncio.get_running_loop().time() < deadline:
         if b"".join(ws.sent).count(b"\x1b[H\x1b[2J") > baseline:
             break
         await asyncio.sleep(0.05)
     else:
-        pytest.fail("gap close never delivered a repaint snapshot to the websocket")
+        pytest.fail("drop never delivered a repaint snapshot to the websocket")
 
     await _kill_and_join(sock, task)
 

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+import omnigent.terminals.control_bridge as control_bridge
+import omnigent.terminals.ws_bridge as ws_bridge
 from omnigent.terminals.control_bridge import (
     _SEND_KEYS_HEX_BYTES_PER_CALL,
     _clipboard_buffer_name,
@@ -769,5 +771,154 @@ async def test_control_bridge_read_only_drops_input() -> None:
     await proc.communicate()
     await asyncio.sleep(0.2)
     assert ws.sent_text == []
+
+    await _kill_and_join(sock, task)
+
+
+# ── Reader backpressure ──────────────────────────────────
+
+
+class _ScriptedStdout:
+    """Stream stand-in whose ``read`` returns scripted batches, then EOF.
+
+    ``read`` never suspends (like a StreamReader with buffered data), so any
+    yielding the parser does must come from the parser itself.
+    """
+
+    def __init__(self, batches: list[bytes]) -> None:
+        self._batches = list(batches)
+
+    async def read(self, _n: int) -> bytes:
+        return self._batches.pop(0) if self._batches else b""
+
+
+@pytest.mark.asyncio
+async def test_parse_control_stream_yields_between_batches() -> None:
+    """The parser gives the event loop a turn after every parsed batch.
+
+    ``read`` returns buffered data without suspending during a flood, so
+    without an explicit yield a sibling task (heartbeats, other bridges)
+    would only run after the whole stream was parsed.
+    """
+    events: list[str] = []
+
+    async def _ticker() -> None:
+        for _ in range(6):
+            events.append("T")
+            await asyncio.sleep(0)
+
+    ticker = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)  # let the ticker record its first turn
+
+    stdout = _ScriptedStdout([b"one\n", b"two\n", b"three\n"])
+
+    def _handle(_line: bytes) -> bool:
+        events.append("L")
+        return True
+
+    await control_bridge._parse_control_stream(stdout, _handle)  # type: ignore[arg-type]
+    await ticker
+
+    seq = "".join(events)
+    assert seq.count("L") == 3
+    # Ticker turns must interleave between batches — consecutive lines from
+    # different batches with no tick between them means the parser never
+    # yielded to the loop.
+    assert "LL" not in seq, f"parser starved the loop between batches: {seq}"
+
+
+@pytest.mark.asyncio
+async def test_parse_control_stream_bounds_partial_line_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial line that outgrows the cap is discarded whole, then parsing
+    resumes cleanly at the next newline instead of buffering without bound."""
+    monkeypatch.setattr(control_bridge, "_CONTROL_MAX_LINE_BYTES", 64)
+
+    seen: list[bytes] = []
+
+    def _handle(line: bytes) -> bool:
+        seen.append(line)
+        return True
+
+    stdout = _ScriptedStdout(
+        [
+            b"x" * 100,  # oversized partial line: no newline yet -> shed
+            b"y" * 100,  # continuation of the same line, still no newline
+            b"tail-of-giant-line\nok\n",  # its end is skipped; "ok" parses
+        ]
+    )
+    await control_bridge._parse_control_stream(stdout, _handle)  # type: ignore[arg-type]
+
+    assert seen == [b"ok"], f"oversized line leaked through: {seen!r}"
+
+
+@pytest.mark.asyncio
+async def test_parse_control_stream_yields_while_discarding_oversized_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even batches consumed by oversized-line discard yield to the loop.
+
+    A giant line arrives as many newline-free reads; skipping the yield on
+    those reads would starve sibling tasks for the whole discard stretch.
+    """
+    monkeypatch.setattr(control_bridge, "_CONTROL_MAX_LINE_BYTES", 64)
+    events: list[str] = []
+
+    class _RecordingStdout(_ScriptedStdout):
+        async def read(self, n: int) -> bytes:
+            events.append("R")
+            return await super().read(n)
+
+    async def _ticker() -> None:
+        for _ in range(8):
+            events.append("T")
+            await asyncio.sleep(0)
+
+    ticker = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)
+
+    stdout = _RecordingStdout([b"x" * 100, b"y" * 100, b"z" * 100, b"end\nok\n"])
+    await control_bridge._parse_control_stream(stdout, lambda _line: True)  # type: ignore[arg-type]
+    await ticker
+
+    seq = "".join(events)
+    # Back-to-back reads with no ticker turn between them means the discard
+    # path skipped the yield and starved the loop.
+    assert "RR" not in seq, f"discard path starved the loop: {seq}"
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_wires_bounded_output_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The %output queue is the bounded one, with the repaint hook attached.
+
+    Guards the saturation policy end to end: the bridge must instantiate the
+    byte/item-bounded queue (not a plain asyncio.Queue) and wire its
+    on_gap_end hook so a drop gap forces a tmux repaint.
+    """
+    created: list[ws_bridge._ByteBoundedOutputQueue] = []
+
+    class _Recording(ws_bridge._ByteBoundedOutputQueue):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            created.append(self)
+
+    monkeypatch.setattr(control_bridge, "_ByteBoundedOutputQueue", _Recording)
+
+    sock, target = await _new_private_tmux("printf 'hello\\n'; sleep 30")
+    await asyncio.sleep(0.3)
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    await asyncio.sleep(1.0)
+
+    assert created, "bridge did not use the bounded output queue"
+    assert created[0].on_gap_end is not None, "repaint hook not wired to the queue"
 
     await _kill_and_join(sock, task)

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1651,27 +1651,41 @@ def test_bounded_output_queue_accounts_oversized_lone_chunk() -> None:
     assert queue.get_nowait() == b"xxxxxxxx"
 
 
-def test_bounded_output_queue_gap_close_resyncs_and_repaints() -> None:
-    """Closing a drop gap injects parser-resync bytes and fires on_gap_end.
+def test_bounded_output_queue_gap_close_injects_resync() -> None:
+    """Closing a drop gap injects parser-resync bytes before resuming output.
 
     The resync bytes (CAN + ST) unwedge a client parser left mid-escape by
-    the gap; the on_gap_end hook is how the bridge forces a full repaint.
+    the gap.
     """
     from omnigent.terminals.ws_bridge import _OUTPUT_GAP_RESYNC, _ByteBoundedOutputQueue
 
-    gap_ends: list[bool] = []
     queue = _ByteBoundedOutputQueue(max_bytes=8, max_items=100)
-    queue.on_gap_end = lambda: gap_ends.append(True)
     queue.put_nowait(b"aaaa")
     queue.put_nowait(b"bbbb")
     queue.put_nowait(b"cccc")  # dropped -> gap opens
-    assert gap_ends == []
 
     assert queue.get_nowait() == b"aaaa"  # consumer drains below budget
     assert queue.get_nowait() == b"bbbb"
     queue.put_nowait(b"dddd")  # gap closes: resync precedes resuming output
     assert [queue.get_nowait(), queue.get_nowait()] == [_OUTPUT_GAP_RESYNC, b"dddd"]
-    assert gap_ends == [True]
+
+
+def test_bounded_output_queue_requests_repaint_on_each_drop() -> None:
+    """The DROP itself fires the recovery hook, not a later accepted chunk.
+
+    A flood tail can be the last output for a long while; recovery waiting
+    on a future accepted chunk would leave the screen stale indefinitely.
+    """
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
+
+    drops: list[int] = []
+    queue = _ByteBoundedOutputQueue(max_bytes=4, max_items=100)
+    queue.on_drop = lambda: drops.append(1)
+    queue.put_nowait(b"aaaa")
+    queue.put_nowait(b"bbbb")  # dropped -> hook fires immediately
+    assert drops == [1]
+    queue.put_nowait(b"cc")  # dropped again -> fires again (repainter throttles)
+    assert drops == [1, 1]
 
 
 def test_bounded_output_queue_eof_sentinel_always_lands_last() -> None:
@@ -1754,6 +1768,68 @@ async def test_gap_repainter_cancel_drops_pending_repaint() -> None:
     repainter.cancel()
     await asyncio.sleep(0.15)
     assert len(runs) == 1, "cancelled pending repaint still fired"
+
+
+@pytest.mark.asyncio
+async def test_gap_repainter_parks_trailing_request_during_inflight_capture() -> None:
+    """A request while a capture is in flight parks ONE trailing run.
+
+    The in-flight capture may predate the event that requested it; skipping
+    the request would leave that gap stale forever if nothing else arrives.
+    """
+    from omnigent.terminals.ws_bridge import _GapRepainter
+
+    gate = asyncio.Event()
+    runs: list[int] = []
+
+    async def _repaint() -> None:
+        runs.append(1)
+        await gate.wait()
+
+    repainter = _GapRepainter(_repaint, min_interval_s=0.01)
+    repainter.request()
+    await asyncio.sleep(0.01)
+    assert runs == [1]  # capture 1 in flight, blocked on the gate
+
+    repainter.request()  # arrives mid-capture: must park, not vanish
+    gate.set()
+    await asyncio.sleep(0.1)
+    assert len(runs) == 2, "request during in-flight capture was lost"
+
+
+@pytest.mark.asyncio
+async def test_dropped_snapshot_leaves_a_parked_repaint() -> None:
+    """A recovery snapshot that is itself dropped re-requests recovery.
+
+    Otherwise the drop reopens the gap with nothing scheduled and the screen
+    stays stale until unrelated output happens to arrive.
+    """
+    from omnigent.terminals.ws_bridge import (
+        _OUTPUT_GAP_RESYNC,
+        _ByteBoundedOutputQueue,
+        _GapRepainter,
+    )
+
+    queue = _ByteBoundedOutputQueue(max_bytes=4, max_items=100)
+    runs: list[int] = []
+
+    async def _repaint() -> None:
+        runs.append(1)
+        queue.put_nowait(b"SNAPSHOT!")  # above the byte budget
+
+    repainter = _GapRepainter(_repaint, min_interval_s=0.05)
+    queue.on_drop = repainter.request
+
+    queue.put_nowait(b"aaaa")  # fills the budget
+    queue.put_nowait(b"bbbb")  # dropped -> repaint requested
+    await asyncio.sleep(0.01)
+    assert runs == [1]  # ran, but its snapshot was itself dropped
+
+    assert queue.get_nowait() == b"aaaa"  # consumer finally drains
+    await asyncio.sleep(0.1)  # the parked trailing repaint fires post-cooldown
+    assert len(runs) == 2, "dropped snapshot left no repaint behind"
+    assert queue.get_nowait() == _OUTPUT_GAP_RESYNC
+    assert queue.get_nowait() == b"SNAPSHOT!"
 
 
 @pytest.mark.asyncio

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -15,6 +15,7 @@ import asyncio
 import contextlib
 import fcntl
 import json
+import logging
 import os
 import pty
 import shutil
@@ -1598,41 +1599,112 @@ async def test_check_pane_dead_definitive_tri_state(
 # ── Output-queue backpressure ────────────────────────────
 
 
-def test_bounded_output_queue_drops_oldest_past_byte_cap() -> None:
-    """A saturated bounded output queue sheds the OLDEST chunks.
+def test_bounded_output_queue_rejects_new_chunks_past_byte_cap() -> None:
+    """A saturated bounded output queue drops the INCOMING chunk whole.
 
-    Terminal bytes are lossy-safe (the next repaint restores the screen),
-    so when the browser send is wedged and the backlog passes the byte cap,
-    the freshest output must win and total queued bytes must stay bounded.
+    Evicting already-queued output could sever an escape sequence whose
+    prefix was already sent (wedging the client terminal parser), so the
+    queued backlog stays intact and the new chunk is shed instead.
     """
     from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
 
-    queue = _ByteBoundedOutputQueue(max_bytes=10)
+    queue = _ByteBoundedOutputQueue(max_bytes=10, max_items=100)
     queue.put_nowait(b"aaaa")
     queue.put_nowait(b"bbbb")
-    queue.put_nowait(b"cccc")  # 12 bytes queued -> oldest drops
+    queue.put_nowait(b"cccc")  # would exceed 10 queued bytes -> dropped whole
 
     assert queue.queued_bytes <= 10
+    assert queue.dropped_chunks == 1
+    assert queue.dropped_bytes == 4
     remaining = [queue.get_nowait() for _ in range(queue.qsize())]
-    assert remaining == [b"bbbb", b"cccc"]
+    assert remaining == [b"aaaa", b"bbbb"]
     assert queue.queued_bytes == 0  # _get accounting drains with the items
 
 
-def test_bounded_output_queue_never_drops_eof_sentinel() -> None:
-    """The None EOF sentinel survives saturation (re-queued, not dropped).
+def test_bounded_output_queue_enforces_item_cap() -> None:
+    """The item cap bounds object memory even when chunks are tiny."""
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
 
-    Losing the sentinel would leave the forwarder blocked on get() forever
-    after the reader exits.
+    queue = _ByteBoundedOutputQueue(max_bytes=1_000_000, max_items=2)
+    queue.put_nowait(b"a")
+    queue.put_nowait(b"b")
+    queue.put_nowait(b"c")  # third item -> dropped
+
+    assert queue.qsize() == 2
+    assert queue.dropped_chunks == 1
+
+
+def test_bounded_output_queue_accounts_oversized_lone_chunk() -> None:
+    """A lone chunk above the byte budget is accepted at its REAL size.
+
+    Producers bound single-chunk size, so accepting one oversized chunk
+    into an empty queue keeps the backlog at most one chunk over budget —
+    and its real byte count must gate every subsequent put.
     """
     from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
 
-    queue = _ByteBoundedOutputQueue(max_bytes=4)
-    queue.put_nowait(None)  # sentinel at the front of an over-cap backlog
-    queue.put_nowait(b"xxxxxxxx")
+    queue = _ByteBoundedOutputQueue(max_bytes=4, max_items=100)
+    queue.put_nowait(b"xxxxxxxx")  # alone: accepted despite exceeding budget
+    assert queue.queued_bytes == 8
+    queue.put_nowait(b"y")  # already over budget with company -> dropped
+    assert queue.dropped_chunks == 1
+    assert queue.get_nowait() == b"xxxxxxxx"
 
-    remaining = [queue.get_nowait() for _ in range(queue.qsize())]
-    assert None in remaining
-    assert b"xxxxxxxx" in remaining
+
+def test_bounded_output_queue_gap_close_resyncs_and_repaints() -> None:
+    """Closing a drop gap injects parser-resync bytes and fires on_gap_end.
+
+    The resync bytes (CAN + ST) unwedge a client parser left mid-escape by
+    the gap; the on_gap_end hook is how the bridge forces a full repaint.
+    """
+    from omnigent.terminals.ws_bridge import _OUTPUT_GAP_RESYNC, _ByteBoundedOutputQueue
+
+    gap_ends: list[bool] = []
+    queue = _ByteBoundedOutputQueue(max_bytes=8, max_items=100)
+    queue.on_gap_end = lambda: gap_ends.append(True)
+    queue.put_nowait(b"aaaa")
+    queue.put_nowait(b"bbbb")
+    queue.put_nowait(b"cccc")  # dropped -> gap opens
+    assert gap_ends == []
+
+    assert queue.get_nowait() == b"aaaa"  # consumer drains below budget
+    assert queue.get_nowait() == b"bbbb"
+    queue.put_nowait(b"dddd")  # gap closes: resync precedes resuming output
+    assert [queue.get_nowait(), queue.get_nowait()] == [_OUTPUT_GAP_RESYNC, b"dddd"]
+    assert gap_ends == [True]
+
+
+def test_bounded_output_queue_eof_sentinel_always_lands_last() -> None:
+    """The None EOF sentinel is accepted even when saturated, in order.
+
+    Losing the sentinel would leave the forwarder blocked on get() forever;
+    displacing queued data for it would drop a live final chunk.
+    """
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
+
+    queue = _ByteBoundedOutputQueue(max_bytes=4, max_items=1)
+    queue.put_nowait(b"aaaaaaaa")  # lone oversized final chunk survives
+    queue.put_nowait(b"bb")  # saturated -> dropped
+    queue.put_nowait(None)
+
+    drained = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert drained == [b"aaaaaaaa", None]
+
+
+def test_bounded_output_queue_saturation_warns_rate_limited(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Saturation logs one WARNING with counters, not one per dropped chunk."""
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
+
+    queue = _ByteBoundedOutputQueue(max_bytes=4, max_items=100)
+    queue.put_nowait(b"xxxxxxxx")
+    with caplog.at_level(logging.WARNING, logger="omnigent.terminals.ws_bridge"):
+        for _ in range(50):
+            queue.put_nowait(b"flood")
+    saturation_warnings = [r for r in caplog.records if "saturated" in r.message]
+    assert len(saturation_warnings) == 1
+    assert queue.dropped_chunks == 50
 
 
 @pytest.mark.asyncio

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1593,3 +1593,88 @@ async def test_check_pane_dead_definitive_tri_state(
     # By calling with non-existent socket/target, tmux probe fails and returns None
     result = await _check_pane_dead_definitive("/nonexistent/socket", "nonexistent")
     assert result is None, "inconclusive probe should return None"
+
+
+# ── Output-queue backpressure ────────────────────────────
+
+
+def test_put_output_chunk_drops_oldest_past_byte_cap() -> None:
+    """A saturated bounded output queue sheds the OLDEST chunks.
+
+    Terminal bytes are lossy-safe (the next repaint restores the screen),
+    so when the browser send is wedged and the backlog passes the byte cap,
+    the freshest output must win and total queued bytes must stay bounded.
+    """
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue, _put_output_chunk
+
+    queue = _ByteBoundedOutputQueue(max_bytes=10)
+    _put_output_chunk(queue, b"aaaa")
+    _put_output_chunk(queue, b"bbbb")
+    _put_output_chunk(queue, b"cccc")  # 12 bytes queued -> oldest drops
+
+    assert queue.queued_bytes <= 10
+    remaining = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert remaining == [b"bbbb", b"cccc"]
+    assert queue.queued_bytes == 0  # _get accounting drains with the items
+
+
+def test_put_output_chunk_never_drops_eof_sentinel() -> None:
+    """The None EOF sentinel survives saturation (re-queued, not dropped).
+
+    Losing the sentinel would leave the forwarder blocked on get() forever
+    after the reader exits.
+    """
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue, _put_output_chunk
+
+    queue = _ByteBoundedOutputQueue(max_bytes=4)
+    queue.put_nowait(None)  # sentinel at the front of an over-cap backlog
+    _put_output_chunk(queue, b"xxxxxxxx")
+
+    remaining = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert None in remaining
+    assert b"xxxxxxxx" in remaining
+
+
+def test_put_output_chunk_passthrough_for_plain_queue() -> None:
+    """Plain (unbounded) queues get no drop policy — every chunk lands."""
+    from omnigent.terminals.ws_bridge import _put_output_chunk
+
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+    for _ in range(64):
+        _put_output_chunk(queue, b"x" * 1024)
+    assert queue.qsize() == 64
+
+
+@pytest.mark.asyncio
+async def test_pump_pty_chunks_caps_reads_per_wakeup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One add_reader wakeup drains at most the per-wakeup read cap.
+
+    add_reader is level-triggered, so leaving data buffered just re-fires the
+    callback next loop pass — but an uncapped drain of a flooding PTY would
+    starve every other callback (tunnel heartbeats included) until EAGAIN.
+    """
+    from omnigent.terminals.ws_bridge import _pump_pty_chunks
+
+    monkeypatch.setattr(ws_bridge, "_PTY_READS_PER_WAKEUP", 4)
+    read_fd, write_fd = os.pipe()
+    try:
+        os.set_blocking(read_fd, False)
+        os.set_blocking(write_fd, False)
+        # More data than 4 reads can drain (reads are ≤ _PTY_READ_CHUNK each).
+        written = 0
+        with contextlib.suppress(BlockingIOError):
+            while written < 8 * ws_bridge._PTY_READ_CHUNK:
+                written += os.write(write_fd, b"z" * ws_bridge._PTY_READ_CHUNK)
+        assert written > 5 * ws_bridge._PTY_READ_CHUNK, "pipe buffer too small for test"
+
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        _pump_pty_chunks(loop, read_fd, queue)
+
+        assert queue.qsize() <= 4, "single wakeup drained past the read cap"
+        assert os.read(read_fd, 1), "cap hit but pipe was fully drained"
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1708,6 +1708,55 @@ def test_bounded_output_queue_saturation_warns_rate_limited(
 
 
 @pytest.mark.asyncio
+async def test_gap_repainter_coalesces_bursts_and_paces_repaints() -> None:
+    """A burst of gap closes runs ONE repaint; the next waits out the floor.
+
+    Unthrottled, a slow-but-live consumer cycling gaps at send rate would
+    spawn a repaint subprocess per gap and each redraw amplifies the flood.
+    The trailing-edge behavior still guarantees the final gap repaints.
+    """
+    from omnigent.terminals.ws_bridge import _GapRepainter
+
+    runs: list[int] = []
+
+    async def _repaint() -> None:
+        runs.append(1)
+
+    repainter = _GapRepainter(_repaint, min_interval_s=0.1)
+    for _ in range(5):
+        repainter.request()  # burst: one outstanding repaint, not five
+    await asyncio.sleep(0.02)
+    assert len(runs) == 1
+
+    repainter.request()  # inside the cooldown: parked, not run yet
+    repainter.request()  # coalesced into the parked one
+    await asyncio.sleep(0.02)
+    assert len(runs) == 1, "repaint ran inside the min-interval floor"
+    await asyncio.sleep(0.15)
+    assert len(runs) == 2, "trailing gap close never repainted"
+
+
+@pytest.mark.asyncio
+async def test_gap_repainter_cancel_drops_pending_repaint() -> None:
+    """Teardown cancel stops a parked repaint from firing later."""
+    from omnigent.terminals.ws_bridge import _GapRepainter
+
+    runs: list[int] = []
+
+    async def _repaint() -> None:
+        runs.append(1)
+
+    repainter = _GapRepainter(_repaint, min_interval_s=0.05)
+    repainter.request()
+    await asyncio.sleep(0.01)
+    assert len(runs) == 1
+    repainter.request()  # parked on the cooldown
+    repainter.cancel()
+    await asyncio.sleep(0.15)
+    assert len(runs) == 1, "cancelled pending repaint still fired"
+
+
+@pytest.mark.asyncio
 async def test_pump_pty_chunks_caps_reads_per_wakeup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1598,19 +1598,19 @@ async def test_check_pane_dead_definitive_tri_state(
 # ── Output-queue backpressure ────────────────────────────
 
 
-def test_put_output_chunk_drops_oldest_past_byte_cap() -> None:
+def test_bounded_output_queue_drops_oldest_past_byte_cap() -> None:
     """A saturated bounded output queue sheds the OLDEST chunks.
 
     Terminal bytes are lossy-safe (the next repaint restores the screen),
     so when the browser send is wedged and the backlog passes the byte cap,
     the freshest output must win and total queued bytes must stay bounded.
     """
-    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue, _put_output_chunk
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
 
     queue = _ByteBoundedOutputQueue(max_bytes=10)
-    _put_output_chunk(queue, b"aaaa")
-    _put_output_chunk(queue, b"bbbb")
-    _put_output_chunk(queue, b"cccc")  # 12 bytes queued -> oldest drops
+    queue.put_nowait(b"aaaa")
+    queue.put_nowait(b"bbbb")
+    queue.put_nowait(b"cccc")  # 12 bytes queued -> oldest drops
 
     assert queue.queued_bytes <= 10
     remaining = [queue.get_nowait() for _ in range(queue.qsize())]
@@ -1618,31 +1618,21 @@ def test_put_output_chunk_drops_oldest_past_byte_cap() -> None:
     assert queue.queued_bytes == 0  # _get accounting drains with the items
 
 
-def test_put_output_chunk_never_drops_eof_sentinel() -> None:
+def test_bounded_output_queue_never_drops_eof_sentinel() -> None:
     """The None EOF sentinel survives saturation (re-queued, not dropped).
 
     Losing the sentinel would leave the forwarder blocked on get() forever
     after the reader exits.
     """
-    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue, _put_output_chunk
+    from omnigent.terminals.ws_bridge import _ByteBoundedOutputQueue
 
     queue = _ByteBoundedOutputQueue(max_bytes=4)
     queue.put_nowait(None)  # sentinel at the front of an over-cap backlog
-    _put_output_chunk(queue, b"xxxxxxxx")
+    queue.put_nowait(b"xxxxxxxx")
 
     remaining = [queue.get_nowait() for _ in range(queue.qsize())]
     assert None in remaining
     assert b"xxxxxxxx" in remaining
-
-
-def test_put_output_chunk_passthrough_for_plain_queue() -> None:
-    """Plain (unbounded) queues get no drop policy — every chunk lands."""
-    from omnigent.terminals.ws_bridge import _put_output_chunk
-
-    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
-    for _ in range(64):
-        _put_output_chunk(queue, b"x" * 1024)
-    assert queue.qsize() == 64
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Part of omnigent-ai/omnigent#4437 (PR 4 of 4 — finding G, backpressure bullet).

## Summary

A TUI output flood could starve the runner asyncio loop and grow memory without bound: the terminal bridges pumped output through unbounded queues with synchronous parse loops between awaits, so a firehosing pane could delay tunnel heartbeats until the server declared a (false) runner disconnect. This bounds the whole output pipeline with a split policy:

- **Terminal output queues (lossy-safe → bounded + drop-oldest):** the tmux control-bridge `%output` queue and the PTY-bridge read queue are now byte-bounded (16 MiB). Past the cap the *oldest* chunks are dropped — the pane's next repaint restores the screen — with a debug log on each saturation drop. The EOF sentinel is never dropped. Normal bursts (multi-MB build logs behind a slow browser send) still deliver in full.
- **Event-loop yields after bounded batches:** the control reader yields to the loop after each parsed read batch (`StreamReader.read` returns buffered data without suspending), and the PTY `add_reader` callback now reads at most 16 chunks per wakeup — it's level-triggered, so it re-fires after other ready callbacks (heartbeats included) get a turn.
- **Tunnel outbound queue (protocol frames → bounded + fail-loud, never drop):** the runner-tunnel outbound frame queue is capped at 1024 frames. A dropped frame would strand its RPC silently, so saturation instead fails `send_text` loudly with `ConnectionError` plus a warning log; retiring a session evicts one dead frame if needed so the sender's stop sentinel always lands.

```
pane ──%output/PTY──▶ [byte-bounded queue, drop-oldest] ──▶ coalescing WS forwarder ──▶ browser
transport ──send_text──▶ [frame-bounded queue, fail-loud ConnectionError] ──▶ tunnel sender task
```

**ELI5:** when a terminal program screams output faster than the browser can draw it, we used to buffer everything forever and let the pump hog the CPU. Now the screen buffer keeps only the freshest 16 MB (the screen repaints anyway), the pump takes breaths so heartbeats get through, and the RPC pipe — where losing a message would silently break things — refuses loudly instead of dropping.

## Test Plan

- New unit tests: drop-oldest byte-cap + EOF-sentinel preservation + plain-queue passthrough for the output queues; per-wakeup PTY read cap via a real non-blocking pipe; `send_text` `ConnectionError` on a saturated outbound queue; retire-through-full-queue sentinel delivery.
- Mutation check: with the source fix stashed (tests kept), all 6 new tests fail — 4 in `tests/terminals/test_ws_bridge.py`, 2 in `tests/runner/transports/ws_tunnel/test_registry_extended.py`.
- No-regression: full `tests/terminals/` + `tests/runner/transports/` (314 passed) and `tests/server/integration/test_runner_tunnel_route.py` + `test_sessions_tunnel_three_layer.py` (38 passed). The existing 2 MB burst-then-exit full-tail test still passes, confirming the byte cap doesn't clip normal bursts. (`test_bridge_splits_pty_redraw_after_control_key_input` fails identically on the clean base on this machine — pre-existing environmental failure.)
- `pre-commit run --all-files` clean (the `vscode-tsc` hook fails only because `editors/vscode/node_modules` isn't installed in this worktree; no files it watches are touched).

## Demo

N/A (non-visual).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing burst/coalescing/drain tests for both bridges and the tunnel-registry suites guard the no-behavior-change contract at normal output rates; new unit tests cover the saturation paths.

## Round-1 fixes

Review round-1 (77b603b) reworks the drop and backpressure policies:

- **Safe drop boundaries** — the bounded output queue now sheds the *incoming* chunk whole instead of evicting queued output, so delivered bytes stay contiguous and a drop can never sever an already-partially-sent escape sequence. On gap close the queue injects CAN+ST parser-resync bytes and the bridges force a tmux `refresh-client` repaint.
- **Hard cap** — a lone oversized chunk is accepted at its real size (producers bound single-chunk size) and gates every later put; a companion item cap bounds object memory under tiny-chunk floods.
- **Tunnel backpressure** — `send_text` on a full outbound queue now waits for the sender to drain (never drops, never spuriously fails a healthy-but-slow socket) and only raises `ConnectionError` after a bounded stall deadline.
- **Observability** — saturation logs one rate-limited WARNING with cumulative drop counters (was per-chunk DEBUG), emitted outside the registry lock.
- **Reader coverage** — the control-stream line parser is extracted, bounds its partial-line buffer, yields to the loop on every batch (including oversized-line discard batches), and is now covered by tests shown red with the fixes reverted.

## Round-2 fixes

Review round-2 (933d76e) hardens the round-1 code:

- **No orphaned sends** — the owner-loop enqueue task settles its ack on every exit path (including cancellation at route teardown), the timeout branch re-checks staleness so a replaced session reports `replaced` rather than `stalled`, and the stall error names sender-contention as a possible cause. Adjudication: the sentinel/retire path was empirically sound (the bounded wait always resolves); the real forever-hang was task cancellation orphaning the ack, now closed and covered by repro tests.
- **Repaint throttle** — gap repaints run through a `_GapRepainter`: one outstanding repaint at a time, a 2 s pacing floor with trailing-edge delivery (the last gap always recovers), cancelled at bridge teardown.
- **Real control-mode recovery** — `refresh-client` re-emits nothing toward a control-mode client, so the control bridge now recovers a drop gap by re-emitting a `capture-pane -p -e` snapshot (clear+home, pane rows, cursor restore) as synthetic output, proven end-to-end against real tmux.
- **Complete-line cap** — the control-line parser validates complete lines against the cap too, closing the bypass where a near-cap partial completed by the next read dodged the partial-buffer check.

## Round-3 fixes

Review round-3 (234e9d5) fixes one shared root cause — gap recovery was only ever triggered by a *later accepted chunk*:

- **Drop-triggered recovery** — the bounded queue's hook is now `on_drop`, fired by every rejected chunk (throttled by the repainter), so a dropped flood tail followed by silence still repaints; gap close keeps injecting the parser-resync bytes. A recovery snapshot that is itself dropped re-requests recovery instead of reopening the gap with nothing scheduled.
- **Trailing-park during capture** — `_GapRepainter.request` during an in-flight capture parks exactly one trailing run (the capture may predate the event); requests during the parked cooldown still coalesce.
- **Ack backstops** — `send_text` also settles its ack from a task-done callback (a task cancelled before its coroutine's first step never enters the `try/finally`), and fails loud with `ConnectionError` when the owner loop is stopped or closed. Adjudication: the stopped-loop hang is reachable in-process only at shutdown, but the guard is cheap — both shapes are repro'd as tests.
- **Snapshot atomicity adjudicated** — %output enqueued before the snapshot almost always predates the capture (repaint over it is a no-op) and post-capture output re-renders on top in FIFO order; the screen capture now runs last (after the cursor query) to shrink the ms-scale inversion window. Mode bytes (alt-screen, cursor visibility) are documented as outside snapshot recovery.

This pull request and its description were written by Isaac.
