### PR TITLE
fix(web): keep the archive spinner up until the sidebar row leaves

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_archive.py
+++ b/tests/e2e_ui/sessions/test_sidebar_archive.py
@@ -28,16 +28,54 @@ to tear down. Server-side coverage for that lives in
 
 from __future__ import annotations
 
+import asyncio
+import threading
 import time
 import uuid
+from collections.abc import Coroutine
+from typing import Any
+from urllib.parse import urlparse
 
 import httpx
+from playwright.async_api import Route, WebSocketRoute, async_playwright
+from playwright.async_api import expect as async_expect
 from playwright.sync_api import Locator, Page, Request, expect
 
 
 def _row(page: Page, session_id: str) -> Locator:
     """Locate the sidebar row (``<li>``) for *session_id* by its href."""
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    This file mixes sync ``page``-fixture tests with one async-Playwright test
+    (the spinner-persistence test below holds a route open across UI
+    assertions). The e2e_ui suite runs many pytest-playwright **sync** tests in
+    the same session; once one has run, pytest-asyncio can't start a loop on the
+    main thread ("Runner.run() cannot be called from a running event loop").
+    Running the coroutine from a fresh thread via :func:`asyncio.run` sidesteps
+    that. Any exception — including assertion failures — is captured and
+    re-raised on the calling thread so the test fails normally. Mirrors
+    ``test_cross_session_routing._run_in_fresh_loop``.
+
+    :param coro: The coroutine to run to completion.
+    :raises BaseException: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except BaseException as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
 
 
 def test_archive_session_removes_row_without_stop_event(
@@ -112,3 +150,199 @@ def test_archive_session_removes_row_without_stop_event(
     # stop here would either serialize the runner's timeouts ahead of
     # the flag flip or race the server's own stop against the runner.
     assert stop_events == [], f"archive must not send a stop_session event, sent {stop_events}"
+
+
+def test_archiving_spinner_stays_until_row_leaves(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The "Archiving…" spinner must persist until the row actually leaves.
+
+    Regression test for a visible flicker: the spinner disappeared the
+    instant the archive PATCH resolved, but the row lingered in the
+    sidebar for the extra round-trip it takes the ``["conversations"]``
+    list refetch to drop the now-archived row. For that window the row
+    swapped back to its plain, interactive form — no spinner, still
+    clickable — which reads as "archive finished" while the session is
+    plainly still listed.
+
+    The fix keeps the spinner mounted for the whole span, tearing it down
+    only when the row itself unmounts. This asserts that ordering directly.
+
+    Driven through async Playwright (not the sync ``page`` fixture) because
+    it holds the list-refetch response open across UI assertions to freeze
+    the exact window where the two events can separate.
+
+    :param seeded_session: ``(base_url, session_id)`` for a runner-bound
+        session.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_archiving_spinner_persists(base_url, session_id))
+
+
+async def _drive_archiving_spinner_persists(base_url: str, session_id: str) -> None:
+    """Async body of the spinner-persistence test. See the test docstring.
+
+    Reproduction hinges on freezing the window between "PATCH resolved" and
+    "row gone". A row leaves the sidebar by exactly two paths, and BOTH are
+    pinned open here so the window can't close on its own:
+
+    - **List refetch.** ``useArchiveConversation`` invalidates
+      ``["conversations"]`` on PATCH success, which refetches
+      ``GET /v1/sessions?…&include_archived=true``; that response, re-peeled
+      through the sidebar's archived filter, is what drops the row. The
+      handler lets the PATCH itself through (so the mutation resolves — and
+      the buggy code's ``onSettled`` fires) but holds the *list refetch*
+      open until the assertions have run.
+    - **WS push.** An ``archived: true`` frame over
+      ``WS /v1/sessions/updates`` would splice the row out client-side
+      (``violatesKnownMembership``). The socket is intercepted and its
+      client frames swallowed, so no live push arrives to close the window
+      behind the test's back.
+
+    With both frozen, the spinner's fate is decided purely by the row's own
+    state: the fixed code keeps ``conversation-archiving`` mounted; the old
+    code unmounts it and re-shows the interactive ``/c/{id}`` link while the
+    row is still present. Releasing the held refetch then proves the row
+    really does leave (and the spinner with it), so the freeze didn't merely
+    stall the whole flow.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The runner-bound session archived in this test.
+    """
+    href = f'a[href="/c/{session_id}"]'
+    spinner = '[data-testid="conversation-archiving"]'
+
+    def _is_sidebar_list_get(request: Any) -> bool:
+        """A GET for the sidebar's paginated session list.
+
+        Distinguished from the sibling ``pinned=true`` query (same
+        ``/v1/sessions`` path) by ``include_archived=true`` + no ``pinned``
+        param — the exact signature the sidebar's ``useConversations("", true)``
+        page issues (``fetchConversationsPage``). Holding the pinned query
+        instead would let the real list refetch through and unfreeze the row.
+        """
+        if request.method != "GET":
+            return False
+        parsed = urlparse(request.url)
+        if parsed.path != "/v1/sessions":
+            return False
+        return "include_archived=true" in (parsed.query or "") and "pinned=true" not in (
+            parsed.query or ""
+        )
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            # Give the row a stable, unique title so it's unambiguous in the
+            # sidebar and its snapshot is easy to assert on.
+            title = f"e2e-archive-spin-{uuid.uuid4().hex[:8]}"
+            rename = await page.request.patch(
+                f"{base_url}/v1/sessions/{session_id}",
+                data={"title": title},
+                timeout=10_000,
+            )
+            assert rename.ok, f"rename failed: {rename.status}"
+
+            release_refetch = asyncio.Event()
+            # Set by the test body right after the Archive item is clicked.
+            # Only list GETs that fire AFTER that are held, so the sidebar's
+            # initial load renders the row first. Gating on the click (not the
+            # PATCH body) keeps the freeze independent of request-body parsing.
+            archiving_started = {"done": False}
+            refetch_held = {"done": False}
+            # Diagnostics: every /v1/sessions request, for a precise failure msg.
+            list_gets: list[str] = []
+
+            async def handle_sessions(route: Route) -> None:
+                request = route.request
+                # The list refetch (or reconcile) that would drop the archived
+                # row: hold the FIRST one that fires after the archive click
+                # until the test releases it. Earlier list GETs (initial
+                # sidebar load) pass through so the row renders first.
+                if _is_sidebar_list_get(request):
+                    list_gets.append(f"{request.method} {request.url}")
+                    if archiving_started["done"] and not refetch_held["done"]:
+                        refetch_held["done"] = True
+                        await release_refetch.wait()
+                    await route.continue_()
+                    return
+                await route.continue_()
+
+            async def handle_updates_ws(ws: WebSocketRoute) -> None:
+                # Swallow client watch-set frames without connecting to the real
+                # server, so no live ``archived: true`` push can splice the row
+                # out from under the test. Mirrors test_hosts_changed_push.
+                ws.on_message(lambda _msg: None)
+
+            # One handler for both the list (``/v1/sessions``) and the
+            # per-session PATCH (``/v1/sessions/{id}``); the glob covers both.
+            await page.route("**/v1/sessions*", handle_sessions)
+            await page.route_web_socket(
+                lambda url: "/v1/sessions/updates" in url, handle_updates_ws
+            )
+
+            await page.goto(f"{base_url}/c/{session_id}")
+
+            row = page.locator("li").filter(has=page.locator(href))
+            await async_expect(row).to_be_visible()
+
+            # Open the kebab → Archive. Arm the refetch-hold on the click, so
+            # only list GETs triggered by the archive (its ['conversations']
+            # invalidation) are frozen — not the initial sidebar load.
+            await row.hover()
+            await row.get_by_test_id("conversation-actions").click()
+            await page.get_by_test_id("archive-conversation").click()
+            archiving_started["done"] = True
+
+            # The spinner appears while the PATCH is in flight.
+            await async_expect(page.locator(spinner)).to_be_visible()
+
+            # Wait until the post-archive list refetch is actually held — from
+            # here the ONLY thing that can remove the row is releasing it, so
+            # the window is genuinely frozen and the next assertion is not a
+            # race against a refetch that simply hasn't fired yet.
+            deadline = asyncio.get_running_loop().time() + 15.0
+            while not refetch_held["done"]:
+                if asyncio.get_running_loop().time() > deadline:
+                    raise AssertionError(
+                        "post-archive sidebar-list refetch never fired within 15s — "
+                        "the archive PATCH may not have invalidated ['conversations']. "
+                        f"sidebar-list GETs seen: {list_gets}"
+                    )
+                await page.wait_for_timeout(50)
+
+            # KEY ASSERTION. The PATCH has resolved (the refetch it triggered is
+            # what we're holding), so the buggy code has already cleared
+            # `isArchiving` and swapped the row back to its interactive link.
+            # The fix keeps the spinner mounted. Give the buggy behavior ~1.5s
+            # of settle time so a regression fails loudly, not flakily. The
+            # visible spinner also proves the row's <li> is still present — the
+            # spinner IS the row's content mid-archive.
+            await page.wait_for_timeout(1_500)
+            await async_expect(page.locator(spinner)).to_be_visible()
+            # The row must still be its spinner form (a <div>, no anchor), NOT
+            # back to the interactive `/c/{id}` link. A reappearing link here —
+            # count 1 instead of the expected 0 — is the exact regression: the
+            # spinner was torn down a round-trip before the row actually left.
+            await async_expect(page.locator(href)).to_have_count(0)
+            assert await page.get_by_role("link", name=title).count() == 0, (
+                "the interactive session link reappeared while the row was still "
+                "in the sidebar — the spinner was torn down too early"
+            )
+
+            # Release the held refetch: the row — and its spinner — must now
+            # leave the default list. This proves the freeze stalled removal
+            # rather than the whole flow, and that the spinner ends exactly at
+            # unmount (not before, per the assertions above; not lingering
+            # after, per this one).
+            release_refetch.set()
+            await async_expect(page.locator(spinner)).to_have_count(0)
+            await async_expect(page.locator(href)).to_have_count(0)
+
+            # Durable, not just a cache splice: the store row carries the flag.
+            snap = await page.request.get(f"{base_url}/v1/sessions/{session_id}", timeout=10_000)
+            assert snap.ok, f"snapshot fetch failed: {snap.status}"
+            assert (await snap.json())["archived"] is True, "session should report archived=true"
+        finally:
+            await browser.close()

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -1,9 +1,13 @@
 // Tests for the archive flow in the sidebar. Contract: archiving sends ONLY
-// the archive PATCH (`archived: true`, with an onSettled that clears the
-// "Archiving…" status row). The runner stop is the server's job once the
-// flag commits — a client stop would race the server's against the same
-// runner, and it would also put the runner's stop timeouts in front of the
-// flag flip. The kebab's user-facing "Stop session" action is a separate
+// the archive PATCH (`archived: true`). The "Archiving…" status row stays up
+// until the row LEAVES the sidebar — on success it's held (the row unmounts
+// when the list refetch drops the archived row, taking the spinner with it),
+// and only an error clears it to restore the interactive row for retry.
+// Clearing on settle would flash the row back to its clickable form a
+// round-trip before it actually leaves. The runner stop is the server's job
+// once the flag commits — a client stop would race the server's against the
+// same runner, and it would also put the runner's stop timeouts in front of
+// the flag flip. The kebab's user-facing "Stop session" action is a separate
 // affordance covered by Sidebar.stop.test.tsx. Unarchiving flips the flag
 // back with no status row. See ConversationRow.runArchive in Sidebar.tsx.
 //
@@ -143,7 +147,10 @@ describe("archive flow", () => {
       { id: "conv_1", archived: true },
       expect.objectContaining({
         onSuccess: expect.any(Function),
-        onSettled: expect.any(Function),
+        // Only an error restores the interactive row; success intentionally
+        // leaves the spinner up until the row unmounts (see the "keeps the
+        // 'Archiving…' row up after the archive succeeds" case below).
+        onError: expect.any(Function),
       }),
     );
     // The server owns the stop. A client stop here would race it against
@@ -187,18 +194,40 @@ describe("archive flow", () => {
     expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
   });
 
-  it("clears the 'Archiving…' row once the archive settles", () => {
+  it("keeps the 'Archiving…' row up after the archive succeeds", () => {
+    // On success the spinner must NOT be cleared: the row leaves the sidebar
+    // only when the ['conversations'] refetch drops the archived row (which
+    // unmounts this row and its spinner together). Clearing on success would
+    // flash the row back to its plain, clickable form for the round-trip until
+    // the refetch lands — the exact regression this guards. Here the mocked
+    // list still contains the row (no refetch modeled), so firing onSuccess
+    // must leave the status row in place.
     mockConversations([CONV]);
     renderSidebar();
     clickArchive();
 
     expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
 
-    // Settle the archive → the row returns to its interactive state
-    // (onSettled runs on success or error). The stop's settle is irrelevant
-    // to the row state.
-    const archiveOnSettled = mocks.archive.mutate.mock.calls[0][1].onSettled as () => void;
-    act(() => archiveOnSettled());
+    const archiveOnSuccess = mocks.archive.mutate.mock.calls[0][1].onSuccess as () => void;
+    act(() => archiveOnSuccess());
+
+    // Still archiving, still no interactive link — the row hasn't left yet.
+    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
+  });
+
+  it("restores the interactive row when the archive errors", () => {
+    // The only escape hatch from the status row: a failed archive clears the
+    // flag so the user gets the clickable row back to retry. Success has no
+    // such clear (see above) — the row instead leaves via the refetch.
+    mockConversations([CONV]);
+    renderSidebar();
+    clickArchive();
+
+    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
+
+    const archiveOnError = mocks.archive.mutate.mock.calls[0][1].onError as () => void;
+    act(() => archiveOnError());
 
     expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3290,12 +3290,13 @@ function ConversationRow({
     );
   }
 
-  // Archiving is a single PATCH (see runArchive); show a
-  // status row for the span instead of leaving the row looking idle. On
-  // success
-  // the list refetches and the row drops out of the default view (or
-  // flips to its archived state under "Show archived"); on failure the
-  // flag clears and the interactive row returns so the user can retry.
+  // Archiving is a single PATCH (see runArchive); show a status row for the
+  // span instead of leaving the row looking idle. The spinner stays up until
+  // the row itself leaves the sidebar: on success the list refetches and this
+  // row unmounts (dropped from the default view), which removes the spinner
+  // with it — it is deliberately NOT cleared on PATCH-settle, or it would
+  // vanish a round-trip before the row does. On failure the flag clears and
+  // the interactive row returns so the user can retry.
   if (isArchiving) {
     return (
       <li>
@@ -3338,8 +3339,17 @@ function ConversationRow({
     // tears down a host-spawned runner) in the background once the flag is
     // committed. Sending a client stop too would race that one against the
     // same runner, and the loser gets a 503 from the already-killed pane.
-    // "Archiving…" shows until the archive settles (success → row leaves
-    // the default list; failure → interactive row returns for a retry).
+    //
+    // "Archiving…" must stay up until the row actually LEAVES the sidebar,
+    // not merely until the PATCH resolves. The PATCH success only kicks off
+    // an async `["conversations"]` refetch (see useArchiveConversation); the
+    // row drops out a round-trip later, once that refetch lands and the
+    // archived row is filtered out of the rendered list. Clearing the
+    // spinner on settle (the old behavior) reopened that gap: the row flashed
+    // back to its plain, clickable form — spinner gone — while the session
+    // was still listed. So we DON'T clear it on success: this row unmounts
+    // when the refetch removes it, which tears the spinner down with it.
+    // Only an error clears the flag, restoring the interactive row for retry.
     setIsArchiving(true);
     archive.mutate(
       { id: conversation.id, archived: true },
@@ -3347,7 +3357,7 @@ function ConversationRow({
         // Point the user at where the session went — it's no longer in
         // the sidebar list, so surface its new home in Settings.
         onSuccess: showArchivedToast,
-        onSettled: () => setIsArchiving(false),
+        onError: () => setIsArchiving(false),
       },
     );
   }


### PR DESCRIPTION
## Problem

When archiving a session from the sidebar row kebab, the "Archiving…" spinner
disappeared **before** the row left the sidebar. For the round-trip between the
archive `PATCH` resolving and the `["conversations"]` list refetch dropping the
now-archived row, the row flashed back to its plain, interactive (clickable)
form with no spinner — reading as "archive finished" while the session was
still plainly listed.

## Root cause

`ConversationRow.runArchive` cleared the `isArchiving` flag in the mutation's
`onSettled` — i.e. the instant the `PATCH` *resolved*. But the row only leaves
the list a round-trip later, when `useArchiveConversation`'s
`invalidateQueries(["conversations"])` refetch lands and the archived row is
filtered out of the rendered list. Clearing on settle reopened that gap.

## Fix

Keep the spinner mounted until the row itself unmounts. On success we no longer
clear `isArchiving` — the row (and its spinner) disappear together when the
refetch drops the archived row. Only an **error** clears the flag, restoring the
interactive row so the user can retry.

```
onSettled: () => setIsArchiving(false)   →   onError: () => setIsArchiving(false)
```

## Tests

- **New e2e-ui regression test** `test_archiving_spinner_stays_until_row_leaves`
  (`tests/e2e_ui/sessions/test_sidebar_archive.py`). It freezes the exact window
  between "PATCH resolved" and "row gone" by holding the post-archive
  `GET /v1/sessions` list refetch open and swallowing the `WS /v1/sessions/updates`
  stream (the two paths that remove the row), then asserts the spinner is still
  visible and the interactive link has not returned. Releasing the held refetch
  then confirms the row and spinner leave together. Verified to **fail on the
  pre-fix code** at the spinner assertion and **pass on the fix** unmodified.
- **Unit test** `Sidebar.archive.test.tsx` updated to the new contract: success
  keeps the spinner up (row leaves via the refetch), and only an error restores
  the interactive row.

Scope: single-row archive only. The bulk-archive selection-mode path uses a
separate action-bar `isPending` indicator and is unaffected.
