### PR TITLE
Recover Claude SDK sessions from context overflow

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -58,6 +58,7 @@ from .async_utils import run_sync_on_thread
 from .claude_gateway_shim import DATABRICKS_CLAUDE_ADAPTIVE_THINKING_PREFIXES, ClaudeGatewayShim
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .executor import (
+    CompactionComplete,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -279,9 +280,13 @@ class _UserMessageObj(Protocol):
 class _ResultMessageObj(Protocol):
     """Structural view of ``claude_agent_sdk.ResultMessage``."""
 
+    session_id: str
     result: str | None
     is_error: bool | None
     usage: dict[str, Any] | None  # type: ignore[explicit-any]
+    errors: list[str] | None
+    api_error_status: int | None
+    stop_reason: str | None
 
 
 class _SystemMessageObj(Protocol):
@@ -349,6 +354,21 @@ _QUERY_START_TIMEOUT_SECONDS = 30.0
 # but keep waiting — a long-running native tool can legitimately block
 # the stream far longer than any fixed deadline.
 _STREAM_IDLE_WARN_SECONDS = 600.0
+
+
+def _is_context_window_overflow(result: _ResultMessageObj) -> bool:
+    """Return whether an SDK error is specifically a provider context overflow."""
+    if getattr(result, "stop_reason", None) == "model_context_window_exceeded":
+        return True
+    if getattr(result, "api_error_status", None) != 400:
+        return False
+    errors = getattr(result, "errors", None) or []
+    text = " ".join([result.result or "", *errors]).lower()
+    normalized = " ".join(text.split())
+    return (
+        "context window" in normalized and ("exceed" in normalized or "too long" in normalized)
+    ) or "prompt is too long" in normalized
+
 
 # ── Multimodal content block conversion ──────────────────────
 
@@ -1505,6 +1525,8 @@ class ClaudeSDKExecutor(Executor):
         # Force-close tasks for clients evicted on turn cancellation, kept
         # referenced so they are not GC'd mid-close.
         self._cancel_close_tasks: set[asyncio.Task[None]] = set()
+        # One native compact-and-retry attempt per user turn.
+        self._overflow_recovery_sessions: set[str] = set()
 
         # Prefer system-installed claude over the SDK's bundled CLI.
         # The bundled CLI may be older and send beta flags that the
@@ -1762,6 +1784,67 @@ class ClaudeSDKExecutor(Executor):
         task = asyncio.create_task(self._force_close_client(state.client))
         self._cancel_close_tasks.add(task)
         task.add_done_callback(self._cancel_close_tasks.discard)
+
+    async def _compact_live_client(
+        self,
+        sdk: _ClaudeSDK,
+        *,
+        client: _ClaudeClient,
+        session_key: str,
+        fallback_session_id: str | None,
+        model: str | None,
+    ) -> CompactionComplete | None:
+        """Force Claude Code's native compaction and export its replacement history."""
+        await client.query("/compact", session_id=session_key)
+        stream = client.receive_response()
+        saw_precompact = False
+        compact_session_id = fallback_session_id
+        compact_usage: dict[str, Any] | None = None  # type: ignore[explicit-any]
+        try:
+            async for message in stream:
+                if isinstance(message, sdk.SystemMessage):
+                    saw_precompact = saw_precompact or (
+                        getattr(message, "hook_event_name", None) == "PreCompact"
+                    )
+                elif isinstance(message, sdk.ResultMessage):
+                    result = cast(_ResultMessageObj, message)
+                    compact_session_id = result.session_id or compact_session_id
+                    if result.is_error:
+                        return None
+                    compact_usage = result.usage
+        finally:
+            aclose = getattr(stream, _ACLOSE_ATTR, None)
+            if aclose is not None:
+                await aclose()
+        if not saw_precompact or not compact_session_id:
+            return None
+
+        from claude_agent_sdk import get_session_messages
+
+        session_messages = get_session_messages(compact_session_id, directory=self._cwd)
+        compacted_messages = [
+            {"type": "message", "role": item.type, "content": item.message.get("content", [])}
+            for item in session_messages
+            if isinstance(item.message, dict)
+        ]
+        if not compacted_messages:
+            return None
+        context_tokens = 0
+        if compact_usage:
+            context_tokens = sum(
+                int(compact_usage.get(key) or 0)
+                for key in (
+                    "input_tokens",
+                    "cache_creation_input_tokens",
+                    "cache_read_input_tokens",
+                )
+            )
+        return CompactionComplete(
+            summary="[Claude Code compaction — context recovered after overflow]",
+            token_count=context_tokens,
+            model=model,
+            compacted_messages=compacted_messages,
+        )
 
     async def close(self) -> None:
         session_keys = list(self._clients)
@@ -2437,6 +2520,7 @@ class ClaudeSDKExecutor(Executor):
         observed_model: str | None = None
         system_diagnostics: list[str] = []
         terminal_error: str | None = None
+        context_overflow = False
         compaction_occurred: bool = False
         claude_session_id: str | None = None
 
@@ -2732,6 +2816,7 @@ class ClaudeSDKExecutor(Executor):
                             # Harness-level failure (e.g. expired login). Surface
                             # as an executor error rather than assistant content.
                             failure_text = result_msg.result or "claude-sdk harness error"
+                            context_overflow = _is_context_window_overflow(result_msg)
                             logger.error(
                                 "claude-sdk ResultMessage is_error=True for agent %r: %s",
                                 self._agent_name,
@@ -2884,6 +2969,44 @@ class ClaudeSDKExecutor(Executor):
             )
             return
         if terminal_error:
+            if context_overflow:
+                if session_key in self._overflow_recovery_sessions:
+                    # The one allowed retry also overflowed. Drop the dead
+                    # transcript; the persisted boundary makes the next turn
+                    # cold-start safely.
+                    await self._close_live_client(session_key)
+                else:
+                    self._overflow_recovery_sessions.add(session_key)
+                    try:
+                        compaction = await self._compact_live_client(
+                            sdk,
+                            client=client,
+                            session_key=session_key,
+                            fallback_session_id=claude_session_id,
+                            model=observed_model or model,
+                        )
+                        if compaction is not None:
+                            yield compaction
+                            async for event in self.run_turn(
+                                messages,
+                                tools,
+                                system_prompt,
+                                config,
+                            ):
+                                yield event
+                            return
+                    except asyncio.CancelledError:
+                        self._evict_client_on_cancel(session_key)
+                        raise
+                    except Exception:  # noqa: BLE001 — recovery failure preserves original error
+                        logger.warning(
+                            "Claude SDK native compaction recovery failed for session %s",
+                            session_key,
+                            exc_info=True,
+                        )
+                    finally:
+                        self._overflow_recovery_sessions.discard(session_key)
+                    await self._close_live_client(session_key)
             yield ExecutorError(message=terminal_error)
             return
 
@@ -2931,8 +3054,6 @@ class ClaudeSDKExecutor(Executor):
         _notify_usage_from_dict(model=model, usage=turn_usage)
 
         if compaction_occurred and claude_session_id:
-            from omnigent.inner.executor import CompactionComplete
-
             _compaction_tokens = 0
             if turn_usage is not None:
                 _compaction_tokens = turn_usage.get("context_tokens", 0) or 0

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -350,10 +350,20 @@ class _ClaudeSDK(Protocol):
 
 _CONNECT_TIMEOUT_SECONDS = 60.0
 _QUERY_START_TIMEOUT_SECONDS = 30.0
+_COMPACT_TIMEOUT_SECONDS = 60.0
+_OVERFLOW_RETRY_PROMPT = "Continue responding to the previous user message after compaction."
 # When the response stream is quiet for this long we emit a warning,
 # but keep waiting — a long-running native tool can legitimately block
 # the stream far longer than any fixed deadline.
 _STREAM_IDLE_WARN_SECONDS = 600.0
+
+
+def _is_compaction_boundary(message: _SystemMessageObj) -> bool:
+    """Return whether a real SDK system message marks compaction."""
+    return (
+        message.subtype == "compact_boundary"
+        or message.data.get("hook_event_name") == "PreCompact"
+    )
 
 
 def _is_context_window_overflow(result: _ResultMessageObj) -> bool:
@@ -1803,8 +1813,8 @@ class ClaudeSDKExecutor(Executor):
         try:
             async for message in stream:
                 if isinstance(message, sdk.SystemMessage):
-                    saw_precompact = saw_precompact or (
-                        getattr(message, "hook_event_name", None) == "PreCompact"
+                    saw_precompact = saw_precompact or _is_compaction_boundary(
+                        cast(_SystemMessageObj, message)
                     )
                 elif isinstance(message, sdk.ResultMessage):
                     result = cast(_ResultMessageObj, message)
@@ -2925,9 +2935,9 @@ class ClaudeSDKExecutor(Executor):
                                     f"{endpoint_hint}"
                                 )
                                 break
-                        elif getattr(system_msg, "hook_event_name", None) == "PreCompact":
+                        elif _is_compaction_boundary(system_msg):
                             compaction_occurred = True
-                            logger.info("Claude SDK compaction detected (PreCompact hook)")
+                            logger.info("Claude SDK compaction detected (compact boundary)")
                         else:
                             logger.info("Claude CLI system message: %s", data)
             finally:
@@ -2978,17 +2988,27 @@ class ClaudeSDKExecutor(Executor):
                 else:
                     self._overflow_recovery_sessions.add(session_key)
                     try:
-                        compaction = await self._compact_live_client(
-                            sdk,
-                            client=client,
-                            session_key=session_key,
-                            fallback_session_id=claude_session_id,
-                            model=observed_model or model,
+                        compaction = await asyncio.wait_for(
+                            self._compact_live_client(
+                                sdk,
+                                client=client,
+                                session_key=session_key,
+                                fallback_session_id=claude_session_id,
+                                model=observed_model or model,
+                            ),
+                            timeout=_COMPACT_TIMEOUT_SECONDS,
                         )
                         if compaction is not None:
                             yield compaction
+                            retry_messages: list[Message] = [
+                                {
+                                    "role": "user",
+                                    "content": _OVERFLOW_RETRY_PROMPT,
+                                    "session_id": session_key,
+                                }
+                            ]
                             async for event in self.run_turn(
-                                messages,
+                                retry_messages,
                                 tools,
                                 system_prompt,
                                 config,

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -380,6 +380,17 @@ def _is_context_window_overflow(result: _ResultMessageObj) -> bool:
     ) or "prompt is too long" in normalized
 
 
+def _read_compacted_messages(session_id: str, *, directory: str | None) -> list[_JsonObject]:
+    """Export the CLI's post-compaction transcript for durable resume."""
+    from claude_agent_sdk import get_session_messages
+
+    return [
+        {"type": "message", "role": item.type, "content": item.message.get("content", [])}
+        for item in get_session_messages(session_id, directory=directory)
+        if isinstance(item.message, dict)
+    ]
+
+
 # ── Multimodal content block conversion ──────────────────────
 
 
@@ -1829,14 +1840,7 @@ class ClaudeSDKExecutor(Executor):
         if not saw_precompact or not compact_session_id:
             return None
 
-        from claude_agent_sdk import get_session_messages
-
-        session_messages = get_session_messages(compact_session_id, directory=self._cwd)
-        compacted_messages = [
-            {"type": "message", "role": item.type, "content": item.message.get("content", [])}
-            for item in session_messages
-            if isinstance(item.message, dict)
-        ]
+        compacted_messages = _read_compacted_messages(compact_session_id, directory=self._cwd)
         if not compacted_messages:
             return None
         context_tokens = 0
@@ -2359,11 +2363,13 @@ class ClaudeSDKExecutor(Executor):
         # ``""`` here would still leave an empty key in the child env.
         env = dict(self._extra_env)
         api_key_helper = env.pop(_CLAUDE_API_KEY_HELPER_ENV_KEY, None)
-        settings_payload = (
-            json.dumps({"apiKeyHelper": api_key_helper}, separators=(",", ":"))
-            if api_key_helper
-            else None
-        )
+        # Claude CLI JSONL transcripts contain conversation and tool inputs/outputs.
+        # They are local working data for compaction export, retained for seven days;
+        # Omnigent's conversation store remains authoritative.
+        settings: _JsonObject = {"cleanupPeriodDays": 7}
+        if api_key_helper:
+            settings["apiKeyHelper"] = api_key_helper
+        settings_payload = json.dumps(settings, separators=(",", ":"))
 
         # Capture stderr from the CLI subprocess for diagnostics
         stderr_lines: list[str] = []
@@ -2396,9 +2402,9 @@ class ClaudeSDKExecutor(Executor):
         # NOT passed: bare mode skips CLAUDE.md auto-discovery,
         # plugin sync, and auto-memory — exactly the host config
         # users expect to leak through to a ``claude-sdk`` harness
-        # they explicitly opted into. ``no-session-persistence``
-        # stays because omnigent owns conversation persistence
-        # via its own conversation store.
+        # they explicitly opted into. CLI transcript persistence stays
+        # enabled as the local compaction/export source; Omnigent's
+        # conversation store remains authoritative.
         # OS-environment tools are provided via Omnigent ``sys_os_*``
         # MCP tools (declared via ``os_env`` in the spec), not the
         # SDK's native Bash/Read/Edit/Write.  Only the Skill tool
@@ -2435,7 +2441,6 @@ class ClaudeSDKExecutor(Executor):
             "include_hook_events": True,
             "skills": resolved.skills,
             "plugins": bundle_plugins,
-            "extra_args": {"no-session-persistence": None},
             "max_buffer_size": 10 * 1024 * 1024,
         }
         # Only forward ``setting_sources`` when explicitly set.
@@ -2998,23 +3003,24 @@ class ClaudeSDKExecutor(Executor):
                             ),
                             timeout=_COMPACT_TIMEOUT_SECONDS,
                         )
-                        if compaction is not None:
+                        if compaction is not None and session_key in self._clients:
                             yield compaction
-                            retry_messages: list[Message] = [
-                                {
-                                    "role": "user",
-                                    "content": _OVERFLOW_RETRY_PROMPT,
-                                    "session_id": session_key,
-                                }
-                            ]
-                            async for event in self.run_turn(
-                                retry_messages,
-                                tools,
-                                system_prompt,
-                                config,
-                            ):
-                                yield event
-                            return
+                            if session_key in self._clients:
+                                retry_messages: list[Message] = [
+                                    {
+                                        "role": "user",
+                                        "content": _OVERFLOW_RETRY_PROMPT,
+                                        "session_id": session_key,
+                                    }
+                                ]
+                                async for event in self.run_turn(
+                                    retry_messages,
+                                    tools,
+                                    system_prompt,
+                                    config,
+                                ):
+                                    yield event
+                                return
                     except asyncio.CancelledError:
                         self._evict_client_on_cancel(session_key)
                         raise
@@ -3082,14 +3088,7 @@ class ClaudeSDKExecutor(Executor):
             # environments where the CLI's own transcript is lost.
             _compacted: list[_JsonObject] | None = None
             try:
-                from claude_agent_sdk import get_session_messages
-
-                _msgs = get_session_messages(claude_session_id, directory=self._cwd)
-                _compacted = [
-                    {"type": "message", "role": m.type, "content": m.message.get("content", [])}
-                    for m in _msgs
-                    if isinstance(m.message, dict)
-                ]
+                _compacted = _read_compacted_messages(claude_session_id, directory=self._cwd)
                 if not _compacted:
                     logger.warning(
                         "Claude post-compaction read returned no messages "

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1366,6 +1366,7 @@ class TestSystemMessages(unittest.TestCase):
             settings["apiKeyHelper"],
             "databricks auth token --host https://host",
         )
+        self.assertEqual(settings["cleanupPeriodDays"], 7)
         # The CLI talks to the loopback shim; the shim forwards to the
         # real gateway. A direct gateway URL here would mean the shim was
         # bypassed and opus thinking.display stays stripped.
@@ -1665,6 +1666,7 @@ class TestStreamEventStreaming(unittest.TestCase):
                             "prompt": prompt,
                             "session_id": session_id,
                             "extra_args": getattr(self.options, "extra_args", {}),
+                            "settings": getattr(self.options, "settings", None),
                             "tools": getattr(self.options, "tools", None),
                             "allowed_tools": getattr(self.options, "allowed_tools", None),
                         }
@@ -1698,9 +1700,10 @@ class TestStreamEventStreaming(unittest.TestCase):
             # leakage. It was dropped because bare mode also kills
             # CLAUDE.md auto-discovery, plugin sync, and skill loading —
             # which the spec's ``skills:`` field is the proper knob for.
+            self.assertEqual(query_calls[0]["extra_args"], {})
             self.assertEqual(
-                query_calls[0]["extra_args"],
-                {"no-session-persistence": None},
+                json.loads(query_calls[0]["settings"]),
+                {"cleanupPeriodDays": 7},
             )
             # Skill is always in the base tool set so the Skill tool is
             # actually exposed to the model when ``skills="all"`` (the
@@ -4291,6 +4294,31 @@ class TestToolCallPolicyGate(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+def test_read_compacted_messages_exports_disk_transcript() -> None:
+    from omnigent.inner.claude_sdk_executor import _read_compacted_messages
+
+    disk_messages = [
+        SimpleNamespace(
+            type="user",
+            message={"content": [{"type": "text", "text": "kept"}]},
+        ),
+        SimpleNamespace(type="assistant", message="ignored"),
+    ]
+    with patch(
+        "claude_agent_sdk.get_session_messages", return_value=disk_messages
+    ) as mock_get_messages:
+        exported = _read_compacted_messages("claude-session", directory="/workspace")
+
+    assert exported == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": "kept"}],
+        }
+    ]
+    mock_get_messages.assert_called_once_with("claude-session", directory="/workspace")
+
+
 def test_compaction_boundary_uses_real_sdk_system_message_shape() -> None:
     from omnigent.inner.claude_sdk_executor import _is_compaction_boundary
 
@@ -4384,9 +4412,16 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
                 return_value=_FakeSDK,
             ),
             patch(
-                "claude_agent_sdk.get_session_messages",
-                return_value=fake_session_msgs,
-            ) as mock_get_msgs,
+                "omnigent.inner.claude_sdk_executor._read_compacted_messages",
+                return_value=[
+                    {
+                        "type": "message",
+                        "role": msg.type,
+                        "content": msg.message["content"],
+                    }
+                    for msg in fake_session_msgs
+                ],
+            ) as mock_read_compacted,
         ):
             events = [
                 e
@@ -4404,7 +4439,7 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
         assert len(ce.compacted_messages) == 2
         assert ce.compacted_messages[0]["role"] == "user"
         assert ce.compacted_messages[1]["role"] == "assistant"
-        mock_get_msgs.assert_called_once_with("claude-uuid-123", directory=None)
+        mock_read_compacted.assert_called_once_with("claude-uuid-123", directory=None)
         # CompactionComplete before TurnComplete
         turn_completes = [e for e in events if isinstance(e, TurnComplete)]
         assert len(turn_completes) == 1
@@ -4617,10 +4652,7 @@ def _overflow_test_sdk(responses):
 
 
 @pytest.mark.asyncio
-async def test_context_overflow_compacts_persistent_client_and_retries_once(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from types import SimpleNamespace
+async def test_context_overflow_compacts_persistent_client_and_retries_once() -> None:
     from unittest.mock import patch
 
     from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
@@ -4646,20 +4678,26 @@ async def test_context_overflow_compacts_persistent_client_and_retries_once(
             [recovered],
         ]
     )
-    monkeypatch.setattr(
-        "claude_agent_sdk.get_session_messages",
-        lambda *args, **kwargs: [
-            SimpleNamespace(
-                type="user", message={"content": [{"type": "text", "text": "summary"}]}
-            )
-        ],
-    )
+    compacted_messages = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": "summary"}],
+        }
+    ]
 
     executor = ClaudeSDKExecutor()
     messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
-    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk):
+    with (
+        patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk),
+        patch(
+            "omnigent.inner.claude_sdk_executor._read_compacted_messages",
+            return_value=compacted_messages,
+        ) as mock_read_compacted,
+    ):
         events = [event async for event in executor.run_turn(messages, [], "")]
 
+    mock_read_compacted.assert_called_once_with(compacted.session_id, directory=None)
     assert len(created) == 1
     assert created[0].queries == [
         "hello",
@@ -4676,6 +4714,56 @@ async def test_context_overflow_compacts_persistent_client_and_retries_once(
     ]
     assert isinstance(events[-1], TurnComplete)
     assert events[-1].response == "recovered"
+    assert executor._overflow_recovery_sessions == set()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_evicted_client_does_not_retry() -> None:
+    from unittest.mock import patch
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete, ExecutorError
+
+    overflow_text = "API Error: 400 input exceeds context window"
+    overflow = _OverflowTestResult(
+        overflow_text,
+        is_error=True,
+        api_error_status=400,
+    )
+    compacted = _OverflowTestResult("Compacted", is_error=False)
+    sdk, created = _overflow_test_sdk(
+        [
+            [overflow],
+            [SDKSystemMessage(subtype="compact_boundary", data={}), compacted],
+        ]
+    )
+
+    executor = ClaudeSDKExecutor()
+    messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+    with (
+        patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk),
+        patch(
+            "omnigent.inner.claude_sdk_executor._read_compacted_messages",
+            return_value=[
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "summary"}],
+                }
+            ],
+        ),
+    ):
+        events = []
+        async for event in executor.run_turn(messages, [], ""):
+            events.append(event)
+            if isinstance(event, CompactionComplete):
+                await executor.close_session("session-a")
+
+    assert created[0].queries == ["hello", "/compact"]
+    assert created[0].disconnects == 1
+    assert isinstance(events[-1], ExecutorError)
+    assert events[-1].message == overflow_text
+    assert executor._clients == {}
     assert executor._overflow_recovery_sessions == set()
 
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4531,3 +4531,187 @@ async def test_enqueue_session_message_returns_false_without_queuing() -> None:
 
     assert result is False
     assert not query_called, "query() must not be called during enqueue"
+
+
+class _OverflowTestResult:
+    def __init__(
+        self,
+        result: str,
+        *,
+        is_error: bool,
+        api_error_status: int | None = None,
+    ) -> None:
+        self.session_id = "claude-overflow-session"
+        self.result = result
+        self.is_error = is_error
+        self.api_error_status = api_error_status
+        self.errors = None
+        self.stop_reason = None
+        self.usage = None
+
+
+class _OverflowTestSystem:
+    hook_event_name = "PreCompact"
+
+
+class _OverflowTestSentinel:
+    pass
+
+
+def _overflow_test_sdk(responses):
+    created = []
+
+    class _FakeSDK:
+        AssistantMessage = _OverflowTestSentinel
+        UserMessage = _OverflowTestSentinel
+        SystemMessage = _OverflowTestSystem
+        ResultMessage = _OverflowTestResult
+        StreamEvent = _OverflowTestSentinel
+        TextBlock = _OverflowTestSentinel
+        ThinkingBlock = _OverflowTestSentinel
+        ToolUseBlock = _OverflowTestSentinel
+        ToolResultBlock = _OverflowTestSentinel
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+
+        @staticmethod
+        def create_sdk_mcp_server(**kwargs):
+            return kwargs
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+                self.queries = []
+                self.current = []
+                self.disconnects = 0
+                created.append(self)
+
+            async def connect(self):
+                return None
+
+            async def query(self, prompt, session_id="default"):
+                self.queries.append(prompt)
+                self.current = responses[len(self.queries) - 1]
+
+            async def receive_response(self):
+                for message in self.current:
+                    yield message
+
+            async def disconnect(self):
+                self.disconnects += 1
+
+    return _FakeSDK, created
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_compacts_persistent_client_and_retries_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete, TurnComplete
+
+    overflow = _OverflowTestResult(
+        "API Error: 400 Your input exceeds the context window of this model",
+        is_error=True,
+        api_error_status=400,
+    )
+    compacted = _OverflowTestResult("Compacted", is_error=False)
+    recovered = _OverflowTestResult("recovered", is_error=False)
+    sdk, created = _overflow_test_sdk(
+        [[overflow], [_OverflowTestSystem(), compacted], [recovered]]
+    )
+    monkeypatch.setattr(
+        "claude_agent_sdk.get_session_messages",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                type="user", message={"content": [{"type": "text", "text": "summary"}]}
+            )
+        ],
+    )
+
+    executor = ClaudeSDKExecutor()
+    messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk):
+        events = [event async for event in executor.run_turn(messages, [], "")]
+
+    assert len(created) == 1
+    assert created[0].queries == ["hello", "/compact", "hello"]
+    boundary = next(event for event in events if isinstance(event, CompactionComplete))
+    assert boundary.compacted_messages == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": "summary"}],
+        }
+    ]
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "recovered"
+    assert executor._overflow_recovery_sessions == set()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_second_failure_does_not_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import ExecutorError
+
+    overflow = _OverflowTestResult(
+        "API Error: 400 input exceeds context window",
+        is_error=True,
+        api_error_status=400,
+    )
+    compacted = _OverflowTestResult("Compacted", is_error=False)
+    sdk, created = _overflow_test_sdk([[overflow], [_OverflowTestSystem(), compacted], [overflow]])
+    monkeypatch.setattr(
+        "claude_agent_sdk.get_session_messages",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                type="assistant", message={"content": [{"type": "text", "text": "summary"}]}
+            )
+        ],
+    )
+
+    executor = ClaudeSDKExecutor()
+    messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk):
+        events = [event async for event in executor.run_turn(messages, [], "")]
+
+    assert len(created) == 1
+    assert created[0].queries == ["hello", "/compact", "hello"]
+    assert isinstance(events[-1], ExecutorError)
+    assert executor._clients == {}
+    assert executor._overflow_recovery_sessions == set()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_provider_400_does_not_trigger_context_recovery() -> None:
+    from unittest.mock import patch
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import ExecutorError
+
+    bad_request = _OverflowTestResult(
+        "API Error: 400 invalid temperature",
+        is_error=True,
+        api_error_status=400,
+    )
+    sdk, created = _overflow_test_sdk([[bad_request]])
+
+    executor = ClaudeSDKExecutor()
+    messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk):
+        events = [event async for event in executor.run_turn(messages, [], "")]
+
+    assert len(created) == 1
+    assert created[0].queries == ["hello"]
+    assert isinstance(events[-1], ExecutorError)

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from claude_agent_sdk.types import SystemMessage as SDKSystemMessage
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -4290,6 +4291,23 @@ class TestToolCallPolicyGate(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+def test_compaction_boundary_uses_real_sdk_system_message_shape() -> None:
+    from omnigent.inner.claude_sdk_executor import _is_compaction_boundary
+
+    real = SDKSystemMessage(
+        subtype="compact_boundary",
+        data={"hook_event_name": "PreCompact"},
+    )
+    fictional = SimpleNamespace(
+        subtype="hook_started",
+        data={"hook_event": "PreCompact"},
+        hook_event_name="PreCompact",
+    )
+
+    assert _is_compaction_boundary(real)
+    assert not _is_compaction_boundary(fictional)
+
+
 def test_precompact_hook_emits_compaction_complete_with_session_messages() -> None:
     """When PreCompact fires and a ResultMessage carries a session_id,
     CompactionComplete is emitted with compacted_messages read from
@@ -4312,15 +4330,6 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
                 },
             )()
 
-    class _SystemMessage:
-        def __init__(self, subtype, data, hook_event_name=None):
-            self.subtype = subtype
-            self.data = data
-            self.hook_event_name = hook_event_name
-
-    class _HookEventMessage(_SystemMessage):
-        pass
-
     class _FakeSessionMessage:
         def __init__(self, type, message):
             self.type = type
@@ -4329,7 +4338,7 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
     class _FakeSDK:
         AssistantMessage = type("AssistantMessage", (), {})
         UserMessage = type("UserMessage", (), {})
-        SystemMessage = _SystemMessage
+        SystemMessage = SDKSystemMessage
         ResultMessage = _ResultMessage
         StreamEvent = type("StreamEvent", (), {})
         ClaudeAgentOptions = type(
@@ -4348,10 +4357,9 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
 
             async def query(self, prompt, session_id="default"):
                 _FakeSDK.messages = [
-                    _HookEventMessage(
-                        subtype="hook_started",
-                        data={"hook_event": "PreCompact"},
-                        hook_event_name="PreCompact",
+                    SDKSystemMessage(
+                        subtype="compact_boundary",
+                        data={"hook_event_name": "PreCompact"},
                     ),
                     _ResultMessage("claude-uuid-123", "compacted result"),
                 ]
@@ -4550,8 +4558,8 @@ class _OverflowTestResult:
         self.usage = None
 
 
-class _OverflowTestSystem:
-    hook_event_name = "PreCompact"
+class _OverflowTestHang:
+    pass
 
 
 class _OverflowTestSentinel:
@@ -4564,7 +4572,7 @@ def _overflow_test_sdk(responses):
     class _FakeSDK:
         AssistantMessage = _OverflowTestSentinel
         UserMessage = _OverflowTestSentinel
-        SystemMessage = _OverflowTestSystem
+        SystemMessage = SDKSystemMessage
         ResultMessage = _OverflowTestResult
         StreamEvent = _OverflowTestSentinel
         TextBlock = _OverflowTestSentinel
@@ -4595,6 +4603,8 @@ def _overflow_test_sdk(responses):
             async def query(self, prompt, session_id="default"):
                 self.queries.append(prompt)
                 self.current = responses[len(self.queries) - 1]
+                if isinstance(self.current, _OverflowTestHang):
+                    await asyncio.Event().wait()
 
             async def receive_response(self):
                 for message in self.current:
@@ -4624,7 +4634,17 @@ async def test_context_overflow_compacts_persistent_client_and_retries_once(
     compacted = _OverflowTestResult("Compacted", is_error=False)
     recovered = _OverflowTestResult("recovered", is_error=False)
     sdk, created = _overflow_test_sdk(
-        [[overflow], [_OverflowTestSystem(), compacted], [recovered]]
+        [
+            [overflow],
+            [
+                SDKSystemMessage(
+                    subtype="compact_boundary",
+                    data={"hook_event_name": "PreCompact"},
+                ),
+                compacted,
+            ],
+            [recovered],
+        ]
     )
     monkeypatch.setattr(
         "claude_agent_sdk.get_session_messages",
@@ -4641,7 +4661,11 @@ async def test_context_overflow_compacts_persistent_client_and_retries_once(
         events = [event async for event in executor.run_turn(messages, [], "")]
 
     assert len(created) == 1
-    assert created[0].queries == ["hello", "/compact", "hello"]
+    assert created[0].queries == [
+        "hello",
+        "/compact",
+        "Continue responding to the previous user message after compaction.",
+    ]
     boundary = next(event for event in events if isinstance(event, CompactionComplete))
     assert boundary.compacted_messages == [
         {
@@ -4671,7 +4695,13 @@ async def test_context_overflow_second_failure_does_not_loop(
         api_error_status=400,
     )
     compacted = _OverflowTestResult("Compacted", is_error=False)
-    sdk, created = _overflow_test_sdk([[overflow], [_OverflowTestSystem(), compacted], [overflow]])
+    sdk, created = _overflow_test_sdk(
+        [
+            [overflow],
+            [SDKSystemMessage(subtype="compact_boundary", data={}), compacted],
+            [overflow],
+        ]
+    )
     monkeypatch.setattr(
         "claude_agent_sdk.get_session_messages",
         lambda *args, **kwargs: [
@@ -4687,10 +4717,46 @@ async def test_context_overflow_second_failure_does_not_loop(
         events = [event async for event in executor.run_turn(messages, [], "")]
 
     assert len(created) == 1
-    assert created[0].queries == ["hello", "/compact", "hello"]
+    assert created[0].queries == [
+        "hello",
+        "/compact",
+        "Continue responding to the previous user message after compaction.",
+    ]
     assert isinstance(events[-1], ExecutorError)
     assert executor._clients == {}
     assert executor._overflow_recovery_sessions == set()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_compaction_timeout_preserves_original_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import ExecutorError
+
+    overflow_text = "API Error: 400 input exceeds context window"
+    overflow = _OverflowTestResult(
+        overflow_text,
+        is_error=True,
+        api_error_status=400,
+    )
+    sdk, created = _overflow_test_sdk([[overflow], _OverflowTestHang()])
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor._COMPACT_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    executor = ClaudeSDKExecutor()
+    messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=sdk):
+        events = [event async for event in executor.run_turn(messages, [], "")]
+
+    assert created[0].queries == ["hello", "/compact"]
+    assert isinstance(events[-1], ExecutorError)
+    assert events[-1].message == overflow_text
+    assert executor._clients == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — discovered from a production context-overflow incident.

## Summary

- Detect provider context-window overflow results in the shared Claude SDK executor.
- Ask the persistent Claude Code client to run native `/compact`, export the replacement transcript, and retry the failed user turn once.
- Evict the client if recovery fails or the retry overflows, preventing loops and unsafe reuse.

ELI5: when a Claude-SDK-backed model fills its working memory, Omnigent now asks the same live client to summarize that memory and retries once.

```text
provider overflow -> /compact -> persist replacement history -> retry once
                         \-> failure/second overflow -> evict client
```

## Test Plan

- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest -q tests/inner/test_claude_sdk_executor.py` — 125 passed.
- `uv run --extra dev pre-commit run --all-files` — Ruff, Pyrefly, Python safety checks, and repository checks passed. Frontend-only hooks could not run because this Python-only worktree has no frontend `node_modules`.
- Reviewed the installed `claude-agent-sdk` result fields and post-compaction transcript-chain behavior.

## Demo

N/A — non-visual executor recovery.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the installed SDK exposes `stop_reason`, `errors`, and `api_error_status`, and that its session reader follows the compacted summary chain without replaying discarded history.

## Changelog

Claude SDK sessions recover from provider context overflow by compacting and retrying once.
