### PR TITLE
feat(web): import native Claude and Codex chats from New Session

### DIFF
--- a/omnigent/claude_transcript.py
+++ b/omnigent/claude_transcript.py
@@ -1,0 +1,13 @@
+"""Shared recognition helpers for Claude Code transcript records."""
+
+from __future__ import annotations
+
+import re
+
+_INTERRUPT_RECORD_RE = re.compile(r"^\[Request interrupted by user(?: for tool use)?\]$")
+
+
+def is_claude_interrupt_text(text: str) -> bool:
+    """Return whether text is Claude Code's synthetic interrupted-turn marker."""
+    first_line = text.strip().split("\n", 1)[0]
+    return _INTERRUPT_RECORD_RE.fullmatch(first_line) is not None

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5722,6 +5722,7 @@ def import_session_command(
             "source": imported.source,
             "external_session_id": imported.external_session_id,
             "workspace": imported.workspace,
+            "title": imported.title,
             "force": force,
             "items": [
                 {

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -33,6 +33,8 @@ from omnigent.host import HOST_FATAL_EXIT_CODE
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     WORKSPACE_MISSING_ERROR_CODE,
+    HostChatImportFrame,
+    HostChatImportResultFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -2061,6 +2063,65 @@ class HostProcess:
             payload=payload,
         )
 
+    def _handle_chat_import(self, frame: HostChatImportFrame) -> HostChatImportResultFrame:
+        """Discover or normalize a local Claude/Codex transcript."""
+        from omnigent.session_import.local import (
+            list_recent_local_session_ids,
+            load_local_session,
+        )
+
+        if frame.source not in {"claude", "codex"}:
+            return HostChatImportResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error="Only Claude and Codex chats can be imported here",
+            )
+        try:
+            payload: dict[str, Any]
+            if frame.session_id is None:
+                rows = []
+                for session_id in list_recent_local_session_ids(frame.source, limit=frame.limit):
+                    try:
+                        chat = load_local_session(frame.source, session_id)
+                    except (OSError, TypeError, ValueError):
+                        continue
+                    rows.append(
+                        {
+                            "session_id": session_id,
+                            "title": chat.title,
+                            "workspace": chat.workspace,
+                            "item_count": len(chat.items),
+                        }
+                    )
+                payload = {"sessions": rows}
+            else:
+                chat = load_local_session(frame.source, frame.session_id)
+                payload = {
+                    "source": chat.source,
+                    "external_session_id": chat.external_session_id,
+                    "workspace": chat.workspace,
+                    "title": chat.title,
+                    "items": [
+                        {
+                            "type": item.type,
+                            "response_id": item.response_id,
+                            "data": item.data.model_dump(mode="json", exclude_none=True),
+                        }
+                        for item in chat.items
+                    ],
+                }
+        except (OSError, TypeError, ValueError) as exc:
+            return HostChatImportResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error=str(exc),
+            )
+        return HostChatImportResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            payload=payload,
+        )
+
     async def _handle_model_options(
         self,
         frame: HostModelOptionsFrame,
@@ -2857,6 +2918,9 @@ class HostProcess:
             await ws.send(encode_host_frame(fs_result))
         elif isinstance(frame, HostModelOptionsFrame):
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))
+        elif isinstance(frame, HostChatImportFrame):
+            result = await asyncio.to_thread(self._handle_chat_import, frame)
+            await ws.send(encode_host_frame(result))
 
 
 def run_host_process(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -73,6 +73,8 @@ class HostFrameKind(str, Enum):
     FS_RESULT = "host.fs_result"
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
+    CHAT_IMPORT = "host.chat_import"
+    CHAT_IMPORT_RESULT = "host.chat_import_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -849,6 +851,26 @@ class HostModelOptionsResultFrame:
     routable_models: list[str] = field(default_factory=list)
 
 
+@dataclass
+class HostChatImportFrame:
+    """Server → host: discover or load a local Claude/Codex chat."""
+
+    request_id: str
+    source: str
+    session_id: str | None = None
+    limit: int = 10
+
+
+@dataclass
+class HostChatImportResultFrame:
+    """Host → server: local chat discovery/load result."""
+
+    request_id: str
+    status: str
+    payload: _JsonObject | None = None
+    error: str | None = None
+
+
 HostFrame = (
     HostHelloFrame
     | HostHarnessReadinessFrame
@@ -881,6 +903,8 @@ HostFrame = (
     | HostFsResultFrame
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
+    | HostChatImportFrame
+    | HostChatImportResultFrame
 )
 
 
@@ -1233,6 +1257,26 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "routable_models": frame.routable_models,
             }
         )
+    if isinstance(frame, HostChatImportFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.CHAT_IMPORT.value,
+                "request_id": frame.request_id,
+                "source": frame.source,
+                "session_id": frame.session_id,
+                "limit": frame.limit,
+            }
+        )
+    if isinstance(frame, HostChatImportResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.CHAT_IMPORT_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "payload": frame.payload,
+                "error": frame.error,
+            }
+        )
     raise TypeError(f"unknown host frame type: {type(frame).__name__}")
 
 
@@ -1355,6 +1399,23 @@ def _decode_known_host_frame(
             return _decode_model_options(msg)
         case HostFrameKind.MODEL_OPTIONS_RESULT:
             return _decode_model_options_result(msg)
+        case HostFrameKind.CHAT_IMPORT:
+            return HostChatImportFrame(
+                request_id=_required_str(msg, "request_id"),
+                source=_required_str(msg, "source"),
+                session_id=_optional_nullable_str(msg, "session_id"),
+                limit=_required_int(msg, "limit"),
+            )
+        case HostFrameKind.CHAT_IMPORT_RESULT:
+            payload = msg.get("payload")
+            if payload is not None and not isinstance(payload, dict):
+                raise ValueError("frame field must be a JSON object or null: 'payload'")
+            return HostChatImportResultFrame(
+                request_id=_required_str(msg, "request_id"),
+                status=_required_str(msg, "status"),
+                payload=payload,
+                error=_optional_nullable_str(msg, "error"),
+            )
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1931,6 +1931,7 @@ def create_app(
             agent_store,
             auth_provider=auth_provider,
             permission_store=permission_store,
+            host_store=host_store,
         ),
         prefix="/v1",
         tags=["imports"],

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -259,6 +259,8 @@ class HostConnection:
         ``error_code``, and ``error``.
     :param pending_model_options: Per-``request_id`` futures for pre-launch
         model catalogs resolved by the selected host.
+    :param pending_chat_imports: Per-``request_id`` futures for local native
+        chat discovery and normalization on the selected host.
     """
 
     workspace_id: int
@@ -313,6 +315,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_model_options: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_chat_imports: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
 

--- a/omnigent/server/routes/_host_chat_import.py
+++ b/omnigent/server/routes/_host_chat_import.py
@@ -1,0 +1,38 @@
+"""One round-trip helper for native chat discovery and loading."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import Any
+
+from omnigent.host.frames import HostChatImportFrame, encode_host_frame
+from omnigent.server.host_registry import HostConnection, HostRegistry
+
+
+async def request_host_chat_import(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    source: str,
+    session_id: str | None,
+    limit: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    """Ask a host to discover or normalize a local native chat."""
+    request_id = secrets.token_hex(8)
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    host_conn.pending_chat_imports[request_id] = future
+    frame = encode_host_frame(
+        HostChatImportFrame(
+            request_id=request_id,
+            source=source,
+            session_id=session_id,
+            limit=limit,
+        )
+    )
+    try:
+        host_registry.send_text(host_conn, frame)
+        return await asyncio.wait_for(future, timeout=timeout_s)
+    finally:
+        host_conn.pending_chat_imports.pop(request_id, None)

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-import re
 import secrets
 import time
 import urllib.parse
@@ -38,6 +37,7 @@ from fastapi.responses import Response
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, StatementError
 
+from omnigent.claude_transcript import is_claude_interrupt_text
 from omnigent.cost_plan import (
     COST_CONTROL_LABEL_NAMESPACE,
     reserved_cost_control_keys,
@@ -3306,9 +3306,6 @@ def _is_kiro_native_session(conv: Conversation) -> bool:
 # user's bracketed question such as "[Request interrupted by user?]" stays a
 # real message. Kept in sync with `INTERRUPT_RE` in web/src/lib/systemMessage.ts,
 # which re-classifies the mirrored record as a muted "Interrupted" marker.
-_CLAUDE_INTERRUPT_RECORD_RE = re.compile(r"^\[Request interrupted by user(?: for tool use)?\]$")
-
-
 def _is_native_interrupt_record(data: MessageData) -> bool:
     """
     Whether a mirrored user item is the vendor CLI's own interrupt record.
@@ -3343,8 +3340,7 @@ def _is_native_interrupt_record(data: MessageData) -> bool:
     text = _message_text(data.content)
     if text is None:
         return False
-    first_line = text.strip().split("\n", 1)[0]
-    return _CLAUDE_INTERRUPT_RECORD_RE.match(first_line) is not None
+    return is_claude_interrupt_text(text)
 
 
 def _merge_pending_file_blocks(

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.host.frames import (
+    HostChatImportResultFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeResultFrame,
     HostDetectCredentialsResultFrame,
@@ -687,6 +688,14 @@ async def _receive_loop(
                         "routable_models": frame.routable_models,
                         "error": frame.error,
                     }
+                )
+            continue
+
+        if isinstance(frame, HostChatImportResultFrame):
+            import_future = conn.pending_chat_imports.pop(frame.request_id, None)
+            if import_future is not None and not import_future.done():
+                import_future.set_result(
+                    {"status": frame.status, "payload": frame.payload, "error": frame.error}
                 )
             continue
 

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -20,10 +20,10 @@ import asyncio
 import logging
 import os
 import secrets
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from omnigent.db.utils import now_epoch
 from omnigent.entities import Conversation
@@ -71,6 +71,7 @@ _LIST_DIR_MAX_LIMIT = 1000
 # for transient network slowness without making the picker feel hung.
 _CREATE_DIR_TIMEOUT_S = 5.0
 _MODEL_OPTIONS_TIMEOUT_S = 15.0
+_CHAT_IMPORT_TIMEOUT_S = 30.0
 # Per-call timeout for host.install_harness round-trips. The host runs
 # `npm install -g <pkg>` — install_harness_cli caps that subprocess at 300s —
 # then recomputes readiness and sends the result back over the tunnel. The
@@ -84,6 +85,13 @@ _INSTALL_HARNESS_TIMEOUT_S = 420.0
 # off). Named once here and shared by the route (this file) and the /v1/info
 # flag in app.py so the two reads can never diverge on a typo.
 HARNESS_INSTALL_ENABLED_ENV = "OMNIGENT_HARNESS_INSTALL_ENABLED"
+
+
+class LoadHostChatRequest(BaseModel):
+    """One native chat to normalize on a selected host."""
+
+    source: Literal["claude", "codex"]
+    session_id: str = Field(min_length=1, max_length=128)
 
 
 async def _proxy_model_options(
@@ -552,6 +560,72 @@ def create_hosts_router(
     :returns: A FastAPI router with host endpoints.
     """
     router = APIRouter()
+
+    async def _chat_import_host(request: Request, host_id: str) -> HostConnection:
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+        return conn
+
+    async def _request_chat_import(
+        conn: HostConnection,
+        *,
+        source: Literal["claude", "codex"],
+        session_id: str | None,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        from omnigent.server.routes._host_chat_import import request_host_chat_import
+
+        try:
+            result = await request_host_chat_import(
+                host_registry=host_registry,
+                host_conn=conn,
+                source=source,
+                session_id=session_id,
+                limit=limit,
+                timeout_s=_CHAT_IMPORT_TIMEOUT_S,
+            )
+        except ConnectionError as exc:
+            raise HTTPException(status_code=502, detail="host connection was lost") from exc
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=504, detail="host did not respond") from None
+        if result.get("status") != "ok":
+            raise HTTPException(
+                status_code=422,
+                detail=result.get("error") or "chat import failed",
+            )
+        payload = result.get("payload")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=502, detail="host returned an invalid import response")
+        return payload
+
+    @router.get("/hosts/{host_id}/chat-imports")
+    async def recent_chat_imports(
+        request: Request,
+        host_id: str,
+        source: Literal["claude", "codex"] = Query(),
+        limit: int = Query(default=10, ge=1, le=50),
+    ) -> dict[str, Any]:
+        """List recent importable native chats on a selected host."""
+        conn = await _chat_import_host(request, host_id)
+        return await _request_chat_import(conn, source=source, session_id=None, limit=limit)
+
+    @router.post("/hosts/{host_id}/chat-imports/load")
+    async def load_chat_import(
+        request: Request, host_id: str, body: LoadHostChatRequest
+    ) -> dict[str, Any]:
+        """Normalize one native chat on a selected host for ``/v1/imports``."""
+        session_id = body.session_id.strip()
+        if not session_id:
+            raise HTTPException(status_code=400, detail="session_id must not be blank")
+        conn = await _chat_import_host(request, host_id)
+        return await _request_chat_import(conn, source=body.source, session_id=session_id)
 
     @router.get("/hosts")
     async def list_hosts(request: Request) -> dict[str, list[dict[str, Any]]]:

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -27,6 +27,7 @@ from omnigent.session_import import (
 )
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.conversation_store import ConversationAlreadyExistsError
+from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 
 
@@ -55,6 +56,8 @@ class ImportSessionRequest(BaseModel):
     source: ImportSource
     external_session_id: str = Field(min_length=1, max_length=128)
     workspace: str | None = Field(default=None, max_length=2048)
+    title: str | None = Field(default=None, max_length=512)
+    host_id: str | None = Field(default=None, max_length=128)
     force: bool = False
     items: list[ImportItemInput] = Field(min_length=1, max_length=100_000)
 
@@ -66,6 +69,14 @@ class ImportSessionRequest(BaseModel):
         if not value:
             raise ValueError("external_session_id must not be blank")
         return value
+
+    @field_validator("title")
+    @classmethod
+    def strip_title(cls, value: str | None) -> str | None:
+        """Normalize an optional source-provided title."""
+        if value is None:
+            return None
+        return value.strip() or None
 
 
 class ImportSessionResponse(BaseModel):
@@ -116,6 +127,7 @@ def create_imports_router(
     *,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
+    host_store: HostStore | None = None,
 ) -> APIRouter:
     """Create the local-session import router."""
     router = APIRouter()
@@ -135,6 +147,19 @@ def create_imports_router(
     ) -> ImportSessionResponse:
         """Import one normalized transcript, optionally replacing its prior import."""
         user_id = require_user(request, auth_provider)
+        if body.host_id is not None:
+            if body.workspace is None:
+                raise OmnigentError(
+                    "Imported chats need a workspace when a host is selected",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            host = (
+                None
+                if host_store is None
+                else await asyncio.to_thread(host_store.get_host, body.host_id)
+            )
+            if host is None or (user_id is not None and host.user_id != user_id):
+                raise OmnigentError("Host not found", code=ErrorCode.NOT_FOUND)
         items = [item.to_item() for item in body.items]
         existing = await asyncio.to_thread(
             conversation_store.find_imported_conversation,
@@ -174,9 +199,10 @@ def create_imports_router(
         try:
             conversation = await asyncio.to_thread(
                 conversation_store.create_conversation,
-                title=title_from_items(items),
+                title=body.title or title_from_items(items),
                 agent_id=agent_id,
                 workspace=body.workspace,
+                host_id=body.host_id,
                 conversation_id=_import_conversation_id(body.source, body.external_session_id),
             )
         except ConversationAlreadyExistsError as exc:

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -10,8 +10,10 @@ from hashlib import sha256
 from pathlib import Path
 
 from omnigent.claude_native_bridge import read_transcript_items_from_offset
+from omnigent.claude_transcript import is_claude_interrupt_text
 from omnigent.codex_native import _CODEX_THREAD_ID_RE, _find_codex_rollout
-from omnigent.entities import NewConversationItem, parse_item_data
+from omnigent.entities import MessageData, NewConversationItem, parse_item_data
+from omnigent.entities.conversation import synthesize_conversation_title
 from omnigent.kimi_native_credentials import resolve_user_kimi_home
 from omnigent.kimi_native_forwarder import (
     read_kimi_wire_items,
@@ -27,6 +29,7 @@ from omnigent.opencode_native_app_server import (
 )
 from omnigent.opencode_native_forwarder import opencode_tool_output_text
 from omnigent.session_import.models import (
+    SESSION_IMPORT_TITLE_LIMIT,
     ImportSource,
     LocalSessionImport,
     SessionImportNotFoundError,
@@ -276,6 +279,42 @@ def _claude_workspace(transcript_path: Path) -> str | None:
     return None
 
 
+def _claude_session_summary(transcript_path: Path) -> str | None:
+    """Read Claude Code's explicit human-readable session summary."""
+    with transcript_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict) or record.get("type") != "summary":
+                continue
+            summary = record.get("summary")
+            if isinstance(summary, str) and (value := summary.strip()):
+                return value
+    return None
+
+
+def _claude_import_title(
+    transcript_path: Path,
+    items: tuple[NewConversationItem, ...],
+) -> str | None:
+    """Prefer Claude's summary, then the first non-synthetic user prompt."""
+    summary = _claude_session_summary(transcript_path)
+    if summary is not None:
+        return summary
+    for item in items:
+        if not isinstance(item.data, MessageData) or item.data.role != "user":
+            continue
+        title = synthesize_conversation_title(
+            item.data.content,
+            limit=SESSION_IMPORT_TITLE_LIMIT,
+        )
+        if title is not None and not is_claude_interrupt_text(title):
+            return title
+    return None
+
+
 def load_claude_session(
     session_id: str,
     *,
@@ -312,6 +351,7 @@ def load_claude_session(
         external_session_id=session_id,
         workspace=_claude_workspace(transcript_path),
         items=items,
+        title_hint=_claude_import_title(transcript_path, items),
     )
 
 

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -10,6 +10,7 @@ from omnigent.entities import MessageData, NewConversationItem
 from omnigent.entities.conversation import synthesize_conversation_title
 
 ImportSource = Literal["claude", "codex", "kimi", "kiro", "opencode", "pi", "qwen"]
+SESSION_IMPORT_TITLE_LIMIT = 512
 
 IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"
@@ -33,14 +34,19 @@ class LocalSessionImport:
     external_session_id: str
     workspace: str | None
     items: tuple[NewConversationItem, ...]
+    title_hint: str | None = None
 
     @property
     def title(self) -> str | None:
         """Return a sidebar title derived from the first user message."""
-        return title_from_items(self.items)
+        return self.title_hint or title_from_items(self.items, limit=SESSION_IMPORT_TITLE_LIMIT)
 
 
-def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
+def title_from_items(
+    items: Sequence[NewConversationItem],
+    *,
+    limit: int = SESSION_IMPORT_TITLE_LIMIT,
+) -> str | None:
     """Return a sidebar title derived from the first user message."""
     for item in items:
         if (
@@ -48,5 +54,5 @@ def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
             and item.data.role == "user"
             and not item.data.is_meta
         ):
-            return synthesize_conversation_title(item.data.content)
+            return synthesize_conversation_title(item.data.content, limit=limit)
     return None

--- a/openapi.json
+++ b/openapi.json
@@ -1798,6 +1798,18 @@
             "title": "Force",
             "type": "boolean"
           },
+          "host_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Id"
+          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/ImportItemInput"
@@ -1819,6 +1831,18 @@
             ],
             "title": "Source",
             "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           },
           "workspace": {
             "anyOf": [
@@ -1977,6 +2001,31 @@
           "workspace"
         ],
         "title": "LaunchRunnerRequest",
+        "type": "object"
+      },
+      "LoadHostChatRequest": {
+        "description": "One native chat to normalize on a selected host.",
+        "properties": {
+          "session_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Session Id",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "claude",
+              "codex"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "session_id"
+        ],
+        "title": "LoadHostChatRequest",
         "type": "object"
       },
       "MCPServerSummary": {
@@ -7256,6 +7305,131 @@
           }
         },
         "summary": "Get Host",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/chat-imports": {
+      "get": {
+        "description": "List recent importable native chats on a selected host.",
+        "operationId": "recent_chat_imports_v1_hosts__host_id__chat_imports_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "enum": [
+                "claude",
+                "codex"
+              ],
+              "title": "Source",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Recent Chat Imports V1 Hosts  Host Id  Chat Imports Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Recent Chat Imports",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
+    "/v1/hosts/{host_id}/chat-imports/load": {
+      "post": {
+        "description": "Normalize one native chat on a selected host for `/v1/imports`.",
+        "operationId": "load_chat_import_v1_hosts__host_id__chat_imports_load_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoadHostChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Load Chat Import V1 Hosts  Host Id  Chat Imports Load Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Load Chat Import",
         "tags": [
           "hosts"
         ]

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -73,6 +73,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
         "source": "claude",
         "external_session_id": session_id,
         "workspace": "/repo",
+        "title": "inspect TODO.md",
         "force": False,
         "items": [
             {

--- a/tests/e2e_ui/start_session/test_import_chat.py
+++ b/tests/e2e_ui/start_session/test_import_chat.py
@@ -1,0 +1,95 @@
+"""E2E coverage for importing a native chat from the new-session page."""
+
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import Page, Route, expect
+
+_HOST_ID = "host_import_e2e"
+_CLAUDE_SESSION_ID = "claude-import-e2e"
+
+
+def test_import_recent_claude_chat(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A recent Claude chat can be selected and imported from the landing page."""
+    base_url, imported_session_id = seeded_session
+
+    def handle_hosts(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "hosts": [
+                        {
+                            "host_id": _HOST_ID,
+                            "name": "This machine",
+                            "owner": "e2e",
+                            "status": "online",
+                        }
+                    ]
+                }
+            ),
+        )
+
+    def handle_recent(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "sessions": [
+                        {
+                            "session_id": _CLAUDE_SESSION_ID,
+                            "title": "Improve native chat importing",
+                            "workspace": "/work/omnigent",
+                            "item_count": 12,
+                        }
+                    ]
+                }
+            ),
+        )
+
+    def handle_load(route: Route) -> None:
+        assert route.request.post_data_json == {
+            "source": "claude",
+            "session_id": _CLAUDE_SESSION_ID,
+        }
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"source": "claude", "items": []}),
+        )
+
+    def handle_import(route: Route) -> None:
+        body = route.request.post_data_json
+        assert body["host_id"] == _HOST_ID
+        assert body["source"] == "claude"
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"session_id": imported_session_id}),
+        )
+
+    page.route("**/v1/hosts", handle_hosts)
+    page.route(f"**/v1/hosts/{_HOST_ID}/chat-imports?*", handle_recent)
+    page.route(f"**/v1/hosts/{_HOST_ID}/chat-imports/load", handle_load)
+    page.route("**/v1/imports", handle_import)
+
+    page.goto(f"{base_url}/")
+    page.get_by_test_id("new-chat-import-chat").click()
+
+    dialog = page.get_by_test_id("import-chat-dialog")
+    expect(dialog).to_be_visible()
+    expect(page.get_by_test_id("import-chat-host")).to_contain_text("This machine")
+    expect(dialog.get_by_text("Improve native chat importing")).to_be_visible()
+    expect(dialog.get_by_text("/work/omnigent · 12 items")).to_be_visible()
+
+    dialog.get_by_text("Improve native chat importing").click()
+    expect(page.get_by_test_id("import-chat-session-id")).to_have_value(_CLAUDE_SESSION_ID)
+    dialog.get_by_role("button", name="Import chat", exact=True).click()
+
+    expect(page).to_have_url(f"{base_url}/c/{imported_session_id}")

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -8,6 +8,8 @@ import pytest
 
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HostChatImportFrame,
+    HostChatImportResultFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -43,6 +45,33 @@ from omnigent.host.frames import (
     decode_host_frame,
     encode_host_frame,
 )
+
+
+def test_chat_import_frames_round_trip() -> None:
+    """Native chat discovery and load payloads survive the host tunnel."""
+    request = HostChatImportFrame(
+        request_id="req_import",
+        source="codex",
+        session_id="thread-123",
+        limit=10,
+    )
+    assert decode_host_frame(encode_host_frame(request)) == request
+
+    result = HostChatImportResultFrame(
+        request_id="req_import",
+        status="ok",
+        payload={
+            "sessions": [
+                {
+                    "session_id": "thread-123",
+                    "title": "Fix login",
+                    "workspace": "/repo",
+                    "item_count": 12,
+                }
+            ]
+        },
+    )
+    assert decode_host_frame(encode_host_frame(result)) == result
 
 
 def test_model_options_frames_round_trip() -> None:

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -390,6 +390,76 @@ def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
         load_claude_session(session_id, claude_home=tmp_path)
 
 
+def test_load_claude_session_prefers_summary_and_skips_interrupt_title(tmp_path: Path) -> None:
+    """Claude's summary names the chat instead of its synthetic interrupt record."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345679"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "summary",
+            "summary": "Repair authentication redirects",
+            "leafUuid": "assistant-2",
+        },
+        {
+            "type": "user",
+            "uuid": "interrupt-1",
+            "cwd": "/repo",
+            "message": {
+                "role": "user",
+                "content": "[Request interrupted by user for tool use]",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "user-1",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "Fix the login callback"},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.title == "Repair authentication redirects"
+
+
+def test_load_claude_session_title_falls_through_interrupt_record(tmp_path: Path) -> None:
+    """Without a summary, the first real prompt follows Claude's interrupt marker."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345670"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    prompt = (
+        "Fix the login callback and preserve the original redirect target "
+        "after authentication completes"
+    )
+    records = [
+        {
+            "type": "user",
+            "uuid": "interrupt-1",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "[Request interrupted by user]"},
+        },
+        {
+            "type": "user",
+            "uuid": "user-1",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": prompt},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.title == prompt
+
+
 def test_list_recent_claude_sessions_orders_parents_and_applies_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/src/lib/chatImports.ts
+++ b/web/src/lib/chatImports.ts
@@ -1,0 +1,59 @@
+import { authenticatedFetch } from "@/lib/identity";
+
+export type ChatImportSource = "claude" | "codex";
+
+export interface RecentNativeChat {
+  session_id: string;
+  title: string | null;
+  workspace: string | null;
+  item_count: number;
+}
+
+async function responseError(response: Response): Promise<Error> {
+  try {
+    const body = (await response.json()) as { detail?: string; error?: { message?: string } };
+    return new Error(body.detail ?? body.error?.message ?? `Request failed (${response.status})`);
+  } catch {
+    return new Error(`Request failed (${response.status})`);
+  }
+}
+
+export async function listRecentNativeChats(
+  hostId: string,
+  source: ChatImportSource,
+  limit = 10,
+): Promise<RecentNativeChat[]> {
+  const params = new URLSearchParams({ source, limit: String(limit) });
+  const response = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/chat-imports?${params.toString()}`,
+  );
+  if (!response.ok) throw await responseError(response);
+  const body = (await response.json()) as { sessions: RecentNativeChat[] };
+  return body.sessions;
+}
+
+export async function importNativeChat(
+  hostId: string,
+  source: ChatImportSource,
+  sessionId: string,
+): Promise<string> {
+  const loaded = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/chat-imports/load`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source, session_id: sessionId }),
+    },
+  );
+  if (!loaded.ok) throw await responseError(loaded);
+
+  const payload = (await loaded.json()) as Record<string, unknown>;
+  const imported = await authenticatedFetch("/v1/imports", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...payload, host_id: hostId, force: false }),
+  });
+  if (!imported.ok) throw await responseError(imported);
+  const result = (await imported.json()) as { session_id: string };
+  return result.session_id;
+}

--- a/web/src/shell/ImportChatDialog.test.tsx
+++ b/web/src/shell/ImportChatDialog.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { authenticatedFetch } from "@/lib/identity";
+import type { RoutingApi } from "@/lib/routing";
+import { ImportChatDialog } from "./ImportChatDialog";
+
+const navigate = vi.fn();
+
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+vi.mock("@/lib/routing", async () => {
+  const actual = await vi.importActual<RoutingApi>("@/lib/routing");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const fetchMock = vi.mocked(authenticatedFetch);
+
+describe("ImportChatDialog", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    navigate.mockReset();
+  });
+
+  it("lists recent chats with transcript context", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessions: [
+            {
+              session_id: "claude-session-1",
+              title: "Fix the login redirect",
+              workspace: "/repo/omnigent",
+              item_count: 14,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    render(
+      <ImportChatDialog
+        open
+        onOpenChange={vi.fn()}
+        hosts={[{ host_id: "host_local", name: "This machine", owner: "me", status: "online" }]}
+        defaultHostId="host_local"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("import-chat-host")).toHaveTextContent("This machine"),
+    );
+    expect(await screen.findByText("Fix the login redirect")).toBeTruthy();
+    expect(screen.getByText("/repo/omnigent · 14 items")).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/hosts/host_local/chat-imports?source=claude&limit=10",
+    );
+  });
+
+  it("selects this machine when hosts arrive after the dialog opens", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { rerender } = render(
+      <ImportChatDialog open onOpenChange={vi.fn()} hosts={[]} defaultHostId={null} />,
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    rerender(
+      <ImportChatDialog
+        open
+        onOpenChange={vi.fn()}
+        hosts={[{ host_id: "host_local", name: "This machine", owner: "me", status: "online" }]}
+        defaultHostId={null}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("import-chat-host")).toHaveTextContent("This machine"),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("restores the recent list when the selected session ID is cleared", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessions: [
+            {
+              session_id: "claude-session-1",
+              title: "Fix login",
+              workspace: "/repo",
+              item_count: 4,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(
+      <ImportChatDialog
+        open
+        onOpenChange={vi.fn()}
+        hosts={[{ host_id: "host_local", name: "This machine", owner: "me", status: "online" }]}
+        defaultHostId="host_local"
+      />,
+    );
+
+    fireEvent.click(await screen.findByText("Fix login"));
+    const input = screen.getByTestId("import-chat-session-id");
+    expect(input).toHaveValue("claude-session-1");
+    expect(screen.queryByText("Fix login")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear selected session" }));
+    expect(screen.getByText("Fix login")).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/shell/ImportChatDialog.tsx
+++ b/web/src/shell/ImportChatDialog.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Loader2Icon, XIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  importNativeChat,
+  listRecentNativeChats,
+  type ChatImportSource,
+  type RecentNativeChat,
+} from "@/lib/chatImports";
+import { useNavigate } from "@/lib/routing";
+import type { Host } from "@/hooks/useHosts";
+
+export function ImportChatDialog({
+  open,
+  onOpenChange,
+  hosts,
+  defaultHostId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hosts: readonly Host[];
+  defaultHostId: string | null;
+}) {
+  const navigate = useNavigate();
+  const onlineHosts = useMemo(() => hosts.filter((host) => host.status === "online"), [hosts]);
+  const [source, setSource] = useState<ChatImportSource>("claude");
+  const [hostId, setHostId] = useState("");
+  const [sessionId, setSessionId] = useState("");
+  const [recent, setRecent] = useState<RecentNativeChat[] | null>(null);
+  const [expandedSessionId, setExpandedSessionId] = useState<string | null>(null);
+  const [loadingRecent, setLoadingRecent] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const recentRequestRef = useRef(0);
+
+  useEffect(() => {
+    if (!open) return;
+    setRecent(null);
+    setExpandedSessionId(null);
+    setSessionId("");
+    setError(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHostId((current) => {
+      if (onlineHosts.some((host) => host.host_id === current)) return current;
+      if (defaultHostId !== null && onlineHosts.some((host) => host.host_id === defaultHostId)) {
+        return defaultHostId;
+      }
+      return onlineHosts[0]?.host_id ?? "";
+    });
+  }, [open, onlineHosts, defaultHostId]);
+
+  const loadRecent = useCallback(async () => {
+    if (!hostId) return;
+    const request = ++recentRequestRef.current;
+    setLoadingRecent(true);
+    setError(null);
+    setRecent(null);
+    try {
+      const chats = await listRecentNativeChats(hostId, source);
+      if (recentRequestRef.current === request) setRecent(chats);
+    } catch (caught) {
+      if (recentRequestRef.current === request) {
+        setError(caught instanceof Error ? caught.message : "Could not load recent chats");
+      }
+    } finally {
+      if (recentRequestRef.current === request) setLoadingRecent(false);
+    }
+  }, [hostId, source]);
+
+  useEffect(() => {
+    if (!open || !hostId) return;
+    void loadRecent();
+    return () => {
+      recentRequestRef.current += 1;
+    };
+  }, [open, hostId, source, loadRecent]);
+
+  const importChat = async () => {
+    const trimmedId = sessionId.trim();
+    if (!hostId || !trimmedId) return;
+    setImporting(true);
+    setError(null);
+    try {
+      const importedSessionId = await importNativeChat(hostId, source, trimmedId);
+      onOpenChange(false);
+      navigate(`/c/${importedSessionId}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not import chat");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden sm:max-w-2xl"
+        data-testid="import-chat-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>Import chat</DialogTitle>
+          <DialogDescription>
+            Load an existing Claude Code or Codex chat from a connected host.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid min-h-0 gap-4 overflow-y-auto py-2 pr-1">
+          <label className="grid gap-1.5 text-sm">
+            <span className="font-medium">Model</span>
+            <Select
+              value={source}
+              onValueChange={(value) => {
+                setSource(value as ChatImportSource);
+                setRecent(null);
+                setSessionId("");
+                setExpandedSessionId(null);
+              }}
+            >
+              <SelectTrigger data-testid="import-chat-model">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="claude">Claude</SelectItem>
+                <SelectItem value="codex">Codex</SelectItem>
+              </SelectContent>
+            </Select>
+          </label>
+
+          <label className="grid gap-1.5 text-sm">
+            <span className="font-medium">Host</span>
+            <Select
+              value={hostId}
+              onValueChange={(value) => {
+                setHostId(value);
+                setRecent(null);
+                setSessionId("");
+                setExpandedSessionId(null);
+              }}
+            >
+              <SelectTrigger data-testid="import-chat-host">
+                <SelectValue placeholder="Select a host" />
+              </SelectTrigger>
+              <SelectContent>
+                {onlineHosts.map((host) => (
+                  <SelectItem key={host.host_id} value={host.host_id}>
+                    {host.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+
+          <label className="grid gap-1.5 text-sm">
+            <span className="font-medium">Session ID</span>
+            <div className="flex gap-2">
+              <Input
+                className="min-w-0 flex-1"
+                value={sessionId}
+                onChange={(event) => setSessionId(event.target.value)}
+                placeholder={`${source} session ID`}
+                data-testid="import-chat-session-id"
+              />
+              {sessionId !== "" && (
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label="Clear selected session"
+                  onClick={() => setSessionId("")}
+                >
+                  <XIcon className="size-4" />
+                </Button>
+              )}
+            </div>
+          </label>
+
+          {sessionId.trim() === "" && loadingRecent && (
+            <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+              <Loader2Icon className="size-4 animate-spin" />
+              Loading recent {source} chats…
+            </div>
+          )}
+          {sessionId.trim() === "" && recent !== null && (
+            <div
+              className="max-h-80 overflow-y-auto rounded-md border"
+              data-testid="import-chat-recent"
+            >
+              {recent.length === 0 ? (
+                <p className="p-4 text-sm text-muted-foreground">No recent {source} chats found.</p>
+              ) : (
+                recent.map((chat) => {
+                  const expanded = expandedSessionId === chat.session_id;
+                  const canExpand = (chat.title?.length ?? 0) > 80;
+                  return (
+                    <div key={chat.session_id} className="border-b last:border-b-0">
+                      <button
+                        type="button"
+                        className="flex w-full flex-col gap-0.5 px-3 pt-3 pb-2 text-left hover:bg-muted"
+                        onClick={() => {
+                          setSessionId(chat.session_id);
+                        }}
+                      >
+                        <span
+                          className={`text-sm leading-5 font-medium break-words ${expanded ? "" : "line-clamp-2"}`}
+                        >
+                          {chat.title || "Untitled chat"}
+                        </span>
+                        <span className="truncate text-xs text-muted-foreground">
+                          {chat.workspace || "No workspace"} · {chat.item_count} items
+                        </span>
+                        <span className="truncate font-mono text-[11px] text-muted-foreground">
+                          {chat.session_id}
+                        </span>
+                      </button>
+                      {canExpand && (
+                        <button
+                          type="button"
+                          className="px-3 pb-2 text-xs font-medium text-muted-foreground hover:text-foreground"
+                          onClick={() => setExpandedSessionId(expanded ? null : chat.session_id)}
+                        >
+                          {expanded ? "Show less" : "Show more"}
+                        </button>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!hostId || !sessionId.trim() || importing}
+            onClick={() => void importChat()}
+          >
+            {importing && <Loader2Icon className="mr-2 size-4 animate-spin" />}
+            Import chat
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -194,6 +194,7 @@ import type { CostControlMode } from "@/components/CostRoutingControl";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
+import { ImportChatDialog } from "./ImportChatDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
 import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
 
@@ -2139,6 +2140,7 @@ export function NewChatLandingScreen() {
   } | null>(null);
   // Harness-config modal, opened from the composer's gear icon.
   const [configOpen, setConfigOpen] = useState(false);
+  const [importChatOpen, setImportChatOpen] = useState(false);
 
   // Mirror the current draft fields into a ref every render so the unmount
   // cleanup below can snapshot the latest values without re-subscribing.
@@ -4159,6 +4161,17 @@ export function NewChatLandingScreen() {
                     </>
                   )}
                 </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-xs text-muted-foreground"
+                  onClick={() => setImportChatOpen(true)}
+                  disabled={creating}
+                  data-testid="new-chat-import-chat"
+                >
+                  Import chat
+                </Button>
                 {selectedAgent && selectedAgentHasKnobs && (
                   <HarnessConfigModal
                     open={configOpen}
@@ -4194,6 +4207,12 @@ export function NewChatLandingScreen() {
                     setCostControlMode={setCostControlMode}
                   />
                 )}
+                <ImportChatDialog
+                  open={importChatOpen}
+                  onOpenChange={setImportChatOpen}
+                  hosts={hosts ?? []}
+                  defaultHostId={selectedHostId}
+                />
                 {/* Routing is not a standalone composer toggle — it folds into
                   the gear modal's Model dropdown as an "Smart Routing"
                   option (see HarnessConfigModal). */}


### PR DESCRIPTION
## Related issue

Closes #4462

## Summary

The New Session page now exposes the existing native-chat import workflow through an **Import chat** action beside model selection. The new modal connects to an online host, lists recent Claude Code or Codex sessions with concise expandable titles and transcript context, and imports the selected conversation into Omnigent. Native transcript discovery and title generation are consistent across both sources, with Claude structured summaries preferred over synthetic interruption messages.

ELI5: Omnigent asks the selected machine for its recent Claude or Codex chats, shows a useful preview, and copies the chosen chat into Omnigent.

```mermaid
flowchart LR
  UI[New Session UI] --> API[Server host route]
  API --> Host[Connected host]
  Host --> Native[Claude / Codex transcripts]
  Native --> Import[Omnigent import]
  Import --> Session[Imported session]
```

## Test Plan

- `uv run pytest tests/host/test_frames.py tests/cli/test_import.py tests/server/routes/test_imports.py`
- `cd web && pnpm test -- ImportChatDialog.test.tsx`
- `uv run pytest tests/e2e_ui/start_session/test_import_chat.py -v`
- `SKIP=vscode-tsc uv run pre-commit run --all-files` (`vscode-tsc` skipped because `editors/vscode/node_modules/.bin/tsc` is not installed; no VS Code files changed.)
- Manually verified both Claude and Codex recent-session lists, expandable summaries, host selection, importing, and clearing a selected session to restore the list.

## Demo
**Codex**
<img width="697" height="700" alt="Screenshot 2026-08-09 at 10 37 20 AM" src="https://github.com/user-attachments/assets/38f2b541-5d0c-4230-be9f-d18e12f3db2f" />
**Claude**
<img width="689" height="703" alt="Screenshot 2026-08-09 at 10 37 08 AM" src="https://github.com/user-attachments/assets/41007457-826a-403d-91da-5c2b4925372b" />



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the modal against local Claude and Codex transcript history on a connected macOS host, including selection, title expansion, and deselection.

## Changelog

Import recent Claude Code and Codex chats directly from the New Session page.
