### PR TITLE
fix(host): restart runners after unexpected exits

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -183,6 +184,12 @@ _LOG_TAIL_MAX_LINES = 15
 # client's online-poll cadence (daemon_launch.DAEMON_POLL_INTERVAL_S),
 # so a crashed runner is reported within about one client poll.
 _RUNNER_WATCH_INTERVAL_S = 0.5
+
+# Restart unexpected runner exits in place while the host daemon is healthy.
+# The rolling window prevents a deterministic failure from crash-looping.
+_RUNNER_RESTART_MAX_ATTEMPTS = 3
+_RUNNER_RESTART_WINDOW_S = 60.0
+_RUNNER_RESTART_BASE_DELAY_S = 0.5
 
 # Cadence of the orphan-reaper sweep. The host installs itself as a child
 # subreaper (Linux — see :func:`_install_child_subreaper`), so a harness's
@@ -699,6 +706,15 @@ def _paginate_list_dir(
     )
 
 
+@dataclass(frozen=True)
+class _RunnerLaunchSpec:
+    """Inputs the host needs to restart a runner in place."""
+
+    env: dict[str, str]
+    session_slug: str
+    workspace: Path
+
+
 @dataclass
 class _RunnerHandle:
     """A spawned runner subprocess and where its output lands.
@@ -708,10 +724,15 @@ class _RunnerHandle:
         ``Path("~/.omnigent/logs/runner/runner-ab12.log")``.
         Read back for diagnostics when the runner dies before
         connecting its tunnel.
+    :param launch_spec: Inputs for an automatic restart. ``None`` when
+        this handle is not recoverable.
+    :param restarting: Whether the watcher is replacing an exited process.
     """
 
     proc: subprocess.Popen[bytes] | ZygoteRunnerProc
     log_path: Path
+    launch_spec: _RunnerLaunchSpec | None = None
+    restarting: bool = False
 
 
 class HostProcess:
@@ -999,13 +1020,18 @@ class HostProcess:
         return None
 
     def _alive_runner_ids(self) -> list[str]:
-        """Return IDs of runners that are still alive.
+        """Return IDs of runners that are alive or being recovered.
 
-        Cleans up dead entries as a side effect.
+        A launchable dead handle is retained for its watcher to restart. Other
+        dead entries are cleaned up as before.
 
-        :returns: List of alive runner ID strings.
+        :returns: List of active runner ID strings.
         """
-        dead = [rid for rid, handle in self._runners.items() if handle.proc.poll() is not None]
+        dead = [
+            rid
+            for rid, handle in self._runners.items()
+            if handle.proc.poll() is not None and handle.launch_spec is None
+        ]
         for rid in dead:
             self._runners.pop(rid)
         return list(self._runners.keys())
@@ -1255,6 +1281,11 @@ class HostProcess:
         _session_slug = (
             re.sub(r"[^\w-]", "", frame.session_id)[:32] + "-" if frame.session_id else ""
         )
+        launch_spec = _RunnerLaunchSpec(
+            env=dict(env),
+            session_slug=_session_slug,
+            workspace=workspace,
+        )
 
         # Spawning blocks (log-file open, plus the zygote's one-time import on
         # first launch), so run it off the event loop. Shielded so a
@@ -1288,7 +1319,11 @@ class HostProcess:
                 error=_runner_exit_error(proc.returncode, log_path),
             )
 
-        self._runners[runner_id] = _RunnerHandle(proc=proc, log_path=log_path)
+        self._runners[runner_id] = _RunnerHandle(
+            proc=proc,
+            log_path=log_path,
+            launch_spec=launch_spec,
+        )
         watcher = asyncio.create_task(self._watch_runner(runner_id))
         self._watcher_tasks.add(watcher)
         watcher.add_done_callback(self._watcher_tasks.discard)
@@ -1483,8 +1518,10 @@ class HostProcess:
         the runner's :class:`subprocess.Popen`. A runner tracked with a
         still-running process is ``alive`` (covers a runner that is still
         booting — it is inserted at ``Popen`` time, before its tunnel
-        connects — so the server waits for it). A tracked-but-exited
-        process is ``dead``. A runner this host has no record of is
+        connects — so the server waits for it). A tracked-but-exited process
+        scheduled for recovery also reads ``alive`` so the server does not
+        launch a competing replacement; other exited processes are ``dead``.
+        A runner this host has no record of is
         ``unknown`` — it was stopped (``_handle_stop`` popped it) or a
         fresh post-restart host never spawned it; either way it will never
         connect, so the server relaunches without waiting.
@@ -1495,30 +1532,30 @@ class HostProcess:
         handle = self._runners.get(frame.runner_id)
         if handle is None:
             status = "unknown"
+        elif handle.restarting:
+            # Keep the server's connect grace while the replacement starts.
+            status = "alive"
         else:
             # poll() is a lock-free waitpid for a direct-Popen runner, but a
             # blocking control-socket round-trip (bounded only by the 30s
             # control timeout, and contended against a booting zygote) for a
             # zygote-forked one — so run it off the loop, matching
             # _watch_runner / _handle_stop, lest a slow zygote stall the daemon.
-            status = "alive" if await asyncio.to_thread(handle.proc.poll) is None else "dead"
+            returncode = await asyncio.to_thread(handle.proc.poll)
+            status = "alive" if returncode is None or handle.launch_spec is not None else "dead"
         return HostRunnerStatusResultFrame(
             request_id=frame.request_id,
             status=status,
         )
 
     async def _watch_runner(self, runner_id: str) -> None:
-        """Watch a spawned runner and report an unexpected exit.
+        """Watch a spawned runner, recovering bounded unexpected exits.
 
-        Polls the runner subprocess until it exits. An exit while the
-        runner is still tracked in ``self._runners`` is unexpected (a
-        ``host.stop_runner`` pops the entry *before* terminating), so
-        the watcher composes the exit error — code plus log tail — and
-        reports it to the server via ``host.runner_exited``. Without
-        this, a runner that crashes before connecting its tunnel
-        (auth rejection, bad env, import error) leaves the client
-        polling to a timeout with the cause stranded in a log file on
-        this host.
+        An exit while the runner remains tracked is unexpected because
+        ``host.stop_runner`` removes the handle before terminating it. The
+        watcher restarts unexpected non-zero exits with the original launch
+        inputs. Clean exits remain wake-on-message; repeated crashes exhaust
+        the retry budget and retain the existing ``host.runner_exited`` error.
 
         :param runner_id: The runner to watch, e.g.
             ``"runner_abc123..."``.
@@ -1528,28 +1565,86 @@ class HostProcess:
         handle = self._runners.get(runner_id)
         if handle is None:  # pragma: no cover — spawned just before us
             return
-        # poll() is a lock-free waitpid for a direct-Popen runner, but a
-        # blocking control-socket round-trip (with lock contention against a
-        # booting zygote) for a zygote-forked one — so run it off the event
-        # loop to avoid freezing the daemon on the enabled path.
-        while await asyncio.to_thread(handle.proc.poll) is None:
-            await asyncio.sleep(_RUNNER_WATCH_INTERVAL_S)
-        if self._runners.get(runner_id) is not handle:
-            # _handle_stop (or _cleanup_runners) removed it first —
-            # an intentional termination, not a crash to report.
-            return
-        if handle.proc.returncode == 0:
-            # A clean exit (code 0) is a graceful shutdown, not a crash — the
-            # idle reaper shutting an inactive runner down, or any orderly
-            # self-exit. Reporting it as host.runner_exited would attach a
-            # scary "runner process exited" error to a session the user only
-            # has to message to reactivate, so stay silent. A non-zero exit
-            # below is a genuine crash and still reports its cause.
-            _logger.info("Runner %s exited cleanly (code 0); no crash report", runner_id)
-            return
-        error = _runner_exit_error(handle.proc.returncode, handle.log_path)
-        _logger.warning("Runner %s died unexpectedly: %s", runner_id, error)
-        await self._report_runner_exit(runner_id, error)
+        await self._supervise_runner(runner_id, handle)
+
+    async def _supervise_runner(self, runner_id: str, handle: _RunnerHandle) -> None:
+        """Restart consecutive runner crashes within a bounded rolling window."""
+        crash_times: list[float] = []
+        while True:
+            while await asyncio.to_thread(handle.proc.poll) is None:
+                await asyncio.sleep(_RUNNER_WATCH_INTERVAL_S)
+            if self._runners.get(runner_id) is not handle:
+                return
+            if handle.proc.returncode == 0:
+                # Idle reaping and other orderly exits stay wake-on-message.
+                handle.launch_spec = None
+                _logger.info("Runner %s exited cleanly (code 0); no crash report", runner_id)
+                return
+
+            error = _runner_exit_error(handle.proc.returncode, handle.log_path)
+            launch_spec = handle.launch_spec
+            now = time.monotonic()
+            crash_times = [
+                crashed_at
+                for crashed_at in crash_times
+                if now - crashed_at < _RUNNER_RESTART_WINDOW_S
+            ]
+            crash_times.append(now)
+            if launch_spec is None or len(crash_times) > _RUNNER_RESTART_MAX_ATTEMPTS:
+                if launch_spec is not None:
+                    error += (
+                        "\nAutomatic restart stopped after "
+                        f"{_RUNNER_RESTART_MAX_ATTEMPTS} attempts within "
+                        f"{_RUNNER_RESTART_WINDOW_S:g}s."
+                    )
+                self._runners.pop(runner_id, None)
+                _logger.warning("Runner %s died unexpectedly: %s", runner_id, error)
+                await self._report_runner_exit(runner_id, error)
+                return
+
+            attempt = len(crash_times)
+            delay_s = _RUNNER_RESTART_BASE_DELAY_S * (2 ** (attempt - 1))
+            handle.restarting = True
+            _logger.warning(
+                "Runner %s died unexpectedly; restarting in %.1fs (attempt %d/%d): %s",
+                runner_id,
+                delay_s,
+                attempt,
+                _RUNNER_RESTART_MAX_ATTEMPTS,
+                error,
+            )
+            await asyncio.sleep(delay_s)
+            if self._runners.get(runner_id) is not handle:
+                return
+            try:
+                proc, log_path = await asyncio.to_thread(
+                    self._spawn_runner_proc,
+                    dict(launch_spec.env),
+                    launch_spec.session_slug,
+                    launch_spec.workspace,
+                )
+            except OSError as exc:
+                self._runners.pop(runner_id, None)
+                error += f"\nAutomatic restart failed: {exc}"
+                _logger.warning("Runner %s restart failed: %s", runner_id, exc)
+                await self._report_runner_exit(runner_id, error)
+                return
+            if self._runners.get(runner_id) is not handle:
+                # A stop raced the blocking spawn. Do not orphan its result.
+                await asyncio.to_thread(self._stop_runner_proc, proc)
+                return
+            handle = _RunnerHandle(
+                proc=proc,
+                log_path=log_path,
+                launch_spec=launch_spec,
+            )
+            self._runners[runner_id] = handle
+            _logger.info("Restarted runner %s (pid=%d)", runner_id, proc.pid)
+            print(
+                f"  ↻ Runner restarted: {runner_id} (pid={proc.pid})\n"
+                f"    log: {display_log_path(log_path)}",
+                flush=True,
+            )
 
     async def _report_runner_exit(self, runner_id: str, error: str) -> None:
         """Send a ``host.runner_exited`` report, queueing on failure.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1426,13 +1426,14 @@ class HostProcess:
             log_fh.close()
 
     def _discard_abandoned_spawn(self, spawn: asyncio.Future[Any]) -> None:
-        """Tear down a runner whose launch was cancelled before registration.
+        """Tear down a runner whose spawn was cancelled before registration.
 
-        ``_handle_launch`` shields the spawn, so a cancellation still lets the
-        fork land — but nothing registered it in ``self._runners``, so it would
-        never be watched, stopped, or reaped (and the zygote would hold its exit
-        status forever). Kill it off the loop, since for a zygote-forked runner
-        the terminate/wait round-trips are blocking control-socket exchanges.
+        Initial launches and supervised restarts shield the spawn, so a
+        cancellation still lets the fork land — but nothing registered it in
+        ``self._runners``, so it would never be watched, stopped, or reaped (and
+        the zygote would hold its exit status forever). Kill it off the loop,
+        since for a zygote-forked runner the terminate/wait round-trips are
+        blocking control-socket exchanges.
 
         :param spawn: The completed spawn future.
         """
@@ -1616,13 +1617,19 @@ class HostProcess:
             await asyncio.sleep(delay_s)
             if self._runners.get(runner_id) is not handle:
                 return
-            try:
-                proc, log_path = await asyncio.to_thread(
+            spawn = asyncio.ensure_future(
+                asyncio.to_thread(
                     self._spawn_runner_proc,
                     dict(launch_spec.env),
                     launch_spec.session_slug,
                     launch_spec.workspace,
                 )
+            )
+            try:
+                proc, log_path = await asyncio.shield(spawn)
+            except asyncio.CancelledError:
+                spawn.add_done_callback(self._discard_abandoned_spawn)
+                raise
             except OSError as exc:
                 self._runners.pop(runner_id, None)
                 error += f"\nAutomatic restart failed: {exc}"

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -799,7 +799,7 @@ def test_repl_recover_after_runner_death(
     tmp_path: Path,
 ) -> None:
     """
-    ``--server`` auto-relaunches a killed daemon-owned runner.
+    ``--server`` restarts a killed daemon-owned runner in place.
 
     Uses the mock LLM server for deterministic marker responses.
 
@@ -844,9 +844,8 @@ def test_repl_recover_after_runner_death(
                 recovered_runner_id = _wait_session_runner_online(
                     server.base_url,
                     first_result.session_id,
-                    previous_runner_id=first_result.runner_id,
                 )
-                assert recovered_runner_id != first_result.runner_id
+                assert recovered_runner_id == first_result.runner_id
                 clean_exit(child, timeout=_EXIT_TIMEOUT)
             finally:
                 child.close(force=True)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1205,6 +1205,7 @@ async def test_watch_runner_reports_unexpected_exit(
     """
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
     monkeypatch.setattr("omnigent.host.connect._RUNNER_WATCH_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_RESTART_MAX_ATTEMPTS", 0)
     host = _make_host_process()
     tunnel = _FakeTunnel()
     host._ws = tunnel  # type: ignore[assignment] — duck-typed send
@@ -1253,6 +1254,109 @@ async def test_watch_runner_reports_unexpected_exit(
     # The report carries the exit code and the log tail with the cause.
     assert "code 3" in report.error
     assert "tunnel rejected: crash-cause" in report.error
+
+
+async def test_watch_runner_restarts_unexpected_exit_in_place(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient runner crash is restarted without rebinding the session."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_WATCH_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_RESTART_BASE_DELAY_S", 0.0)
+    host = _make_host_process()
+    host._zygote = None
+    tunnel = _FakeTunnel()
+    host._ws = tunnel  # type: ignore[assignment] — duck-typed send
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    original_popen = subprocess.Popen
+    spawned: list[subprocess.Popen[bytes]] = []
+
+    def _fake_popen(args: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
+        command = "sleep 0.2; exit 3" if not spawned else "sleep 60"
+        proc = original_popen(
+            ["sh", "-c", command],
+            stdin=subprocess.DEVNULL,
+            stdout=kwargs["stdout"],
+            stderr=kwargs["stderr"],
+        )
+        spawned.append(proc)
+        return proc
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_restart",
+        binding_token="tok_restart",
+        workspace=str(workspace),
+    )
+    with patch("omnigent.host.connect.subprocess.Popen", side_effect=_fake_popen):
+        result = await host._handle_launch(frame)
+        assert result.status == "launched", result.error
+        runner_id = token_bound_runner_id("tok_restart")
+
+        deadline = time.monotonic() + 5.0
+        while len(spawned) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert len(spawned) == 2, "runner was not restarted after its transient crash"
+        assert host._runners[runner_id].proc is spawned[1]
+        assert spawned[1].poll() is None
+        assert tunnel.sent == []
+
+        stop = await host._handle_stop(
+            HostStopRunnerFrame(request_id="req_restart_stop", runner_id=runner_id)
+        )
+        assert stop.status == "stopped"
+
+    await asyncio.wait_for(asyncio.gather(*host._watcher_tasks), timeout=5.0)
+    assert tunnel.sent == []
+
+
+async def test_watch_runner_reports_after_restart_budget_is_exhausted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deterministic runner crash stops retrying and keeps its diagnostics."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_WATCH_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_RESTART_BASE_DELAY_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_RESTART_MAX_ATTEMPTS", 2)
+    host = _make_host_process()
+    host._zygote = None
+    tunnel = _FakeTunnel()
+    host._ws = tunnel  # type: ignore[assignment] — duck-typed send
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    original_popen = subprocess.Popen
+    spawned: list[subprocess.Popen[bytes]] = []
+
+    def _fake_popen(args: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
+        proc = original_popen(
+            ["sh", "-c", "sleep 0.1; exit 7"],
+            stdin=subprocess.DEVNULL,
+            stdout=kwargs["stdout"],
+            stderr=kwargs["stderr"],
+        )
+        spawned.append(proc)
+        return proc
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_crash_loop",
+        binding_token="tok_crash_loop",
+        workspace=str(workspace),
+    )
+    with patch("omnigent.host.connect.subprocess.Popen", side_effect=_fake_popen):
+        result = await host._handle_launch(frame)
+        assert result.status == "launched", result.error
+        await asyncio.wait_for(asyncio.gather(*host._watcher_tasks), timeout=5.0)
+
+    assert len(spawned) == 3
+    assert len(tunnel.sent) == 1
+    report = decode_host_frame(tunnel.sent[0])
+    assert isinstance(report, HostRunnerExitedFrame)
+    assert "code 7" in report.error
+    assert "Automatic restart stopped after 2 attempts within 60s" in report.error
 
 
 async def test_watch_runner_silent_on_intentional_stop(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1312,6 +1312,63 @@ async def test_watch_runner_restarts_unexpected_exit_in_place(
     assert tunnel.sent == []
 
 
+async def test_watch_runner_cancelled_midrestart_does_not_leak_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling a blocked restart tears down the unregistered process."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_WATCH_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.host.connect._RUNNER_RESTART_BASE_DELAY_S", 0.0)
+    host = _make_host_process()
+    host._zygote = None
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    original_popen = subprocess.Popen
+    spawned: list[subprocess.Popen[bytes]] = []
+    restart_spawned = threading.Event()
+    release_restart = threading.Event()
+
+    def _fake_popen(args: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
+        command = ["sh", "-c", "sleep 0.1; exit 3"] if not spawned else ["sleep", "60"]
+        proc = original_popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=kwargs["stdout"],
+            stderr=kwargs["stderr"],
+        )
+        spawned.append(proc)
+        if len(spawned) == 2:
+            restart_spawned.set()
+            release_restart.wait(10.0)
+        return proc
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_cancel_restart",
+        binding_token="tok_cancel_restart",
+        workspace=str(workspace),
+    )
+    with patch("omnigent.host.connect.subprocess.Popen", side_effect=_fake_popen):
+        result = await host._handle_launch(frame)
+        assert result.status == "launched", result.error
+        watcher = next(iter(host._watcher_tasks))
+        assert await asyncio.to_thread(restart_spawned.wait, 5.0)
+        watcher.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await watcher
+        finally:
+            release_restart.set()
+
+    assert len(spawned) == 2
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and spawned[1].poll() is None:
+        await asyncio.sleep(0.05)
+    assert spawned[1].poll() is not None, "cancelled restart leaked an untracked runner"
+    host._cleanup_runners()
+
+
 async def test_watch_runner_reports_after_restart_budget_is_exhausted(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #4459

## Summary

- Make the host daemon supervise runners and restart unexpected non-zero exits with the same runner ID, workspace, and launch environment.
- Bound recovery to three restart attempts within 60 seconds with exponential backoff; explicit stops and clean exits remain stopped.
- Preserve the existing `host.runner_exited` diagnostics after the retry budget is exhausted. Interrupted turns are not replayed automatically, avoiding duplicate side effects.
- Shield restart spawns so daemon shutdown cannot leave an untracked runner process behind.

**ELI5:** The host now acts like a foreman. If a runner crashes, it starts a replacement with the same badge and workspace. If the replacement keeps crashing, it stops retrying and reports the original diagnostics.

```text
unexpected non-zero exit
          |
          v
  bounded backoff/restart ----> same runner ID reconnects
          |                              |
          |                              v
          |                    disconnect state clears
          v
  budget exhausted
          |
          v
  host.runner_exited + log tail
```

## Test Plan

- `.venv/bin/pytest tests/host/test_connect.py` — 111 passed.
- `.venv/bin/pytest tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_recover_after_runner_death` — passed; the test sends `SIGKILL` to a live runner and verifies the same session and runner ID recover.
- `.venv/bin/pre-commit run --files omnigent/host/connect.py tests/host/test_connect.py tests/e2e/omnigent/test_repl_session_lifecycle.py` — all hooks passed.

## Demo

The deterministic E2E sends `SIGKILL` to the live runner. The host detects exit code `-9`, restarts it after 0.5 seconds with the same runner ID and a new PID, and the same session responds successfully.

![Runner recovery E2E demo](https://gist.githubusercontent.com/akuwano/5d083ec9775f27069997db0358582cc9/raw/.runner-recovery-demo.svg)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused host tests cover transient restart, retry exhaustion, preserved diagnostics, and cancellation during a blocked restart spawn. The updated E2E kills a live daemon-owned runner and verifies the same session resumes through the same runner ID.

## Changelog

Host-managed runners now recover automatically when their process exits unexpectedly.
