### PR TITLE
fix(tools): key the MCP discovery cache by env/headers/profile, not just command

### DIFF
--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -14,12 +14,13 @@ is the only production consumer; see designs/RUNNER_MCP.md.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import shlex
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack, suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -359,14 +360,45 @@ def _is_sse_endpoint(url: str) -> bool:
     return urlparse(url).path.rstrip("/").endswith("/sse")
 
 
+def _mapping_digest(mapping: Mapping[str, str] | None) -> str:
+    """
+    Digest a possibly-secret str→str mapping for use inside a cache key.
+
+    Order-insensitive: same entries in any insertion order digest
+    identically. An empty or ``None`` mapping digests to a stable
+    constant so keys stay comparable across processes.
+
+    :param mapping: The env / headers mapping, or ``None``.
+    :returns: A short hex digest, e.g. ``"9f86d081884c7d65"``.
+    """
+    items = sorted((mapping or {}).items())
+    payload = json.dumps(items, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
 def _cache_key(config: MCPServerConfig, cwd: Path | None = None) -> str:
     """
     Build a stable cache key for an MCP server config + stdio cwd.
 
-    Keys include the transport + identifying fields so that two
-    configs pointing at the same live server share the cache
-    entry and two configs pointing at different servers (same
-    name, different url / command / cwd) don't collide.
+    Invariant: the key contains every config field the SERVER can
+    observe — anything that can change what ``tools/list`` returns.
+    For stdio that is the spawned command line (``command`` /
+    ``args`` / ``cwd``) and the ``env`` overlay; for HTTP it is the
+    ``url`` and the request identity (``headers``, and
+    ``databricks_profile``, which resolves to an Authorization
+    header at connect() time). A server may register different
+    tools depending on any of these (an env-gated read-only mode, a
+    remote server that scopes tools per principal), and two configs
+    differing in one must never share a cached tools/list — the
+    second would silently inherit the first's tool surface until
+    the TTL expires. Fields the CLIENT applies after the response
+    (the ``tools:`` allowlist, ``timeout`` / ``retry``,
+    ``description``) stay out so same-server configs keep sharing
+    one entry. When adding a config field, decide which side of
+    that line it falls on.
+
+    The env / headers maps are folded in as a digest, not verbatim:
+    they routinely carry secrets, and cache keys end up in logs.
 
     :param config: The MCP server configuration.
     :param cwd: Optional stdio subprocess working directory;
@@ -376,8 +408,15 @@ def _cache_key(config: MCPServerConfig, cwd: Path | None = None) -> str:
     if config.transport == "stdio":
         args_part = shlex.join(config.args) if config.args else ""
         cwd_part = "" if cwd is None else str(cwd)
-        return f"stdio:{config.name}:{config.command}:{args_part}:{cwd_part}"
-    return f"http:{config.name}:{config.url}"
+        env_part = _mapping_digest(config.env)
+        return f"stdio:{config.name}:{config.command}:{args_part}:{cwd_part}:{env_part}"
+    headers_part = _mapping_digest(config.headers)
+    # databricks_profile resolves to an Authorization header at
+    # connect() time, so it is an identity field even though the
+    # static ``headers`` map doesn't show it. A profile name is not
+    # a secret; keyed verbatim.
+    profile_part = config.databricks_profile or ""
+    return f"http:{config.name}:{config.url}:{profile_part}:{headers_part}"
 
 
 def clear_discovery_cache() -> None:

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -205,6 +205,80 @@ def test_cache_key_stdio_args_changes_key() -> None:
     assert key_prod != key_dev
 
 
+def _stdio_config_with_env(env: dict[str, str]) -> MCPServerConfig:
+    """A stdio config fixed in every field except the ``env`` overlay."""
+    return MCPServerConfig(
+        name="my-mcp",
+        transport="stdio",
+        command="my-mcp",
+        args=["run"],
+        env=env,
+    )
+
+
+def test_cache_key_stdio_env_changes_key() -> None:
+    """
+    Different ``env`` overlays on an otherwise-identical stdio
+    config produce different cache keys — a server's registered
+    tool surface can depend on its env (e.g. a read-only gate
+    like ``MY_MCP_READONLY``).
+
+    What breaks if this fails: an orchestrator that declares a
+    read-only variant of a server (``READONLY=1``) and a
+    sub-agent that declares the full variant (``READONLY=0``),
+    identical command/args, share one cache entry; whichever
+    connects first pins the tools/list, so a sub-agent dispatched
+    within the TTL sees the read-only surface and its remaining
+    tools silently vanish.
+    """
+    key_ro = _cache_key(_stdio_config_with_env({"MY_MCP_READONLY": "1"}))
+    key_rw = _cache_key(_stdio_config_with_env({"MY_MCP_READONLY": "0"}))
+    assert key_ro != key_rw
+    # Same mapping (any insertion order) still shares one entry.
+    assert _cache_key(_stdio_config_with_env({"A": "1", "B": "2"})) == _cache_key(
+        _stdio_config_with_env({"B": "2", "A": "1"})
+    )
+    # Secrets never appear verbatim in the key (keys reach logs).
+    key_secret = _cache_key(_stdio_config_with_env({"TOKEN": "sk-hunter2"}))
+    assert "sk-hunter2" not in key_secret
+
+
+def _http_config(
+    headers: dict[str, str] | None = None,
+    databricks_profile: str | None = None,
+) -> MCPServerConfig:
+    """An HTTP config fixed in every field except headers / profile."""
+    return MCPServerConfig(
+        name="remote",
+        transport="http",
+        url="https://mcp.example.com/sse",
+        headers=headers or {},
+        databricks_profile=databricks_profile,
+    )
+
+
+def test_cache_key_http_headers_and_profile_change_key() -> None:
+    """
+    Different HTTP ``headers`` (e.g. different Authorization
+    bearers) or a different ``databricks_profile`` produce
+    different cache keys, and header values never appear verbatim
+    in the key.
+
+    What breaks if this fails: two agents pointing at one MCP URL
+    with different credentials share a cached tools/list even when
+    the server scopes its tool surface by principal —
+    ``databricks_profile`` resolves to an Authorization header at
+    connect() time, so it is an identity field too.
+    """
+    key_a = _cache_key(_http_config(headers={"Authorization": "Bearer tok_a"}))
+    key_b = _cache_key(_http_config(headers={"Authorization": "Bearer tok_b"}))
+    assert key_a != key_b
+    assert "tok_a" not in key_a
+    assert _cache_key(_http_config(databricks_profile="oss")) != _cache_key(
+        _http_config(databricks_profile="prod")
+    )
+
+
 def test_cache_key_stdio_and_http_do_not_collide() -> None:
     """
     A stdio server named ``my-mcp`` and an HTTP server named


### PR DESCRIPTION
## Related issue

Closes #4456

## Summary

- The module-level MCP tool-discovery cache (`_discovery_cache`, TTL 300s) keys stdio servers by `name:command:args:cwd` only — the `env` overlay is omitted, and the HTTP key omits `headers` / `databricks_profile`. Two configs that differ only in those fields share one cache entry, so whichever connects first pins the tools/list and the other silently inherits it for up to the TTL.
- This is not theoretical: a server's *registered tool surface* can depend on its env (e.g. a read-only gate like `MY_MCP_READONLY=1`). An orchestrator declaring the read-only variant and its sub-agent declaring the full variant — identical command/args — is exactly the recommended spec shape, and the sub-agent intermittently loses its extra tools depending on dispatch timing.
- Fix: fold an order-insensitive SHA-256 digest of the env (stdio) / headers (http) map into the key, plus `databricks_profile` verbatim (it resolves to an `Authorization` header at `connect()` time, so it's an identity field the static headers map doesn't show). Digest rather than verbatim because those maps routinely carry secrets and cache keys end up in logs. Same-mapping configs still share an entry, so the cache's dedup purpose is preserved.

### ELI5

Two agents both declare an MCP server called `my_mcp`, launched with the same command — but one sets `READONLY=1` in its env and the other `READONLY=0`. The server registers different tools depending on that variable. The discovery cache couldn't tell the two apart, so for 5 minutes after the read-only one connected, the full one was told "this server has 1 tool" and its write tools just weren't there.

```
parent spec:    my_mcp  env={READONLY: "1"}  ──discover──▶  tools=[query]
                                                                     │  cached under
                                                                     ▼  stdio:my_mcp:my-mcp:run:…  (no env in key!)
sub-agent spec: my_mcp  env={READONLY: "0"}  ──t+3m48s─────▶  cache HIT → tools=[query]   ✗ write tools gone
                                             ──t+5m01s─────▶  fresh discovery → tools=[query, write, launch]  ✓
```

Observed live on a deployment: same spec hash, same server config, `tools=1` for a sub-agent dispatched 3m48s after the parent's discovery, `tools=3` at 4m18s and beyond — matching the 300s TTL exactly. The only log signal is the *absence* of the `discovered N tool(s)` line on cache hits.

## Test Plan

- `uv run --extra dev pytest tests/tools/test_mcp.py` — 86 passed (2 new tests: stdio env differentiates the key / order-insensitive sharing / secrets never verbatim in keys; HTTP headers and `databricks_profile` differentiate the key).
- `uv run --no-sync ruff check` / `ruff format --check` clean on both files; `pyrefly check` introduces no new errors.
- Manually reproduced the collision on a live deployment (orchestrator declaring the read-only variant of a stdio server, sub-agent declaring the full one) and verified the patched `_cache_key` yields distinct keys for the two real configs.

## Demo

N/A — non-visual runtime fix; the behaviour change is captured by the regression tests (`test_cache_key_stdio_env_changes_key`, `test_cache_key_http_headers_and_profile_change_key`). A runnable end-to-end repro (a minimal env-gated stdio server + a driver that connects the read-only variant then the full one through `McpServerConnection`) is on [this branch](https://github.com/joncarter1/omnigent/tree/assets/mcp-cache-key-demo): on unpatched main the second config receives the first's cached read-only tools/list; with this PR it gets its own.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the live repro above: on a deployment exhibiting the bug, confirmed the two real-world configs (read-only vs full variant of the same server) collide on the old key and separate on the new one, and that a sub-agent dispatched inside the TTL window now gets its own discovery. Unit tests lock in the key semantics; the TTL-timing race itself isn't integration-tested (it would need a 5-minute clock or cache injection).

## Changelog

Sub-agents no longer inherit a sibling config's cached MCP tool list when two declarations share a command but differ in env, headers, or Databricks profile.
