### PR TITLE
fix(terminal): skip allow-passthrough on tmux < 3.3

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -201,6 +201,12 @@ _REAP_KILL_TIMEOUT_S = 10.0
 # status segments and window formats; it is not an application sentinel.
 _TMUX_EMPTY_OPTION_VALUE = ""
 
+# ``set-option -g allow-passthrough`` was added in tmux 3.3. Stock
+# Ubuntu 22.04 still ships 3.2a; sending the option there rejects the
+# entire ``new-session`` command sequence (issue #4442). Mirror the
+# parse-and-compare style of :func:`omnigent.repl._tmux_pane._tmux_version_ok`.
+_MIN_TMUX_ALLOW_PASSTHROUGH_VERSION = (3, 3)
+
 
 def _tmux_command_sequence(commands: list[list[str]]) -> list[str]:
     """
@@ -223,6 +229,57 @@ def _tmux_command_sequence(commands: list[list[str]]) -> list[str]:
     return sequence
 
 
+def _parse_tmux_version(version_text: str) -> tuple[int, ...] | None:
+    """
+    Parse ``tmux -V`` stdout into a ``(major, minor)`` tuple.
+
+    Suffix letters (``"a"`` in ``"3.2a"``) are ignored so a stable
+    3.2.x release counts as 3.2 — same convention as
+    :func:`omnigent.repl._tmux_pane._tmux_version_ok`.
+
+    :param version_text: Raw ``tmux -V`` output, e.g. ``"tmux 3.2a"``.
+    :returns: Leading two integers, or ``None`` when the text is
+        unparseable.
+    """
+    parts = version_text.strip().split()
+    if len(parts) != 2:
+        return None
+    nums: list[int] = []
+    for piece in parts[1].replace("-", ".").split("."):
+        digits = "".join(ch for ch in piece if ch.isdigit())
+        if digits:
+            nums.append(int(digits))
+        if len(nums) >= 2:
+            break
+    if len(nums) < 2:
+        return None
+    return tuple(nums[:2])
+
+
+def _tmux_supports_allow_passthrough() -> bool:
+    """
+    Return whether the installed tmux accepts ``allow-passthrough``.
+
+    Parses ``tmux -V`` and compares against
+    :data:`_MIN_TMUX_ALLOW_PASSTHROUGH_VERSION`. Returns ``False`` when
+    tmux is missing, unparseable, or older than 3.3 so callers can
+    omit the option instead of failing the whole launch.
+    """
+    try:
+        out = subprocess.run(
+            ["tmux", "-V"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return False
+    parsed = _parse_tmux_version(out)
+    if parsed is None:
+        return False
+    return parsed >= _MIN_TMUX_ALLOW_PASSTHROUGH_VERSION
+
+
 def _tmux_managed_option_commands(
     scrollback: int,
     *,
@@ -235,6 +292,8 @@ def _tmux_managed_option_commands(
     :param scrollback: Tmux history limit, e.g. ``10000``.
     :param allow_passthrough: Whether to allow pane programs to send
         passthrough escape sequences to the real attached terminal.
+        Ignored when the installed tmux is older than 3.3 (the option
+        did not exist yet); the launch proceeds without it.
     :param keep_alive_after_exit: When ``True``, keep the private tmux server
         alive after the pane's process exits (see
         :func:`_tmux_session_persistence_commands`). Opt-in because it changes
@@ -250,7 +309,13 @@ def _tmux_managed_option_commands(
     if keep_alive_after_exit:
         commands.extend(_tmux_session_persistence_commands())
     if allow_passthrough:
-        commands.append(["set-option", "-g", "allow-passthrough", "on"])
+        if _tmux_supports_allow_passthrough():
+            commands.append(["set-option", "-g", "allow-passthrough", "on"])
+        else:
+            logger.warning(
+                "tmux >= %s required for allow-passthrough; omitting option",
+                ".".join(str(n) for n in _MIN_TMUX_ALLOW_PASSTHROUGH_VERSION),
+            )
     return commands
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5593,9 +5593,11 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
         e.g. ``ImportError("Native Codex requires the 'codex' CLI on PATH.")``.
     :param runtime_name: Human-readable runtime name, e.g. ``"Codex"``.
     :returns: ``{"code": ..., "message": ...}`` payload for SSE and
-        JSON error responses. The message is a client-safe string naming
-        the runner's log file; the raw cause is logged there for operators,
-        not surfaced to the caller.
+        JSON error responses. The message names the runner's log file.
+        Most causes stay log-only (CLI-missing text can embed paths), but
+        ``tmux launch failed …`` stderr is included so hosts with an old
+        or misconfigured tmux get a self-diagnosing client error (issue
+        #4442) without opening the runner log.
     """
     _logger.warning("Native %s terminal start failed: %s", runtime_name, exc, exc_info=exc)
     if IS_WINDOWS:
@@ -5608,10 +5610,20 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
         )
     else:
         log_reference = process_log_reference("runner")
-        message = (
-            f"Native {runtime_name} terminal failed to start; "
-            f"see the runner log for details: {log_reference}"
-        )
+        cause = str(exc).strip()
+        if cause.startswith("tmux launch failed"):
+            # Surface the real tmux stderr: without it, allow-passthrough /
+            # socket / binary failures collapse into an undiagnosable
+            # "see the runner log" message.
+            message = (
+                f"Native {runtime_name} terminal failed to start: {cause}; "
+                f"see the runner log for details: {log_reference}"
+            )
+        else:
+            message = (
+                f"Native {runtime_name} terminal failed to start; "
+                f"see the runner log for details: {log_reference}"
+            )
     return {"code": _NATIVE_TERMINAL_START_FAILED_CODE, "message": message}
 
 

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -22,6 +22,8 @@ from omnigent.inner.terminal import (
     _apply_utf8_locale_default,
     _has_utf8_locale,
     _is_utf8_locale_value,
+    _parse_tmux_version,
+    _tmux_managed_option_commands,
     create_terminal_instance,
     resolve_terminal_transport,
 )
@@ -536,6 +538,85 @@ async def test_launch_omits_keep_alive_options_by_default(
     cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=False)
     assert not contains_subsequence(cmd, ["set-option", "-gq", "remain-on-exit", "on"])
     assert not contains_subsequence(cmd, ["set-option", "-sq", "exit-empty", "off"])
+
+
+@pytest.mark.parametrize(
+    ("version_text", "expected"),
+    [
+        ("tmux 3.3", (3, 3)),
+        ("tmux 3.2a", (3, 2)),
+        ("tmux 3.4", (3, 4)),
+        ("tmux next-3.5", (3, 5)),
+        ("not-a-version", None),
+    ],
+)
+def test_parse_tmux_version(version_text: str, expected: tuple[int, int] | None) -> None:
+    """
+    ``_parse_tmux_version`` extracts ``(major, minor)`` and ignores letter suffixes.
+
+    :param version_text: Fake ``tmux -V`` stdout.
+    :param expected: Parsed tuple, or ``None`` when unparseable.
+    """
+    assert _parse_tmux_version(version_text) == expected
+
+
+def test_tmux_managed_option_commands_includes_allow_passthrough_on_tmux_3_3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    tmux >= 3.3 still receives ``allow-passthrough on`` when requested (issue #4442).
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        assert cmd[:2] == ["tmux", "-V"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="tmux 3.3\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    commands = _tmux_managed_option_commands(10000, allow_passthrough=True)
+    assert ["set-option", "-g", "allow-passthrough", "on"] in commands
+
+
+def test_tmux_managed_option_commands_skips_allow_passthrough_on_old_tmux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    tmux < 3.3 must omit ``allow-passthrough`` so launch does not fail (issue #4442).
+
+    Stock Ubuntu 22.04 ships tmux 3.2a; sending the option rejects the entire
+    ``new-session`` sequence with ``invalid option: allow-passthrough``.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        assert cmd[:2] == ["tmux", "-V"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="tmux 3.2a\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    commands = _tmux_managed_option_commands(10000, allow_passthrough=True)
+    assert ["set-option", "-g", "allow-passthrough", "on"] not in commands
+    # Other managed options must still be present — we degrade only the
+    # unsupported option, not the whole option sequence.
+    assert any(cmd[:2] == ["set-option", "-g"] for cmd in commands)
+
+
+def test_tmux_managed_option_commands_omits_allow_passthrough_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``allow_passthrough=False`` never probes or sets the option.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    def fail_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("tmux -V must not run when allow_passthrough is False")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    commands = _tmux_managed_option_commands(10000, allow_passthrough=False)
+    assert ["set-option", "-g", "allow-passthrough", "on"] not in commands
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -57,6 +57,7 @@ from omnigent.runner.app import (
     _KiroNativeLaunchConfig,
     _load_claude_launch_metadata,
     _log_terminal_lookup_miss,
+    _native_terminal_start_error_payload,
     _PiNativeLaunchConfig,
     _publish_native_terminal_start_error,
     _publish_terminal_pending,
@@ -1777,6 +1778,26 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
         },
     ]
     assert all(p.session_id == "415c9954e2fe4b9276083a4d2c66f689" for p in published)
+
+
+def test_native_terminal_start_error_payload_surfaces_tmux_launch_stderr(
+    pinned_runner_log: Path,
+) -> None:
+    """
+    ``tmux launch failed …`` stderr is included in the client-facing message.
+
+    Issue #4442: without the real tmux text, an ``invalid option:
+    allow-passthrough`` (or any other tmux reject) collapses into a generic
+    "see the runner log" string that users cannot diagnose.
+
+    :param pinned_runner_log: The log path the message must still name.
+    """
+    cause = "tmux launch failed (rc=1): invalid option: allow-passthrough"
+    error = _native_terminal_start_error_payload(RuntimeError(cause), "Cursor")
+    assert error["code"] == "native_terminal_start_failed"
+    assert cause in error["message"]
+    assert "Native Cursor terminal failed to start:" in error["message"]
+    assert str(pinned_runner_log) in error["message"]
 
 
 def test_terminal_lookup_miss_log_explains_stopped_registered_terminal(


### PR DESCRIPTION
## Summary
- Version-gate `set-option -g allow-passthrough` so native harness launches omit the option on tmux < 3.3 (e.g. Ubuntu 22.04 / WSL2 shipping 3.2a) instead of rejecting the whole `new-session` sequence.
- Mirror the parse-and-compare style of `omnigent.repl._tmux_pane._tmux_version_ok`.
- Surface `tmux launch failed …` stderr in the client-facing native terminal start error so failures are self-diagnosing without opening the runner log.

Fixes #4442

## Test plan
- [x] `uv run pytest tests/inner/test_terminal.py tests/runner/test_app_sessions_native_terminals_autocreate.py`
- [x] `uv run ruff check` / `ruff format --check` on changed files
- [x] `uv run --no-sync pyrefly check`
- [x] `uv run pre-commit run --files` (changed files)
- [ ] On a host with tmux 3.2a, confirm a `*-native` harness launches without `invalid option: allow-passthrough`
- [ ] On tmux >= 3.3, confirm `allow-passthrough on` is still set when requested


Made with [Cursor](https://cursor.com)