### PR TITLE
fix(cli): stop routing loopback server traffic through HTTP proxies

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -75,6 +75,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -589,7 +590,12 @@ async def _prepare_antigravity_terminal(
     :raises click.ClickException: If any server operation fails.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         bridge_id: str
         conversation_id: str
         resume = False
@@ -781,7 +787,12 @@ async def _prepare_antigravity_terminal_via_daemon(
     :raises click.ClickException: If setup fails.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         bridge_id: str
         conversation_id: str
         resume = False
@@ -1612,6 +1623,7 @@ async def _close_antigravity_terminal(
     try:
         async with httpx.AsyncClient(
             base_url=base_url,
+            trust_env=not is_loopback_url(base_url),
             headers=headers,
             timeout=httpx.Timeout(10.0),
         ) as client:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -37,6 +37,7 @@ from omnigent_client import (
 from omnigent_client import (
     OmnigentError as ClientOmnigentError,
 )
+from omnigent_client._http import is_loopback_url
 from rich.console import Console
 
 from omnigent._wrapper_labels import (
@@ -1404,6 +1405,29 @@ def _await_accounts_first_run_setup(
     )
 
 
+def _unreachable_server_message(base_url: str) -> str:
+    """
+    Build the user-facing message for a server we could not connect to.
+
+    A refused connection is an environment problem, not a bug worth a
+    crash-handler traceback, so name the URL and the likeliest fix.
+
+    :param base_url: Server base URL that refused the connection, e.g.
+        ``"http://127.0.0.1:6767"``.
+    :returns: A message naming the URL and how to recover.
+    """
+    if is_loopback_url(base_url):
+        return (
+            f"Could not connect to the local Omnigent server at {base_url}. "
+            "It may have stopped — run `omnigent stop`, then try again. "
+            "Server logs are under ~/.omnigent/logs/server/."
+        )
+    return (
+        f"Could not connect to the Omnigent server at {base_url}. "
+        "Check the URL, your network connection, and any HTTP proxy settings."
+    )
+
+
 async def _prepare_chat_session_via_daemon(
     *,
     base_url: str,
@@ -1442,8 +1466,8 @@ async def _prepare_chat_session_via_daemon(
         slow cold start is not silent. ``None`` (the default) runs without
         any progress updates.
     :returns: The prepared session id + bound runner id.
-    :raises click.ClickException: If session create/fork or runner launch
-        fails.
+    :raises click.ClickException: If the server is unreachable, or session
+        create/fork or runner launch fails.
     """
     from omnigent_client import OmnigentClient
 
@@ -1458,49 +1482,62 @@ async def _prepare_chat_session_via_daemon(
     )
     from omnigent.native_terminal import bind_session_runner
 
-    async with OmnigentClient(base_url=base_url, headers=headers, auth=auth) as sdk:
-        try:
-            if fork_session_id is not None:
-                fork_result = await sdk.sessions.fork(fork_session_id)
-                session_id = fork_result["id"]
-            elif resume_conversation_id is not None:
-                session_id = resume_conversation_id
-            else:
-                created = await sdk.sessions.create(
-                    bundle, filename="agent.tar.gz", workspace=workspace
-                )
-                session_id = created.id
-        except ClientOmnigentError as exc:
-            # Any create/fork/resume rejection here is a server-side answer, not
-            # a client bug worth a traceback: a wrong base URL that answers
-            # /health but has no session API, a fork of a session that is gone,
-            # a permission refusal. Name the URL, since a wrong one is the case
-            # that looks least like itself, and pass the server's message through.
-            raise click.ClickException(f"Could not start a session on {base_url}: {exc}") from exc
+    try:
+        async with OmnigentClient(base_url=base_url, headers=headers, auth=auth) as sdk:
+            try:
+                if fork_session_id is not None:
+                    fork_result = await sdk.sessions.fork(fork_session_id)
+                    session_id = fork_result["id"]
+                elif resume_conversation_id is not None:
+                    session_id = resume_conversation_id
+                else:
+                    created = await sdk.sessions.create(
+                        bundle, filename="agent.tar.gz", workspace=workspace
+                    )
+                    session_id = created.id
+            except ClientOmnigentError as exc:
+                # Any create/fork/resume rejection here is a server-side answer, not
+                # a client bug worth a traceback: a wrong base URL that answers
+                # /health but has no session API, a fork of a session that is gone,
+                # a permission refusal. Name the URL, since a wrong one is the case
+                # that looks least like itself, and pass the server's message through.
+                raise click.ClickException(
+                    f"Could not start a session on {base_url}: {exc}"
+                ) from exc
 
-    # A separate raw httpx client for the host-runner protocol (the daemon
-    # launch helpers operate on httpx, not the SDK).
-    timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
-        if progress is not None:
-            progress.update(STARTUP_PHASE_CONNECTING)
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S)
-        if progress is not None:
-            progress.update(STARTUP_PHASE_LAUNCHING_AGENT)
-        runner_id = await launch_or_reuse_daemon_runner(
-            client, host_id=host_id, session_id=session_id, workspace=workspace
-        )
-        await wait_for_runner_online(
-            client, runner_id, timeout_s=_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S
-        )
-        # launch_or_reuse_daemon_runner's atomic-bind / online-reuse paths
-        # don't pass through replace_runner_id, so re-bind via PATCH to
-        # clear the ``omnigent.stopped`` marker on resumed sessions. Must run
-        # AFTER wait_for_runner_online — a freshly launched runner isn't
-        # registered until then, and replace_runner_id 400s on an unregistered id.
-        await bind_session_runner(client, session_id, runner_id)
+        # A separate raw httpx client for the host-runner protocol (the daemon
+        # launch helpers operate on httpx, not the SDK).
+        timeout = httpx.Timeout(30.0, read=120.0)
+        async with httpx.AsyncClient(
+            base_url=base_url,
+            headers=headers,
+            auth=auth,
+            timeout=timeout,
+            trust_env=not is_loopback_url(base_url),
+        ) as client:
+            if progress is not None:
+                progress.update(STARTUP_PHASE_CONNECTING)
+            await wait_for_host_online(
+                client, host_id, timeout_s=_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S
+            )
+            if progress is not None:
+                progress.update(STARTUP_PHASE_LAUNCHING_AGENT)
+            runner_id = await launch_or_reuse_daemon_runner(
+                client, host_id=host_id, session_id=session_id, workspace=workspace
+            )
+            await wait_for_runner_online(
+                client, runner_id, timeout_s=_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S
+            )
+            # launch_or_reuse_daemon_runner's atomic-bind / online-reuse paths
+            # don't pass through replace_runner_id, so re-bind via PATCH to
+            # clear the ``omnigent.stopped`` marker on resumed sessions. Must run
+            # AFTER wait_for_runner_online — a freshly launched runner isn't
+            # registered until then, and replace_runner_id 400s on an unregistered id.
+            await bind_session_runner(client, session_id, runner_id)
+    except httpx.ConnectError as exc:
+        # The server never answered the socket — a stopped local server, a
+        # wrong --server URL, or a proxy that swallowed the request.
+        raise click.ClickException(_unreachable_server_message(base_url)) from exc
     return _DaemonChatSession(session_id=session_id, runner_id=runner_id)
 
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1534,9 +1534,10 @@ async def _prepare_chat_session_via_daemon(
             # AFTER wait_for_runner_online — a freshly launched runner isn't
             # registered until then, and replace_runner_id 400s on an unregistered id.
             await bind_session_runner(client, session_id, runner_id)
-    except httpx.ConnectError as exc:
-        # The server never answered the socket — a stopped local server, a
-        # wrong --server URL, or a proxy that swallowed the request.
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ProxyError) as exc:
+        # No connection was ever established — a stopped local server, a wrong
+        # --server URL, or a proxy refusing the tunnel. These three are
+        # siblings under TransportError, so each has to be named.
         raise click.ClickException(_unreachable_server_message(base_url)) from exc
     return _DaemonChatSession(session_id=session_id, runner_id=runner_id)
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 from websockets.exceptions import ConnectionClosed, ConnectionClosedError, WebSocketException
 from websockets.frames import Close
 
@@ -1480,7 +1481,12 @@ def _fetch_external_session_id_for_redirect(
     if base_url is None:
         return None
     try:
-        with httpx.Client(base_url=base_url, headers=headers, timeout=10.0) as client:
+        with httpx.Client(
+            base_url=base_url,
+            headers=headers,
+            timeout=10.0,
+            trust_env=not is_loopback_url(base_url),
+        ) as client:
             resp = client.get(f"/v1/sessions/{url_component(session_id)}")
         if resp.status_code >= 400:
             return None
@@ -2978,6 +2984,7 @@ async def _is_terminal_resource_gone(
     try:
         async with httpx.AsyncClient(
             base_url=base_url,
+            trust_env=not is_loopback_url(base_url),
             headers=headers,
             timeout=httpx.Timeout(timeout_s),
         ) as client:
@@ -3079,7 +3086,10 @@ async def _close_claude_terminal(
     )
     with contextlib.suppress(Exception):
         async with httpx.AsyncClient(
-            base_url=base_url, headers=headers, timeout=httpx.Timeout(10.0)
+            base_url=base_url,
+            headers=headers,
+            timeout=httpx.Timeout(10.0),
+            trust_env=not is_loopback_url(base_url),
         ) as client:
             await client.delete(path)
 
@@ -3217,7 +3227,12 @@ async def _prepare_claude_terminal_via_daemon(
     startup_profiler = startup_profiler or StartupProfiler(name="omnigent claude", enabled=False)
     persist_args = list(_strip_resume_from_claude_args(claude_args))
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         startup_profiler.mark("daemon prepare http client ready")
         # Resuming an existing session must not re-close its terminal on
         # exit; a fresh launch owns teardown.
@@ -3621,7 +3636,12 @@ async def _prepare_claude_terminal(
     """
     startup_profiler = startup_profiler or StartupProfiler(name="omnigent claude", enabled=False)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         startup_profiler.mark("prepare http client ready")
         cold_resume_args: tuple[str, ...] = ()
         # Cold resume = session existed but no live terminal. Even when

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5933,7 +5933,10 @@ def usage(limit: int, server: str | None, as_json: bool) -> None:
     base_url = base_url.rstrip("/")
 
     with httpx.Client(
-        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=60.0
+        base_url=base_url,
+        headers=_remote_headers(server_url=base_url),
+        timeout=60.0,
+        trust_env=_trust_env_for(base_url),
     ) as client:
         resp = client.get("/v1/usage")
         resp.raise_for_status()
@@ -6014,7 +6017,10 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     out_path = Path(output) if output else Path(f"{session_id}.jsonl")
 
     with httpx.Client(
-        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=30.0
+        base_url=base_url,
+        headers=_remote_headers(server_url=base_url),
+        timeout=30.0,
+        trust_env=_trust_env_for(base_url),
     ) as client:
         # Fetch session metadata (items fetched separately via pagination).
         resp = client.get(
@@ -6253,7 +6259,10 @@ def session_import(input_path: str, title: str | None, server: str | None) -> No
         return client.post("/v1/sessions", json=body)
 
     with httpx.Client(
-        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=120.0
+        base_url=base_url,
+        headers=_remote_headers(server_url=base_url),
+        timeout=120.0,
+        trust_env=_trust_env_for(base_url),
     ) as client:
         candidates = [a for a in (exported_agent_id, fallback_agent_id) if a]
         if not candidates:
@@ -8114,6 +8123,21 @@ _host_http_headers_cache: dict[str, dict[str, str]] = {}
 _host_http_headers_lock = threading.Lock()
 
 
+def _trust_env_for(base_url: str) -> bool:
+    """
+    Report whether calls to *base_url* should honor environment proxies.
+
+    A proxy resolves ``127.0.0.1`` against itself, so it can never reach
+    our local server; loopback targets opt out of proxying entirely.
+
+    :param base_url: Server base URL, e.g. ``"http://127.0.0.1:6767"``.
+    :returns: ``False`` for a loopback target, ``True`` otherwise.
+    """
+    from omnigent_client._http import is_loopback_url
+
+    return not is_loopback_url(base_url)
+
+
 def _host_http_json(
     *,
     base_url: str,
@@ -8152,6 +8176,7 @@ def _host_http_json(
             base_url=base_url,
             headers=headers,
             timeout=timeout_s,
+            trust_env=_trust_env_for(base_url),
         ) as client:
             resp = client.request(method, path, params=params, json=json_body)
     except (httpx.HTTPError, OSError) as exc:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -22,6 +22,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -839,7 +840,12 @@ async def _prepare_codex_terminal_via_daemon(
     """
     persist_args = list(codex_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = session_id is not None
         if session_id is None:
             if session_bundle is None:
@@ -1012,6 +1018,7 @@ async def _post_initial_prompt(
     """
     async with httpx.AsyncClient(
         base_url=base_url,
+        trust_env=not is_loopback_url(base_url),
         headers=headers,
         auth=auth,
         timeout=httpx.Timeout(30.0),
@@ -1060,7 +1067,12 @@ async def _prepare_codex_terminal(
     :returns: Prepared terminal details.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         bridge_id: str
         thread_id: str | None = None
         if session_id is None:
@@ -1391,6 +1403,7 @@ async def _initialize_fresh_terminal_thread(
     thread_id = await _wait_for_thread_started(prepared.event_client)
     async with httpx.AsyncClient(
         base_url=base_url,
+        trust_env=not is_loopback_url(base_url),
         headers=headers,
         timeout=httpx.Timeout(30.0),
     ) as client:
@@ -2699,6 +2712,7 @@ async def _close_codex_terminal(
     with contextlib.suppress(Exception):
         async with httpx.AsyncClient(
             base_url=base_url,
+            trust_env=not is_loopback_url(base_url),
             headers=headers,
             timeout=httpx.Timeout(10.0),
         ) as client:

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -30,6 +30,7 @@ from typing import TypedDict, cast
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -497,7 +498,12 @@ async def _prepare_cursor_terminal_via_daemon(
     """
     persist_args = list(cursor_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         # Resuming an existing session can either reattach to a live
         # terminal (prior chat intact) or, if that terminal has exited,
         # cold-start a fresh TUI. We only know which after probing for a

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -29,6 +29,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -317,7 +318,12 @@ async def _prepare_goose_terminal_via_daemon(
     """
     persist_args = list(goose_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = False
         cold_resumed = False
         if session_id is None:

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -28,6 +28,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -315,7 +316,12 @@ async def _prepare_hermes_terminal_via_daemon(
     """
     persist_args = list(hermes_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = False
         cold_resumed = False
         if session_id is None:

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -26,6 +26,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -320,7 +321,12 @@ async def _prepare_kimi_terminal_via_daemon(
     """
     persist_args = list(kimi_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         # Resuming an existing session can either reattach to a live
         # terminal (prior chat intact) or, if that terminal has exited,
         # cold-start a fresh TUI. We only know which after probing for a

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -15,6 +15,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -355,7 +356,12 @@ async def _prepare_kiro_terminal_via_daemon(
     if prompt:
         persist_args.append(prompt)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = False
         cold_resumed = False
         if session_id is None:

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -30,6 +30,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -285,7 +286,12 @@ async def _prepare_opencode_terminal_via_daemon(  # pragma: no cover
     """Create or resume an opencode-native session through a daemon runner."""
     persist_args = list(opencode_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = session_id is not None
         if session_id is None:
             if session_bundle is None:

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -15,6 +15,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -369,7 +370,12 @@ async def _prepare_pi_terminal_via_daemon(
     """
     persist_args = list(pi_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = session_id is not None
         if session_id is None:
             if session_bundle is None:

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -29,6 +29,7 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
+from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -315,7 +316,12 @@ async def _prepare_qwen_terminal_via_daemon(
     """
     persist_args = list(qwen_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    ) as client:
         reattached = False
         cold_resumed = False
         if session_id is None:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -832,6 +832,8 @@ def _mint_managed_owner_token(
     :raises httpx.HTTPError: On network failure or a non-2xx response.
     :raises KeyError: If the response is missing the expected fields.
     """
+    from omnigent_client._http import is_loopback_url
+
     from omnigent.cli_auth import databricks_request_headers
     from omnigent.runner.identity import (
         OMNIGENT_INTERNAL_WS_ORIGIN,
@@ -843,7 +845,7 @@ def _mint_managed_owner_token(
         RUNNER_TUNNEL_TOKEN_HEADER: binding_token,
         **databricks_request_headers(server_url, bearer_token=proxy_bearer),
     }
-    with httpx.Client(timeout=10.0) as client:
+    with httpx.Client(timeout=10.0, trust_env=not is_loopback_url(server_url)) as client:
         response = client.post(mint_url, headers=headers)
         response.raise_for_status()
         payload = response.json()
@@ -1179,6 +1181,8 @@ def create_app(
     # tunnel the runner opened to the Omnigent server at startup).
     # stdio_cwd=runner_workspace ensures relative command paths like
     # ".venv/bin/python" resolve against the user's project root.
+    from omnigent_client._http import is_loopback_url
+
     from omnigent.runner.mcp_manager import RunnerMcpManager
 
     # Reuse the caller's factory when given (shares one resolved SDK auth +
@@ -1188,6 +1192,8 @@ def create_app(
     binding_token = _runner_tunnel_binding_token_from_env()
     server_client = httpx.AsyncClient(
         base_url=server_url,
+        # A proxy cannot reach a loopback server, so local targets bypass it.
+        trust_env=not is_loopback_url(server_url),
         auth=_RunnerDatabricksAuth(auth_token_factory),
         # Announce the runner as a first-party non-browser client via the
         # sentinel Origin. The server's require_trusted_origin CSRF guard on

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8785,9 +8785,13 @@ def create_runner_app_from_env() -> FastAPI:
     server_url = os.environ.get("RUNNER_SERVER_URL", "").strip()
     if not server_url:
         raise RuntimeError("RUNNER_SERVER_URL is required for the runner subprocess factory")
+    from omnigent_client._http import is_loopback_url
+
     server_client = httpx.AsyncClient(
         base_url=server_url,
         timeout=httpx.Timeout(5.0, read=None),
+        # A proxy cannot reach a loopback server, so local targets bypass it.
+        trust_env=not is_loopback_url(server_url),
     )
     return create_runner_app(server_client=server_client)
 

--- a/sdks/python-client/omnigent_client/_client.py
+++ b/sdks/python-client/omnigent_client/_client.py
@@ -92,7 +92,8 @@ class OmnigentClient:
             auth=auth,
             timeout=sse_timeout,
             # A proxy cannot reach our loopback server, so bypass the
-            # environment's proxy settings when the target is local.
+            # environment for local targets. Loopback is plain HTTP with
+            # explicit headers, so losing netrc/CA env with it costs nothing.
             trust_env=not is_loopback_url(self._base_url),
         )
 

--- a/sdks/python-client/omnigent_client/_client.py
+++ b/sdks/python-client/omnigent_client/_client.py
@@ -10,6 +10,7 @@ import httpx
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 
 from ._files import FilesNamespace
+from ._http import is_loopback_url
 from ._query import QueryResult, QueryStream
 from ._responses import ResponsesNamespace
 from ._session import Session
@@ -90,6 +91,9 @@ class OmnigentClient:
             headers=default_headers,
             auth=auth,
             timeout=sse_timeout,
+            # A proxy cannot reach our loopback server, so bypass the
+            # environment's proxy settings when the target is local.
+            trust_env=not is_loopback_url(self._base_url),
         )
 
         self.sessions = SessionsNamespace(self._http, self._base_url)

--- a/sdks/python-client/omnigent_client/_http.py
+++ b/sdks/python-client/omnigent_client/_http.py
@@ -1,0 +1,35 @@
+"""HTTP transport helpers shared by the client and its callers."""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlsplit
+
+
+def is_loopback_url(url: str) -> bool:
+    """
+    Report whether *url* addresses this machine's loopback interface.
+
+    Loopback traffic must never go through an HTTP proxy: the proxy
+    resolves ``127.0.0.1`` against itself, so the request reaches the
+    wrong host or is refused outright. httpx reads proxy settings from
+    the environment by default, and on Windows that also covers the
+    system registry — so a machine with any proxy configured cannot
+    reach its own local server unless the caller passes
+    ``trust_env=False``.
+
+    :param url: Absolute URL to classify, e.g.
+        ``"http://127.0.0.1:6767"``.
+    :returns: ``True`` for loopback targets — ``localhost``, any
+        ``.localhost`` name, ``127.0.0.0/8``, or ``::1``. ``False``
+        otherwise, including for a URL with no host.
+    """
+    host = urlsplit(url).hostname
+    if host is None:
+        return False
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -657,8 +657,13 @@ def _socks_proxy_without_extra(monkeypatch: pytest.MonkeyPatch, base_url: str) -
 def test_host_http_json_reports_failure_when_socks_extra_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A proxy httpx cannot build is a transport failure, not a crash."""
-    base_url = "http://127.0.0.1:8123"
+    """A proxy httpx cannot build is a transport failure, not a crash.
+
+    Uses a remote server because that is where a proxy still applies:
+    loopback targets bypass proxies outright (see the companion test), so
+    there is no proxy transport left to fail to build.
+    """
+    base_url = "https://server.example.com"
     _socks_proxy_without_extra(monkeypatch, base_url)
 
     result = cli._host_http_json(
@@ -670,6 +675,31 @@ def test_host_http_json_reports_failure_when_socks_extra_missing(
 
     assert result.status_code == 0
     assert "socksio" in str(result.body)
+
+
+def test_host_http_json_ignores_proxy_for_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local server is reached directly, never through a proxy.
+
+    A proxy resolves ``127.0.0.1`` against itself, so honoring one here
+    means a developer who exports ``ALL_PROXY`` cannot reach their own
+    server at all — every call fails before it leaves the machine.
+    """
+    base_url = "http://127.0.0.1:8123"
+    _socks_proxy_without_extra(monkeypatch, base_url)
+
+    result = cli._host_http_json(
+        base_url=base_url,
+        method="GET",
+        path="/v1/hosts/host_abc",
+        timeout_s=2.0,
+    )
+
+    assert result.status_code == 0
+    # The SOCKS transport was never built, so this is an ordinary refused
+    # connection rather than the missing-extra ImportError.
+    assert "socksio" not in str(result.body)
 
 
 def test_daemon_host_online_false_when_socks_extra_missing(

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1483,6 +1483,15 @@ def test_prepare_chat_session_via_daemon_reports_create_failure_as_click_error(
 
 
 @pytest.mark.parametrize(
+    "transport_error",
+    [
+        httpx.ConnectError("All connection attempts failed"),
+        httpx.ConnectTimeout("timed out establishing a connection"),
+        httpx.ProxyError("proxy refused the tunnel"),
+    ],
+    ids=["connect-error", "connect-timeout", "proxy-error"],
+)
+@pytest.mark.parametrize(
     ("server_url", "expected_hint"),
     [
         # A local server that stopped — the user restarts it.
@@ -1494,20 +1503,22 @@ def test_prepare_chat_session_via_daemon_reports_create_failure_as_click_error(
 def test_prepare_chat_session_via_daemon_reports_unreachable_server_as_click_error(
     server_url: str,
     expected_hint: str,
+    transport_error: httpx.HTTPError,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A refused connection is a ``ClickException``, not a crash screen.
 
-    ``httpx.ConnectError`` is a transport failure, so it never reaches the
-    SDK's ``OmnigentError`` handling above and used to escape all the way to
-    the crash handler — turning "the server isn't reachable" into a branded
-    crash report with a traceback and no actionable advice.
+    These are transport failures, so they never reach the SDK's
+    ``OmnigentError`` handling above and used to escape all the way to the
+    crash handler — turning "the server isn't reachable" into a branded crash
+    report with a traceback and no actionable advice. All three are siblings
+    under ``TransportError``, so catching one does not cover the others.
     """
     captured: dict[str, object] = {}
     _patch_daemon_launch(monkeypatch, captured)
 
     async def _refused(_self: object, _bundle: bytes, *, filename: str, workspace: str) -> object:
-        raise httpx.ConnectError("All connection attempts failed")
+        raise transport_error
 
     monkeypatch.setattr(_FakeSessionsApi, "create", _refused)
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1482,6 +1482,59 @@ def test_prepare_chat_session_via_daemon_reports_create_failure_as_click_error(
     assert "launch" not in captured
 
 
+@pytest.mark.parametrize(
+    ("server_url", "expected_hint"),
+    [
+        # A local server that stopped — the user restarts it.
+        ("http://127.0.0.1:6767", "omnigent stop"),
+        # A remote target — the URL, the network, or a proxy is at fault.
+        ("https://example.databricksapps.com", "proxy"),
+    ],
+)
+def test_prepare_chat_session_via_daemon_reports_unreachable_server_as_click_error(
+    server_url: str,
+    expected_hint: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused connection is a ``ClickException``, not a crash screen.
+
+    ``httpx.ConnectError`` is a transport failure, so it never reaches the
+    SDK's ``OmnigentError`` handling above and used to escape all the way to
+    the crash handler — turning "the server isn't reachable" into a branded
+    crash report with a traceback and no actionable advice.
+    """
+    captured: dict[str, object] = {}
+    _patch_daemon_launch(monkeypatch, captured)
+
+    async def _refused(_self: object, _bundle: bytes, *, filename: str, workspace: str) -> object:
+        raise httpx.ConnectError("All connection attempts failed")
+
+    monkeypatch.setattr(_FakeSessionsApi, "create", _refused)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        asyncio.run(
+            _prepare_chat_session_via_daemon(
+                base_url=server_url,
+                headers={},
+                auth=None,
+                host_id="host_x",
+                bundle=b"bundle-bytes",
+                resume_conversation_id=None,
+                fork_session_id=None,
+                workspace="/tmp/proj",
+            )
+        )
+
+    message = str(excinfo.value)
+    # The URL identifies which server was unreachable.
+    assert server_url in message
+    # The advice has to differ: restarting a local server is not the fix for
+    # an unreachable remote one.
+    assert expected_hint in message
+    # No runner is launched against a server we could not reach.
+    assert "launch" not in captured
+
+
 # ── OMNIGENT_MODEL env-var fallback ───────────────────
 #
 # These tests pin explicit-environment and discovered-default precedence on

--- a/tests/frontends/sdk/test_http.py
+++ b/tests/frontends/sdk/test_http.py
@@ -1,0 +1,85 @@
+"""Loopback detection and the proxy bypass it drives on the SDK client.
+
+A machine with an HTTP proxy configured — via ``HTTP_PROXY``/``ALL_PROXY``,
+or on Windows via the system registry, which ``getproxies()`` also reads —
+cannot reach its own local Omnigent server through that proxy: the proxy
+resolves ``127.0.0.1`` against itself. httpx trusts the environment by
+default, so a client built without ``trust_env=False`` fails with
+``httpx.ConnectError: All connection attempts failed`` even though the
+server is listening and healthy.
+"""
+
+from __future__ import annotations
+
+import pytest
+from omnigent_client import OmnigentClient
+from omnigent_client._http import is_loopback_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:6767",
+        "http://127.0.0.1:6767/v1/sessions",
+        # The whole 127.0.0.0/8 block is loopback, not just .0.1.
+        "http://127.9.9.9:80",
+        "http://localhost:8080",
+        # urlsplit lowercases the host, so casing must not matter.
+        "http://LocalHost:8080",
+        # RFC 6761 reserves .localhost names for the loopback interface.
+        "http://dev.localhost:8080",
+        "http://[::1]:6767",
+        "https://127.0.0.1",
+    ],
+)
+def test_loopback_urls_are_detected(url: str) -> None:
+    """Every form of "this machine" must be classified as loopback.
+
+    A false negative here is the bug: the client keeps trusting the
+    environment's proxy and cannot reach the local server at all.
+    """
+    assert is_loopback_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.databricksapps.com",
+        "https://omnigent.internal:6767",
+        # Private, but still another host — reaching it may require the proxy.
+        "http://10.0.0.5:6767",
+        # Hostname that merely starts with the loopback IP.
+        "http://127.0.0.1.example.com",
+        "http://notlocalhost:8080",
+        "",
+    ],
+)
+def test_remote_urls_are_not_loopback(url: str) -> None:
+    """Remote targets keep their proxy.
+
+    A false positive would strip the proxy a corporate network needs to
+    reach the server at all, so the check must not over-match.
+    """
+    assert is_loopback_url(url) is False
+
+
+@pytest.mark.parametrize(
+    ("server_url", "expected_trust_env"),
+    [
+        ("http://127.0.0.1:6767", False),
+        ("http://localhost:6767", False),
+        ("https://example.databricksapps.com", True),
+    ],
+)
+def test_client_bypasses_env_proxies_only_for_loopback(
+    server_url: str, expected_trust_env: bool
+) -> None:
+    """The client wires loopback detection into httpx's ``trust_env``.
+
+    Without this the CLI's session-create call against a healthy local
+    server dies on a proxied connection, which surfaces as a crash rather
+    than anything the user can act on.
+    """
+    client = OmnigentClient(base_url=server_url)
+
+    assert client._http.trust_env is expected_trust_env

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -5908,6 +5908,7 @@ def test_fetch_external_session_id_for_redirect_uses_session_endpoint(
         :param base_url: Omnigent server base URL.
         :param headers: HTTP headers passed by the wrapper.
         :param timeout: Request timeout in seconds.
+        :param trust_env: Whether env proxy settings are honored.
         """
 
         def __init__(
@@ -5916,6 +5917,7 @@ def test_fetch_external_session_id_for_redirect_uses_session_endpoint(
             base_url: str,
             headers: dict[str, str],
             timeout: float,
+            trust_env: bool,
         ) -> None:
             """
             Capture construction arguments for later assertions.
@@ -5923,6 +5925,7 @@ def test_fetch_external_session_id_for_redirect_uses_session_endpoint(
             :param base_url: Omnigent server base URL.
             :param headers: HTTP headers passed by the wrapper.
             :param timeout: Request timeout in seconds.
+            :param trust_env: Whether env proxy settings are honored.
             :returns: None.
             """
             calls.append(
@@ -5930,6 +5933,7 @@ def test_fetch_external_session_id_for_redirect_uses_session_endpoint(
                     "base_url": base_url,
                     "headers": headers,
                     "timeout": timeout,
+                    "trust_env": trust_env,
                 }
             )
 
@@ -5987,6 +5991,9 @@ def test_fetch_external_session_id_for_redirect_uses_session_endpoint(
             "base_url": "http://ap.example",
             "headers": {"Authorization": "Bearer token"},
             "timeout": 10.0,
+            # A remote host keeps the environment's proxy — only loopback
+            # targets, which a proxy cannot reach, opt out.
+            "trust_env": True,
         },
         {"url": "/v1/sessions/conv%20with%20space"},
     ]

--- a/tests/test_loopback_proxy_guards.py
+++ b/tests/test_loopback_proxy_guards.py
@@ -1,0 +1,79 @@
+"""Guard: server-directed HTTP clients must opt out of environment proxies.
+
+An HTTP proxy resolves ``127.0.0.1`` against itself, so it can never reach
+this machine's local Omnigent server. httpx trusts the environment by
+default — and on Windows ``getproxies()`` also reads the system registry —
+so any client built without ``trust_env`` fails against a perfectly healthy
+local server with ``ConnectError: All connection attempts failed``.
+
+The construction below is copied verbatim into every new native harness, so
+this guard is a static check rather than a per-harness test: adding harness
+number twelve by copy-paste must not silently reintroduce the bug.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Modules whose httpx clients are bound to the Omnigent server's base URL.
+# Deliberately not repo-wide: runner tool/transport clients talk to harnesses
+# and MCP endpoints, where the environment's proxy is the right thing to use.
+_SERVER_CLIENT_MODULES: list[Path] = [
+    *sorted((_REPO_ROOT / "omnigent").glob("*_native.py")),
+    _REPO_ROOT / "omnigent" / "chat.py",
+    _REPO_ROOT / "omnigent" / "cli.py",
+    _REPO_ROOT / "omnigent" / "runner" / "_entry.py",
+    _REPO_ROOT / "omnigent" / "runner" / "app.py",
+]
+
+
+def _clients_missing_trust_env(path: Path) -> list[int]:
+    """
+    Return the line numbers of server-bound httpx clients lacking ``trust_env``.
+
+    Only calls that pass ``base_url`` are considered: a client with no base
+    URL is not pinned to the Omnigent server, so the proxy question is the
+    caller's to answer at the request site.
+
+    :param path: Module to scan, e.g. ``omnigent/claude_native.py``.
+    :returns: Line numbers of offending ``httpx.Client``/``AsyncClient`` calls.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in {"Client", "AsyncClient"}:
+            continue
+        keywords = {kw.arg for kw in node.keywords}
+        if "base_url" in keywords and "trust_env" not in keywords:
+            offenders.append(node.lineno)
+    return offenders
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    _SERVER_CLIENT_MODULES,
+    ids=lambda p: str(p.relative_to(_REPO_ROOT)),
+)
+def test_server_clients_opt_out_of_env_proxies(module_path: Path) -> None:
+    """Every server-bound httpx client must decide ``trust_env`` explicitly.
+
+    Without it, a user whose machine has any proxy configured cannot reach
+    their own local server, and the failure surfaces as a crash rather than
+    as a connectivity problem.
+    """
+    offenders = _clients_missing_trust_env(module_path)
+
+    assert not offenders, (
+        f"{module_path.relative_to(_REPO_ROOT)} builds an httpx client bound to a "
+        f"server base_url without trust_env at line(s) {offenders}. "
+        f"Pass trust_env=not is_loopback_url(base_url) so loopback targets "
+        f"bypass the environment's proxy settings."
+    )


### PR DESCRIPTION
## Related issue

Closes #4308

## Summary

A bare `omni` crashed with `ConnectError: All connection attempts failed` on a
machine with an HTTP proxy configured — even though the local server was running
and healthy.

**Root cause.** httpx trusts the environment's proxy settings by default, and on
Windows `getproxies()` also reads the **system registry** — so this fires with no
proxy env vars set at all, just Windows/VPN proxy settings. A proxy resolves
`127.0.0.1` against *itself*, so it can never reach our local server.

The local-server health probe already passed `trust_env=False`, which is exactly
why the failure looked so strange — discovery succeeded, then the very next call
died:

```
omni
 ├─ discover local server → GET  /health        trust_env=False → 200 OK       OK
 └─ start session         → POST /v1/sessions   trust_env=True
                                  └─→ HTTP proxy → ConnectError → crash screen
```

And because `ConnectError` is a *transport* error, it never reached the SDK's
existing `OmnigentError` handling — it escaped to the crash handler and was
reported as a crash rather than a connectivity problem.

**Fix.**

- Loopback targets (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`) bypass the
  environment's proxies. Remote targets keep their proxy, which a corporate
  network may well need. This covers the SDK client, the CLI clients, the runner's
  server clients, and all 21 server-bound clients across the 11 native harness modules
  (`omni --harness claude|codex|cursor|…`), which spawn the same local server but
  never go through the SDK client.
- A connection that was never established now raises a `ClickException` naming the
  URL and the likely fix, instead of a crash screen. `ConnectError`,
  `ConnectTimeout` and `ProxyError` are siblings under `TransportError`, so all
  three are named; `TransportError` itself is deliberately *not* caught, since
  `ReadTimeout`/`DecodingError` are not "could not connect".
- `tests/test_loopback_proxy_guards.py` is an AST guard (matching the existing
  `*_guards.py` pattern) asserting every server-bound httpx client decides
  `trust_env` explicitly — the construction is copy-pasted into each new harness,
  so harness number thirteen must not silently reintroduce this.

The WS tunnel needs no change — the pinned `websockets<15` has no proxy support at
all (verified).

<details>
<summary>ELI5</summary>

Your computer has a mail-forwarding service (the proxy) for reaching the outside
world. We were handing it letters addressed to *your own house*. It went looking
for that address out on the internet, couldn't find it, and gave up — so the app
concluded something had gone badly wrong and showed a crash report. Now letters
addressed to your own house get walked straight to the door.
</details>

## Test Plan

**Before/after, real sockets:** a live, healthy loopback server with a bogus proxy
in the environment (`ALL_PROXY`/`HTTP_PROXY`/`HTTPS_PROXY` pointed at a dead port).
Only the fix differs between rows:

| | `trust_env` | result |
|---|---|---|
| before | `True` | `ConnectError: All connection attempts failed` |
| after | `False` | `HTTP 200` |
| remote target (before *and* after) | `True` | still routed via the proxy |

The "before" row reproduces the reporter's exact error string.

**Automated:** `pytest tests/cli tests/frontends/sdk tests/runner tests/test_*native*.py`
plus the new guard. Pre-existing failures unrelated to this change (4 PTY/TUI
rendering tests) were confirmed to fail identically on a clean `origin/main`
worktree.

`ruff format`, `ruff check` and `pyrefly` are clean on every changed file.

## Demo

Non-visual CLI change; terminal transcript in lieu of a screenshot.

**Before** — a healthy server, but a proxy configured:

```
$ omni
omnigent: Connecting to the server…
omnigent: Preparing your agent…

Omnigent ran into an issue.

A crash report was saved to:
  ~/.omnigent/crashes/crash-20260807T035753Z.md

--- technical details ---
Traceback (most recent call last):
  File "omnigent/chat.py", line 1457, in _prepare_chat_session_via_daemon
    created = await sdk.sessions.create(
  ...
httpx.ConnectError: All connection attempts failed
```

**After** — the same machine now connects normally. And when the server genuinely
is unreachable, the failure is legible instead of a crash:

```
$ omnigent run hello_world.yaml --server http://127.0.0.1:53402 -p hi
omnigent: Connecting to the server…
omnigent: Preparing your agent…
Error: Could not connect to the local Omnigent server at http://127.0.0.1:53402.
It may have stopped — run `omnigent stop`, then try again. Server logs are under
~/.omnigent/logs/server/.
$ echo $?
1
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover loopback classification (including deliberate near-misses like
`127.0.0.1.example.com` and `notlocalhost`, which must *not* lose their proxy), the
client's `trust_env` wiring, and all three transport errors → `ClickException` for
both the local and remote message variants. The AST guard covers every server-bound
client in `omnigent/*_native.py`, `chat.py`, `cli.py` and the runner.

Manual verification covered what a unit test cannot: real sockets in a real
proxy-configured environment (the before/after table above), and the real CLI
binary emitting a clean error instead of a crash screen.

## Changelog

`omni` now works on machines with an HTTP proxy configured, and reports an unreachable server as a clear error instead of a crash.
