### PR TITLE
fix: distinguish self-managed model workers and unblock Antigravity children

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1017,10 +1017,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         entry = build_databricks_provider_entry(profile)
 
     from omnigent.onboarding.configure_models import family_label
-    from omnigent.onboarding.provider_config import (
-        provider_families,
-        surface_default_provider,
-    )
+    from omnigent.onboarding.provider_config import provider_families
 
     # Persist the entry (deep-merge — doesn't disturb sibling entries).
     _save_global_config(
@@ -1048,7 +1045,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     became_default: list[str] = []
     for fam in default_families:
         cfg = _load_global_config()
-        if surface_default_provider(cfg, fam) is not None:
+        if _surface_already_driven(cfg, fam, name, claimed=bool(became_default)):
             continue
         block = cfg.get("providers")
         if isinstance(block, dict):
@@ -1058,6 +1055,39 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         labels = " · ".join(family_label(f) for f in became_default)
         return f"✓ Added {name} — default for {labels}"
     return f"✓ Added {name}"
+
+
+def _surface_already_driven(
+    config: dict[str, object], surface: str, name: str, *, claimed: bool
+) -> bool:
+    """Whether *surface* is already driven, so entry *name* must not claim it.
+
+    The "don't re-route what the user configured" guard, asked of the config
+    as it stands AFTER the new entry was persisted — which is why the
+    self-match needs handling. Two self-match cases, opposite answers:
+
+    - *claimed* is ``False``: the entry has taken no default yet, and it only
+      resolves for *surface* because pi's effective default is a fallback scan
+      over every pi-capable provider, which now includes it. Treating that as
+      "already driven" would drop the explicit scope the user picked (the
+      ``+Add`` → Databricks-under-Pi path claims ``pi`` and nothing else).
+    - *claimed* is ``True``: the entry took a family default a moment ago, and
+      that claim is what drives *surface*. A second explicit scope would only
+      restate it — the whole-served-set spelling (``default: true``) is the
+      one the config should keep.
+
+    :param config: The parsed global config, including the new entry.
+    :param surface: ``"anthropic"`` / ``"openai"`` / ``"gemini"`` / ``"pi"``.
+    :param name: The provider entry being decided about.
+    :param claimed: Whether *name* already took a default in this pass.
+    :returns: ``True`` when *surface* must be left alone.
+    """
+    from omnigent.onboarding.provider_config import surface_default_provider
+
+    current = surface_default_provider(config, surface)
+    if current is None:
+        return False
+    return claimed or current.name != name
 
 
 def _adopt_detected_providers() -> list[str]:
@@ -1115,7 +1145,6 @@ def _promote_global_auth_to_provider() -> str | None:
         provider_entry_settings,
         provider_families,
         set_default_provider,
-        surface_default_provider,
     )
 
     config = _load_global_config()
@@ -1135,16 +1164,18 @@ def _promote_global_auth_to_provider() -> str | None:
         deep_merge_keys=("providers",),
     )
     parsed = load_providers({"providers": {name: entry}})[name]
+    claimed = False
     for fam in sorted(provider_families(parsed)):
         cfg = _load_global_config()
         # Effective check (matters for the pi surface): a default that
         # already drives the surface — explicitly or via pi's fallback —
         # outranks the legacy auth: block, exactly like routing does.
-        if surface_default_provider(cfg, fam) is not None:
+        if _surface_already_driven(cfg, fam, name, claimed=claimed):
             continue  # respect an existing provider default (it outranks auth:)
         block = cfg.get("providers")
         if isinstance(block, dict):
             _save_global_config({"providers": set_default_provider(block, name, fam)})
+            claimed = True
     return name
 
 

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -24,8 +24,20 @@ Enumeration is deterministic per provider kind:
 - ``cli-config`` → the codex curated static list (source ``"static"``,
   ``verified: false`` — the credential lives in the CLI's own config
   file and is resolved by the CLI at launch).
-- anything unresolvable → source ``"none"`` with an explanatory note,
-  which doubles as a dead-worker preflight signal.
+
+Everything else splits three ways, because "Omnigent enumerated nothing"
+is three different facts with three different consequences for a caller:
+
+- ``self-managed`` → the harness authenticates itself (goose, hermes,
+  opencode, generic ACP agents), so Omnigent wires no credential and can
+  enumerate no models. Dispatch is UNAFFECTED — the harness picks the
+  model from its own config.
+- ``unconfigured`` → no USABLE Omnigent provider resolved for a harness
+  that needs one — nothing configured, or a configured provider whose
+  credential could not be resolved. A dispatch is at risk.
+- ``unavailable`` → a provider resolved but its listing could not be
+  fetched. Only the sub-case this module can prove launch-blocking (the
+  backing CLI is not installed) says a dispatch cannot run.
 """
 
 from __future__ import annotations
@@ -80,6 +92,19 @@ _logger = logging.getLogger(__name__)
 
 # Sentinel kind for "no usable provider resolved" rows.
 NONE_KIND = "none"
+
+# Sentinel kind for a harness that authenticates itself: there is no Omnigent
+# provider to resolve (or to fail resolving), so the readout must not imply one
+# was missing. Mirrors how _CURSOR_HARNESSES short-circuits to a subscription
+# readout instead of reporting cursor as unresolvable.
+SELF_MANAGED_KIND = "self-managed"
+
+# ``ModelListing.source`` values for the empty-list rows. The single legacy
+# ``"none"`` conflated all three, so a caller could not tell a working
+# self-authenticating worker from a dead one.
+SELF_MANAGED_SOURCE = "self-managed"
+UNCONFIGURED_SOURCE = "unconfigured"
+UNAVAILABLE_SOURCE = "unavailable"
 
 # ~5 min: provider listings change rarely; a turn that fans out many
 # dispatches should never re-fetch per call.
@@ -190,8 +215,9 @@ class ModelListing:
     """A worker's enumerated model list plus its provenance.
 
     :param source: Where the list came from — ``"gateway"``,
-        ``"openai-compatible"``, ``"anthropic-api"``, ``"cli"``,
-        ``"static"``, or ``"none"``.
+        ``"openai-compatible"``, ``"anthropic-api"``, ``"cli"``, or
+        ``"static"``; else why it is empty — :data:`SELF_MANAGED_SOURCE`,
+        :data:`UNCONFIGURED_SOURCE`, or :data:`UNAVAILABLE_SOURCE`.
     :param verified: ``True`` when the list was fetched live from the
         provider; ``False`` for static/curated or empty listings.
     :param models: The enumerated models, e.g.
@@ -214,8 +240,9 @@ class ResolvedModelProvider:
 
     :param kind: Provider kind — ``"key"`` / ``"gateway"`` / ``"local"``
         / ``"subscription"`` / ``"databricks"`` / ``"cli-config"`` from
-        the provider config layer, or ``"none"`` when no usable provider
-        resolved.
+        the provider config layer, :data:`SELF_MANAGED_KIND` when the
+        harness supplies its own credential, or ``"none"`` when a
+        provider was needed and none resolved.
     :param family: ``"anthropic"`` / ``"openai"`` for inline-family
         kinds, else ``None``.
     :param profile: Databricks profile for ``kind="databricks"``, e.g.
@@ -541,16 +568,42 @@ def _resolve_model_provider_unsafe(spec: object, harness: str | None) -> Resolve
 
     harness_type = _PROVIDER_RESOLUTION_HARNESS.get(harness or "")
     if harness_type is None:
-        return ResolvedModelProvider(
-            kind=NONE_KIND,
-            detail=f"harness {harness or 'unknown'!r} has no model-provider resolution",
-        )
+        return _unresolved_provider(harness)
 
     agent_spec = cast("AgentSpec", spec)
     entry = _resolve_provider_for_build(agent_spec, harness_type=harness_type)
     if entry is not None:
         return _provider_from_entry(entry, harness_type)
     return _provider_from_legacy_auth(agent_spec, harness_type)
+
+
+def _unresolved_provider(harness: str | None) -> ResolvedModelProvider:
+    """Classify a harness absent from :data:`_PROVIDER_RESOLUTION_HARNESS`.
+
+    A missing entry is not one fact but two. For a self-authenticating
+    harness (goose, hermes, opencode, a generic ACP agent) the absence is
+    CORRECT: its spawn builder deliberately wires no credential — see
+    :func:`omnigent.runtime.workflow._build_goose_spawn_env`, "Goose owns its
+    own auth via ``goose configure``" — so there is nothing to resolve and
+    dispatch works fine. Reporting that as ``kind="none"`` made the readout
+    claim a live worker was dead. For anything else the absence really does
+    mean no provider was determined.
+
+    :param harness: The worker's harness id, e.g. ``"goose"``.
+    :returns: A :data:`SELF_MANAGED_KIND` provider for a self-authenticating
+        harness, else a ``kind="none"`` provider.
+    """
+    from omnigent.onboarding.provider_config import harness_declares_own_auth
+
+    if harness and harness_declares_own_auth(harness):
+        return ResolvedModelProvider(
+            kind=SELF_MANAGED_KIND,
+            detail=f"the {harness} harness authenticates itself; Omnigent wires no credential",
+        )
+    return ResolvedModelProvider(
+        kind=NONE_KIND,
+        detail=f"harness {harness or 'unknown'!r} has no model-provider resolution",
+    )
 
 
 def _provider_from_legacy_auth(
@@ -838,8 +891,9 @@ def catalog_for_spec(
 
     One row per declared sub-agent, keyed by sub-agent name, plus a
     ``"self"`` row for the calling agent's own (brain) harness. Failures
-    are isolated per worker: one broken provider yields a ``"none"`` row
-    with the failure in its note and never hides the other workers.
+    are isolated per worker: one broken provider yields an
+    :data:`UNAVAILABLE_SOURCE` row with the failure in its note and never
+    hides the other workers.
 
     :param spec: The calling agent's spec (sub-agents enumerated from
         ``spec.sub_agents``).
@@ -875,7 +929,7 @@ def _worker_row(
     except Exception as exc:  # noqa: BLE001 — per-worker isolation: fail informative, never crash the tool
         _logger.debug("worker model enumeration failed", exc_info=True)
         listing = ModelListing(
-            source=NONE_KIND,
+            source=UNAVAILABLE_SOURCE,
             verified=False,
             models=(),
             note=f"model enumeration failed: {_redacted_failure_reason(exc)}",
@@ -981,14 +1035,17 @@ def _listing_for_provider(
     :param transport: Optional httpx transport override for tests.
     :returns: The provider's :class:`ModelListing`.
     """
+    if provider.kind == SELF_MANAGED_KIND:
+        return _self_managed_listing(provider)
     if provider.kind == NONE_KIND:
         return ModelListing(
-            source=NONE_KIND,
+            source=UNCONFIGURED_SOURCE,
             verified=False,
             models=(),
             note=(
-                f"no usable model provider ({provider.detail}) — dispatches to "
-                "this worker cannot run here"
+                f"no usable Omnigent model provider resolved for this worker "
+                f"({provider.detail}), so no models can be enumerated; a dispatch "
+                "will fail unless the harness supplies its own credentials"
             ),
         )
     if provider.kind == SUBSCRIPTION_KIND and provider.cli != "cursor-agent":
@@ -1020,18 +1077,60 @@ def _listing_for_provider(
         _logger.debug(
             "model enumeration failed for %s", provider.detail or provider.kind, exc_info=True
         )
-        return ModelListing(
-            source=NONE_KIND,
-            verified=False,
-            models=(),
-            note=(
-                f"model enumeration failed for {provider.detail or provider.kind}: "
-                f"{_redacted_failure_reason(exc)}"
-            ),
-        )
+        return _unavailable_listing(provider, exc)
     with _listing_cache_lock:
         _listing_cache[cache_key] = listing
     return listing
+
+
+def _self_managed_listing(provider: ResolvedModelProvider) -> ModelListing:
+    """Build the empty-but-healthy listing for a self-authenticating harness.
+
+    ``verified`` stays ``False`` and ``models`` stays empty — nothing was
+    fetched, and fabricating a curated list here would advertise ids the
+    user's own vendor config may not serve. The note carries the one fact a
+    supervisor needs: the emptiness is not a failure, so dispatch to this
+    worker without an ``args.model``.
+
+    :param provider: A :data:`SELF_MANAGED_KIND` provider descriptor.
+    :returns: A :data:`SELF_MANAGED_SOURCE` listing.
+    """
+    return ModelListing(
+        source=SELF_MANAGED_SOURCE,
+        verified=False,
+        models=(),
+        note=(
+            f"{provider.detail}, so its models cannot be enumerated from here — "
+            "this is not a failure: dispatches to this worker run normally and the "
+            "harness picks the model from its own configuration (omit 'args.model')"
+        ),
+    )
+
+
+def _unavailable_listing(provider: ResolvedModelProvider, exc: Exception) -> ModelListing:
+    """Build the listing for a resolved provider whose enumeration failed.
+
+    A failed fetch is usually transient (endpoint 503, expired token) and says
+    nothing about whether a dispatch would launch, so the note must not claim
+    the worker is dead. The one exception this module can actually prove is a
+    missing CLI binary: ``FileNotFoundError`` out of a CLI-backed provider's
+    subprocess means the executable is absent, which IS launch-blocking.
+
+    :param provider: The resolved provider whose listing failed.
+    :param exc: The caught enumeration failure.
+    :returns: An :data:`UNAVAILABLE_SOURCE` listing.
+    """
+    if isinstance(exc, FileNotFoundError) and provider.cli:
+        note = (
+            f"the {provider.cli} CLI is not installed — dispatches to this worker cannot run here"
+        )
+    else:
+        note = (
+            f"model enumeration failed for {provider.detail or provider.kind}: "
+            f"{_redacted_failure_reason(exc)}; the provider is configured, so a "
+            "dispatch may still run"
+        )
+    return ModelListing(source=UNAVAILABLE_SOURCE, verified=False, models=(), note=note)
 
 
 def _fetch_cursor_cli_listing(provider: ResolvedModelProvider) -> ModelListing:

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -76,6 +76,7 @@ from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
+    GEMINI_FAMILY,
     KEY_KIND,
     OPENAI_FAMILY,
     SUBSCRIPTION_KIND,
@@ -180,7 +181,9 @@ _KEY_AUTH_FAMILY: dict[str, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
-    "antigravity": OPENAI_FAMILY,
+    # Antigravity's SDK is Gemini-native.  Treating it as OpenAI here made
+    # an unrelated Codex subscription fallback appear as its vendor identity.
+    "antigravity": GEMINI_FAMILY,
     "qwen": OPENAI_FAMILY,
 }
 

--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -131,6 +131,10 @@ def _pin_defaults_after_write(
 
     ``set_default_provider`` rewrites the whole providers block (it clears
     sibling default flags a deep-merge can't reach), so each pin re-reads first.
+
+    Pin 2 deliberately counts the entry pin 1 just wrote: once Pi's resolver
+    reaches it through the family default, Pi is unstuck and a second,
+    explicit pi scope would only duplicate what already routes.
     """
     from omnigent.onboarding.provider_config import (
         PI_SURFACE,

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -1138,10 +1138,12 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
     codex/native-codex/openai-agents→openai) and returns that family's
     default. The ``pi`` harness (and any unmapped harness) consumes both
     families: an explicit :data:`PI_SURFACE` default wins; otherwise it
-    falls back to the ``anthropic`` then ``openai`` family default,
-    skipping ``subscription`` and ``bedrock`` defaults (a CLI login is
-    unusable outside its own CLI, and ``bedrock`` is native-``omnigent
-    claude`` only — routing pi to either fails). A ``cli-config`` default is
+    walks the ``anthropic`` then ``openai`` candidates — each family's
+    default first, then its remaining providers in config order (see
+    :func:`_pi_candidate_providers`) — skipping ``subscription`` and
+    ``bedrock`` entries (a CLI login is unusable outside its own CLI, and
+    ``bedrock`` is native-``omnigent claude`` only — routing pi to either
+    fails). A ``cli-config`` entry is
     skipped UNLESS it is a pi-consumable Databricks AI Gateway (see
     :func:`_cli_config_serves_pi`): such a gateway exposes an Anthropic
     surface Pi speaks natively, so pi-native translates it
@@ -1168,28 +1170,60 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
     # and skip the CLI-bound kinds (unusable outside their own CLI). Gemini is
     # excluded (a gemini key serves only the Gemini surface, never pi).
     for fam in _PI_FALLBACK_FAMILIES:
-        provider = get_default_provider(config, fam)
-        if provider is None:
-            continue
-        # Subscription logins live in the claude/codex CLI's own login, which
-        # an unmapped harness doesn't wrap; a bedrock provider is
-        # native-``omnigent claude`` only (configure_agent_harness_with_provider
-        # raises for it). Neither can serve pi, so skip them and fall through —
-        # otherwise a bedrock Claude default would turn a working pi run (own
-        # login) into a hard error.
-        if provider.kind in (SUBSCRIPTION_KIND, BEDROCK_KIND):
-            continue
-        # A cli-config provider pins a model_provider in the codex CLI's own
-        # config.toml. Most such pins are unusable outside codex, BUT a
-        # Databricks AI Gateway exposes an Anthropic surface Pi speaks natively
-        # (translated by ``_cli_config_pi_provider`` for pi-native, and routed
-        # by ``configure_agent_harness_with_provider`` for the gateway-harness
-        # pi path). Route pi to it rather than skipping; a non-Databricks
-        # cli-config still falls through (it can't serve pi).
-        if provider.kind == CLI_CONFIG_KIND and not _cli_config_serves_pi(provider):
-            continue
-        return provider
+        for provider in _pi_candidate_providers(config, fam):
+            # Subscription logins live in the claude/codex CLI's own login,
+            # which an unmapped harness doesn't wrap; a bedrock provider is
+            # native-``omnigent claude`` only
+            # (configure_agent_harness_with_provider raises for it). Neither can
+            # serve pi, so skip them and keep looking — otherwise a bedrock
+            # Claude default would turn a working pi run (own login) into a
+            # hard error.
+            if provider.kind in (SUBSCRIPTION_KIND, BEDROCK_KIND):
+                continue
+            # A cli-config provider pins a model_provider in the codex CLI's own
+            # config.toml. Most such pins are unusable outside codex, BUT a
+            # Databricks AI Gateway exposes an Anthropic surface Pi speaks natively
+            # (translated by ``_cli_config_pi_provider`` for pi-native, and routed
+            # by ``configure_agent_harness_with_provider`` for the gateway-harness
+            # pi path). Route pi to it rather than skipping; a non-Databricks
+            # cli-config still falls through (it can't serve pi).
+            if provider.kind == CLI_CONFIG_KIND and not _cli_config_serves_pi(provider):
+                continue
+            return provider
     return None
+
+
+def _pi_candidate_providers(config: dict[str, object], family: str) -> list[ProviderEntry]:
+    """Order the providers an unmapped harness (pi) may fall back to in *family*.
+
+    The family's ``default: true`` provider first, then every other provider
+    serving *family* in config order. Both halves matter: the default is the
+    user's stated preference, and the remainder is what keeps a usable
+    credential reachable when that default is one of the kinds pi cannot
+    consume (``subscription`` / ``bedrock`` / non-Databricks ``cli-config``).
+
+    Iterating only the defaults — one per family — is what previously stranded
+    pi on a machine whose anthropic AND openai defaults were both subscription
+    CLI logins: the loop skipped the unusable default and moved to the next
+    *family*, never reaching a perfectly usable API-key provider one slot down
+    in the same family. The skip rules are unchanged; only the candidate set
+    they run against widened.
+
+    :param config: The parsed config mapping (``providers:`` block).
+    :param family: The pi-capable family to draw candidates from,
+        ``"anthropic"`` or ``"openai"``.
+    :returns: The candidate providers, most-preferred first.
+    :raises OmnigentError: If a provider is malformed, or more than one
+        ``default: true`` provider serves *family*.
+    """
+    default = get_default_provider(config, family)
+    candidates = [default] if default is not None else []
+    candidates.extend(
+        entry
+        for entry in load_providers(config).values()
+        if family in provider_families(entry) and (default is None or entry.name != default.name)
+    )
+    return candidates
 
 
 def surface_default_provider(config: dict[str, object], surface: str) -> ProviderEntry | None:
@@ -1288,6 +1322,40 @@ def _source_descriptor(family: FamilyConfig) -> str:
     )
 
 
+def harness_declares_own_auth(harness: str) -> bool:
+    """Whether *harness* authenticates itself, whatever its integration mode.
+
+    The broad form of the own-auth question: the harness's capability record
+    declares :attr:`~omnigent.harness_capabilities.AuthModel.OWN_AUTH` (a
+    vendor login or vendor-side API key) and the harness is not
+    provider-routed at spawn via :data:`_HARNESS_FAMILY`. True for the
+    ACP-backed harnesses (``acp``/``acp:<slug>``, ``goose``) AND for the
+    native harnesses whose launch copies the user's own vendor config forward
+    rather than wiring an Omnigent credential — ``goose-native``,
+    ``hermes``/``hermes-native``, ``opencode-native``, ``kiro-native``.
+
+    A harness mapped in :data:`_HARNESS_FAMILY` is provider-routed at spawn
+    (e.g. qwen consumes the openai family via its gateway env) even when its
+    capability record declares own-auth for the unconfigured fallback, so it
+    is never declined here — its family default is genuinely what it runs on.
+
+    Used by :mod:`omnigent.model_catalog` to tell "Omnigent enumerates no
+    models because the harness owns its auth" (dispatch works fine) apart
+    from "no provider is configured" (dispatch is at risk).
+
+    :param harness: The harness name, canonical or ``acp:<slug>``.
+    :returns: ``True`` when the harness supplies its own credential.
+    """
+    from omnigent.harness_capabilities import AuthModel
+    from omnigent.harness_plugins import harness_capabilities
+
+    canonical = canonicalize_harness(harness) or harness
+    if canonical in _HARNESS_FAMILY:
+        return False
+    caps = harness_capabilities().get(canonical)
+    return caps is not None and caps.auth is AuthModel.OWN_AUTH
+
+
 def harness_owns_its_credential(harness: str) -> bool:
     """Whether *harness* carries its own auth, so Omnigent resolves none.
 
@@ -1296,26 +1364,22 @@ def harness_owns_its_credential(harness: str) -> bool:
     the external agent authenticates itself, so describing an Omnigent
     provider for one would name a credential the session never uses.
 
-    A harness mapped in :data:`_HARNESS_FAMILY` is provider-routed at spawn
-    (e.g. qwen consumes the openai family via its gateway env) even when its
-    capability record declares own-auth for the unconfigured fallback, so it
-    is never declined here — its family default is genuinely what it runs on.
+    The narrow form of :func:`harness_declares_own_auth`, additionally
+    requiring the ACP subprocess integration mode. The credential readouts
+    (REPL header, ``describe_active_credential``) use this one: a native TUI
+    harness still shows its resolved provider row there.
 
     :param harness: The harness name, canonical or ``acp:<slug>``.
     :returns: ``True`` when the harness owns its own credential.
     """
-    from omnigent.harness_capabilities import AuthModel, IntegrationMode
+    from omnigent.harness_capabilities import IntegrationMode
     from omnigent.harness_plugins import harness_capabilities
 
+    if not harness_declares_own_auth(harness):
+        return False
     canonical = canonicalize_harness(harness) or harness
-    if canonical in _HARNESS_FAMILY:
-        return False
     caps = harness_capabilities().get(canonical)
-    if caps is None:
-        return False
-    return (
-        caps.integration_mode is IntegrationMode.ACP_SUBPROCESS and caps.auth is AuthModel.OWN_AUTH
-    )
+    return caps is not None and caps.integration_mode is IntegrationMode.ACP_SUBPROCESS
 
 
 def describe_active_credential(

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -164,9 +164,9 @@ _HARNESS_FAMILY: dict[str, str] = {
     # normally maps it down via _provider_harness_name; accept both spellings
     # here so callers that pass the spec/CLI spelling directly resolve too.
     "openai-agents-sdk": OPENAI_FAMILY,
-    # Antigravity is Gemini-native but routes generic-provider traffic over
-    # the OpenAI-compatible wire, so it consumes the ``openai`` family.
-    "antigravity": OPENAI_FAMILY,
+    # Antigravity's SDK consumes Gemini credentials directly; it has no
+    # OpenAI-compatible provider path.
+    "antigravity": GEMINI_FAMILY,
     # NB: ``kimi`` is intentionally absent. Upstream Kimi Code CLI has no
     # per-spawn provider override flag, so Omnigent cannot thread a generic
     # provider through. Provider routing for kimi lives in ``~/.kimi/config.toml``

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4092,16 +4092,13 @@ async def _auto_create_antigravity_terminal(
     over tmux whether or not a web client has opened the Terminal panel (see
     the ``tmux_start_on_attach`` note on the spec below).
 
-    **Permissions are web-attended, not headless.** The web client attaches
-    to the agy pane through the runner tunnel and answers agy's
-    ``request-review`` TUI prompt there, so the launch is treated as
-    *attended* (``headless=False``). Auto-bypass comes only from the user's
-    persisted ``terminal_launch_args`` (which carry
-    ``--dangerously-skip-permissions`` when the user asked for bypass) —
-    the same pass-through mechanism codex/claude use. A server-spawned
-    launch must NOT key headlessness on the runner process's (absent) TTY,
-    which would silently disable the per-tool prompt for a watching web
-    user.
+    **Permissions distinguish attended sessions from dispatched children.** A
+    top-level web session is attended: its user can answer agy's
+    ``request-review`` prompt through the terminal tunnel. A sub-agent child
+    (identified by ``parent_session_id``) is autonomous: its parent cannot
+    answer the child TUI prompt. It therefore launches headlessly with agy's
+    bypass flag, preventing a first shell command from parking at an
+    elicitation and then being misreported as a completed child task.
 
     Fresh sessions launch with no ``--conversation``: the runner cold-starts
     the conversation over connect-RPC (11a) so the reader binds agy's real id
@@ -4149,6 +4146,8 @@ async def _auto_create_antigravity_terminal(
     snapshot = await _session_payload_for_host_spawn_check(server_client, session_id)
     if snapshot is None:
         raise RuntimeError(f"Could not fetch Antigravity launch config for {session_id!r}.")
+    parent_session_id = snapshot.get("parent_session_id")
+    autonomous_subagent = isinstance(parent_session_id, str) and bool(parent_session_id)
 
     session_workspace = snapshot.get("workspace")
     if session_workspace is not None and (
@@ -4215,12 +4214,12 @@ async def _auto_create_antigravity_terminal(
         conversation_id=external_session_id if resume else None,
         model=model,
         resume=resume,
-        # Web-attended: a web client drives agy's request-review prompt over the
-        # tunnel, so this is NOT headless. Bypass comes only via the pass-through
-        # args below (see docstring). permission_mode is left unset for the same
-        # reason — the runner has no separate per-tool mode to map here.
+        # A top-level web session is attended through the terminal tunnel, but a
+        # dispatched child has no human attached to answer agy's TUI prompt.
+        # The latter must launch headlessly so its first tool call cannot remain
+        # blocked forever and later be reported as an empty completion.
         permission_mode=None,
-        headless=False,
+        headless=autonomous_subagent,
         extra_args=terminal_launch_args,
     )
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -48,6 +48,7 @@ from omnigent.onboarding.provider_config import (
     BEDROCK_KIND,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
+    GEMINI_FAMILY,
     OPENAI_FAMILY,
     RESPONSES_WIRE_API,
     SUBSCRIPTION_KIND,
@@ -400,10 +401,9 @@ _PROVIDER_HARNESS_FAMILY: dict[AgentHarnessType, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
-    # Antigravity is Gemini-native but routes generic-provider traffic over
-    # the OpenAI-compatible wire (OpenRouter / LiteLLM / Databricks gateway),
-    # so it consumes the ``openai`` family like openai-agents-sdk.
-    "antigravity": OPENAI_FAMILY,
+    # Antigravity's SDK consumes Gemini credentials directly; it has no
+    # OpenAI-compatible provider path.
+    "antigravity": GEMINI_FAMILY,
     # Qwen Code routes through OpenAI-compatible providers (like Kimi v1).
     "qwen": OPENAI_FAMILY,
 }

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -166,9 +166,13 @@ async def _fetch_runner_catalog(
                 item[0],
             ),
         )
-        models = [model for _, model in ordered_models]
-        if models:
-            result[worker_name] = models
+        # Preserve declared workers even when discovery has no model ids.  A
+        # self-managed harness deliberately reports an empty list: Omnigent
+        # cannot enumerate its vendor-managed models, but the worker is still
+        # a viable dispatch target.  Dropping that row made it invisible to
+        # callers of ``fetch_runner_models`` and, consequently,
+        # ``sys_advise_models``.
+        result[worker_name] = [model for _, model in ordered_models]
     return result or None
 
 

--- a/omnigent/tools/builtins/list_models.py
+++ b/omnigent/tools/builtins/list_models.py
@@ -56,12 +56,17 @@ class SysListModelsTool(Tool):
             "itself, under 'self' — can actually run here, resolved from "
             "each worker's real model provider and filtered to its "
             "harness's model family. Call this BEFORE passing an "
-            "unfamiliar 'args.model' to sys_session_send, when the user "
-            "asks which models are available, or to preflight a worker "
-            "(source 'none' means dispatches to that worker cannot run "
-            "in this deployment). Each entry reports {source, verified, "
-            "models: [{id, family, context_window?}], note}; pick "
-            "'args.model' values verbatim from the target worker's list."
+            "unfamiliar 'args.model' to sys_session_send, or when the user "
+            "asks which models are available. Each entry reports {source, "
+            "verified, models: [{id, family, context_window?}], note}; pick "
+            "'args.model' values verbatim from the target worker's list. An "
+            "EMPTY list is not by itself a dead worker — read 'source': "
+            "'self-managed' means the harness authenticates itself and "
+            "Omnigent cannot enumerate its models, so dispatch normally and "
+            "omit 'args.model'; 'unconfigured' means no provider is set up "
+            "for that worker; 'unavailable' means its listing could not be "
+            "fetched. Only a note saying dispatches 'cannot run here' is a "
+            "launch-blocking verdict."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -13,7 +13,9 @@ from omnigent.onboarding.provider_config import (
     OPENAI_FAMILY,
     PI_SURFACE,
     default_provider_for_harness,
+    harness_declares_own_auth,
     harness_family,
+    harness_owns_its_credential,
     load_providers,
     provider_families,
     provider_family_for_harness,
@@ -793,6 +795,121 @@ def test_default_provider_for_pi_skips_bedrock_default() -> None:
     }
     assert default_provider_for_harness(config, "pi").name == "oai"
     assert default_provider_for_harness(config, "claude-sdk").name == "bedrock"
+
+
+def test_default_provider_for_pi_reaches_non_default_provider_in_same_family() -> None:
+    """pi falls through an unusable DEFAULT to a usable provider beside it.
+
+    The regression this pins: the fallback iterated one provider per family —
+    that family's ``default: true`` entry — and on hitting an unusable kind
+    moved to the next FAMILY rather than the next PROVIDER. On a machine whose
+    anthropic and openai defaults are both subscription CLI logins (the common
+    ``claude``/``codex`` setup), a perfectly usable OpenRouter key sitting one
+    slot down in the openai family was never reached and pi resolved to
+    ``None`` — which the model catalog then reported as a dead worker.
+    """
+    config = {
+        "providers": {
+            "claude": {"kind": "subscription", "cli": "claude", "default": ANTHROPIC_FAMILY},
+            "codex": {"kind": "subscription", "cli": "codex", "default": OPENAI_FAMILY},
+            "openrouter": {
+                "kind": "key",
+                "openai": {"base_url": "https://openrouter.ai/api/v1", "api_key": "k"},
+            },
+        }
+    }
+    assert default_provider_for_harness(config, "pi").name == "openrouter"
+    # The mapped harnesses still take their own family's explicit default —
+    # widening the pi candidate set must not re-route them.
+    assert default_provider_for_harness(config, "claude-sdk").name == "claude"
+    assert default_provider_for_harness(config, "codex").name == "codex"
+
+
+def test_default_provider_for_pi_prefers_the_family_default_over_its_neighbours() -> None:
+    """A usable default still wins over the other providers in its family.
+
+    The widened candidate set is ordered, not unordered: the user's stated
+    ``default: true`` preference is tried first, and only an unusable kind
+    lets a neighbour through.
+    """
+    config = {
+        "providers": {
+            "chosen": {
+                "kind": "key",
+                "default": OPENAI_FAMILY,
+                "openai": {"base_url": "https://api.openai.com/v1", "api_key": "k"},
+            },
+            "other": {
+                "kind": "key",
+                "openai": {"base_url": "https://openrouter.ai/api/v1", "api_key": "k2"},
+            },
+        }
+    }
+    assert default_provider_for_harness(config, "pi").name == "chosen"
+
+
+def test_default_provider_for_pi_still_skips_unusable_kinds_without_a_default() -> None:
+    """The widened candidate set does not weaken the subscription/bedrock skips.
+
+    Every candidate — default or not — must still pass the kind rules, or pi
+    would be handed a CLI login it cannot wrap and a previously-working run
+    (pi's own auth) would become a hard error.
+    """
+    config = {
+        "providers": {
+            "claude": {"kind": "subscription", "cli": "claude"},
+            "bedrock": {
+                "kind": "bedrock",
+                "anthropic": {
+                    "base_url": "https://bedrock-runtime.us-east-1.amazonaws.com",
+                    "api_key": "k",
+                    "models": {"default": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+                },
+            },
+        }
+    }
+    assert default_provider_for_harness(config, "pi") is None
+
+
+@pytest.mark.parametrize(
+    ("harness", "declares_own_auth", "owns_its_credential"),
+    [
+        # ACP-backed: both predicates agree (the narrow one's original set).
+        ("goose", True, True),
+        ("acp", True, True),
+        # Native harnesses that copy the user's own vendor config forward.
+        # These are own-auth but NOT ACP, so only the broad predicate holds —
+        # the narrow one still drives the credential readouts unchanged.
+        ("goose-native", True, False),
+        ("hermes-native", True, False),
+        ("opencode-native", True, False),
+        # Provider-routed at spawn via _HARNESS_FAMILY: never own-auth here,
+        # even though qwen-native's capability record declares OWN_AUTH for
+        # its unconfigured fallback.
+        ("qwen-native", False, False),
+        ("claude-sdk", False, False),
+        ("codex", False, False),
+        # Unknown harnesses carry no capability record to declare anything.
+        ("no-such-harness", False, False),
+    ],
+)
+def test_own_auth_predicates_split_broad_from_acp_only(
+    harness: str, declares_own_auth: bool, owns_its_credential: bool
+) -> None:
+    """The broad own-auth predicate covers native harnesses; the narrow one doesn't.
+
+    ``harness_declares_own_auth`` answers "does Omnigent wire a credential for
+    this harness?" — what the model catalog needs to say *self-managed* instead
+    of *no usable provider*. ``harness_owns_its_credential`` keeps its narrower
+    ACP-only contract so the REPL creds line and ``describe_active_credential``
+    behave exactly as before.
+
+    :param harness: The harness under test.
+    :param declares_own_auth: Expected broad-predicate verdict.
+    :param owns_its_credential: Expected narrow-predicate verdict.
+    """
+    assert harness_declares_own_auth(harness) is declares_own_auth
+    assert harness_owns_its_credential(harness) is owns_its_credential
 
 
 def test_default_provider_for_pi_none_when_only_bedrock_default() -> None:

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -358,6 +358,27 @@ async def test_fetch_runner_models_orders_reported_cost_tiers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_runner_models_keeps_self_managed_worker_with_no_models() -> None:
+    """An empty self-managed row remains visible to model-advice callers."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "workers": {
+            "goose": {
+                "source": "self-managed",
+                "verified": False,
+                "models": [],
+                "note": "Goose owns its model configuration.",
+            }
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    assert await fetch_runner_models("conv_123", mock_client) == {"goose": []}
+
+
+@pytest.mark.asyncio
 async def test_fetch_runner_models_returns_none_on_http_error() -> None:
     import httpx
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1012,6 +1012,33 @@ def test_unconfigured_listing_does_not_claim_the_worker_cannot_run(
     assert "cannot run here" not in listing.note
 
 
+def test_antigravity_resolves_the_gemini_provider_not_codex_subscription(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SIL-1039: Antigravity is Gemini-family, never a Codex CLI alias."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n"
+        "  codex:\n"
+        "    kind: subscription\n"
+        "    cli: codex\n"
+        "    default: [openai]\n"
+        "  gemini:\n"
+        "    kind: key\n"
+        "    default: [gemini]\n"
+        "    gemini:\n"
+        "      base_url: https://generativelanguage.googleapis.com\n"
+        "      api_key: $GEMINI_API_KEY\n",
+    )
+
+    provider = resolve_model_provider(_worker_spec("antigravity"), "antigravity")
+    assert provider.kind == "key"
+    assert provider.family == "gemini"
+    assert provider.cli is None
+
+
 @pytest.mark.parametrize("harness", ["goose", "goose-native", "hermes-native", "opencode-native"])
 def test_self_authenticating_harness_reports_self_managed_not_none(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, harness: str

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -953,25 +953,116 @@ def test_cursor_listing_failure_is_empty_and_retryable(
     first = list_models_for_worker(_worker_spec("cursor-native"), "cursor-native")
     second = list_models_for_worker(_worker_spec("cursor-native"), "cursor-native")
 
-    assert first.source == second.source == "none"
+    assert first.source == second.source == "unavailable"
     assert first.models == second.models == ()
     assert calls == 2
+    # A transient failure is NOT a launch verdict — the CLI may well be there.
+    assert "cannot run here" not in first.note
+    assert "may still run" in first.note
 
 
-def test_none_listing_explains_dead_worker(
+def test_cursor_cli_absent_is_the_one_launch_blocking_verdict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """An unresolvable provider yields an empty list with a preflight note.
+    """A missing cursor-agent binary is reported as genuinely unrunnable.
+
+    This is the only condition the catalog can actually prove launch-blocking:
+    the CLI the provider is bound to does not exist, so the spawn cannot start.
+    It must keep saying so — the point of splitting the old blanket ``none``
+    was to stop over-claiming, not to stop reporting real dead workers.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    from omnigent import cursor_native
+
+    _isolate_config(monkeypatch, tmp_path, "")
+
+    def missing_binary() -> list[dict[str, object]]:
+        """Raise what subprocess raises when the executable is not on PATH."""
+        raise FileNotFoundError(2, "No such file or directory: 'cursor-agent'")
+
+    monkeypatch.setattr(cursor_native, "list_cursor_cli_model_options", missing_binary)
+
+    listing = list_models_for_worker(_worker_spec("cursor-native"), "cursor-native")
+    assert listing.source == "unavailable"
+    assert listing.models == ()
+    assert "cursor-agent CLI is not installed" in listing.note
+    assert "cannot run here" in listing.note
+
+
+def test_unconfigured_listing_does_not_claim_the_worker_cannot_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A provider-routed harness with no provider reads ``unconfigured``.
+
+    claude-sdk genuinely needs an Omnigent credential, so an empty config is a
+    real problem — but the note says what is missing rather than asserting a
+    launch verdict the catalog cannot prove (the harness may still find its
+    own credentials at spawn).
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Per-test temp dir.
     """
     _isolate_config(monkeypatch, tmp_path, "")
     listing = list_models_for_worker(_worker_spec("claude-native"), "claude-native")
-    assert listing.source == "none"
+    assert listing.source == "unconfigured"
     assert listing.models == ()
-    # The note is the dead-worker preflight signal the orchestrator reads.
-    assert "cannot run here" in listing.note
+    assert "no usable Omnigent model provider resolved" in listing.note
+    assert "cannot run here" not in listing.note
+
+
+@pytest.mark.parametrize("harness", ["goose", "goose-native", "hermes-native", "opencode-native"])
+def test_self_authenticating_harness_reports_self_managed_not_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, harness: str
+) -> None:
+    """Own-auth harnesses read ``self-managed``, never a dead-worker verdict.
+
+    The bug this pins (SIL-1039): these harnesses are absent from
+    ``_PROVIDER_RESOLUTION_HARNESS`` *by design* — their spawn builders wire no
+    credential because the vendor CLI authenticates itself (see
+    ``_build_goose_spawn_env``). Resolution therefore returned ``none`` and the
+    row claimed "dispatches to this worker cannot run here" for workers that
+    dispatch and run perfectly well.
+
+    The row must also not swing the other way: nothing was fetched, so
+    ``verified`` stays False and no model ids may be fabricated.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    :param harness: The self-authenticating harness under test.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+
+    provider = resolve_model_provider(_worker_spec(harness), harness)
+    assert provider.kind == "self-managed"
+    assert "authenticates itself" in provider.detail
+
+    listing = list_models_for_worker(_worker_spec(harness), harness)
+    assert listing.source == "self-managed"
+    assert listing.models == ()
+    assert listing.verified is False
+    assert "cannot run here" not in listing.note
+    # The note must tell a supervisor what to DO with an empty list.
+    assert "omit 'args.model'" in listing.note
+
+
+def test_provider_routed_native_harness_is_not_declared_self_managed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """qwen-native declares OWN_AUTH but IS provider-routed — no short-circuit.
+
+    Its capability record declares own-auth for the unconfigured fallback, yet
+    ``_build_qwen_spawn_env`` really does wire the openai family's provider. A
+    blanket "capability says own-auth → self-managed" rule would mislabel a
+    gateway-routed worker as unenumerable, hiding models it can actually run.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    provider = resolve_model_provider(_worker_spec("qwen-native"), "qwen-native")
+    assert provider.kind != "self-managed"
 
 
 # ── TTL cache + failure behavior ───────────────────────────
@@ -1014,7 +1105,7 @@ def test_listing_cached_within_ttl_and_refetched_after_expiry(
 def test_listing_failure_reported_and_not_cached(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A failed fetch reports source ``none`` and retries on the next call.
+    """A failed fetch reports source ``unavailable`` and retries on the next call.
 
     Caching a failure would pin a transient provider outage for the full
     TTL; the second call here must succeed once the endpoint recovers.
@@ -1038,7 +1129,7 @@ def test_listing_failure_reported_and_not_cached(
     failed = list_models_for_worker(
         _worker_spec("codex-native"), "codex-native", transport=transport
     )
-    assert failed.source == "none"
+    assert failed.source == "unavailable"
     assert failed.models == ()
     # The note names the failure so the orchestrator can report it.
     assert "enumeration failed" in failed.note
@@ -1151,7 +1242,7 @@ def test_failed_auth_command_note_never_leaks_the_command(
     catalog = catalog_for_spec(parent, transport=httpx.MockTransport(_handler))
 
     # The note names the redacted category so the orchestrator can react…
-    assert catalog["worker"]["source"] == "none"
+    assert catalog["worker"]["source"] == "unavailable"
     assert "provider auth command failed" in catalog["worker"]["note"]
     # …and the secret embedded in the failing command never reaches ANY
     # part of the serialized tool payload. If this fails, raw exception
@@ -1169,7 +1260,7 @@ def test_catalog_isolates_per_worker_failures(
 
     The claude worker resolves a subscription (static, no HTTP) while
     the codex worker's gateway listing 503s — the codex row must degrade
-    to ``none`` with the failure note while claude and self stay intact.
+    to ``unavailable`` with the failure note while claude and self stay intact.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Per-test temp dir.
@@ -1215,7 +1306,7 @@ def test_catalog_isolates_per_worker_failures(
     assert next(m["id"] for m in catalog["worker"]["models"]) == "claude-fable-5"
     assert catalog["self"]["source"] == "static"
     # The broken worker degrades informatively instead of crashing the tool.
-    assert catalog["codex"]["source"] == "none"
+    assert catalog["codex"]["source"] == "unavailable"
     assert catalog["codex"]["models"] == []
     assert "enumeration failed" in catalog["codex"]["note"]
 
@@ -1469,7 +1560,7 @@ def test_openai_compatible_listing_mints_bearer_via_auth_command(
 
     Dynamic-credential providers carry no static key at all — the
     enumerator must run the command and send its stdout as the bearer,
-    or every such deployment silently degrades to ``none``.
+    or every such deployment silently degrades to an empty row.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Per-test temp dir.
@@ -1539,6 +1630,8 @@ def test_keychain_credential_ref_degrades_not_crashes(
         _worker_spec("codex-native"), "codex-native", transport=httpx.MockTransport(_handler)
     )
 
-    assert listing.source == "none"
+    # An unresolvable credential fails during provider RESOLUTION, so the row
+    # is "no usable provider" rather than "the listing fetch failed".
+    assert listing.source == "unconfigured"
     assert not listing.models
     assert listing.note, "degraded keychain row must carry an explanatory note"


### PR DESCRIPTION
## Summary
- classify self-authenticating harnesses separately from unconfigured and unavailable provider readouts
- retain empty self-managed worker rows for advisory routing and resolve Antigravity through Gemini credentials
- launch autonomous Antigravity sub-agents with the permission bypass required to avoid an unanswerable TUI approval

## Validation
- `OMNIGENT_DATABASE_URI=sqlite:///:memory: uv run --extra dev pytest tests/test_model_catalog.py tests/onboarding/test_provider_config.py tests/server/test_smart_routing.py tests/runtime/test_antigravity_spawn_env.py -q`
- `uv run --extra dev ruff check omnigent/model_catalog.py omnigent/onboarding/provider_config.py omnigent/runtime/workflow.py omnigent/runner/native/orchestration.py omnigent/server/smart_routing.py tests/test_model_catalog.py tests/server/test_smart_routing.py`

Omnigent-Agent: codex

## Issues

Closes #6617
Resolves [OMNI-6420](https://linear.app/omnigent/issue/OMNI-6420/bug-sys-list-models-reports-antigravity-native-as-having-no-usable)
