### PR TITLE
fix(cli): survive a SOCKS proxy without the httpx socks extra

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8154,7 +8154,10 @@ def _host_http_json(
             timeout=timeout_s,
         ) as client:
             resp = client.request(method, path, params=params, json=json_body)
-    except (httpx.HTTPError, OSError) as exc:
+    except (httpx.HTTPError, OSError, ImportError) as exc:
+        # httpx raises ImportError while building the client when the ambient
+        # environment selects a proxy whose optional extra is missing (e.g. an
+        # ``ALL_PROXY=socks5://…`` shell without ``httpx[socks]`` installed).
         return _HostHttpResult(
             status_code=0,
             body=f"{type(exc).__name__}: {exc}",

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -14,6 +14,7 @@ import hashlib
 import io
 import json
 import re
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -617,6 +618,71 @@ def test_daemon_host_online_false_when_no_host_id(
         resolved_server_url="http://127.0.0.1:8123",
     )
     assert cli._daemon_host_online(record) is False
+
+
+# Every proxy variable httpx consults, so the cases below see exactly the
+# ambient proxy configuration they set up (a developer's own ``NO_PROXY``
+# would otherwise exempt loopback and skip the proxy transport entirely).
+_PROXY_ENV_VARS = (
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+)
+
+
+def _socks_proxy_without_extra(monkeypatch: pytest.MonkeyPatch, base_url: str) -> None:
+    """Point the ambient environment at a SOCKS proxy httpx cannot build.
+
+    Reproduces a shell exporting ``ALL_PROXY=socks5://…`` on an install
+    without the ``httpx[socks]`` extra: httpx raises ``ImportError`` while
+    constructing the client. Blanking ``socksio`` in :data:`sys.modules`
+    makes the extra look absent whether or not it is really installed.
+
+    :param monkeypatch: Fixture used to scope the environment changes.
+    :param base_url: Server URL to pre-seed headers for, so the probe does
+        not resolve real credentials.
+    """
+    for name in _PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ALL_PROXY", "socks5://127.0.0.1:1080")
+    monkeypatch.setitem(sys.modules, "socksio", None)
+    monkeypatch.setitem(cli._host_http_headers_cache, base_url, {})
+
+
+def test_host_http_json_reports_failure_when_socks_extra_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proxy httpx cannot build is a transport failure, not a crash."""
+    base_url = "http://127.0.0.1:8123"
+    _socks_proxy_without_extra(monkeypatch, base_url)
+
+    result = cli._host_http_json(
+        base_url=base_url,
+        method="GET",
+        path="/v1/hosts/host_abc",
+        timeout_s=2.0,
+    )
+
+    assert result.status_code == 0
+    assert "socksio" in str(result.body)
+
+
+def test_daemon_host_online_false_when_socks_extra_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reuse probe degrades to "offline" instead of failing the command.
+
+    ``_daemon_host_online`` runs on the way into every command that ensures
+    the backend, so an unbuildable proxy must not escape as an exception.
+    """
+    _socks_proxy_without_extra(monkeypatch, "http://127.0.0.1:8123")
+
+    assert cli._daemon_host_online(_online_record()) is False
 
 
 def test_daemon_tunnel_recovers_returns_true_on_immediate_online(


### PR DESCRIPTION
## Related issue

Closes #4245

## Summary

`omnigent cursor` (and every other command that ensures the backend) crashed
outright for users whose shell exports a SOCKS proxy:

```
ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
Make sure to install httpx using `pip install httpx[socks]`.
```

`_host_http_json` already models "couldn't reach the server" as a transport
failure (`status_code=0`), and every caller handles that — `_daemon_host_online`
turns it into "host offline" so the daemon heals. But its `except` clause only
covered `httpx.HTTPError` and `OSError`. httpx raises **`ImportError`** from
`Client.__init__` when the ambient environment selects a proxy whose optional
extra is missing, so that one failure mode walked straight past the handler and
out through the top-level crash reporter.

ELI5: the CLI knew how to say "I can't reach the server", but one specific way
of failing to reach it wasn't on the list, so it panicked instead.

```
omnigent cursor
  └─ _ensure_backend → _ensure_host_daemon → _reuse_existing_daemon_record
       └─ _daemon_tunnel_recovers → _daemon_host_online
            └─ _host_http_json → httpx.Client(...)   ← ImportError escaped here
```

This adds `ImportError` to the caught tuple. The proxy is still honoured when it
works; `trust_env` is deliberately left alone so users who genuinely need a proxy
to reach a remote Omnigent server keep working.

## Test Plan

Reproduced and verified against real `httpx` with a real proxy environment — no
mocking of the transport:

```bash
# before: crashes with the traceback from #4245
# after:  _HostHttpResult(status_code=0, body="ImportError: Using SOCKS proxy, ...")
ALL_PROXY=socks5://127.0.0.1:1080 python -c "
from omnigent import cli
print(cli._host_http_json(base_url='http://127.0.0.1:8123', method='GET',
                          path='/v1/hosts/host_abc', timeout_s=2.0))"
```

`_daemon_host_online` — the frame in the reported traceback — now returns
`False` instead of raising.

Two regression tests were added to the existing `tests/cli/test_backend.py`
suite. They drive the real httpx code path (`ALL_PROXY` set, `socksio` blanked
in `sys.modules`) rather than stubbing `httpx.Client`, so they hold whether or
not the extra happens to be installed in the test environment. Both were
confirmed to **fail** on the unfixed code at
`httpx/_transports/default.py:191` and pass with the fix.

```
pytest tests/cli/test_backend.py     # 85 passed
pytest tests/cli/                    # 1064 passed
pre-commit run --files omnigent/cli.py tests/cli/test_backend.py   # clean
```

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the exact crash from #4245 on an install without
`socksio` by exporting `ALL_PROXY=socks5://127.0.0.1:1080`, confirmed the
traceback matched the report frame-for-frame, then confirmed the same call
returns `status_code=0` after the fix and that `_daemon_host_online` returns
`False`. The automated tests cover the same path in CI.

## Changelog

`omnigent` no longer crashes on startup when your shell sets a SOCKS proxy (e.g. `ALL_PROXY=socks5://…`) and the `httpx[socks]` extra isn't installed
