### PR TITLE
Import native Claude Code and Codex chats from New Session

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -287,6 +287,25 @@ class MessageData(BaseModel):
         return self
 
 
+def strip_attachment_marker_lines(text: str) -> str:
+    """
+    Drop lines that are native attachment path markers.
+
+    Shared by title synthesis and any other view that collapses message
+    content blocks into plain text, so a temp-file path never leaks in
+    from either place.
+
+    :param text: Raw text from one content block, e.g.
+        ``"hello\\n[Attached: /tmp/abc/x.png]"``.
+    :returns: ``text`` with attachment-marker lines
+        (:data:`_ATTACHMENT_MARKER_RE`) removed.
+    """
+    kept_lines = [
+        line for line in text.splitlines() if not _ATTACHMENT_MARKER_RE.match(line.strip())
+    ]
+    return "\n".join(kept_lines)
+
+
 def synthesize_conversation_title(
     content: list[dict[str, Any]],
     *,
@@ -311,12 +330,7 @@ def synthesize_conversation_title(
         if block.get("type") == "input_text":
             text = block.get("text")
             if isinstance(text, str):
-                kept_lines = [
-                    line
-                    for line in text.splitlines()
-                    if not _ATTACHMENT_MARKER_RE.match(line.strip())
-                ]
-                parts.append("\n".join(kept_lines))
+                parts.append(strip_attachment_marker_lines(text))
     collapsed = " ".join(" ".join(parts).split())
     if not collapsed:
         return None

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -50,8 +50,12 @@ from omnigent.host.frames import (
     HostListDirEntry,
     HostListDirFrame,
     HostListDirResultFrame,
+    HostListLocalSessionsFrame,
+    HostListLocalSessionsResultFrame,
     HostListWorktreesFrame,
     HostListWorktreesResultFrame,
+    HostLoadLocalSessionFrame,
+    HostLoadLocalSessionResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
     HostRemoveWorktreeFrame,
@@ -712,6 +716,11 @@ class _RunnerHandle:
 
     proc: subprocess.Popen[bytes] | ZygoteRunnerProc
     log_path: Path
+
+
+# Only the first-party harnesses the web import picker offers; the
+# CLI still imports the rest by session id.
+_IMPORTABLE_SOURCES = ("claude", "codex")
 
 
 class HostProcess:
@@ -2374,6 +2383,114 @@ class HostProcess:
             ],
         )
 
+    async def _handle_list_local_sessions(
+        self,
+        frame: HostListLocalSessionsFrame,
+    ) -> HostListLocalSessionsResultFrame:
+        """Handle a ``host.list_local_sessions`` request from the server.
+
+        Parsing transcripts blocks, so the scan runs in a worker thread
+        and the tunnel loop keeps servicing pings.
+
+        :param frame: The browse request frame.
+        :returns: Result frame with session summaries, or
+            ``status: "failed"`` with an error message.
+        """
+        from omnigent.session_import.local import list_recent_local_sessions
+
+        if frame.source not in _IMPORTABLE_SOURCES:
+            return HostListLocalSessionsResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=f"unsupported import source: {frame.source}",
+            )
+        try:
+            summaries = await asyncio.to_thread(
+                list_recent_local_sessions,
+                frame.source,
+                limit=frame.limit,
+            )
+        except Exception as exc:
+            _logger.exception("host list_local_sessions for %r failed", frame.source)
+            return HostListLocalSessionsResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=str(exc),
+            )
+        return HostListLocalSessionsResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            sessions=[
+                {
+                    "source": summary.source,
+                    "external_session_id": summary.external_session_id,
+                    "workspace": summary.workspace,
+                    "title": summary.title,
+                    "item_count": summary.item_count,
+                    "preview": [
+                        {"role": entry.role, "text": entry.text} for entry in summary.preview
+                    ],
+                }
+                for summary in summaries
+            ],
+        )
+
+    async def _handle_load_local_session(
+        self,
+        frame: HostLoadLocalSessionFrame,
+    ) -> HostLoadLocalSessionResultFrame:
+        """Handle a ``host.load_local_session`` request from the server.
+
+        :param frame: The load request frame.
+        :returns: Result frame with the normalized transcript, or a
+            ``"not_found"`` / ``"failed"`` status with an error message.
+        """
+        from omnigent.session_import import SessionImportNotFoundError
+        from omnigent.session_import.local import load_local_session
+
+        if frame.source not in _IMPORTABLE_SOURCES:
+            return HostLoadLocalSessionResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=f"unsupported import source: {frame.source}",
+            )
+        try:
+            loaded = await asyncio.to_thread(
+                load_local_session,
+                frame.source,
+                frame.external_session_id,
+            )
+        except SessionImportNotFoundError as exc:
+            return HostLoadLocalSessionResultFrame(
+                request_id=frame.request_id,
+                status="not_found",
+                error=str(exc),
+            )
+        except Exception as exc:
+            _logger.exception("host load_local_session %r failed", frame.external_session_id)
+            return HostLoadLocalSessionResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=str(exc),
+            )
+        return HostLoadLocalSessionResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            session={
+                "source": loaded.source,
+                "external_session_id": loaded.external_session_id,
+                "workspace": loaded.workspace,
+                "items": [
+                    {
+                        "type": item.type,
+                        "response_id": item.response_id,
+                        "data": item.data.model_dump(mode="json", exclude_none=True),
+                    }
+                    for item in loaded.items
+                ],
+            },
+        )
+
     async def run(self) -> None:
         """Run the host process with reconnection.
 
@@ -2857,6 +2974,10 @@ class HostProcess:
             await ws.send(encode_host_frame(fs_result))
         elif isinstance(frame, HostModelOptionsFrame):
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))
+        elif isinstance(frame, HostListLocalSessionsFrame):
+            await ws.send(encode_host_frame(await self._handle_list_local_sessions(frame)))
+        elif isinstance(frame, HostLoadLocalSessionFrame):
+            await ws.send(encode_host_frame(await self._handle_load_local_session(frame)))
 
 
 def run_host_process(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 from omnigent.harness_availability import HarnessAvailability, is_harness_availability
 from omnigent.json_types import JsonObject as _JsonObject
@@ -73,6 +74,10 @@ class HostFrameKind(str, Enum):
     FS_RESULT = "host.fs_result"
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
+    LIST_LOCAL_SESSIONS = "host.list_local_sessions"
+    LIST_LOCAL_SESSIONS_RESULT = "host.list_local_sessions_result"
+    LOAD_LOCAL_SESSION = "host.load_local_session"
+    LOAD_LOCAL_SESSION_RESULT = "host.load_local_session_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -849,6 +854,80 @@ class HostModelOptionsResultFrame:
     routable_models: list[str] = field(default_factory=list)
 
 
+@dataclass
+class HostListLocalSessionsFrame:
+    """Server → host: list recent local harness sessions to import.
+
+    Backs ``GET /v1/imports/local-sessions``, used by the Web UI's
+    import-chat picker. Read-only: the host parses transcripts under
+    the harness's own config directory and returns summaries.
+
+    :param request_id: Correlates the result, e.g. ``"req_ls_1"``.
+    :param source: Harness that owns the sessions — ``"claude"`` or
+        ``"codex"``.
+    :param limit: Maximum sessions to return, e.g. ``10``.
+    """
+
+    request_id: str
+    source: str
+    limit: int
+
+
+@dataclass
+class HostListLocalSessionsResultFrame:
+    """Host → server: outcome of a local-session listing.
+
+    :param request_id: Correlates to the
+        :class:`HostListLocalSessionsFrame`, e.g. ``"req_ls_1"``.
+    :param status: ``"ok"`` or ``"failed"``.
+    :param sessions: One dict per session with keys ``source`` (str),
+        ``external_session_id`` (str), ``workspace`` (str | None),
+        ``title`` (str | None), ``item_count`` (int), and ``preview``
+        (list of ``{role, text}``), newest first. ``None`` on failure.
+    :param error: Error message when ``status`` is ``"failed"``.
+    """
+
+    request_id: str
+    status: str
+    sessions: list[dict[str, Any]] | None = None
+    error: str | None = None
+
+
+@dataclass
+class HostLoadLocalSessionFrame:
+    """Server → host: load one local transcript for import.
+
+    :param request_id: Correlates the result, e.g. ``"req_load_1"``.
+    :param source: Harness that owns the session — ``"claude"`` or
+        ``"codex"``.
+    :param external_session_id: Harness-native session id.
+    """
+
+    request_id: str
+    source: str
+    external_session_id: str
+
+
+@dataclass
+class HostLoadLocalSessionResultFrame:
+    """Host → server: outcome of a local transcript load.
+
+    :param request_id: Correlates to the
+        :class:`HostLoadLocalSessionFrame`, e.g. ``"req_load_1"``.
+    :param status: ``"ok"``, ``"not_found"``, or ``"failed"``.
+    :param session: The normalized transcript with keys ``source``,
+        ``external_session_id``, ``workspace`` (str | None), and
+        ``items`` (list of ``{type, response_id, data}``). ``None``
+        unless ``status`` is ``"ok"``.
+    :param error: Error message when ``status`` is not ``"ok"``.
+    """
+
+    request_id: str
+    status: str
+    session: dict[str, Any] | None = None
+    error: str | None = None
+
+
 HostFrame = (
     HostHelloFrame
     | HostHarnessReadinessFrame
@@ -881,6 +960,10 @@ HostFrame = (
     | HostFsResultFrame
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
+    | HostListLocalSessionsFrame
+    | HostListLocalSessionsResultFrame
+    | HostLoadLocalSessionFrame
+    | HostLoadLocalSessionResultFrame
 )
 
 
@@ -1233,6 +1316,44 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "routable_models": frame.routable_models,
             }
         )
+    if isinstance(frame, HostListLocalSessionsFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_LOCAL_SESSIONS.value,
+                "request_id": frame.request_id,
+                "source": frame.source,
+                "limit": frame.limit,
+            }
+        )
+    if isinstance(frame, HostListLocalSessionsResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_LOCAL_SESSIONS_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "sessions": frame.sessions,
+                "error": frame.error,
+            }
+        )
+    if isinstance(frame, HostLoadLocalSessionFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LOAD_LOCAL_SESSION.value,
+                "request_id": frame.request_id,
+                "source": frame.source,
+                "external_session_id": frame.external_session_id,
+            }
+        )
+    if isinstance(frame, HostLoadLocalSessionResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LOAD_LOCAL_SESSION_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "session": frame.session,
+                "error": frame.error,
+            }
+        )
     raise TypeError(f"unknown host frame type: {type(frame).__name__}")
 
 
@@ -1355,6 +1476,14 @@ def _decode_known_host_frame(
             return _decode_model_options(msg)
         case HostFrameKind.MODEL_OPTIONS_RESULT:
             return _decode_model_options_result(msg)
+        case HostFrameKind.LIST_LOCAL_SESSIONS:
+            return _decode_list_local_sessions(msg)
+        case HostFrameKind.LIST_LOCAL_SESSIONS_RESULT:
+            return _decode_list_local_sessions_result(msg)
+        case HostFrameKind.LOAD_LOCAL_SESSION:
+            return _decode_load_local_session(msg)
+        case HostFrameKind.LOAD_LOCAL_SESSION_RESULT:
+            return _decode_load_local_session_result(msg)
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 
@@ -1870,6 +1999,76 @@ def _decode_model_options_result(msg: _JsonObject) -> HostModelOptionsResultFram
         models=models,
         error=_optional_nullable_str(msg, "error"),
         routable_models=routable,
+    )
+
+
+def _decode_list_local_sessions(msg: _JsonObject) -> HostListLocalSessionsFrame:
+    """Decode a host.list_local_sessions request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_local_sessions frame.
+    """
+    return HostListLocalSessionsFrame(
+        request_id=_required_str(msg, "request_id"),
+        source=_required_str(msg, "source"),
+        limit=_required_int(msg, "limit"),
+    )
+
+
+def _decode_list_local_sessions_result(
+    msg: _JsonObject,
+) -> HostListLocalSessionsResultFrame:
+    """Decode a host.list_local_sessions_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_local_sessions_result frame.
+    :raises ValueError: When 'sessions' is not a list of objects.
+    """
+    raw = msg.get("sessions")
+    if raw is not None:
+        if not isinstance(raw, list):
+            raise ValueError("frame field must be a list or null: 'sessions'")
+        for entry in raw:
+            if not isinstance(entry, dict):
+                raise ValueError("each entry in 'sessions' must be a JSON object")
+    return HostListLocalSessionsResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        sessions=raw,
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_load_local_session(msg: _JsonObject) -> HostLoadLocalSessionFrame:
+    """Decode a host.load_local_session request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.load_local_session frame.
+    """
+    return HostLoadLocalSessionFrame(
+        request_id=_required_str(msg, "request_id"),
+        source=_required_str(msg, "source"),
+        external_session_id=_required_str(msg, "external_session_id"),
+    )
+
+
+def _decode_load_local_session_result(
+    msg: _JsonObject,
+) -> HostLoadLocalSessionResultFrame:
+    """Decode a host.load_local_session_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.load_local_session_result frame.
+    :raises ValueError: When 'session' is present but not an object.
+    """
+    raw = msg.get("session")
+    if raw is not None and not isinstance(raw, dict):
+        raise ValueError("frame field must be a JSON object or null: 'session'")
+    return HostLoadLocalSessionResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        session=raw,
+        error=_optional_nullable_str(msg, "error"),
     )
 
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1931,6 +1931,11 @@ def create_app(
             agent_store,
             auth_provider=auth_provider,
             permission_store=permission_store,
+            # Lets the web import picker browse and import the Claude /
+            # Codex transcripts that live on the user's own machine.
+            # Absent a host store the endpoints answer 503.
+            host_registry=host_registry,
+            host_store=host_store,
         ),
         prefix="/v1",
         tags=["imports"],

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -259,6 +259,17 @@ class HostConnection:
         ``error_code``, and ``error``.
     :param pending_model_options: Per-``request_id`` futures for pre-launch
         model catalogs resolved by the selected host.
+    :param pending_list_local_sessions: Per-``request_id`` futures for
+        in-flight ``host.list_local_sessions`` requests (the import-chat
+        picker). Resolved when the host sends
+        ``host.list_local_sessions_result``. Values carry ``status``,
+        ``sessions``, and ``error``. Same ``Any`` typing rationale as
+        ``pending_stats``.
+    :param pending_load_local_session: Per-``request_id`` futures for
+        in-flight ``host.load_local_session`` requests. Resolved when
+        the host sends ``host.load_local_session_result``. Values
+        carry ``status``, ``session``, and ``error``. Same ``Any``
+        typing rationale as ``pending_stats``.
     """
 
     workspace_id: int
@@ -313,6 +324,12 @@ class HostConnection:
         default_factory=dict,
     )
     pending_model_options: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_list_local_sessions: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_load_local_session: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
 

--- a/omnigent/server/routes/_host_session_import.py
+++ b/omnigent/server/routes/_host_session_import.py
@@ -1,0 +1,222 @@
+"""
+Server-side proxy for the local-session import tunnel frames.
+
+The web import picker runs in a browser and the transcripts live on the
+host's disk, so the server never reads them directly: it enqueues a
+``host.list_local_sessions`` / ``host.load_local_session`` frame,
+registers a future on the host connection, and awaits the result.
+Mirrors ``_host_worktree``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from typing import Any
+
+from omnigent.host.frames import (
+    HostListLocalSessionsFrame,
+    HostLoadLocalSessionFrame,
+    encode_host_frame,
+)
+from omnigent.server.host_registry import HostConnection, HostRegistry
+
+_logger = logging.getLogger(__name__)
+
+# Browsing parses up to twenty full transcripts and a load can move a
+# large one across the tunnel, so allow well over the git-op budget.
+_LOCAL_SESSION_TIMEOUT_S: float = 60.0
+
+
+class LocalSessionProxyError(Exception):
+    """
+    The host reported a local-session operation failure.
+
+    User-correctable conditions (unsupported source, unreadable
+    transcript), so the route layer maps this to ``INVALID_INPUT``
+    (400).
+
+    :param message: Human-readable error for the API response body.
+    """
+
+    def __init__(self, message: str) -> None:
+        """
+        Initialize with the user-facing error message.
+
+        :param message: Error string surfaced to the API caller.
+        """
+        super().__init__(message)
+        self.message = message
+
+
+class LocalSessionNotFoundError(LocalSessionProxyError):
+    """
+    The requested session does not exist on the host.
+
+    The route layer maps this to ``NOT_FOUND`` (404).
+    """
+
+
+class LocalSessionHostUnavailableError(LocalSessionProxyError):
+    """
+    The host could not be reached for the operation.
+
+    Connection loss or no reply within the timeout — an infrastructure
+    condition, not user input. The route layer maps this to
+    ``CONFLICT`` (409). Subclasses :class:`LocalSessionProxyError` so
+    best-effort callers that catch the base type still catch it; a
+    caller distinguishing the two **must** catch this subclass first.
+    """
+
+
+async def _await_result(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    pending: dict[str, asyncio.Future[dict[str, Any]]],
+    request_id: str,
+    frame: str,
+    op: str,
+) -> dict[str, Any]:
+    """
+    Send one frame and await its correlated result.
+
+    Shared plumbing for the list/load proxies: register a future on
+    ``pending`` keyed by ``request_id``, enqueue ``frame``, await the
+    reply, and clean up on every path.
+
+    :param host_registry: Registry used to enqueue the outbound frame.
+    :param host_conn: Live host connection.
+    :param pending: The connection's pending-future map for this op
+        (``pending_list_local_sessions`` or
+        ``pending_load_local_session``).
+    :param request_id: Correlation id already embedded in ``frame``.
+    :param frame: Encoded outbound frame.
+    :param op: Short label for log and error text, e.g.
+        ``"list_local_sessions"``.
+    :returns: The host's decoded result dict.
+    :raises LocalSessionHostUnavailableError: On connection loss or no
+        reply within :data:`_LOCAL_SESSION_TIMEOUT_S`.
+    """
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    pending[request_id] = future
+    try:
+        try:
+            host_registry.send_text(host_conn, frame)
+        except ConnectionError as exc:
+            raise LocalSessionHostUnavailableError(
+                f"host '{host_conn.host_id}' connection lost during {op}"
+            ) from exc
+        try:
+            return await asyncio.wait_for(future, timeout=_LOCAL_SESSION_TIMEOUT_S)
+        except asyncio.TimeoutError as exc:
+            _logger.warning(
+                "host '%s' did not answer %s within %.0fs",
+                host_conn.host_id,
+                op,
+                _LOCAL_SESSION_TIMEOUT_S,
+            )
+            raise LocalSessionHostUnavailableError(
+                f"host '{host_conn.host_id}' did not respond to {op} within "
+                f"{_LOCAL_SESSION_TIMEOUT_S:.0f}s (it may be running an older version)"
+            ) from exc
+    finally:
+        pending.pop(request_id, None)
+
+
+async def list_local_sessions_on_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    source: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """
+    Send a ``host.list_local_sessions`` frame and await the result.
+
+    :param host_registry: Server-side registry; used to enqueue the
+        outbound frame on the host's send queue.
+    :param host_conn: Live host connection to list sessions on.
+    :param source: Harness that owns the sessions — ``"claude"`` or
+        ``"codex"``.
+    :param limit: Maximum sessions to return, e.g. ``10``.
+    :returns: Session summary dicts, newest first.
+    :raises LocalSessionHostUnavailableError: If the host connection
+        drops or doesn't respond within :data:`_LOCAL_SESSION_TIMEOUT_S`.
+    :raises LocalSessionProxyError: If the host reports a listing
+        failure.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostListLocalSessionsFrame(request_id=request_id, source=source, limit=limit)
+    )
+    result = await _await_result(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        pending=host_conn.pending_list_local_sessions,
+        request_id=request_id,
+        frame=frame,
+        op="list_local_sessions",
+    )
+    if result.get("status") != "ok":
+        raise LocalSessionProxyError(
+            str(result.get("error") or "the host could not list local sessions")
+        )
+    sessions = result.get("sessions")
+    if not isinstance(sessions, list):
+        raise LocalSessionProxyError("the host returned an invalid session list")
+    return sessions
+
+
+async def load_local_session_on_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    source: str,
+    external_session_id: str,
+) -> dict[str, Any]:
+    """
+    Send a ``host.load_local_session`` frame and await the result.
+
+    :param host_registry: Server-side registry; used to enqueue the
+        outbound frame on the host's send queue.
+    :param host_conn: Live host connection to load the session from.
+    :param source: Harness that owns the session — ``"claude"`` or
+        ``"codex"``.
+    :param external_session_id: Harness-native session id.
+    :returns: ``{"source", "external_session_id", "workspace", "items"}``.
+    :raises LocalSessionNotFoundError: If the host has no such session.
+    :raises LocalSessionHostUnavailableError: If the host connection
+        drops or doesn't respond within :data:`_LOCAL_SESSION_TIMEOUT_S`.
+    :raises LocalSessionProxyError: If the host reports a load failure.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostLoadLocalSessionFrame(
+            request_id=request_id,
+            source=source,
+            external_session_id=external_session_id,
+        )
+    )
+    result = await _await_result(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        pending=host_conn.pending_load_local_session,
+        request_id=request_id,
+        frame=frame,
+        op="load_local_session",
+    )
+    status = result.get("status")
+    if status == "not_found":
+        raise LocalSessionNotFoundError(
+            str(result.get("error") or f"{source} session {external_session_id!r} was not found")
+        )
+    if status != "ok":
+        raise LocalSessionProxyError(
+            str(result.get("error") or "the host could not load the session")
+        )
+    session = result.get("session")
+    if not isinstance(session, dict):
+        raise LocalSessionProxyError("the host returned an invalid session payload")
+    return session

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -36,7 +36,9 @@ from omnigent.host.frames import (
     HostInstallHarnessResultFrame,
     HostLaunchRunnerResultFrame,
     HostListDirResultFrame,
+    HostListLocalSessionsResultFrame,
     HostListWorktreesResultFrame,
+    HostLoadLocalSessionResultFrame,
     HostModelOptionsResultFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -614,6 +616,30 @@ async def _receive_loop(
                     {
                         "status": frame.status,
                         "worktrees": frame.worktrees,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostListLocalSessionsResultFrame):
+            list_ls_future = conn.pending_list_local_sessions.pop(frame.request_id, None)
+            if list_ls_future is not None and not list_ls_future.done():
+                list_ls_future.set_result(
+                    {
+                        "status": frame.status,
+                        "sessions": frame.sessions,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostLoadLocalSessionResultFrame):
+            load_ls_future = conn.pending_load_local_session.pop(frame.request_id, None)
+            if load_ls_future is not None and not load_ls_future.done():
+                load_ls_future.set_result(
+                    {
+                        "status": frame.status,
+                        "session": frame.session,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import threading
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Literal
 
@@ -94,9 +95,22 @@ def _import_conversation_id(source: ImportSource, external_session_id: str) -> s
     return hashlib.sha256(value.encode()).hexdigest()[:32]
 
 
-async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
-    """Serialize concurrent imports for one source identity in this server."""
-    key = (body.source, body.external_session_id)
+@asynccontextmanager
+async def _source_import_lock(
+    source: ImportSource,
+    external_session_id: str,
+) -> AsyncIterator[None]:
+    """Serialize concurrent imports for one source identity in this server.
+
+    The sole owner of :data:`_IMPORT_LOCKS`; both the CLI's
+    ``POST /v1/imports`` and the Web UI's
+    ``POST /v1/imports/local-sessions`` contend on the same map.
+
+    :param source: Harness that owns the source session.
+    :param external_session_id: Harness-native session id.
+    :returns: Async context manager held for the duration of one import.
+    """
+    key = (source, external_session_id)
     with _IMPORT_LOCKS_GUARD:
         entry = _IMPORT_LOCKS.setdefault(key, _ImportLockEntry(lock=asyncio.Lock()))
         entry.users += 1
@@ -108,6 +122,126 @@ async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[
             entry.users -= 1
             if entry.users == 0:
                 _IMPORT_LOCKS.pop(key, None)
+
+
+async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
+    """Serialize concurrent imports for one source identity in this server."""
+    async with _source_import_lock(body.source, body.external_session_id):
+        yield
+
+
+async def _create_imported_session(
+    *,
+    conversation_store: ConversationStore,
+    agent_store: AgentStore,
+    permission_store: PermissionStore | None,
+    user_id: str | None,
+    source: ImportSource,
+    external_session_id: str,
+    workspace: str | None,
+    items: list[NewConversationItem],
+    force: bool = False,
+) -> ImportSessionResponse:
+    """Create one imported session, rejecting an already-imported source.
+
+    Shared by the CLI's ``POST /v1/imports`` and the Web UI's
+    ``POST /v1/imports/local-sessions`` so both produce identical
+    provenance labels, duplicate handling, and ownership grants.
+
+    :param conversation_store: Store the session is created in.
+    :param agent_store: Store used to confirm the built-in agent exists.
+    :param permission_store: Store granting the caller ownership, or
+        ``None`` when permissions are disabled.
+    :param user_id: Authenticated caller, or ``None`` when auth is off.
+    :param source: Harness that owns the source session.
+    :param external_session_id: Harness-native session id.
+    :param workspace: Working directory recorded in the transcript.
+    :param items: Normalized items to append.
+    :param force: Replace a prior import of the same source session
+        instead of rejecting it.
+    :returns: The import result.
+    :raises OmnigentError: ``CONFLICT`` when already imported,
+        ``INVALID_INPUT`` for an unsupported source, ``INTERNAL_ERROR``
+        when the built-in agent is missing.
+    """
+    existing = await asyncio.to_thread(
+        conversation_store.find_imported_conversation,
+        source,
+        external_session_id,
+    )
+    if existing is not None:
+        await require_access(
+            user_id,
+            existing.id,
+            LEVEL_OWNER,
+            permission_store,
+            conversation_store,
+        )
+        if not force:
+            raise OmnigentError(
+                f"This {source} session has already been imported as {existing.id}",
+                code=ErrorCode.CONFLICT,
+            )
+
+    native_agent = native_coding_agent_for_harness(f"{source}-native")
+    if native_agent is None:
+        raise OmnigentError(
+            f"Unsupported import source: {source}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    agent_id = builtin_agent_id(native_agent.agent_name)
+    if await asyncio.to_thread(agent_store.get, agent_id) is None:
+        raise OmnigentError(
+            f"The {native_agent.display_name} built-in agent is unavailable",
+            code=ErrorCode.INTERNAL_ERROR,
+        )
+
+    if existing is not None:
+        await conversation_store.delete_conversation(existing.id)
+
+    try:
+        conversation = await asyncio.to_thread(
+            conversation_store.create_conversation,
+            title=title_from_items(items),
+            agent_id=agent_id,
+            workspace=workspace,
+            conversation_id=_import_conversation_id(source, external_session_id),
+        )
+    except ConversationAlreadyExistsError as exc:
+        raise OmnigentError(
+            "This source session has already been imported",
+            code=ErrorCode.CONFLICT,
+        ) from exc
+    try:
+        await asyncio.to_thread(
+            conversation_store.set_external_session_id,
+            conversation.id,
+            external_session_id,
+        )
+        await asyncio.to_thread(conversation_store.append, conversation.id, items)
+        labels = {
+            **native_agent.presentation_labels,
+            IMPORT_SOURCE_LABEL_KEY: source,
+            IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: external_session_id,
+        }
+        await asyncio.to_thread(conversation_store.set_labels, conversation.id, labels)
+        if permission_store is not None and user_id is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+            await asyncio.to_thread(
+                permission_store.grant,
+                user_id,
+                conversation.id,
+                LEVEL_OWNER,
+            )
+    except Exception:
+        await conversation_store.delete_conversation(conversation.id)
+        raise
+
+    return ImportSessionResponse(
+        session_id=conversation.id,
+        status="imported",
+        item_count=len(items),
+    )
 
 
 def create_imports_router(
@@ -136,84 +270,18 @@ def create_imports_router(
         """Import one normalized transcript, optionally replacing its prior import."""
         user_id = require_user(request, auth_provider)
         items = [item.to_item() for item in body.items]
-        existing = await asyncio.to_thread(
-            conversation_store.find_imported_conversation,
-            body.source,
-            body.external_session_id,
+        result = await _create_imported_session(
+            conversation_store=conversation_store,
+            agent_store=agent_store,
+            permission_store=permission_store,
+            user_id=user_id,
+            source=body.source,
+            external_session_id=body.external_session_id,
+            workspace=body.workspace,
+            items=items,
+            force=body.force,
         )
-        if existing is not None:
-            await require_access(
-                user_id,
-                existing.id,
-                LEVEL_OWNER,
-                permission_store,
-                conversation_store,
-            )
-            if not body.force:
-                raise OmnigentError(
-                    f"This {body.source} session has already been imported as {existing.id}",
-                    code=ErrorCode.CONFLICT,
-                )
-
-        native_agent = native_coding_agent_for_harness(f"{body.source}-native")
-        if native_agent is None:
-            raise OmnigentError(
-                f"Unsupported import source: {body.source}",
-                code=ErrorCode.INVALID_INPUT,
-            )
-        agent_id = builtin_agent_id(native_agent.agent_name)
-        if await asyncio.to_thread(agent_store.get, agent_id) is None:
-            raise OmnigentError(
-                f"The {native_agent.display_name} built-in agent is unavailable",
-                code=ErrorCode.INTERNAL_ERROR,
-            )
-
-        if existing is not None:
-            await conversation_store.delete_conversation(existing.id)
-
-        try:
-            conversation = await asyncio.to_thread(
-                conversation_store.create_conversation,
-                title=title_from_items(items),
-                agent_id=agent_id,
-                workspace=body.workspace,
-                conversation_id=_import_conversation_id(body.source, body.external_session_id),
-            )
-        except ConversationAlreadyExistsError as exc:
-            raise OmnigentError(
-                "This source session has already been imported",
-                code=ErrorCode.CONFLICT,
-            ) from exc
-        try:
-            await asyncio.to_thread(
-                conversation_store.set_external_session_id,
-                conversation.id,
-                body.external_session_id,
-            )
-            await asyncio.to_thread(conversation_store.append, conversation.id, items)
-            labels = {
-                **native_agent.presentation_labels,
-                IMPORT_SOURCE_LABEL_KEY: body.source,
-                IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: body.external_session_id,
-            }
-            await asyncio.to_thread(conversation_store.set_labels, conversation.id, labels)
-            if permission_store is not None and user_id is not None:
-                await asyncio.to_thread(permission_store.ensure_user, user_id)
-                await asyncio.to_thread(
-                    permission_store.grant,
-                    user_id,
-                    conversation.id,
-                    LEVEL_OWNER,
-                )
-        except Exception:
-            await conversation_store.delete_conversation(conversation.id)
-            raise
-
         response.status_code = 201
-        return ImportSessionResponse(
-            session_id=conversation.id,
-            status="imported",
-            item_count=len(items),
-        )
+        return result
 
     return router

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import NewConversationItem, parse_item_data
@@ -38,6 +39,8 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.conversation_store import ConversationAlreadyExistsError
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
+
+_logger = logging.getLogger(__name__)
 
 # The web picker only browses the two harnesses whose transcripts the
 # host daemon can read; the CLI still imports the other sources by id.
@@ -110,6 +113,13 @@ class LocalSessionSummaryOutput(BaseModel):
     title: str | None = None
     item_count: int
     preview: list[LocalSessionPreviewOutput] = Field(default_factory=list)
+
+
+class LocalSessionListOutput(BaseModel):
+    """Envelope returned by the local-session browse endpoint."""
+
+    object: Literal["list"] = "list"
+    data: list[LocalSessionSummaryOutput] = Field(default_factory=list)
 
 
 class ImportLocalSessionRequest(BaseModel):
@@ -383,13 +393,13 @@ def create_imports_router(
             raise HTTPException(status_code=409, detail="host is offline")
         return user_id, host_registry, conn
 
-    @router.get("/imports/local-sessions")
+    @router.get("/imports/local-sessions", response_model=LocalSessionListOutput)
     async def list_local_sessions(
         request: Request,
         host_id: Annotated[str, Query()],
         source: Annotated[ImportBrowseSource, Query()],
         limit: Annotated[int, Query(ge=1, le=_MAX_RECENT_LOCAL_SESSIONS)] = 10,
-    ) -> dict[str, Any]:
+    ) -> LocalSessionListOutput:
         """
         List recent Claude Code or Codex sessions on a host.
 
@@ -397,6 +407,11 @@ def create_imports_router(
         title, workspace, item count, and expandable context. Titles use
         the same synthesis the import itself applies, so a browsed row
         and the session it creates read the same.
+
+        A row the server cannot parse — e.g. from a host running an
+        older protocol version — is skipped rather than failing the
+        whole listing, matching how the CLI's own local scan treats an
+        unreadable transcript.
 
         :param request: FastAPI request (for auth).
         :param host_id: Host to browse, e.g. ``"host_a1b2c3d4..."``.
@@ -422,10 +437,18 @@ def create_imports_router(
             raise HTTPException(status_code=409, detail=exc.message) from exc
         except LocalSessionProxyError as exc:
             raise HTTPException(status_code=400, detail=exc.message) from exc
-        return {
-            "object": "list",
-            "data": [LocalSessionSummaryOutput(**entry).model_dump() for entry in sessions],
-        }
+        summaries: list[LocalSessionSummaryOutput] = []
+        for entry in sessions:
+            try:
+                summaries.append(LocalSessionSummaryOutput(**entry))
+            except (TypeError, ValidationError):
+                # A host on a different version can send a row this server
+                # can't parse; skip it rather than failing the whole picker.
+                _logger.warning(
+                    "host '%s' returned a malformed local-session row, skipping it",
+                    conn.host_id,
+                )
+        return LocalSessionListOutput(data=summaries)
 
     @router.post(
         "/imports/local-sessions",
@@ -453,8 +476,8 @@ def create_imports_router(
             session is unknown, 409 when the host is offline, 503 when
             the server has no host support.
         :raises OmnigentError: ``INVALID_INPUT`` when the host found no
-            importable history, plus whatever
-            :func:`_create_imported_session` raises.
+            importable history or returned a malformed item, plus
+            whatever :func:`_create_imported_session` raises.
         """
         user_id, registry, conn = await _resolve_online_host(request, body.host_id)
         try:
@@ -479,7 +502,13 @@ def create_imports_router(
                 "The host returned no importable history for this session",
                 code=ErrorCode.INVALID_INPUT,
             )
-        items = [ImportItemInput(**entry).to_item() for entry in raw_items]
+        try:
+            items = [ImportItemInput(**entry).to_item() for entry in raw_items]
+        except (TypeError, ValidationError) as exc:
+            raise OmnigentError(
+                f"host '{conn.host_id}' returned an invalid session item",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
         workspace = payload.get("workspace")
         async with _source_import_lock(body.source, body.external_session_id):
             result = await _create_imported_session(

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -8,9 +8,9 @@ import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Literal
+from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field, field_validator
 
 from omnigent.db.utils import builtin_agent_id
@@ -18,8 +18,16 @@ from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.native_coding_agents import native_coding_agent_for_harness
 from omnigent.server.auth import LEVEL_OWNER, AuthProvider
+from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_access, require_user
 from omnigent.server.routes._content_type import require_json_content_type
+from omnigent.server.routes._host_session_import import (
+    LocalSessionHostUnavailableError,
+    LocalSessionNotFoundError,
+    LocalSessionProxyError,
+    list_local_sessions_on_host,
+    load_local_session_on_host,
+)
 from omnigent.session_import import (
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
@@ -28,7 +36,16 @@ from omnigent.session_import import (
 )
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.conversation_store import ConversationAlreadyExistsError
+from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
+
+# The web picker only browses the two harnesses whose transcripts the
+# host daemon can read; the CLI still imports the other sources by id.
+ImportBrowseSource = Literal["claude", "codex"]
+
+# The picker parses a full transcript per row, so a deep list is slow
+# for little benefit; the CLI still imports older chats by id.
+_MAX_RECENT_LOCAL_SESSIONS = 20
 
 
 class ImportItemInput(BaseModel):
@@ -75,6 +92,41 @@ class ImportSessionResponse(BaseModel):
     session_id: str
     status: Literal["imported"]
     item_count: int
+
+
+class LocalSessionPreviewOutput(BaseModel):
+    """One preview message shown when a picker row is expanded."""
+
+    role: str
+    text: str
+
+
+class LocalSessionSummaryOutput(BaseModel):
+    """One browsable local session, as returned to the import picker."""
+
+    source: ImportBrowseSource
+    external_session_id: str
+    workspace: str | None = None
+    title: str | None = None
+    item_count: int
+    preview: list[LocalSessionPreviewOutput] = Field(default_factory=list)
+
+
+class ImportLocalSessionRequest(BaseModel):
+    """Request body for importing one session read from a host."""
+
+    host_id: str = Field(min_length=1, max_length=128)
+    source: ImportBrowseSource
+    external_session_id: str = Field(min_length=1, max_length=128)
+
+    @field_validator("external_session_id")
+    @classmethod
+    def strip_external_session_id(cls, value: str) -> str:
+        """Reject a source session id that is only whitespace."""
+        value = value.strip()
+        if not value:
+            raise ValueError("external_session_id must not be blank")
+        return value
 
 
 @dataclass
@@ -250,8 +302,24 @@ def create_imports_router(
     *,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
+    host_registry: HostRegistry | None = None,
+    host_store: HostStore | None = None,
 ) -> APIRouter:
-    """Create the local-session import router."""
+    """Create the local-session import router.
+
+    :param conversation_store: Store imported sessions are created in.
+    :param agent_store: Store used to confirm the built-in agent exists.
+    :param auth_provider: Provider resolving the caller, or ``None``
+        when auth is disabled.
+    :param permission_store: Store granting the caller ownership, or
+        ``None`` when permissions are disabled.
+    :param host_registry: Per-replica live host connections; ``None``
+        on a server without host support, which makes the
+        browse/import-from-host endpoints answer 503.
+    :param host_store: Store of registered hosts; ``None`` on a server
+        without host support.
+    :returns: The router, to be mounted under ``/v1``.
+    """
     router = APIRouter()
 
     @router.post(
@@ -281,6 +349,149 @@ def create_imports_router(
             items=items,
             force=body.force,
         )
+        response.status_code = 201
+        return result
+
+    async def _resolve_online_host(
+        request: Request,
+        host_id: str,
+    ) -> tuple[str | None, HostRegistry, HostConnection]:
+        """Authorize the caller and return a live connection to their host.
+
+        Also returns the registry so callers get it already narrowed out
+        of the optional host-support configuration.
+
+        :param request: FastAPI request (for auth).
+        :param host_id: Host identifier from the caller.
+        :returns: ``(user_id, host_registry, host_connection)``.
+        :raises HTTPException: 503 when host support is unconfigured,
+            404 when the host is unknown, 403 when it is not the
+            caller's, 409 when it is offline.
+        """
+        if host_registry is None or host_store is None:
+            raise HTTPException(
+                status_code=503, detail="host support is not configured on this server"
+            )
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+        return user_id, host_registry, conn
+
+    @router.get("/imports/local-sessions")
+    async def list_local_sessions(
+        request: Request,
+        host_id: Annotated[str, Query()],
+        source: Annotated[ImportBrowseSource, Query()],
+        limit: Annotated[int, Query(ge=1, le=_MAX_RECENT_LOCAL_SESSIONS)] = 10,
+    ) -> dict[str, Any]:
+        """
+        List recent Claude Code or Codex sessions on a host.
+
+        Backs the New Session import picker, which shows each session's
+        title, workspace, item count, and expandable context. Titles use
+        the same synthesis the import itself applies, so a browsed row
+        and the session it creates read the same.
+
+        :param request: FastAPI request (for auth).
+        :param host_id: Host to browse, e.g. ``"host_a1b2c3d4..."``.
+        :param source: ``"claude"`` or ``"codex"``.
+        :param limit: Maximum sessions to return (1-20).
+        :returns: ``{"object": "list", "data": [...]}`` newest first.
+        :raises HTTPException: 400 when the host reports a failure, 403
+            when the host is not the caller's, 404 when the host is
+            unknown, 409 when it is offline, 503 when the server has no
+            host support.
+        """
+        _user_id, registry, conn = await _resolve_online_host(request, host_id)
+        try:
+            sessions = await list_local_sessions_on_host(
+                host_registry=registry,
+                host_conn=conn,
+                source=source,
+                limit=limit,
+            )
+        # The unavailable subclass must precede its base or a dropped
+        # tunnel would read as bad user input.
+        except LocalSessionHostUnavailableError as exc:
+            raise HTTPException(status_code=409, detail=exc.message) from exc
+        except LocalSessionProxyError as exc:
+            raise HTTPException(status_code=400, detail=exc.message) from exc
+        return {
+            "object": "list",
+            "data": [LocalSessionSummaryOutput(**entry).model_dump() for entry in sessions],
+        }
+
+    @router.post(
+        "/imports/local-sessions",
+        response_model=ImportSessionResponse,
+        dependencies=[Depends(require_json_content_type)],
+    )
+    async def import_local_session(
+        body: ImportLocalSessionRequest,
+        request: Request,
+        response: Response,
+    ) -> ImportSessionResponse:
+        """
+        Import one Claude Code or Codex session read from a host.
+
+        The host loads and normalizes the transcript; the session is
+        then created through the same path the CLI's ``POST /v1/imports``
+        uses, so provenance labels and duplicate handling match.
+
+        :param body: Host, source, and harness-native session id.
+        :param request: FastAPI request (for auth).
+        :param response: Response, set to 201 on success.
+        :returns: The created session id and item count.
+        :raises HTTPException: 400 when the host reports a failure, 403
+            when the host is not the caller's, 404 when the host or the
+            session is unknown, 409 when the host is offline, 503 when
+            the server has no host support.
+        :raises OmnigentError: ``INVALID_INPUT`` when the host found no
+            importable history, plus whatever
+            :func:`_create_imported_session` raises.
+        """
+        user_id, registry, conn = await _resolve_online_host(request, body.host_id)
+        try:
+            payload = await load_local_session_on_host(
+                host_registry=registry,
+                host_conn=conn,
+                source=body.source,
+                external_session_id=body.external_session_id,
+            )
+        # Both specific errors subclass LocalSessionProxyError, so they
+        # must be caught before it or every 404/409 becomes a 400.
+        except LocalSessionNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=exc.message) from exc
+        except LocalSessionHostUnavailableError as exc:
+            raise HTTPException(status_code=409, detail=exc.message) from exc
+        except LocalSessionProxyError as exc:
+            raise HTTPException(status_code=400, detail=exc.message) from exc
+
+        raw_items = payload.get("items")
+        if not isinstance(raw_items, list) or not raw_items:
+            raise OmnigentError(
+                "The host returned no importable history for this session",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        items = [ImportItemInput(**entry).to_item() for entry in raw_items]
+        workspace = payload.get("workspace")
+        async with _source_import_lock(body.source, body.external_session_id):
+            result = await _create_imported_session(
+                conversation_store=conversation_store,
+                agent_store=agent_store,
+                permission_store=permission_store,
+                user_id=user_id,
+                source=body.source,
+                external_session_id=body.external_session_id,
+                workspace=workspace if isinstance(workspace, str) else None,
+                items=items,
+            )
         response.status_code = 201
         return result
 

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -22,6 +22,7 @@ from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_access, require_user
 from omnigent.server.routes._content_type import require_json_content_type
+from omnigent.server.routes._host_launch import resolve_host_owner
 from omnigent.server.routes._host_session_import import (
     LocalSessionHostUnavailableError,
     LocalSessionNotFoundError,
@@ -369,7 +370,12 @@ def create_imports_router(
         """Authorize the caller and return a live connection to their host.
 
         Also returns the registry so callers get it already narrowed out
-        of the optional host-support configuration.
+        of the optional host-support configuration. Ownership is checked
+        via :func:`resolve_host_owner`, the same helper the host-launch
+        routes use, so the 404/403 semantics can't drift between them —
+        these endpoints read a user's private local transcripts off
+        their host, so a cross-tenant leak here is just as serious as a
+        cross-tenant runner launch.
 
         :param request: FastAPI request (for auth).
         :param host_id: Host identifier from the caller.
@@ -383,11 +389,12 @@ def create_imports_router(
                 status_code=503, detail="host support is not configured on this server"
             )
         user_id = require_user(request, auth_provider)
-        host = await asyncio.to_thread(host_store.get_host, host_id)
-        if host is None:
-            raise HTTPException(status_code=404, detail="host not found")
-        if user_id is not None and host.user_id != user_id:
-            raise HTTPException(status_code=403, detail="not your host")
+        host = await asyncio.to_thread(
+            resolve_host_owner,
+            user_id=user_id,
+            host_id=host_id,
+            host_store=host_store,
+        )
         conn = host_registry.get(host.host_id)
         if conn is None:
             raise HTTPException(status_code=409, detail="host is offline")

--- a/omnigent/session_import/__init__.py
+++ b/omnigent/session_import/__init__.py
@@ -6,7 +6,10 @@ from omnigent.session_import.models import (
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
     LocalSessionImport,
+    LocalSessionPreviewMessage,
+    LocalSessionSummary,
     SessionImportNotFoundError,
+    summarize_local_session,
     title_from_items,
 )
 
@@ -16,6 +19,9 @@ __all__ = [
     "IMPORT_SOURCE_LABEL_KEY",
     "ImportSource",
     "LocalSessionImport",
+    "LocalSessionPreviewMessage",
+    "LocalSessionSummary",
     "SessionImportNotFoundError",
+    "summarize_local_session",
     "title_from_items",
 ]

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -29,7 +29,9 @@ from omnigent.opencode_native_forwarder import opencode_tool_output_text
 from omnigent.session_import.models import (
     ImportSource,
     LocalSessionImport,
+    LocalSessionSummary,
     SessionImportNotFoundError,
+    summarize_local_session,
 )
 
 _PI_IMPORT_SESSION_ID_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
@@ -258,6 +260,37 @@ def list_recent_local_session_ids(
         return _recent_unique_session_ids(candidates, limit=limit)
 
     raise ValueError(f"Unsupported import source: {source}")
+
+
+def list_recent_local_sessions(
+    source: ImportSource,
+    *,
+    limit: int,
+    preview_limit: int = 6,
+) -> tuple[LocalSessionSummary, ...]:
+    """Summarize the most recent local sessions for one harness.
+
+    Each candidate is loaded through :func:`load_local_session` — the
+    same path the import itself takes — so the browsed title, workspace,
+    and item count match what importing would produce. A transcript that
+    fails to load is skipped rather than failing the whole listing.
+
+    :param source: Harness that owns the sessions, e.g. ``"claude"``.
+    :param limit: Maximum sessions to return.
+    :param preview_limit: Maximum preview messages per session.
+    :returns: Summaries ordered newest transcript first.
+    :raises SessionImportNotFoundError: When the harness's session
+        directory cannot be enumerated at all.
+    :raises ValueError: When ``source`` is not a supported harness.
+    """
+    summaries: list[LocalSessionSummary] = []
+    for session_id in list_recent_local_session_ids(source, limit=limit):
+        try:
+            imported = load_local_session(source, session_id)
+        except (SessionImportNotFoundError, OSError, TypeError, ValueError):
+            continue
+        summaries.append(summarize_local_session(imported, preview_limit=preview_limit))
+    return tuple(summaries)
 
 
 def _claude_workspace(transcript_path: Path) -> str | None:
@@ -1218,6 +1251,7 @@ def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImp
 
 __all__ = [
     "list_recent_local_session_ids",
+    "list_recent_local_sessions",
     "load_claude_session",
     "load_codex_session",
     "load_kimi_session",

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from omnigent.entities import MessageData, NewConversationItem
-from omnigent.entities.conversation import synthesize_conversation_title
+from omnigent.entities.conversation import (
+    strip_attachment_marker_lines,
+    synthesize_conversation_title,
+)
 
 ImportSource = Literal["claude", "codex", "kimi", "kiro", "opencode", "pi", "qwen"]
 
@@ -79,13 +82,20 @@ class LocalSessionSummary:
     preview: tuple[LocalSessionPreviewMessage, ...]
 
 
-def _preview_text(content: list[dict[str, object]]) -> str | None:
-    """Collapse message content blocks into one truncated preview line."""
-    parts = [
-        text.strip()
-        for block in content
-        if isinstance(block, dict) and isinstance(text := block.get("text"), str)
-    ]
+def _preview_text(content: list[dict[str, Any]]) -> str | None:
+    """Collapse message content blocks into one truncated preview line.
+
+    Mirrors :func:`synthesize_conversation_title`: only text-bearing
+    blocks are read, and native attachment path markers are stripped
+    so a temp-file path never shows up in a picker preview.
+    """
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") not in ("input_text", "output_text"):
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            parts.append(strip_attachment_marker_lines(text))
     collapsed = " ".join(" ".join(parts).split())
     if not collapsed:
         return None

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -40,6 +40,96 @@ class LocalSessionImport:
         return title_from_items(self.items)
 
 
+# Preview text is one line in a picker row; longer strings only push the
+# useful part of the message off screen.
+_PREVIEW_TEXT_LIMIT = 240
+
+
+@dataclass(frozen=True)
+class LocalSessionPreviewMessage:
+    """One visible message shown when a picker row is expanded.
+
+    :param role: ``"user"`` or ``"assistant"``.
+    :param text: Collapsed message text, truncated to 240 characters.
+    """
+
+    role: str
+    text: str
+
+
+@dataclass(frozen=True)
+class LocalSessionSummary:
+    """One local transcript described well enough to pick from a list.
+
+    :param source: Harness that owns the session, e.g. ``"claude"``.
+    :param external_session_id: Harness-native session id.
+    :param workspace: Absolute working directory recorded in the
+        transcript, or ``None`` when the harness records none.
+    :param title: Title synthesized by :func:`title_from_items`, or
+        ``None`` when the transcript has no usable user text.
+    :param item_count: Number of Omnigent items the import would create.
+    :param preview: Leading visible messages, for the expandable row.
+    """
+
+    source: ImportSource
+    external_session_id: str
+    workspace: str | None
+    title: str | None
+    item_count: int
+    preview: tuple[LocalSessionPreviewMessage, ...]
+
+
+def _preview_text(content: list[dict[str, object]]) -> str | None:
+    """Collapse message content blocks into one truncated preview line."""
+    parts = [
+        text.strip()
+        for block in content
+        if isinstance(block, dict) and isinstance(text := block.get("text"), str)
+    ]
+    collapsed = " ".join(" ".join(parts).split())
+    if not collapsed:
+        return None
+    if len(collapsed) > _PREVIEW_TEXT_LIMIT:
+        return collapsed[: _PREVIEW_TEXT_LIMIT - 1] + "…"
+    return collapsed
+
+
+def summarize_local_session(
+    imported: LocalSessionImport,
+    *,
+    preview_limit: int = 6,
+) -> LocalSessionSummary:
+    """Describe one loaded transcript for the import picker.
+
+    The title comes from :func:`title_from_items` so a browsed row and
+    the session it creates always read the same.
+
+    :param imported: The loaded transcript.
+    :param preview_limit: Maximum preview messages to keep.
+    :returns: The picker-facing summary.
+    """
+    preview: list[LocalSessionPreviewMessage] = []
+    for item in imported.items:
+        if len(preview) >= preview_limit:
+            break
+        data = item.data
+        if not isinstance(data, MessageData) or data.is_meta:
+            continue
+        if data.role not in ("user", "assistant"):
+            continue
+        text = _preview_text(data.content)
+        if text is not None:
+            preview.append(LocalSessionPreviewMessage(role=data.role, text=text))
+    return LocalSessionSummary(
+        source=imported.source,
+        external_session_id=imported.external_session_id,
+        workspace=imported.workspace,
+        title=imported.title,
+        item_count=len(imported.items),
+        preview=tuple(preview),
+    )
+
+
 def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
     """Return a sidebar title derived from the first user message."""
     for item in items:

--- a/openapi.json
+++ b/openapi.json
@@ -1784,6 +1784,38 @@
         "title": "ImportItemInput",
         "type": "object"
       },
+      "ImportLocalSessionRequest": {
+        "description": "Request body for importing one session read from a host.",
+        "properties": {
+          "external_session_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "External Session Id",
+            "type": "string"
+          },
+          "host_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Host Id",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "claude",
+              "codex"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "host_id",
+          "source",
+          "external_session_id"
+        ],
+        "title": "ImportLocalSessionRequest",
+        "type": "object"
+      },
       "ImportSessionRequest": {
         "description": "Request body for importing one local harness session.",
         "properties": {
@@ -7890,6 +7922,119 @@
           }
         },
         "summary": "Import Session",
+        "tags": [
+          "imports"
+        ]
+      }
+    },
+    "/v1/imports/local-sessions": {
+      "get": {
+        "description": "List recent Claude Code or Codex sessions on a host.\n\nBacks the New Session import picker, which shows each session's\ntitle, workspace, item count, and expandable context. Titles use\nthe same synthesis the import itself applies, so a browsed row\nand the session it creates read the same.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...]}` newest first.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host is unknown, 409 when it is offline, 503 when the server has no host support.",
+        "operationId": "list_local_sessions_v1_imports_local_sessions_get",
+        "parameters": [
+          {
+            "description": "Host to browse, e.g. `\"host_a1b2c3d4...\"`.",
+            "in": "query",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`\"claude\"` or `\"codex\"`.",
+            "in": "query",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "enum": [
+                "claude",
+                "codex"
+              ],
+              "title": "Source",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum sessions to return (1-20).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Local Sessions V1 Imports Local Sessions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Local Sessions",
+        "tags": [
+          "imports"
+        ]
+      },
+      "post": {
+        "description": "Import one Claude Code or Codex session read from a host.\n\nThe host loads and normalizes the transcript; the session is\nthen created through the same path the CLI's `POST /v1/imports`\nuses, so provenance labels and duplicate handling match.\n\n**Parameters**\n\n- `body` \u2014 Host, source, and harness-native session id.\n\n**Returns:** The created session id and item count.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host or the session is unknown, 409 when the host is offline, 503 when the server has no host support.\n- `OmnigentError` \u2014 `INVALID_INPUT` when the host found no importable history, plus whatever `_create_imported_session` raises.",
+        "operationId": "import_local_session_v1_imports_local_sessions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportLocalSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Import Local Session",
         "tags": [
           "imports"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -2011,6 +2011,102 @@
         "title": "LaunchRunnerRequest",
         "type": "object"
       },
+      "LocalSessionListOutput": {
+        "description": "Envelope returned by the local-session browse endpoint.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LocalSessionSummaryOutput"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "object": {
+            "const": "list",
+            "default": "list",
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "title": "LocalSessionListOutput",
+        "type": "object"
+      },
+      "LocalSessionPreviewOutput": {
+        "description": "One preview message shown when a picker row is expanded.",
+        "properties": {
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "text"
+        ],
+        "title": "LocalSessionPreviewOutput",
+        "type": "object"
+      },
+      "LocalSessionSummaryOutput": {
+        "description": "One browsable local session, as returned to the import picker.",
+        "properties": {
+          "external_session_id": {
+            "title": "External Session Id",
+            "type": "string"
+          },
+          "item_count": {
+            "title": "Item Count",
+            "type": "integer"
+          },
+          "preview": {
+            "items": {
+              "$ref": "#/components/schemas/LocalSessionPreviewOutput"
+            },
+            "title": "Preview",
+            "type": "array"
+          },
+          "source": {
+            "enum": [
+              "claude",
+              "codex"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "workspace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace"
+          }
+        },
+        "required": [
+          "source",
+          "external_session_id",
+          "item_count"
+        ],
+        "title": "LocalSessionSummaryOutput",
+        "type": "object"
+      },
       "MCPServerSummary": {
         "description": "Safe subset of an MCP server's configuration for API exposure.\n\nHeader values are redacted (`\"[REDACTED]\"`) so callers can see\nwhich headers are configured without leaking the actual secrets.\n`env` is still fully excluded.",
         "properties": {
@@ -7929,7 +8025,7 @@
     },
     "/v1/imports/local-sessions": {
       "get": {
-        "description": "List recent Claude Code or Codex sessions on a host.\n\nBacks the New Session import picker, which shows each session's\ntitle, workspace, item count, and expandable context. Titles use\nthe same synthesis the import itself applies, so a browsed row\nand the session it creates read the same.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...]}` newest first.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host is unknown, 409 when it is offline, 503 when the server has no host support.",
+        "description": "List recent Claude Code or Codex sessions on a host.\n\nBacks the New Session import picker, which shows each session's\ntitle, workspace, item count, and expandable context. Titles use\nthe same synthesis the import itself applies, so a browsed row\nand the session it creates read the same.\n\nA row the server cannot parse \u2014 e.g. from a host running an\nolder protocol version \u2014 is skipped rather than failing the\nwhole listing, matching how the CLI's own local scan treats an\nunreadable transcript.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...]}` newest first.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host is unknown, 409 when it is offline, 503 when the server has no host support.",
         "operationId": "list_local_sessions_v1_imports_local_sessions_get",
         "parameters": [
           {
@@ -7975,9 +8071,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response List Local Sessions V1 Imports Local Sessions Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/LocalSessionListOutput"
                 }
               }
             },
@@ -8000,7 +8094,7 @@
         ]
       },
       "post": {
-        "description": "Import one Claude Code or Codex session read from a host.\n\nThe host loads and normalizes the transcript; the session is\nthen created through the same path the CLI's `POST /v1/imports`\nuses, so provenance labels and duplicate handling match.\n\n**Parameters**\n\n- `body` \u2014 Host, source, and harness-native session id.\n\n**Returns:** The created session id and item count.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host or the session is unknown, 409 when the host is offline, 503 when the server has no host support.\n- `OmnigentError` \u2014 `INVALID_INPUT` when the host found no importable history, plus whatever `_create_imported_session` raises.",
+        "description": "Import one Claude Code or Codex session read from a host.\n\nThe host loads and normalizes the transcript; the session is\nthen created through the same path the CLI's `POST /v1/imports`\nuses, so provenance labels and duplicate handling match.\n\n**Parameters**\n\n- `body` \u2014 Host, source, and harness-native session id.\n\n**Returns:** The created session id and item count.\n\n**Raises**\n\n- `HTTPException` \u2014 400 when the host reports a failure, 403 when the host is not the caller's, 404 when the host or the session is unknown, 409 when the host is offline, 503 when the server has no host support.\n- `OmnigentError` \u2014 `INVALID_INPUT` when the host found no importable history or returned a malformed item, plus whatever `_create_imported_session` raises.",
         "operationId": "import_local_session_v1_imports_local_sessions_post",
         "requestBody": {
           "content": {

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import subprocess
 import threading
@@ -3784,3 +3785,116 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     while time.monotonic() < deadline and spawned[0].poll() is None:
         await asyncio.sleep(0.05)
     assert spawned[0].poll() is not None, "abandoned runner was leaked, still alive"
+
+
+async def test_handle_list_local_sessions_returns_summaries(monkeypatch) -> None:
+    """The host answers a browse request with picker-ready summaries."""
+    from omnigent.host.frames import HostListLocalSessionsFrame
+    from omnigent.session_import.models import (
+        LocalSessionPreviewMessage,
+        LocalSessionSummary,
+    )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_local_sessions",
+        lambda source, *, limit: (
+            LocalSessionSummary(
+                source="claude",
+                external_session_id="abc",
+                workspace="/repo",
+                title="inspect TODO.md",
+                item_count=4,
+                preview=(LocalSessionPreviewMessage(role="user", text="inspect TODO.md"),),
+            ),
+        ),
+    )
+
+    host = _make_host_process()
+    result = await host._handle_list_local_sessions(
+        HostListLocalSessionsFrame(request_id="r1", source="claude", limit=10)
+    )
+
+    assert result.status == "ok"
+    assert result.sessions == [
+        {
+            "source": "claude",
+            "external_session_id": "abc",
+            "workspace": "/repo",
+            "title": "inspect TODO.md",
+            "item_count": 4,
+            "preview": [{"role": "user", "text": "inspect TODO.md"}],
+        }
+    ]
+
+
+async def test_handle_list_local_sessions_rejects_unsupported_source() -> None:
+    """Only Claude and Codex can be browsed from the web picker."""
+    from omnigent.host.frames import HostListLocalSessionsFrame
+
+    host = _make_host_process()
+    result = await host._handle_list_local_sessions(
+        HostListLocalSessionsFrame(request_id="r1", source="qwen", limit=10)
+    )
+
+    assert result.status == "failed"
+    assert result.sessions is None
+    assert "qwen" in (result.error or "")
+
+
+async def test_handle_load_local_session_returns_serializable_items(monkeypatch) -> None:
+    """A loaded transcript comes back as JSON-ready item dicts."""
+    from omnigent.entities import NewConversationItem, parse_item_data
+    from omnigent.host.frames import HostLoadLocalSessionFrame
+    from omnigent.session_import.models import LocalSessionImport
+
+    loaded = LocalSessionImport(
+        source="claude",
+        external_session_id="abc",
+        workspace="/repo",
+        items=(
+            NewConversationItem(
+                type="message",
+                response_id="claude:1",
+                data=parse_item_data(
+                    "message",
+                    {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.session_import.local.load_local_session", lambda source, sid: loaded
+    )
+
+    host = _make_host_process()
+    result = await host._handle_load_local_session(
+        HostLoadLocalSessionFrame(request_id="r2", source="claude", external_session_id="abc")
+    )
+
+    assert result.status == "ok"
+    assert result.session is not None
+    assert result.session["external_session_id"] == "abc"
+    assert result.session["workspace"] == "/repo"
+    assert result.session["items"][0]["type"] == "message"
+    assert result.session["items"][0]["response_id"] == "claude:1"
+    assert json.dumps(result.session)  # must be JSON-serializable
+
+
+async def test_handle_load_local_session_reports_missing_session(monkeypatch) -> None:
+    """A missing transcript is a not_found status, not an exception."""
+    from omnigent.host.frames import HostLoadLocalSessionFrame
+    from omnigent.session_import import SessionImportNotFoundError
+
+    def _missing(source, session_id):
+        raise SessionImportNotFoundError("Claude Code session 'gone' was not found")
+
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _missing)
+
+    host = _make_host_process()
+    result = await host._handle_load_local_session(
+        HostLoadLocalSessionFrame(request_id="r2", source="claude", external_session_id="gone")
+    )
+
+    assert result.status == "not_found"
+    assert result.session is None
+    assert "gone" in (result.error or "")

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -25,8 +25,12 @@ from omnigent.host.frames import (
     HostListDirEntry,
     HostListDirFrame,
     HostListDirResultFrame,
+    HostListLocalSessionsFrame,
+    HostListLocalSessionsResultFrame,
     HostListWorktreesFrame,
     HostListWorktreesResultFrame,
+    HostLoadLocalSessionFrame,
+    HostLoadLocalSessionResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
     HostRemoveWorktreeFrame,
@@ -1540,3 +1544,119 @@ def test_fs_result_null_payload_round_trip() -> None:
     assert isinstance(decoded, HostFsResultFrame)
     assert decoded.payload is None
     assert decoded.error_status == 500
+
+
+# ── host.list_local_sessions frames ─────────────────────
+
+
+def test_list_local_sessions_frame_round_trip() -> None:
+    """A browse request survives encode/decode."""
+    frame = HostListLocalSessionsFrame(request_id="req_ls_1", source="claude", limit=10)
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+
+
+def test_list_local_sessions_result_frame_round_trip() -> None:
+    """A successful browse result survives encode/decode."""
+    frame = HostListLocalSessionsResultFrame(
+        request_id="req_ls_1",
+        status="ok",
+        sessions=[
+            {
+                "source": "claude",
+                "external_session_id": "abc",
+                "workspace": "/repo",
+                "title": "inspect TODO.md",
+                "item_count": 4,
+                "preview": [{"role": "user", "text": "inspect TODO.md"}],
+            }
+        ],
+    )
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+
+
+def test_list_local_sessions_result_frame_failure_round_trip() -> None:
+    """A failed browse result carries the error and no sessions."""
+    frame = HostListLocalSessionsResultFrame(
+        request_id="req_ls_1", status="failed", error="no claude sessions"
+    )
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+    assert isinstance(decoded, HostListLocalSessionsResultFrame)
+    assert decoded.sessions is None
+
+
+def test_list_local_sessions_result_frame_rejects_non_list() -> None:
+    """A non-list 'sessions' field is rejected at decode time."""
+    with pytest.raises(ValueError):
+        decode_host_frame(
+            '{"kind": "host.list_local_sessions_result", "request_id": "r", '
+            '"status": "ok", "sessions": {}}'
+        )
+
+
+# ── host.load_local_session frames ──────────────────────
+
+
+def test_load_local_session_frame_round_trip() -> None:
+    """A load request survives encode/decode."""
+    frame = HostLoadLocalSessionFrame(
+        request_id="req_load_1", source="codex", external_session_id="thread-1"
+    )
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+
+
+def test_load_local_session_result_frame_round_trip() -> None:
+    """A loaded transcript survives encode/decode."""
+    frame = HostLoadLocalSessionResultFrame(
+        request_id="req_load_1",
+        status="ok",
+        session={
+            "source": "codex",
+            "external_session_id": "thread-1",
+            "workspace": "/repo",
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "codex:1",
+                    "data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                }
+            ],
+        },
+    )
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+
+
+def test_load_local_session_result_frame_reports_not_found() -> None:
+    """A missing session round-trips as a not_found status."""
+    frame = HostLoadLocalSessionResultFrame(
+        request_id="req_load_1", status="not_found", error="session 'x' was not found"
+    )
+
+    decoded = decode_host_frame(encode_host_frame(frame))
+
+    assert decoded == frame
+    assert isinstance(decoded, HostLoadLocalSessionResultFrame)
+    assert decoded.session is None
+
+
+def test_load_local_session_result_frame_rejects_non_object_session() -> None:
+    """A non-object 'session' field is rejected at decode time."""
+    with pytest.raises(ValueError):
+        decode_host_frame(
+            '{"kind": "host.load_local_session_result", "request_id": "r", '
+            '"status": "ok", "session": []}'
+        )

--- a/tests/server/routes/test_host_session_import.py
+++ b/tests/server/routes/test_host_session_import.py
@@ -1,0 +1,288 @@
+"""
+Tests for ``omnigent.server.routes._host_session_import``.
+
+Drives the list/load local-session proxies with a fake host that
+auto-replies to the outbound frames — verifies the request_id/future
+plumbing, success unpacking, failure surfacing, and offline/timeout
+handling without a live host process. Mirrors ``test_host_worktree.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from omnigent.host.frames import (
+    HostHelloFrame,
+    HostListLocalSessionsFrame,
+    HostLoadLocalSessionFrame,
+    decode_host_frame,
+)
+from omnigent.server.host_registry import HostRegistry
+from omnigent.server.routes._host_session_import import (
+    LocalSessionHostUnavailableError,
+    LocalSessionNotFoundError,
+    LocalSessionProxyError,
+    list_local_sessions_on_host,
+    load_local_session_on_host,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_HOST_ID = "host_ls_test"
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in capturing outbound frames."""
+
+    def __init__(self) -> None:
+        """Initialize with an empty outbound capture."""
+        self.sent: list[str] = []
+
+    async def send_text(self, data: str) -> None:
+        """Capture an outbound frame.
+
+        :param data: JSON-encoded frame text.
+        """
+        self.sent.append(data)
+
+
+def _hello_frame() -> HostHelloFrame:
+    """Construct a hello frame for registry registration.
+
+    :returns: Hello frame with default version + empty runners.
+    """
+    return HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="ls-host")
+
+
+@pytest.fixture()
+async def host_setup() -> AsyncIterator[HostRegistry]:
+    """Register a host plus a background auto-replier for local-session frames.
+
+    Tests set ``registry._list_reply_for_test`` /
+    ``registry._load_reply_for_test`` before calling the proxy; the
+    drain task resolves the matching pending future with that reply,
+    mimicking ``host_tunnel.py``'s receive loop.
+
+    :returns: Async iterator yielding the registry.
+    """
+    registry = HostRegistry()
+    ws = _FakeWebSocket()
+    conn = registry.register(
+        host_id=_HOST_ID,
+        ws=ws,  # type: ignore[arg-type] — duck-typed
+        hello=_hello_frame(),
+        owner=None,
+    )
+
+    list_reply: dict[str, Any] = {}
+    load_reply: dict[str, Any] = {}
+    # Frames the proxy sent, captured here (registry.send_text enqueues
+    # to outbound_queue rather than ws.send_text, so we record from the
+    # drain task instead of from the fake ws).
+    sent_frames: list[Any] = []
+
+    async def _drain() -> None:
+        """Read outbound frames, record them, and resolve the future."""
+        while True:
+            frame_text = await conn.outbound_queue.get()
+            if frame_text is None:
+                return
+            frame = decode_host_frame(frame_text)
+            sent_frames.append(frame)
+            if isinstance(frame, HostListLocalSessionsFrame):
+                fut = conn.pending_list_local_sessions.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result(list_reply)
+            elif isinstance(frame, HostLoadLocalSessionFrame):
+                fut = conn.pending_load_local_session.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result(load_reply)
+
+    drain_task = asyncio.create_task(_drain())
+    registry._list_reply_for_test = list_reply  # type: ignore[attr-defined]
+    registry._load_reply_for_test = load_reply  # type: ignore[attr-defined]
+    registry._sent_frames_for_test = sent_frames  # type: ignore[attr-defined]
+
+    try:
+        yield registry
+    finally:
+        conn.outbound_queue.put_nowait(None)
+        try:
+            await asyncio.wait_for(drain_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            drain_task.cancel()
+
+
+async def test_list_local_sessions_success_returns_sessions(host_setup: HostRegistry) -> None:
+    """A successful host reply is returned as the session list."""
+    registry = host_setup
+    sessions = [{"source": "claude", "external_session_id": "abc", "item_count": 3}]
+    registry._list_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "ok", "sessions": sessions, "error": None}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    result = await list_local_sessions_on_host(
+        host_registry=registry, host_conn=conn, source="claude", limit=10
+    )
+
+    assert result == sessions
+    sent = registry._sent_frames_for_test[-1]  # type: ignore[attr-defined]
+    assert isinstance(sent, HostListLocalSessionsFrame)
+    assert sent.source == "claude"
+    assert sent.limit == 10
+
+
+async def test_list_local_sessions_failure_surfaced(host_setup: HostRegistry) -> None:
+    """A host ``status: failed`` reply raises with the host's error message."""
+    registry = host_setup
+    registry._list_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "failed", "sessions": None, "error": "no sessions"}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(LocalSessionProxyError) as exc:
+        await list_local_sessions_on_host(
+            host_registry=registry, host_conn=conn, source="claude", limit=10
+        )
+    assert "no sessions" in exc.value.message
+
+
+async def test_list_local_sessions_invalid_ok_result_rejected(host_setup: HostRegistry) -> None:
+    """An ``ok`` reply missing the sessions list is rejected, not silently accepted."""
+    registry = host_setup
+    registry._list_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "ok", "sessions": None, "error": None}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(LocalSessionProxyError) as exc:
+        await list_local_sessions_on_host(
+            host_registry=registry, host_conn=conn, source="claude", limit=10
+        )
+    assert "invalid session list" in exc.value.message
+
+
+async def test_load_local_session_success_returns_session(host_setup: HostRegistry) -> None:
+    """A successful host reply is returned as the session payload."""
+    registry = host_setup
+    session = {
+        "source": "claude",
+        "external_session_id": "abc",
+        "workspace": "/repo",
+        "items": [{"type": "user", "response_id": None, "data": {}}],
+    }
+    registry._load_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "ok", "session": session, "error": None}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    result = await load_local_session_on_host(
+        host_registry=registry, host_conn=conn, source="claude", external_session_id="abc"
+    )
+
+    assert result == session
+    sent = registry._sent_frames_for_test[-1]  # type: ignore[attr-defined]
+    assert isinstance(sent, HostLoadLocalSessionFrame)
+    assert sent.source == "claude"
+    assert sent.external_session_id == "abc"
+
+
+async def test_load_local_session_not_found_surfaced(host_setup: HostRegistry) -> None:
+    """A ``not_found`` host reply raises the not-found subclass, not the base error."""
+    registry = host_setup
+    registry._load_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "not_found", "session": None, "error": "gone"}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(LocalSessionNotFoundError) as exc:
+        await load_local_session_on_host(
+            host_registry=registry, host_conn=conn, source="claude", external_session_id="x"
+        )
+    assert "gone" in exc.value.message
+
+
+async def test_load_local_session_failure_surfaced(host_setup: HostRegistry) -> None:
+    """A host ``status: failed`` reply raises the base proxy error, not not-found."""
+    registry = host_setup
+    registry._load_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "failed", "session": None, "error": "unreadable transcript"}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(LocalSessionProxyError) as exc:
+        await load_local_session_on_host(
+            host_registry=registry, host_conn=conn, source="claude", external_session_id="x"
+        )
+    assert "unreadable transcript" in exc.value.message
+    assert not isinstance(exc.value, LocalSessionNotFoundError)
+
+
+async def test_list_local_sessions_connection_lost_raises_unavailable(
+    host_setup: HostRegistry,
+) -> None:
+    """A dropped host connection raises LocalSessionHostUnavailableError.
+
+    Distinct from a host-reported failure: send_text raises
+    ConnectionError when the conn was replaced/deregistered, and the
+    proxy must classify that as host-unavailable (mapped to 409 by the
+    route), not a user-input LocalSessionProxyError (400).
+    """
+    registry = host_setup
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    # Deregister so the registry no longer recognizes this conn ->
+    # send_text raises ConnectionError on the next send.
+    registry.deregister(_HOST_ID)
+
+    with pytest.raises(LocalSessionHostUnavailableError) as exc:
+        await list_local_sessions_on_host(
+            host_registry=registry, host_conn=conn, source="claude", limit=10
+        )
+    assert "connection lost" in exc.value.message
+    # It IS a LocalSessionProxyError subclass (so best-effort callers still
+    # catch it) but the specific type drives the 409 mapping.
+    assert isinstance(exc.value, LocalSessionProxyError)
+
+
+async def test_load_local_session_timeout_raises_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No host reply within the timeout raises LocalSessionHostUnavailableError.
+
+    Uses a host with no auto-replier so the pending future never
+    resolves; a tiny patched timeout keeps the test fast (well under
+    the real 60s budget).
+    """
+    import omnigent.server.routes._host_session_import as proxy
+
+    monkeypatch.setattr(proxy, "_LOCAL_SESSION_TIMEOUT_S", 0.05)
+    registry = HostRegistry()
+    registry.register(
+        host_id="host_silent",
+        ws=_FakeWebSocket(),  # type: ignore[arg-type] — duck-typed
+        hello=_hello_frame(),
+        owner=None,
+    )
+    conn = registry.get("host_silent")
+    assert conn is not None
+
+    with pytest.raises(LocalSessionHostUnavailableError) as exc:
+        await load_local_session_on_host(
+            host_registry=registry, host_conn=conn, source="claude", external_session_id="x"
+        )
+    assert "did not respond" in exc.value.message
+    # The finally-block cleanup must run even on the timeout path, or the
+    # pending-future map leaks an entry per silent host.
+    assert conn.pending_load_local_session == {}

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -318,6 +318,20 @@ async def test_list_local_sessions_returns_host_summaries(
     assert body["data"][0]["external_session_id"] == "abc"
     assert body["data"][0]["item_count"] == 4
     assert body["data"][0]["preview"] == [{"role": "user", "text": "inspect TODO.md"}]
+    # The picker reads this envelope directly, so lock its exact shape.
+    assert body == {
+        "object": "list",
+        "data": [
+            {
+                "source": "claude",
+                "external_session_id": "abc",
+                "workspace": "/repo",
+                "title": "inspect TODO.md",
+                "item_count": 4,
+                "preview": [{"role": "user", "text": "inspect TODO.md"}],
+            }
+        ],
+    }
 
 
 async def test_list_local_sessions_rejects_unsupported_source(host_env: _HostEnv) -> None:
@@ -410,6 +424,45 @@ async def test_list_local_sessions_maps_lost_connection_to_conflict(
     )
 
     assert response.status_code == 409
+
+
+async def test_list_local_sessions_skips_malformed_row(
+    host_env: _HostEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row this server can't parse is skipped, not a 500 for the whole picker."""
+    import omnigent.server.routes.imports as imports_module
+
+    async def _fake_list(
+        *, host_registry: object, host_conn: object, source: str, limit: int
+    ) -> list[object]:
+        """Return well-formed rows around the shapes a skewed host might send."""
+        return [
+            {
+                "source": "claude",
+                "external_session_id": "good",
+                "workspace": "/repo",
+                "title": "inspect TODO.md",
+                "item_count": 4,
+                "preview": [],
+            },
+            {"source": "claude", "external_session_id": "bad"},  # missing item_count
+            "not-even-a-mapping",
+            # Trailing good row: a loop that aborts on the first bad
+            # entry would drop this one.
+            {"source": "claude", "external_session_id": "also-good", "item_count": 2},
+        ]
+
+    monkeypatch.setattr(imports_module, "list_local_sessions_on_host", _fake_list)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_A, "source": "claude"}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [row["external_session_id"] for row in body["data"]] == ["good", "also-good"]
 
 
 async def test_local_session_endpoints_require_host_support(client: httpx.AsyncClient) -> None:
@@ -601,4 +654,48 @@ async def test_import_local_session_rejects_empty_history(
     assert response.status_code == 400
     assert (
         SqlAlchemyConversationStore(db_uri).find_imported_conversation("claude", "empty") is None
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_item",
+    [
+        pytest.param({"type": "message"}, id="missing-required-fields"),
+        pytest.param("not-even-a-mapping", id="not-a-mapping"),
+    ],
+)
+async def test_import_local_session_rejects_malformed_item(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_item: object,
+) -> None:
+    """A host-returned item the server can't parse is a 400, not a crash."""
+    import omnigent.server.routes.imports as imports_module
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Return a transcript whose one item this server cannot parse."""
+        return {
+            "source": "claude",
+            "external_session_id": external_session_id,
+            "workspace": "/repo",
+            "items": [bad_item],
+        }
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "malformed"},
+    )
+
+    assert response.status_code == 400
+    assert (
+        SqlAlchemyConversationStore(db_uri).find_imported_conversation("claude", "malformed")
+        is None
     )

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -104,6 +104,49 @@ async def host_env(
         )
 
 
+@pytest_asyncio.fixture()
+async def auth_host_env(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> AsyncIterator[_HostEnv]:
+    """Build a ``host_env`` with a real auth provider wired in.
+
+    ``host_env`` builds its app without an ``auth_provider``, so
+    ``require_user`` always returns ``None`` and the cross-tenant
+    branch of the host-owner check can never fire. This mirrors it but
+    adds ``UnifiedAuthProvider`` in strict header mode (the deployed
+    multi-user posture), so requests need an ``X-Forwarded-Email``
+    header and the ownership check is actually exercised.
+
+    :param runtime_init: Ensures runtime singletons are initialized.
+    :param db_uri: SQLite URI shared by every store in the app.
+    :param tmp_path: Per-test scratch dir for artifact/cache stores.
+    :returns: Async iterator yielding the assembled environment.
+    """
+    from omnigent.server.auth import UnifiedAuthProvider
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    host_store = HostStore(db_uri)
+    app: FastAPI = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        host_store=host_store,
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield _HostEnv(
+            client=client,
+            host_store=host_store,
+            host_registry=app.state.host_registry,
+        )
+
+
 def _register_offline_host(env: _HostEnv, host_id: str) -> None:
     """Record a host the caller owns that has no live connection.
 
@@ -114,18 +157,19 @@ def _register_offline_host(env: _HostEnv, host_id: str) -> None:
     env.host_store.set_offline(host_id)
 
 
-def _connect_host(env: _HostEnv, host_id: str) -> None:
-    """Record a host the caller owns and put a live connection in the registry.
+def _connect_host(env: _HostEnv, host_id: str, owner: str = _HOST_OWNER) -> None:
+    """Record a host owned by ``owner`` and put a live connection in the registry.
 
     :param env: The host-enabled environment.
     :param host_id: Host identifier to connect.
+    :param owner: User id the host is registered under.
     """
-    env.host_store.upsert_on_connect(host_id, name=host_id, user_id=_HOST_OWNER)
+    env.host_store.upsert_on_connect(host_id, name=host_id, user_id=owner)
     env.host_registry.register(
         host_id=host_id,
         ws=_FakeHostWebSocket(),  # type: ignore[arg-type] — duck-typed
         hello=HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name=host_id),
-        owner=_HOST_OWNER,
+        owner=owner,
     )
 
 
@@ -377,6 +421,26 @@ async def test_list_local_sessions_reports_unknown_host(host_env: _HostEnv) -> N
     assert response.status_code == 404
 
 
+async def test_list_local_sessions_rejects_other_users_host(auth_host_env: _HostEnv) -> None:
+    """Browsing another user's host is a 403, via the shared host-owner check.
+
+    Pins the browse endpoint to :func:`resolve_host_owner`'s exact
+    contract rather than a bespoke inline check: same status code and
+    the same ``"not your host"`` detail text asserted for the
+    host-launch routes.
+    """
+    _connect_host(auth_host_env, _HOST_A, owner="alice@example.com")
+
+    response = await auth_host_env.client.get(
+        "/v1/imports/local-sessions",
+        params={"host_id": _HOST_A, "source": "claude"},
+        headers={"X-Forwarded-Email": "bob@example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json().get("detail") == "not your host"
+
+
 async def test_list_local_sessions_surfaces_host_failure(
     host_env: _HostEnv,
     monkeypatch: pytest.MonkeyPatch,
@@ -533,6 +597,29 @@ async def test_import_local_session_creates_session(
     assert conversation.workspace == "/repo"
     assert conversation.external_session_id == "abc"
     assert conversation.labels["omnigent.wrapper"] == "claude-code-native-ui"
+
+
+async def test_import_local_session_rejects_other_users_host(
+    auth_host_env: _HostEnv,
+) -> None:
+    """Importing from another user's host is a 403, not a private transcript leak.
+
+    Without the shared ownership check, naming another user's
+    ``host_id`` would proxy that user's local Claude/Codex history
+    into the caller's session. Asserting the same detail text as the
+    host-launch routes pins this to :func:`resolve_host_owner` rather
+    than a route-local reimplementation.
+    """
+    _connect_host(auth_host_env, _HOST_A, owner="alice@example.com")
+
+    response = await auth_host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+        headers={"X-Forwarded-Email": "bob@example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json().get("detail") == "not your host"
 
 
 async def test_import_local_session_reports_missing_source_session(

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -3,12 +3,33 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
 
 from omnigent.db.utils import builtin_agent_id
+from omnigent.host.frames import HostHelloFrame
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.host_registry import HostRegistry
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_store import HostStore
+
+_HOST_OWNER = "local"
+# Host ids are stored as 32-char hex uuids, so the fixtures cannot use
+# bare labels.
+_HOST_A = "aa" * 16
+_HOST_B = "bb" * 16
+_HOST_UNKNOWN = "cc" * 16
 
 
 def _seed_claude_agent(db_uri: str) -> str:
@@ -20,6 +41,92 @@ def _seed_claude_agent(db_uri: str) -> str:
         bundle_location="builtin://claude-native-ui",
     )
     return agent_id
+
+
+class _FakeHostWebSocket:
+    """Minimal WebSocket stand-in so a host can be registered without a tunnel."""
+
+    async def send_text(self, data: str) -> None:
+        """Discard an outbound frame; these tests stub the proxy layer.
+
+        :param data: JSON-encoded frame text.
+        """
+
+
+@dataclass
+class _HostEnv:
+    """App wired with host support, plus the stores the tests register hosts in.
+
+    :param client: HTTP client bound to the host-enabled app.
+    :param host_store: Store backing the ownership/existence checks.
+    :param host_registry: Per-replica registry backing the online check.
+    """
+
+    client: httpx.AsyncClient
+    host_store: HostStore
+    host_registry: HostRegistry
+
+
+@pytest_asyncio.fixture()
+async def host_env(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> AsyncIterator[_HostEnv]:
+    """Build an app whose imports router has host support configured.
+
+    The shared ``app`` fixture passes no ``host_store``, which is the
+    unconfigured (503) posture; the browse/import endpoints need a real
+    one, so this builds a parallel app against the same database.
+
+    :param runtime_init: Ensures runtime singletons are initialized.
+    :param db_uri: SQLite URI shared by every store in the app.
+    :param tmp_path: Per-test scratch dir for artifact/cache stores.
+    :returns: Async iterator yielding the assembled environment.
+    """
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    host_store = HostStore(db_uri)
+    app: FastAPI = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        host_store=host_store,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield _HostEnv(
+            client=client,
+            host_store=host_store,
+            host_registry=app.state.host_registry,
+        )
+
+
+def _register_offline_host(env: _HostEnv, host_id: str) -> None:
+    """Record a host the caller owns that has no live connection.
+
+    :param env: The host-enabled environment.
+    :param host_id: Host identifier to record.
+    """
+    env.host_store.upsert_on_connect(host_id, name=host_id, user_id=_HOST_OWNER)
+    env.host_store.set_offline(host_id)
+
+
+def _connect_host(env: _HostEnv, host_id: str) -> None:
+    """Record a host the caller owns and put a live connection in the registry.
+
+    :param env: The host-enabled environment.
+    :param host_id: Host identifier to connect.
+    """
+    env.host_store.upsert_on_connect(host_id, name=host_id, user_id=_HOST_OWNER)
+    env.host_registry.register(
+        host_id=host_id,
+        ws=_FakeHostWebSocket(),  # type: ignore[arg-type] — duck-typed
+        hello=HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name=host_id),
+        owner=_HOST_OWNER,
+    )
 
 
 async def test_import_session_creates_normal_session_and_blocks_duplicate(
@@ -171,3 +278,327 @@ async def test_import_session_rejects_empty_history(client: httpx.AsyncClient) -
     )
 
     assert response.status_code == 422
+
+
+async def test_list_local_sessions_returns_host_summaries(
+    host_env: _HostEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The browse endpoint returns what the host reported."""
+    import omnigent.server.routes.imports as imports_module
+
+    async def _fake_list(
+        *, host_registry: object, host_conn: object, source: str, limit: int
+    ) -> list[dict[str, object]]:
+        """Stand in for the host round-trip with one canned summary."""
+        assert source == "claude"
+        assert limit == 10
+        return [
+            {
+                "source": "claude",
+                "external_session_id": "abc",
+                "workspace": "/repo",
+                "title": "inspect TODO.md",
+                "item_count": 4,
+                "preview": [{"role": "user", "text": "inspect TODO.md"}],
+            }
+        ]
+
+    monkeypatch.setattr(imports_module, "list_local_sessions_on_host", _fake_list)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions",
+        params={"host_id": _HOST_A, "source": "claude", "limit": 10},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "list"
+    assert body["data"][0]["external_session_id"] == "abc"
+    assert body["data"][0]["item_count"] == 4
+    assert body["data"][0]["preview"] == [{"role": "user", "text": "inspect TODO.md"}]
+
+
+async def test_list_local_sessions_rejects_unsupported_source(host_env: _HostEnv) -> None:
+    """Only Claude and Codex may be browsed from the web picker."""
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_A, "source": "qwen"}
+    )
+
+    assert response.status_code == 422
+
+
+async def test_list_local_sessions_rejects_out_of_range_limit(host_env: _HostEnv) -> None:
+    """A deeper listing than the picker supports is refused, not silently capped."""
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions",
+        params={"host_id": _HOST_A, "source": "claude", "limit": 50},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_list_local_sessions_reports_offline_host(host_env: _HostEnv) -> None:
+    """An offline host is a 409, not a hang or a 500."""
+    _register_offline_host(host_env, _HOST_B)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_B, "source": "claude"}
+    )
+
+    assert response.status_code == 409
+
+
+async def test_list_local_sessions_reports_unknown_host(host_env: _HostEnv) -> None:
+    """A host that was never registered is a 404."""
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_UNKNOWN, "source": "claude"}
+    )
+
+    assert response.status_code == 404
+
+
+async def test_list_local_sessions_surfaces_host_failure(
+    host_env: _HostEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host-reported listing failure is a 400 carrying the host's message."""
+    import omnigent.server.routes.imports as imports_module
+    from omnigent.server.routes._host_session_import import LocalSessionProxyError
+
+    async def _fake_list(
+        *, host_registry: object, host_conn: object, source: str, limit: int
+    ) -> list[dict[str, object]]:
+        """Fail the way a host with an unreadable transcript dir would."""
+        raise LocalSessionProxyError("the host could not list local sessions")
+
+    monkeypatch.setattr(imports_module, "list_local_sessions_on_host", _fake_list)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_A, "source": "claude"}
+    )
+
+    assert response.status_code == 400
+    assert "could not list local sessions" in response.text
+
+
+async def test_list_local_sessions_maps_lost_connection_to_conflict(
+    host_env: _HostEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection lost mid-listing is a 409, not the base error's 400."""
+    import omnigent.server.routes.imports as imports_module
+    from omnigent.server.routes._host_session_import import LocalSessionHostUnavailableError
+
+    async def _fake_list(
+        *, host_registry: object, host_conn: object, source: str, limit: int
+    ) -> list[dict[str, object]]:
+        """Fail the way a host that dropped its tunnel would."""
+        raise LocalSessionHostUnavailableError("host connection lost")
+
+    monkeypatch.setattr(imports_module, "list_local_sessions_on_host", _fake_list)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_A, "source": "claude"}
+    )
+
+    assert response.status_code == 409
+
+
+async def test_local_session_endpoints_require_host_support(client: httpx.AsyncClient) -> None:
+    """A server built without a host store answers 503 rather than 404."""
+    listed = await client.get(
+        "/v1/imports/local-sessions", params={"host_id": _HOST_A, "source": "claude"}
+    )
+    imported = await client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+    )
+
+    assert listed.status_code == 503
+    assert imported.status_code == 503
+
+
+async def test_import_local_session_creates_session(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing from a host creates the same session the CLI would."""
+    import omnigent.server.routes.imports as imports_module
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Return one normalized item the way the host's loader would."""
+        return {
+            "source": "claude",
+            "external_session_id": external_session_id,
+            "workspace": "/repo",
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "claude:turn-1",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                    },
+                }
+            ],
+        }
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    created = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+    )
+    repeated = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+    )
+
+    assert created.status_code == 201
+    assert created.json()["status"] == "imported"
+    assert created.json()["item_count"] == 1
+    assert repeated.status_code == 409
+
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        created.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.workspace == "/repo"
+    assert conversation.external_session_id == "abc"
+    assert conversation.labels["omnigent.wrapper"] == "claude-code-native-ui"
+
+
+async def test_import_local_session_reports_missing_source_session(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session the host cannot find is a 404."""
+    import omnigent.server.routes.imports as imports_module
+    from omnigent.server.routes._host_session_import import LocalSessionNotFoundError
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Fail the way a host asked for a deleted transcript would."""
+        raise LocalSessionNotFoundError("Claude Code session 'gone' was not found")
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "gone"},
+    )
+
+    assert response.status_code == 404
+    assert "was not found" in response.text
+
+
+async def test_import_local_session_maps_lost_connection_to_conflict(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection lost mid-load is a 409, not the base error's 400."""
+    import omnigent.server.routes.imports as imports_module
+    from omnigent.server.routes._host_session_import import LocalSessionHostUnavailableError
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Fail the way a host that dropped its tunnel mid-load would."""
+        raise LocalSessionHostUnavailableError("host connection lost during load_local_session")
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+    )
+
+    assert response.status_code == 409
+    assert "connection lost" in response.text
+
+
+async def test_import_local_session_surfaces_host_failure(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host-reported load failure is a 400 carrying the host's message."""
+    import omnigent.server.routes.imports as imports_module
+    from omnigent.server.routes._host_session_import import LocalSessionProxyError
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Fail the way a host with an unparsable transcript would."""
+        raise LocalSessionProxyError("the host could not load the session")
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "abc"},
+    )
+
+    assert response.status_code == 400
+    assert "could not load the session" in response.text
+
+
+async def test_import_local_session_rejects_empty_history(
+    host_env: _HostEnv,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty host payload cannot permanently claim a source session."""
+    import omnigent.server.routes.imports as imports_module
+
+    _seed_claude_agent(db_uri)
+
+    async def _fake_load(
+        *, host_registry: object, host_conn: object, source: str, external_session_id: str
+    ) -> dict[str, object]:
+        """Return a transcript the parser found nothing importable in."""
+        return {
+            "source": "claude",
+            "external_session_id": external_session_id,
+            "workspace": "/repo",
+            "items": [],
+        }
+
+    monkeypatch.setattr(imports_module, "load_local_session_on_host", _fake_load)
+    _connect_host(host_env, _HOST_A)
+
+    response = await host_env.client.post(
+        "/v1/imports/local-sessions",
+        json={"host_id": _HOST_A, "source": "claude", "external_session_id": "empty"},
+    )
+
+    assert response.status_code == 400
+    assert (
+        SqlAlchemyConversationStore(db_uri).find_imported_conversation("claude", "empty") is None
+    )

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.kimi_native_forwarder import KimiWireItem, read_kimi_wire_items
 from omnigent.kiro_native_session_forwarder import (
     KiroConversationMessage,
@@ -16,6 +17,7 @@ from omnigent.kiro_native_session_forwarder import (
 from omnigent.session_import import local as local_import
 from omnigent.session_import.local import (
     list_recent_local_session_ids,
+    list_recent_local_sessions,
     load_claude_session,
     load_codex_session,
     load_kimi_session,
@@ -1242,3 +1244,138 @@ def test_list_recent_kimi_sessions_uses_wire_recency(tmp_path: Path, monkeypatch
     recent = list_recent_local_session_ids("kimi", limit=10)
 
     assert recent == ("session_new", "session_old")
+
+
+def test_summarize_local_session_uses_shared_title_rules() -> None:
+    """A summary's title matches the import's own title synthesis."""
+    from omnigent.session_import.models import LocalSessionImport, summarize_local_session
+
+    imported = LocalSessionImport(
+        source="claude",
+        external_session_id="session-a",
+        workspace="/repo",
+        items=(
+            NewConversationItem(
+                type="message",
+                response_id="claude:1",
+                data=parse_item_data(
+                    "message",
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                    },
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="claude:1",
+                data=parse_item_data(
+                    "message",
+                    {
+                        "role": "assistant",
+                        "agent": "claude-native-ui",
+                        "content": [{"type": "output_text", "text": "Done."}],
+                    },
+                ),
+            ),
+        ),
+    )
+
+    summary = summarize_local_session(imported)
+
+    assert summary.title == imported.title
+    assert summary.source == "claude"
+    assert summary.external_session_id == "session-a"
+    assert summary.workspace == "/repo"
+    assert summary.item_count == 2
+    assert [(entry.role, entry.text) for entry in summary.preview] == [
+        ("user", "inspect TODO.md"),
+        ("assistant", "Done."),
+    ]
+
+
+def test_summarize_local_session_bounds_preview_length_and_count() -> None:
+    """Preview keeps the first N messages and truncates long text."""
+    from omnigent.session_import.models import LocalSessionImport, summarize_local_session
+
+    items = tuple(
+        NewConversationItem(
+            type="message",
+            response_id=f"claude:{index}",
+            data=parse_item_data(
+                "message",
+                {"role": "user", "content": [{"type": "input_text", "text": "x" * 500}]},
+            ),
+        )
+        for index in range(10)
+    )
+    imported = LocalSessionImport(
+        source="claude", external_session_id="s", workspace=None, items=items
+    )
+
+    summary = summarize_local_session(imported, preview_limit=3)
+
+    assert summary.item_count == 10
+    assert len(summary.preview) == 3
+    assert len(summary.preview[0].text) == 240
+    assert summary.preview[0].text.endswith("…")
+
+
+def test_list_recent_local_sessions_summarizes_newest_first(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recent Claude sessions come back newest first with real item counts."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    projects = tmp_path / "projects" / "repo"
+    projects.mkdir(parents=True)
+    for index, name in enumerate(("older", "newer")):
+        transcript = projects / f"{name}.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "uuid": f"{name}-1",
+                    "cwd": "/repo",
+                    "message": {"role": "user", "content": f"question {name}"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(transcript, (1_000 + index, 1_000 + index))
+
+    summaries = list_recent_local_sessions("claude", limit=5)
+
+    assert [summary.external_session_id for summary in summaries] == ["newer", "older"]
+    assert summaries[0].title == "question newer"
+    assert summaries[0].workspace == "/repo"
+    assert summaries[0].item_count >= 1
+
+
+def test_list_recent_local_sessions_skips_unreadable_sessions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One corrupt transcript does not break the whole listing."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    projects = tmp_path / "projects" / "repo"
+    projects.mkdir(parents=True)
+    good = projects / "good.jsonl"
+    good.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "good-1",
+                "cwd": "/repo",
+                "message": {"role": "user", "content": "hello"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (projects / "empty.jsonl").write_text("", encoding="utf-8")
+
+    summaries = list_recent_local_sessions("claude", limit=5)
+
+    assert [summary.external_session_id for summary in summaries] == ["good"]

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -1321,6 +1321,39 @@ def test_summarize_local_session_bounds_preview_length_and_count() -> None:
     assert summary.preview[0].text.endswith("…")
 
 
+def test_summarize_local_session_preview_strips_attachment_markers() -> None:
+    """A message that is purely an attachment marker leaves no temp-file path in preview."""
+    from omnigent.session_import.models import LocalSessionImport, summarize_local_session
+
+    imported = LocalSessionImport(
+        source="claude",
+        external_session_id="s",
+        workspace=None,
+        items=(
+            NewConversationItem(
+                type="message",
+                response_id="claude:1",
+                data=parse_item_data(
+                    "message",
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "[Attached: /tmp/abc123/screenshot.png]",
+                            }
+                        ],
+                    },
+                ),
+            ),
+        ),
+    )
+
+    summary = summarize_local_session(imported)
+
+    assert summary.preview == ()
+
+
 def test_list_recent_local_sessions_summarizes_newest_first(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/src/hooks/useHostLocalSessions.test.tsx
+++ b/web/src/hooks/useHostLocalSessions.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/identity", () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+const { authenticatedFetch } = await import("@/lib/identity");
+const mockFetch = vi.mocked(authenticatedFetch);
+
+import { useHostLocalSessions } from "./useHostLocalSessions";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useHostLocalSessions", () => {
+  it("stays idle and does not fetch when hostId is null or enabled is false", async () => {
+    const { result: noHost } = renderHook(() => useHostLocalSessions(null, "claude", true), {
+      wrapper,
+    });
+    const { result: disabled } = renderHook(() => useHostLocalSessions("host_a", "claude", false), {
+      wrapper,
+    });
+    await Promise.resolve();
+
+    expect(noHost.current.fetchStatus).toBe("idle");
+    expect(disabled.current.fetchStatus).toBe("idle");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves data to the fetched list when hostId is set and enabled is true", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        object: "list",
+        data: [
+          {
+            source: "claude",
+            external_session_id: "abc",
+            workspace: "/repo",
+            title: "inspect TODO.md",
+            item_count: 4,
+            preview: [{ role: "user", text: "inspect TODO.md" }],
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useHostLocalSessions("host_a", "claude", true), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([
+      {
+        source: "claude",
+        external_session_id: "abc",
+        workspace: "/repo",
+        title: "inspect TODO.md",
+        item_count: 4,
+        preview: [{ role: "user", text: "inspect TODO.md" }],
+      },
+    ]);
+  });
+});

--- a/web/src/hooks/useHostLocalSessions.test.tsx
+++ b/web/src/hooks/useHostLocalSessions.test.tsx
@@ -26,6 +26,15 @@ function wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
+/** Mirrors `main.tsx`'s real QueryClient, which sets no `retry` default (so
+ *  React Query's own default of 3 would apply if the hook didn't opt out). */
+function productionDefaultsWrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { staleTime: 30_000, refetchOnWindowFocus: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
 beforeEach(() => {
   mockFetch.mockReset();
 });
@@ -81,5 +90,21 @@ describe("useHostLocalSessions", () => {
         preview: [{ role: "user", text: "inspect TODO.md" }],
       },
     ]);
+  });
+
+  it("does not retry a failed browse, even under React Query's default retry policy", async () => {
+    // The server-side browse RPC has a 60s timeout; letting the default
+    // retry: 3 apply would turn one failed request into ~4 sequential 60s
+    // waits before the picker ever shows an error. Uses a client with no
+    // `retry` override (like the app's real one) so this actually exercises
+    // the hook's own opt-out rather than the test wrapper's.
+    mockFetch.mockRejectedValue(new Error("host is offline"));
+
+    const { result } = renderHook(() => useHostLocalSessions("host_a", "claude", true), {
+      wrapper: productionDefaultsWrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/hooks/useHostLocalSessions.ts
+++ b/web/src/hooks/useHostLocalSessions.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchHostLocalSessions, type ImportSourceId } from "@/lib/localSessionImportApi";
+
+/**
+ * React Query hook: browse a host's recent local chats (Claude Code / Codex)
+ * for the "Import chat" picker.
+ *
+ * Lazy — only fires when `hostId` is set and `enabled` is true, so the
+ * dialog can defer fetching until the user actually opens the import flow.
+ * Unlike `useHostWorktrees`, a non-OK response (including 400) is a real
+ * error and propagates to the caller rather than resolving to an empty
+ * list — the dialog shows the message.
+ *
+ * @param hostId Host id, e.g. ``"host_a1b2..."``. `null` disables.
+ * @param source Which local chat tool to browse.
+ * @param enabled Whether the query should run at all, e.g. gated on the
+ *   import dialog being open.
+ * @returns React Query result with ``data: LocalSessionSummary[]``.
+ */
+export function useHostLocalSessions(
+  hostId: string | null,
+  source: ImportSourceId,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["host-local-sessions", hostId, source],
+    queryFn: () => fetchHostLocalSessions(hostId as string, source),
+    enabled: hostId !== null && enabled,
+    staleTime: 5_000,
+  });
+}

--- a/web/src/hooks/useHostLocalSessions.ts
+++ b/web/src/hooks/useHostLocalSessions.ts
@@ -28,5 +28,10 @@ export function useHostLocalSessions(
     queryFn: () => fetchHostLocalSessions(hostId as string, source),
     enabled: hostId !== null && enabled,
     staleTime: 5_000,
+    // The server's browse RPC has a 60s timeout, and an older host that
+    // silently drops the frame (no reply at all) hits exactly that timeout —
+    // the default retry: 3 would turn one failure into ~4 minutes of
+    // "Loading recent chats…" before the picker shows anything.
+    retry: false,
   });
 }

--- a/web/src/lib/localSessionImportApi.test.ts
+++ b/web/src/lib/localSessionImportApi.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchHostLocalSessions, importHostLocalSession } from "./localSessionImportApi";
+
+vi.mock("@/lib/identity", () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+const { authenticatedFetch } = await import("@/lib/identity");
+const mockFetch = vi.mocked(authenticatedFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchHostLocalSessions", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("requests the host's recent sessions and returns the list", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        object: "list",
+        data: [
+          {
+            source: "claude",
+            external_session_id: "abc",
+            workspace: "/repo",
+            title: "inspect TODO.md",
+            item_count: 4,
+            preview: [{ role: "user", text: "inspect TODO.md" }],
+          },
+        ],
+      }),
+    );
+
+    const sessions = await fetchHostLocalSessions("host_a", "claude", 10);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].external_session_id).toBe("abc");
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/v1/imports/local-sessions");
+    expect(url).toContain("host_id=host_a");
+    expect(url).toContain("source=claude");
+    expect(url).toContain("limit=10");
+  });
+
+  it("throws the server's message when the host cannot be reached", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ detail: "host is offline" }, 409));
+
+    await expect(fetchHostLocalSessions("host_a", "claude")).rejects.toThrow("host is offline");
+  });
+});
+
+describe("importHostLocalSession", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("posts the source and session id and returns the new session", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ session_id: "conv_1", status: "imported", item_count: 4 }, 201),
+    );
+
+    const result = await importHostLocalSession("host_a", "codex", "thread-1");
+
+    expect(result.session_id).toBe("conv_1");
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      host_id: "host_a",
+      source: "codex",
+      external_session_id: "thread-1",
+    });
+  });
+
+  it("throws the server's message when the session was already imported", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ error: { message: "already imported as conv_1" } }, 409),
+    );
+
+    await expect(importHostLocalSession("host_a", "claude", "abc")).rejects.toThrow(
+      "already imported as conv_1",
+    );
+  });
+});

--- a/web/src/lib/localSessionImportApi.ts
+++ b/web/src/lib/localSessionImportApi.ts
@@ -1,0 +1,123 @@
+// Client for the two `/v1/imports/local-sessions` endpoints, which let a user
+// browse and import Claude Code / Codex chats that already exist on a
+// connected host. The wire shape is used verbatim (snake_case) — there is no
+// camelCase mapping layer, since Task 7's dialog is written directly against
+// these field names.
+
+import { authenticatedFetch } from "@/lib/identity";
+
+/** A host-local chat source this app knows how to import from. */
+export type ImportSourceId = "claude" | "codex";
+
+/** One preview turn of a host-local session, shown in the import picker. */
+export interface LocalSessionPreview {
+  role: string;
+  text: string;
+}
+
+/**
+ * Summary of one host-local chat, as returned by
+ * `GET /v1/imports/local-sessions`. `workspace` and `title` are nullable —
+ * the host couldn't always determine them from the transcript.
+ */
+export interface LocalSessionSummary {
+  source: ImportSourceId;
+  external_session_id: string;
+  workspace: string | null;
+  title: string | null;
+  item_count: number;
+  preview: LocalSessionPreview[];
+}
+
+/** Result of `POST /v1/imports/local-sessions`: the newly created session. */
+export interface ImportedSessionResult {
+  session_id: string;
+  status: string;
+  item_count: number;
+}
+
+interface LocalSessionsListResponse {
+  object: string;
+  data: LocalSessionSummary[];
+}
+
+/**
+ * Extract a human-readable error message from a failed response, matching
+ * `scheduledTasksApi.ts`'s `errorFromResponse`. Both error-body shapes the
+ * backend can return must be handled: FastAPI's bare `{"detail": "..."}` and
+ * the app's `{"error": {"message": "..."}}`. Falls back to `HTTP ${status}`
+ * when neither shape is present (or the body isn't JSON).
+ */
+async function errorMessageFromResponse(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { detail?: string; error?: { message?: string } };
+    if (body.detail) return body.detail;
+    if (body.error?.message) return body.error.message;
+  } catch {
+    // Non-JSON / empty body — fall through to the status fallback.
+  }
+  return `HTTP ${res.status}`;
+}
+
+/**
+ * Fetch a host's recent local chats for one source (Claude Code or Codex).
+ *
+ * Rows the host reports as malformed are silently skipped server-side, so
+ * the returned array may be shorter than `limit`.
+ *
+ * @param hostId Host identifier, e.g. ``"host_a1b2..."``.
+ * @param source Which local chat tool to browse.
+ * @param limit Max rows to return, 1-20. Server defaults to 10 when omitted.
+ * @returns The host's local sessions for that source, most recent first.
+ * @throws Error with the server's message (`detail` / `error.message`) on a
+ *   non-OK response — including 400 (invalid source / host failure), 403
+ *   (not your host), 404 (host or session not found), 409 (host offline),
+ *   and 503 (server has no host support).
+ */
+export async function fetchHostLocalSessions(
+  hostId: string,
+  source: ImportSourceId,
+  limit?: number,
+): Promise<LocalSessionSummary[]> {
+  const params = new URLSearchParams({ host_id: hostId, source });
+  if (limit !== undefined) params.set("limit", String(limit));
+  const res = await authenticatedFetch(`/v1/imports/local-sessions?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(await errorMessageFromResponse(res));
+  }
+  const body = (await res.json()) as LocalSessionsListResponse;
+  return body.data;
+}
+
+/**
+ * Import one host-local chat into Omnigent as a new session.
+ *
+ * @param hostId Host identifier the session lives on.
+ * @param source Which local chat tool the session came from.
+ * @param externalSessionId The source tool's own session id, from
+ *   {@link LocalSessionSummary.external_session_id}.
+ * @returns The newly created Omnigent session's id and imported item count.
+ * @throws Error with the server's message on a non-OK response — including
+ *   400 (invalid source / host failure), 403 (not your host), 404 (host or
+ *   session not found), 409 (host offline, or already imported), and 503
+ *   (server has no host support).
+ */
+export async function importHostLocalSession(
+  hostId: string,
+  source: ImportSourceId,
+  externalSessionId: string,
+): Promise<ImportedSessionResult> {
+  const res = await authenticatedFetch("/v1/imports/local-sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      host_id: hostId,
+      source,
+      external_session_id: externalSessionId,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(await errorMessageFromResponse(res));
+  }
+  return (await res.json()) as ImportedSessionResult;
+}

--- a/web/src/shell/ImportChatDialog.test.tsx
+++ b/web/src/shell/ImportChatDialog.test.tsx
@@ -1,0 +1,282 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImportChatDialog } from "./ImportChatDialog";
+import { useHosts, type Host } from "@/hooks/useHosts";
+import { useHostLocalSessions } from "@/hooks/useHostLocalSessions";
+import {
+  importHostLocalSession,
+  type ImportedSessionResult,
+  type ImportSourceId,
+  type LocalSessionSummary,
+} from "@/lib/localSessionImportApi";
+
+vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+vi.mock("@/hooks/useHostLocalSessions", () => ({ useHostLocalSessions: vi.fn() }));
+vi.mock("@/lib/localSessionImportApi", () => ({ importHostLocalSession: vi.fn() }));
+
+const useHostsMock = vi.mocked(useHosts);
+const useHostLocalSessionsMock = vi.mocked(useHostLocalSessions);
+const importHostLocalSessionMock = vi.mocked(importHostLocalSession);
+
+function host(overrides: Partial<Host> = {}): Host {
+  return {
+    host_id: "host_1",
+    name: "serena-laptop",
+    owner: "serena",
+    status: "online",
+    ...overrides,
+  } as Host;
+}
+
+function setHosts(hosts: Host[]): void {
+  useHostsMock.mockReturnValue({ data: hosts } as ReturnType<typeof useHosts>);
+}
+
+// Two Claude rows: one fully populated, one with the nullable title/workspace
+// the server passes through when the host couldn't determine them.
+const CLAUDE_SESSIONS: LocalSessionSummary[] = [
+  {
+    source: "claude",
+    external_session_id: "abc",
+    workspace: "/Users/serena/proj",
+    title: "Fix the flaky parser",
+    item_count: 12,
+    preview: [
+      { role: "user", text: "why is the parser flaky?" },
+      { role: "assistant", text: "Let me look at the tokenizer." },
+    ],
+  },
+  {
+    source: "claude",
+    external_session_id: "def",
+    workspace: null,
+    title: null,
+    item_count: 3,
+    preview: [],
+  },
+];
+
+const CODEX_SESSIONS: LocalSessionSummary[] = [
+  {
+    source: "codex",
+    external_session_id: "xyz",
+    workspace: "/Users/serena/api",
+    title: "Add retries",
+    item_count: 7,
+    preview: [{ role: "user", text: "retry the 429s" }],
+  },
+];
+
+type LocalSessionsResult = ReturnType<typeof useHostLocalSessions>;
+
+function queryResult(
+  data: LocalSessionSummary[] | undefined,
+  extra: { isLoading?: boolean; error?: Error | null } = {},
+): LocalSessionsResult {
+  const error = extra.error ?? null;
+  return {
+    data,
+    isLoading: extra.isLoading ?? false,
+    isError: error !== null,
+    error,
+  } as unknown as LocalSessionsResult;
+}
+
+/** Serve each source its own rows, so a source switch is observable. */
+function setLocalSessionsBySource(
+  bySource: Partial<Record<ImportSourceId, LocalSessionsResult>>,
+): void {
+  useHostLocalSessionsMock.mockImplementation(
+    (_hostId, source) => bySource[source] ?? queryResult([]),
+  );
+}
+
+function renderDialog(props: { defaultHostId?: string | null } = {}): {
+  onImported: ReturnType<typeof vi.fn>;
+  onOpenChange: ReturnType<typeof vi.fn>;
+} {
+  const onImported = vi.fn();
+  const onOpenChange = vi.fn();
+  render(
+    <ImportChatDialog
+      open
+      onOpenChange={onOpenChange}
+      defaultHostId={props.defaultHostId ?? null}
+      onImported={onImported}
+    />,
+  );
+  return { onImported, onOpenChange };
+}
+
+beforeEach(() => {
+  useHostsMock.mockReset();
+  useHostLocalSessionsMock.mockReset();
+  importHostLocalSessionMock.mockReset();
+  setHosts([host()]);
+  setLocalSessionsBySource({
+    claude: queryResult(CLAUDE_SESSIONS),
+    codex: queryResult(CODEX_SESSIONS),
+  });
+});
+
+afterEach(cleanup);
+
+describe("ImportChatDialog", () => {
+  it("renders recent sessions with title, workspace, and item count", async () => {
+    renderDialog();
+
+    const row = await screen.findByTestId("import-chat-recent-row-abc");
+    expect(row).toHaveTextContent("Fix the flaky parser");
+    expect(row).toHaveTextContent("/Users/serena/proj");
+    expect(row).toHaveTextContent("12 items");
+
+    // The host can return a row with no title/workspace; it still lists.
+    const untitled = screen.getByTestId("import-chat-recent-row-def");
+    expect(untitled).toHaveTextContent("Untitled session");
+    expect(untitled).toHaveTextContent("3 items");
+
+    // The list defaults to Claude Code and browses the only online host.
+    expect(useHostLocalSessionsMock).toHaveBeenLastCalledWith("host_1", "claude", true);
+  });
+
+  it("expanding a row reveals its preview messages", () => {
+    renderDialog();
+
+    expect(screen.queryByTestId("import-chat-preview-abc")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("import-chat-expand-abc"));
+
+    const preview = screen.getByTestId("import-chat-preview-abc");
+    expect(preview).toHaveTextContent("why is the parser flaky?");
+    expect(preview).toHaveTextContent("Let me look at the tokenizer.");
+    // Peeking at a preview must not select the row — the full list stays.
+    expect(screen.getByTestId("import-chat-recent-row-def")).toBeInTheDocument();
+    expect(screen.getByTestId("import-chat-session-id")).toHaveValue("");
+  });
+
+  it("selecting a row fills the session id input and collapses the list", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByTestId("import-chat-recent-row-abc"));
+
+    expect(screen.getByTestId("import-chat-session-id")).toHaveValue("abc");
+    // Only the picked chat remains on screen.
+    expect(screen.getByTestId("import-chat-recent-row-abc")).toBeInTheDocument();
+    expect(screen.queryByTestId("import-chat-recent-row-def")).not.toBeInTheDocument();
+  });
+
+  it("restores the recent list when the selection is cleared", async () => {
+    renderDialog();
+
+    fireEvent.click(await screen.findByTestId("import-chat-recent-row-abc"));
+    expect(screen.queryByTestId("import-chat-recent-row-def")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("import-chat-clear-selection"));
+
+    expect(await screen.findByTestId("import-chat-recent-row-def")).toBeInTheDocument();
+    expect(screen.getByTestId("import-chat-session-id")).toHaveValue("");
+  });
+
+  it("switching source from Claude to Codex refetches and clears the selection", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByTestId("import-chat-recent-row-abc"));
+    expect(screen.getByTestId("import-chat-session-id")).toHaveValue("abc");
+
+    fireEvent.click(screen.getByTestId("import-chat-source-codex"));
+
+    // Refetch: the browse hook is re-keyed on the new source.
+    expect(useHostLocalSessionsMock).toHaveBeenLastCalledWith("host_1", "codex", true);
+    // The Claude pick can't survive into Codex — it isn't a Codex session.
+    expect(screen.getByTestId("import-chat-session-id")).toHaveValue("");
+    expect(screen.getByTestId("import-chat-recent-row-xyz")).toBeInTheDocument();
+    expect(screen.queryByTestId("import-chat-recent-row-abc")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when the host has no recent chats", () => {
+    setLocalSessionsBySource({ claude: queryResult([]), codex: queryResult([]) });
+    renderDialog();
+
+    // Copy names the harness the user is browsing, not a generic "no results".
+    expect(screen.getByTestId("import-chat-empty")).toHaveTextContent(
+      "No recent Claude Code chats on this machine",
+    );
+    expect(screen.queryByTestId("import-chat-recent-list")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("import-chat-source-codex"));
+    expect(screen.getByTestId("import-chat-empty")).toHaveTextContent(
+      "No recent Codex chats on this machine",
+    );
+  });
+
+  it("import posts the selected session and calls onImported with the new id", async () => {
+    // Two online hosts, and the composer preselected the second one.
+    setHosts([host(), host({ host_id: "host_2", name: "serena-desktop" })]);
+    let settle!: (result: ImportedSessionResult) => void;
+    importHostLocalSessionMock.mockReturnValue(
+      new Promise<ImportedSessionResult>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    const { onImported, onOpenChange } = renderDialog({ defaultHostId: "host_2" });
+
+    // Nothing to import until a session id exists.
+    expect(screen.getByTestId("import-chat-submit")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("import-chat-recent-row-abc"));
+    expect(screen.getByTestId("import-chat-submit")).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    expect(importHostLocalSessionMock).toHaveBeenCalledWith("host_2", "claude", "abc");
+    // In flight: the button locks and shows a spinner.
+    const submit = screen.getByTestId("import-chat-submit");
+    expect(submit).toBeDisabled();
+    expect(within(submit).getByRole("status")).toBeInTheDocument();
+
+    settle({ session_id: "conv_new", status: "imported", item_count: 12 });
+
+    await waitFor(() => expect(onImported).toHaveBeenCalledWith("conv_new"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("a failed import shows the server message and keeps the dialog open", async () => {
+    importHostLocalSessionMock.mockRejectedValue(new Error("already imported as conv_1"));
+    const { onImported, onOpenChange } = renderDialog();
+
+    fireEvent.click(screen.getByTestId("import-chat-recent-row-abc"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    // The server's own wording, verbatim — never a bare status code.
+    await waitFor(() =>
+      expect(screen.getByTestId("import-chat-error")).toHaveTextContent(
+        "already imported as conv_1",
+      ),
+    );
+    expect(onImported).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // Still open and retryable.
+    expect(screen.getByTestId("import-chat-dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("import-chat-submit")).not.toBeDisabled();
+  });
+
+  it("with no online hosts, the controls are disabled and a connect hint shows", () => {
+    // An offline host plus a server-managed sandbox host: neither is importable.
+    setHosts([
+      host({ status: "offline" }),
+      host({ host_id: "host_sb", name: "sandbox", sandbox_provider: "modal" }),
+    ]);
+    renderDialog();
+
+    expect(screen.getByText("Connect a machine to import chats")).toBeInTheDocument();
+    expect(screen.getByTestId("import-chat-host-select")).toBeDisabled();
+    expect(screen.getByTestId("import-chat-source-claude")).toBeDisabled();
+    expect(screen.getByTestId("import-chat-source-codex")).toBeDisabled();
+    expect(screen.getByTestId("import-chat-submit")).toBeDisabled();
+    // No host to browse, so neither the list nor the empty state renders.
+    expect(screen.queryByTestId("import-chat-recent-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("import-chat-empty")).not.toBeInTheDocument();
+    expect(useHostLocalSessionsMock).toHaveBeenLastCalledWith(null, "claude", true);
+    // The manual session-id path the CLI supports stays open regardless.
+    expect(screen.getByTestId("import-chat-session-id")).not.toBeDisabled();
+  });
+});

--- a/web/src/shell/ImportChatDialog.test.tsx
+++ b/web/src/shell/ImportChatDialog.test.tsx
@@ -33,6 +33,11 @@ function setHosts(hosts: Host[]): void {
   useHostsMock.mockReturnValue({ data: hosts } as ReturnType<typeof useHosts>);
 }
 
+/** A cold `useHosts` cache: the list hasn't arrived yet. */
+function setHostsLoading(): void {
+  useHostsMock.mockReturnValue({ data: undefined } as ReturnType<typeof useHosts>);
+}
+
 // Two Claude rows: one fully populated, one with the nullable title/workspace
 // the server passes through when the host couldn't determine them.
 const CLAUDE_SESSIONS: LocalSessionSummary[] = [
@@ -278,5 +283,44 @@ describe("ImportChatDialog", () => {
     expect(useHostLocalSessionsMock).toHaveBeenLastCalledWith(null, "claude", true);
     // The manual session-id path the CLI supports stays open regardless.
     expect(screen.getByTestId("import-chat-session-id")).not.toBeDisabled();
+  });
+
+  it("waits for the host list before telling the user to connect a machine", () => {
+    // A cold hosts cache is not "no machines" — showing the connect hint here
+    // instructs the user to set up a machine they may already have connected.
+    setHostsLoading();
+    renderDialog();
+
+    expect(screen.queryByText("Connect a machine to import chats")).not.toBeInTheDocument();
+    expect(screen.getByText("Loading machines…")).toBeInTheDocument();
+    // Still nothing to act on until the list lands, so the controls stay locked.
+    expect(screen.getByTestId("import-chat-host-select")).toBeDisabled();
+    expect(screen.getByTestId("import-chat-source-claude")).toBeDisabled();
+    expect(screen.getByTestId("import-chat-submit")).toBeDisabled();
+  });
+
+  it("shows a loading state, not an empty one, while the recent chats load", () => {
+    setLocalSessionsBySource({ claude: queryResult(undefined, { isLoading: true }) });
+    renderDialog();
+
+    expect(screen.getByText("Loading recent chats…")).toBeInTheDocument();
+    // Flashing "no recent chats" mid-load would misreport the machine.
+    expect(screen.queryByTestId("import-chat-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("import-chat-recent-list")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the server's message when the recent chats can't be listed", () => {
+    setLocalSessionsBySource({
+      claude: queryResult(undefined, { error: new Error("host is offline") }),
+    });
+    renderDialog();
+
+    expect(screen.getByTestId("import-chat-error")).toHaveTextContent("host is offline");
+    expect(screen.queryByTestId("import-chat-recent-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("import-chat-empty")).not.toBeInTheDocument();
+
+    // A failed browse must not close off the manual path: a pasted id still imports.
+    fireEvent.change(screen.getByTestId("import-chat-session-id"), { target: { value: "abc" } });
+    expect(screen.getByTestId("import-chat-submit")).not.toBeDisabled();
   });
 });

--- a/web/src/shell/ImportChatDialog.tsx
+++ b/web/src/shell/ImportChatDialog.tsx
@@ -121,13 +121,18 @@ function ImportChatForm({
 
   const { data: hosts } = useHosts();
   // Only a live, user-connected machine has transcripts to import: sandbox
-  // hosts are server-managed launch targets. A host from an older server omits
-  // `sandbox_provider` entirely, which must read as "not a sandbox".
+  // hosts are server-managed launch targets. `useHosts` already drops them,
+  // so the sandbox clause is defence-in-depth against a future
+  // `includeSandbox` caller; a host omitting the field is NOT a sandbox.
   const onlineHosts = useMemo(
     () => (hosts ?? []).filter((h) => h.status === "online" && !h.sandbox_provider),
     [hosts],
   );
-  const noOnlineHosts = onlineHosts.length === 0;
+  const hostsLoading = hosts === undefined;
+  // Only "no machines" once the list has actually arrived — a cold cache must
+  // not tell the user to connect a machine they already have.
+  const noOnlineHosts = !hostsLoading && onlineHosts.length === 0;
+  const hostsUnusable = hostsLoading || noOnlineHosts;
 
   // Default to the composer's host when it's online, else the first online
   // one. Only fills an empty slot, so an explicit pick is never overridden.
@@ -143,7 +148,8 @@ function ImportChatForm({
   // An import failure takes precedence: it's the action the user just took.
   const shownError = errorMessage ?? recent.error?.message ?? null;
 
-  function clearSelection(): void {
+  /** Back to a clean slate: no pick, empty id, and any stale error dropped. */
+  function resetSelection(): void {
     setSelected(null);
     setSessionId("");
     setExpandedId(null);
@@ -161,7 +167,7 @@ function ImportChatForm({
     setSource(next);
     // A pick from the other source isn't valid here, and its id would import
     // the wrong transcript.
-    clearSelection();
+    resetSelection();
   }
 
   async function handleImport(): Promise<void> {
@@ -205,7 +211,7 @@ function ImportChatForm({
                 size="sm"
                 variant={source === id ? "secondary" : "ghost"}
                 aria-pressed={source === id}
-                disabled={noOnlineHosts}
+                disabled={hostsUnusable}
                 data-testid={`import-chat-source-${id}`}
                 onClick={() => changeSource(id)}
               >
@@ -222,9 +228,9 @@ function ImportChatForm({
             onValueChange={(v) => {
               setHostId(v);
               // Chats are per-machine, so a pick from the old host is stale.
-              clearSelection();
+              resetSelection();
             }}
-            disabled={noOnlineHosts}
+            disabled={hostsUnusable}
           >
             <SelectTrigger
               aria-label="Machine"
@@ -245,9 +251,11 @@ function ImportChatForm({
               ))}
             </SelectContent>
           </Select>
-          {noOnlineHosts && (
+          {hostsLoading ? (
+            <p className="text-sm text-muted-foreground">Loading machines…</p>
+          ) : noOnlineHosts ? (
             <p className="text-sm text-muted-foreground">Connect a machine to import chats</p>
-          )}
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-1.5">
@@ -318,7 +326,7 @@ function ImportChatForm({
               size="sm"
               className="self-start"
               data-testid="import-chat-clear-selection"
-              onClick={clearSelection}
+              onClick={resetSelection}
             >
               Clear selection
             </Button>

--- a/web/src/shell/ImportChatDialog.tsx
+++ b/web/src/shell/ImportChatDialog.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useHosts } from "@/hooks/useHosts";
+import { useHostLocalSessions } from "@/hooks/useHostLocalSessions";
+import {
+  importHostLocalSession,
+  type ImportSourceId,
+  type LocalSessionSummary,
+} from "@/lib/localSessionImportApi";
+
+/** Human labels for the two importable chat sources, used in copy and tabs. */
+const SOURCE_LABELS: Record<ImportSourceId, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+};
+
+const SOURCES: readonly ImportSourceId[] = ["claude", "codex"];
+
+export interface ImportChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Host preselected from the composer's host chip, if any. */
+  defaultHostId?: string | null;
+  /** Called with the created Omnigent session id after a successful import. */
+  onImported: (sessionId: string) => void;
+}
+
+/**
+ * "Import chat" dialog — browse the Claude Code / Codex chats that already
+ * exist on a connected machine and pull one into Omnigent as a new session.
+ *
+ * A thin `Dialog` shell around {@link ImportChatForm}, which holds all the
+ * state. The form lives inside `DialogContent`, so closing the dialog unmounts
+ * it and a reopen starts clean — no stale pick or error from last time.
+ *
+ * @param open - Whether the dialog is visible.
+ * @param onOpenChange - Visibility setter (Radix-controlled).
+ * @param defaultHostId - Host preselected from the composer's host chip.
+ * @param onImported - Receives the created session id after a successful
+ *   import, just before the dialog closes.
+ */
+export function ImportChatDialog({
+  open,
+  onOpenChange,
+  defaultHostId,
+  onImported,
+}: ImportChatDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="import-chat-dialog"
+        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>Import chat</DialogTitle>
+          <DialogDescription>
+            Bring a Claude Code or Codex chat that already exists on a connected machine into
+            Omnigent as a new session.
+          </DialogDescription>
+        </DialogHeader>
+        <ImportChatForm
+          defaultHostId={defaultHostId}
+          onImported={onImported}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The import picker itself — source toggle, machine picker, session-ID field,
+ * and the browsable list of the machine's recent chats.
+ *
+ * Clicking a chat fills the session-ID field and narrows the list to that one
+ * row; clearing the selection brings the whole list back. The field stays
+ * editable throughout, so a session id can always be pasted by hand — the
+ * manual path the CLI already supports. A failed import surfaces the server's
+ * own message inline and leaves everything editable for a straight retry.
+ *
+ * @param defaultHostId - Host to preselect when it is online.
+ * @param onImported - Called with the new session id on success.
+ * @param onClose - Closes the host dialog (Cancel, and after a successful
+ *   import).
+ */
+function ImportChatForm({
+  defaultHostId,
+  onImported,
+  onClose,
+}: {
+  defaultHostId?: string | null;
+  onImported: (sessionId: string) => void;
+  onClose: () => void;
+}) {
+  const [source, setSource] = useState<ImportSourceId>("claude");
+  const [hostId, setHostId] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState("");
+  const [selected, setSelected] = useState<LocalSessionSummary | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { data: hosts } = useHosts();
+  // Only a live, user-connected machine has transcripts to import: sandbox
+  // hosts are server-managed launch targets. A host from an older server omits
+  // `sandbox_provider` entirely, which must read as "not a sandbox".
+  const onlineHosts = useMemo(
+    () => (hosts ?? []).filter((h) => h.status === "online" && !h.sandbox_provider),
+    [hosts],
+  );
+  const noOnlineHosts = onlineHosts.length === 0;
+
+  // Default to the composer's host when it's online, else the first online
+  // one. Only fills an empty slot, so an explicit pick is never overridden.
+  useEffect(() => {
+    if (hostId !== null || onlineHosts.length === 0) return;
+    const preferred = onlineHosts.find((h) => h.host_id === defaultHostId);
+    setHostId(preferred?.host_id ?? onlineHosts[0].host_id);
+  }, [hostId, defaultHostId, onlineHosts]);
+
+  // The form only mounts while the dialog is open, so the browse is always on.
+  const recent = useHostLocalSessions(hostId, source, true);
+  const rows = recent.data ?? [];
+  // An import failure takes precedence: it's the action the user just took.
+  const shownError = errorMessage ?? recent.error?.message ?? null;
+
+  function clearSelection(): void {
+    setSelected(null);
+    setSessionId("");
+    setExpandedId(null);
+    setErrorMessage(null);
+  }
+
+  function selectRow(row: LocalSessionSummary): void {
+    setSelected(row);
+    setSessionId(row.external_session_id);
+    setErrorMessage(null);
+  }
+
+  function changeSource(next: ImportSourceId): void {
+    if (next === source) return;
+    setSource(next);
+    // A pick from the other source isn't valid here, and its id would import
+    // the wrong transcript.
+    clearSelection();
+  }
+
+  async function handleImport(): Promise<void> {
+    const externalId = sessionId.trim();
+    if (hostId === null || externalId === "" || importing) return;
+    setImporting(true);
+    setErrorMessage(null);
+    try {
+      const result = await importHostLocalSession(hostId, source, externalId);
+      onImported(result.session_id);
+      onClose();
+    } catch (e) {
+      // The server's text is the useful part ("host is offline", "already
+      // imported as conv_1"), so show it verbatim and stay open for a retry.
+      setErrorMessage(e instanceof Error ? e.message : "Couldn't import that chat. Try again.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const canImport = hostId !== null && sessionId.trim() !== "" && !importing;
+  // Picking a chat narrows the list to that one row; clearing restores it.
+  const visibleRows = selected !== null ? [selected] : rows;
+
+  return (
+    <>
+      <div className="-mr-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
+        <div className="flex flex-col gap-1.5">
+          <span id="import-chat-source-label" className="text-sm font-medium text-muted-foreground">
+            Chat source
+          </span>
+          <div
+            role="group"
+            aria-labelledby="import-chat-source-label"
+            className="inline-flex self-start gap-1 rounded-lg bg-muted p-[3px]"
+          >
+            {SOURCES.map((id) => (
+              <Button
+                key={id}
+                type="button"
+                size="sm"
+                variant={source === id ? "secondary" : "ghost"}
+                aria-pressed={source === id}
+                disabled={noOnlineHosts}
+                data-testid={`import-chat-source-${id}`}
+                onClick={() => changeSource(id)}
+              >
+                {SOURCE_LABELS[id]}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm font-medium text-muted-foreground">Machine</span>
+          <Select
+            value={hostId ?? ""}
+            onValueChange={(v) => {
+              setHostId(v);
+              // Chats are per-machine, so a pick from the old host is stale.
+              clearSelection();
+            }}
+            disabled={noOnlineHosts}
+          >
+            <SelectTrigger
+              aria-label="Machine"
+              data-testid="import-chat-host-select"
+              className="w-full text-sm"
+            >
+              <SelectValue placeholder="Select a machine" />
+            </SelectTrigger>
+            <SelectContent>
+              {onlineHosts.map((h) => (
+                <SelectItem
+                  key={h.host_id}
+                  value={h.host_id}
+                  data-testid={`import-chat-host-option-${h.host_id}`}
+                >
+                  <span className="font-mono text-sm">{h.name}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {noOnlineHosts && (
+            <p className="text-sm text-muted-foreground">Connect a machine to import chats</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="import-chat-session-id"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            Session ID
+          </label>
+          <Input
+            id="import-chat-session-id"
+            data-testid="import-chat-session-id"
+            value={sessionId}
+            onChange={(e) => {
+              setSessionId(e.target.value);
+              // A hand-edited id no longer describes the picked row, so drop the
+              // selection rather than show a chat that isn't the import target.
+              setSelected(null);
+            }}
+            placeholder="Pick a chat below, or paste a session ID"
+            className="font-mono"
+          />
+        </div>
+
+        {/* A height floor keeps the dialog from collapsing while a source
+            switch refetches — the list is the only part that resizes. */}
+        <div className="flex min-h-36 flex-col gap-2">
+          <span id="import-chat-recent-label" className="text-sm font-medium text-muted-foreground">
+            {selected !== null ? "Selected chat" : `Recent ${SOURCE_LABELS[source]} chats`}
+          </span>
+          {hostId === null ? null : recent.isLoading ? (
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner className="size-3.5" />
+              Loading recent chats…
+            </p>
+          ) : recent.error ? (
+            // The server's wording renders once, in the shared error line below.
+            <p className="text-sm text-muted-foreground">Couldn't list this machine's chats.</p>
+          ) : visibleRows.length === 0 ? (
+            <p data-testid="import-chat-empty" className="text-sm text-muted-foreground">
+              No recent {SOURCE_LABELS[source]} chats on this machine
+            </p>
+          ) : (
+            <ul
+              data-testid="import-chat-recent-list"
+              aria-labelledby="import-chat-recent-label"
+              className="flex flex-col gap-1.5"
+            >
+              {visibleRows.map((row) => (
+                <RecentRow
+                  key={row.external_session_id}
+                  row={row}
+                  selected={selected?.external_session_id === row.external_session_id}
+                  expanded={expandedId === row.external_session_id}
+                  onSelect={() => selectRow(row)}
+                  onToggleExpand={() =>
+                    setExpandedId((id) =>
+                      id === row.external_session_id ? null : row.external_session_id,
+                    )
+                  }
+                />
+              ))}
+            </ul>
+          )}
+          {selected !== null && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="self-start"
+              data-testid="import-chat-clear-selection"
+              onClick={clearSelection}
+            >
+              Clear selection
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {shownError !== null && (
+        <p data-testid="import-chat-error" className="text-sm text-destructive">
+          {shownError}
+        </p>
+      )}
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose} disabled={importing}>
+          Cancel
+        </Button>
+        <Button data-testid="import-chat-submit" onClick={handleImport} disabled={!canImport}>
+          {importing && <Spinner className="size-3.5" />}
+          {importing ? "Importing…" : "Import"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/**
+ * One browsable chat: a click target that selects it, plus a disclosure
+ * button revealing the preview turns the host sent along.
+ */
+function RecentRow({
+  row,
+  selected,
+  expanded,
+  onSelect,
+  onToggleExpand,
+}: {
+  row: LocalSessionSummary;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: () => void;
+  onToggleExpand: () => void;
+}) {
+  // The host can't always recover a title or a workspace from the transcript.
+  const title = row.title ?? "Untitled session";
+  const previewId = `import-chat-preview-${row.external_session_id}`;
+  return (
+    <li className="rounded-lg border border-border">
+      <div className="flex items-start">
+        <button
+          type="button"
+          data-testid={`import-chat-recent-row-${row.external_session_id}`}
+          aria-pressed={selected}
+          onClick={onSelect}
+          className="flex min-w-0 flex-1 cursor-pointer flex-col items-start gap-0.5 rounded-l-lg px-3 py-2 text-left transition-colors hover:bg-muted"
+        >
+          <span className="w-full truncate text-sm font-medium">{title}</span>
+          <span className="flex w-full min-w-0 gap-2 text-xs text-muted-foreground">
+            <span className="truncate font-mono">{row.workspace ?? "Unknown folder"}</span>
+            <span className="shrink-0">
+              {row.item_count} {row.item_count === 1 ? "item" : "items"}
+            </span>
+          </span>
+        </button>
+        <button
+          type="button"
+          data-testid={`import-chat-expand-${row.external_session_id}`}
+          aria-expanded={expanded}
+          aria-controls={expanded ? previewId : undefined}
+          aria-label={`${expanded ? "Hide" : "Show"} preview of ${title}`}
+          onClick={onToggleExpand}
+          className="cursor-pointer rounded-r-lg px-2 py-3 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? (
+            <ChevronDownIcon className="size-4" />
+          ) : (
+            <ChevronRightIcon className="size-4" />
+          )}
+        </button>
+      </div>
+      {expanded && (
+        <div
+          id={previewId}
+          data-testid={previewId}
+          className="flex flex-col gap-1 border-t border-border px-3 py-2 text-xs"
+        >
+          {row.preview.length === 0 ? (
+            <p className="text-muted-foreground">No preview available</p>
+          ) : (
+            row.preview.map((message, i) => (
+              // Preview turns carry no id and never reorder — index is stable.
+              // eslint-disable-next-line react/no-array-index-key
+              <p key={i} className="truncate">
+                <span className="font-medium text-muted-foreground">{message.role}: </span>
+                {message.text}
+              </p>
+            ))
+          )}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -5,7 +5,7 @@ import type * as ChatStoreModule from "@/store/chatStore";
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import {
@@ -41,6 +41,8 @@ import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFile
 import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
+import { useHostLocalSessions } from "@/hooks/useHostLocalSessions";
+import { importHostLocalSession, type LocalSessionSummary } from "@/lib/localSessionImportApi";
 import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
 import { writeHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
@@ -90,6 +92,10 @@ vi.mock("@/hooks/useDirectorySessions", () => ({
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useRunnerHealthRegistration: vi.fn(),
 }));
+// The composer's Import-chat dialog browses/imports via these — stubbed so
+// the two import-flow tests below can drive it without a real host/server.
+vi.mock("@/hooks/useHostLocalSessions", () => ({ useHostLocalSessions: vi.fn() }));
+vi.mock("@/lib/localSessionImportApi", () => ({ importHostLocalSession: vi.fn() }));
 // The composer's project chip lists projects via useProjects; stub it to an
 // empty list so it doesn't fire its own authenticatedFetch (which would skew
 // the create-POST call-count / call-order assertions below).
@@ -173,6 +179,8 @@ const useHostWorktreesMock = vi.mocked(useHostWorktrees);
 const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
 const setPendingInitialPromptMock = vi.mocked(setPendingInitialPrompt);
+const useHostLocalSessionsMock = vi.mocked(useHostLocalSessions);
+const importHostLocalSessionMock = vi.mocked(importHostLocalSession);
 
 const RECENT_KEY = "omnigent:recent-workspaces";
 // Per-harness remembered option knobs (see lib/modePreferences).
@@ -671,6 +679,20 @@ function mockAgents(agents: AvailableAgent[]) {
   } as unknown as ReturnType<typeof useAvailableAgents>);
 }
 
+/** A `useHostLocalSessions` result, for the Import-chat composer tests. */
+function localSessionsResult(
+  data: LocalSessionSummary[] | undefined,
+  extra: { isLoading?: boolean; error?: Error | null } = {},
+): ReturnType<typeof useHostLocalSessions> {
+  const error = extra.error ?? null;
+  return {
+    data,
+    isLoading: extra.isLoading ?? false,
+    isError: error !== null,
+    error,
+  } as unknown as ReturnType<typeof useHostLocalSessions>;
+}
+
 // Shared mock setup for the landing-screen tests: one online host (host_1,
 // auto-selected), two agents (Claude Code default + Codex), inert
 // directory-session / runner-health / filesystem stubs, and a persisted
@@ -684,6 +706,8 @@ function setupLandingMocks() {
   useHostWorktreesMock.mockReset();
   useDirectorySessionsMock.mockReset();
   useRunnerHealthMock.mockReset();
+  useHostLocalSessionsMock.mockReset();
+  importHostLocalSessionMock.mockReset();
   // Reset the install hooks to their inert defaults: per-test overrides
   // (a pending install set, a callback-firing mutate) must not leak into the
   // next test — a stale pending set would disable the Install button and make
@@ -771,6 +795,55 @@ function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
         <TooltipProvider>
           <MemoryRouter initialEntries={[route]}>
             <NewChatLandingScreen />
+          </MemoryRouter>
+        </TooltipProvider>
+      </CapabilitiesProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Renders the `conversationId` route param, so a post-import `navigate()` can
+ *  be observed by asserting this marker appeared with the imported session id. */
+function ImportNavTarget() {
+  const { conversationId } = useParams<{ conversationId: string }>();
+  return <div data-testid="import-nav-target">{conversationId}</div>;
+}
+
+/**
+ * Same as `renderLanding`, but with a `/c/:conversationId` route mounted
+ * alongside it (matching Sidebar.test.tsx's own MemoryRouter+Routes idiom),
+ * so a successful import's navigation can be asserted by the target rendering.
+ */
+function renderLandingWithImportNavTarget(): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const info: ServerInfo = {
+    accounts_enabled: false,
+    single_user: false,
+    login_url: null,
+    needs_setup: false,
+    databricks_features: false,
+    managed_sandboxes_enabled: false,
+    sandbox_provider: null,
+    sharing_mode: "on",
+    public_sharing_enabled: true,
+    server_version: null,
+    smart_routing_enabled: false,
+    smart_routing_sources: { external: false, oss: false },
+    harness_install_enabled: false,
+    installable_harnesses: [],
+    dictation_available: false,
+  };
+  render(
+    <QueryClientProvider client={client}>
+      <CapabilitiesProvider info={info}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/"]}>
+            <Routes>
+              <Route path="/" element={<NewChatLandingScreen />} />
+              <Route path="/c/:conversationId" element={<ImportNavTarget />} />
+            </Routes>
           </MemoryRouter>
         </TooltipProvider>
       </CapabilitiesProvider>
@@ -2428,6 +2501,42 @@ describe("NewChatLandingScreen", () => {
       target: { value: "https://github.com/org/repo" },
     });
     expect(submit.disabled).toBe(false);
+  });
+
+  it("opens the import-chat dialog from the composer", async () => {
+    useHostLocalSessionsMock.mockReturnValue(localSessionsResult([]));
+    renderLanding();
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-import-chat"));
+
+    expect(await screen.findByTestId("import-chat-dialog")).toBeInTheDocument();
+  });
+
+  it("navigates to the imported session after a successful import", async () => {
+    useHostLocalSessionsMock.mockReturnValue(
+      localSessionsResult([
+        {
+          source: "claude",
+          external_session_id: "abc",
+          workspace: "/Users/corey/repo",
+          title: "Fix the flaky parser",
+          item_count: 4,
+          preview: [],
+        },
+      ]),
+    );
+    importHostLocalSessionMock.mockResolvedValue({
+      session_id: "conv_new",
+      status: "imported",
+      item_count: 4,
+    });
+    renderLandingWithImportNavTarget();
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-import-chat"));
+    fireEvent.click(await screen.findByTestId("import-chat-recent-row-abc"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    expect(await screen.findByTestId("import-nav-target")).toHaveTextContent("conv_new");
   });
 });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2538,6 +2538,44 @@ describe("NewChatLandingScreen", () => {
 
     expect(await screen.findByTestId("import-nav-target")).toHaveTextContent("conv_new");
   });
+
+  it("refreshes the sidebar's conversation list after a successful import", async () => {
+    // The imports router never announces `session_added`, so there is no WS
+    // push to backfill the sidebar the way a normal create's push (or its
+    // own refetch/invalidate below) does — this has to trigger it itself.
+    useHostLocalSessionsMock.mockReturnValue(
+      localSessionsResult([
+        {
+          source: "claude",
+          external_session_id: "abc",
+          workspace: "/Users/corey/repo",
+          title: "Fix the flaky parser",
+          item_count: 4,
+          preview: [],
+        },
+      ]),
+    );
+    importHostLocalSessionMock.mockResolvedValue({
+      session_id: "conv_new",
+      status: "imported",
+      item_count: 4,
+    });
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    const refetchSpy = vi.spyOn(QueryClient.prototype, "refetchQueries");
+    renderLandingWithImportNavTarget();
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-import-chat"));
+    fireEvent.click(await screen.findByTestId("import-chat-recent-row-abc"));
+    fireEvent.click(screen.getByTestId("import-chat-submit"));
+
+    await screen.findByTestId("import-nav-target");
+    expect(refetchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["conversations"] }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["directory-sessions"] }),
+    );
+  });
 });
 
 // The landing composer's "/" skills menu: bundled skills of the chosen

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -16,6 +16,7 @@ import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  DownloadIcon,
   GitBranchIcon,
   ArrowUpIcon,
   Loader2Icon,
@@ -194,6 +195,7 @@ import type { CostControlMode } from "@/components/CostRoutingControl";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
+import { ImportChatDialog } from "./ImportChatDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
 import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
 
@@ -2139,6 +2141,8 @@ export function NewChatLandingScreen() {
   } | null>(null);
   // Harness-config modal, opened from the composer's gear icon.
   const [configOpen, setConfigOpen] = useState(false);
+  // Import-chat dialog, opened from the composer's import icon.
+  const [importOpen, setImportOpen] = useState(false);
 
   // Mirror the current draft fields into a ref every render so the unmount
   // cleanup below can snapshot the latest values without re-subscribing.
@@ -4159,6 +4163,27 @@ export function NewChatLandingScreen() {
                     </>
                   )}
                 </div>
+                {/* Import chat — independent of the selected agent, so unlike
+                  the gear it is never hidden behind the knobs check above. */}
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="size-9 text-muted-foreground md:size-8"
+                        disabled={creating}
+                        onClick={() => setImportOpen(true)}
+                        data-testid="new-chat-landing-import-chat"
+                        aria-label="Import chat"
+                      >
+                        <DownloadIcon className="size-4" data-icon-size="16" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">Import chat</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 {selectedAgent && selectedAgentHasKnobs && (
                   <HarnessConfigModal
                     open={configOpen}
@@ -4194,6 +4219,15 @@ export function NewChatLandingScreen() {
                     setCostControlMode={setCostControlMode}
                   />
                 )}
+                <ImportChatDialog
+                  open={importOpen}
+                  onOpenChange={setImportOpen}
+                  defaultHostId={selectedHostId}
+                  onImported={(sessionId) => {
+                    setImportOpen(false);
+                    navigate(`/c/${sessionId}`);
+                  }}
+                />
                 {/* Routing is not a standalone composer toggle — it folds into
                   the gear modal's Model dropdown as an "Smart Routing"
                   option (see HarnessConfigModal). */}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4225,6 +4225,11 @@ export function NewChatLandingScreen() {
                   defaultHostId={selectedHostId}
                   onImported={(sessionId) => {
                     setImportOpen(false);
+                    // The imports router never announces `session_added`, so the
+                    // sidebar has no push to pick this session up on its own —
+                    // refresh it the same way a normal create does.
+                    void queryClient.refetchQueries({ queryKey: ["conversations"] });
+                    void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
                     navigate(`/c/${sessionId}`);
                   }}
                 />


### PR DESCRIPTION
## Related issue

Closes #4462

## Summary

Existing Claude Code and Codex chats could only be imported through the CLI, and only if you already
knew the session id. The New Session UI exposed nothing. This adds an **Import chat** action to the
composer that lets you pick Claude Code or Codex, an online host, and a session — browsing recent
sessions with their title, workspace, item count, and expandable preview — then imports the transcript.

**ELI5:** your old Claude Code / Codex chats live as files on your machine. The web UI runs in a
browser and can't read those files. But the *host* process already connected to Omnigent can. So the
server asks the host "what chats do you have?", shows you the list, and when you pick one the host
reads it and hands it back — and from there the chat is imported through exactly the same code path
the CLI already used.

Two design points worth a reviewer's attention:

- **The host stays the only filesystem reader.** Nothing under `omnigent/server/` touches `~/.claude`
  or `~/.codex`. Browse and load ride the existing host tunnel as two new frame pairs, following the
  `host.list_worktrees` pattern already in the codebase.
- **Web and CLI imports share one creation path.** `POST /v1/imports`' body was extracted into
  `_create_imported_session`, which the new endpoint also calls, so duplicate detection, provenance
  labels, and ownership grants can't drift between the two clients. The refactor is isolated in its own
  commit (`eb83f2ca`) ahead of the new endpoints, so the CLI-regression question is reviewable on its
  own. Recent-session titles reuse `title_from_items`, so a browsed row and the session it creates
  always read the same.

```mermaid
sequenceDiagram
    participant UI as Web UI (browser)
    participant API as Server (/v1/imports)
    participant Host as Host daemon
    participant Disk as ~/.claude, ~/.codex

    UI->>API: GET /v1/imports/local-sessions?host_id&source
    API->>Host: host.list_local_sessions (tunnel)
    Host->>Disk: read recent transcripts
    Host-->>API: summaries (title, workspace, item_count, preview)
    API-->>UI: rows for the picker

    UI->>API: POST /v1/imports/local-sessions
    API->>Host: host.load_local_session (tunnel)
    Host-->>API: normalized items
    Note over API: _create_imported_session — the same helper POST /v1/imports uses
    API-->>UI: session_id → navigate to the chat
```

Scope is deliberately Claude Code and Codex only (`ImportBrowseSource`), enforced at the query model,
the REST handler, and the host handler. The manual paste-a-session-id path stays alongside browsing, so
sessions older than the 20-row window are still reachable.

## Test Plan

Automated, all run on the final commit:

| Suite | Result |
|---|---|
| `pytest tests/test_session_import.py tests/host/ tests/cli/test_import.py` | 398 passed |
| `pytest tests/server/routes/` | 941 passed |
| `pytest tests/server/routes/test_imports.py tests/cli/test_import.py` | 32 passed |
| `vitest run src/shell/ImportChatDialog.test.tsx` | 12 passed |
| `vitest run src/lib/localSessionImportApi.test.ts src/hooks/useHostLocalSessions.test.tsx` | 6 passed |
| `vitest run src/shell/NewChatDialog.test.tsx` | 268 passed, 3 pre-existing failures |
| `npm run lint`, `npx tsc -b` | clean |

Two notes so reviewers don't chase them:

- The 3 failures in `NewChatDialog.test.tsx` (`switching between a host and the sandbox swaps the
  workspace chrome`, `shows 'Create custom agent' on a host and opens the dialog`, `drops a selected
  pending custom agent when the target switches to a sandbox`) reproduce identically on unmodified
  `main` — verified by running that suite in a clean worktree at the branch point. They are not caused
  by this PR.
- `tests/server/routes/` emits one warning: a third-party `StarletteDeprecationWarning` from
  `fastapi/testclient.py`, also pre-existing.

To exercise it by hand:

```bash
omnigent host      # one terminal — connect this machine
omnigent serve     # another
```

Then in the web UI: New Session → the Import chat icon beside the agent picker → source **Claude Code**
→ the list should match `omnigent import --harness claude --last 5`. Expand a row for its first
messages, select it, clear it (the list should come back), then import. Re-importing the same session
should report it as already imported. Repeat with **Codex**.

## Demo

_Pending — a screen recording of the picker, an expanded preview, and the post-import navigation still
needs to be attached before merge._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New coverage spans every layer: summary/preview generation and the skip-a-corrupt-transcript path;
round-trip and malformed-payload rejection for all four frames; the host handlers including the
unsupported-source and not-found cases; the server proxy's host-failure, dropped-connection, and
timeout-with-cleanup paths; both endpoints' 400/403/404/409/503 outcomes plus the already-imported
409; and the dialog's nine behaviours including the issue's clear-selection-restores-the-list
requirement. `POST /v1/imports`' pre-existing tests and `tests/cli/test_import.py` were left
**unmodified** and still pass, which is the CLI-regression guard for the shared-helper refactor.

Being straight about the gap: **no manual end-to-end run against a live host was performed** — hence
that box left unchecked and the Demo section still open. Everything above is automated coverage.

## Changelog

Import your existing Claude Code and Codex chats straight from the New Session screen, browsing recent
sessions instead of pasting a session ID
