### PR TITLE
test: fix three more ambient-state leaks from the #4279 family (follow-up to #4363/#4369)

### DIFF
--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -26,10 +26,19 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     this file so the developer's real ``~/.omnigent/config.yaml`` (e.g.
     a default provider) cannot hijack the legacy-profile path under test.
 
+    ``HOME`` is redirected there too. An empty omnigent config is not enough
+    isolation on its own: ambient provider detection also reads
+    ``~/.codex/config.toml`` and ``~/.databrickscfg``, so a developer whose
+    codex config pins a Databricks gateway has pi consume that detected
+    cli-config provider and stall in databricks-sdk workspace lookups.
+    ``USERPROFILE`` is the Windows spelling of the same home.
+
     :param monkeypatch: Pytest monkeypatch fixture.
-    :param tmp_path: Temporary directory for the isolated config.
+    :param tmp_path: Temporary directory for the isolated config and home.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr(
         "omnigent.runtime.workflow._resolve_catalog_default_model",
         lambda provider_name, family, *, context: f"catalog-{provider_name}-{family}-default",

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -23,8 +23,10 @@ import stat
 import struct
 import subprocess
 import sys
+import tempfile
 import termios
 import tty
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -71,6 +73,23 @@ def test_importing_claude_native_does_not_pull_in_fastapi() -> None:
     assert result.returncode == 0, (
         f"claude_native import pulled in the FastAPI stack. stderr:\n{result.stderr}"
     )
+
+
+@pytest.fixture
+def short_tmp_parent() -> Iterator[Path]:
+    """
+    Per-test parent directory under ``/tmp`` with a short path.
+
+    macOS caps an AF_UNIX socket path at ~103 bytes, and pytest's
+    :data:`tmp_path` resolves under ``/private/var/folders/...`` — long
+    enough on its own to blow that budget. A ``tmux -S`` server on such a
+    path never starts, failing with "File name too long".
+    """
+    parent = Path(tempfile.mkdtemp(prefix="omni-ws-", dir="/tmp"))
+    try:
+        yield parent
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
 
 
 @pytest.mark.asyncio
@@ -376,7 +395,9 @@ def _new_tmux_session(socket_path: Path, target: str = "main") -> list[str]:
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")
 @pytest.mark.asyncio
-async def test_tmux_session_alive_tracks_real_session(tmp_path: Path) -> None:
+async def test_tmux_session_alive_tracks_real_session(
+    short_tmp_parent: Path, tmp_path: Path
+) -> None:
     """
     ``_tmux_session_alive`` is ``True`` for a live session, ``False``
     once the server is killed, and ``False`` for an unknown socket.
@@ -384,9 +405,11 @@ async def test_tmux_session_alive_tracks_real_session(tmp_path: Path) -> None:
     This is the signal the bridge uses to tell a detach (session alive)
     apart from a session exit.
 
-    :param tmp_path: Pytest tmp directory for the private socket.
+    :param short_tmp_parent: Short-pathed tmp directory for the private socket.
+    :param tmp_path: Pytest tmp directory for the never-created socket path.
     """
-    socket_path = tmp_path / "tmux.sock"
+    # short_tmp_parent keeps tmux -S within macOS's 103-byte AF_UNIX cap.
+    socket_path = short_tmp_parent / "tmux.sock"
     base = _new_tmux_session(socket_path)
     try:
         assert await _tmux_session_alive(str(socket_path), "main") is True
@@ -403,7 +426,7 @@ async def test_tmux_session_alive_tracks_real_session(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")
 @pytest.mark.asyncio
-async def test_tmux_session_alive_false_for_dead_pane(tmp_path: Path) -> None:
+async def test_tmux_session_alive_false_for_dead_pane(short_tmp_parent: Path) -> None:
     """
     A kept-alive session whose pane process exited reads as not-alive.
 
@@ -413,9 +436,10 @@ async def test_tmux_session_alive_false_for_dead_pane(tmp_path: Path) -> None:
     would treat the crash as a mere detach and the web client would reconnect
     to a dead pane forever instead of closing.
 
-    :param tmp_path: Pytest tmp directory for the private socket.
+    :param short_tmp_parent: Short-pathed tmp directory for the private socket.
     """
-    socket_path = tmp_path / "tmux.sock"
+    # short_tmp_parent keeps tmux -S within macOS's 103-byte AF_UNIX cap.
+    socket_path = short_tmp_parent / "tmux.sock"
     base = ["tmux", "-S", str(socket_path), "-f", "/dev/null"]
     # One command sequence on a fresh server (";" separates tmux commands):
     # set remain-on-exit globally BEFORE new-session so the session inherits it
@@ -523,7 +547,7 @@ async def test_bridge_advertises_safe_osc52_capability(
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")
 @pytest.mark.asyncio
 async def test_bridge_detach_closes_4405_and_leaves_session_alive(
-    tmp_path: Path,
+    short_tmp_parent: Path,
 ) -> None:
     """
     A tmux detach closes the attach WS with 4405, not 4404, and leaves
@@ -541,9 +565,10 @@ async def test_bridge_detach_closes_4405_and_leaves_session_alive(
     retry ``detach-client`` until the bridge actually ends, polling the
     external tmux server's client state rather than guessing a delay.
 
-    :param tmp_path: Pytest tmp directory for the private socket.
+    :param short_tmp_parent: Short-pathed tmp directory for the private socket.
     """
-    socket_path = tmp_path / "tmux.sock"
+    # short_tmp_parent keeps tmux -S within macOS's 103-byte AF_UNIX cap.
+    socket_path = short_tmp_parent / "tmux.sock"
     base = _new_tmux_session(socket_path)
     ws = _ParkingFakeWebSocket()
     bridge_task = asyncio.create_task(
@@ -617,7 +642,7 @@ class _CollectingFakeWebSocket(_ParkingFakeWebSocket):
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")
 @pytest.mark.asyncio
 async def test_bridge_attach_renders_pane_with_dumb_ambient_term(
-    tmp_path: Path,
+    short_tmp_parent: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -638,14 +663,15 @@ async def test_bridge_attach_renders_pane_with_dumb_ambient_term(
     "open terminal failed" error and exits — the marker never arrives
     and this test times out at the wait below.
 
-    :param tmp_path: Pytest tmp directory for the private socket.
+    :param short_tmp_parent: Short-pathed tmp directory for the private socket.
     :param monkeypatch: Used to set the ambient ``TERM=dumb``.
     """
     # The sandbox condition: every process in the chain (including the
     # tmux server about to be spawned) sees a dumb TERM.
     monkeypatch.setenv("TERM", "dumb")
 
-    socket_path = tmp_path / "tmux.sock"
+    # short_tmp_parent keeps tmux -S within macOS's 103-byte AF_UNIX cap.
+    socket_path = short_tmp_parent / "tmux.sock"
     base = ["tmux", "-S", str(socket_path), "-f", "/dev/null"]
     marker = "BRIDGE_TERM_PIN_OK"
     subprocess.run(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -7754,6 +7754,8 @@ def test_resolve_native_claude_config_ambient_key(
     """
     monkeypatch.delenv("CLAUDE_CODE_USE_GATEWAY", raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+    # The default-endpoint assertion must not inherit an ambient gateway URL.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
 
     cfg = claude_native.resolve_native_claude_config(spec=None)
     assert cfg is not None
@@ -7768,6 +7770,8 @@ def test_resolve_native_claude_config_ambient_prefixed_key(
     """A prefixed Anthropic key routes native Claude without raw env exposure."""
     monkeypatch.delenv("CLAUDE_CODE_USE_GATEWAY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # The default-endpoint assertion must not inherit an ambient gateway URL.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     monkeypatch.setenv("OMNIGENT_ANTHROPIC_API_KEY", "sk-ant-prefixed")
 
     cfg = claude_native.resolve_native_claude_config(spec=None)


### PR DESCRIPTION
## Related issue

Addresses #4279 — a follow-up to #4363 (classes 1 & 3) and #4369 (classes 2 & 4), fixing three more instances of the same leak families in files neither PR touches. Deliberately does **not** close the issue and has zero file overlap with either PR, so all three can land in any order.

## Summary

- **`tests/terminals/test_ws_bridge.py`** (class 2): four real-tmux tests bind their AF_UNIX socket under pytest's `tmp_path`, overflowing the macOS ~103-byte `sun_path` cap — same root cause as #4369's proxy/terminal fixes. Adds the same `short_tmp_parent` fixture shape and binds the tmux socket under it.
- **`tests/runtime/test_pi_spawn_env.py`** (class 4): the file's autouse config-isolation fixture pins `OMNIGENT_CONFIG_HOME` but not `HOME`, so a provider-pinning `~/.codex/config.toml` on a Databricks dev box routes pi through the detected cli-config gateway and wedges `_build_pi_spawn_env` in databricks-sdk host-metadata retries until pytest-timeout. Adds the same `HOME`/`USERPROFILE` redirect #4369 added to the openai-agents twin file.
- **`tests/test_claude_native.py`** (new, fifth leak of the same family): the two ambient-credential tests assert `cfg.env["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"`, but an ambient gateway `ANTHROPIC_BASE_URL` is (correctly, in production) honored by detection, flipping both red. Clears it inline, mirroring the existing `ANTHROPIC_API_KEY` delenv one line above.

## Test Plan

Each fix was proven red-before/green-after on a macOS 26 arm64 checkout:

- ws_bridge: pre-fix `4 failed` ("File name too long" connecting to the tmux socket) → post-fix `6 passed, 31 deselected`.
- pi_spawn_env: with a constructed polluted HOME (multi-profile `.databrickscfg` + a `~/.codex/config.toml` whose `[model_providers.Databricks.auth]` block makes detection accept it), pre-fix wedges in `databricks/sdk/oauth.py` retries until `--timeout=60` kills it → post-fix `5 passed` under the same polluted HOME.
- claude_native: `ANTHROPIC_BASE_URL=https://example.invalid` pre-fix `2 failed` → post-fix `2 passed`.
- Clean-env regression across all three files: `212 passed`, 1 pre-existing failure (`test_bridge_splits_pty_redraw_after_control_key_input`, asyncio timeout) proven identical on the pristine files by stashing the edits.
- `pre-commit run` on the three files: all hooks pass.

One repro subtlety worth recording: a `~/.codex/config.toml` with only `name`/`base_url` is rejected by `_provider_table_has_self_contained_auth` (`omnigent/onboarding/ambient.py:234`) and detects nothing — the polluting config must carry its own `[model_providers.<name>.auth]` block for the class-4 leak to fire.

## Demo

N/A — test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the red/green matrix above (deterministic socket-cap and env-leak repros, plus the constructed polluted-HOME immunity proof). The changes are themselves test isolation; no product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
