### PR TITLE
fix(claude-native): wake idle runner before /compact

### DIFF
--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -909,6 +909,31 @@ def register_events_routes(
                 {"type": _COMPACT_TYPE},
                 timeout_s=_TUI_INJECT_FORWARD_TIMEOUT_S,
             )
+            if runner_result is None:
+                runner_client, conv = await ensure_runner_connected(
+                    session_id=session_id,
+                    conv=conv,
+                    app_state=request.app.state,
+                    conversation_store=conversation_store,
+                    runner_router=runner_router or get_server_runner_router(),
+                )
+                if runner_client is not None:
+                    await _ensure_runner_session_initialized(
+                        session_id,
+                        conv,
+                        runner_client,
+                        conversation_store,
+                        initializer=getattr(
+                            request.app.state,
+                            "runner_session_initializer",
+                            None,
+                        ),
+                    )
+                    runner_result = await _forward_session_change_to_runner(
+                        session_id,
+                        runner_router,
+                        {"type": _COMPACT_TYPE},
+                    )
             if runner_result is not None and runner_result.status_code == 200:
                 return {"queued": False}
             if runner_result is not None and runner_result.status_code != 204:

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -146,6 +146,56 @@ async def test_compact_skips_omnigent_compaction_when_runner_handles_it(
     )
 
 
+async def test_compact_wakes_sleeping_native_runner(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.server.routes import sessions as sessions_routes
+
+    calls: list[str] = []
+    online = False
+
+    async def _forward(*_: Any, **__: Any) -> httpx.Response | None:
+        calls.append("forward")
+        return httpx.Response(200) if online else None
+
+    async def _wake(**kwargs: Any) -> tuple[object, Any]:
+        nonlocal online
+        calls.append("wake")
+        online = True
+        return object(), kwargs["conv"]
+
+    async def _initialize(*_: Any, **__: Any) -> bool:
+        calls.append("initialize")
+        return True
+
+    monkeypatch.setattr(sessions_routes, "_forward_session_change_to_runner", _forward)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.routes_events.ensure_runner_connected",
+        _wake,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.routes_events._ensure_runner_session_initialized",
+        _initialize,
+    )
+
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "claude-native"}},
+        include_llm=False,
+    )
+    sid = await _create_session(client, agent["id"])
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "compact", "data": {}},
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"queued": False}
+    assert calls == ["forward", "wake", "initialize", "forward"]
+
+
 async def test_compact_runs_omnigent_compaction_when_runner_noops(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #4453

## Summary

- Wake a host-bound runner when `/compact` finds no live runner connection.
- Reinitialize the native runner session before retrying the compact control.
- Preserve server-side compaction for runners that explicitly return `204` and for non-wakeable sessions.

Root cause: host runners exit after the default one-hour idle timeout. The compact route did not use the existing reconnect path, so it fell through to server-side compaction. `claude-native` agents intentionally lack a server-side LLM declaration, producing a misleading 400 response.

ELI5: sending a message already wakes a sleeping runner; this makes `/compact` wake it the same way.

```text
/compact -> runner missing -> wake + initialize -> retry native /compact
                                |
                                +-> unavailable -> existing server fallback
```

## Test Plan

- `uv run pytest tests/server/integration/test_sessions_compact.py -q` (10 passed)
- `uv run pytest tests/frontends/sdk/test_sessions_chat.py tests/frontends/sdk/test_sessions_namespace.py tests/server/integration/test_session_host_launch.py tests/repl/test_subagent_chat.py tests/server/routes/test_subagent_status_forward_recovery.py tests/runner/test_app_sessions_native_terminal_routing.py tests/runner/test_comment_relay.py tests/server/routes/test_ensure_runner_connected.py -q` (135 passed)
- `uv run ruff check omnigent/server/routes/sessions/routes_events.py tests/server/integration/test_sessions_compact.py`
- `uv run ruff format --check omnigent/server/routes/sessions/routes_events.py tests/server/integration/test_sessions_compact.py`

## Demo

N/A — server-side reconnect behavior with integration coverage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test verifies the full route sequence: initial forward misses, the runner wakes, session initialization completes, and native `/compact` is retried successfully.

## Changelog

Native `/compact` now reconnects sessions whose host runner exited while idle.
