### PR TITLE
fix(deploy): read execution_timeout from the Docker entrypoint's config

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -304,6 +304,22 @@ def _build_routing(
     return _build_local_llm_routing_client(server_llm), settings
 
 
+def _resolve_execution_timeout(cfg: dict[str, Any]) -> int:
+    """Resolve the max wall-clock seconds per agent execution.
+
+    Mirrors the CLI's ``execution_timeout`` resolution (``omnigent server
+    --execution-timeout``) minus the flag layer, since a Docker deploy has no
+    CLI invocation to read one from: config file, else ``RuntimeCaps``'s own
+    default (7200s = 2 hours).
+
+    :param cfg: The parsed server config mapping.
+    :returns: The effective timeout in seconds.
+    """
+    from omnigent.runtime.caps import RuntimeCaps
+
+    return int(cfg.get("execution_timeout") or RuntimeCaps.execution_timeout)
+
+
 def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     """Resolve config if needed, wire the stores, and build the app.
 
@@ -374,6 +390,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     routing_client, routing_settings = _build_routing(cfg, server_llm)
 
     caps = RuntimeCaps(
+        execution_timeout=_resolve_execution_timeout(cfg),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -185,3 +185,23 @@ def test_build_routing_defaults_without_a_routing_block() -> None:
     client, settings = _build_routing({}, None)
     assert client is None
     assert settings == RoutingSettings()
+
+
+# ── execution timeout ───────────────────────────────────────────────────────
+# The CLI's `omnigent server --execution-timeout` has no equivalent flag for a
+# Docker deploy, so `execution_timeout:` in the server config YAML is the only
+# way to raise it there — this must actually reach RuntimeCaps, not silently
+# stay pinned to the 7200s (2h) dataclass default.
+
+
+def test_resolve_execution_timeout_reads_the_config_value() -> None:
+    from deploy.docker.entrypoint import _resolve_execution_timeout
+
+    assert _resolve_execution_timeout({"execution_timeout": 86400}) == 86400
+
+
+def test_resolve_execution_timeout_defaults_without_config() -> None:
+    from deploy.docker.entrypoint import _resolve_execution_timeout
+    from omnigent.runtime.caps import RuntimeCaps
+
+    assert _resolve_execution_timeout({}) == RuntimeCaps.execution_timeout


### PR DESCRIPTION
## Related issue

Closes #4466

## Summary

`omnigent server --execution-timeout` (and its config-file equivalent,
`execution_timeout:`) lets a local server raise the max wall-clock time per
agent execution above the 7200s (2h) `RuntimeCaps` default. The OSS Docker
entrypoint (`deploy/docker/entrypoint.py`, what `deploy/docker/Dockerfile` /
Kubernetes deployments actually boot) has no equivalent — `build_app()`
constructed `RuntimeCaps()` without `execution_timeout` at all, so every
Docker/Kubernetes deployment was silently pinned to 7200s with **no way to
raise it**, config file or otherwise.

Adds `_resolve_execution_timeout(cfg)`, mirroring the CLI's own
config-resolution (minus the flag layer, since a Docker boot has no CLI
invocation to read one from): `execution_timeout: <seconds>` in the server
config YAML now reaches `RuntimeCaps`, the same way it already does for
`omnigent server -c`.

### ELI5

A long-running agent task in a Docker/Kubernetes deployment got cut off at 2
hours no matter what the operator put in their config file, because the
Docker boot path never read that setting in the first place. This wires it
up so `execution_timeout: 86400` (or whatever an operator wants) in
`config.yaml` actually takes effect.

## Test Plan

- `pytest tests/deploy/test_docker_entrypoint_import.py` — 10/10 passing,
  including 2 new tests: the config value reaches `RuntimeCaps`, and the
  behavior is unchanged (still defaults to `RuntimeCaps.execution_timeout`,
  7200s) when the key is absent.
- Manual: deployed to a live Kubernetes cluster with `execution_timeout:
  86400` set in the operator config; confirmed the server boots with the
  raised cap wired into `RuntimeCaps` rather than falling back to 7200s.

## Demo

N/A — backend config-resolution fix, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both branches of `_resolve_execution_timeout` (config value
present / absent) in isolation, matching the existing pattern in this file
for `_build_routing` and `_resolve_config`. Manual verification confirmed the
fix on a live Kubernetes deployment; no automated integration test exercises
a full `build_app()` boot against a real database, consistent with how the
rest of this file's helpers are tested (unit-level, not full-boot).

## Changelog

Fix: `execution_timeout:` in the server config YAML now works for Docker /
Kubernetes deployments, not just `omnigent server -c` — it was previously
silently ignored, capping every such deployment's agent runs at 2 hours

