### PR TITLE
fix(sessions): spawn the session's harness override, not the spec default

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2684,7 +2684,14 @@ def create_runner_app(
                     )
                 else:
                     _warn_unresolved_sub_agent(session_id, _sa_name_assign)
-            harness_name = spec.executor.config.get("harness") or spec.executor.type
+            # The session's override outranks the spec: resolving from the spec
+            # alone made init spawn a harness the turns never ask for, evicting
+            # the override's live subprocess (entries are keyed by conversation).
+            harness_name = (
+                _session_harness_overrides.get(session_id)
+                or spec.executor.config.get("harness")
+                or spec.executor.type
+            )
             harness_name = canonicalize_harness(harness_name) or harness_name
 
             _start_verdict = await _evaluate_agent_start_gate(spec, harness_name)

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -48,6 +48,7 @@ from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.routing import RunnerRouter
+from omnigent.runner.session_init_protocol import build_runner_session_init_payload
 from omnigent.runtime import (
     pending_elicitations,
     user_session_stream,
@@ -325,15 +326,23 @@ def register_core_routes(
         if _terminal_first_create:
             _publish_terminal_pending(resp.id, True)
         _rc = await _get_runner_client(resp.id, runner_router)
-        if _rc is not None and conv is not None:
+        if _rc is not None and conv is not None and conv.agent_id is not None:
+            # The versioned payload's snapshot is what carries harness_override,
+            # so a create-time cross-harness override lands before the spawn.
+            # ``initial_items`` are already persisted and forwarded by now, so
+            # suppress the runner's recovery turn or they run twice. The
+            # agent_id guard keeps the builder's ValueError out of the narrow
+            # except below, which would 500 the create.
+            from omnigent.version import VERSION
+
             try:
                 await _rc.post(
                     "/v1/sessions",
-                    json={
-                        "session_id": resp.id,
-                        "agent_id": conv.agent_id,
-                        "sub_agent_name": conv.sub_agent_name,
-                    },
+                    json=build_runner_session_init_payload(
+                        conv,
+                        server_version=VERSION,
+                        suppress_recovery_turn=True,
+                    ),
                     timeout=10.0,
                 )
             except (httpx.HTTPError, ConnectionError):

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -2050,6 +2050,70 @@ async def test_create_session_threads_resolved_bundle_dir_to_codex_spawn_env(
 
 
 @pytest.mark.asyncio
+async def test_create_session_spawns_the_snapshot_harness_override() -> None:
+    """Session init must spawn the session's overridden harness, not the spec's.
+
+    ``get_client`` entries are keyed by conversation, so resolving the spawn
+    from the spec made init request a harness the turns never asked for: the
+    mismatch tears down the override subprocess the kickoff turn is streaming
+    through and replaces it with the spec's
+    (``omnigent/runtime/harnesses/process_manager.py:749-770``). When the
+    spec's harness is a native one, init also launches its terminal on top of
+    that spawn, leaving two live processes for the one session.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        name="override-agent",
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+    )
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    session_id = "5b0c1f7a4d2e4c8fa1b3d6e9c0f2a4b6"
+    agent_id = "9d3e2b1c7a504f6e8c2d1b0a3f5e7c9d"
+    payload = {
+        "session_id": session_id,
+        "agent_id": agent_id,
+        "sub_agent_name": None,
+        "session_init": {
+            "protocol_version": 2,
+            "server_version": "0.6.0.dev0",
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "sub_agent_name": None,
+            "snapshot": {
+                "created_at": 1234,
+                "updated_at": 1234,
+                "workspace": None,
+                "labels": {},
+                "harness_override": "pi",
+            },
+        },
+    }
+
+    async with _runner_client(app) as client:
+        resp = await client.post("/v1/sessions", json=payload)
+
+    assert resp.status_code == 201, resp.text
+    # Whole list, not just the last call: spawning the spec's harness *as well*
+    # is the defect, and a trailing-call assertion cannot see it.
+    spawned = [(conv_id, harness) for conv_id, harness, _env in pm.get_client_calls]
+    assert spawned == [(session_id, "pi")], (
+        f"Session init must spawn the snapshot's harness_override 'pi' and "
+        f"nothing else; got {spawned}. Spawning the spec's 'claude-sdk' evicts "
+        f"the override harness the session's turns run on."
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_session_envelope_is_single_flight_and_skips_metadata_callbacks() -> None:
     """Concurrent v2 initialization resolves once and uses supplied metadata."""
 

--- a/tests/server/integration/test_sessions_harness_override.py
+++ b/tests/server/integration/test_sessions_harness_override.py
@@ -32,6 +32,7 @@ class _CaptureClient:
         """Record the path + body and return a fake 202 response."""
         self._captured["path"] = path
         self._captured["body"] = json
+        self._captured.setdefault("posts", []).append((path, json))
 
         class _Resp:
             status_code = 202
@@ -49,7 +50,8 @@ def _stub_runner_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: A dict the test inspects after the runner POST runs;
-        contains ``path`` and ``body`` keys once the route fires.
+        contains ``path`` and ``body`` for the last POST plus a ``posts``
+        list of every ``(path, body)`` pair, once the route fires.
     """
     from omnigent.server.routes import sessions as sessions_mod
 
@@ -219,6 +221,58 @@ async def test_runner_first_event_forwards_harness_override(
         f"override; got {captured['body'].get('harness_override')!r}. The "
         f"create route did not persist harness_override before the first "
         f"turn, or the forwarding site dropped it."
+    )
+
+
+async def test_create_session_init_carries_harness_override(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The create route's runner notification must carry the override.
+
+    With ``initial_items`` the kickoff turn is forwarded before this
+    notification lands. A notification that omits the session-init envelope
+    leaves the runner resolving the harness from the spec, so init evicts the
+    override harness the kickoff turn is already streaming through.
+    """
+    from omnigent.server.routes import sessions as sessions_mod
+
+    captured = _stub_runner_client(monkeypatch)
+
+    async def _skip_relay_readiness(*_: Any, **__: Any) -> None:
+        return None
+
+    monkeypatch.setattr(sessions_mod, "_ensure_runner_relay_ready", _skip_relay_readiness)
+
+    agent = await create_test_agent(client)
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "harness_override": "pi",
+            "initial_items": [
+                {
+                    "type": "message",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "kickoff"}],
+                    },
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    init_posts = [body for path, body in captured.get("posts", []) if path == "/v1/sessions"]
+    assert init_posts, (
+        "The create route never notified the runner about the new session — "
+        "check the runner-stub wiring."
+    )
+    snapshot = init_posts[-1].get("session_init", {}).get("snapshot", {})
+    assert snapshot.get("harness_override") == "pi", (
+        f"Session-init notification lost the create-time harness override; "
+        f"got {init_posts[-1]!r}. The runner then resolves the harness from "
+        f"the spec and spawns that one instead."
     )
 
 


### PR DESCRIPTION
## Related issue

Closes #2854

## Summary

A session created with a cross-harness `harness_override` and a non-empty `initial_items` starts its kickoff turn on the override harness, and then session init tears that harness down and replaces it with the spec's.

The two causes suggested in the issue don't hold up. The kickoff body does carry the override, and `_ensure_runner_relay_ready` only opens an SSE stream. The actual causes:

- The create route in `routes_core.py` notified the runner with a hand-rolled `{session_id, agent_id, sub_agent_name}` body instead of `build_runner_session_init_payload`. `snapshot.harness_override` lives in that envelope, so it never crossed.
- `_initialize_session` in `runner/app.py` resolved the harness to spawn from `spec.executor` alone. It reads `snapshot.harness_override` a few lines earlier, but only to record it for later reads.

`initial_items` is what makes them collide in one request, since the kickoff POST lands before the init POST.

### What actually happens to the process

`HarnessProcessManager` keys entries by conversation id, so two SDK harnesses cannot coexist for one session. When init asks for a harness that doesn't match the live entry, `get_client` tears the running subprocess down and respawns (`omnigent/runtime/harnesses/process_manager.py:749-770`; `_close_entry` SIGTERMs at `:1276`). So the symptom is an eviction, not coexistence: the override harness the kickoff turn is streaming through is killed and replaced by the spec's.

The literal "two live harnesses" case is the native/SDK boundary. When the spec's harness is a native one, `_initialize_session` also launches a native terminal (`omnigent/runner/app.py:2765`) on top of the `get_client` spawn, which is a second process outside `_entries`.

### Why the server-side half isn't redundant

The obvious objection is that the runner already learns the override from the kickoff turn, so the envelope shouldn't be needed. It is, because of ordering.

The kickoff `/events` POST does record the override, at `omnigent/runner/app.py:5224`. But that line lives inside `_run_turn_bg_setup_and_stream`, which `post_session_events` launches as an `asyncio.create_task` at `:6190` **after** returning 202 at `:6200` (the server forwards with the default `stream=False`). The create route's init POST is fired right after that 202 comes back, so without the envelope there is a real race where init reaches the harness resolution at `:2690` before the background turn task has populated `_session_harness_overrides`. The envelope removes the race: `_initialize_session` seeds the override from `snapshot.harness_override` before it resolves.

## Test Plan

- [x] One test per side. Reverting each production file individually fails only that side's test:

```
AssertionError: Session init must spawn the snapshot's harness_override 'pi' and nothing else;
  got [('5b0c1f7a4d2e4c8fa1b3d6e9c0f2a4b6', 'claude-sdk')].

AssertionError: Session-init notification lost the create-time harness override;
  got {'session_id': '2895...', 'agent_id': '0bb7...', 'sub_agent_name': None}.
```

- [x] 190 passed / 2 failed over the eight server + runner files that cover this path (`test_sessions_harness_override`, `test_sessions_model_override`, `test_sessions_native_kickoff_duplicate`, `test_sessions_attribution`, `test_runner_session_init`, `test_session_host_launch`, `test_app_sessions_native_workflow_init`, `test_app_sessions_native_terminals_autocreate`). Both failures reproduce unchanged on the base commit and are Windows-only environment failures (`tmux`/PTY unavailable, so a native Codex terminal can't start).
- [x] Wider sweep for the `suppress_recovery_turn` rider: 691 passed across `tests/server/integration -k session`, the one failure being the same pre-existing host-launch one above (plus two collection errors from a missing `argon2` in my env, unrelated).
- [x] `ruff check` clean on all four changed files.

Not run: `pyrefly` isn't installed here, and the full `tests/server` suite didn't finish on my machine.

The runner regression test now pins the whole `get_client` call list rather than the last call. Asserting only on the last call could not have caught the "spec's harness spawned as well" shape it claims to guard, since `pi` would still be last.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One regression test per side, each proven to fail on the unfixed tree.

Being upfront about scope: the create route now sends the whole envelope rather than only the harness, which moves this caller to `_load_envelope_session_init_context`. That's the same payload `_on_runner_connect` already sends on every reconnect, so the path is well exercised, but it is broader than a harness-only change.

Two small riders on that, both intentional:

- The route now passes `suppress_recovery_turn=True`. By the time this notification fires, `_create_session_from_existing_agent` has already persisted and forwarded every `initial_items` entry, so this is exactly the invariant the flag documents. Without it the runner's history load would see the pending kickoff message and start a recovery turn for it, and the forward would then be buffered and re-processed. This matches what `routes_events.py:1418` already does for the same reason.
- The call is now guarded on `conv.agent_id is not None`. `build_runner_session_init_payload` raises `ValueError` on a `None` agent id, which the narrow `except (httpx.HTTPError, ConnectionError)` would not catch, and that would 500 the create.

Remaining legacy callers: of the five server-to-runner session-init call sites, three now send the versioned envelope. Two still send the hand-rolled body, the runner-rebind leg of `PATCH /v1/sessions/{id}` (`omnigent/server/routes/sessions/routes_core.py:1714-1721`) and `_notify_runner_of_bundled_child` (`omnigent/server/routes/_sessions/helpers.py:8260-8268`). Left out to keep this reviewable. Happy to fold them in here or file a follow-up, whichever you prefer.

*(Correcting an earlier version of this description: it said the leftover legacy body was on the `/switch` and `/clear` routes. Those are REPL slash commands, not server routes; the real sites are the two listed above.)*

## Changelog

A session created with a harness override and initial items now runs that override on its first turn, instead of having it replaced by the agent's default harness.
