### PR TITLE
fix(routing): count managed-settings AIGW backing for claude-native

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -606,6 +606,40 @@ def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
     return None
 
 
+def managed_claude_gateway_signal() -> tuple[str | None, bool]:
+    """Read the AI-Gateway backing Claude Code applies from managed settings.
+
+    Managed settings win at Claude Code's actual launch, so an enterprise file
+    can pin all inference through an AI Gateway even when omnigent's own
+    provider config resolves nothing (a ``subscription`` login). This reports
+    that backing: the managed ``env.ANTHROPIC_BASE_URL`` and whether a
+    credential is delivered, either through a top-level ``apiKeyHelper`` or a
+    truthy ``env.CLAUDE_CODE_USE_GATEWAY``.
+
+    :returns: ``(base_url, has_credential)`` from the first readable managed
+        settings file, or ``(None, False)`` when none is present or parseable.
+    """
+    for path in _CLAUDE_CODE_MANAGED_SETTINGS_PATHS:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        raw_env = payload.get("env")
+        env = raw_env if isinstance(raw_env, dict) else {}
+        raw_base_url = env.get("ANTHROPIC_BASE_URL")
+        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else None
+        has_helper = bool(payload.get("apiKeyHelper"))
+        use_gateway = str(env.get("CLAUDE_CODE_USE_GATEWAY", "")).strip().lower() not in (
+            "",
+            "0",
+            "false",
+        )
+        return base_url or None, has_helper or use_gateway
+    return None, False
+
+
 def claude_native_model_options(
     claude_config: ClaudeNativeUcodeConfig | None,
 ) -> list[dict[str, object]]:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -42,6 +42,7 @@ from omnigent.codex_native_app_server import (
     client_for_transport,
     codex_session_meta_model_provider,
     codex_terminal_env,
+    native_codex_launch_base_url,
     normalize_codex_permission_launch_args,
     preload_codex_thread_for_resume,
     resolve_native_codex_launch,
@@ -251,7 +252,9 @@ def _codex_auth_unavailable_reason() -> HarnessUnavailableReason | None:
     try:
         launch = resolve_native_codex_launch(model=None)
         routes_through_provider = (
-            launch.profile is not None or codex_session_meta_model_provider(launch) != "openai"
+            launch.profile is not None
+            or codex_session_meta_model_provider(launch) != "openai"
+            or native_codex_launch_base_url(launch) is not None
         )
     except Exception:  # noqa: BLE001 - readiness must never raise; fail onto auth.json.
         _logger.debug("codex readiness: launch resolve failed; using auth.json", exc_info=True)

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1939,7 +1939,51 @@ def native_codex_launch_base_url(launch: NativeCodexLaunch) -> str | None:
     # A cli-config entry pins only a provider *name*; its table (with the
     # base_url) lives in the user's shared ~/.codex/config.toml. Read that
     # file to resolve the base URL a cli-config launch actually routes through.
-    return _cli_config_provider_base_url(codex_session_meta_model_provider(launch))
+    if _launch_pins_model_provider(launch):
+        return _cli_config_provider_base_url(codex_session_meta_model_provider(launch))
+    # No provider pinned at all: the deliberate config-default path leaves
+    # overrides empty so Codex uses its own config.toml top-level
+    # ``model_provider`` default (a Databricks-wide setup). Resolve that.
+    return _config_default_provider_base_url()
+
+
+def _launch_pins_model_provider(launch: NativeCodexLaunch) -> bool:
+    """Whether a launch carries an explicit ``model_provider=`` override.
+
+    Distinguishes a launch that pins a provider name (cli-config, or the
+    literal ``model_provider="openai"`` the subscription / dismissed paths
+    set) from the empty-override config-default launch, which pins none.
+    """
+    return any(override.startswith("model_provider=") for override in launch.config_overrides)
+
+
+def _config_default_provider_base_url() -> str | None:
+    """Base URL Codex's config.toml top-level ``model_provider`` default routes to.
+
+    When omnigent pins no provider, Codex falls back to the top-level
+    ``model_provider`` in the user's shared ``config.toml`` — unless the user
+    dismissed that default, which pins Codex's built-in ``openai`` instead.
+
+    :returns: The default provider table's ``base_url``, or ``None`` when the
+        default is dismissed, absent, or unreadable.
+    """
+    import tomllib
+
+    from omnigent.inner.codex_executor import _codex_home_config_source_from_env
+    from omnigent.onboarding.detected import codex_config_provider_dismissed
+    from omnigent.onboarding.provider_config import load_config
+
+    if codex_config_provider_dismissed(load_config()):
+        return None
+    config_path = _codex_home_config_source_from_env() / "config.toml"
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        provider_name = data["model_provider"]
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError):
+        return None
+    if not isinstance(provider_name, str):
+        return None
+    return _config_toml_provider_base_url(provider_name)
 
 
 def _cli_config_provider_base_url(provider_name: str) -> str | None:
@@ -1958,12 +2002,21 @@ def _cli_config_provider_base_url(provider_name: str) -> str | None:
     :returns: The provider table's ``base_url``, or ``None`` when it cannot be
         read.
     """
+    if provider_name in ("openai", "omnigent_databricks"):
+        return None
+    return _config_toml_provider_base_url(provider_name)
+
+
+def _config_toml_provider_base_url(provider_name: str) -> str | None:
+    """Read ``[model_providers.<provider_name>].base_url`` from the shared config.toml.
+
+    :param provider_name: A provider table key in the user's ``config.toml``.
+    :returns: That table's ``base_url``, or ``None`` when it cannot be read.
+    """
     import tomllib
 
     from omnigent.inner.codex_executor import _codex_home_config_source_from_env
 
-    if provider_name in ("openai", "omnigent_databricks"):
-        return None
     config_path = _codex_home_config_source_from_env() / "config.toml"
     try:
         data = tomllib.loads(config_path.read_text(encoding="utf-8"))

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1936,9 +1936,41 @@ def native_codex_launch_base_url(launch: NativeCodexLaunch) -> str | None:
             continue
         if isinstance(base_url, str):
             return base_url
-    # A cli-config entry pins only a provider *name*; its table lives in the
-    # user's ~/.codex/config.toml, which this process does not read.
-    return None
+    # A cli-config entry pins only a provider *name*; its table (with the
+    # base_url) lives in the user's shared ~/.codex/config.toml. Read that
+    # file to resolve the base URL a cli-config launch actually routes through.
+    return _cli_config_provider_base_url(codex_session_meta_model_provider(launch))
+
+
+def _cli_config_provider_base_url(provider_name: str) -> str | None:
+    """Base URL a cli-config provider name resolves to in the user's codex config.
+
+    A ``cli-config`` launch pins only a ``model_provider`` name; the provider
+    table lives in the user's shared ``config.toml``, which the launch never
+    inlines. Read it here so the gateway-inference probe can see the URL.
+
+    Only genuine cli-config provider names are looked up: ``"openai"`` is
+    Codex's own login (no pinned AIGW) and ``"omnigent_databricks"`` is the
+    profile branch's generated id, so both return ``None``.
+
+    :param provider_name: Provider id from
+        :func:`codex_session_meta_model_provider`.
+    :returns: The provider table's ``base_url``, or ``None`` when it cannot be
+        read.
+    """
+    import tomllib
+
+    from omnigent.inner.codex_executor import _codex_home_config_source_from_env
+
+    if provider_name in ("openai", "omnigent_databricks"):
+        return None
+    config_path = _codex_home_config_source_from_env() / "config.toml"
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        base_url = data["model_providers"][provider_name]["base_url"]
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError):
+        return None
+    return base_url if isinstance(base_url, str) else None
 
 
 def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCodexLaunch | None:

--- a/omnigent/gateway_inference.py
+++ b/omnigent/gateway_inference.py
@@ -31,17 +31,36 @@ def claude_gateway_inference_backed() -> bool:
 
     A gateway-backed launch pins ``ANTHROPIC_BASE_URL`` and delivers its bearer
     token through Claude Code's ``apiKeyHelper``. The Bedrock path sets
-    ``ANTHROPIC_BEDROCK_BASE_URL`` with no helper, and a subscription / CLI
-    login resolves no config at all — neither is routable.
+    ``ANTHROPIC_BEDROCK_BASE_URL`` with no helper — not routable.
 
-    :returns: ``True`` iff the resolved config is AI-Gateway-backed.
+    A subscription / CLI login resolves no omnigent config, yet Claude Code
+    still routes all inference through an AI Gateway when an enterprise managed
+    settings file pins it. Managed settings win at the actual launch, so that
+    signal counts too: it flips the answer to ``True`` even when resolution
+    yields nothing.
+
+    :returns: ``True`` iff a claude-native launch resolves AI-Gateway-backed
+        inference, from omnigent config or managed settings.
     """
-    from omnigent.claude_native import resolve_native_claude_config
+    from omnigent.claude_native import (
+        managed_claude_gateway_signal,
+        resolve_native_claude_config,
+    )
+    from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 
     config = resolve_native_claude_config(spec=None, refresh_models=False)
-    if config is None:
-        return False
-    return bool(config.env.get("ANTHROPIC_BASE_URL")) and bool(config.api_key_helper)
+    if config is not None and config.env.get("ANTHROPIC_BASE_URL") and config.api_key_helper:
+        return True
+
+    managed_base_url, managed_has_credential = managed_claude_gateway_signal()
+    if (
+        managed_base_url is not None
+        and managed_has_credential
+        and is_databricks_ai_gateway_url(managed_base_url)
+    ):
+        return True
+
+    return False
 
 
 def codex_gateway_inference_backed() -> bool:

--- a/omnigent/gateway_inference.py
+++ b/omnigent/gateway_inference.py
@@ -29,9 +29,13 @@ _CODEX_GATEWAY_PATH_SUFFIX = "/codex/v1"
 def claude_gateway_inference_backed() -> bool:
     """Whether a claude-native launch on this host resolves gateway-backed inference.
 
-    A gateway-backed launch pins ``ANTHROPIC_BASE_URL`` and delivers its bearer
-    token through Claude Code's ``apiKeyHelper``. The Bedrock path sets
-    ``ANTHROPIC_BEDROCK_BASE_URL`` with no helper — not routable.
+    A gateway-backed launch pins a Databricks AI Gateway ``ANTHROPIC_BASE_URL``
+    and delivers its bearer token through Claude Code's ``apiKeyHelper``. The
+    base URL must be a genuine Databricks AI Gateway (validated with
+    :func:`is_databricks_ai_gateway_url`, parity with the Codex check), since
+    the external router's picks are Databricks catalog ids only that endpoint
+    serves. The Bedrock path sets ``ANTHROPIC_BEDROCK_BASE_URL`` with no
+    helper — not routable.
 
     A subscription / CLI login resolves no omnigent config, yet Claude Code
     still routes all inference through an AI Gateway when an enterprise managed
@@ -49,8 +53,10 @@ def claude_gateway_inference_backed() -> bool:
     from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 
     config = resolve_native_claude_config(spec=None, refresh_models=False)
-    if config is not None and config.env.get("ANTHROPIC_BASE_URL") and config.api_key_helper:
-        return True
+    if config is not None:
+        base_url = config.env.get("ANTHROPIC_BASE_URL")
+        if base_url and config.api_key_helper and is_databricks_ai_gateway_url(base_url):
+            return True
 
     managed_base_url, managed_has_credential = managed_claude_gateway_signal()
     if (

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -64,6 +64,9 @@ def _point_codex_auth_check_at(
         launch = codex_native_app_server.NativeCodexLaunch(
             config_overrides=[], model=None, profile=None
         )
+    # Isolate the shared codex config.toml the config-default launch reads, so a
+    # defer-to-login test doesn't pick up the real machine's provider default.
+    monkeypatch.setenv("CODEX_HOME", str(auth_path.parent))
     monkeypatch.setattr(codex_native, "resolve_native_codex_launch", lambda model=None: launch)
     monkeypatch.setattr(
         codex_native,
@@ -202,6 +205,60 @@ def test_codex_auth_unavailable_reason_provider_override_available(
     _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True, launch=launch)
 
     assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_config_default_provider_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty-override launch routed by the config.toml provider default is ready.
+
+    omnigent pins no provider (empty overrides, profile None, meta "openai") but
+    defers to Codex's own config.toml top-level ``model_provider`` default — a
+    Databricks AIGW provider. auth.json is deliberately absent; availability must
+    come from the resolvable launch base URL.
+    """
+    codex_home = tmp_path / "codex-home"
+    auth_path = codex_home / "auth.json"  # never created
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    from omnigent.onboarding import detected
+
+    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda _config: False)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "config.toml").write_text(
+        'model_provider = "Databricks"\n[model_providers.Databricks]\n'
+        'base_url = "https://example.cloud.databricks.com/ai-gateway/codex/v1"\n',
+        encoding="utf-8",
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_explicit_openai_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit ``model_provider="openai"`` launch still gates on auth.json.
+
+    Even with a Databricks provider default in config.toml, an explicit openai
+    pin is Codex's built-in login — a logged-out openai user must report
+    needs-auth, never read the config default.
+    """
+    codex_home = tmp_path / "codex-home"
+    auth_path = codex_home / "auth.json"  # never created
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=['model_provider="openai"'], model=None, profile=None
+    )
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True, launch=launch)
+    from omnigent.onboarding import detected
+
+    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda _config: False)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "config.toml").write_text(
+        'model_provider = "Databricks"\n[model_providers.Databricks]\n'
+        'base_url = "https://example.cloud.databricks.com/ai-gateway/codex/v1"\n',
+        encoding="utf-8",
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 
 
 def test_codex_auth_unavailable_reason_resolver_failure_falls_back_to_auth_json(

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -75,6 +75,22 @@ def test_claude_gateway_backed_for_gateway_env_with_helper(
     assert calls == [{"spec": None, "refresh_models": False}]
 
 
+def test_claude_not_gateway_backed_for_resolved_non_databricks_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    _stub_claude(
+        monkeypatch,
+        ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+            api_key_helper="databricks auth token --profile dev",
+        ),
+    )
+    _stub_managed_settings(monkeypatch, tmp_path, None)
+
+    assert claude_gateway_inference_backed() is False
+
+
 def test_claude_not_gateway_backed_without_api_key_helper(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -317,7 +317,8 @@ def test_codex_gateway_backed_for_config_default_provider(
     _stub_codex_dismissed(monkeypatch, False)
     _write_codex_config(
         tmp_path,
-        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+        f'model_provider = "Databricks"\n'
+        f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
     )
     _stub_codex(
         monkeypatch,
@@ -335,7 +336,8 @@ def test_codex_not_gateway_backed_for_config_default_when_dismissed(
     _stub_codex_dismissed(monkeypatch, True)
     _write_codex_config(
         tmp_path,
-        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+        f'model_provider = "Databricks"\n'
+        f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
     )
     _stub_codex(
         monkeypatch,
@@ -353,7 +355,8 @@ def test_codex_not_gateway_backed_for_explicit_openai_ignores_config_default(
     _stub_codex_dismissed(monkeypatch, False)
     _write_codex_config(
         tmp_path,
-        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+        f'model_provider = "Databricks"\n'
+        f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
     )
     _stub_codex(
         monkeypatch,

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -216,7 +216,12 @@ def test_codex_not_gateway_backed_for_non_databricks_provider(
     assert codex_gateway_inference_backed() is False
 
 
-def test_codex_not_gateway_backed_for_cli_login(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_codex_not_gateway_backed_for_cli_login(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, False)
     _stub_codex(
         monkeypatch,
         NativeCodexLaunch(config_overrides=[], model=None, profile=None),
@@ -298,11 +303,90 @@ def test_codex_not_gateway_backed_for_cli_config_missing_provider_table(
     assert codex_gateway_inference_backed() is False
 
 
-def test_codex_not_gateway_backed_for_openai_login_ignores_config(
+def _stub_codex_dismissed(monkeypatch: pytest.MonkeyPatch, dismissed: bool) -> None:
+    from omnigent.onboarding import detected
+
+    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda _config: dismissed)
+
+
+def test_codex_gateway_backed_for_config_default_provider(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, False)
+    _write_codex_config(
+        tmp_path,
+        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(config_overrides=[], model=None, profile=None),
+    )
+
+    assert codex_gateway_inference_backed() is True
+
+
+def test_codex_not_gateway_backed_for_config_default_when_dismissed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, True)
+    _write_codex_config(
+        tmp_path,
+        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(config_overrides=[], model=None, profile=None),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
+def test_codex_not_gateway_backed_for_explicit_openai_ignores_config_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, False)
+    _write_codex_config(
+        tmp_path,
+        f'model_provider = "Databricks"\n[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(config_overrides=['model_provider="openai"'], model=None, profile=None),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
+def test_codex_not_gateway_backed_for_config_default_non_databricks_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, False)
+    _write_codex_config(
+        tmp_path,
+        'model_provider = "OpenAI"\n[model_providers.OpenAI]\nbase_url = "https://api.openai.com/v1"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(config_overrides=[], model=None, profile=None),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
+def test_codex_not_gateway_backed_for_config_default_without_top_level_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _stub_codex_dismissed(monkeypatch, False)
     _write_codex_config(
         tmp_path,
         f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -237,6 +237,84 @@ def test_codex_not_gateway_backed_when_profile_has_no_host(
     assert codex_gateway_inference_backed() is False
 
 
+def _write_codex_config(tmp_path: Any, providers_toml: str) -> None:
+    (tmp_path / "config.toml").write_text(providers_toml, encoding="utf-8")
+
+
+def test_codex_gateway_backed_for_cli_config_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_codex_config(
+        tmp_path,
+        f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(
+            config_overrides=['model_provider="Databricks"'], model=None, profile=None
+        ),
+    )
+
+    assert codex_gateway_inference_backed() is True
+
+
+def test_codex_not_gateway_backed_for_cli_config_non_databricks_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_codex_config(
+        tmp_path,
+        '[model_providers.Databricks]\nbase_url = "https://api.openai.com/v1"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(
+            config_overrides=['model_provider="Databricks"'], model=None, profile=None
+        ),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
+def test_codex_not_gateway_backed_for_cli_config_missing_provider_table(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_codex_config(
+        tmp_path,
+        f'[model_providers.Other]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(
+            config_overrides=['model_provider="Databricks"'], model=None, profile=None
+        ),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
+def test_codex_not_gateway_backed_for_openai_login_ignores_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_codex_config(
+        tmp_path,
+        f'[model_providers.Databricks]\nbase_url = "{_GATEWAY_CODEX_URL}"\n',
+    )
+    _stub_codex(
+        monkeypatch,
+        NativeCodexLaunch(config_overrides=[], model=None, profile=None),
+    )
+
+    assert codex_gateway_inference_backed() is False
+
+
 def test_launch_base_url_extracts_generated_databricks_override() -> None:
     overrides = codex_executor._databricks_codex_config_overrides(
         model="databricks-gpt-5-5",
@@ -248,7 +326,11 @@ def test_launch_base_url_extracts_generated_databricks_override() -> None:
     assert native_codex_launch_base_url(launch) == _GATEWAY_CODEX_URL
 
 
-def test_launch_base_url_none_for_cli_config_provider_name_only() -> None:
+def test_launch_base_url_none_for_cli_config_provider_name_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     launch = NativeCodexLaunch(
         config_overrides=['model_provider="my_custom"'],
         model=None,

--- a/tests/test_gateway_inference.py
+++ b/tests/test_gateway_inference.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -37,6 +38,20 @@ def _stub_claude(
     return calls
 
 
+def _stub_managed_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    payload: dict[str, Any] | None,
+) -> None:
+    if payload is None:
+        paths: tuple[Any, ...] = (tmp_path / "absent.json",)
+    else:
+        settings = tmp_path / "managed-settings.json"
+        settings.write_text(json.dumps(payload), encoding="utf-8")
+        paths = (settings,)
+    monkeypatch.setattr(claude_native, "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS", paths)
+
+
 def _stub_codex(monkeypatch: pytest.MonkeyPatch, launch: NativeCodexLaunch) -> None:
     monkeypatch.setattr(
         codex_native_app_server,
@@ -62,16 +77,21 @@ def test_claude_gateway_backed_for_gateway_env_with_helper(
 
 def test_claude_not_gateway_backed_without_api_key_helper(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
 ) -> None:
     _stub_claude(
         monkeypatch,
         ClaudeNativeUcodeConfig(env={"ANTHROPIC_BASE_URL": _GATEWAY_ANTHROPIC_URL}),
     )
+    _stub_managed_settings(monkeypatch, tmp_path, None)
 
     assert claude_gateway_inference_backed() is False
 
 
-def test_claude_not_gateway_backed_for_bedrock(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_claude_not_gateway_backed_for_bedrock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     _stub_claude(
         monkeypatch,
         ClaudeNativeUcodeConfig(
@@ -81,12 +101,70 @@ def test_claude_not_gateway_backed_for_bedrock(monkeypatch: pytest.MonkeyPatch) 
             },
         ),
     )
+    _stub_managed_settings(monkeypatch, tmp_path, None)
 
     assert claude_gateway_inference_backed() is False
 
 
-def test_claude_not_gateway_backed_for_cli_login(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_claude_not_gateway_backed_for_cli_login(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
     _stub_claude(monkeypatch, None)
+    _stub_managed_settings(monkeypatch, tmp_path, None)
+
+    assert claude_gateway_inference_backed() is False
+
+
+def test_claude_gateway_backed_for_subscription_with_managed_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    _stub_claude(monkeypatch, None)
+    _stub_managed_settings(
+        monkeypatch,
+        tmp_path,
+        {
+            "env": {"ANTHROPIC_BASE_URL": _GATEWAY_ANTHROPIC_URL},
+            "apiKeyHelper": "jq -r '.access_token' ~/.databricks/model-serving-token.json",
+        },
+    )
+
+    assert claude_gateway_inference_backed() is True
+
+
+def test_claude_gateway_backed_for_subscription_with_use_gateway_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    _stub_claude(monkeypatch, None)
+    _stub_managed_settings(
+        monkeypatch,
+        tmp_path,
+        {
+            "env": {
+                "ANTHROPIC_BASE_URL": _GATEWAY_ANTHROPIC_URL,
+                "CLAUDE_CODE_USE_GATEWAY": "1",
+            }
+        },
+    )
+
+    assert claude_gateway_inference_backed() is True
+
+
+def test_claude_not_gateway_backed_for_managed_non_databricks_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    _stub_claude(monkeypatch, None)
+    _stub_managed_settings(
+        monkeypatch,
+        tmp_path,
+        {
+            "env": {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+            "apiKeyHelper": "jq -r '.access_token' ~/.databricks/model-serving-token.json",
+        },
+    )
 
     assert claude_gateway_inference_backed() is False
 


### PR DESCRIPTION
## Summary

`claude_gateway_inference_backed()` treated a `subscription` Claude provider as
not gateway-backed, silently disabling Smart Routing for users whose Claude Code
inference is actually pinned to a Databricks AI Gateway by an enterprise
managed-settings file (`/Library/Application Support/ClaudeCode/managed-settings.json`).
omnigent's check only consulted its own provider config + ucode state, never
Claude Code's managed-settings layer — so a fleet pinned to AIGW read as
"not AI-Gateway-backed on this host."

The fix adds a managed-settings fallback — parity with the existing Codex
`config.toml` check — that counts a claude-native launch as gateway-backed when
the managed `env.ANTHROPIC_BASE_URL` is a validated Databricks AI Gateway URL
(via `is_databricks_ai_gateway_url`, so a non-Databricks base URL does not
qualify) and a credential is delivered via top-level `apiKeyHelper` or
`env.CLAUDE_CODE_USE_GATEWAY`. Managed settings win at the real Claude Code
launch, so this flips the verdict to `True` even when omnigent's own provider
config resolves nothing. The existing resolve-based path is unchanged.

## Test Plan

- `uv run --extra dev pytest tests/test_gateway_inference.py` → 42 passed
  (3 new cases: subscription + managed `apiKeyHelper` → true; subscription +
  `CLAUDE_CODE_USE_GATEWAY` → true; subscription + non-Databricks URL → false;
  existing "expect false" tests isolated from the real machine file).
- Live, on a machine with a `subscription` global Claude provider and an AIGW
  managed-settings file: `claude_gateway_inference_backed()` returns `False`
  before the fix and `True` after.
- Full stack (server with an agent-platform routing config, host on the user's
  global settings): `/v1/hosts` now reports `claude-native: true` and
  `/v1/info` shows `smart_routing_sources.external: true`.

## Demo

video demos:

- UI: https://drive.google.com/file/d/1Y3W7On46x-G1tkZH0D1O9b7jm-Xm__cV/view?usp=drive_link
- TUI: https://drive.google.com/file/d/1HU1AdwRkg2PDNJAWCv6fRBFWk_aFoMmE/view?usp=drive_link

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added/updated
- [x] Manual verification completed

## Coverage notes

Unit tests mock the managed-settings path and `resolve_native_claude_config`.
The end-to-end flip was verified manually against a real machine managed-settings
file, since the signal source is a system-level file outside the test sandbox.
