### PR TITLE
feat(server): provider-agnostic per-user credential store (AWS KMS)

### DIFF
--- a/designs/CREDENTIAL_STORE.md
+++ b/designs/CREDENTIAL_STORE.md
@@ -1,0 +1,254 @@
+# Per-user integration credential store
+
+## Motivation
+
+The GitHub App integration needs to persist a per-user OAuth token set and vend
+it to managed sandboxes on demand (see the credential broker below). That secret
+material must be encrypted at rest, per user, with the key never sitting in the
+app process.
+
+Two forces shape the design:
+
+1. **More providers.** Connecting MCP integrations (Datadog, Slack, a hosted
+   GitHub MCP, …) needs the same shape: a per-user secret + some non-secret
+   metadata, connected once and re-vended to sandboxes. We do not want one
+   bespoke table per provider.
+2. **Managed key material.** The secret material is encrypted with **AWS KMS** —
+   the key lives in KMS, the server only holds an IAM permission to call
+   `Encrypt`/`Decrypt`, and each ciphertext is bound to its row's identity as the
+   KMS *encryption context*. This gives per-user encryption, rotation, audit, and
+   "the app process never holds the raw key" without us managing key material.
+
+Getting the schema generic now is cheap; reshaping a provider-specific table
+after users have connected means migrating encrypted rows. Hence this store
+lands at the base of the integration stack, with GitHub as its first (and,
+today, only) provider.
+
+## Two independent axes
+
+The design deliberately separates two concerns that are easy to conflate:
+
+| Axis | What varies | This design |
+| --- | --- | --- |
+| **Data model** | "a credential for *any* provider, per user" | one generic table + typed façades per provider |
+| **Secret backend** | *where* the key lives and *who* encrypts | a `SecretCipher` port; AWS KMS is the implementation |
+
+Keeping them orthogonal means a new provider is a façade (no schema change) and
+a different key backend (GCP/Azure KMS, Vault Transit) is a cipher adapter (no
+schema change).
+
+## Data model
+
+One table, `connections`:
+
+| column | type | notes |
+| --- | --- | --- |
+| `workspace_id` | bigint | tenant partition, part of PK (`0` = default) |
+| `user_id` | str(128) | omnigent user, part of PK |
+| `provider` | str(64) | e.g. `"github"`, part of PK |
+| `account_id` | str(128) | provider account discriminator, part of PK; `""` = the user's single account for that provider |
+| `secret_enc` | text | KMS ciphertext (base64) of a JSON blob holding *all* secret material (access token, refresh token, …) |
+| `metadata_json` | text | non-secret provider metadata (login, ids, scopes, expiries, …) as JSON |
+| `created_at` / `updated_at` | integer | unix epoch seconds (repo convention; `workspace_id` is the lone `bigint`) |
+
+Primary key: `(workspace_id, user_id, provider, account_id)`.
+
+Why a JSON secret blob rather than typed token columns: any provider's secret
+shape (single API key, OAuth access+refresh, client-cert, …) fits one encrypted
+column, and the ciphertext is opaque to SQL. Non-secret fields that a provider
+needs at refresh time (token expiries, granted scopes, the connected login/id)
+live in `metadata_json` — queryable enough for our access patterns (we always
+load the whole connection) without widening the schema per provider.
+
+The `account_id` column is `""` today (one account per provider per user) but is
+in the PK so a future "connect two GitHub orgs" needs no migration.
+
+## `SecretCipher` port
+
+```python
+class SecretCipher(Protocol):
+    def encrypt(self, plaintext: str, *, context: Mapping[str, str]) -> str: ...
+    def decrypt(self, ciphertext: str, *, context: Mapping[str, str]) -> str | None: ...  # None on mismatch
+```
+
+`context` is the row's identity (`workspace`/`user`/`provider`/`account`) and is
+**required** — every secret is bound to a user; there is no unbound/global-key
+path. The store depends on this port, not on a concrete backend, so the KMS
+implementation can be swapped for GCP/Azure KMS or Vault Transit without a
+schema change.
+
+`KmsSecretCipher` is the implementation: `encrypt` is one `kms:Encrypt` call
+under the configured key with `context` as the KMS encryption context; the
+returned ciphertext blob is stored base64. Blobs are small (a token JSON
+object), well under the 4 KB `Encrypt` limit, so no envelope/data-key layer is
+needed. `decrypt` is `kms:Decrypt` with the same context.
+
+`build_secret_cipher()` is the single seam where a deployment selects the
+backend; it reads the **store-level** key `OMNIGENT_CREDENTIAL_KMS_KEY_ID` (id,
+ARN, or `alias/…`) and returns the cipher, or `None` when unset — the store, and
+every integration on it, is then disabled. **There is no non-KMS fallback:** no
+key configured means the feature is off, not that it silently encrypts with a
+local key.
+
+The key belongs to the **credential store**, not to any one provider: every
+provider façade shares the one cipher, so connecting an MCP server or Datadog
+account needs no provider-specific key and does not depend on GitHub being
+configured. Provider config gates that provider's routes, not the store's
+ability to encrypt.
+
+### What the encryption context buys (and what it doesn't)
+
+The *tenancy boundary* is the primary key and the `workspace_id`-scoped queries
+— that is what stops user A reading user B's row, and it holds regardless of the
+cipher. The KMS encryption context is not an access-control boundary; it is
+cryptographic binding. What it buys:
+
+- **The master key never enters the process.** KMS does the crypto inside its
+  HSM; the server holds only an IAM permission (via IRSA). A stolen DB dump *and*
+  a compromised server yield no exportable key — an attacker can only call
+  `Decrypt` while the pod's credentials are valid, which is logged in CloudTrail
+  and revocable.
+- **Per-row binding.** A ciphertext can only be decrypted by presenting the same
+  `{workspace, user, provider, account}` context, so a blob can't be replayed
+  under a different identity, and a leak is scoped to one row.
+- **Rotation / revocation / audit** are KMS key-policy operations, not app
+  changes: rotate the key (versions, no re-encrypt), disable it to stop all
+  decrypts, read every call in CloudTrail. An encryption-context *condition* in
+  the key policy can further constrain what the server may decrypt.
+
+Empty-valued context fields (`account_id=""`, the default single account) are
+dropped before the KMS call — KMS rejects empty encryption-context values — done
+consistently on encrypt and decrypt, so the binding is unchanged and a named
+account still yields a distinct context.
+
+`decrypt` returning `None` (not raising) on a ciphertext/context mismatch
+(`InvalidCiphertextException` / `IncorrectKeyException`) is load-bearing: a
+rotated-away key degrades to "reconnect this integration," never a 500 on the
+vend path. Operational failures — access denied, disabled key, throttling —
+propagate instead, since telling the user to reconnect wouldn't help and would
+hide a misconfiguration.
+
+### Pod → KMS auth (IRSA)
+
+On the demo/prod EKS cluster the server runs as the `omnigent-server`
+ServiceAccount, annotated with an IAM role (`eks.amazonaws.com/role-arn`) whose
+policy allows `kms:Encrypt`/`kms:Decrypt`/`kms:DescribeKey` on the one
+credential key. No AWS credentials sit in the pod; the KMS key ARN is passed as
+plain config (`OMNIGENT_CREDENTIAL_KMS_KEY_ID`), not a secret. The key + role +
+policy are provisioned in the infra repo (Pulumi, `cloud-infra/core`).
+
+## Layers
+
+The stack has four layers, each with one job:
+
+```
+route layer            provider-specific writes, uniform credential reads
+   │
+   ▼
+ConnectionStore(ABC)   per-provider façade: maps the provider surface ⇄ a row
+   │                   (GithubConnectionStore, DatabricksConnectionStore, …)
+   ▼
+CredentialStore        the one concrete DB backend (SQLAlchemy) — uniform writes
+   │
+   ▼
+SecretCipher(Protocol) encrypt/decrypt the secret blob (KmsSecretCipher impl)
+```
+
+- **`CredentialStore`** is the generic, provider-agnostic persistence: rows keyed
+  by `(workspace_id, user_id, provider, account_id)`, secret blob + metadata,
+  returning plain `ProviderConnection` entities.
+- **`ConnectionStore(ABC)`** is the per-provider façade base. It owns a
+  `CredentialStore`, carries the provider key (`_PROVIDER`), and factors the
+  uniform reads (`get`, `delete`, `list_all`) so a concrete façade only sets
+  `_PROVIDER`, implements `_to_entity`, and adds its provider-specific writes.
+  Callers (routes, broker, launch path) talk to the façade, never the generic
+  store, so nothing changes when a second provider is added.
+
+**This base PR ships `CredentialStore` + `ConnectionStore` + `SecretCipher`; the
+first concrete façade lands in the connect PR (#4235):**
+
+- `GithubConnectionStore(ConnectionStore[GithubConnection])` — `provider="github"`;
+  secret = `{access_token, refresh_token}`; metadata = `{github_login,
+  github_user_id, token_expires_at, refresh_token_expires_at, scopes}`; adds
+  `upsert` / `update_tokens` and implements `_to_entity`.
+
+A future MCP-credential façade is the same pattern with `provider="mcp:<name>"`.
+
+## Migration
+
+This PR adds a single new migration (`add_connections`) that
+`CREATE`s `connections` with the generic schema. There is no
+provider-specific table in the tree to reshape — the generic store lands at the
+base of the stack, before any such table existed, which is the whole point of
+sequencing it first. The migration chains off the current `upstream/main` head
+(the branch is kept rebased on main) so the branch and the PR merge both resolve
+to a single Alembic head; a test guards that
+(`tests/db/test_migration_connections.py`).
+
+## Broker endpoint (future generalization)
+
+The credential broker currently vends only GitHub:
+`GET /v1/hosts/{host_id}/github-credential`. When a second provider needs
+on-demand delivery to a sandbox, this becomes
+`GET /v1/hosts/{host_id}/credentials/{provider}` returning the provider's secret
++ attribution metadata, with the git credential helper and the GitHub MCP proxy
+passing `provider=github`. Kept GitHub-specific for now to limit blast radius;
+the store change is the prerequisite that makes it a small follow-up.
+
+## Revocation & audit note
+
+A vended GitHub token's blast radius is bounded by the launch token: the broker
+resolves `(host_id, launch_token)` server-side and stops vending the moment the
+launch token expires or the host row is deleted, and the raw token never touches
+sandbox disk. KMS adds its own layer — CloudTrail logs every `Decrypt`, and
+disabling the key stops all decrypts globally — but KMS does not know about
+launch tokens. So "stops vending when the session ends" must remain a
+server-side check on the broker path, independent of KMS; KMS is defence in
+depth on the storage, not the session boundary.
+
+## Dependency
+
+The KMS cipher needs boto3, declared as the `credentials` extra
+(`omnigent[credentials]`). It is imported lazily and only when a KMS key is
+configured, so a deployment that doesn't enable the integration credential store
+neither needs boto3 nor talks to AWS.
+
+## MCP auth & roadmap
+
+The store is the base for two credential needs; the encryption above is shared,
+the delivery differs.
+
+**MCP auth → Databricks AI Gateway (AIGW), primary.** Routing MCP through AIGW
+makes per-MCP OAuth *Databricks's* problem, not Omnigent's. The store then holds
+only a small `provider="databricks"` exchange grant (per-user, KMS-encrypted);
+the server performs the omni→databricks token exchange + refresh, and the
+sandbox's MCP proxy fetches a short-lived AIGW token from the broker per
+connection, never persisted. Leave an "MCP connection backend" seam (mirroring
+the `SecretCipher` port) so a self-hosted OSS layer (e.g. Nango) can slot in
+later.
+
+**GitHub clone stays on the broker.** MCP can't `git clone`, so the GitHub App
+token remains in the store and the broker vends it into the sandbox for git
+(the credential-helper path); a wrapper `gh` CLI can do the Open-in-Omnigent PR
+stamp instead of the MCP proxy.
+
+### Phased plan
+
+1. Generic per-user store + KMS cipher behind `SecretCipher`. *(this PR)*
+2. KMS key + IRSA role provisioned in infra (Pulumi); wired into the demo
+   deployment. *(connect PR / infra)*
+3. AIGW MCP track: `provider="databricks"` + omni→databricks exchange/refresh +
+   AIGW MCP proxy + the sandbox Databricks plugin behind the connection seam.
+
+### Open questions
+
+- **Envelope vs direct:** direct `Encrypt`/`Decrypt` is fine while blobs stay
+  under 4 KB. If a provider's secret grows, switch that cipher to envelope
+  (`GenerateDataKey` + local AES, wrapped key stored alongside) behind the same
+  port — a per-`(context, process)` KMS call instead of per vend.
+- **Encryption-context IAM condition:** whether to constrain the server's key
+  policy with a `kms:EncryptionContext:*` condition (tighter, but couples the
+  policy to the identity shape) or keep it key-scoped (simpler).
+- **Databricks token exchange:** what the server exchanges the omni identity for
+  (AIGW OAuth token / RFC 8693 token exchange / Databricks U2M/M2M grant) —
+  drives the `provider=databricks` row shape and refresh cadence.

--- a/omnigent/connections/__init__.py
+++ b/omnigent/connections/__init__.py
@@ -1,0 +1,58 @@
+"""Provider-façade base over the generic credential store.
+
+:class:`ConnectionStore` is the per-provider surface the routes talk to: it owns
+a :class:`~omnigent.stores.credential_store.CredentialStore` and maps the
+generic :class:`~omnigent.entities.ProviderConnection` rows into a typed,
+provider-specific entity. Concrete façades (``GithubConnectionStore``,
+``DatabricksConnectionStore``) subtype this, set ``_PROVIDER``, implement
+``_to_entity``, and add the provider-specific writes (``upsert`` /
+``update_tokens``); the uniform reads (``get`` / ``delete`` / ``list_all``) are
+shared here. See ``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar, Generic, TypeVar
+
+from omnigent.entities import ProviderConnection
+from omnigent.stores.credential_store.secret_cipher import SecretCipher
+from omnigent.stores.credential_store.sqlalchemy_store import CredentialStore
+
+EntityT = TypeVar("EntityT")
+
+
+class ConnectionStore(ABC, Generic[EntityT]):
+    """Typed per-provider façade over the shared :class:`CredentialStore`.
+
+    :param storage_location: SQLAlchemy database URI (shares the pool).
+    :param secret_cipher: Cipher for the secret blob at rest.
+    """
+
+    #: Provider key this façade owns, e.g. ``"github"``. Set by each subclass.
+    _PROVIDER: ClassVar[str]
+
+    def __init__(self, storage_location: str, secret_cipher: SecretCipher) -> None:
+        self._store = CredentialStore(storage_location, secret_cipher)
+
+    @staticmethod
+    @abstractmethod
+    def _to_entity(conn: ProviderConnection) -> EntityT:
+        """Map a generic connection row into this provider's typed entity."""
+
+    def get(self, user_id: str, *, with_tokens: bool = False) -> EntityT | None:
+        """Return the user's connection for this provider, or ``None``.
+
+        ``with_tokens=True`` decrypts the secret onto the entity (vend path);
+        the default metadata-only view is the safe shape for status endpoints.
+        """
+        conn = self._store.get(user_id, self._PROVIDER, with_secret=with_tokens)
+        return self._to_entity(conn) if conn is not None else None
+
+    def delete(self, user_id: str) -> bool:
+        """Remove the user's connection for this provider. ``True`` if a row went."""
+        return self._store.delete(user_id, self._PROVIDER)
+
+    def list_all(self) -> list[EntityT]:
+        """All connections for this provider (metadata only) — tests/admin."""
+        return [self._to_entity(c) for c in self._store.list_all(provider=self._PROVIDER)]

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -455,6 +455,61 @@ class SqlAccountToken(OmnigentBase):
     )
 
 
+class SqlConnection(OmnigentBase):
+    """
+    SQLAlchemy model for the ``connections`` table.
+
+    One row per ``(workspace_id, user_id, provider, account_id)`` recording a
+    user's connected third-party integration (GitHub App today; MCP connectors
+    later). Backs the "Connect …" flows and the per-user sandbox credential
+    broker that vends the secret to managed sandboxes on demand.
+
+    The secret material is stored as one encrypted JSON blob
+    (:attr:`secret_enc`, AWS KMS ciphertext via
+    :class:`omnigent.stores.credential_store.secret_cipher.KmsSecretCipher`)
+    so any provider's secret shape fits without a schema change — plaintext
+    never touches the database.
+    Non-secret provider metadata (login, ids, scopes, expiries) lives in
+    :attr:`metadata_json`. See ``designs/CREDENTIAL_STORE.md``.
+
+    :param user_id: The omnigent user the connection belongs to —
+        email in header/OIDC modes, username in accounts mode.
+    :param provider: Integration provider key, e.g. ``"github"``.
+    :param account_id: Provider account discriminator; ``""`` for the user's
+        single account for that provider (in the PK so multi-account needs no
+        migration).
+    :param secret_enc: Encrypted JSON secret blob (all secret material).
+    :param metadata_json: Non-secret provider metadata as a JSON object.
+    :param created_at: Unix epoch seconds the connection was first made.
+    :param updated_at: Unix epoch seconds of the last refresh/reconnect.
+    """
+
+    __tablename__ = "connections"
+
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    provider: Mapped[str] = mapped_column(String(64), primary_key=True)
+    account_id: Mapped[str] = mapped_column(
+        String(128), primary_key=True, nullable=False, server_default=""
+    )
+    # Both plain Text, deliberately (not CompressedText): secret_enc is KMS
+    # ciphertext (base64) — high-entropy, so compression buys nothing — and
+    # metadata_json is a small fixed set of provider fields (login, ids, scopes,
+    # expiries), far below the size where zstd's framing overhead pays off.
+    # Neither is filtered or pattern-matched in SQL.
+    secret_enc: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
 class SqlDeviceGrant(OmnigentBase):
     """
     SQLAlchemy model for the ``device_grants`` table.

--- a/omnigent/db/migrations/versions/ga1b2c3d4e5f_add_connections.py
+++ b/omnigent/db/migrations/versions/ga1b2c3d4e5f_add_connections.py
@@ -1,0 +1,59 @@
+"""add connections table
+
+Revision ID: ga1b2c3d4e5f
+Revises: e5d9bc8ac650
+Create Date: 2026-07-15 00:00:00.000000
+
+Adds the provider-agnostic ``connections`` table backing every
+per-user "Connect …" integration (GitHub App today; MCP connectors later) and
+the credential broker that vends the secret to managed sandboxes on demand. See
+``designs/CREDENTIAL_STORE.md``.
+
+One row per ``(workspace_id, user_id, provider, account_id)``. ``secret_enc``
+holds an AWS KMS ciphertext (base64) of the secret-material JSON blob (encrypted
+server-side, bound to the row identity as the KMS encryption context); plaintext
+never lands in the database. Non-secret metadata (login, ids, scopes, expiries)
+is JSON in ``metadata_json``. New table only — no existing table changes — so no
+batch rebuild is required.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ga1b2c3d4e5f"
+# Chains off the current alembic head. The branch is rebased onto upstream main,
+# so this revision is a real ancestor here — a single head on the branch *and*
+# on the PR merge (see tests/db/test_migration_connections.py, which
+# guards against a second head). Re-point if main lands a newer migration before
+# this merges.
+down_revision: str | None = "e5d9bc8ac650"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the connections table."""
+    op.create_table(
+        "connections",
+        sa.Column(
+            "workspace_id", sa.BigInteger, primary_key=True, nullable=False, server_default="0"
+        ),
+        sa.Column("user_id", sa.String(128), primary_key=True),
+        sa.Column("provider", sa.String(64), primary_key=True),
+        sa.Column(
+            "account_id", sa.String(128), primary_key=True, nullable=False, server_default=""
+        ),
+        sa.Column("secret_enc", sa.Text, nullable=False),
+        sa.Column("metadata_json", sa.Text, nullable=False),
+        sa.Column("created_at", sa.Integer, nullable=False),
+        sa.Column("updated_at", sa.Integer, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop the connections table."""
+    op.drop_table("connections")

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -3,6 +3,7 @@
 from omnigent.entities.account import Account, AccountToken
 from omnigent.entities.agent import Agent, LoadedAgent
 from omnigent.entities.comment import Comment, CommentsFingerprint
+from omnigent.entities.connection import ProviderConnection
 from omnigent.entities.conversation import (
     NON_CONTENT_ITEM_TYPES,
     CompactionData,
@@ -61,6 +62,7 @@ __all__ = [
     "PagedList",
     "Policy",
     "Project",
+    "ProviderConnection",
     "ReasoningData",
     "ResolvedAccess",
     "ResourceEventData",

--- a/omnigent/entities/connection.py
+++ b/omnigent/entities/connection.py
@@ -1,0 +1,50 @@
+"""Per-user integration credential entity (provider-agnostic).
+
+Plain dataclass returned from
+:class:`omnigent.stores.credential_store.CredentialStore`. The
+``secret`` mapping carries the *decrypted* secret material and is only ever
+populated on server-side vend paths, never serialized to a client;
+``metadata`` holds non-secret provider fields. See
+``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class ProviderConnection:
+    """A user's connected third-party integration.
+
+    :param user_id: The omnigent user id the connection belongs to.
+    :param provider: Provider key, e.g. ``"github"``.
+    :param account_id: Provider account discriminator (``""`` = single account).
+    :param secret: Decrypted secret material as a mapping, or ``None`` when the
+        store returned a metadata-only view (status endpoints).
+    :param metadata: Non-secret provider metadata (login, ids, scopes, expiries).
+    :param created_at: Unix epoch seconds the connection was first made.
+    :param updated_at: Unix epoch seconds of the last refresh / reconnect.
+    """
+
+    user_id: str
+    provider: str
+    account_id: str
+    # repr=False keeps decrypted tokens out of the auto-generated repr; the
+    # explicit __repr__ below reduces the secret to a presence marker so a log
+    # line, exception frame, or APM capture never emits token material.
+    secret: dict[str, Any] | None = dataclasses.field(repr=False)
+    metadata: dict[str, Any]
+    created_at: int
+    updated_at: int
+
+    def __repr__(self) -> str:
+        # ``is not None`` (not truthiness) so a loaded-but-empty secret still
+        # shows as present, distinct from the metadata-only ``None`` view.
+        secret = "<redacted>" if self.secret is not None else None
+        return (
+            f"ProviderConnection(user_id={self.user_id!r}, provider={self.provider!r}, "
+            f"account_id={self.account_id!r}, secret={secret}, metadata={self.metadata!r}, "
+            f"created_at={self.created_at}, updated_at={self.updated_at})"
+        )

--- a/omnigent/stores/credential_store/__init__.py
+++ b/omnigent/stores/credential_store/__init__.py
@@ -1,0 +1,24 @@
+"""Provider-agnostic per-user credential store.
+
+The SQLAlchemy backend (:class:`CredentialStore`) behind the
+:class:`SecretCipher` port (AWS-KMS implementation). Provider façades live in
+:mod:`omnigent.connections`. See ``designs/CREDENTIAL_STORE.md``.
+"""
+
+from omnigent.stores.credential_store.secret_cipher import (
+    CREDENTIAL_KMS_KEY_ENV_VAR,
+    KmsSecretCipher,
+    SecretCipher,
+    SecretContext,
+    build_secret_cipher,
+)
+from omnigent.stores.credential_store.sqlalchemy_store import CredentialStore
+
+__all__ = [
+    "CREDENTIAL_KMS_KEY_ENV_VAR",
+    "CredentialStore",
+    "KmsSecretCipher",
+    "SecretCipher",
+    "SecretContext",
+    "build_secret_cipher",
+]

--- a/omnigent/stores/credential_store/secret_cipher.py
+++ b/omnigent/stores/credential_store/secret_cipher.py
@@ -1,0 +1,164 @@
+"""AWS KMS-backed encryption for integration secrets stored at rest.
+
+Integration credentials (GitHub App tokens today; MCP connector secrets later)
+are encrypted before they touch the database. Encryption is delegated to AWS
+KMS: the key material never leaves KMS, and the server holds only an IAM
+permission to call ``Encrypt``/``Decrypt`` (granted via IRSA — no key or master
+secret lives in the process or its environment). Each secret is bound to its
+row's identity — ``(workspace_id, user_id, provider, account_id)`` — passed as
+the KMS *encryption context*, so a ciphertext can only be decrypted by
+presenting the same identity. That is per-user encryption enforced by KMS, not
+by a key the server derives, and there is no global-key path.
+
+A deployment selects the key with ``OMNIGENT_CREDENTIAL_KMS_KEY_ID``; unset ⇒
+the credential store, and every integration built on it, is disabled. There is
+no non-KMS fallback. See ``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+_logger = logging.getLogger(__name__)
+
+#: A row's identity, passed as the encryption ``context`` so each
+#: ``(workspace, user, provider, account)`` is bound to its own ciphertext.
+SecretContext = Mapping[str, str]
+
+#: Names the AWS KMS key (id, ARN, or ``alias/…``) used to encrypt integration
+#: secrets. Owned by the credential store, not any one provider, so every
+#: "Connect …" integration shares it. Unset ⇒ the store is disabled.
+CREDENTIAL_KMS_KEY_ENV_VAR = "OMNIGENT_CREDENTIAL_KMS_KEY_ID"
+
+#: KMS error codes that mean "this ciphertext can't be read under this identity"
+#: — a wrong/rotated key, a mismatched encryption context, or a corrupt blob.
+#: These degrade to "reconnect" (``decrypt`` → ``None``); anything else
+#: (AccessDenied, disabled key, throttling) is operational and propagates.
+_SOFT_FAIL_KMS_CODES = frozenset({"InvalidCiphertextException", "IncorrectKeyException"})
+
+
+@runtime_checkable
+class SecretCipher(Protocol):
+    """Port for encrypting integration secrets at rest.
+
+    The credential store depends on this, not on a concrete backend, so the KMS
+    implementation can be swapped (e.g. for GCP/Azure KMS or Vault Transit)
+    without a schema change. See ``designs/CREDENTIAL_STORE.md``.
+
+    ``context`` is the row's identity (``workspace``/``user``/``provider``/
+    ``account``) and is **required** — every secret is bound to a user, there is
+    no unbound/global-key path. Decryption must be given the *same* context; a
+    mismatch yields ``None`` (⇒ reconnect), never a wrong plaintext.
+    """
+
+    def encrypt(self, plaintext: str, *, context: SecretContext) -> str:
+        """Return the ciphertext for *plaintext*, bound to *context*."""
+        ...
+
+    def decrypt(self, ciphertext: str, *, context: SecretContext) -> str | None:
+        """Return the plaintext, or ``None`` when the ciphertext/context is unusable."""
+        ...
+
+
+def build_secret_cipher() -> SecretCipher | None:
+    """Construct the credential store's cipher from deployment config.
+
+    Single seam where a deployment selects the secret backend. Reads
+    ``OMNIGENT_CREDENTIAL_KMS_KEY_ID`` and returns a :class:`KmsSecretCipher`;
+    returns ``None`` when it is unset — the credential store, and every
+    integration built on it, is then disabled (the caller decides how to surface
+    that). See ``designs/CREDENTIAL_STORE.md``.
+    """
+    key_id = os.environ.get(CREDENTIAL_KMS_KEY_ENV_VAR, "").strip()
+    if not key_id:
+        return None
+    return KmsSecretCipher(key_id)
+
+
+def _kms_context(context: SecretContext) -> dict[str, str]:
+    """Encryption context for a KMS call.
+
+    KMS rejects empty-string encryption-context values, so drop them — done
+    consistently on encrypt and decrypt, the binding is unchanged, and the
+    remaining fields (workspace/user/provider, plus ``account_id`` only when a
+    named account is used) still uniquely identify the row.
+    """
+    return {k: v for k, v in context.items() if v != ""}
+
+
+class KmsSecretCipher:
+    """:class:`SecretCipher` backed by AWS KMS direct encrypt/decrypt.
+
+    Each secret is a single ``kms:Encrypt`` call under ``key_id`` with the row
+    identity as the encryption context; the ciphertext blob is stored base64.
+    The blobs are small (a token JSON object), well under the 4 KB KMS
+    ``Encrypt`` limit, so no envelope/data-key layer is needed. The KMS client
+    is created lazily so importing this module never requires boto3 or AWS
+    credentials — only constructing the cipher (which only happens when a key is
+    configured) does.
+
+    :param key_id: KMS key id, ARN, or ``alias/…``.
+    :param client: Optional pre-built boto3 KMS client (tests inject a fake).
+    """
+
+    def __init__(self, key_id: str, *, client: Any | None = None) -> None:
+        self._key_id = key_id
+        self._client = client
+
+    @property
+    def _kms(self) -> Any:
+        if self._client is None:
+            import boto3
+
+            self._client = boto3.client("kms")
+        return self._client
+
+    def encrypt(self, plaintext: str, *, context: SecretContext) -> str:
+        response = self._kms.encrypt(
+            KeyId=self._key_id,
+            Plaintext=plaintext.encode("utf-8"),
+            EncryptionContext=_kms_context(context),
+        )
+        return base64.b64encode(response["CiphertextBlob"]).decode("ascii")
+
+    def decrypt(self, ciphertext: str, *, context: SecretContext) -> str | None:
+        """Return the plaintext for *ciphertext*, or ``None`` if unreadable.
+
+        Returns ``None`` (rather than raising) when the ciphertext was written
+        under a different key/context or is corrupt, so a rotated key degrades
+        to "reconnect" instead of a 500. Operational failures (access denied,
+        disabled key, throttling) propagate — telling the user to reconnect
+        wouldn't help and would hide a misconfiguration.
+        """
+        from botocore.exceptions import ClientError
+
+        try:
+            blob = base64.b64decode(ciphertext.encode("ascii"), validate=True)
+        except ValueError:
+            _logger.warning(
+                "secretbox: stored ciphertext is not valid base64 (corrupt) — "
+                "the affected integration will read as disconnected until reconnected"
+            )
+            return None
+        try:
+            response = self._kms.decrypt(
+                CiphertextBlob=blob,
+                EncryptionContext=_kms_context(context),
+                KeyId=self._key_id,
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in _SOFT_FAIL_KMS_CODES:
+                _logger.warning(
+                    "secretbox: KMS could not decrypt (code=%s: wrong key/context or "
+                    "corrupt) — the affected integration will read as disconnected "
+                    "until reconnected",
+                    code,
+                )
+                return None
+            raise
+        return response["Plaintext"].decode("utf-8")

--- a/omnigent/stores/credential_store/sqlalchemy_store.py
+++ b/omnigent/stores/credential_store/sqlalchemy_store.py
@@ -1,0 +1,266 @@
+"""Provider-agnostic per-user integration credential store.
+
+Backs every "Connect …" integration (GitHub App today, MCP connectors later):
+one encrypted secret blob + non-secret metadata per
+``(workspace_id, user_id, provider, account_id)``. The secret material is the
+only thing encrypted (via a :class:`~omnigent.stores.credential_store.secret_cipher.SecretCipher`);
+it is the sole place ciphertext ⇄ plaintext crosses, so callers work with plain
+:class:`~omnigent.entities.ProviderConnection` entities. Provider-specific
+typed façades (e.g. :class:`~omnigent.server.github_store.GithubConnectionStore`)
+sit on top of this. See ``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from sqlalchemy import delete, select
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.db_models import SqlConnection, current_workspace_id
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker, now_epoch
+from omnigent.entities import ProviderConnection
+from omnigent.stores.credential_store.secret_cipher import SecretCipher
+
+_logger = logging.getLogger(__name__)
+
+
+def _enc_context(
+    workspace_id: int, user_id: str, provider: str, account_id: str
+) -> dict[str, str]:
+    """The row's identity, passed to the cipher so each row encrypts under its
+    own derived key (per-user encryption). Decryption must use the same
+    identity, so it is always taken from the row being read."""
+    return {
+        "workspace_id": str(workspace_id),
+        "user_id": user_id,
+        "provider": provider,
+        "account_id": account_id,
+    }
+
+
+def _safe_json_obj(raw: str | None) -> dict[str, Any] | None:
+    """Parse a JSON object column, returning ``None`` on empty/corrupt/non-object
+    data instead of raising.
+
+    The vend path is deliberately soft-fail: :meth:`SecretCipher.decrypt`
+    already degrades a wrong key to ``None`` (⇒ reconnect), so the JSON parse
+    that immediately follows must not re-introduce a 500 on a truncated or
+    malformed column.
+    """
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except ValueError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+class CredentialStore:
+    """SQLAlchemy-backed persistence for per-user integration credentials.
+
+    :param storage_location: SQLAlchemy database URI (shares the pool with the
+        other stores via :func:`get_or_create_engine`).
+    :param secret_cipher: Cipher for the secret blob at rest.
+    """
+
+    def __init__(self, storage_location: str, secret_cipher: SecretCipher) -> None:
+        self.storage_location = storage_location
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_named_managed_session_maker(
+            self._engine, query_name_prefix="omnigent.credential_store"
+        )
+        self._cipher = secret_cipher
+
+    def _build_entity(
+        self, row: SqlConnection, secret: dict[str, Any] | None
+    ) -> ProviderConnection:
+        """Build an entity from a row and an already-resolved *secret*.
+
+        Metadata is parsed soft-fail (a corrupt column reads as ``{}`` rather
+        than 500-ing the caller).
+        """
+        return ProviderConnection(
+            user_id=row.user_id,
+            provider=row.provider,
+            account_id=row.account_id,
+            secret=secret,
+            metadata=_safe_json_obj(row.metadata_json) or {},
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+    def _to_entity(self, row: SqlConnection, *, with_secret: bool) -> ProviderConnection:
+        """Convert an ORM row to an entity, optionally decrypting the secret."""
+        secret: dict[str, Any] | None = None
+        if with_secret:
+            context = _enc_context(row.workspace_id, row.user_id, row.provider, row.account_id)
+            plaintext = self._cipher.decrypt(row.secret_enc, context=context)
+            # ``None`` (wrong key/context or corrupt) degrades to "reconnect",
+            # not a 500; the JSON parse is soft-fail for the same reason.
+            secret = _safe_json_obj(plaintext) if plaintext is not None else None
+        return self._build_entity(row, secret)
+
+    def upsert(
+        self,
+        user_id: str,
+        provider: str,
+        *,
+        secret: dict[str, Any],
+        metadata: dict[str, Any],
+        account_id: str = "",
+    ) -> ProviderConnection:
+        """Create or replace a user's connection for *provider*.
+
+        Idempotent on ``(user_id, provider, account_id)``: reconnecting
+        overwrites the secret and metadata in place, preserving ``created_at``.
+        Concurrency-safe — two simultaneous connects (a double-clicked
+        "Connect") don't 500 on a primary-key violation; the loser retries as an
+        update.
+        """
+        now = now_epoch()
+        workspace_id = current_workspace_id()
+        pk = (workspace_id, user_id, provider, account_id)
+        context = _enc_context(workspace_id, user_id, provider, account_id)
+        secret_enc = self._cipher.encrypt(json.dumps(secret), context=context)
+        metadata_json = json.dumps(metadata)
+
+        def _apply(session: Any, row: SqlConnection | None) -> SqlConnection:
+            if row is None:
+                row = SqlConnection(
+                    user_id=user_id,
+                    provider=provider,
+                    account_id=account_id,
+                    secret_enc=secret_enc,
+                    metadata_json=metadata_json,
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(row)
+            else:
+                row.secret_enc = secret_enc
+                row.metadata_json = metadata_json
+                row.updated_at = now
+            return row
+
+        with self._session("upsert") as session:
+            row = _apply(session, session.get(SqlConnection, pk))
+            try:
+                session.flush()
+            except IntegrityError:
+                # A concurrent reconnect inserted the same PK between our get
+                # and flush. Roll back and retry as an update below.
+                session.rollback()
+            else:
+                # Return the entity from the secret we just wrote — no wasted
+                # decrypt of the ciphertext we produced a few lines up.
+                return self._build_entity(row, secret)
+        with self._session("upsert_retry") as session:
+            row = _apply(session, session.get(SqlConnection, pk))
+            session.flush()
+            return self._build_entity(row, secret)
+
+    def update_secret(
+        self,
+        user_id: str,
+        provider: str,
+        *,
+        secret: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        account_id: str = "",
+    ) -> bool:
+        """Persist a refreshed secret (and optional metadata) for an existing row.
+
+        Returns ``True`` when a row was updated, ``False`` when the connection
+        was removed between read and refresh. The caller must not treat
+        ``False`` as success: providers that rotate refresh tokens (GitHub does)
+        have already spent the old one, so a silently-dropped refresh wedges the
+        user until they reconnect — worth surfacing, not swallowing.
+        """
+        workspace_id = current_workspace_id()
+        with self._session("update_secret") as session:
+            row = session.get(SqlConnection, (workspace_id, user_id, provider, account_id))
+            if row is None:
+                _logger.warning(
+                    "credential_store: update_secret found no %s connection for the user "
+                    "(removed mid-refresh); the refreshed secret was discarded",
+                    provider,
+                )
+                return False
+            context = _enc_context(workspace_id, user_id, provider, account_id)
+            row.secret_enc = self._cipher.encrypt(json.dumps(secret), context=context)
+            if metadata is not None:
+                row.metadata_json = json.dumps(metadata)
+            row.updated_at = now_epoch()
+            return True
+
+    def get(
+        self,
+        user_id: str,
+        provider: str,
+        *,
+        account_id: str = "",
+        with_secret: bool = False,
+    ) -> ProviderConnection | None:
+        """Look up a user's connection for *provider*.
+
+        :param with_secret: When ``True``, decrypt the secret onto the returned
+            entity (vend path). When ``False`` (default), ``secret`` is ``None``
+            — the safe shape for status endpoints that must not surface secrets.
+        :returns: ``None`` iff there is no connection row. A returned entity
+            always exists; disambiguate its ``secret``: with ``with_secret=False``
+            it is ``None`` by construction, while with ``with_secret=True`` a
+            ``None`` secret means the ciphertext could not be decrypted (wrong
+            key/context or corrupt) — treat that as "reconnect", not "no row".
+        """
+        with self._session("get") as session:
+            row = session.get(
+                SqlConnection, (current_workspace_id(), user_id, provider, account_id)
+            )
+            return self._to_entity(row, with_secret=with_secret) if row is not None else None
+
+    def delete(self, user_id: str, provider: str, *, account_id: str = "") -> bool:
+        """Remove a user's connection for *provider*. Returns ``True`` if a row went."""
+        with self._session("delete") as session:
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    delete(SqlConnection).where(
+                        SqlConnection.workspace_id == current_workspace_id(),
+                        SqlConnection.user_id == user_id,
+                        SqlConnection.provider == provider,
+                        SqlConnection.account_id == account_id,
+                    )
+                ),
+            )
+            return result.rowcount > 0
+
+    def list_for_user(self, user_id: str) -> list[ProviderConnection]:
+        """All of a user's connections (metadata only), across providers."""
+        with self._session("list_for_user") as session:
+            rows = (
+                session.execute(
+                    select(SqlConnection).where(
+                        SqlConnection.workspace_id == current_workspace_id(),
+                        SqlConnection.user_id == user_id,
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return [self._to_entity(r, with_secret=False) for r in rows]
+
+    def list_all(self, *, provider: str | None = None) -> list[ProviderConnection]:
+        """All connections (metadata only), optionally filtered by *provider* — tests/admin."""
+        with self._session("list_all") as session:
+            stmt = select(SqlConnection).where(
+                SqlConnection.workspace_id == current_workspace_id()
+            )
+            if provider is not None:
+                stmt = stmt.where(SqlConnection.provider == provider)
+            rows = session.execute(stmt).scalars().all()
+            return [self._to_entity(r, with_secret=False) for r in rows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,10 @@ all = [
 ]
 # From omnigent.
 bedrock = ["boto3>=1.30,<2", "botocore>=1.30,<2"]
+# The credential-store KMS cipher (omnigent/stores/credential_store/secret_cipher.py)
+# imports boto3 lazily, only when OMNIGENT_CREDENTIAL_KMS_KEY_ID is set. boto3 is
+# already provided by the bedrock / s3 / all extras, so deployments that enable the
+# Connect features install one of those (no dedicated extra needed).
 # S3-compatible artifact store (AWS S3, Cloudflare R2, MinIO, …). Selected
 # with ``OMNIGENT_ARTIFACT_URI=s3://bucket/prefix``; the store imports boto3
 # lazily, so only users of this backend need the extra.

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -1,0 +1,67 @@
+"""Tests for the connections migration (ga1b2c3d4e5f).
+
+The single-head test is the guard: a stacked PR whose migration chains off a
+revision that isn't a real ancestor leaves the tree with two heads, and
+``alembic upgrade head`` — which runs on every server boot and every DB-touching
+test — then raises. Asserting a single head catches that before CI does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.script import ScriptDirectory
+
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache
+
+
+def _upgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, revision)
+
+
+def test_single_alembic_head() -> None:
+    script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
+    heads = script.get_heads()
+    assert heads == ["ga1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+
+
+def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path / 'connections.db'}"
+    engine = sa.create_engine(uri)
+
+    # Upgrading to head exercises the full chain onto our migration — this is
+    # exactly the call that raises on multiple heads.
+    _upgrade(uri, engine, "head")
+    inspector = sa.inspect(engine)
+    assert "connections" in inspector.get_table_names()
+    columns = {c["name"] for c in inspector.get_columns("connections")}
+    assert {
+        "workspace_id",
+        "user_id",
+        "provider",
+        "account_id",
+        "secret_enc",
+        "metadata_json",
+        "created_at",
+        "updated_at",
+    } <= columns
+    pk = set(inspector.get_pk_constraint("connections")["constrained_columns"])
+    assert pk == {"workspace_id", "user_id", "provider", "account_id"}
+
+    _downgrade(uri, engine, "za2b3c4d5e6f")
+    assert "connections" not in sa.inspect(engine).get_table_names()
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/entities/test_connection.py
+++ b/tests/entities/test_connection.py
@@ -1,0 +1,49 @@
+"""Tests for the ProviderConnection entity."""
+
+from __future__ import annotations
+
+from omnigent.entities import ProviderConnection
+
+
+def test_repr_redacts_secret() -> None:
+    # A frozen entity holding a decrypted token must never emit it via repr
+    # (log lines, exception frames, APM captures).
+    conn = ProviderConnection(
+        user_id="alice",
+        provider="github",
+        account_id="",
+        secret={"access_token": "ghu_supersecret", "refresh_token": "ghr_supersecret"},
+        metadata={"github_login": "alice"},
+        created_at=1,
+        updated_at=2,
+    )
+    text = repr(conn)
+    assert "ghu_supersecret" not in text
+    assert "ghr_supersecret" not in text
+    assert "<redacted>" in text
+    assert "alice" in text  # non-secret fields still shown
+
+
+def test_repr_distinguishes_empty_secret_from_metadata_only() -> None:
+    # secret={} is a loaded (if empty) secret, not the metadata-only None view;
+    # the repr must not conflate the two.
+    loaded_empty = ProviderConnection(
+        user_id="a",
+        provider="github",
+        account_id="",
+        secret={},
+        metadata={},
+        created_at=1,
+        updated_at=1,
+    )
+    metadata_only = ProviderConnection(
+        user_id="a",
+        provider="github",
+        account_id="",
+        secret=None,
+        metadata={},
+        created_at=1,
+        updated_at=1,
+    )
+    assert "secret=<redacted>" in repr(loaded_empty)
+    assert "secret=None" in repr(metadata_only)

--- a/tests/server/test_credential_store.py
+++ b/tests/server/test_credential_store.py
@@ -1,0 +1,155 @@
+"""Tests for the provider-agnostic CredentialStore."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import sqlalchemy as sa
+
+from omnigent.db.db_models import workspace_scope
+from omnigent.db.utils import get_or_create_engine
+from omnigent.stores.credential_store.sqlalchemy_store import CredentialStore
+
+
+class _FakeCipher:
+    """In-memory SecretCipher standing in for the KMS cipher.
+
+    Binds ciphertext to ``(key, context)`` so a wrong key or a mismatched
+    identity decrypts to ``None`` — the same observable contract as
+    :class:`~omnigent.stores.credential_store.secret_cipher.KmsSecretCipher`, without AWS. The
+    plaintext is base64-wrapped (not stored in the clear), so the at-rest test
+    is still meaningful.
+    """
+
+    def __init__(self, key: str = "test-key") -> None:
+        self._key = key
+
+    def encrypt(self, plaintext: str, *, context: Any) -> str:
+        payload = {"key": self._key, "ctx": dict(context), "pt": plaintext}
+        return base64.b64encode(json.dumps(payload).encode()).decode("ascii")
+
+    def decrypt(self, ciphertext: str, *, context: Any) -> str | None:
+        try:
+            payload = json.loads(base64.b64decode(ciphertext.encode("ascii")))
+        except ValueError:
+            return None
+        if payload["key"] != self._key or payload["ctx"] != dict(context):
+            return None
+        return payload["pt"]
+
+
+def _store(db_uri: str) -> CredentialStore:
+    return CredentialStore(db_uri, _FakeCipher())
+
+
+def test_upsert_get_roundtrip(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert(
+        "alice@example.com",
+        "github",
+        secret={"access_token": "ghu_1", "refresh_token": "ghr_1"},
+        metadata={"github_login": "alice"},
+    )
+    # Metadata-only view hides the secret.
+    meta_only = store.get("alice@example.com", "github")
+    assert meta_only is not None
+    assert meta_only.secret is None
+    assert meta_only.metadata["github_login"] == "alice"
+    # With-secret view decrypts.
+    full = store.get("alice@example.com", "github", with_secret=True)
+    assert full is not None and full.secret == {"access_token": "ghu_1", "refresh_token": "ghr_1"}
+
+
+def test_provider_isolation(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert("alice", "github", secret={"k": "gh"}, metadata={})
+    store.upsert("alice", "datadog", secret={"k": "dd"}, metadata={})
+    gh = store.get("alice", "github", with_secret=True)
+    dd = store.get("alice", "datadog", with_secret=True)
+    assert gh is not None and gh.secret == {"k": "gh"}
+    assert dd is not None and dd.secret == {"k": "dd"}
+    assert store.get("alice", "slack") is None
+    assert {c.provider for c in store.list_for_user("alice")} == {"github", "datadog"}
+
+
+def test_update_secret_and_delete(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert("bob", "github", secret={"access_token": "old"}, metadata={"scopes": "repo"})
+    assert store.update_secret("bob", "github", secret={"access_token": "new"}) is True
+    conn = store.get("bob", "github", with_secret=True)
+    assert conn is not None and conn.secret == {"access_token": "new"}
+    assert conn.metadata["scopes"] == "repo"  # metadata preserved when not patched
+    assert store.delete("bob", "github") is True
+    assert store.get("bob", "github") is None
+
+
+def test_update_secret_missing_row_returns_false(db_uri: str) -> None:
+    # A refresh racing a disconnect must report the drop, not silently discard
+    # the freshly-minted (and now-spent) token.
+    store = _store(db_uri)
+    assert store.update_secret("ghost", "github", secret={"access_token": "x"}) is False
+
+
+def test_secret_never_stored_in_plaintext(db_uri: str) -> None:
+    # The actual at-rest guarantee: the token bytes must not appear in the
+    # column, only the cipher's ciphertext.
+    store = _store(db_uri)
+    store.upsert("dave", "github", secret={"access_token": "ghu_plaintext_leak"}, metadata={})
+    engine = get_or_create_engine(db_uri)
+    with engine.connect() as conn:
+        stored = conn.execute(sa.text("SELECT secret_enc FROM connections")).scalar_one()
+    assert "ghu_plaintext_leak" not in stored
+    # And it still round-trips back to the plaintext through the cipher.
+    full = store.get("dave", "github", with_secret=True)
+    assert full is not None and full.secret == {"access_token": "ghu_plaintext_leak"}
+
+
+def test_wrong_key_decrypts_to_none(db_uri: str) -> None:
+    _store(db_uri).upsert("carol", "github", secret={"access_token": "x"}, metadata={})
+    other = CredentialStore(db_uri, _FakeCipher("different-key"))
+    conn = other.get("carol", "github", with_secret=True)
+    assert conn is not None and conn.secret is None  # soft-fail, not a crash
+
+
+def test_list_all_filters_by_provider(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert("a", "github", secret={"k": "1"}, metadata={})
+    store.upsert("b", "github", secret={"k": "2"}, metadata={})
+    store.upsert("a", "datadog", secret={"k": "3"}, metadata={})
+    assert len(store.list_all(provider="github")) == 2
+    assert len(store.list_all()) == 3
+
+
+def test_workspace_isolation(db_uri: str) -> None:
+    # The core multi-tenant guarantee: the same (user, provider) in two
+    # workspaces are distinct rows and never read across the boundary.
+    store = _store(db_uri)
+    with workspace_scope(1):
+        store.upsert("alice", "github", secret={"access_token": "ws1"}, metadata={})
+    with workspace_scope(2):
+        store.upsert("alice", "github", secret={"access_token": "ws2"}, metadata={})
+        w2 = store.get("alice", "github", with_secret=True)
+        assert w2 is not None and w2.secret == {"access_token": "ws2"}
+        assert [c.user_id for c in store.list_all(provider="github")] == [
+            "alice"
+        ]  # only ws2's row
+    with workspace_scope(1):
+        w1 = store.get("alice", "github", with_secret=True)
+        assert w1 is not None and w1.secret == {"access_token": "ws1"}
+        assert len(store.list_all(provider="github")) == 1
+
+
+def test_non_empty_account_id(db_uri: str) -> None:
+    # account_id is in the PK, so two accounts of one provider coexist per user.
+    store = _store(db_uri)
+    store.upsert("alice", "github", secret={"k": "org1"}, metadata={}, account_id="org1")
+    store.upsert("alice", "github", secret={"k": "org2"}, metadata={}, account_id="org2")
+    a1 = store.get("alice", "github", account_id="org1", with_secret=True)
+    a2 = store.get("alice", "github", account_id="org2", with_secret=True)
+    assert a1 is not None and a1.secret == {"k": "org1"}
+    assert a2 is not None and a2.secret == {"k": "org2"}
+    # The default-account view ("") is a distinct, absent row.
+    assert store.get("alice", "github") is None
+    assert len(store.list_for_user("alice")) == 2

--- a/tests/server/test_secretbox.py
+++ b/tests/server/test_secretbox.py
@@ -1,0 +1,135 @@
+"""Tests for the AWS KMS-backed at-rest secret cipher.
+
+These use an in-memory fake KMS client (no AWS, no moto) to exercise
+:class:`KmsSecretCipher`'s wrapping, encryption-context binding, and soft-fail
+behaviour. Real KMS semantics are covered by the demo end-to-end verification.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from omnigent.stores.credential_store.secret_cipher import (
+    CREDENTIAL_KMS_KEY_ENV_VAR,
+    KmsSecretCipher,
+    build_secret_cipher,
+)
+
+CTX_ALICE = {"workspace_id": "0", "user_id": "alice", "provider": "github", "account_id": ""}
+CTX_BOB = {"workspace_id": "0", "user_id": "bob", "provider": "github", "account_id": ""}
+
+
+class _FakeKmsClient:
+    """In-memory stand-in for boto3's KMS client.
+
+    ``encrypt`` records ``(key_id, encryption_context, plaintext)`` under an
+    opaque blob; ``decrypt`` returns the plaintext only when the *same*
+    encryption context is presented, otherwise raises the ``ClientError`` KMS
+    raises for a context/key mismatch.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[bytes, tuple[str, dict[str, str], bytes]] = {}
+        self._n = 0
+
+    def encrypt(self, *, KeyId: str, Plaintext: bytes, EncryptionContext: dict[str, str]) -> Any:
+        self._n += 1
+        blob = f"ct-{self._n}".encode()
+        self.store[blob] = (KeyId, dict(EncryptionContext), Plaintext)
+        return {"CiphertextBlob": blob, "KeyId": KeyId}
+
+    def decrypt(
+        self, *, CiphertextBlob: bytes, EncryptionContext: dict[str, str], KeyId: str | None = None
+    ) -> Any:
+        entry = self.store.get(CiphertextBlob)
+        if entry is None or entry[1] != dict(EncryptionContext):
+            raise ClientError(
+                {"Error": {"Code": "InvalidCiphertextException", "Message": "mismatch"}},
+                "Decrypt",
+            )
+        return {"Plaintext": entry[2], "KeyId": entry[0]}
+
+
+def _cipher() -> KmsSecretCipher:
+    return KmsSecretCipher("alias/omnigent-credentials", client=_FakeKmsClient())
+
+
+def test_encrypt_decrypt_roundtrip() -> None:
+    box = _cipher()
+    ct = box.encrypt("ghu_secret_token", context=CTX_ALICE)
+    assert ct != "ghu_secret_token"
+    assert box.decrypt(ct, context=CTX_ALICE) == "ghu_secret_token"
+
+
+def test_wrong_context_returns_none() -> None:
+    """A secret encrypted for one identity can't be read under another's."""
+    box = _cipher()
+    ct = box.encrypt("ghu_alice", context=CTX_ALICE)
+    assert box.decrypt(ct, context=CTX_BOB) is None
+
+
+def test_context_is_required() -> None:
+    # There is no unbound/global-key path: the identity is mandatory.
+    box = _cipher()
+    with pytest.raises(TypeError):
+        box.encrypt("x")  # type: ignore[call-arg]
+
+
+def test_empty_context_values_dropped() -> None:
+    # KMS rejects empty encryption-context values; account_id="" is dropped
+    # consistently, and a named account still produces a distinct context.
+    client = _FakeKmsClient()
+    box = KmsSecretCipher("k", client=client)
+    ct = box.encrypt("x", context=CTX_ALICE)
+    (_key, stored_ctx, _pt) = client.store[next(iter(client.store))]
+    assert "account_id" not in stored_ctx
+    assert stored_ctx == {"workspace_id": "0", "user_id": "alice", "provider": "github"}
+    # A named account yields a different, still-decryptable context.
+    named = {**CTX_ALICE, "account_id": "org1"}
+    assert box.decrypt(box.encrypt("y", context=named), context=named) == "y"
+    assert box.decrypt(ct, context=named) is None
+
+
+def test_corrupt_ciphertext_returns_none() -> None:
+    box = _cipher()
+    assert box.decrypt("not-valid-base64!!", context=CTX_ALICE) is None
+
+
+def test_unknown_blob_returns_none() -> None:
+    # Valid base64 but not a real KMS blob (InvalidCiphertextException) → reconnect.
+    box = _cipher()
+    assert box.decrypt("aGVsbG8=", context=CTX_ALICE) is None
+
+
+def test_operational_error_propagates() -> None:
+    # AccessDenied / disabled key are operational, not per-row: they must NOT be
+    # masked as "reconnect" (which wouldn't help); they propagate.
+    class _DenyingClient(_FakeKmsClient):
+        def decrypt(self, **kwargs: Any) -> Any:
+            raise ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "no"}}, "Decrypt"
+            )
+
+    box = KmsSecretCipher("k", client=_DenyingClient())
+    ct = box.encrypt("x", context=CTX_ALICE)
+    with pytest.raises(ClientError):
+        box.decrypt(ct, context=CTX_ALICE)
+
+
+def test_build_secret_cipher_disabled_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CREDENTIAL_KMS_KEY_ENV_VAR, raising=False)
+    assert build_secret_cipher() is None
+
+
+def test_build_secret_cipher_disabled_with_whitespace_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CREDENTIAL_KMS_KEY_ENV_VAR, "   \t\n")
+    assert build_secret_cipher() is None
+
+
+def test_build_secret_cipher_from_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CREDENTIAL_KMS_KEY_ENV_VAR, "arn:aws:kms:us-east-1:1:key/abc")
+    cipher = build_secret_cipher()
+    assert isinstance(cipher, KmsSecretCipher)


### PR DESCRIPTION
Part of #5626

> **Stack (review bottom-up):** #4514 credential store → #4235 GitHub App connect → #4236 credential broker → #4237 repo picker → #4238 GitHub MCP → #4239 session PRs. All target `main` (GitHub can't base a cross-fork PR on a fork branch), so file diffs are cumulative — **review each PR's single commit**.

## Summary

This is the base of the GitHub-integration stack: a **provider-agnostic
per-user credential store** that every "Connect …" integration builds on. The
GitHub App connect flow (next PR) and future MCP connectors sit on top with no
schema change.

Why a generic store rather than a `github_connections` table: connecting an MCP
server, a Datadog account, etc. all need the same shape — an encrypted secret
plus some non-secret metadata, per user, per provider. Modeling that once means
new providers are code, not migrations.

- **`integration_connections`** table keyed `(workspace_id, user_id, provider,
  account_id)`: one encrypted JSON `secret_enc` + a `metadata_json` object.
- **`IntegrationCredentialStore`** reads/writes plain `IntegrationConnection`
  entities and is the sole place ciphertext ⇄ plaintext crosses.
- **`SecretCipher`** port; **AWS KMS (`KmsSecretCipher`)** is the implementation.
  Each secret is a `kms:Encrypt` call bound to the row identity as the KMS
  **encryption context**, so a ciphertext only decrypts under the same
  `(workspace, user, provider, account)` — per-user encryption enforced by KMS,
  with the key material never in the process (the pod calls KMS via IRSA).
  `decrypt` soft-fails to `None` (⇒ reconnect) on a wrong/rotated key; operational
  errors (access denied, disabled key) propagate.

**Config / no global key.** `build_secret_cipher()` reads
`OMNIGENT_CREDENTIAL_KMS_KEY_ID` and is the single construction seam every façade
goes through; unset ⇒ the store (and every integration on it) is disabled —
there is **no non-KMS fallback**. The `context` (identity) argument is
**required**, so there is no unbound/global-key path. boto3 ships as the
`credentials` extra, imported lazily. The port keeps GCP/Azure KMS or Vault
Transit a drop-in swap with no schema or caller change.

See `designs/CREDENTIAL_STORE.md` for the data-model / backend axes, the
encryption-context reasoning, IRSA wiring, and migration/revocation notes.

## Test Plan

- `pytest tests/server/test_secretbox.py` — the KMS cipher against an in-memory
  fake KMS client: encrypt/decrypt round-trip, wrong-context → `None`, context
  required, empty-value drop, corrupt → `None`, operational-error propagation,
  disabled-without-key.
- `pytest tests/server/test_credential_store.py` — upsert/get roundtrip,
  update-secret (+ missing-row → `False`), delete, provider/workspace isolation,
  at-rest (plaintext never appears in the column), wrong-key → `None`.
- `pytest tests/db/test_migration_integration_connections.py` — single Alembic
  head + upgrade→create / downgrade→drop.
- **Verified end-to-end against real AWS KMS** on the github-mvp demo: the
  deployed server (IRSA, no AWS creds in the pod) encrypts/decrypts per-user
  tokens, and a **private repo cloned** through the broker-vended, KMS-decrypted
  token.

## Demo

N/A — no user-facing UI in this PR (the Connect UI ships with the GitHub App
connect PR on top of this one).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

## Test coverage

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Manual verification: deployed to the github-mvp demo and confirmed, in the
running pod, real KMS `Encrypt`/`Decrypt` via IRSA (no AWS creds), the stored
token decrypting to a live `ghu_` token, and a private-repo clone using the
KMS-decrypted token vended by the broker.