### PR TITLE
feat(web): default speech recognition to browser locale

### DIFF
--- a/web/src/components/ComposerMicButton.test.tsx
+++ b/web/src/components/ComposerMicButton.test.tsx
@@ -59,19 +59,30 @@ function installDictationSession() {
 let handlers: Record<string, (event: unknown) => void>;
 let startSpy: ReturnType<typeof vi.fn>;
 let stopSpy: ReturnType<typeof vi.fn>;
+let recognitionLang: string | undefined;
 /** Original navigator.mediaDevices descriptor, restored after each test. */
 let originalMediaDevices: PropertyDescriptor | undefined;
+/** Original navigator.language descriptor, restored after each test. */
+let originalLanguage: PropertyDescriptor | undefined;
 
 function installSpeechRecognition() {
   handlers = {};
   startSpy = vi.fn();
   stopSpy = vi.fn();
+  recognitionLang = undefined;
   // A class (not an arrow fn) so `new Ctor()` is constructable — the component
   // does `new Ctor()` in its mount effect.
   class FakeRecognition {
+    private language = "en-US";
+    get lang() {
+      return this.language;
+    }
+    set lang(value: string) {
+      this.language = value;
+      recognitionLang = value;
+    }
     continuous = false;
     interimResults = false;
-    lang = "en-US";
     start = startSpy;
     stop = stopSpy;
     addEventListener(type: string, handler: (event: unknown) => void) {
@@ -97,6 +108,7 @@ beforeEach(() => {
   // (unavailable in jsdom) is ever constructed. Capture the original descriptor
   // first so afterEach can restore it — otherwise this navigator stub leaks.
   originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+  originalLanguage = Object.getOwnPropertyDescriptor(navigator, "language");
   Object.defineProperty(navigator, "mediaDevices", {
     configurable: true,
     value: { getUserMedia: vi.fn().mockRejectedValue(new Error("no mic")) },
@@ -113,6 +125,11 @@ afterEach(() => {
   } else {
     delete (navigator as { mediaDevices?: unknown }).mediaDevices;
   }
+  if (originalLanguage) {
+    Object.defineProperty(navigator, "language", originalLanguage);
+  } else {
+    delete (navigator as { language?: unknown }).language;
+  }
 });
 
 describe("ComposerMicButton", () => {
@@ -127,6 +144,30 @@ describe("ComposerMicButton", () => {
     render(<ComposerMicButton onTranscript={vi.fn()} />);
     const button = screen.getByRole("button", { name: "Voice dictation" });
     expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("defaults Web Speech to the browser language", () => {
+    Object.defineProperty(navigator, "language", { configurable: true, value: "ja-JP" });
+
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+
+    expect(recognitionLang).toBe("ja-JP");
+  });
+
+  it("prefers an explicit language over the browser language", () => {
+    Object.defineProperty(navigator, "language", { configurable: true, value: "ja-JP" });
+
+    render(<ComposerMicButton onTranscript={vi.fn()} lang="en-GB" />);
+
+    expect(recognitionLang).toBe("en-GB");
+  });
+
+  it("falls back to en-US when the browser language is empty", () => {
+    Object.defineProperty(navigator, "language", { configurable: true, value: "" });
+
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+
+    expect(recognitionLang).toBe("en-US");
   });
 
   it("starts recognition on click and reflects the recording state", () => {

--- a/web/src/components/ComposerMicButton.tsx
+++ b/web/src/components/ComposerMicButton.tsx
@@ -47,6 +47,15 @@ const getRecognitionCtor = (): SpeechRecognitionCtor | null => {
   return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 };
 
+const getDefaultDictationLang = (): string => {
+  if (typeof navigator === "undefined") return "en-US";
+  try {
+    return navigator.language || "en-US";
+  } catch {
+    return "en-US";
+  }
+};
+
 // FFT bin ranges per bar, weighted toward voice frequencies (~100Hz–3kHz).
 const BAR_BINS: readonly (readonly [number, number])[] = [
   [1, 3],
@@ -90,7 +99,7 @@ export const ComposerMicButton = ({
   onTranscript,
   onInterim,
   disabled,
-  lang = "en-US",
+  lang = getDefaultDictationLang(),
   enableHotkey = false,
   onVoiceStart,
   onVoiceDiscard,


### PR DESCRIPTION
## Related issue

Closes #4455

## Summary

- Default browser Web Speech dictation to `navigator.language` when callers do not pass `lang`.
- Preserve explicit `lang` as the highest-priority value and fall back to `en-US` when the browser locale is empty or unavailable.
- Add focused unit coverage for browser locale, explicit override, and fallback behavior.

Related to #3868, which covers broader configurable dictation behavior.

## Test Plan

- `./node_modules/.bin/vitest run src/components/ComposerMicButton.test.tsx`
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives .`
- `./node_modules/.bin/prettier --check src/components/ComposerMicButton.tsx src/components/ComposerMicButton.test.tsx`
- `.venv/bin/pre-commit run --all-files`

## Demo

Manual verification completed: Japanese dictation was recognized successfully on both macOS and iPhone.

*Japanese dictation demo (macOS, 10 seconds, no audio)*

[Japanese dictation demo](https://github.com/user-attachments/assets/55f89acc-c90f-4893-9394-3236ce2dfd8b)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Web Speech recognizer is stubbed in unit tests so the assigned language can be verified without microphone access or a browser speech backend.

## Changelog

Voice dictation now follows your browser language by default while still honoring explicit language overrides.
