### PR TITLE
feat(web-ui): import native Claude Code and Codex chats from New Session

### DIFF
--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -6,28 +6,35 @@ import asyncio
 import hashlib
 import threading
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 from pydantic import BaseModel, Field, field_validator
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.native_coding_agents import native_coding_agent_for_harness
-from omnigent.server.auth import LEVEL_OWNER, AuthProvider
+from omnigent.server.auth import LEVEL_OWNER, AuthProvider, local_single_user_enabled
 from omnigent.server.routes._auth_helpers import require_access, require_user
 from omnigent.server.routes._content_type import require_json_content_type
 from omnigent.session_import import (
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
+    SessionImportNotFoundError,
     title_from_items,
 )
+from omnigent.session_import.local import list_recent_local_sessions, load_local_session
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.conversation_store import ConversationAlreadyExistsError
 from omnigent.stores.permission_store import PermissionStore
+
+# Ceiling on one discovery pass. Each candidate is parsed to read its title and
+# item count, so an unbounded limit would walk every transcript on disk.
+_MAX_LOCAL_SESSION_LIST_LIMIT = 50
 
 
 class ImportItemInput(BaseModel):
@@ -68,12 +75,46 @@ class ImportSessionRequest(BaseModel):
         return value
 
 
+class ImportLocalSessionRequest(BaseModel):
+    """Request body for importing one transcript from the server's own disk."""
+
+    source: ImportSource
+    external_session_id: str = Field(min_length=1, max_length=128)
+    force: bool = False
+
+    @field_validator("external_session_id")
+    @classmethod
+    def strip_external_session_id(cls, value: str) -> str:
+        """Reject a source session id that is only whitespace."""
+        value = value.strip()
+        if not value:
+            raise ValueError("external_session_id must not be blank")
+        return value
+
+
 class ImportSessionResponse(BaseModel):
     """Result of importing or locating one source session."""
 
     session_id: str
     status: Literal["imported"]
     item_count: int
+
+
+class LocalSessionSummaryResponse(BaseModel):
+    """One local transcript offered to the import picker."""
+
+    session_id: str
+    title: str | None
+    workspace: str | None
+    item_count: int
+    # POSIX seconds, like the timestamps on every other API object.
+    modified_at: float | None
+
+
+class LocalSessionListResponse(BaseModel):
+    """Recent local transcripts for one harness, newest first."""
+
+    sessions: list[LocalSessionSummaryResponse]
 
 
 @dataclass
@@ -94,9 +135,13 @@ def _import_conversation_id(source: ImportSource, external_session_id: str) -> s
     return hashlib.sha256(value.encode()).hexdigest()[:32]
 
 
-async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
+@asynccontextmanager
+async def _source_import_lock(
+    source: ImportSource,
+    external_session_id: str,
+) -> AsyncIterator[None]:
     """Serialize concurrent imports for one source identity in this server."""
-    key = (body.source, body.external_session_id)
+    key = (source, external_session_id)
     with _IMPORT_LOCKS_GUARD:
         entry = _IMPORT_LOCKS.setdefault(key, _ImportLockEntry(lock=asyncio.Lock()))
         entry.users += 1
@@ -110,6 +155,28 @@ async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[
                 _IMPORT_LOCKS.pop(key, None)
 
 
+async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
+    """Hold the source-identity lock for the duration of one import request."""
+    async with _source_import_lock(body.source, body.external_session_id):
+        yield
+
+
+def _require_local_transcript_access() -> None:
+    """Refuse to read the server's own transcripts on a shared server.
+
+    The local endpoints expose whatever harness history sits in the server
+    process's home directory. That is the caller's own machine only on a
+    single-user local runtime; on a deployed server it belongs to the
+    operator, so importing another machine's chats has to go through that
+    host rather than the server's disk.
+    """
+    if not local_single_user_enabled():
+        raise OmnigentError(
+            "Importing local chats is only available on a single-user local server",
+            code=ErrorCode.FORBIDDEN,
+        )
+
+
 def create_imports_router(
     conversation_store: ConversationStore,
     agent_store: AgentStore,
@@ -120,26 +187,20 @@ def create_imports_router(
     """Create the local-session import router."""
     router = APIRouter()
 
-    @router.post(
-        "/imports",
-        response_model=ImportSessionResponse,
-        dependencies=[
-            Depends(require_json_content_type),
-            Depends(_serialize_source_import),
-        ],
-    )
-    async def import_session(
-        body: ImportSessionRequest,
-        request: Request,
-        response: Response,
+    async def store_imported_session(
+        source: ImportSource,
+        external_session_id: str,
+        *,
+        workspace: str | None,
+        force: bool,
+        items: list[NewConversationItem],
+        user_id: str | None,
     ) -> ImportSessionResponse:
-        """Import one normalized transcript, optionally replacing its prior import."""
-        user_id = require_user(request, auth_provider)
-        items = [item.to_item() for item in body.items]
+        """Persist one normalized transcript as an owned native session."""
         existing = await asyncio.to_thread(
             conversation_store.find_imported_conversation,
-            body.source,
-            body.external_session_id,
+            source,
+            external_session_id,
         )
         if existing is not None:
             await require_access(
@@ -149,16 +210,16 @@ def create_imports_router(
                 permission_store,
                 conversation_store,
             )
-            if not body.force:
+            if not force:
                 raise OmnigentError(
-                    f"This {body.source} session has already been imported as {existing.id}",
+                    f"This {source} session has already been imported as {existing.id}",
                     code=ErrorCode.CONFLICT,
                 )
 
-        native_agent = native_coding_agent_for_harness(f"{body.source}-native")
+        native_agent = native_coding_agent_for_harness(f"{source}-native")
         if native_agent is None:
             raise OmnigentError(
-                f"Unsupported import source: {body.source}",
+                f"Unsupported import source: {source}",
                 code=ErrorCode.INVALID_INPUT,
             )
         agent_id = builtin_agent_id(native_agent.agent_name)
@@ -176,8 +237,8 @@ def create_imports_router(
                 conversation_store.create_conversation,
                 title=title_from_items(items),
                 agent_id=agent_id,
-                workspace=body.workspace,
-                conversation_id=_import_conversation_id(body.source, body.external_session_id),
+                workspace=workspace,
+                conversation_id=_import_conversation_id(source, external_session_id),
             )
         except ConversationAlreadyExistsError as exc:
             raise OmnigentError(
@@ -188,13 +249,13 @@ def create_imports_router(
             await asyncio.to_thread(
                 conversation_store.set_external_session_id,
                 conversation.id,
-                body.external_session_id,
+                external_session_id,
             )
             await asyncio.to_thread(conversation_store.append, conversation.id, items)
             labels = {
                 **native_agent.presentation_labels,
-                IMPORT_SOURCE_LABEL_KEY: body.source,
-                IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: body.external_session_id,
+                IMPORT_SOURCE_LABEL_KEY: source,
+                IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: external_session_id,
             }
             await asyncio.to_thread(conversation_store.set_labels, conversation.id, labels)
             if permission_store is not None and user_id is not None:
@@ -209,11 +270,101 @@ def create_imports_router(
             await conversation_store.delete_conversation(conversation.id)
             raise
 
-        response.status_code = 201
         return ImportSessionResponse(
             session_id=conversation.id,
             status="imported",
             item_count=len(items),
         )
+
+    @router.post(
+        "/imports",
+        response_model=ImportSessionResponse,
+        dependencies=[
+            Depends(require_json_content_type),
+            Depends(_serialize_source_import),
+        ],
+    )
+    async def import_session(
+        body: ImportSessionRequest,
+        request: Request,
+        response: Response,
+    ) -> ImportSessionResponse:
+        """Import one normalized transcript, optionally replacing its prior import."""
+        user_id = require_user(request, auth_provider)
+        items = [item.to_item() for item in body.items]
+        result = await store_imported_session(
+            body.source,
+            body.external_session_id,
+            workspace=body.workspace,
+            force=body.force,
+            items=items,
+            user_id=user_id,
+        )
+        response.status_code = 201
+        return result
+
+    @router.get("/imports/local/sessions", response_model=LocalSessionListResponse)
+    async def list_local_sessions(
+        request: Request,
+        source: ImportSource,
+        limit: int = Query(default=20, ge=1, le=_MAX_LOCAL_SESSION_LIST_LIMIT),
+    ) -> LocalSessionListResponse:
+        """List recent transcripts the given harness left on the server's disk."""
+        require_user(request, auth_provider)
+        _require_local_transcript_access()
+        try:
+            summaries = await asyncio.to_thread(list_recent_local_sessions, source, limit=limit)
+        except SessionImportNotFoundError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.NOT_FOUND) from exc
+        return LocalSessionListResponse(
+            sessions=[
+                LocalSessionSummaryResponse(
+                    session_id=summary.session_id,
+                    title=summary.title,
+                    workspace=summary.workspace,
+                    item_count=summary.item_count,
+                    modified_at=summary.modified_at,
+                )
+                for summary in summaries
+            ]
+        )
+
+    @router.post(
+        "/imports/local",
+        response_model=ImportSessionResponse,
+        dependencies=[Depends(require_json_content_type)],
+    )
+    async def import_local_session(
+        body: ImportLocalSessionRequest,
+        request: Request,
+        response: Response,
+    ) -> ImportSessionResponse:
+        """Read one transcript off the server's disk and import it."""
+        user_id = require_user(request, auth_provider)
+        _require_local_transcript_access()
+        try:
+            imported = await asyncio.to_thread(
+                load_local_session,
+                body.source,
+                body.external_session_id,
+            )
+        except SessionImportNotFoundError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.NOT_FOUND) from exc
+        except (OSError, TypeError, ValueError) as exc:
+            raise OmnigentError(
+                f"Could not read the {body.source} session: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        async with _source_import_lock(body.source, body.external_session_id):
+            result = await store_imported_session(
+                body.source,
+                body.external_session_id,
+                workspace=imported.workspace,
+                force=body.force,
+                items=list(imported.items),
+                user_id=user_id,
+            )
+        response.status_code = 201
+        return result
 
     return router

--- a/omnigent/session_import/__init__.py
+++ b/omnigent/session_import/__init__.py
@@ -6,6 +6,7 @@ from omnigent.session_import.models import (
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
     LocalSessionImport,
+    LocalSessionSummary,
     SessionImportNotFoundError,
     title_from_items,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "IMPORT_SOURCE_LABEL_KEY",
     "ImportSource",
     "LocalSessionImport",
+    "LocalSessionSummary",
     "SessionImportNotFoundError",
     "title_from_items",
 ]

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -29,8 +30,11 @@ from omnigent.opencode_native_forwarder import opencode_tool_output_text
 from omnigent.session_import.models import (
     ImportSource,
     LocalSessionImport,
+    LocalSessionSummary,
     SessionImportNotFoundError,
 )
+
+_logger = logging.getLogger(__name__)
 
 _PI_IMPORT_SESSION_ID_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
 _OPENCODE_IMPORT_SESSION_ID_RE = re.compile(r"ses_[A-Za-z0-9_-]+")
@@ -59,12 +63,12 @@ def _find_transcript(root: Path, session_id: str) -> Path | None:
     return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
 
 
-def _recent_unique_session_ids(
+def _recent_unique_session_entries(
     candidates: list[tuple[Path, str]],
     *,
     limit: int,
-) -> tuple[str, ...]:
-    """Return unique session ids ordered from newest transcript to oldest."""
+) -> tuple[tuple[str, float], ...]:
+    """Return unique session ids and mtimes, newest transcript first."""
     newest_by_id: dict[str, float] = {}
     for path, session_id in candidates:
         try:
@@ -77,7 +81,7 @@ def _recent_unique_session_ids(
         key=lambda session_id: (newest_by_id[session_id], session_id),
         reverse=True,
     )
-    return tuple(ordered[:limit])
+    return tuple((session_id, newest_by_id[session_id]) for session_id in ordered[:limit])
 
 
 def _pi_session_id_from_path(path: Path) -> str | None:
@@ -152,12 +156,12 @@ def _qwen_session_locator(path: Path) -> str:
     return f"{project_digest}:{sha256(session_id.encode()).hexdigest()}"
 
 
-def list_recent_local_session_ids(
+def _recent_local_session_entries(
     source: ImportSource,
     *,
     limit: int,
-) -> tuple[str, ...]:
-    """List recent parent session ids for one local harness."""
+) -> tuple[tuple[str, float | None], ...]:
+    """List recent parent session ids and modification times for one harness."""
     if source == "claude":
         configured_home = os.environ.get("CLAUDE_CONFIG_DIR")
         home = Path(configured_home).expanduser() if configured_home else Path.home() / ".claude"
@@ -167,14 +171,14 @@ def list_recent_local_session_ids(
             for path in root.rglob("*.jsonl")
             if "subagents" not in path.parts and path.is_file()
         ]
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     if source == "qwen":
         configured_home = os.environ.get("QWEN_HOME")
         home = Path(configured_home).expanduser() if configured_home else Path.home() / ".qwen"
         paths = [path for path in (home / "projects").glob("*/chats/*.jsonl") if path.is_file()]
         candidates = [(path, _qwen_session_locator(path)) for path in paths]
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     if source == "kiro":
         root = kiro_cli_sessions_dir()
@@ -183,7 +187,7 @@ def list_recent_local_session_ids(
             for path in root.glob("*.jsonl")
             if path.is_file() and path.with_suffix(".json").is_file()
         ]
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     if source == "opencode":
         payload = _run_opencode_json(
@@ -212,7 +216,14 @@ def list_recent_local_session_ids(
             key=lambda session_id: (updated_by_id[session_id], session_id),
             reverse=True,
         )
-        return tuple(ordered[:limit])
+        # OpenCode reports JavaScript epoch milliseconds; every other source
+        # here carries a POSIX mtime, so normalize to seconds. An entry that
+        # arrived without a usable timestamp reports none.
+        entries: list[tuple[str, float | None]] = []
+        for ordered_id in ordered[:limit]:
+            updated_ms = updated_by_id[ordered_id]
+            entries.append((ordered_id, updated_ms / 1000 if updated_ms else None))
+        return tuple(entries)
 
     if source == "pi":
         configured_home = os.environ.get("PI_CODING_AGENT_DIR")
@@ -227,7 +238,7 @@ def list_recent_local_session_ids(
             for path in (home / "sessions").rglob("*.jsonl")
             if path.is_file() and (session_id := _pi_session_id_from_path(path)) is not None
         ]
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     if source == "kimi":
         home = resolve_user_kimi_home()
@@ -236,7 +247,7 @@ def list_recent_local_session_ids(
             for path in (home / "sessions").glob("*/session_*/agents/main/wire.jsonl")
             if path.is_file()
         ]
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     if source == "codex":
         configured_home = os.environ.get("CODEX_HOME")
@@ -255,9 +266,50 @@ def list_recent_local_session_ids(
             session_id = path.stem[-36:]
             if _CODEX_THREAD_ID_RE.fullmatch(session_id):
                 candidates.append((path, session_id))
-        return _recent_unique_session_ids(candidates, limit=limit)
+        return _recent_unique_session_entries(candidates, limit=limit)
 
     raise ValueError(f"Unsupported import source: {source}")
+
+
+def list_recent_local_session_ids(
+    source: ImportSource,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    """List recent parent session ids for one local harness."""
+    entries = _recent_local_session_entries(source, limit=limit)
+    return tuple(session_id for session_id, _ in entries)
+
+
+def list_recent_local_sessions(
+    source: ImportSource,
+    *,
+    limit: int,
+) -> tuple[LocalSessionSummary, ...]:
+    """Describe recent parent sessions for one local harness, newest first.
+
+    Each candidate is parsed to read its title, workspace, and item count. A
+    candidate that cannot be parsed — a half-written transcript, a harness
+    format this build does not understand — is skipped so one bad file never
+    hides the rest of the list.
+    """
+    summaries: list[LocalSessionSummary] = []
+    for session_id, modified_at in _recent_local_session_entries(source, limit=limit):
+        try:
+            imported = load_local_session(source, session_id)
+        except (OSError, TypeError, ValueError) as exc:
+            _logger.debug("Skipping unreadable %s session %s: %s", source, session_id, exc)
+            continue
+        summaries.append(
+            LocalSessionSummary(
+                session_id=session_id,
+                title=imported.title,
+                workspace=imported.workspace,
+                item_count=len(imported.items),
+                modified_at=modified_at,
+            )
+        )
+    return tuple(summaries)
 
 
 def _claude_workspace(transcript_path: Path) -> str | None:
@@ -1218,6 +1270,7 @@ def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImp
 
 __all__ = [
     "list_recent_local_session_ids",
+    "list_recent_local_sessions",
     "load_claude_session",
     "load_codex_session",
     "load_kimi_session",

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -40,6 +40,19 @@ class LocalSessionImport:
         return title_from_items(self.items)
 
 
+@dataclass(frozen=True)
+class LocalSessionSummary:
+    """One recent local transcript described for an import picker."""
+
+    session_id: str
+    title: str | None
+    workspace: str | None
+    item_count: int
+    # POSIX seconds, matching the API's other timestamps. ``None`` when the
+    # harness reported no usable modification time.
+    modified_at: float | None
+
+
 def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
     """Return a sidebar title derived from the first user message."""
     for item in items:

--- a/openapi.json
+++ b/openapi.json
@@ -1784,6 +1784,41 @@
         "title": "ImportItemInput",
         "type": "object"
       },
+      "ImportLocalSessionRequest": {
+        "description": "Request body for importing one transcript from the server's own disk.",
+        "properties": {
+          "external_session_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "External Session Id",
+            "type": "string"
+          },
+          "force": {
+            "default": false,
+            "title": "Force",
+            "type": "boolean"
+          },
+          "source": {
+            "enum": [
+              "claude",
+              "codex",
+              "kimi",
+              "kiro",
+              "opencode",
+              "pi",
+              "qwen"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "external_session_id"
+        ],
+        "title": "ImportLocalSessionRequest",
+        "type": "object"
+      },
       "ImportSessionRequest": {
         "description": "Request body for importing one local harness session.",
         "properties": {
@@ -1977,6 +2012,78 @@
           "workspace"
         ],
         "title": "LaunchRunnerRequest",
+        "type": "object"
+      },
+      "LocalSessionListResponse": {
+        "description": "Recent local transcripts for one harness, newest first.",
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/LocalSessionSummaryResponse"
+            },
+            "title": "Sessions",
+            "type": "array"
+          }
+        },
+        "required": [
+          "sessions"
+        ],
+        "title": "LocalSessionListResponse",
+        "type": "object"
+      },
+      "LocalSessionSummaryResponse": {
+        "description": "One local transcript offered to the import picker.",
+        "properties": {
+          "item_count": {
+            "title": "Item Count",
+            "type": "integer"
+          },
+          "modified_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modified At"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "workspace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace"
+          }
+        },
+        "required": [
+          "session_id",
+          "title",
+          "workspace",
+          "item_count",
+          "modified_at"
+        ],
+        "title": "LocalSessionSummaryResponse",
         "type": "object"
       },
       "MCPServerSummary": {
@@ -7890,6 +7997,112 @@
           }
         },
         "summary": "Import Session",
+        "tags": [
+          "imports"
+        ]
+      }
+    },
+    "/v1/imports/local": {
+      "post": {
+        "description": "Read one transcript off the server's disk and import it.",
+        "operationId": "import_local_session_v1_imports_local_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportLocalSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Import Local Session",
+        "tags": [
+          "imports"
+        ]
+      }
+    },
+    "/v1/imports/local/sessions": {
+      "get": {
+        "description": "List recent transcripts the given harness left on the server's disk.",
+        "operationId": "list_local_sessions_v1_imports_local_sessions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "enum": [
+                "claude",
+                "codex",
+                "kimi",
+                "kiro",
+                "opencode",
+                "pi",
+                "qwen"
+              ],
+              "title": "Source",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalSessionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Local Sessions",
         "tags": [
           "imports"
         ]

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+from pathlib import Path
 
 import httpx
+import pytest
 
 from omnigent.db.utils import builtin_agent_id
+from omnigent.server.routes import imports as imports_routes
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 
@@ -20,6 +25,42 @@ def _seed_claude_agent(db_uri: str) -> str:
         bundle_location="builtin://claude-native-ui",
     )
     return agent_id
+
+
+@pytest.fixture()
+def claude_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point local Claude discovery at a throwaway home, never the developer's."""
+    home = tmp_path / "claude-home"
+    (home / "projects" / "-repo").mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(home))
+    return home
+
+
+def _write_claude_transcript(
+    home: Path,
+    session_id: str,
+    *,
+    text: str,
+    workspace: str = "/repo",
+    modified_at: int | None = None,
+) -> Path:
+    """Write one minimal parent transcript under a fake Claude home."""
+    transcript = home / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": f"user-{session_id}",
+                "cwd": workspace,
+                "message": {"role": "user", "content": text},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if modified_at is not None:
+        os.utime(transcript, (modified_at, modified_at))
+    return transcript
 
 
 async def test_import_session_creates_normal_session_and_blocks_duplicate(
@@ -171,3 +212,164 @@ async def test_import_session_rejects_empty_history(client: httpx.AsyncClient) -
     )
 
     assert response.status_code == 422
+
+
+async def test_list_local_sessions_describes_recent_transcripts(
+    client: httpx.AsyncClient,
+    claude_home: Path,
+) -> None:
+    """The picker list carries the title, workspace, and size of each chat."""
+    _write_claude_transcript(claude_home, "older-session", text="old prompt", modified_at=1000)
+    _write_claude_transcript(
+        claude_home,
+        "newer-session",
+        text="inspect TODO.md",
+        workspace="/repo/web",
+        modified_at=2000,
+    )
+
+    response = await client.get("/v1/imports/local/sessions?source=claude")
+
+    assert response.status_code == 200
+    sessions = response.json()["sessions"]
+    assert [session["session_id"] for session in sessions] == [
+        "newer-session",
+        "older-session",
+    ]
+    assert sessions[0] == {
+        "session_id": "newer-session",
+        "title": "inspect TODO.md",
+        "workspace": "/repo/web",
+        "item_count": 1,
+        "modified_at": 2000,
+    }
+
+
+async def test_list_local_sessions_applies_limit_and_rejects_unknown_source(
+    client: httpx.AsyncClient,
+    claude_home: Path,
+) -> None:
+    """The list is bounded by `limit` and only serves supported harnesses."""
+    for index, session_id in enumerate(("first", "second", "third")):
+        _write_claude_transcript(
+            claude_home, session_id, text=session_id, modified_at=1000 + index
+        )
+
+    limited = await client.get("/v1/imports/local/sessions?source=claude&limit=2")
+    unknown = await client.get("/v1/imports/local/sessions?source=cursor")
+
+    assert limited.status_code == 200
+    assert [session["session_id"] for session in limited.json()["sessions"]] == [
+        "third",
+        "second",
+    ]
+    assert unknown.status_code == 422
+
+
+async def test_import_local_session_reads_the_transcript_off_disk(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    claude_home: Path,
+) -> None:
+    """Importing by id parses the local transcript server-side."""
+    agent_id = _seed_claude_agent(db_uri)
+    _write_claude_transcript(claude_home, "local-session-1", text="inspect TODO.md")
+
+    created = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "local-session-1"},
+    )
+
+    assert created.status_code == 201
+    body = created.json()
+    assert body["status"] == "imported"
+    assert body["item_count"] == 1
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(body["session_id"])
+    assert conversation is not None
+    assert conversation.agent_id == agent_id
+    assert conversation.external_session_id == "local-session-1"
+    assert conversation.workspace == "/repo"
+    assert conversation.title == "inspect TODO.md"
+    items = await client.get(f"/v1/sessions/{body['session_id']}/items")
+    assert items.status_code == 200
+    assert [item["content"][0]["text"] for item in items.json()["data"]] == ["inspect TODO.md"]
+
+
+async def test_import_local_session_reports_a_missing_transcript(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    claude_home: Path,
+) -> None:
+    """An id with no transcript on disk is a 404, not a blank session."""
+    _seed_claude_agent(db_uri)
+
+    response = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "never-existed"},
+    )
+
+    assert response.status_code == 404
+    assert "was not found" in response.text
+
+
+async def test_import_local_session_blocks_duplicates_until_forced(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    claude_home: Path,
+) -> None:
+    """A second import is rejected, and forcing it replaces the transcript."""
+    _seed_claude_agent(db_uri)
+    _write_claude_transcript(claude_home, "local-session-2", text="old prompt")
+
+    created = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "local-session-2"},
+    )
+    repeated = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "local-session-2"},
+    )
+    _write_claude_transcript(
+        claude_home, "local-session-2", text="new prompt", workspace="/repo/new"
+    )
+    replaced = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "local-session-2", "force": True},
+    )
+
+    assert created.status_code == 201
+    assert repeated.status_code == 409
+    assert "already been imported" in repeated.text
+    assert replaced.status_code == 201
+    assert replaced.json()["session_id"] == created.json()["session_id"]
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        replaced.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.workspace == "/repo/new"
+    assert conversation.title == "new prompt"
+
+
+async def test_local_import_routes_refuse_a_shared_server(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    claude_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a multi-user server the disk belongs to the operator, not the caller."""
+    _seed_claude_agent(db_uri)
+    _write_claude_transcript(claude_home, "local-session-3", text="inspect TODO.md")
+    monkeypatch.setattr(imports_routes, "local_single_user_enabled", lambda: False)
+
+    listed = await client.get("/v1/imports/local/sessions?source=claude")
+    imported = await client.post(
+        "/v1/imports/local",
+        json={"source": "claude", "external_session_id": "local-session-3"},
+    )
+
+    assert listed.status_code == 403
+    assert imported.status_code == 403
+    assert (
+        SqlAlchemyConversationStore(db_uri).find_imported_conversation("claude", "local-session-3")
+        is None
+    )

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -416,6 +416,52 @@ def test_list_recent_claude_sessions_orders_parents_and_applies_limit(
     assert recent == ("new", "middle")
 
 
+def test_list_recent_local_sessions_describes_parents_and_skips_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery reports picker metadata and drops transcripts it cannot parse."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    project = tmp_path / "projects" / "-repo"
+    project.mkdir(parents=True)
+    readable = project / "readable.jsonl"
+    readable.write_text(
+        "".join(
+            f"{json.dumps(record)}\n"
+            for record in (
+                {
+                    "type": "user",
+                    "uuid": "user-1",
+                    "cwd": "/repo",
+                    "message": {"role": "user", "content": "inspect TODO.md"},
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "assistant-1",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Done."}],
+                    },
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+    os.utime(readable, (1000, 1000))
+    # An empty transcript has no importable history: it must not hide the rest.
+    empty = project / "empty.jsonl"
+    empty.touch()
+    os.utime(empty, (2000, 2000))
+
+    sessions = local_import.list_recent_local_sessions("claude", limit=5)
+
+    assert [session.session_id for session in sessions] == ["readable"]
+    assert sessions[0].title == "inspect TODO.md"
+    assert sessions[0].workspace == "/repo"
+    assert sessions[0].item_count == 2
+    assert sessions[0].modified_at == 1000
+
+
 def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
     """Codex response items retain turn grouping and omit scaffolding."""
     session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"

--- a/web/src/lib/importsApi.ts
+++ b/web/src/lib/importsApi.ts
@@ -1,0 +1,124 @@
+// Typed client for the `/v1/imports` session-import endpoints
+// (`omnigent/server/routes/imports.py`) — the web-side equivalent of the
+// `omnigent import` CLI command.
+//
+// The `local` routes read transcripts from the SERVER's own disk, which is the
+// user's machine only on a single-user local runtime; a deployed server refuses
+// them with 403. Importing another machine's chats would need the same listing
+// relayed through that host, so the source is a request parameter rather than
+// baked into the path.
+//
+// Naming: TS surface is camelCase; the wire is snake_case. The helpers below
+// convert at the boundary so callers never see raw wire fields.
+
+import { authenticatedFetch } from "./identity";
+import { ApiError } from "./sessionsApi";
+
+/**
+ * Local harnesses whose transcripts Omnigent can normalize, ordered the way the
+ * picker lists them (the two fully supported harnesses first). Mirrors
+ * `ImportSource` in `omnigent/session_import/models.py` and the `--harness`
+ * choices on `omnigent import`.
+ */
+export const IMPORT_SOURCES = [
+  "claude",
+  "codex",
+  "opencode",
+  "pi",
+  "kiro",
+  "kimi",
+  "qwen",
+] as const;
+
+export type ImportSource = (typeof IMPORT_SOURCES)[number];
+
+/** One local transcript offered to the import picker. */
+export interface LocalImportSession {
+  sessionId: string;
+  /** First user message, or `null` when the transcript opens with tool work. */
+  title: string | null;
+  /** Directory the chat ran in, as recorded by the harness. */
+  workspace: string | null;
+  itemCount: number;
+  /** POSIX seconds; `null` when the harness reported no usable time. */
+  modifiedAt: number | null;
+}
+
+/** Result of an import — the new Omnigent session and how much it carried. */
+export interface ImportedSession {
+  sessionId: string;
+  itemCount: number;
+}
+
+interface LocalImportSessionWire {
+  session_id: string;
+  title: string | null;
+  workspace: string | null;
+  item_count: number;
+  modified_at: number | null;
+}
+
+async function apiErrorFromResponse(res: Response): Promise<ApiError> {
+  let message = `${res.status} ${res.statusText}`;
+  let code: string | null = null;
+  try {
+    const body = (await res.json()) as { error?: { code?: string; message?: string } };
+    if (body.error?.message) message = body.error.message;
+    if (body.error?.code) code = body.error.code;
+  } catch {
+    // Non-JSON / empty body — keep the status-line fallback.
+  }
+  return new ApiError(message, res.status, code);
+}
+
+/**
+ * List the given harness's most recent chats on the server's machine, newest
+ * first. Each entry is parsed server-side, so `itemCount` is the real number of
+ * items the import would carry.
+ */
+export async function listLocalImportSessions(
+  source: ImportSource,
+  limit = 20,
+): Promise<LocalImportSession[]> {
+  const res = await authenticatedFetch(
+    `/v1/imports/local/sessions?source=${encodeURIComponent(source)}&limit=${limit}`,
+  );
+  if (!res.ok) throw await apiErrorFromResponse(res);
+  const body = (await res.json()) as { sessions: LocalImportSessionWire[] };
+  return body.sessions.map((session) => ({
+    sessionId: session.session_id,
+    title: session.title,
+    workspace: session.workspace,
+    itemCount: session.item_count,
+    modifiedAt: session.modified_at,
+  }));
+}
+
+/**
+ * Import one local chat into Omnigent as an ordinary session.
+ *
+ * A source chat can only be imported once: a repeat rejects with a 409
+ * {@link ApiError} naming the existing session unless `force` replaces it.
+ */
+export async function importLocalSession({
+  source,
+  externalSessionId,
+  force = false,
+}: {
+  source: ImportSource;
+  externalSessionId: string;
+  force?: boolean;
+}): Promise<ImportedSession> {
+  const res = await authenticatedFetch("/v1/imports/local", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source,
+      external_session_id: externalSessionId,
+      force,
+    }),
+  });
+  if (!res.ok) throw await apiErrorFromResponse(res);
+  const body = (await res.json()) as { session_id: string; item_count: number };
+  return { sessionId: body.session_id, itemCount: body.item_count };
+}

--- a/web/src/shell/ImportChatDialog.test.tsx
+++ b/web/src/shell/ImportChatDialog.test.tsx
@@ -1,0 +1,189 @@
+import type * as ImportsApiModule from "@/lib/importsApi";
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ImportChatDialog } from "./ImportChatDialog";
+import { importLocalSession, listLocalImportSessions } from "@/lib/importsApi";
+import { ApiError } from "@/lib/sessionsApi";
+
+const navigateMock = vi.fn();
+vi.mock("@/lib/routing", () => ({ useNavigate: () => navigateMock }));
+vi.mock("@/lib/importsApi", async (importActual) => ({
+  ...(await importActual<typeof ImportsApiModule>()),
+  listLocalImportSessions: vi.fn(),
+  importLocalSession: vi.fn(),
+}));
+
+const listMock = vi.mocked(listLocalImportSessions);
+const importMock = vi.mocked(importLocalSession);
+
+const CLAUDE_SESSIONS = [
+  {
+    sessionId: "claude-1",
+    title: "inspect TODO.md",
+    workspace: "/Users/dev/omnigent",
+    itemCount: 12,
+    modifiedAt: 1_700_000_000,
+  },
+  {
+    sessionId: "claude-2",
+    title: null,
+    workspace: null,
+    itemCount: 3,
+    modifiedAt: null,
+  },
+];
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <ImportChatDialog open onOpenChange={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { ...utils, invalidateSpy };
+}
+
+/** Open the Radix harness <Select> (mirrors ForkSessionDialog.test). */
+function openSourceSelect(): void {
+  const trigger = screen.getByTestId("import-chat-source-select");
+  fireEvent.pointerDown(trigger, new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+  fireEvent.click(trigger);
+}
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  listMock.mockReset();
+  listMock.mockResolvedValue(CLAUDE_SESSIONS);
+  importMock.mockReset();
+  importMock.mockResolvedValue({ sessionId: "conv_imported", itemCount: 12 });
+});
+
+afterEach(cleanup);
+
+describe("ImportChatDialog", () => {
+  it("lists this machine's recent Claude Code chats with their workspace and size", async () => {
+    renderDialog();
+
+    await waitFor(() => expect(listMock).toHaveBeenCalledWith("claude", 20));
+    const row = await screen.findByTestId("import-chat-session-claude-1");
+    expect(row).toHaveTextContent("inspect TODO.md");
+    // Only the directory name shows; the full path stays available on hover.
+    expect(row).toHaveTextContent("omnigent");
+    expect(row).toHaveTextContent("12");
+    // A title-less transcript still has to be pickable, so it falls back to its id.
+    expect(await screen.findByTestId("import-chat-session-claude-2")).toHaveTextContent("claude-2");
+  });
+
+  it("refetches for the picked harness and drops the previous selection", async () => {
+    renderDialog();
+
+    fireEvent.click(await screen.findByTestId("import-chat-session-claude-1"));
+    expect(screen.getByTestId("import-chat-selected")).toBeInTheDocument();
+
+    listMock.mockResolvedValue([]);
+    openSourceSelect();
+    fireEvent.click(screen.getByTestId("import-chat-source-option-codex"));
+
+    await waitFor(() => expect(listMock).toHaveBeenCalledWith("codex", 20));
+    // The selection belonged to the old harness — keeping it would import the
+    // wrong transcript on submit.
+    expect(screen.queryByTestId("import-chat-selected")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("import-chat-empty")).toHaveTextContent(
+      "No recent Codex chats found on this machine.",
+    );
+  });
+
+  it("keeps Import disabled until a chat is picked and restores the list on clear", async () => {
+    renderDialog();
+
+    expect(screen.getByTestId("import-chat-submit")).toBeDisabled();
+    fireEvent.click(await screen.findByTestId("import-chat-session-claude-1"));
+    expect(screen.getByTestId("import-chat-submit")).not.toBeDisabled();
+    // The list collapses to the pick; clearing brings it back.
+    expect(screen.queryByTestId("import-chat-session-claude-1")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("import-chat-clear-selection"));
+
+    expect(screen.getByTestId("import-chat-submit")).toBeDisabled();
+    expect(await screen.findByTestId("import-chat-session-claude-1")).toBeInTheDocument();
+  });
+
+  it("imports the picked chat, refreshes the sidebar, and opens the new session", async () => {
+    const { invalidateSpy } = renderDialog();
+
+    fireEvent.click(await screen.findByTestId("import-chat-session-claude-1"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    await waitFor(() => expect(importMock).toHaveBeenCalledTimes(1));
+    expect(importMock).toHaveBeenCalledWith({
+      source: "claude",
+      externalSessionId: "claude-1",
+      force: false,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_imported"));
+  });
+
+  it("offers a forced re-import when the chat was already imported", async () => {
+    importMock.mockRejectedValueOnce(
+      new ApiError("This claude session has already been imported as conv_old", 409, "conflict"),
+    );
+    renderDialog();
+
+    fireEvent.click(await screen.findByTestId("import-chat-session-claude-1"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("import-chat-conflict")).toHaveTextContent("already been imported"),
+    );
+    // A duplicate is not an error the user should have to leave the dialog for.
+    expect(screen.queryByTestId("import-chat-error")).not.toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("import-chat-force"));
+
+    await waitFor(() => expect(importMock).toHaveBeenCalledTimes(2));
+    expect(importMock).toHaveBeenLastCalledWith({
+      source: "claude",
+      externalSessionId: "claude-1",
+      force: true,
+    });
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_imported"));
+  });
+
+  it("surfaces a failed import inline and stays on the screen", async () => {
+    importMock.mockRejectedValue(new ApiError("500 internal error", 500, "internal_error"));
+    renderDialog();
+
+    fireEvent.click(await screen.findByTestId("import-chat-session-claude-1"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("import-chat-error")).toHaveTextContent("500 internal error"),
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed listing instead of an empty-looking machine", async () => {
+    listMock.mockRejectedValue(
+      new ApiError(
+        "Importing local chats is only available on a single-user local server",
+        403,
+        "forbidden",
+      ),
+    );
+    renderDialog();
+
+    expect(await screen.findByTestId("import-chat-list-error")).toHaveTextContent(
+      "single-user local server",
+    );
+    expect(screen.queryByTestId("import-chat-empty")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/shell/ImportChatDialog.tsx
+++ b/web/src/shell/ImportChatDialog.tsx
@@ -1,0 +1,284 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@/lib/routing";
+import { FolderIcon, MessageSquareIcon, XIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ApiError } from "@/lib/sessionsApi";
+import {
+  IMPORT_SOURCES,
+  importLocalSession,
+  listLocalImportSessions,
+  type ImportSource,
+  type LocalImportSession,
+} from "@/lib/importsApi";
+import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
+import { relativeTime } from "@/lib/relativeTime";
+
+const RECENT_SESSION_LIMIT = 20;
+
+/** Vendor name for a source, e.g. `"claude"` → `"Claude Code"`. */
+function sourceLabel(source: ImportSource): string {
+  return nativeCodingAgentForHarness(`${source}-native`)?.displayName ?? source;
+}
+
+/** Last path segment of a workspace, e.g. `"/Users/x/repo"` → `"repo"`. */
+function workspaceName(workspace: string): string {
+  const segments = workspace.split("/").filter(Boolean);
+  return segments[segments.length - 1] ?? workspace;
+}
+
+function SessionRow({ session, onSelect }: { session: LocalImportSession; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-testid={`import-chat-session-${session.sessionId}`}
+      className="flex w-full flex-col gap-1 rounded-md px-3 py-2 text-left transition-colors hover:bg-muted"
+    >
+      <span className="truncate text-sm font-medium">{session.title ?? session.sessionId}</span>
+      <span className="flex items-center gap-3 text-xs text-muted-foreground">
+        {session.workspace !== null && (
+          <span className="flex min-w-0 items-center gap-1" title={session.workspace}>
+            <FolderIcon className="size-3 shrink-0" />
+            <span className="truncate">{workspaceName(session.workspace)}</span>
+          </span>
+        )}
+        <span className="flex shrink-0 items-center gap-1">
+          <MessageSquareIcon className="size-3" />
+          {session.itemCount}
+        </span>
+        {session.modifiedAt !== null && (
+          <span className="shrink-0">{relativeTime(session.modifiedAt * 1000)}</span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Dialog for pulling an existing local coding-harness chat into Omnigent —
+ * the web equivalent of `omnigent import`.
+ *
+ * The transcripts live on the SERVER's disk (that machine's `~/.claude`,
+ * `~/.codex`, …), so the list is only meaningful on a single-user local
+ * server; the trigger is hidden elsewhere and the API refuses it anyway.
+ * Picking a harness lists its recent chats, selecting one collapses the list
+ * to that chat, and importing navigates into the new Omnigent session.
+ *
+ * @param open - Whether the dialog is visible.
+ * @param onOpenChange - Radix-controlled visibility setter.
+ */
+export function ImportChatDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [source, setSource] = useState<ImportSource>("claude");
+  const [selected, setSelected] = useState<LocalImportSession | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Set when the chosen chat was already imported: the only error the user can
+  // act on from here, by re-importing over the previous copy.
+  const [conflict, setConflict] = useState<string | null>(null);
+
+  const {
+    data: sessions,
+    isLoading,
+    error: listError,
+  } = useQuery({
+    queryKey: ["local-import-sessions", source],
+    queryFn: () => listLocalImportSessions(source, RECENT_SESSION_LIMIT),
+    enabled: open,
+    staleTime: 4_000,
+  });
+
+  function handleOpenChange(next: boolean): void {
+    if (!next) {
+      setSelected(null);
+      setImporting(false);
+      setError(null);
+      setConflict(null);
+    }
+    onOpenChange(next);
+  }
+
+  function handleSelectSource(next: ImportSource): void {
+    setSource(next);
+    setSelected(null);
+    setError(null);
+    setConflict(null);
+  }
+
+  function handleSelectSession(session: LocalImportSession): void {
+    setSelected(session);
+    setError(null);
+    setConflict(null);
+  }
+
+  async function handleImport(force: boolean): Promise<void> {
+    if (selected === null) return;
+    setImporting(true);
+    setError(null);
+    setConflict(null);
+    try {
+      const imported = await importLocalSession({
+        source,
+        externalSessionId: selected.sessionId,
+        force,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      handleOpenChange(false);
+      navigate(`/c/${imported.sessionId}`);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        setConflict(e.message);
+      } else {
+        setError(e instanceof Error ? e.message : "Couldn't import the chat. Try again.");
+      }
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const label = sourceLabel(source);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="import-chat-dialog" className="flex flex-col gap-4 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import a chat</DialogTitle>
+          <DialogDescription>
+            Bring an existing chat from a coding agent on this machine into Omnigent. The transcript
+            is copied as an ordinary session — the original is left untouched.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-muted-foreground">Coding agent</span>
+          <Select value={source} onValueChange={(v) => handleSelectSource(v as ImportSource)}>
+            <SelectTrigger className="w-full text-sm" data-testid="import-chat-source-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {IMPORT_SOURCES.map((option) => (
+                <SelectItem
+                  key={option}
+                  value={option}
+                  data-testid={`import-chat-source-option-${option}`}
+                >
+                  {sourceLabel(option)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {selected !== null ? (
+          <div
+            className="flex items-start justify-between gap-2 rounded-md border border-input px-3 py-2"
+            data-testid="import-chat-selected"
+          >
+            <span className="flex min-w-0 flex-col gap-1">
+              <span className="truncate text-sm font-medium">
+                {selected.title ?? selected.sessionId}
+              </span>
+              {selected.workspace !== null && (
+                <span className="truncate text-xs text-muted-foreground" title={selected.workspace}>
+                  {selected.workspace}
+                </span>
+              )}
+            </span>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="size-8 shrink-0 text-muted-foreground"
+              onClick={() => setSelected(null)}
+              data-testid="import-chat-clear-selection"
+            >
+              <XIcon className="size-4" />
+              <span className="sr-only">Choose a different chat</span>
+            </Button>
+          </div>
+        ) : isLoading ? (
+          <div className="flex flex-col gap-2" data-testid="import-chat-loading">
+            {[0, 1, 2].map((row) => (
+              <div key={row} className="h-11 animate-pulse rounded-md bg-muted" />
+            ))}
+          </div>
+        ) : listError !== null ? (
+          <p className="text-sm text-destructive" data-testid="import-chat-list-error">
+            {listError instanceof Error ? listError.message : "Couldn't list local chats."}
+          </p>
+        ) : (sessions ?? []).length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="import-chat-empty">
+            No recent {label} chats found on this machine.
+          </p>
+        ) : (
+          <ScrollArea className="max-h-64" data-testid="import-chat-session-list">
+            <div className="flex flex-col">
+              {(sessions ?? []).map((session) => (
+                <SessionRow
+                  key={session.sessionId}
+                  session={session}
+                  onSelect={() => handleSelectSession(session)}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+
+        {conflict !== null && (
+          <p className="text-sm text-warning" data-testid="import-chat-conflict">
+            {conflict}{" "}
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              disabled={importing}
+              onClick={() => void handleImport(true)}
+              data-testid="import-chat-force"
+            >
+              Import again?
+            </button>
+          </p>
+        )}
+        {error !== null && (
+          <p className="text-sm text-destructive" data-testid="import-chat-error">
+            {error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            disabled={selected === null || importing}
+            onClick={() => void handleImport(false)}
+            data-testid="import-chat-submit"
+          >
+            {importing ? "Importing…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3035,6 +3035,28 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
   });
 });
 
+describe("NewChatLandingScreen import chat", () => {
+  beforeEach(setupLandingMocks);
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("hides the import action on a multi-user server", () => {
+    // The transcripts sit on the SERVER's disk, which isn't the caller's
+    // machine here — the API refuses it, so the action must not be offered.
+    renderLanding();
+    expect(screen.queryByTestId("new-chat-landing-import")).toBeNull();
+  });
+
+  it("opens the import dialog from the composer on a single-user server", () => {
+    renderLanding({ single_user: true });
+    expect(screen.queryByTestId("import-chat-dialog")).toBeNull();
+    fireEvent.click(screen.getByTestId("new-chat-landing-import"));
+    expect(screen.getByTestId("import-chat-dialog")).toBeTruthy();
+  });
+});
+
 describe("NewChatLandingScreen custom-agent sandbox gating", () => {
   beforeEach(setupLandingMocks);
   afterEach(() => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -22,6 +22,7 @@ import {
   FileTextIcon,
   FolderIcon,
   ImageIcon,
+  ImportIcon,
   PaperclipIcon,
   PlusIcon,
   SettingsIcon,
@@ -73,6 +74,7 @@ import { attachmentKey } from "@/lib/attachments";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { HarnessSetupDialog } from "@/shell/HarnessSetupDialog";
+import { ImportChatDialog } from "@/shell/ImportChatDialog";
 import {
   harnessUnavailableReasonOnHost,
   harnessUnconfiguredOnHost,
@@ -83,7 +85,7 @@ import {
 
 // Re-exported for tests that import the readiness helpers from this module.
 export { harnessUnavailableReasonOnHost, harnessUnconfiguredOnHost, harnessWarningBadgeText };
-import { sandboxOptionLabel } from "@/lib/capabilities";
+import { isSingleUserMode, sandboxOptionLabel } from "@/lib/capabilities";
 import {
   isSlashCommandText,
   rankedSlashCommandNames,
@@ -1937,6 +1939,10 @@ export function NewChatLandingScreen() {
   const info = useServerInfo();
   const managedSandboxesEnabled = info !== "loading" && info.managed_sandboxes_enabled;
   const smartRoutingEnabled = info !== "loading" && info.smart_routing_enabled;
+  // Importing reads transcripts off the SERVER's disk, which is the user's own
+  // machine only on a single-user local runtime. Elsewhere the API refuses it,
+  // so don't offer it.
+  const importChatAvailable = isSingleUserMode(info);
   // Which router can answer a pick. The external AI-Gateway router only covers
   // a family the host runs through the gateway; the built-in judge covers any
   // family. Read once here and reused by every routing gate below. "loading"
@@ -2139,6 +2145,8 @@ export function NewChatLandingScreen() {
   } | null>(null);
   // Harness-config modal, opened from the composer's gear icon.
   const [configOpen, setConfigOpen] = useState(false);
+  // Import-a-local-chat modal, opened from the composer's import icon.
+  const [importOpen, setImportOpen] = useState(false);
 
   // Mirror the current draft fields into a ref every render so the unmount
   // cleanup below can snapshot the latest values without re-subscribing.
@@ -4082,6 +4090,30 @@ export function NewChatLandingScreen() {
                 />
               </div>
               <div className="flex items-center gap-0.5 md:gap-2">
+                {/* Import — pulls an existing Claude Code / Codex chat off this
+                  machine into a normal session (the web form of
+                  `omnigent import`). */}
+                {importChatAvailable && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="size-9 text-muted-foreground md:size-8"
+                          disabled={creating}
+                          onClick={() => setImportOpen(true)}
+                          data-testid="new-chat-landing-import"
+                        >
+                          <ImportIcon className="size-4" data-icon-size="16" />
+                          <span className="sr-only">Import chat</span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">Import chat</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
                 <div className="flex items-center rounded-lg transition-colors has-[button:not(:disabled)]:hover:bg-muted dark:has-[button:not(:disabled)]:hover:bg-muted/50 has-aria-expanded:bg-muted dark:has-aria-expanded:bg-muted/50 [&>button]:bg-transparent!">
                   {/* Agent / harness picker — selects the agent or harness only.
                     Its run-config knobs (model / effort / permission mode for
@@ -4193,6 +4225,9 @@ export function NewChatLandingScreen() {
                     setPickedHarness={handleSetPickedHarness}
                     setCostControlMode={setCostControlMode}
                   />
+                )}
+                {importChatAvailable && (
+                  <ImportChatDialog open={importOpen} onOpenChange={setImportOpen} />
                 )}
                 {/* Routing is not a standalone composer toggle — it folds into
                   the gear modal's Model dropdown as an "Smart Routing"


### PR DESCRIPTION
## Related issue

Closes #4462

## Summary

- Exposes the existing local-transcript import flow in the web UI: a new **Import chat** action beside model selection on the New Session screen opens a dialog that lists recent local Claude Code / Codex (and other supported harness) chats with title, workspace, and item count, and imports the selected transcript.
- Adds two server routes: `GET /v1/imports/local/sessions` (recent local sessions with metadata) and `POST /v1/imports/local` (server-side import by session id). Both reuse the existing `session_import` loaders and share the exact persistence path of `POST /v1/imports` (extracted into a helper — the existing endpoint's behavior is unchanged).
- **Scope: local single-user servers only.** Both routes 403 unless `local_single_user_enabled()`, because they read the *server process's* home directory — on a shared deployment that would let any authenticated user enumerate the operator's transcripts. The UI hides the trigger via the existing `single_user` capability. This is also the natural seam for later remote support (routing listing through the owning host, like `host.model_options`).

ELI5: the CLI could already do `omnigent import --harness claude --session <id>`, but you had to dig up the session id yourself. Now there's a button: pick a chat from a list, click Import, land in the imported session.

```
before:  browser ──(can't read ~/.claude)──✗
         CLI ── parses transcript ──► POST /v1/imports (items in request)

after:   browser ──► GET  /v1/imports/local/sessions ──► server reads ~/.claude, returns metadata
         browser ──► POST /v1/imports/local {source, session_id} ──► server parses + stores
                                                    └── same persistence helper as /v1/imports
```

## Test Plan

- `uv run pytest tests/server/routes/test_imports.py` — 10 passed (new: listing metadata/order/limit, 422 unknown source, import-by-id happy path, 404 unknown id, 409 duplicate + `force` replace, 403 when not single-user; fixture pins `CLAUDE_CONFIG_DIR` to a throwaway dir).
- `uv run pytest tests/server/routes/ tests/test_session_import.py tests/cli/test_import.py tests/server/test_openapi_drift.py` — 968 passed.
- `pnpm -C web exec vitest run` — 9 new tests pass (`ImportChatDialog.test.tsx`, `NewChatDialog.test.tsx`); the 3 failures in `NewChatDialog.test.tsx` are pre-existing on `main` (verified identical with this change stashed).
- `pre-commit run` on all touched files (ruff, pyrefly, prettier, oxlint, tsc) — clean; `scripts/dump_openapi.py --check` — up to date; `pnpm -C web run build` — clean.
- Manually verified end-to-end against a source-built server with a seeded fake `CLAUDE_CONFIG_DIR`: list → select → import → lands on the imported conversation (screenshots below).

## Demo

Dialog listing recent local Claude Code chats:

![Import dialog with recent chats](https://raw.githubusercontent.com/josuediazflores/omnigent/pr-assets/demo-2-dialog-list.png)

Selection collapses the list (clearing restores it, per the issue):

![Selected session](https://raw.githubusercontent.com/josuediazflores/omnigent/pr-assets/demo-3-selected.png)

Imported transcript as an ordinary session:

![Imported conversation](https://raw.githubusercontent.com/josuediazflores/omnigent/pr-assets/demo-4-imported.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No Playwright test under `tests/e2e_ui/` yet — I didn't want to submit one I couldn't run locally. If maintainers want it, the natural shape is `tests/e2e_ui/start_session/test_import_chat.py`: seed a fake transcript into the spawned server's `CLAUDE_CONFIG_DIR`, then drive `new-chat-landing-import` → `import-chat-session-<id>` → `import-chat-submit`. Happy to add it, or take the `skip-e2e-ui-test` label — whichever you prefer. Manual verification covered the full flow (see Demo).

## Changelog

Import your existing Claude Code and Codex chats from the New Session screen — browse recent local sessions and bring one in with one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
