### PR TITLE
fix(search): index-back session content search with pg_trgm + bound it

### DIFF
--- a/omnigent/db/migrations/versions/d5e9f1a2b3c4_conversation_search_trgm_indexes.py
+++ b/omnigent/db/migrations/versions/d5e9f1a2b3c4_conversation_search_trgm_indexes.py
@@ -1,0 +1,77 @@
+"""Trigram GIN indexes so session search stops sequential-scanning content.
+
+Revision ID: d5e9f1a2b3c4
+Revises: f7a8b9c0d1e2
+Create Date: 2026-08-09 00:00:00.000000
+
+Session search (``GET /v1/sessions?search_query=``) matches a conversation when
+``LOWER(title) LIKE '%q%'`` OR any item's ``LOWER(search_text) LIKE '%q%'``. The
+leading wildcard makes both predicates unindexable by a b-tree, so on Postgres
+the content half sequential-scans every ``conversation_items`` row in the
+workspace (and lowercases its wide ``search_text``). On a real deployment that
+runs for tens of seconds; the palette has no request timeout, so it hangs on
+"Searching…" forever.
+
+``pg_trgm`` fixes this without changing match semantics: a GIN index on the
+``LOWER(...)`` expression accelerates the existing substring ``LIKE`` directly
+(no switch to ``tsvector``, so the UI's substring highlighting still lines up).
+Both sides of the OR are indexed — the content scan is the bottleneck, but
+leaving ``title`` unindexed would let the planner fall back to scanning
+``conversations`` for the OR.
+
+Postgres-only. SQLite (dev/tests) keeps its FTS5 virtual table and small tables,
+so the substring scan there is a non-issue; this migration is a no-op on any
+non-Postgres dialect. Plain ``CREATE INDEX`` (not ``CONCURRENTLY``) because the
+Alembic runner wraps every migration in a transaction, where ``CONCURRENTLY`` is
+illegal — matching every other index migration in this chain.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "d5e9f1a2b3c4"
+down_revision: str | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ITEMS_INDEX = "ix_conversation_items_search_text_trgm"
+_TITLE_INDEX = "ix_conversations_title_trgm"
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    """
+    Enable ``pg_trgm`` and add GIN trigram indexes on the lowercased search
+    expressions the session-search query uses. No-op off Postgres.
+    """
+    if not _is_postgres():
+        return
+    # IF NOT EXISTS so a deployment that already enabled the extension (or
+    # pre-created an index) migrates cleanly.
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_ITEMS_INDEX} "
+        "ON conversation_items USING gin (LOWER(search_text) gin_trgm_ops)"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_TITLE_INDEX} "
+        "ON conversations USING gin (LOWER(title) gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    """
+    Drop the trigram indexes. The ``pg_trgm`` extension is left installed — it is
+    cheap, may back other objects, and dropping it could fail if anything else
+    depends on it. No-op off Postgres.
+    """
+    if not _is_postgres():
+        return
+    op.execute(f"DROP INDEX IF EXISTS {_TITLE_INDEX}")
+    op.execute(f"DROP INDEX IF EXISTS {_ITEMS_INDEX}")

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -96,6 +96,18 @@ from omnigent.stores.conversation_store import (
 
 _logger = logging.getLogger(__name__)
 
+# Server-side deadline (ms) for the content-search query in
+# ``list_conversations``. Session search matches ``LOWER(search_text) LIKE
+# '%q%'`` across ``conversation_items``; that is index-backed by the pg_trgm
+# GIN index (migration ``d5e9f1a2b3c4``), but if the index is ever missing the
+# scan can run unbounded and — since the query runs in a worker thread — a
+# client disconnect does not stop it. ``SET LOCAL statement_timeout`` caps it so
+# a degraded deployment fails the search fast instead of pinning a DB
+# connection. Postgres-only; ``SET LOCAL`` reverts on commit so it never leaks
+# to the connection's next pooled use. Longer than the client's own
+# ``SEARCH_FETCH_TIMEOUT_MS`` so the browser gives up first on the happy path.
+_SEARCH_STATEMENT_TIMEOUT_MS = 15_000
+
 
 class _RowCountResult(Protocol):
     rowcount: int
@@ -2312,6 +2324,20 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
 
         with self._conv_session("list_conversations") as session:
+            # Bound the content-search scan server-side (Postgres only). SET
+            # LOCAL scopes to this transaction and reverts on commit, so it
+            # can't leak to the connection's next pooled use. See
+            # _SEARCH_STATEMENT_TIMEOUT_MS. A worker-thread query is not stopped
+            # by a client disconnect, so this is the only server-side bound.
+            is_postgres = session.bind is not None and session.bind.dialect.name == "postgresql"
+            if search_query and is_postgres:
+                # Postgres SET does not accept a bind parameter, so the value is
+                # inlined. Safe from injection: it is an int module constant, not
+                # caller input — coerced through int() to keep it that way.
+                session.execute(
+                    text(f"SET LOCAL statement_timeout = {int(_SEARCH_STATEMENT_TIMEOUT_MS)}")
+                )
+
             stmt = select(SqlConversation).where(
                 SqlConversation.workspace_id == current_workspace_id()
             )

--- a/tests/db/test_migration_conversation_search_trgm_indexes.py
+++ b/tests/db/test_migration_conversation_search_trgm_indexes.py
@@ -1,0 +1,124 @@
+"""Tests for the conversation-search trigram indexes migration.
+
+Session search (``GET /v1/sessions?search_query=``) matches on
+``LOWER(title) LIKE '%q%'`` OR ``LOWER(search_text) LIKE '%q%'``. The leading
+wildcard makes both unindexable by a b-tree, so on Postgres the content half
+sequential-scans every ``conversation_items`` row. Migration ``d5e9f1a2b3c4``
+adds ``pg_trgm`` GIN indexes on those two lowercased expressions so the existing
+``LIKE`` becomes index-backed (Postgres only; a no-op on SQLite, which keeps its
+FTS5 table and small dev tables).
+
+These tests assert the post-migration shape per dialect and that the chain stays
+reversible. The Postgres leg (marked ``databricks``) additionally proves the
+planner uses the content index for the real search predicate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+_NEW_REVISION = "d5e9f1a2b3c4"
+# Revision just before this one (its down_revision).
+_PRE_REVISION = "f7a8b9c0d1e2"
+_ITEMS_INDEX = "ix_conversation_items_search_text_trgm"
+_TITLE_INDEX = "ix_conversations_title_trgm"
+
+
+@pytest.fixture
+def sqlite_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite DB with the full alembic chain applied (at head)."""
+    engine = get_or_create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def _index_names(engine: Engine, table: str) -> set[str]:
+    return {i["name"] for i in sa.inspect(engine).get_indexes(table)}
+
+
+def test_trgm_indexes_absent_on_sqlite(sqlite_engine: Engine) -> None:
+    """
+    On SQLite the migration is a no-op: neither trigram index is created.
+
+    ``pg_trgm``/GIN are Postgres-only, and SQLite search rides its FTS5 table,
+    so the migration must skip cleanly rather than emit unsupported DDL. A
+    failure here means the dialect guard regressed and the chain would break on
+    a fresh SQLite database.
+    """
+    assert _ITEMS_INDEX not in _index_names(sqlite_engine, "conversation_items")
+    assert _TITLE_INDEX not in _index_names(sqlite_engine, "conversations")
+
+
+def test_roundtrip_reversible_on_sqlite(tmp_path: Path) -> None:
+    """
+    Upgrade → downgrade → upgrade roundtrips on a throwaway SQLite DB.
+
+    The downgrade leg is otherwise uncovered (the engine fixtures only run
+    ``upgrade head``), so this proves the migration stays reversible even though
+    both directions are no-ops on SQLite.
+    """
+    uri = f"sqlite:///{tmp_path / 'roundtrip.db'}"
+    cfg = _build_alembic_config(uri)
+    engine = sa.create_engine(uri)
+    try:
+        for target in (_NEW_REVISION, _PRE_REVISION, _NEW_REVISION):
+            with engine.begin() as conn:
+                cfg.attributes["connection"] = conn
+                command.upgrade(cfg, target) if target == _NEW_REVISION else command.downgrade(
+                    cfg, target
+                )
+        # No trigram indexes on SQLite regardless of direction.
+        assert _ITEMS_INDEX not in _index_names(engine, "conversation_items")
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+@pytest.mark.databricks
+def test_trgm_indexes_present_on_postgres(db_uri: str) -> None:
+    """
+    On Postgres both trigram GIN indexes exist at head, on the lowercased
+    expressions the search query filters on.
+
+    Asserts the migration's contract structurally — index type ``gin`` with
+    ``gin_trgm_ops`` over a ``lower(...)`` expression — rather than a query plan,
+    which depends on table statistics and would be non-deterministic against the
+    empty per-worker test DB. (Whether the planner *chooses* the index at scale
+    is a property of Postgres + ``pg_trgm``, not of this DDL.)
+
+    Runs only in the Postgres-backed ``databricks`` lane (the ``db_uri`` fixture
+    yields the migrated per-worker Postgres DB there; on SQLite this test is
+    deselected). Read-only — it never downgrades the shared worker DB.
+    """
+    engine = get_or_create_engine(db_uri)
+    if engine.dialect.name != "postgresql":
+        pytest.skip("trigram indexes are Postgres-only")
+
+    with engine.connect() as conn:
+        defs = dict(
+            conn.execute(
+                sa.text(
+                    "SELECT indexname, indexdef FROM pg_indexes "
+                    "WHERE indexname IN (:items, :title)"
+                ),
+                {"items": _ITEMS_INDEX, "title": _TITLE_INDEX},
+            ).fetchall()
+        )
+    assert set(defs) == {_ITEMS_INDEX, _TITLE_INDEX}, defs
+    for definition in defs.values():
+        lowered = definition.lower()
+        assert "gin" in lowered and "gin_trgm_ops" in lowered and "lower(" in lowered, definition

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 
 from omnigent.db.utils import get_or_create_engine
 from omnigent.entities import (
@@ -1346,6 +1346,72 @@ def test_list_conversations_search_snippet_absent_without_query(
     )
     page = conversation_store.list_conversations()
     assert all(c.search_snippet is None for c in page.data)
+
+
+def _captured_sql(store: SqlAlchemyConversationStore, run) -> list[str]:
+    """
+    Capture every SQL statement the conversation engine executes during ``run``.
+
+    Attaches a ``before_cursor_execute`` listener to the store's conversation
+    engine, invokes ``run()``, then detaches. Used to assert which session-level
+    SET statements the search path emits.
+    """
+    statements: list[str] = []
+
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(store._conv_engine, "before_cursor_execute", _before)
+    try:
+        run()
+    finally:
+        event.remove(store._conv_engine, "before_cursor_execute", _before)
+    return statements
+
+
+@pytest.mark.databricks
+def test_list_conversations_search_sets_statement_timeout(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A content search bounds itself with ``SET LOCAL statement_timeout`` on
+    Postgres, so an unindexed scan can't run unbounded (the query runs in a
+    worker thread a client disconnect wouldn't stop).
+
+    Postgres-only: SQLite has no ``statement_timeout``; the search path skips
+    the SET there, which the companion assertion below guards.
+    """
+    if conversation_store._conv_engine.dialect.name != "postgresql":
+        pytest.skip("statement_timeout is a Postgres feature")
+
+    conv = conversation_store.create_conversation()
+    conversation_store.update_conversation(conv.id, title="deployment runbook")
+
+    statements = _captured_sql(
+        conversation_store,
+        lambda: conversation_store.list_conversations(search_query="deployment"),
+    )
+    assert any("statement_timeout" in s.lower() for s in statements), statements
+
+
+def test_list_conversations_no_search_skips_statement_timeout(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A plain (non-search) listing never sets ``statement_timeout``.
+
+    Ordinary pagination is indexed and fast; bounding it could abort a
+    legitimately larger page. Holds on every dialect — the SET is gated on
+    ``search_query`` being set, not just on Postgres.
+    """
+    conv = conversation_store.create_conversation()
+    conversation_store.update_conversation(conv.id, title="deployment runbook")
+
+    statements = _captured_sql(
+        conversation_store,
+        lambda: conversation_store.list_conversations(),
+    )
+    assert not any("statement_timeout" in s.lower() for s in statements), statements
 
 
 def test_list_conversations_search_snippet_uses_earliest_match(

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -224,6 +224,64 @@ describe("useConversations project filter", () => {
   });
 });
 
+describe("useConversations search timeout", () => {
+  function renderSearch(searchQuery: string) {
+    fetchMock.mockResolvedValue(
+      mockResponse({ data: [], first_id: null, last_id: null, has_more: false }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations(searchQuery, true), { wrapper });
+    return queryClient;
+  }
+
+  it("bounds a search fetch with an AbortSignal", async () => {
+    renderSearch("linear");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    // A search request can hang if its server-side index is missing, so it
+    // carries a timeout signal; the URL still requests the search.
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("search_query=linear");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("does not bound an ordinary (non-search) list fetch", async () => {
+    renderSearch("");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    // Plain pagination is indexed/fast; adding a deadline could abort a
+    // legitimately larger page, so no signal is attached.
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain("search_query=");
+    expect(init.signal).toBeUndefined();
+  });
+
+  it("does not retry a client-side search timeout, but retries other errors", () => {
+    const queryClient = renderSearch("linear");
+    const query = queryClient.getQueryCache().find({
+      queryKey: ["conversations", "linear", true],
+    });
+    const retry = (query?.options as { retry?: unknown } | undefined)?.retry as (
+      failureCount: number,
+      error: unknown,
+    ) => boolean;
+    expect(typeof retry).toBe("function");
+
+    // A fired AbortSignal.timeout rejects with a TimeoutError DOMException —
+    // terminal, so retrying would only re-arm the same slow request.
+    const timeoutError = new DOMException("timeout", "TimeoutError");
+    expect(retry(0, timeoutError)).toBe(false);
+
+    // A genuine server/network error still retries (up to the default cap).
+    expect(retry(0, new Error("500 Internal Server Error"))).toBe(true);
+    expect(retry(3, new Error("500 Internal Server Error"))).toBe(false);
+  });
+});
+
 describe("fetchAllArchivedProjectNames", () => {
   it("pages through all archived sessions and returns distinct sorted project names", async () => {
     fetchMock

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -54,6 +54,31 @@ export const CONNECTED_STREAM_REFETCH_INTERVAL_MS = 60_000;
 export const DISCONNECTED_STREAM_REFETCH_INTERVAL_MS = 45_000;
 
 /**
+ * Client-side deadline for a *search* page fetch (`?search_query=`). Content
+ * search is a substring scan server-side; if its trigram index is ever missing
+ * the query can run for tens of seconds, and the palette would otherwise sit on
+ * "Searching…" forever (the fetch has no timeout of its own). Aborting here
+ * settles the query to a terminal state so the user sees "No results found"
+ * rather than an endless spinner. Deliberately shorter than the server's own
+ * search `statement_timeout` (see `_SEARCH_STATEMENT_TIMEOUT_MS` in the store)
+ * so the client gives up first and the row-limited fast path still has room.
+ * Only search fetches are bounded — ordinary (indexed) list pagination is left
+ * untouched.
+ */
+export const SEARCH_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * True for the DOMException a fetch raises when its `AbortSignal.timeout`
+ * fires. Used to keep the query layer from retrying a client-side search
+ * timeout: retrying would just re-arm the same slow request three more times
+ * (React Query's default), turning one hung spinner into a retry storm. A real
+ * server/network error still retries normally.
+ */
+function isAbortTimeout(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "TimeoutError";
+}
+
+/**
  * Query key for the archived-project-names scan (see `useArchivedProjectNames`).
  *
  * Deliberately NOT under the `["projects"]` prefix: that scan pages the whole
@@ -268,7 +293,12 @@ async function fetchConversationsPage({
   // query key (which drops `project`) and the cache-membership check. This
   // list never requests the server's "unfiled" (`project=`) slice.
   if (project) params.set("project", project);
-  const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
+  // Bound search fetches with a client-side deadline (see
+  // SEARCH_FETCH_TIMEOUT_MS): a search whose server-side index is missing can
+  // hang, and the palette shows "Searching…" for the whole in-flight window.
+  // Plain list pagination is indexed/fast, so it keeps no timeout.
+  const signal = searchQuery ? AbortSignal.timeout(SEARCH_FETCH_TIMEOUT_MS) : undefined;
+  const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`, { signal });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as ConversationsPage;
 }
@@ -327,6 +357,10 @@ export function useConversations(
     // share the cache instead of each triggering a background refetch.
     // The WS stream handles real-time updates within that window.
     staleTime: 30_000,
+    // A client-side search timeout is terminal — retrying would just re-arm the
+    // same slow request (default 3×) and prolong the spinner. Any other failure
+    // keeps React Query's default retry behaviour.
+    retry: (failureCount, error) => !isAbortTimeout(error) && failureCount < 3,
     refetchInterval: streamConnected
       ? options.reconcileWhileConnected
         ? CONNECTED_STREAM_REFETCH_INTERVAL_MS


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; this is a bug fix surfaced from the deployed web UI. -->

## Summary

Session search (the ⌘K command palette / sidebar search, `GET /v1/sessions?search_query=`) hung on **"Searching…" forever** on the deployed app.

- **Root cause:** the content-search predicate is `LOWER(search_text) LIKE '%q%'` over `conversation_items`, which has **no index on `search_text`** (only `(workspace_id, conversation_id, …)` prefix indexes). On Postgres/Lakebase that is a full sequential scan that lowercases every row's wide `search_text`; with no timeout anywhere, the palette's fetch never settles.
- **Fix:** add a `pg_trgm` GIN index on `LOWER(search_text)` (and `LOWER(title)`) so the existing substring `LIKE` becomes index-backed — **no change to match semantics** (still substring), so the UI's highlighting still lines up. Then bound the query on both ends so a missing index can never hang the UI again.

Search results are identical with or without the index — it's a pure performance optimization.

### ELI5

Searching your sessions was like looking for a word by reading every page of every book in the library. We added an index (like a book's index) so Postgres jumps straight to the matches. And we added a stopwatch on both the browser and the server so that if search is ever slow again, it stops and says "no results" instead of spinning forever.

```
Before:  type "linear" -> Seq Scan every conversation_item -> (tens of seconds) -> "Searching…" forever
After:   type "linear" -> Bitmap Index Scan (pg_trgm GIN) -> fast results
                                 └─ if ever slow: client 10s / server 15s timeout -> terminal state, no hang
```

## Test Plan

Verified against a real **PostgreSQL 16** instance (not just SQLite):

- `EXPLAIN` on the content-search query flips from `Parallel Seq Scan on conversation_items` (cost ~4917, 99 995 rows filtered) to `Bitmap Index Scan on ix_conversation_items_search_text_trgm` (cost ~127). Gap widens with table size.
- Ran the **real Alembic migration** against Postgres: both indexes created on the correct `LOWER(...) gin_trgm_ops` expressions, `pg_trgm` enabled, idempotent (re-upgrade) and reversible (downgrade drops them).
- Backend suite: **181 passed on Postgres**, **182 passed / 2 skipped on SQLite** (`tests/stores/test_conversation_store.py`, `tests/db/test_migration_conversation_search_trgm_indexes.py`) — existing search-behaviour tests confirm results are unchanged.
- Frontend: **71 passed** (`web/src/hooks/useConversations.test.ts`, incl. new timeout/no-retry tests), **16 passed** (`CommandPalette`). `tsc`, `oxlint`, `prettier` clean.

Commands:

```bash
# SQLite
python3 -m pytest tests/stores/test_conversation_store.py tests/db/test_migration_conversation_search_trgm_indexes.py -k "search or trgm or timeout"
# Postgres
docker run -d --name pg -e POSTGRES_PASSWORD=pg -p 55432:5432 postgres:16
export OMNIGENT_TEST_DB_URI="postgresql+psycopg://postgres:pg@localhost:55432/postgres"
python3 -m pytest tests/stores/test_conversation_store.py tests/db/test_migration_conversation_search_trgm_indexes.py
# Frontend
cd web && node_modules/.bin/vitest run src/hooks/useConversations.test.ts
```

## Demo

N/A — no visual change. The user-visible effect is that search returns quickly instead of hanging on "Searching…"; behaviour/results are otherwise unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the `EXPLAIN`/plan check against a real Postgres 16 instance (SQLite can't exercise `pg_trgm`), plus a real end-to-end Alembic upgrade/downgrade against that instance. Automated tests cover: the migration shape per dialect (SQLite no-op + reversibility; Postgres index definitions, marked `databricks`), the server `statement_timeout` being applied only for search, and the frontend search fetch carrying an `AbortSignal` and not retrying a client timeout. The Postgres `statement_timeout` test caught a real bug during development (`SET` rejects a bind parameter), now fixed.

## Changelog

Session search no longer hangs on "Searching…" — content search is now backed by a trigram index and bounded by a timeout.
