### PR TITLE
fix(openai): close owned Agents SDK client

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -1018,7 +1018,9 @@ class OpenAIAgentsSDKExecutor(Executor):
         """Create an OpenAIAgentsSDKExecutor.
 
         :param client: A preconfigured ``openai.AsyncOpenAI`` client.  When
-            ``None`` the executor calls :func:`_get_openai_async_client`.
+            ``None`` the executor calls :func:`_get_openai_async_client` and
+            closes the resulting client when the executor is closed. An
+            injected client remains owned by the caller.
         :param profile: Optional ``~/.databrickscfg`` profile name for the
             Databricks fallback path, e.g. ``"<your-profile>"``.
         :param api_key: Direct OpenAI-compatible API key, e.g.
@@ -1082,6 +1084,7 @@ class OpenAIAgentsSDKExecutor(Executor):
         self._client = (
             _wrap_client_for_reasoning_models(raw_client) if not use_responses else raw_client
         )
+        self._owns_client = client is None
         self._profile = profile
         self._use_responses = use_responses
         self._model_override = model
@@ -1174,6 +1177,12 @@ class OpenAIAgentsSDKExecutor(Executor):
 
     async def close_session(self, session_key: str) -> None:
         self._session_states.pop(session_key, None)
+
+    async def close(self) -> None:
+        """Release session state and the client created by this executor."""
+        self._session_states.clear()
+        if self._owns_client:
+            await self._client.close()
 
     async def interrupt_session(self, session_key: str) -> bool:
         """

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -419,6 +419,31 @@ def test_wrap_client_non_streaming_create_not_wrapped() -> None:
 
 
 class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
+    def test_close_closes_owned_client_but_not_injected_client(self):
+        class _ClosableClient:
+            def __init__(self):
+                self.close_calls = 0
+
+            async def close(self):
+                self.close_calls += 1
+
+        async def _t():
+            owned_client = _ClosableClient()
+            with patch(
+                "omnigent.inner.openai_agents_sdk_executor._get_openai_async_client",
+                return_value=owned_client,
+            ):
+                executor = OpenAIAgentsSDKExecutor()
+            await executor.close()
+            self.assertEqual(owned_client.close_calls, 1)
+
+            injected_client = _ClosableClient()
+            executor = OpenAIAgentsSDKExecutor(client=injected_client)
+            await executor.close()
+            self.assertEqual(injected_client.close_calls, 0)
+
+        _run(_t())
+
     def test_sanitize_replay_item_drops_long_ids(self):
         item = {
             "type": "message",


### PR DESCRIPTION
## Related issue

Closes #4504

## Summary

OpenAI Agents SDK executors created a provider client but inherited the base executor's no-op shutdown method, leaving its HTTP connection pool open across executor lifecycles.

This change:

* Tracks whether the executor created or received the client.
* Closes the executor-owned client during shutdown.
* Leaves injected clients owned by their caller.
* Clears executor session state during shutdown.
* Adds regression coverage for both ownership paths.

## Test Plan

* Direct async lifecycle smoke test passed for an auto-created fake client and an injected fake client.
* Ruff format check passed for the changed source and test files.
* Python compileall passed for the changed source and test files.
* Full pytest was attempted but collection is blocked on this native Windows host by unavailable project dependencies and POSIX-only tests.
* Pyrefly, pre-commit, just, and uv are unavailable in the local environment.

## Demo

N/A — non-visual backend change.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] UI / frontend change
* [ ] Refactor / chore
* [ ] Docs
* [x] Test / CI
* [ ] Breaking change

## Test coverage

* [x] Unit tests added / updated
* [ ] Integration tests added / updated
* [ ] E2E tests added / updated
* [ ] Manual verification completed
* [ ] Existing tests cover this change
* [ ] Not applicable

## Coverage notes

The new unit test verifies that shutdown closes an executor-created client exactly once and does not close a caller-injected client.

## Changelog

* Fixes an HTTP client resource leak when OpenAI Agents SDK executors shut down.
