### PR TITLE
fix(web): navigate to ~/ paths and show an error for nonexistent paths in the workspace picker

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -2595,6 +2595,95 @@ async def _drive_type_tilde_path(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_type_nonexistent_path(seeded_session: tuple[str, str]) -> None:
+    """Typing a path that doesn't exist shows an error, not the old listing.
+
+    Previously a typed path the host 404s on left the picker showing the
+    *previous* valid directory's contents: the filesystem query kept the old
+    listing on screen as placeholder data while it burned through its default
+    retries on the deterministic 404, so for several seconds nothing signalled
+    that the path was bad (the reported bug). With the 404 no longer retried,
+    the picker drops the stale rows immediately and surfaces a "doesn't exist"
+    message.
+
+    This drives that end to end: open the browser (seeded at ``/home/e2e``,
+    showing ``Desktop``), type a nonexistent ``~/does-not-exist``, press Enter,
+    and assert the picker shows the doesn't-exist error and no longer lists the
+    previous directory's ``Desktop`` entry.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_type_nonexistent_path(base_url, session_id))
+
+
+async def _drive_type_nonexistent_path(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_filesystem(route: Route) -> None:
+                # Home ("/home/e2e", and the bare home listing) shows "Desktop";
+                # the typed "/home/e2e/does-not-exist" 404s exactly as the host
+                # does for a missing path.
+                path_part = route.request.url.split("?")[0]
+                if path_part.endswith("/filesystem/home/e2e/does-not-exist"):
+                    await route.fulfill(
+                        status=404,
+                        content_type="application/json",
+                        body=json.dumps({"detail": "path does not exist"}),
+                    )
+                    return
+                entries = [
+                    {
+                        "name": "Desktop",
+                        "path": "/home/e2e/Desktop",
+                        "type": "directory",
+                        "bytes": None,
+                        "modified_at": 0,
+                    }
+                ]
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"object": "list", "data": entries, "has_more": False}),
+                )
+
+            # Registered last so it wins over the broader **/v1/hosts glob.
+            await page.route(_FILESYSTEM_RE, handle_filesystem)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "e2e"
+            )
+
+            # Open the browser; the valid home listing shows Desktop.
+            await page.get_by_test_id("new-chat-landing-workspace-chip").click()
+            await expect(page.get_by_test_id("workspace-picker")).to_be_visible()
+            await expect(page.get_by_test_id("workspace-picker-entry-Desktop")).to_be_visible()
+
+            # Type a nonexistent path and commit with Enter.
+            path_input = page.get_by_test_id("workspace-picker-path-input")
+            await path_input.fill("~/does-not-exist")
+            await path_input.press("Enter")
+
+            # The picker surfaces a doesn't-exist error (pre-fix it silently kept
+            # showing the previous directory while retrying the 404)...
+            error = page.get_by_test_id("workspace-picker-error")
+            await expect(error).to_be_visible()
+            await expect(error).to_contain_text("doesn't exist")
+            # ...and the previous directory's rows are gone — no stale listing.
+            await expect(page.get_by_test_id("workspace-picker-entry-Desktop")).to_have_count(0)
+        finally:
+            await browser.close()
+
+
 def test_start_session_add_worktree(seeded_session: tuple[str, str]) -> None:
     """Naming a branch attaches a git worktree spec to the create call.
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -2492,6 +2492,109 @@ async def _drive_create_folder(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_type_tilde_path(seeded_session: tuple[str, str]) -> None:
+    """Typing a ``~/…`` path in the workspace picker navigates there.
+
+    The picker opens at the composer's seeded working directory — an
+    *absolute* path (the host's home). Because it never lands on the empty
+    "home" view, it used to never resolve the host's home dir, so a typed
+    ``~/Desktop`` couldn't be expanded and the path bar silently snapped back
+    to the previous directory (the reported bug: ``~/…`` "just reverts").
+
+    This drives that gesture end to end: open the browser (seeded at
+    ``/home/e2e``), type ``~/Desktop`` in the path bar, press Enter, and assert
+    the listing navigates into ``/home/e2e/Desktop`` and the picked path reaches
+    ``POST /v1/sessions`` as ``workspace``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_type_tilde_path(base_url, session_id))
+
+
+async def _drive_type_tilde_path(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_filesystem(route: Route) -> None:
+                # Home ("/home/e2e", listed as "~" and as the absolute path)
+                # shows "Desktop"; "/home/e2e/Desktop" shows its child. The
+                # entries carry absolute paths so home resolves to "/home/e2e"
+                # from any listing's parent.
+                path_part = route.request.url.split("?")[0]
+                if path_part.endswith("/filesystem/home/e2e/Desktop"):
+                    entries = [
+                        {
+                            "name": "notes",
+                            "path": "/home/e2e/Desktop/notes",
+                            "type": "directory",
+                            "bytes": None,
+                            "modified_at": 0,
+                        }
+                    ]
+                else:
+                    entries = [
+                        {
+                            "name": "Desktop",
+                            "path": "/home/e2e/Desktop",
+                            "type": "directory",
+                            "bytes": None,
+                            "modified_at": 0,
+                        }
+                    ]
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"object": "list", "data": entries, "has_more": False}),
+                )
+
+            # Registered last so it wins over the broader **/v1/hosts glob.
+            await page.route(_FILESYSTEM_RE, handle_filesystem)
+
+            # No recent seed: the composer derives home from the listing and
+            # seeds the working directory to it, so the picker opens at the
+            # absolute "/home/e2e" — never the empty home view.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "e2e"
+            )
+
+            # Open the browser and type a ~-relative path, then commit with Enter.
+            await page.get_by_test_id("new-chat-landing-workspace-chip").click()
+            await expect(page.get_by_test_id("workspace-picker")).to_be_visible()
+            path_input = page.get_by_test_id("workspace-picker-path-input")
+            await path_input.fill("~/Desktop")
+            await path_input.press("Enter")
+
+            # The listing navigated into the tilde-expanded directory — its
+            # child confirms we're inside /home/e2e/Desktop (pre-fix the bar
+            # reverted to /home/e2e and this row never appeared).
+            await expect(page.get_by_test_id("workspace-picker-entry-notes")).to_be_visible()
+
+            # Filling the message closes the popover; the chip follows the
+            # navigated folder.
+            await page.get_by_test_id("new-chat-landing-input").fill("explore the desktop")
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "Desktop"
+            )
+
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/home/e2e/Desktop", body
+        finally:
+            await browser.close()
+
+
 def test_start_session_add_worktree(seeded_session: tuple[str, str]) -> None:
     """Naming a branch attaches a git worktree spec to the create call.
 

--- a/web/src/hooks/useHostFilesystem.test.ts
+++ b/web/src/hooks/useHostFilesystem.test.ts
@@ -13,6 +13,7 @@ import type { HostFilesystemEntry } from "./useHostFilesystem";
 import {
   buildHostFilesystemUrl,
   createHostDirectory,
+  shouldRetryHostFilesystem,
   useHostFilesystem,
 } from "./useHostFilesystem";
 
@@ -175,13 +176,14 @@ describe("useHostFilesystem", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("throws a FetchError carrying the HTTP status on a non-OK response", async () => {
+  it("throws a friendly doesn't-exist error carrying the status on a 404", async () => {
     // WHY: the picker distinguishes 404 (no such dir) from other failures via
-    // err.status, so the thrown error must surface the response status.
+    // err.status, and a typed bad path is the common 404 — so the message must
+    // read as "doesn't exist" (naming the path), not a bare status code.
     fetchMock.mockResolvedValue({
       ok: false,
       status: 404,
-      json: async () => ({}),
+      json: async () => ({ detail: "path does not exist" }),
     } as unknown as Response);
 
     const { result } = renderHook(() => useHostFilesystem("host_1", "/missing"), {
@@ -191,7 +193,37 @@ describe("useHostFilesystem", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     const err = result.current.error as (Error & { status?: number }) | null;
     expect(err?.status).toBe(404);
-    expect(err?.message).toContain("HTTP 404");
+    expect(err?.message).toContain("/missing");
+    expect(err?.message).toContain("doesn't exist");
+  });
+});
+
+// The listing must not retry a deterministic 4xx (retries keep the query
+// pending, leaving the previous directory's rows on screen behind the
+// placeholder), but must still retry transient failures up to the cap.
+describe("shouldRetryHostFilesystem", () => {
+  function withStatus(status: number): Error {
+    const err = new Error(`HTTP ${status}`) as Error & { status?: number };
+    err.status = status;
+    return err;
+  }
+
+  it("never retries a 4xx (missing path, bad path, not owner)", () => {
+    expect(shouldRetryHostFilesystem(0, withStatus(404))).toBe(false);
+    expect(shouldRetryHostFilesystem(0, withStatus(403))).toBe(false);
+    expect(shouldRetryHostFilesystem(0, withStatus(400))).toBe(false);
+  });
+
+  it("retries a transient 5xx up to the cap, then stops", () => {
+    expect(shouldRetryHostFilesystem(0, withStatus(502))).toBe(true);
+    expect(shouldRetryHostFilesystem(2, withStatus(502))).toBe(true);
+    expect(shouldRetryHostFilesystem(3, withStatus(502))).toBe(false);
+  });
+
+  it("retries a status-less error (network failure) up to the cap", () => {
+    // A thrown network error carries no HTTP status — treat it as transient.
+    expect(shouldRetryHostFilesystem(0, new Error("network down"))).toBe(true);
+    expect(shouldRetryHostFilesystem(3, new Error("network down"))).toBe(false);
   });
 });
 

--- a/web/src/hooks/useHostFilesystem.ts
+++ b/web/src/hooks/useHostFilesystem.ts
@@ -73,6 +73,61 @@ interface FetchError extends Error {
   status?: number;
 }
 
+// The directory listing inherits React Query's default retry count for
+// transient failures; 4xx responses opt out of it (see
+// ``shouldRetryHostFilesystem``).
+const MAX_LIST_RETRIES = 3;
+
+/**
+ * Build a human-readable error for a failed directory listing.
+ *
+ * A 404 means the path doesn't exist (or isn't a directory) — the common case
+ * when a user types a bad path into the picker — so it gets a plain "doesn't
+ * exist" message naming the path instead of a bare status code. Other failures
+ * use the server's ``detail`` when present, else fall back to the status code.
+ *
+ * @param res Non-OK response from a listing request.
+ * @param path The path that was being listed, for the 404 message.
+ * @returns The message to attach to the thrown ``FetchError``.
+ */
+async function describeListError(res: Response, path: string): Promise<string> {
+  if (res.status === 404) {
+    const where = path === "" || path === "~" ? "That directory" : path;
+    return `${where} doesn't exist on this host (or isn't a directory).`;
+  }
+  // Host offline / timed out (409/502/504) or another failure — surface the
+  // server's detail so the user sees why, else fall back to the status code.
+  let detail: string | null;
+  try {
+    const body = (await res.json()) as { detail?: string };
+    detail = typeof body.detail === "string" && body.detail !== "" ? body.detail : null;
+  } catch {
+    detail = null;
+  }
+  return detail ?? `Couldn't list the directory (HTTP ${res.status}).`;
+}
+
+/**
+ * React Query retry predicate for the directory listing.
+ *
+ * 4xx responses are deterministic (missing path, bad path, not the owner), so
+ * retrying them just delays the error behind the stale placeholder listing the
+ * picker keeps on screen while a query is pending. Skip retries for those and
+ * let the error surface immediately; retry only transient failures (5xx,
+ * network) up to the default cap, matching the untuned default's 3 retries.
+ *
+ * @param failureCount Number of failures so far (0 on the first failure).
+ * @param error The thrown error; a ``FetchError`` carries the HTTP ``status``.
+ * @returns Whether React Query should retry the request.
+ */
+export function shouldRetryHostFilesystem(failureCount: number, error: Error): boolean {
+  const status = (error as FetchError).status;
+  if (status !== undefined && status >= 400 && status < 500) {
+    return false;
+  }
+  return failureCount < MAX_LIST_RETRIES;
+}
+
 /**
  * A directory's listing plus whether it was cut short by the page
  * cap. ``truncated`` lets the picker tell the user the view is
@@ -126,7 +181,7 @@ async function fetchHostFilesystem(hostId: string, path: string): Promise<HostDi
     const sep = baseUrl.includes("?") ? "&" : "?";
     const res = await authenticatedFetch(`${baseUrl}${sep}${params.toString()}`);
     if (!res.ok) {
-      const err: FetchError = new Error(`host filesystem fetch failed: HTTP ${res.status}`);
+      const err: FetchError = new Error(await describeListError(res, path));
       err.status = res.status;
       throw err;
     }
@@ -174,6 +229,11 @@ export function useHostFilesystem(hostId: string | null, path: string | null) {
     // loads, so navigating up/into a folder doesn't flicker through
     // an empty "Loading…" collapse.
     placeholderData: (prev) => prev,
+    // Don't retry a 4xx (e.g. a typed path that doesn't exist): retries keep
+    // the query pending, so the placeholder above would leave the previous
+    // directory's rows on screen instead of surfacing the error. Transient
+    // failures still retry.
+    retry: shouldRetryHostFilesystem,
   });
 }
 

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -291,29 +291,35 @@ export function WorkspacePicker({
 
   const { data, isLoading, error, isPlaceholderData } = useHostFilesystem(hostId, path);
 
-  // Once the home listing comes back, derive the home dir's
-  // absolute path from the first entry's parent. Only first
-  // entry — they all share the same parent. Skip placeholder data
-  // (the prior directory kept on screen during a load) or we'd
-  // derive home from the wrong directory's entries.
+  // Resolve the host's home dir independently of where the picker is
+  // browsing, so a typed "~"-relative path can be expanded even when the
+  // picker opened straight at an absolute initialPath and thus never visits
+  // the "" home view. The query fires at mount and disables once home
+  // resolves; when the picker IS at the home view it shares the main
+  // listing's query key, so this adds no extra fetch there. An empty home
+  // has no entry to derive from and stays unresolved (the picker still
+  // opens onto it fine, and "~" typing is moot in an empty home).
+  const { data: homeData, isPlaceholderData: homeIsPlaceholder } = useHostFilesystem(
+    hostId,
+    resolvedHome === null ? "" : null,
+  );
+
+  // Derive the home dir's absolute path from the first entry's parent (all
+  // entries share one parent). Skip placeholder data (the prior directory
+  // kept on screen during a load) or we'd derive home from the wrong dir.
   useEffect(() => {
-    if (
-      path === "" &&
-      resolvedHome === null &&
-      !isPlaceholderData &&
-      data &&
-      data.entries.length > 0
-    ) {
-      const first = data.entries[0];
-      // first.path is "/Users/corey/x" → parent is "/Users/corey".
-      const idx = first.path.lastIndexOf("/");
-      if (idx > 0) {
-        setResolvedHome(first.path.slice(0, idx));
-      } else if (idx === 0) {
-        setResolvedHome("/");
-      }
+    if (resolvedHome !== null || homeIsPlaceholder || !homeData || homeData.entries.length === 0) {
+      return;
     }
-  }, [path, resolvedHome, data, isPlaceholderData]);
+    const first = homeData.entries[0];
+    // first.path is "/Users/corey/x" → parent is "/Users/corey".
+    const idx = first.path.lastIndexOf("/");
+    if (idx > 0) {
+      setResolvedHome(first.path.slice(0, idx));
+    } else if (idx === 0) {
+      setResolvedHome("/");
+    }
+  }, [resolvedHome, homeData, homeIsPlaceholder]);
 
   // Absolute path of the directory currently shown, derived from the
   // first entry's parent (entries share one parent). This is how a ""


### PR DESCRIPTION
## Related issue

<!-- No existing issue tracks these two picker bugs; both are small,
self-contained bug fixes reported directly. -->

N/A — two directly-reported bugs in the new-session workspace picker; no existing issue.

## Summary

Fixes two bugs in the new-session **workspace picker** (`WorkspacePicker`) where a typed path silently did nothing:

- **`~/…` paths reverted.** Typing e.g. `~/Desktop` and pressing Enter snapped the path bar back to the previous directory. The picker only resolved the host's home directory when it was sitting on the empty "home" view, but in the new-session flow it opens straight at an absolute `initialPath`, so home was never resolved and `~` could not be expanded. Now the home dir is resolved from a dedicated listing independent of where the picker is browsing, so `~`-relative paths expand from any starting point. (When the picker *is* at home, the two queries share a React Query cache key — no extra fetch.)
- **Nonexistent paths showed the old listing.** Typing a path the host 404s on left the previous valid directory's contents on screen with no error. The filesystem query kept the old listing as placeholder data while it burned through its default 3 retries on the deterministic 404 — and React Query only applies `placeholderData` while a query is `pending`, so for several seconds nothing signalled the path was bad. Now 4xx responses are not retried (transient 5xx/network still are), so the error surfaces immediately, and the message reads "…doesn't exist on this host (or isn't a directory)." instead of a bare status code.

## Test Plan

- **New E2E tests** (`tests/e2e_ui/start_session/test_start_session.py`), both driving the real picker in a browser:
  - `test_start_session_type_tilde_path` — opens the picker at an absolute home, types `~/Desktop`, asserts it navigates into `/home/e2e/Desktop` and the picked path reaches `POST /v1/sessions`.
  - `test_start_session_type_nonexistent_path` — types `~/does-not-exist`, asserts the picker shows the doesn't-exist error and drops the previous directory's rows.
  - Both were confirmed to **fail before** the fix and **pass after**, unmodified.
- **Unit tests** (`web/src/hooks/useHostFilesystem.test.ts`): added `shouldRetryHostFilesystem` predicate tests (4xx never retried; 5xx/network retried to the cap) and updated the 404 to assert the friendly message. 66 filesystem-hook + picker unit tests pass.
- Existing `select_folder` / `create_folder` picker E2E tests still pass (they exercise the same hook) — no regression.
- Manually verified against a live host: `~/Desktop` navigates in; `~/nope` and `/tmp/nope` show the doesn't-exist error; valid paths list normally.

## Demo

Verified via the E2E tests above (each drives the real picker in a headless browser and asserts the user-visible behaviour). Before the fix, `~/Desktop` reverted to the prior directory and a bad path kept showing stale rows; after, `~/…` navigates and a bad path shows a clear error.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification against a live host: opened the new-session workspace picker, typed `~/Desktop` (navigates into the expanded home path), typed nonexistent `~/nope` and `/tmp/nope` (each shows "…doesn't exist on this host…" immediately instead of the previous listing), and confirmed valid paths still list. Automated coverage is the two new browser E2E tests plus the `useHostFilesystem` unit tests.

## Changelog

The new-session workspace picker now navigates to `~/…` paths and shows a clear error when a typed path doesn't exist
