### PR TITLE
fix(claude-native): dead-letter and surface stranded sub-agent completions (SIL-925)

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3061,6 +3061,33 @@ async def _forward_available_status_events(
                     decision.attempts,
                     _http_status_for_log(exc),
                 )
+                # Dead-letter the dropped terminal status for recovery (#1120;
+                # replay #1579). Unlike the item/start dead-letter sites, a
+                # dropped ``idle``/``failed`` hook status is the ONLY signal
+                # that ends a sub-agent's turn and wakes its parent's inbox
+                # (SIL-925): with nothing durable recorded here, an exhausted
+                # ``subagent_delivery_not_confirmed`` 503 (the parent-inbox
+                # race in omnigent-ai/omnigent#3274) silently strands the
+                # orchestrator forever, discoverable only via a direct
+                # sys_session_get_info poll. The 503 and any permanent 4xx
+                # both arrive as ``httpx.HTTPStatusError`` — a real response
+                # was received, so this is never an ambiguous delivery (see
+                # ``post_may_have_been_delivered``) and is safe to replay.
+                append_dead_letter(
+                    bridge_dir,
+                    session_id=session_id,
+                    event_type="external_session_status",
+                    payload={
+                        "status": effective_status,
+                        "response_id": response_id,
+                        "background_task_count": (
+                            None if status == "failed" else record.background_task_count
+                        ),
+                    },
+                    reason="permanent HTTP failure after retries",
+                    delivered_ambiguous=False,
+                    http_status=_http_status_for_log(exc),
+                )
                 if status != "failed":
                     await _post_forwarder_failed_status(
                         client,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1212,6 +1212,36 @@ def list_subagent_work(parent_session_id: str) -> list[_SubagentWorkEntry]:
     return sorted(entries, key=lambda entry: entry.created_at)
 
 
+def list_undelivered_terminal_subagent_work(
+    parent_session_id: str,
+) -> list[_SubagentWorkEntry]:
+    """
+    List a parent's sub-agent dispatches that finished but never delivered.
+
+    A terminal work entry (``status`` in ``completed``/``failed``/
+    ``cancelled``) with ``delivered=False`` means
+    :func:`_deliver_subagent_completion` could not find a parent inbox on
+    this runner (``missing_parent_inbox``) and the forward was later
+    dropped after its bounded retries exhausted — the child's result is
+    parked in this registry, but nothing ever reached this parent's inbox
+    queue or wake path (SIL-925: the parent orchestrator strands silently,
+    discoverable only via a direct ``sys_session_get_info`` poll).
+
+    ``sys_read_inbox`` surfaces these explicitly as a structural signal so
+    the caller can detect a stranded child instead of relying on
+    remembering to poll every in-flight dispatch ad hoc.
+
+    :param parent_session_id: Parent session id, e.g.
+        ``"conv_parent123"``.
+    :returns: Terminal, undelivered work entries, oldest first.
+    """
+    return [
+        entry
+        for entry in list_subagent_work(parent_session_id)
+        if entry.status in _SUBAGENT_TERMINAL_STATUSES and not entry.delivered
+    ]
+
+
 def mark_subagent_work_terminal(
     child_session_id: str,
     *,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -38,6 +38,7 @@ from omnigent.json_types import JsonObject as _JsonObject
 if TYPE_CHECKING:
     from omnigent.inner.datamodel import OSEnvSpec
     from omnigent.inner.os_env import OSEnvironment
+    from omnigent.runner.app import _SubagentWorkEntry
     from omnigent.runner.mcp_manager import RunnerMcpManager
     from omnigent.runner.resource_registry import SessionResourceRegistry
     from omnigent.runtime.filesystem_registry import FilesystemRegistry
@@ -6574,6 +6575,29 @@ def _cleanup_drained_subagent_work(payload: _JsonObject) -> None:
     )
 
 
+def _format_undelivered_subagent_notice(entries: list[_SubagentWorkEntry]) -> str:
+    """
+    Render a structural notice for sub-agents that finished but never delivered.
+
+    :param entries: Terminal, undelivered work entries from
+        :func:`omnigent.runner.app.list_undelivered_terminal_subagent_work`,
+        oldest first.
+    :returns: One ``[System: ...]`` block listing every stranded child.
+    """
+    lines = [
+        f"- {entry.agent} ({entry.title or entry.child_session_id}): "
+        f"status={entry.status} conversation_id={entry.child_session_id}"
+        for entry in entries
+    ]
+    return (
+        "[System: {count} sub-agent(s) finished but their completion could "
+        "not be delivered to this inbox (parent-inbox delivery failed and "
+        "exhausted its retries — SIL-925). They will NOT auto-wake you "
+        "again. Call sys_session_get_info on each conversation_id to read "
+        "their result directly:\n{lines}]"
+    ).format(count=len(entries), lines="\n".join(lines))
+
+
 async def _drain_inbox(
     inbox: asyncio.Queue[_JsonObject] | None,
     *,
@@ -6583,7 +6607,13 @@ async def _drain_inbox(
     """
     Non-blocking drain of the per-session inbox queue.
 
-    Returns formatted completion payloads or "Inbox is empty."
+    Returns formatted completion payloads or "Inbox is empty." Also
+    appends a structural notice (SIL-925) for any of this session's
+    dispatched sub-agents that reached a terminal status but whose
+    completion could never be delivered here (see
+    :func:`omnigent.runner.app.list_undelivered_terminal_subagent_work`) —
+    a caller relying solely on push-wake would otherwise never learn
+    those children finished.
 
     :param inbox: The session's asyncio.Queue, or ``None`` if
         no queue has been created yet.
@@ -6592,38 +6622,45 @@ async def _drain_inbox(
         ``"conv_parent123"``.
     :returns: Formatted string of completed tasks.
     """
-    if inbox is None or inbox.empty():
-        return "Inbox is empty — no completed tasks."
     items: list[str] = []
-    retry_payloads: list[_JsonObject] = []
-    while not inbox.empty():
-        try:
-            payload = inbox.get_nowait()
-        except asyncio.QueueEmpty:
-            break
-        if payload.get("type") == "terminal_idle":
+    if inbox is not None and not inbox.empty():
+        retry_payloads: list[_JsonObject] = []
+        while not inbox.empty():
             try:
-                items.append(_format_terminal_idle_item(payload))
-            except ValueError as exc:
-                _logger.warning(
-                    "malformed terminal-idle inbox item ignored: %s",
-                    exc,
-                    exc_info=True,
-                )
-                items.append(f"[System: malformed terminal_idle inbox item ignored — {exc}]")
-            continue
-        evaluation = await _evaluate_subagent_inbox_output(
-            payload,
-            server_client=server_client,
-            conversation_id=conversation_id,
-        )
-        items.append(_format_async_task_item(evaluation.payload))
-        if evaluation.retry_original:
-            retry_payloads.append(payload)
-        else:
-            _cleanup_drained_subagent_work(evaluation.payload)
-    for payload in retry_payloads:
-        inbox.put_nowait(payload)
+                payload = inbox.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if payload.get("type") == "terminal_idle":
+                try:
+                    items.append(_format_terminal_idle_item(payload))
+                except ValueError as exc:
+                    _logger.warning(
+                        "malformed terminal-idle inbox item ignored: %s",
+                        exc,
+                        exc_info=True,
+                    )
+                    items.append(f"[System: malformed terminal_idle inbox item ignored — {exc}]")
+                continue
+            evaluation = await _evaluate_subagent_inbox_output(
+                payload,
+                server_client=server_client,
+                conversation_id=conversation_id,
+            )
+            items.append(_format_async_task_item(evaluation.payload))
+            if evaluation.retry_original:
+                retry_payloads.append(payload)
+            else:
+                _cleanup_drained_subagent_work(evaluation.payload)
+        for payload in retry_payloads:
+            inbox.put_nowait(payload)
+
+    if conversation_id is not None:
+        from omnigent.runner import app as _runner_app
+
+        stranded = _runner_app.list_undelivered_terminal_subagent_work(conversation_id)
+        if stranded:
+            items.append(_format_undelivered_subagent_notice(stranded))
+
     return "\n\n".join(items) if items else "Inbox is empty — no completed tasks."
 
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -2518,6 +2518,73 @@ async def test_runner_read_inbox_continues_after_malformed_terminal_idle_item() 
     assert session_inbox.empty()
 
 
+@pytest.mark.asyncio
+async def test_sys_read_inbox_surfaces_undelivered_terminal_subagent_work() -> None:
+    """
+    ``sys_read_inbox`` surfaces sub-agents that finished but never delivered (SIL-925).
+
+    A work entry can never reach ``delivered=True`` when the runner has no
+    parent inbox for it (``missing_parent_inbox`` —
+    omnigent-ai/omnigent#3274) and the forwarder's bounded retries have
+    since exhausted. The queue-based drain below has nothing to show, but
+    the caller must not conclude nothing happened: this is the structural
+    fallback signal (an empty queue does not mean an empty inbox) — a
+    stranded child is reported explicitly instead of only being
+    discoverable via a direct ``sys_session_get_info`` poll.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    parent_id = "conv_parent_sil925"
+    child_id = "conv_child_sil925"
+    runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="worker",
+        title="stranded",
+    )
+    try:
+        ack = runner_app.mark_subagent_work_terminal(
+            child_id,
+            status="completed",
+            output="DONE_BUT_UNDELIVERED",
+        )
+        assert ack.reason == "missing_parent_inbox"
+        assert ack.delivered is False
+
+        inbox_output = await execute_tool(
+            tool_name="sys_read_inbox",
+            arguments="{}",
+            conversation_id=parent_id,
+        )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert "sub-agent(s) finished but their completion could not be delivered" in inbox_output
+    assert "worker" in inbox_output
+    assert child_id in inbox_output
+    assert "sys_session_get_info" in inbox_output
+
+
+@pytest.mark.asyncio
+async def test_sys_read_inbox_stays_empty_without_undelivered_subagent_work() -> None:
+    """
+    ``sys_read_inbox`` reports empty when nothing is stranded (SIL-925).
+
+    Guards the additive change from firing for every ``conversation_id`` —
+    only a session with a genuinely undelivered terminal child gets the
+    structural notice.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    inbox_output = await execute_tool(
+        tool_name="sys_read_inbox",
+        arguments="{}",
+        conversation_id="conv_parent_with_nothing_pending",
+    )
+    assert inbox_output == "Inbox is empty — no completed tasks."
+
+
 @pytest.mark.parametrize(
     ("arguments", "expected_error"),
     [

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -7859,6 +7859,77 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_forward_status_events_dead_letters_on_exhausted_subagent_delivery(
+    tmp_path: Path,
+) -> None:
+    """
+    An exhausted ``subagent_delivery_not_confirmed`` 503 dead-letters the drop (SIL-925).
+
+    A sub-agent's terminal Stop→idle edge is the ONLY signal that ends its
+    turn and wakes its parent's inbox. If the runner can never accept
+    delivery (``missing_parent_inbox`` — omnigent-ai/omnigent#3274, a
+    parent-inbox map populated only by ``create_session``) the forwarder
+    retries a bounded number of times (``_SUBAGENT_DELIVERY_NOT_CONFIRMED
+    _MAX_ATTEMPTS``, added in #1471 so a permanently orphaned parent does
+    not retry forever), then previously just logged a server-side ERROR and
+    dropped the edge outright — no inbox item, no wake, nothing durable.
+    That is the SIL-925 failure mode: the orchestrator strands silently and
+    the completion is only discoverable via a direct ``sys_session_get_info``
+    poll. Dead-lettering the drop instead makes it a durable, forensic
+    record eligible for a future replay pass.
+    """
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "Stop", "session_id": "claude-session"},
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            json={
+                "error": "subagent_delivery_not_confirmed",
+                "reason": "missing_parent_inbox",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    dedupe = forwarder._ForwardDedupeState()
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        hook_state = await forwarder._ensure_hook_state(
+            bridge_dir, start_at_end=False, session_id="conv_child"
+        )
+        await forwarder._forward_available_status_events(
+            client=client,
+            session_id="conv_child",
+            bridge_dir=bridge_dir,
+            state=hook_state,
+            retry_tracker=_PostRetryTracker(base_delay_s=0.0, max_not_confirmed_attempts=1),
+            dedupe=dedupe,
+            task_subjects={},
+            task_statuses={},
+            task_order=[],
+            response_id=None,
+        )
+
+    dl_path = bridge_dir / "dead_letter.jsonl"
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    # The idle edge exhausts and dead-letters; the synthesized ``failed``
+    # fallback (_post_forwarder_failed_status) then hits the same 503, but
+    # that path is a bare best-effort POST with no retry tracker and no
+    # dead-letter of its own — exactly one record results.
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "conv_child"
+    assert record["event_type"] == "external_session_status"
+    assert record["payload"]["status"] == "idle"
+    assert record["payload"]["background_task_count"] == 0
+    assert record["reason"] == "permanent HTTP failure after retries"
+    assert record["delivered_ambiguous"] is False
+    assert record["http_status"] == 503
+
+
+@pytest.mark.asyncio
 async def test_forwarder_emits_turn_start_running_with_response_id(tmp_path: Path) -> None:
     """
     The first assistant output of a turn publishes ``running`` + its response id.


### PR DESCRIPTION
## Problem (SIL-925, recurring)

A dispatched sub-agent finishes real work (e.g. opens a PR) and goes
idle, but no `[System: sub-agent ... finished (completed)]` inbox
message ever arrives at the parent orchestrator. The only way to
discover this is a direct `sys_session_get_info` poll. Confirmed 3x
across two orchestrator sessions this same day (SIL-912, SIL-915,
SIL-690), which defeats the "dispatch, then end turn, wait for inbox
wake" supervision model.

## Root cause

A sub-agent's terminal Stop-hook status (`idle`/`failed`) is the ONLY
signal that ends its turn and wakes its parent's inbox
(`_forward_available_status_events` in `claude_native_forwarder.py` →
`external_session_status` → runner's `_deliver_subagent_completion`).

The runner's parent-inbox map (`_session_inboxes_ref` in
`omnigent/runner/app.py`) is populated in exactly one place —
`_initialize_session`, reachable only from `create_session`. Any
session not created **on that specific runner process** (a runner
replacement, or a nested sub-agent whose intermediate parent was never
independently `create_session`'d there) has no inbox entry, so
delivery is rejected:

```
503 {"error":"subagent_delivery_not_confirmed",
     "reason":"missing_parent_inbox"}
```

This exactly matches the already-triaged, still-open
**omnigent-ai/omnigent#3274** ("validated:reproduced", filed
2026-08-07), independently corroborating this session's own root-cause
trace.

The forwarder retries this specific 503 up to
`_SUBAGENT_DELIVERY_NOT_CONFIRMED_MAX_ATTEMPTS = 12` bounded attempts
with capped backoff — added in **#1471** specifically so a genuinely
orphaned parent doesn't retry forever and flood the server. On
exhaustion, `_forward_available_status_events` previously just logged
a single server-side `ERROR` and advanced its cursor past the event —
**no inbox item, no wake, nothing durable.** The one remaining
fallback (`_post_forwarder_failed_status`, a synthesized `failed`
status) hits the identical `missing_parent_inbox` condition and has no
retry/dead-letter of its own either. Net effect: the completion is
permanently and silently lost, with the drop visible only in a server
log nobody watching the orchestrator ever sees.

## Why this PR doesn't fix `missing_parent_inbox` directly

`tests/runner/test_app_sessions_native_supervision.py::
test_tracked_subagent_status_without_parent_inbox_returns_503`
deliberately asserts the loud 503 over a silently-faked 204, with an
explicit rationale: lazily creating an inbox Queue for an arbitrary
`parent_session_id` the runner doesn't actually know is live would
trade one silent failure for another (a completion accepted into a
Queue nobody will ever drain). The upstream issue's own "notes toward
a fix" acknowledge the same tension ("for a parent the runner knows
about"), and the maintainers have not yet landed a fix as of
2026-08-07. Forcing that root-cause fix through in one session, in an
unfamiliar codebase, against an existing test's explicit design intent,
felt like the wrong risk/confidence tradeoff.

## What this PR does instead

1. **Dead-letter the exhausted drop** (`claude_native_forwarder.py::
   _forward_available_status_events`): reuses the exact
   `append_dead_letter` pattern already established in this same file
   for subagent-start/item exhaustion (`dead_letter.jsonl`, replay-
   eligible per `_dead_letter_record_replayable` — the 503/4xx is a
   real HTTP response, never an ambiguous delivery). Turns a silent
   loss into a durable, forensically recoverable record.

2. **Structural fallback signal** (the SIL-925 acceptance criteria's
   explicit "at minimum" ask): `sys_read_inbox` now also reports any of
   the caller's dispatched sub-agents that reached a terminal status
   but were never delivered
   (`omnigent/runner/app.py::list_undelivered_terminal_subagent_work`,
   wired into `_drain_inbox` in `omnigent/runner/tool_dispatch.py`).
   An orchestrator polling its own inbox now gets an explicit
   "N sub-agent(s) finished but their completion could not be
   delivered" notice instead of an inbox that looks empty when it
   isn't.

## Out of scope / follow-up

- Fixing `missing_parent_inbox` at the source (lazily/safely
  materializing a parent inbox only when the runner can prove the
  parent is genuinely live on this process) — tracked upstream as
  #3274.
- Wiring `replay_dead_letters` for claude-native on forwarder startup,
  mirroring the pattern `codex_native_forwarder.py` already has
  (`_replay_dead_letters_on_startup`). claude-native already writes
  dead letters at several sites (subagent start/item exhaustion) but
  has never had auto-replay wired up — a pre-existing gap this PR
  doesn't attempt to close, to keep the change surgical.

## Testing

- `tests/test_claude_native_forwarder.py::
  test_forward_status_events_dead_letters_on_exhausted_subagent_delivery`
  — an exhausted `subagent_delivery_not_confirmed` 503 dead-letters the
  drop exactly once.
- `tests/runner/test_runner_dispatch.py::
  test_sys_read_inbox_surfaces_undelivered_terminal_subagent_work` /
  `test_sys_read_inbox_stays_empty_without_undelivered_subagent_work`
  — the structural notice appears only when there's a genuinely
  stranded child.
- Full suites for all three touched files: `324 passed, 1 skipped`
  (pre-existing API-key-gated test), `ruff check`/`ruff format --check`/
  `mypy` clean.

Linear: https://linear.app/silica-v1/issue/SIL-925/kaizen-sub-agent-task-completion-doesnt-reliably-wake-the

Omnigent-Agent: claude