### PR TITLE
feat(runner): classify harness launch failures into clear error cards

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1000,6 +1000,11 @@ class TerminalInstance:
     # not read as agent activity. ``-inf`` until the first interaction.
     _last_client_interaction_at: float = field(default=float("-inf"), repr=False)
     _last_pane_snapshot: str | None = field(default=None, repr=False)
+    # Exit status of the pane's inner process, captured from tmux
+    # ``#{pane_dead_status}`` the first time a dead pane is observed (only
+    # meaningful with ``keep_alive_after_exit`` / ``remain-on-exit``). ``None``
+    # until the process exits or when tmux reports no numeric status.
+    _last_exit_status: int | None = field(default=None, repr=False)
 
     @property
     def tmux_target(self) -> str:
@@ -1043,6 +1048,32 @@ class TerminalInstance:
     def _remember_pane_snapshot(self, snapshot: str) -> None:
         """Store a pane capture for later exit diagnostics."""
         self._last_pane_snapshot = snapshot
+
+    def last_exit_status(self) -> int | None:
+        """Return the inner process's exit code, if the pane has died.
+
+        Captured from tmux ``#{pane_dead_status}`` when a dead pane is first
+        observed (see :meth:`_pane_is_dead` / :meth:`_pane_is_dead_async`).
+        Only meaningful for terminals launched with ``keep_alive_after_exit``
+        (``remain-on-exit``); ``None`` otherwise or before exit.
+        """
+        return self._last_exit_status
+
+    def _remember_exit_status(self, fields: str) -> None:
+        """Record the exit code from a ``#{pane_dead} #{pane_dead_status}`` row.
+
+        A managed terminal is single-pane by construction (:attr:`tmux_target`
+        is always ``"main"``), so ``list-panes`` returns exactly one row and its
+        two fields describe that pane: ``pane_dead`` (``1`` once the inner
+        process exits) and ``pane_dead_status`` (the wait-status, empty while
+        alive). Reading only the first two whitespace tokens is therefore
+        unambiguous. Parsed best-effort — a missing or non-numeric status just
+        leaves the code unset.
+        """
+        parts = fields.split()
+        if len(parts) >= 2 and parts[0] == "1":
+            with contextlib.suppress(ValueError):
+                self._last_exit_status = int(parts[1])
 
     def _tmux_base_cmd(self) -> list[str]:
         """
@@ -1728,11 +1759,12 @@ class TerminalInstance:
         """
         try:
             out = self._tmux_output_sync(
-                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead}"
+                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead} #{pane_dead_status}"
             )
         except RuntimeError:
             return False
-        return "1" in out.split()
+        self._remember_exit_status(out)
+        return out.split()[:1] == ["1"]
 
     def pane_pid_sync(self) -> int | None:
         """Return the pid of the pane's foreground process, or ``None``.
@@ -1862,11 +1894,12 @@ class TerminalInstance:
         """
         try:
             out = await self._tmux_output(
-                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead}"
+                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead} #{pane_dead_status}"
             )
         except RuntimeError:
             return False
-        return "1" in out.split()
+        self._remember_exit_status(out)
+        return out.split()[:1] == ["1"]
 
     async def _tmux(self, *args: str) -> None:
         """Run a tmux command against this instance's server."""

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -81,6 +81,7 @@ from omnigent.runner.background_titles import (
 )
 from omnigent.runner.background_titles.service import BACKGROUND_TITLE_MAX_PROMPT_CHARS
 from omnigent.runner.codex.goal import CodexGoalRunner
+from omnigent.runner.launch_failure import FailureDiagnosis, classify_terminal_failure
 from omnigent.runner.native import (
     _AUTO_OPENCODE_SERVERS,
     _COST_POPUP_REPOP_TASKS,
@@ -2175,17 +2176,35 @@ def create_runner_app(
             "argv omitted because terminal args may contain secrets)"
         )
 
-    def _format_required_terminal_exit_output(event: TerminalExitEvent) -> str:
+    def _format_required_terminal_exit_output(
+        event: TerminalExitEvent, diagnosis: FailureDiagnosis | None
+    ) -> str:
         command = _format_terminal_command_for_failure(event)
         cwd = event.cwd or "unknown"
-        parts = [
-            "Required terminal exited unexpectedly; the session runtime is no longer available.",
-            "",
-            "Terminal diagnostics:",
-            f"terminal: {event.terminal_name}:{event.session_key}",
-            f"command: {command}",
-            f"cwd: {cwd}",
-        ]
+        parts: list[str] = []
+        if diagnosis is not None:
+            # Lead with the human interpretation so the failure reads clearly
+            # even before the raw diagnostics block.
+            parts.extend([diagnosis.title, "", diagnosis.cause])
+            if diagnosis.remediation:
+                parts.extend(["", f"Try this: {diagnosis.remediation}"])
+        else:
+            parts.append(
+                "Required terminal exited unexpectedly; the session runtime is no longer "
+                "available."
+            )
+        exited_with = (
+            f" (exited with status {event.exit_status})" if event.exit_status is not None else ""
+        )
+        parts.extend(
+            [
+                "",
+                "Terminal diagnostics:",
+                f"terminal: {event.terminal_name}:{event.session_key}",
+                f"command: {command}{exited_with}",
+                f"cwd: {cwd}",
+            ]
+        )
         if event.last_output:
             parts.extend(["", "Last captured terminal output:", event.last_output])
         else:
@@ -2197,6 +2216,29 @@ def create_runner_app(
                 ]
             )
         return "\n".join(parts)
+
+    def _build_required_terminal_error(event: TerminalExitEvent) -> dict[str, str]:
+        """Build the structured ``session.status`` error for a required-terminal exit.
+
+        Always carries ``code`` + a fully-composed ``message`` (back-compat: the
+        REPL and older clients render it verbatim). When the failure is
+        recognized, also carries ``title`` / ``cause`` / ``remediation`` so the
+        web UI can render a friendly card instead of the raw enum + blob.
+        """
+        # Classify once; the message formatter reuses the same diagnosis.
+        diagnosis = classify_terminal_failure(
+            command=event.command,
+            exit_status=event.exit_status,
+            output=event.last_output,
+        )
+        message = _format_required_terminal_exit_output(event, diagnosis)
+        error: dict[str, str] = {"code": "required_terminal_exited", "message": message}
+        if diagnosis is not None:
+            error["title"] = diagnosis.title
+            error["cause"] = diagnosis.cause
+            if diagnosis.remediation:
+                error["remediation"] = diagnosis.remediation
+        return error
 
     def _release_required_terminal_session(session_id: str) -> None:
         if process_manager is None:
@@ -2250,22 +2292,19 @@ def create_runner_app(
             _release_required_terminal_session(event.session_id)
             return
 
-        output = _format_required_terminal_exit_output(event)
+        error = _build_required_terminal_error(event)
         _publish_event(
             event.session_id,
             {
                 "type": "session.status",
                 "status": "failed",
-                "error": {
-                    "code": "required_terminal_exited",
-                    "message": output,
-                },
+                "error": error,
             },
         )
         _mark_subagent_terminal_and_wake(
             event.session_id,
             status="failed",
-            output=output,
+            output=error["message"],
         )
         _release_required_terminal_session(event.session_id)
 

--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -1,0 +1,211 @@
+"""Classify harness launch/terminal failures into human-readable diagnoses.
+
+When a harness terminal exits unexpectedly (or a launch/connection step
+fails), the raw signal is a terse code plus a tail of PTY output — hard to
+act on. This module maps that raw signal to a :class:`FailureDiagnosis`
+(``title`` / ``cause`` / ``remediation``) the web UI can render as a clear
+failure card, and provides English fallbacks for the failure *codes* that
+have no output to pattern-match.
+
+The design goal is one shared classification layer for every harness: the
+terminal-exit path is common to all ~20 harnesses, so a matcher added here
+covers them all. A new harness quirk becomes one entry in
+:data:`_TERMINAL_EXIT_MATCHERS`, never per-harness branching.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+__all__ = [
+    "FailureDiagnosis",
+    "classify_terminal_failure",
+    "describe_failure_code",
+]
+
+
+@dataclass(frozen=True)
+class FailureDiagnosis:
+    """A human-readable interpretation of a launch/terminal failure.
+
+    :param title: Short headline naming what went wrong, e.g.
+        ``"Claude Code can't run as root"``. Renders as the card title.
+    :param cause: One or two sentences explaining *why* it failed, in terms
+        the user can act on.
+    :param remediation: The concrete next step, e.g. a command to run or a
+        config to change. ``None`` when there is no single clear fix.
+    """
+
+    title: str
+    cause: str
+    remediation: str | None = None
+
+
+@dataclass(frozen=True)
+class _Signal:
+    """The normalized terminal-exit signal a matcher inspects.
+
+    :param command: Launched executable basename, lowercased (``""`` if unknown).
+    :param exit_code: Inner process exit code, or ``None`` if unknown.
+    :param output: Terminal's last captured output, lowercased (``""`` if none).
+    """
+
+    command: str
+    exit_code: int | None
+    output: str
+
+    def output_contains_any(self, needles: tuple[str, ...]) -> bool:
+        return any(n in self.output for n in needles)
+
+
+@dataclass(frozen=True)
+class _TerminalMatcher:
+    """One declarative rule mapping a terminal-exit signal to a diagnosis.
+
+    :param name: Short slug for the matcher (test/debug identifier).
+    :param predicate: Returns ``True`` when this rule explains the failure,
+        given the normalized :class:`_Signal`.
+    :param diagnosis: The :class:`FailureDiagnosis` to return on a match.
+    """
+
+    name: str
+    predicate: Callable[[_Signal], bool]
+    diagnosis: FailureDiagnosis
+
+
+# --- root + --dangerously-skip-permissions -----------------------------------
+# Claude Code refuses that flag as root ("cannot be run with root privileges
+# for security reasons"). The harness passes the flag for autonomous runs, so a
+# root container's agent terminal exits immediately.
+_ROOT_MARKERS = ("root privileges", "security reasons", "cannot be run with root")
+
+# --- not authenticated --------------------------------------------------------
+_AUTH_MARKERS = (
+    "not logged in",
+    "please run /login",
+    "please run `/login`",
+    "invalid api key",
+    "authentication_error",
+    "401 unauthorized",
+    "not authenticated",
+)
+
+# --- binary missing -----------------------------------------------------------
+_MISSING_MARKERS = (
+    "command not found",
+    "no such file or directory",
+    "not recognized as an internal or external command",
+    "executable file not found",
+)
+
+
+# Ordered most-specific first: the root case also reads like a permission /
+# auth problem, so it must win over the broader rules below it.
+_TERMINAL_EXIT_MATCHERS: tuple[_TerminalMatcher, ...] = (
+    _TerminalMatcher(
+        "root_permission",
+        lambda s: "security reasons" in s.output and s.output_contains_any(_ROOT_MARKERS),
+        FailureDiagnosis(
+            title="Claude Code can't run as root",
+            cause=(
+                "The agent terminal exited immediately because Claude Code refuses "
+                "--dangerously-skip-permissions when running as the root user."
+            ),
+            remediation="Run the host as a non-root user (uid != 0).",
+        ),
+    ),
+    _TerminalMatcher(
+        "missing_binary",
+        lambda s: s.exit_code == 127 or s.output_contains_any(_MISSING_MARKERS),
+        FailureDiagnosis(
+            title="Agent command not found",
+            cause=(
+                "The host couldn't find the agent's CLI on its PATH, so the terminal "
+                "exited before the session could start."
+            ),
+            remediation="Install the harness on the host (e.g. run `omnigent setup`).",
+        ),
+    ),
+    _TerminalMatcher(
+        "not_authenticated",
+        lambda s: s.output_contains_any(_AUTH_MARKERS),
+        FailureDiagnosis(
+            title="Agent isn't signed in",
+            cause=(
+                "The agent CLI exited because it has no valid credentials for this "
+                "host — it needs to be logged in before it can run a session."
+            ),
+            remediation=(
+                "Sign the agent in on the host (e.g. run its `/login`, or `omnigent login`)."
+            ),
+        ),
+    ),
+)
+
+
+def classify_terminal_failure(
+    *,
+    command: str | None,
+    exit_status: int | None,
+    output: str | None,
+) -> FailureDiagnosis | None:
+    """Classify a required-terminal exit into a :class:`FailureDiagnosis`.
+
+    :param command: The launched executable (may be a full path); only the
+        basename is matched, case-insensitively.
+    :param exit_status: The inner process's exit code, or ``None`` if unknown.
+    :param output: The terminal's last captured output, or ``None``.
+    :returns: A diagnosis when a matcher recognizes the failure, else ``None``
+        (the caller falls back to the generic message).
+    """
+    signal = _Signal(
+        command=(command or "").rsplit("/", 1)[-1].lower(),
+        exit_code=exit_status,
+        output=(output or "").lower(),
+    )
+    for matcher in _TERMINAL_EXIT_MATCHERS:
+        if matcher.predicate(signal):
+            return matcher.diagnosis
+    return None
+
+
+# --- failure-code English fallbacks -------------------------------------------
+# Every server-emitted failure code, mapped to a one-line human sentence, so
+# even an unclassified failure reads as English instead of a raw enum. Terminal
+# exits that a matcher recognizes use the richer diagnosis above; this table
+# is the floor for everything else.
+#
+# This is the canonical source; the frontend keeps a hand-mirrored copy
+# (``FAILURE_CODE_DESCRIPTIONS`` in ``web/src/components/blocks/StatusBlocks.tsx``)
+# because the failure card renders client-side. Keep the two in sync when adding
+# or editing a code.
+_FAILURE_CODE_DESCRIPTIONS: dict[str, str] = {
+    "required_terminal_exited": (
+        "The agent's terminal exited unexpectedly, so the session can't continue."
+    ),
+    "terminal_launch_failed": "The agent's terminal couldn't be started on the host.",
+    "runner_error": "Something went wrong setting up the turn on the host.",
+    "runner_disconnected": "The connection to the host dropped unexpectedly.",
+    "connection_error": "The connection to the agent dropped mid-turn.",
+    "context_length_exceeded": "The conversation grew past the model's context window.",
+    "executor_error": "The agent runtime hit an error while running the turn.",
+}
+
+
+def describe_failure_code(code: str | None) -> str | None:
+    """Return a one-line English description for a failure *code*.
+
+    Server-side counterpart of the frontend's ``FAILURE_CODE_DESCRIPTIONS``
+    map. The live failure card is rendered client-side, so this function is
+    currently a parity mirror exercised by tests; it exists so a server-side
+    caller (e.g. a future REPL/CLI failure renderer) has the same code→sentence
+    fallback the web UI uses, without re-deriving it.
+
+    :param code: The machine-readable failure code, e.g. ``"runner_error"``.
+    :returns: A human sentence, or ``None`` for an unknown/empty code (callers
+        fall back to whatever message they already have).
+    """
+    if not code:
+        return None
+    return _FAILURE_CODE_DESCRIPTIONS.get(code)

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -144,6 +144,10 @@ class TerminalExitEvent:
         specs may contain credentials or other launch-only secrets.
     :param cwd: Working directory used to launch the terminal, if known.
     :param last_output: Last visible pane text captured before exit, if any.
+    :param exit_status: The inner process's exit code, when tmux captured one
+        from ``#{pane_dead_status}`` (terminals with ``keep_alive_after_exit``).
+        ``None`` when unknown — e.g. the tmux server vanished before the status
+        could be read, or the terminal doesn't keep the pane alive after exit.
     :param session_was_idle: Whether the session's last PTY-derived status was
         ``idle`` at exit. ``True`` marks a clean shutdown after the turn
         finished; ``False`` (the default — last seen ``running``, or never
@@ -159,6 +163,7 @@ class TerminalExitEvent:
     args_count: int | None = None
     cwd: str | None = None
     last_output: str | None = None
+    exit_status: int | None = None
     session_was_idle: bool = False
 
 
@@ -170,27 +175,32 @@ def _trim_terminal_exit_output(text: str | None) -> str | None:
     if not stripped:
         return None
     lines = stripped.splitlines()
+    omitted_lines = 0
     if len(lines) > _TERMINAL_EXIT_OUTPUT_MAX_LINES:
-        lines = [
-            f"... omitted {len(lines) - _TERMINAL_EXIT_OUTPUT_MAX_LINES} earlier line(s) ...",
-            *lines[-_TERMINAL_EXIT_OUTPUT_MAX_LINES:],
-        ]
-    clipped = "\n".join(lines)
-    if len(clipped) > _TERMINAL_EXIT_OUTPUT_MAX_CHARS:
-        clipped = (
-            f"... omitted {len(clipped) - _TERMINAL_EXIT_OUTPUT_MAX_CHARS} "
-            "earlier character(s) ...\n"
-            f"{clipped[-_TERMINAL_EXIT_OUTPUT_MAX_CHARS:]}"
-        )
-    return clipped
+        omitted_lines = len(lines) - _TERMINAL_EXIT_OUTPUT_MAX_LINES
+        lines = lines[-_TERMINAL_EXIT_OUTPUT_MAX_LINES:]
+    # Drop whole leading lines until the body fits the char budget, so the
+    # first surviving line is never a mid-word fragment (the "rity reasons"
+    # cut). One line longer than the budget is hard-clipped as a last resort.
+    while len(lines) > 1 and len("\n".join(lines)) > _TERMINAL_EXIT_OUTPUT_MAX_CHARS:
+        lines.pop(0)
+        omitted_lines += 1
+    if len(lines) == 1 and len(lines[0]) > _TERMINAL_EXIT_OUTPUT_MAX_CHARS:
+        lines[0] = lines[0][-_TERMINAL_EXIT_OUTPUT_MAX_CHARS:]
+    if omitted_lines:
+        lines.insert(0, f"... omitted {omitted_lines} earlier line(s) ...")
+    return "\n".join(lines)
 
 
 def _terminal_exit_diagnostics(
     instance: TerminalInstance | None,
-) -> tuple[str | None, int | None, str | None, str | None]:
-    """Extract generic launch/output diagnostics from a terminal instance."""
+) -> tuple[str | None, int | None, str | None, str | None, int | None]:
+    """Extract generic launch/output diagnostics from a terminal instance.
+
+    :returns: ``(command, args_count, cwd, last_output, exit_status)``.
+    """
     if instance is None:
-        return None, None, None, None
+        return None, None, None, None, None
 
     raw_command = getattr(instance, "command", None)
     command = raw_command if isinstance(raw_command, str) and raw_command else None
@@ -212,7 +222,18 @@ def _terminal_exit_diagnostics(
             if isinstance(raw_last_output, str):
                 last_output = _trim_terminal_exit_output(raw_last_output)
 
-    return command, args_count, cwd, last_output
+    exit_status: int | None = None
+    read_exit_status = getattr(instance, "last_exit_status", None)
+    if callable(read_exit_status):
+        try:
+            raw_exit_status = read_exit_status()
+        except Exception:
+            _logger.exception("Failed to read terminal exit status")
+        else:
+            if isinstance(raw_exit_status, int):
+                exit_status = raw_exit_status
+
+    return command, args_count, cwd, last_output, exit_status
 
 
 def _monotonic() -> float:
@@ -1324,7 +1345,7 @@ class SessionResourceRegistry:
             )
             lifecycle = observed
 
-        command, args_count, cwd, last_output = _terminal_exit_diagnostics(instance)
+        command, args_count, cwd, last_output, exit_status = _terminal_exit_diagnostics(instance)
         # Idle = clean shutdown after the turn finished. Anything else (running,
         # or never observed → boot failure) stays a failure.
         session_was_idle = self._take_session_status_memo(session_id) == "idle"
@@ -1353,6 +1374,7 @@ class SessionResourceRegistry:
                     args_count=args_count,
                     cwd=cwd,
                     last_output=last_output,
+                    exit_status=exit_status,
                     session_was_idle=session_was_idle,
                 )
             )

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -196,6 +196,18 @@ _LAST_TASK_ERROR_CODE_LABEL_KEY: str = "omnigent.last_task_error_code"
 _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: str = "omnigent.last_task_error_message"
 
 
+# Optional structured failure fields (present when the runner classified the
+# failure — see ``omnigent.runner.launch_failure``), persisted so a reload
+# renders the same clear failure card instead of only the raw code + message.
+_LAST_TASK_ERROR_TITLE_LABEL_KEY: str = "omnigent.last_task_error_title"
+
+
+_LAST_TASK_ERROR_CAUSE_LABEL_KEY: str = "omnigent.last_task_error_cause"
+
+
+_LAST_TASK_ERROR_REMEDIATION_LABEL_KEY: str = "omnigent.last_task_error_remediation"
+
+
 _LABEL_VALUE_MAX_LEN: int = LABEL_VALUE_MAX_LEN
 
 
@@ -804,8 +816,11 @@ __all__ = [
     "_LABEL_VALUE_MAX_LEN",
     "_LAST_CONTEXT_TOKENS_LABEL_KEY",
     "_LAST_CONTEXT_WINDOW_LABEL_KEY",
+    "_LAST_TASK_ERROR_CAUSE_LABEL_KEY",
     "_LAST_TASK_ERROR_CODE_LABEL_KEY",
     "_LAST_TASK_ERROR_MESSAGE_LABEL_KEY",
+    "_LAST_TASK_ERROR_REMEDIATION_LABEL_KEY",
+    "_LAST_TASK_ERROR_TITLE_LABEL_KEY",
     "_MANAGED_RESUMABLE_TUNNEL_STALE_S",
     "_MAX_TERMINAL_LAUNCH_ARGS",
     "_MAX_TERMINAL_LAUNCH_ARG_LEN",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -157,8 +157,11 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _HOOK_ELICITATION_ID_RE,
     _HOST_LAUNCH_RESULT_TIMEOUT_S,
     _LABEL_VALUE_MAX_LEN,
+    _LAST_TASK_ERROR_CAUSE_LABEL_KEY,
     _LAST_TASK_ERROR_CODE_LABEL_KEY,
     _LAST_TASK_ERROR_MESSAGE_LABEL_KEY,
+    _LAST_TASK_ERROR_REMEDIATION_LABEL_KEY,
+    _LAST_TASK_ERROR_TITLE_LABEL_KEY,
     _MAX_TERMINAL_LAUNCH_ARG_LEN,
     _MAX_TERMINAL_LAUNCH_ARGS,
     _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER,
@@ -3698,15 +3701,25 @@ async def _persist_session_status_error_labels(
         ``None`` to clear stale error labels on subsequent activity.
     :param conversation_store: Store used to upsert labels.
     """
+    # Structured fields are optional (present only when the runner classified
+    # the failure). Always write all keys — empty when absent — because the
+    # label store is upsert-only and a stale title/cause from a prior failure
+    # must not leak onto a later, unclassified one.
     updates = (
         {
             _LAST_TASK_ERROR_CODE_LABEL_KEY: _truncate_label(error.code),
             _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: _truncate_label(error.message),
+            _LAST_TASK_ERROR_TITLE_LABEL_KEY: _truncate_label(error.title or ""),
+            _LAST_TASK_ERROR_CAUSE_LABEL_KEY: _truncate_label(error.cause or ""),
+            _LAST_TASK_ERROR_REMEDIATION_LABEL_KEY: _truncate_label(error.remediation or ""),
         }
         if error is not None
         else {
             _LAST_TASK_ERROR_CODE_LABEL_KEY: "",
             _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: "",
+            _LAST_TASK_ERROR_TITLE_LABEL_KEY: "",
+            _LAST_TASK_ERROR_CAUSE_LABEL_KEY: "",
+            _LAST_TASK_ERROR_REMEDIATION_LABEL_KEY: "",
         }
     )
     try:
@@ -3734,10 +3747,19 @@ def _last_task_error_from_labels(labels: Mapping[str, str]) -> dict[str, str] | 
     raw_error_code = labels.get(_LAST_TASK_ERROR_CODE_LABEL_KEY)
     raw_error_message = labels.get(_LAST_TASK_ERROR_MESSAGE_LABEL_KEY)
     if raw_error_code and raw_error_message:
-        return {
+        error: dict[str, str] = {
             "code": raw_error_code,
             "message": raw_error_message,
         }
+        for key, label in (
+            ("title", _LAST_TASK_ERROR_TITLE_LABEL_KEY),
+            ("cause", _LAST_TASK_ERROR_CAUSE_LABEL_KEY),
+            ("remediation", _LAST_TASK_ERROR_REMEDIATION_LABEL_KEY),
+        ):
+            value = labels.get(label)
+            if value:
+                error[key] = value
+        return error
     return None
 
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -899,11 +899,23 @@ class ErrorDetail(BaseModel):
 
     :param code: Error code string, e.g. ``"server_error"``,
         ``"invalid_input"``.
-    :param message: Human-readable error description.
+    :param message: Human-readable error description. Always populated; older
+        clients render this verbatim.
+    :param title: Optional short headline naming what went wrong, e.g.
+        ``"Claude Code can't run as root"``. Present when the runner
+        recognized the failure (see ``omnigent.runner.launch_failure``); lets
+        the UI show a clear card title instead of the raw ``code``.
+    :param cause: Optional one/two-sentence explanation of why it failed.
+        Paired with ``title``.
+    :param remediation: Optional concrete next step to fix it, e.g. a command
+        to run. ``None`` when there is no single clear fix.
     """
 
     code: str
     message: str
+    title: str | None = None
+    cause: str | None = None
+    remediation: str | None = None
 
 
 class IncompleteDetails(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -1506,15 +1506,54 @@
       "ErrorDetail": {
         "description": "Machine-readable error information attached to a failed response.",
         "properties": {
+          "cause": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional one/two-sentence explanation of why it failed. Paired with `title`.",
+            "title": "Cause"
+          },
           "code": {
             "description": "Error code string, e.g. `\"server_error\"`, `\"invalid_input\"`.",
             "title": "Code",
             "type": "string"
           },
           "message": {
-            "description": "Human-readable error description.",
+            "description": "Human-readable error description. Always populated; older clients render this verbatim.",
             "title": "Message",
             "type": "string"
+          },
+          "remediation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional concrete next step to fix it, e.g. a command to run. `None` when there is no single clear fix.",
+            "title": "Remediation"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional short headline naming what went wrong, e.g. `\"Claude Code can't run as root\"`. Present when the runner recognized the failure (see `omnigent.runner.launch_failure`); lets the UI show a clear card title instead of the raw `code`.",
+            "title": "Title"
           }
         },
         "required": [

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -1,0 +1,80 @@
+"""Failure error cards render as clear English, not a raw code + log blob.
+
+A harness launch/turn failure persists an ``error`` transcript item. Before,
+the chat rendered it as ``Error · <code>`` over the raw message. Now the
+banner leads with a human headline: a classified failure shows its friendly
+title, and an unclassified one still maps its ``code`` to a plain-English
+sentence (mirror of ``describe_failure_code`` /
+``FAILURE_CODE_DESCRIPTIONS``) rather than exposing the enum.
+
+Seeds the error item straight into the store (like ``seed_committed_turn``)
+so the assertion is on transcript hydration + rendering, deterministic and
+independent of any live turn.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import _server_state
+
+
+def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
+    """Append a committed ``error`` transcript item to the session's store.
+
+    Mirrors ``seed_committed_turn`` but writes an error banner item, so the
+    chat hydrates and renders it through the same path a real
+    ``response.error`` persists.
+
+    :param session_id: Session to append to, e.g. ``"conv_abc123"``.
+    :param code: Error classifier, e.g. ``"required_terminal_exited"``.
+    :param message: Raw error message stored alongside the code.
+    :raises RuntimeError: If the server under test isn't one we spawned.
+    """
+    from omnigent.entities import ErrorData, NewConversationItem
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    database_uri = _server_state.get("database_uri")
+    if not database_uri:
+        raise RuntimeError(
+            "seeding an error item needs the spawned server's database; it is "
+            "unavailable when running against --ui-base-url."
+        )
+    SqlAlchemyConversationStore(str(database_uri)).append(
+        session_id,
+        [
+            NewConversationItem(
+                type="error",
+                response_id="resp_seeded_error",
+                data=ErrorData(source="execution", code=code, message=message),
+            ),
+        ],
+    )
+
+
+def test_unclassified_failure_renders_english_headline_not_raw_code(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A known failure code reads as a sentence, never the bare enum.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _seed_error_item(
+        session_id,
+        code="required_terminal_exited",
+        message="Required terminal exited unexpectedly; the runtime is no longer available.",
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    alert = page.get_by_role("alert")
+    # The friendly, code-derived headline is shown...
+    expect(alert).to_contain_text("The agent's terminal exited unexpectedly", timeout=15_000)
+    # ...and the raw enum is not surfaced as the headline.
+    expect(alert).not_to_contain_text("Error · required_terminal_exited", timeout=15_000)

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -2477,6 +2477,90 @@ async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_required_terminal_exit_classifies_root_failure(tmp_path: Path) -> None:
+    """A recognized failure carries structured title/cause/remediation.
+
+    When the terminal output matches a known failure (Claude refusing
+    ``--dangerously-skip-permissions`` as root), the ``failed`` status event
+    carries the friendly ``title`` / ``cause`` / ``remediation`` fields (so the
+    web UI can render a clear card) in addition to the composed ``message``.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from tests.runner.helpers import make_test_terminal_instance
+
+    conv_id = uuid.uuid4().hex
+    terminal_registry = TerminalRegistry()
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    instance.command = "claude"
+    instance.args = ["--dangerously-skip-permissions"]
+    instance.launch_cwd = str(tmp_path)
+    instance._remember_pane_snapshot(
+        "--dangerously-skip-permissions cannot be run with root privileges for security reasons"
+    )
+    instance._remember_exit_status("1 1")
+    terminal_registry._by_conversation.setdefault(conv_id, {})[("claude", "main")] = instance
+    callbacks: dict[str, Any] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        on_tick: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
+        callbacks["on_exit"] = on_exit
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    pm._sessions.add(conv_id)
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        terminal_registry=terminal_registry,
+    )
+    resource_registry = app.state.session_resource_registry
+
+    async def _collect_failed() -> dict[str, Any]:
+        while True:
+            queue = _session_event_queues_ref.get(conv_id)
+            if queue is not None:
+                while not queue.empty():
+                    item = queue.get_nowait()
+                    if (
+                        isinstance(item, dict)
+                        and item.get("type") == "session.status"
+                        and item.get("status") == "failed"
+                    ):
+                        return item
+            await asyncio.sleep(0)
+
+    try:
+        await resource_registry.observe_required_terminal(conv_id, "claude", "main", instance)
+        on_exit = callbacks.get("on_exit")
+        assert callable(on_exit)
+        on_exit()
+        failed = await asyncio.wait_for(_collect_failed(), timeout=1.0)
+    finally:
+        _session_event_queues_ref.pop(conv_id, None)
+
+    error = failed["error"]
+    assert error["code"] == "required_terminal_exited"
+    assert error["title"] == "Claude Code can't run as root"
+    assert "root" in error["cause"].lower()
+    assert "non-root" in error["remediation"].lower()
+    # The composed message leads with the diagnosis and still carries the raw
+    # diagnostics (exit status included) for the collapsible details view.
+    assert error["message"].startswith("Claude Code can't run as root")
+    assert "exited with status 1" in error["message"]
+
+
+@pytest.mark.asyncio
 async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path: Path) -> None:
     """
     A required terminal that exits while the session is idle is a clean shutdown.

--- a/tests/runner/test_launch_failure.py
+++ b/tests/runner/test_launch_failure.py
@@ -1,0 +1,132 @@
+"""Tests for the harness launch-failure classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.runner.launch_failure import (
+    FailureDiagnosis,
+    classify_terminal_failure,
+    describe_failure_code,
+)
+
+# The tail Claude Code prints when refusing --dangerously-skip-permissions as
+# root — the exact scenario a root container hits.
+_ROOT_REFUSAL_OUTPUT = (
+    "--dangerously-skip-permissions cannot be run with root privileges for security reasons"
+)
+
+
+def test_classifies_root_permission_failure() -> None:
+    diagnosis = classify_terminal_failure(
+        command="claude",
+        exit_status=1,
+        output=_ROOT_REFUSAL_OUTPUT,
+    )
+    assert diagnosis is not None
+    assert diagnosis.title == "Claude Code can't run as root"
+    assert "root" in diagnosis.cause.lower()
+    assert diagnosis.remediation is not None
+    assert "non-root" in diagnosis.remediation.lower()
+
+
+def test_root_failure_survives_mid_word_truncation() -> None:
+    # The pane snapshot may be clipped to "...for secuRITY REASONS" — the
+    # matcher keys on "security reasons", which line-boundary trimming keeps.
+    diagnosis = classify_terminal_failure(
+        command="claude",
+        exit_status=1,
+        output="root privileges\nfor security reasons",
+    )
+    assert diagnosis is not None
+    assert diagnosis.title == "Claude Code can't run as root"
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Not logged in · Please run /login",
+        "Error: Invalid API key",
+        "authentication_error: 401 Unauthorized",
+    ],
+)
+def test_classifies_auth_failure(output: str) -> None:
+    diagnosis = classify_terminal_failure(command="codex", exit_status=1, output=output)
+    assert diagnosis is not None
+    assert diagnosis.title == "Agent isn't signed in"
+    assert diagnosis.remediation is not None
+
+
+def test_classifies_missing_binary_by_exit_code() -> None:
+    diagnosis = classify_terminal_failure(command="qwen", exit_status=127, output="")
+    assert diagnosis is not None
+    assert diagnosis.title == "Agent command not found"
+
+
+def test_classifies_missing_binary_by_output() -> None:
+    diagnosis = classify_terminal_failure(
+        command="qwen",
+        exit_status=None,
+        output="bash: qwen: command not found",
+    )
+    assert diagnosis is not None
+    assert diagnosis.title == "Agent command not found"
+
+
+def test_root_wins_over_generic_auth_when_both_markers_present() -> None:
+    # Ordering guard: the root case also reads like a permission problem, so it
+    # must be matched before any broader rule.
+    diagnosis = classify_terminal_failure(
+        command="claude",
+        exit_status=1,
+        output="not logged in\nroot privileges\nfor security reasons",
+    )
+    assert diagnosis is not None
+    assert diagnosis.title == "Claude Code can't run as root"
+
+
+def test_unclassified_failure_returns_none() -> None:
+    assert (
+        classify_terminal_failure(
+            command="worker-cli",
+            exit_status=1,
+            output="startup failed\ncomplete setup first",
+        )
+        is None
+    )
+
+
+def test_none_inputs_do_not_raise() -> None:
+    assert classify_terminal_failure(command=None, exit_status=None, output=None) is None
+
+
+def test_command_path_is_matched_by_basename() -> None:
+    # A full path shouldn't defeat the (currently command-agnostic) matchers.
+    diagnosis = classify_terminal_failure(
+        command="/usr/local/bin/claude",
+        exit_status=1,
+        output=_ROOT_REFUSAL_OUTPUT,
+    )
+    assert isinstance(diagnosis, FailureDiagnosis)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_substring"),
+    [
+        ("required_terminal_exited", "terminal exited"),
+        ("terminal_launch_failed", "couldn't be started"),
+        ("runner_error", "setting up the turn"),
+        ("runner_disconnected", "host dropped"),
+        ("connection_error", "connection"),
+        ("context_length_exceeded", "context window"),
+    ],
+)
+def test_describe_failure_code_known(code: str, expected_substring: str) -> None:
+    description = describe_failure_code(code)
+    assert description is not None
+    assert expected_substring in description
+
+
+@pytest.mark.parametrize("code", [None, "", "some_unknown_code"])
+def test_describe_failure_code_unknown(code: str | None) -> None:
+    assert describe_failure_code(code) is None

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -16,11 +16,14 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpe
 from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner.resource_registry import (
+    _TERMINAL_EXIT_OUTPUT_MAX_CHARS,
     CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
     TerminalExitEvent,
     TerminalLifecycle,
+    _terminal_exit_diagnostics,
+    _trim_terminal_exit_output,
 )
 from omnigent.terminals import TerminalRegistry
 from tests.runner.helpers import make_test_terminal_instance
@@ -675,6 +678,53 @@ async def test_required_terminal_exit_while_running_is_failure(tmp_path: Path) -
 
     assert len(exits) == 1
     assert exits[0].session_was_idle is False
+
+
+def test_trim_terminal_exit_output_drops_whole_leading_lines() -> None:
+    # Over the char budget: the first surviving line must be a WHOLE line, never
+    # a mid-word fragment (the "rity reasons" cut). The final line — the one that
+    # matters — stays intact.
+    filler = "\n".join(f"line {i} " + "x" * 80 for i in range(200))
+    text = filler + "\n--dangerously-skip-permissions cannot be run for security reasons"
+    trimmed = _trim_terminal_exit_output(text)
+    assert trimmed is not None
+    assert len(trimmed) <= _TERMINAL_EXIT_OUTPUT_MAX_CHARS + 60  # + the omitted-lines marker
+    assert trimmed.startswith("... omitted ")
+    # The last line survived whole (not clipped mid-word).
+    assert trimmed.endswith("for security reasons")
+    # The first content line after the marker is a complete line.
+    first_content = trimmed.splitlines()[1]
+    assert first_content.startswith("line ")
+
+
+def test_trim_terminal_exit_output_hard_clips_single_overlong_line() -> None:
+    # A single line longer than the budget has no line boundary to snap to, so
+    # it's clipped from the tail as a last resort.
+    line = "y" * (_TERMINAL_EXIT_OUTPUT_MAX_CHARS + 500)
+    trimmed = _trim_terminal_exit_output(line)
+    assert trimmed is not None
+    assert len(trimmed) == _TERMINAL_EXIT_OUTPUT_MAX_CHARS
+
+
+def test_terminal_exit_diagnostics_reads_exit_status(tmp_path: Path) -> None:
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    instance.command = "claude"
+    instance.args = ["--dangerously-skip-permissions"]
+    instance._remember_pane_snapshot("boom")
+    # Simulate tmux having reported a dead pane with a captured status.
+    instance._remember_exit_status("1 42")
+    command, args_count, _cwd, last_output, exit_status = _terminal_exit_diagnostics(instance)
+    assert command == "claude"
+    assert args_count == 1
+    assert last_output == "boom"
+    assert exit_status == 42
+
+
+def test_remember_exit_status_ignores_live_pane() -> None:
+    instance = make_test_terminal_instance("claude", "main", tmp_path=Path("/tmp"))
+    # Live pane: pane_dead=0, empty status → nothing recorded.
+    instance._remember_exit_status("0 ")
+    assert instance.last_exit_status() is None
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -2393,3 +2393,75 @@ def test_runner_reject_detail_tolerates_status_only_response_fake() -> None:
         status_code = 503
 
     assert _runner_reject_detail(_Fake()) == "runner returned status 503"  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_persist_and_project_structured_error_round_trip() -> None:
+    """Structured title/cause/remediation survive persist → project.
+
+    A classified failure stores its friendly fields as labels, and
+    ``_last_task_error_from_labels`` projects them back so a reload renders the
+    same clear card instead of just code + message.
+    """
+    from omnigent.server.routes.sessions import _last_task_error_from_labels
+    from omnigent.server.schemas import ErrorDetail
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _MockStore:
+        def set_labels(self, session_id: str, updates: dict[str, str]) -> None:
+            captured[session_id] = updates
+
+    error = ErrorDetail(
+        code="required_terminal_exited",
+        message="Claude Code can't run as root\n\n...diagnostics...",
+        title="Claude Code can't run as root",
+        cause="The agent terminal exited immediately because Claude Code refuses ...",
+        remediation="Run the host as a non-root user (uid != 0).",
+    )
+    await _persist_session_status_error_labels(
+        "aa11bb22cc33dd44ee55ff6677889900", error, _MockStore()
+    )  # type: ignore[arg-type]
+
+    labels = captured["aa11bb22cc33dd44ee55ff6677889900"]
+    projected = _last_task_error_from_labels(labels)
+    assert projected == {
+        "code": "required_terminal_exited",
+        "message": "Claude Code can't run as root\n\n...diagnostics...",
+        "title": "Claude Code can't run as root",
+        "cause": "The agent terminal exited immediately because Claude Code refuses ...",
+        "remediation": "Run the host as a non-root user (uid != 0).",
+    }
+
+
+@pytest.mark.asyncio
+async def test_persist_error_labels_clears_stale_structured_fields() -> None:
+    """An unclassified failure must not inherit a prior failure's title/cause.
+
+    The label store is upsert-only, so every persist writes all structured keys
+    (empty when absent). An error with no title/cause/remediation therefore
+    projects back to just code + message.
+    """
+    from omnigent.server.routes.sessions import _last_task_error_from_labels
+    from omnigent.server.schemas import ErrorDetail
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _MockStore:
+        def set_labels(self, session_id: str, updates: dict[str, str]) -> None:
+            captured[session_id] = updates
+
+    error = ErrorDetail(code="runner_error", message="turn setup failed")
+    await _persist_session_status_error_labels(
+        "bb22cc33dd44ee55ff66778899001122", error, _MockStore()
+    )  # type: ignore[arg-type]
+
+    labels = captured["bb22cc33dd44ee55ff66778899001122"]
+    # All structured keys are written empty so a stale value can't leak.
+    assert labels["omnigent.last_task_error_title"] == ""
+    assert labels["omnigent.last_task_error_cause"] == ""
+    assert labels["omnigent.last_task_error_remediation"] == ""
+    assert _last_task_error_from_labels(labels) == {
+        "code": "runner_error",
+        "message": "turn setup failed",
+    }

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -154,6 +154,54 @@ describe("BlockRenderer dispatch", () => {
     );
   });
 
+  it("renders a friendly failure card when the error is classified", () => {
+    const items: RenderItem[] = [
+      {
+        kind: "error",
+        itemId: null,
+        source: "",
+        code: "required_terminal_exited",
+        title: "Claude Code can't run as root",
+        cause:
+          "The agent terminal exited immediately because Claude Code refuses the flag as root.",
+        remediation: "Run the host as a non-root user (uid != 0).",
+        message: "Claude Code can't run as root\n\nTerminal diagnostics:\ncommand: claude",
+      },
+    ];
+
+    render(<BlockRenderer items={items} sessionStatus="idle" />);
+
+    // Headline is the friendly title, not the raw code.
+    expect(screen.getByText("Claude Code can't run as root")).toBeDefined();
+    // Cause is shown in plain English.
+    expect(screen.getByText(/refuses the flag as root/)).toBeDefined();
+    // Remediation is surfaced.
+    expect(screen.getByText(/Run the host as a non-root user/)).toBeDefined();
+    // Raw diagnostics are folded away behind a Details toggle (collapsed).
+    expect(screen.getByText(/Details/)).toBeDefined();
+    // The raw enum is NOT the visible headline.
+    expect(screen.queryByText(/Error · required_terminal_exited/)).toBeNull();
+  });
+
+  it("falls back to a code→sentence description for an unclassified failure", () => {
+    const items: RenderItem[] = [
+      {
+        kind: "error",
+        itemId: null,
+        source: "",
+        code: "runner_error",
+        message: "",
+      },
+    ];
+
+    render(<BlockRenderer items={items} sessionStatus="idle" />);
+
+    // Even with an empty message, the known code reads as an English headline
+    // instead of the raw enum.
+    expect(screen.getByText("Something went wrong setting up the turn on the host.")).toBeDefined();
+    expect(screen.queryByText(/runner_error/)).toBeNull();
+  });
+
   it("treats a trailing reasoning item as streaming when sessionStatus is running", () => {
     const items: RenderItem[] = [
       { kind: "reasoning", itemId: null, text: "thinking", duration: undefined },

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -1074,7 +1074,17 @@ function renderItem(
         />
       );
     case "error":
-      return <ErrorBanner key={key} message={item.message} source={item.source} code={item.code} />;
+      return (
+        <ErrorBanner
+          key={key}
+          message={item.message}
+          source={item.source}
+          code={item.code}
+          title={item.title}
+          cause={item.cause}
+          remediation={item.remediation}
+        />
+      );
     case "policy_denied":
       return <PolicyDeniedBanner key={key} reason={item.reason} phase={item.phase} />;
     case "retry":

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -33,15 +33,64 @@ interface ErrorBannerProps {
   message: string;
   source: string;
   code: string;
+  /** Friendly headline for a classified failure, e.g. "Claude Code can't run as root". */
+  title?: string;
+  /** One/two-sentence explanation of why it failed. Paired with `title`. */
+  cause?: string;
+  /** Concrete next step to fix it, e.g. a command to run. */
+  remediation?: string;
 }
 
 /**
- * Loud destructive banner for `error` blocks. Falls back to `code` when
- * `message` is empty (matches the reducer's intent — never show a blank
- * panel even when the LLM error payload omits the message).
+ * One-line English descriptions for known failure `code`s, so an
+ * unclassified failure (no `title`/`cause` from the runner) still reads as a
+ * sentence instead of a raw enum. Mirrors the server-side
+ * `describe_failure_code` table (omnigent/runner/launch_failure.py); keep the
+ * two in sync.
  */
-export function ErrorBanner({ message, source, code }: ErrorBannerProps) {
-  const display = message || code || "Unknown error";
+const FAILURE_CODE_DESCRIPTIONS: Record<string, string> = {
+  required_terminal_exited:
+    "The agent's terminal exited unexpectedly, so the session can't continue.",
+  terminal_launch_failed: "The agent's terminal couldn't be started on the host.",
+  runner_error: "Something went wrong setting up the turn on the host.",
+  runner_disconnected: "The connection to the host dropped unexpectedly.",
+  connection_error: "The connection to the agent dropped mid-turn.",
+  context_length_exceeded: "The conversation grew past the model's context window.",
+  executor_error: "The agent runtime hit an error while running the turn.",
+};
+
+/**
+ * Loud destructive banner for `error` blocks.
+ *
+ * When the runner classified the failure it passes `title` / `cause` /
+ * `remediation`, and the banner renders a clear card: headline, plain-English
+ * cause, a "Try this" remediation line, and the raw diagnostics folded into a
+ * collapsible. Otherwise it falls back to a code→sentence map (so even an
+ * unclassified failure reads as English) and finally to the raw message/code —
+ * never a blank panel.
+ */
+export function ErrorBanner({
+  message,
+  source,
+  code,
+  title,
+  cause,
+  remediation,
+}: ErrorBannerProps) {
+  // Headline: the friendly title, else a plain-English sentence for a known
+  // code, else a generic fallback. Never the raw enum.
+  const headline = title || FAILURE_CODE_DESCRIPTIONS[code] || "Something went wrong";
+  // Body under the headline: the classifier's cause, else the raw message.
+  // Suppressed when it would merely echo the headline (e.g. a known code with
+  // an empty message), so the panel never shows the same sentence twice or a
+  // bare code string.
+  const bodyText = cause || message || "";
+  const explanation = bodyText && bodyText !== headline ? bodyText : null;
+  // With a friendly title, the raw message is the detailed diagnostics blob —
+  // keep it available but folded away. Without one, the message is already the
+  // explanation, so there's nothing extra to fold.
+  const details = title && message && message !== explanation ? message : null;
+
   return (
     <Alert
       variant="destructive"
@@ -49,13 +98,33 @@ export function ErrorBanner({ message, source, code }: ErrorBannerProps) {
     >
       <AlertCircleIcon />
       <AlertTitle className="min-w-0 break-words [overflow-wrap:anywhere]">
-        Error{source ? ` · ${source}` : ""}
-        {code && message ? ` · ${code}` : ""}
+        {headline}
+        {source ? ` · ${source}` : ""}
       </AlertTitle>
-      <AlertDescription className="min-w-0 max-w-full overflow-hidden">
-        <span className="block max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] [text-wrap:wrap]">
-          {display}
-        </span>
+      <AlertDescription className="min-w-0 max-w-full space-y-2 overflow-hidden">
+        {explanation ? (
+          <span className="block max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] [text-wrap:wrap]">
+            {explanation}
+          </span>
+        ) : null}
+        {remediation ? (
+          <span className="block max-w-full break-words font-medium [overflow-wrap:anywhere]">
+            Try this: {remediation}
+          </span>
+        ) : null}
+        {details ? (
+          <Collapsible>
+            <CollapsibleTrigger className="group flex items-center gap-1 text-xs opacity-80 hover:opacity-100">
+              <ChevronRightIcon className="size-3 transition-transform group-data-[state=open]:rotate-90" />
+              Details{code ? ` · ${code}` : ""}
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <span className="mt-1 block max-w-full whitespace-pre-wrap break-words font-mono text-xs opacity-80 [overflow-wrap:anywhere] [text-wrap:wrap]">
+                {details}
+              </span>
+            </CollapsibleContent>
+          </Collapsible>
+        ) : null}
       </AlertDescription>
     </Alert>
   );

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -36,6 +36,7 @@ import {
   type UserMessageBlock,
   slashCommandEchoItemId,
   slashCommandEchoText,
+  structuredErrorFields,
 } from "./blocks";
 import type { StreamEvent } from "./events";
 import { routingExtras } from "./routingDecision";
@@ -778,6 +779,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
         message: event.error.message,
         source: event.source,
         code: event.error.code,
+        ...structuredErrorFields(event.error),
       } satisfies ErrorBlock;
       return;
     }
@@ -810,6 +812,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
           message: event.response.error.message ?? "",
           source: "",
           code: event.response.error.code ?? "response_failed",
+          ...structuredErrorFields(event.response.error),
         } satisfies ErrorBlock;
       }
       yield {

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -310,6 +310,32 @@ export interface ErrorBlock {
   source: string;
   /** Machine-readable error code, e.g. "llm_auth_failed". Empty when omitted. */
   code: string;
+  /**
+   * Optional friendly headline naming what went wrong, e.g. "Claude Code
+   * can't run as root". Present when the runner classified the failure;
+   * lets the banner show a clear title instead of the raw `code`.
+   */
+  title?: string;
+  /** Optional one/two-sentence explanation of why it failed. Paired with `title`. */
+  cause?: string;
+  /** Optional concrete next step to fix it, e.g. a command to run. */
+  remediation?: string;
+}
+
+/**
+ * Extract the optional structured failure fields (`title` / `cause` /
+ * `remediation`) from any error-shaped source, dropping absent ones so an
+ * `ErrorBlock` stays minimal when the failure wasn't classified. Spread the
+ * result into an `ErrorBlock` alongside `message` / `source` / `code`.
+ */
+export function structuredErrorFields(
+  src: { title?: string | null; cause?: string | null; remediation?: string | null } | null,
+): Pick<ErrorBlock, "title" | "cause" | "remediation"> {
+  const out: Pick<ErrorBlock, "title" | "cause" | "remediation"> = {};
+  if (src?.title) out.title = src.title;
+  if (src?.cause) out.cause = src.cause;
+  if (src?.remediation) out.remediation = src.remediation;
+  return out;
 }
 
 /** The server is retrying. */

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -62,6 +62,12 @@ export interface ErrorItem extends BaseItem {
   source: string;
   code: string;
   message: string;
+  /** Friendly headline for a classified failure. Present when the runner classified it. */
+  title?: string;
+  /** One/two-sentence explanation of why it failed. Paired with `title`. */
+  cause?: string;
+  /** Concrete next step to fix it, e.g. a command to run. */
+  remediation?: string;
 }
 
 export interface ReasoningItem extends BaseItem {

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -468,8 +468,12 @@ export interface SessionStatusEvent {
    * the session is not parked.
    */
   blockedOn?: string;
-  /** Structured failure detail; only present when `status === "failed"`. */
-  error?: { code: string; message: string };
+  /**
+   * Structured failure detail; only present when `status === "failed"`.
+   * Carries the optional `title` / `cause` / `remediation` fields when the
+   * runner classified the failure (see `ErrorInfo`).
+   */
+  error?: ErrorInfo;
 }
 
 /**

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -26,6 +26,7 @@ import {
   type UserMessageBlock,
   slashCommandEchoItemId,
   slashCommandEchoText,
+  structuredErrorFields,
 } from "./blocks";
 import { formatNativeLabel, formatToolArgsBrief } from "./blockStream";
 import {
@@ -237,6 +238,7 @@ function errorToBlock(item: ErrorItem): ErrorBlock {
     source: item.source,
     code: item.code,
     message: item.message,
+    ...structuredErrorFields(item),
   };
 }
 

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -92,7 +92,16 @@ export type RenderItem =
       stderr: string | null;
     }
   | { kind: "policy_denied"; itemId: string | null; reason: string; phase: string }
-  | { kind: "error"; itemId: string | null; message: string; source: string; code: string }
+  | {
+      kind: "error";
+      itemId: string | null;
+      message: string;
+      source: string;
+      code: string;
+      title?: string;
+      cause?: string;
+      remediation?: string;
+    }
   | {
       kind: "retry";
       itemId: string | null;
@@ -1319,6 +1328,9 @@ function buildAssistantItems(
         message: b.message,
         source: b.source,
         code: b.code,
+        ...(b.title ? { title: b.title } : {}),
+        ...(b.cause ? { cause: b.cause } : {}),
+        ...(b.remediation ? { remediation: b.remediation } : {}),
       });
       i += 1;
       continue;

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -158,7 +158,13 @@ interface SessionResponseWire {
    * `total_cost_usd`). Absent/`null` when no per-model usage was recorded.
    */
   usage_by_model?: Record<string, ModelUsageWire> | null;
-  last_task_error?: { code: string; message: string } | null;
+  last_task_error?: {
+    code: string;
+    message: string;
+    title?: string;
+    cause?: string;
+    remediation?: string;
+  } | null;
   /**
    * Outstanding `response.elicitation_request` event dicts at the
    * moment the snapshot was built. The live SSE stream has no

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -439,15 +439,15 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
           ? data.background_task_count
           : undefined;
       const rawError = data.error;
+      // Parse via parseErrorInfo so a classified failure's optional
+      // title/cause/remediation flow through, but keep the guard that both
+      // code and message are present (a bare/blank error object is dropped).
       const error =
         rawError != null &&
         typeof rawError === "object" &&
         typeof (rawError as Record<string, unknown>).code === "string" &&
         typeof (rawError as Record<string, unknown>).message === "string"
-          ? {
-              code: (rawError as Record<string, unknown>).code as string,
-              message: (rawError as Record<string, unknown>).message as string,
-            }
+          ? parseErrorInfo(rawError)
           : undefined;
       // Absent = not parked. An empty string is treated the same, so a
       // blank reason never renders as a dangling parenthetical.
@@ -1167,7 +1167,11 @@ function responseFromJson(d: Record<string, unknown>): Response {
 function parseErrorInfo(raw: unknown): ErrorInfo {
   if (raw && typeof raw === "object" && !Array.isArray(raw)) {
     const r = raw as Record<string, unknown>;
-    return { code: String(r.code ?? ""), message: String(r.message ?? "") };
+    const info: ErrorInfo = { code: String(r.code ?? ""), message: String(r.message ?? "") };
+    if (typeof r.title === "string" && r.title) info.title = r.title;
+    if (typeof r.cause === "string" && r.cause) info.cause = r.cause;
+    if (typeof r.remediation === "string" && r.remediation) info.remediation = r.remediation;
+    return info;
   }
   return { code: "", message: String(raw ?? "") };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -69,6 +69,12 @@ export interface Usage {
 export interface ErrorInfo {
   code: string;
   message: string;
+  /** Friendly headline for a classified failure, e.g. "Claude Code can't run as root". */
+  title?: string;
+  /** One/two-sentence explanation of why it failed. Paired with `title`. */
+  cause?: string;
+  /** Concrete next step to fix it, e.g. a command to run. */
+  remediation?: string;
 }
 
 /** Details about why a response stopped early. */
@@ -351,7 +357,13 @@ export interface Session {
    * relying on the transient ``response.error`` SSE event, which may
    * have been emitted before the web client subscribed.
    */
-  lastTaskError?: { code: string; message: string } | null;
+  lastTaskError?: {
+    code: string;
+    message: string;
+    title?: string;
+    cause?: string;
+    remediation?: string;
+  } | null;
   /**
    * Outstanding `response.elicitation_request` event payloads on
    * the snapshot. Replayed into the chat as ApprovalCard blocks on

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -53,7 +53,7 @@ import type {
   ToolGroup,
   UserMessageBlock,
 } from "@/lib/blocks";
-import { LIVE_ITEM_PREFIX } from "@/lib/blocks";
+import { LIVE_ITEM_PREFIX, structuredErrorFields } from "@/lib/blocks";
 import { BlockStream } from "@/lib/blockStream";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
 import { emitBrowserActionRequest } from "@/lib/browserActionBus";
@@ -2687,6 +2687,7 @@ async function bindStream(
               message: session.lastTaskError.message,
               source: "",
               code: session.lastTaskError.code,
+              ...structuredErrorFields(session.lastTaskError),
             }
           : null;
       return {
@@ -4666,6 +4667,7 @@ export function handleSessionEvent(event: StreamEvent): void {
               message: event.error.message,
               source: "",
               code: event.error.code,
+              ...structuredErrorFields(event.error),
             } satisfies ErrorBlock,
           ];
         }


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; this is a Feature/UI change surfaced from a real failure. -->
N/A — Feature / UI change (no existing tracking issue).

## Summary

Harness terminal-launch failures surfaced to the user as a terse code (e.g. `Error · required_terminal_exited`) over a raw, sometimes **mid-word-truncated** PTY tail — for example a Claude Code root-refusal that got clipped to `…for secu` / `rity reasons`. This adds one shared classification layer on the common terminal-exit path so **every harness** benefits:

- **Classify the failure** into a friendly `title` / `cause` / `remediation` (new `omnigent/runner/launch_failure.py`) — ships matchers for root + `--dangerously-skip-permissions`, not-authenticated, and missing-binary, plus a `code → English sentence` table so even unclassified failures read as a sentence, not an enum.
- **Capture the real exit code** from tmux `#{pane_dead_status}` and thread it through `TerminalExitEvent`.
- **Fix output truncation** to drop whole leading lines instead of slicing mid-word (kills the `rity reasons` cut at the source).
- **Carry the structured fields** on `ErrorDetail`, through the `session.status: failed` SSE event and durable labels, so a reload renders the same card. The composed `message` still works for older clients / the REPL.
- **Frontend:** `ErrorBanner` renders a clear card — headline, plain-English cause, a "Try this" remediation line, and the raw diagnostics folded into a collapsible.

**Before** `⛔ Error · required_terminal_exited` + a mid-word-truncated blob.
**After** `⛔ Claude Code can't run as root` — *refuses `--dangerously-skip-permissions` as root* — *Try this: run the host as a non-root user (uid ≠ 0)*, raw diagnostics folded away.

## Test Plan

- `pytest tests/runner/test_launch_failure.py` (new — 19 cases: each matcher, ordering, code table, None-safety).
- `pytest tests/runner/test_resource_registry.py` (line-boundary truncation, exit-status capture/threading).
- `pytest tests/runner/test_app_sessions_native_events_lifecycle.py -k required_terminal` (new lifecycle test asserts the classified `title`/`cause`/`remediation` reach the `failed` status event).
- `pytest tests/server/routes/test_sessions_snapshot.py` (persist → project round-trip of the structured fields; stale-field clearing).
- `vitest` on `BlockRenderer`, `blockStream`, `itemsToBlocks`, `renderItems`, `sse`, `chatStore` (friendly card + code→sentence fallback + field plumbing).
- `pre-commit run` (ruff, pyrefly, prettier, oxlint, tsc) all green; `scripts/dump_openapi.py --check` clean.

## Demo

N/A — verified via the frontend `BlockRenderer` tests (friendly-card + fallback rendering) and a rendered-message dump; see Coverage notes. Happy to attach a UI screen recording if a reviewer wants one.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: dumped the composed failure message end-to-end for the root-refusal case and confirmed it leads with the friendly title, includes `Try this:` remediation, and carries the raw diagnostics (with exit status) for the folded details view. The frontend card is covered by `BlockRenderer.test.tsx` (friendly-card render + code→sentence fallback for an unclassified code); a live browser screenshot wasn't captured in this environment.

## Changelog

Harness launch failures now show a clear title, cause, and suggested fix instead of a raw error code and truncated log tail.

This pull request and its description were written by Isaac.
