### PR TITLE
feat(web): add Cmd/Ctrl+N keyboard shortcut for new session

### DIFF
--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -66,6 +66,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "General",
     items: [
+      { label: "New session", keys: [MOD_KEY, "N"] },
       { label: "Open command palette", keys: [MOD_KEY, "K"] },
       { label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] },
     ],

--- a/web/src/hooks/useNewSessionHotkey.ts
+++ b/web/src/hooks/useNewSessionHotkey.ts
@@ -1,0 +1,31 @@
+// Cmd+N (Ctrl+N on Win/Linux) navigates to "/" for a new session, matching
+// the sidebar "New session" button and the command palette's "New chat" action.
+// Suppressed inside xterm / Monaco surfaces that bind Cmd+N themselves, and
+// guards against AltGraph on international layouts.
+
+import { useEffect } from "react";
+import { useNavigate } from "@/lib/routing";
+
+const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
+
+export function useNewSessionHotkey(): void {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      if (e.repeat) return;
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      if (e.key !== "n" && e.key !== "N") return;
+      if (e.getModifierState("AltGraph")) return;
+
+      const el = document.activeElement;
+      if (el instanceof Element && el.closest(HOTKEY_OWNING_SURFACES) !== null) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      navigate("/");
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [navigate]);
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
 import { useCommandPaletteHotkey } from "@/hooks/useCommandPaletteHotkey";
+import { useNewSessionHotkey } from "@/hooks/useNewSessionHotkey";
 import { useIsEmbedded } from "@/lib/embedded";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
@@ -143,6 +144,7 @@ export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
   // here so it works on every chat route, regardless of where focus sits.
   useApproveHotkey();
+  useNewSessionHotkey();
 
   // Lock the iOS shell to the visual viewport so the soft keyboard can't pan
   // the whole document (which would hide the header and break the layout).


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a `Cmd+N` (`Ctrl+N` on Win/Linux) keyboard shortcut that opens a new session by navigating to `/`, matching the existing sidebar "New session" button and command palette "New chat" action.
- Suppressed inside xterm and Monaco surfaces that bind `Cmd+N` themselves, and guards against AltGr on international layouts.
- Listed in the keyboard shortcuts dialog under the General group.

## Test Plan

1. Start the dev server (`just dev`) and open the app.
2. Press `Cmd+N` (or `Ctrl+N` on Linux/Windows) — should navigate to the new session view.
3. Press `Cmd+/` to open the shortcuts dialog — verify "New session" appears in the General section.
4. Focus a terminal or code editor panel and press `Cmd+N` — the shortcut should be suppressed (the surface keeps its native behavior).

## Demo

N/A — minimal UI change (one new row in the shortcuts dialog).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually: Cmd+N navigates to new session, shortcut is listed in the dialog, and the chord is suppressed when focus is inside xterm/Monaco.

## Changelog

`Cmd+N` (`Ctrl+N` on Win/Linux) keyboard shortcut opens a new session.