### PR TITLE
fix(runner): recover managed-mint auth when a re-mint 403s after JWT expiry

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -401,6 +401,7 @@ class _InitialAuthTokenFactory:
         self._server_url = server_url
         self._fallback_factory: Callable[[], str | None] | None = None
         self._fallback_resolved = False
+        self._no_credential_logged = False
         self._lock = threading.Lock()
 
     def __call__(self) -> str | None:
@@ -427,7 +428,10 @@ class _InitialAuthTokenFactory:
                     _allow_delegated_mint=False,
                 )
                 token = self._fallback_factory() if self._fallback_factory is not None else None
-            if self._fallback_factory is None:
+            if self._fallback_factory is None and not self._no_credential_logged:
+                # This state is terminal for the process, so say it once
+                # rather than on every subsequent callback.
+                self._no_credential_logged = True
                 _logger.error(
                     "host bootstrap bearer expired and no SDK/OIDC credential is available "
                     "to renew it; run `databricks auth login` to re-authenticate"

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -415,22 +415,24 @@ class _InitialAuthTokenFactory:
                     _proxy_bearer=self._last_initial_token,
                 )
                 self._fallback_resolved = True
-            # Managed mint failed because the proxy bearer is expired — the
-            # initial bearer was injected once and cannot self-renew. Skip
-            # managed mint entirely and go straight to SDK/OIDC.
-            if getattr(self._fallback_factory, "proxy_auth_failed", False):
+            token = self._fallback_factory() if self._fallback_factory is not None else None
+            # Managed mint cannot renew itself when its proxy bearer expires —
+            # the injected host bearer before a first mint, or the minted JWT
+            # once a session outlives it. Re-resolve SDK/OIDC in the same call
+            # so the request that hit the failure still gets a credential.
+            if token is None and getattr(self._fallback_factory, "proxy_auth_failed", False):
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
                     _allow_initial_token=False,
                     _allow_delegated_mint=False,
                 )
+                token = self._fallback_factory() if self._fallback_factory is not None else None
             if self._fallback_factory is None:
                 _logger.error(
                     "host bootstrap bearer expired and no SDK/OIDC credential is available "
                     "to renew it; run `databricks auth login` to re-authenticate"
                 )
-                return None
-            return self._fallback_factory()
+            return token
 
     @property
     def declined(self) -> bool:
@@ -675,7 +677,9 @@ def _make_managed_mint_factory(
         until process restart). If such a post-install mint then gets a
         definitive refusal, the factory latches ``declined`` and returns
         ``None`` thereafter, and :class:`_RunnerDatabricksAuth` falls back to
-        bare requests.
+        bare requests. A post-install 401/403 with no still-valid cache
+        latches ``proxy_auth_failed`` instead, which
+        :class:`_InitialAuthTokenFactory` answers by re-resolving SDK/OIDC.
     """
     from omnigent.runner.identity import token_bound_runner_id
 
@@ -712,6 +716,11 @@ class _ManagedMintTokenFactory:
     requests instead of failing closed. The latch matters when the
     construction probe loses a boot race (a connection error installs the
     factory, then the first real mint learns the server never mints).
+
+    A mint 401/403 with no still-valid cached token latches
+    :attr:`proxy_auth_failed` instead: the credential presented to the proxy
+    died (the seeded host bearer, or the minted JWT once a session outlives
+    it), so callers should re-resolve SDK/OIDC rather than send bare requests.
     """
 
     def __init__(
@@ -747,8 +756,10 @@ class _ManagedMintTokenFactory:
         """Return a fresh owner JWT, or ``None``.
 
         :returns: The cached or freshly-minted JWT; ``None`` after a
-            definitive server decline (sets :attr:`declined`) or on a
-            transient mint failure with no still-valid cached token.
+            definitive server decline (sets :attr:`declined`), after a mint
+            401/403 with no still-valid cached token (sets
+            :attr:`proxy_auth_failed`), or on a transient mint failure with
+            no still-valid cached token.
         """
         if self.declined:
             return None
@@ -779,13 +790,15 @@ class _ManagedMintTokenFactory:
                     return None
                 return self._still_valid_cached_token(now)
             if response.status_code in (401, 403):
-                # The proxy bearer is expired or invalid. If we have never
-                # successfully minted, there is no self-sustaining refresh
-                # loop to fall back to — signal proxy_auth_failed so the
-                # caller can try SDK/OIDC instead of looping on a dead bearer.
-                if self._cached_token is None:
+                # The proxy bearer is expired or invalid — the seeded host
+                # bearer, or the minted JWT once a session outlives it. With
+                # no still-valid cache left the mint loop cannot renew itself:
+                # latch proxy_auth_failed so the caller re-resolves SDK/OIDC
+                # instead of failing closed on every callback.
+                cached = self._still_valid_cached_token(now)
+                if cached is None:
                     self.proxy_auth_failed = True
-                    return None
+                return cached
             return self._still_valid_cached_token(now)
         except (httpx.HTTPError, ValueError, KeyError, OSError):
             # Transient mint failure: keep serving the cached token while

--- a/tests/e2e/test_managed_runner_http_auth.py
+++ b/tests/e2e/test_managed_runner_http_auth.py
@@ -27,6 +27,11 @@ the flip:
   ``_make_auth_token_factory`` returns for a managed sandbox on ``main``):
   ``GET /v1/sessions/{id}/agent/contents`` -> **401**.
 * WITH the fix: the same GET -> **200**, returning the agent bundle.
+
+The second test replays the OMNI-2529 deadlock over the same live stack: a
+managed runner whose re-mint gets 403 from the (simulated) Apps edge after its
+owner JWT fully expires must re-resolve a local credential instead of raising
+``httpx.RequestError`` on every callback forever.
 """
 
 from __future__ import annotations
@@ -35,16 +40,25 @@ import asyncio
 import os
 import signal
 import subprocess
+import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import httpx
 import pytest
 
-from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
+from omnigent.runner._entry import (
+    _InitialAuthTokenFactory,
+    _make_auth_token_factory,
+    _ManagedMintTokenFactory,
+    _RunnerDatabricksAuth,
+)
 from omnigent.runner.identity import (
     OMNIGENT_INTERNAL_WS_ORIGIN,
+    RUNNER_DELEGATED_AUTH_ENV_VAR,
+    RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
     token_bound_runner_id,
 )
@@ -158,6 +172,117 @@ def accounts_server(tmp_path: Path) -> Iterator[tuple[str, str]]:
         log_handle.close()
 
 
+def _seed_owned_session_with_managed_runner(base_url: str, db_uri: str) -> str:
+    """Create Alice's session and bind the managed runner id to it.
+
+    Alice's identity comes from a directly-minted accounts cookie signed with
+    the server's shared secret — the same JWT the password login flow issues;
+    only the password dance is skipped. The session-create, agent registration,
+    and owner grant are all real. The runner-id bind is what the managed-launch
+    path does at spawn time via ``replace_runner_id``; WAL journaling + a 20s
+    busy_timeout make this cross-process write safe against the running server,
+    which then resolves runner_id -> owner from this row.
+
+    :param base_url: Live server base URL.
+    :param db_uri: SQLite URI of the server's database.
+    :returns: The created session id.
+    """
+    owner_cookie = mint_session_cookie(_OWNER, bytes.fromhex(_COOKIE_SECRET_HEX), 8, "accounts")
+    bundle = build_agent_bundle(name="e2e-managed-runner-agent")
+    with httpx.Client(base_url=base_url, timeout=30.0) as http:
+        create = http.post(
+            "/v1/sessions",
+            headers={
+                "Authorization": f"Bearer {owner_cookie}",
+                "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
+            },
+            data={"metadata": "{}"},
+            files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        )
+    assert create.status_code in (200, 201), (create.status_code, create.text)
+    session_id = create.json()["session_id"]
+
+    runner_id = token_bound_runner_id(_BINDING_TOKEN)
+    SqlAlchemyConversationStore(db_uri).replace_runner_id(session_id, runner_id)
+    return session_id
+
+
+def _start_apps_edge_proxy(
+    upstream: str,
+) -> tuple[str, threading.Event, Callable[[], None]]:
+    """Run a reverse proxy that can start 403ing the managed-mint endpoint.
+
+    Stands in for the Databricks Apps edge: every request is forwarded to
+    *upstream* over a real socket until ``forbid_mint`` is set, after which
+    ``POST /v1/runners/{id}/token`` is answered ``403 Invalid Token`` without
+    reaching the server — exactly what the edge does once the bearer presented
+    on the mint request has expired.
+
+    :param upstream: Base URL of the real server to forward to.
+    :returns: ``(proxy_base_url, forbid_mint, shutdown)``.
+    """
+    forbid_mint = threading.Event()
+    forward = httpx.Client(base_url=upstream, timeout=30.0)
+
+    class _EdgeHandler(BaseHTTPRequestHandler):
+        """Forwarding handler with a switchable mint-endpoint 403."""
+
+        def log_message(self, format: str, *args: object) -> None:
+            """Suppress default request logging."""
+            del format, args
+
+        def do_GET(self) -> None:
+            self._relay()
+
+        def do_POST(self) -> None:
+            self._relay()
+
+        def _relay(self) -> None:
+            """Forward one request upstream, or 403 a forbidden mint."""
+            if (
+                forbid_mint.is_set()
+                and self.command == "POST"
+                and self.path.startswith("/v1/runners/")
+                and self.path.endswith("/token")
+            ):
+                body = b"Invalid Token"
+                self.send_response(403)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            length = int(self.headers.get("Content-Length") or 0)
+            content = self.rfile.read(length) if length else b""
+            headers = {
+                name: value
+                for name, value in self.headers.items()
+                if name.lower() not in ("host", "content-length", "connection", "accept-encoding")
+            }
+            upstream_resp = forward.request(
+                self.command, self.path, content=content, headers=headers
+            )
+            self.send_response(upstream_resp.status_code)
+            for name in ("Content-Type", "X-Agent-Name", "Location"):
+                value = upstream_resp.headers.get(name)
+                if value:
+                    self.send_header(name, value)
+            self.send_header("Content-Length", str(len(upstream_resp.content)))
+            self.end_headers()
+            self.wfile.write(upstream_resp.content)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _EdgeHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def _shutdown() -> None:
+        server.shutdown()
+        server.server_close()
+        forward.close()
+
+    return f"http://127.0.0.1:{server.server_port}", forbid_mint, _shutdown
+
+
 async def _get_agent_contents(
     base_url: str,
     path: str,
@@ -203,31 +328,8 @@ def test_managed_runner_callback_authenticates_end_to_end(
     """
     base_url, db_uri = accounts_server
 
-    # 1. Alice owns a real session. Her identity comes from a directly-minted
-    #    accounts cookie signed with the server's shared secret — the same JWT
-    #    the password login flow issues; only the password dance is skipped.
-    #    The session-create, agent registration, and owner grant are all real.
-    owner_cookie = mint_session_cookie(_OWNER, bytes.fromhex(_COOKIE_SECRET_HEX), 8, "accounts")
-    bundle = build_agent_bundle(name="e2e-managed-runner-agent")
-    with httpx.Client(base_url=base_url, timeout=30.0) as http:
-        create = http.post(
-            "/v1/sessions",
-            headers={
-                "Authorization": f"Bearer {owner_cookie}",
-                "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
-            },
-            data={"metadata": "{}"},
-            files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
-        )
-    assert create.status_code in (200, 201), (create.status_code, create.text)
-    session_id = create.json()["session_id"]
-
-    # 2. Bind a managed runner id to Alice's session — what the managed-launch
-    #    path does at spawn time via replace_runner_id. WAL journaling + a 20s
-    #    busy_timeout make this cross-process write safe against the running
-    #    server, which then resolves runner_id -> owner from this row.
-    runner_id = token_bound_runner_id(_BINDING_TOKEN)
-    SqlAlchemyConversationStore(db_uri).replace_runner_id(session_id, runner_id)
+    # 1-2. Alice owns a real session with a managed runner id bound to it.
+    session_id = _seed_owned_session_with_managed_runner(base_url, db_uri)
 
     # 3. Put this process in a managed-sandbox posture: the runner holds ONLY
     #    its binding token and the server URL — no omnigent-login token, no
@@ -272,3 +374,83 @@ def test_managed_runner_callback_authenticates_end_to_end(
     # real agent bundle comes back.
     assert authed.headers.get("X-Agent-Name")
     assert authed.content[:2] == b"\x1f\x8b", "expected a gzip agent bundle body"
+
+
+def test_managed_runner_survives_mint_403_after_token_expiry(
+    accounts_server: tuple[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mint 403 after the owner JWT expires must not brick the runner (OMNI-2529).
+
+    Replays the production deadlock end-to-end over real sockets: a
+    host-launched runner bootstraps on the injected bearer, falls back to
+    managed mint when that bearer is rejected (a real mint through the Apps
+    edge stand-in), then the session outlives the minted JWT while idle. The
+    re-mint presents the expired JWT as its own proxy bearer, so the edge
+    answers 403 without reaching the server. Before the fix neither
+    ``declined`` nor ``proxy_auth_failed`` latched in that state, and every
+    subsequent callback raised ``httpx.RequestError("Databricks token refresh
+    returned no token")`` for the remaining life of the process. With the fix
+    the chain re-resolves the machine's stored login credential in the same
+    call, so the callback that hits the 403 still authenticates.
+
+    :param accounts_server: ``(base_url, db_uri)`` from the live-server fixture.
+    :param monkeypatch: Puts this process into the host-launched-runner posture
+        (injected initial bearer, delegated-mint marker, binding token) with a
+        stored login credential available for recovery.
+    :returns: None.
+    """
+    base_url, db_uri = accounts_server
+    session_id = _seed_owned_session_with_managed_runner(base_url, db_uri)
+    proxy_url, forbid_mint, shutdown_proxy = _start_apps_edge_proxy(base_url)
+    try:
+        # Host-launched posture: the runner starts with an injected bearer and
+        # the delegated-mint marker, and everything it sends goes through the
+        # Apps edge. The machine also holds a stored `omnigent login` token —
+        # the recovery credential the pre-fix code never consulted.
+        owner_cookie = mint_session_cookie(
+            _OWNER, bytes.fromhex(_COOKIE_SECRET_HEX), 8, "accounts"
+        )
+        monkeypatch.setenv("RUNNER_SERVER_URL", proxy_url)
+        monkeypatch.setenv(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, _BINDING_TOKEN)
+        monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, owner_cookie)
+        monkeypatch.setenv(RUNNER_DELEGATED_AUTH_ENV_VAR, "1")
+        monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: owner_cookie)
+
+        factory = _make_auth_token_factory()
+        assert isinstance(factory, _InitialAuthTokenFactory)
+        contents_path = f"/v1/sessions/{session_id}/agent/contents"
+
+        # The injected host bearer authenticates the first callback.
+        first = asyncio.run(
+            _get_agent_contents(proxy_url, contents_path, _RunnerDatabricksAuth(factory))
+        )
+        assert first.status_code == 200, (first.status_code, first.text)
+
+        # The host bearer is rejected -> managed mint takes over: a real mint
+        # POST through the edge to the live server, then the callback runs on
+        # the minted owner JWT.
+        factory.invalidate()
+        minted = asyncio.run(
+            _get_agent_contents(proxy_url, contents_path, _RunnerDatabricksAuth(factory))
+        )
+        assert minted.status_code == 200, (minted.status_code, minted.text)
+        mint_factory = factory._fallback_factory
+        assert isinstance(mint_factory, _ManagedMintTokenFactory)
+        assert mint_factory._cached_token, "a real owner JWT should have been minted"
+
+        # The session outlives the JWT: the cache is fully expired and the
+        # edge now 403s every re-mint (the presented bearer is dead).
+        mint_factory._cached_expires_at = time.time() - 1.0
+        forbid_mint.set()
+
+        # Pre-fix this raised httpx.RequestError — and would forever. The
+        # chain must instead latch proxy_auth_failed and hand this same
+        # callback the stored login credential.
+        recovered = asyncio.run(
+            _get_agent_contents(proxy_url, contents_path, _RunnerDatabricksAuth(factory))
+        )
+        assert recovered.status_code == 200, (recovered.status_code, recovered.text)
+        assert mint_factory.proxy_auth_failed is True
+    finally:
+        shutdown_proxy()

--- a/tests/e2e/test_managed_runner_http_auth.py
+++ b/tests/e2e/test_managed_runner_http_auth.py
@@ -45,6 +45,7 @@ import time
 from collections.abc import Callable, Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 import pytest
@@ -239,11 +240,20 @@ def _start_apps_edge_proxy(
 
         def _relay(self) -> None:
             """Forward one request upstream, or 403 a forbidden mint."""
+            # Constrain the request target to the API paths this test drives:
+            # an absolute-form target (scheme/netloc) would override the
+            # forward client's fixed base_url, so only origin-form ``/v1/...``
+            # targets are relayed; everything else is refused.
+            parts = urlsplit(self.path)
+            if parts.scheme or parts.netloc or not parts.path.startswith("/v1/"):
+                self.send_error(404)
+                return
+            target = urlunsplit(("", "", parts.path, parts.query, ""))
             if (
                 forbid_mint.is_set()
                 and self.command == "POST"
-                and self.path.startswith("/v1/runners/")
-                and self.path.endswith("/token")
+                and parts.path.startswith("/v1/runners/")
+                and parts.path.endswith("/token")
             ):
                 body = b"Invalid Token"
                 self.send_response(403)
@@ -259,9 +269,7 @@ def _start_apps_edge_proxy(
                 for name, value in self.headers.items()
                 if name.lower() not in ("host", "content-length", "connection", "accept-encoding")
             }
-            upstream_resp = forward.request(
-                self.command, self.path, content=content, headers=headers
-            )
+            upstream_resp = forward.request(self.command, target, content=content, headers=headers)
             self.send_response(upstream_resp.status_code)
             for name in ("Content-Type", "X-Agent-Name", "Location"):
                 value = upstream_resp.headers.get(name)

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -720,6 +720,115 @@ def test_initial_host_token_re_resolves_to_sdk_when_proxy_auth_fails(
     assert token == "sdk-token"
 
 
+def test_managed_mint_403_after_prior_mint_latches_proxy_auth_failed_at_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-mint 403 latches ``proxy_auth_failed`` once the cache fully expires.
+
+    The OMNI-2529 deadlock: an idle session crosses the owner JWT's 60-minute
+    lifetime, so the re-mint presents the already-expired JWT as its own proxy
+    bearer and the Apps edge answers 403. The old 401/403 branch only latched
+    when no mint had *ever* succeeded, so this state set neither latch and
+    ``auth_flow`` raised ``httpx.RequestError`` forever. Walks the full
+    timeline: mint OK → 403 inside the refresh-skew window (cache still
+    served, no latch) → 403 after full expiry (latch).
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    calls: list[int] = []
+
+    def _mint_ok_then_403(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
+        """Mint once, then 403 every re-mint like an Apps edge on a dead bearer."""
+        calls.append(1)
+        if len(calls) == 1:
+            return ("minted-jwt", time.time() + 3600)
+        request = httpx.Request("POST", mint_url)
+        raise httpx.HTTPStatusError(
+            "Invalid Token", request=request, response=httpx.Response(403, request=request)
+        )
+
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _mint_ok_then_403)
+
+    factory = _make_managed_mint_factory(
+        "https://s.example.com", "btok", proxy_bearer="host-bearer"
+    )
+    assert factory is not None
+    assert factory() == "minted-jwt"  # served from the probe's cache
+
+    # 403 inside the refresh-skew window: the cached JWT is still valid, so it
+    # keeps being served and nothing latches (the next attempt may succeed).
+    factory._cached_expires_at = time.time() + 60.0
+    assert factory() == "minted-jwt"
+    assert factory.proxy_auth_failed is False
+    assert factory.declined is False
+
+    # 403 after full expiry: no still-valid cache remains, so the mint loop
+    # cannot renew itself — proxy_auth_failed must latch so callers re-resolve
+    # SDK/OIDC instead of failing closed on every callback.
+    factory._cached_expires_at = time.time() - 1.0
+    assert factory() is None
+    assert factory.proxy_auth_failed is True
+    assert factory.declined is False  # bare requests would be wrong here
+
+
+def test_initial_host_token_re_resolves_to_sdk_when_remint_403s_after_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-install mint 403 at full expiry re-resolves SDK/OIDC in the same call.
+
+    Extends the construction-time fallback above to the mid-session case: the
+    managed mint worked (the runner ran on minted JWTs), then the session
+    outlived the JWT and the re-mint 403s. The factory chain must hand the
+    *current* request an SDK/OIDC token rather than returning ``None`` — one
+    ``None`` here means a raised callback, and before the fix it was ``None``
+    forever.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+
+    class _SdkAuth:
+        def current_token(self) -> str:
+            return "sdk-token"
+
+    def _resolve(*args: Any, **kwargs: Any) -> tuple[_SdkAuth, str]:
+        return _SdkAuth(), "https://workspace.cloud.databricks.com"
+
+    calls: list[int] = []
+
+    def _mint_ok_then_403(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        calls.append(1)
+        if len(calls) == 1:
+            return ("minted-jwt", time.time() + 3600)
+        request = httpx.Request("POST", "https://app.databricksapps.com/v1/runners/r/token")
+        raise httpx.HTTPStatusError(
+            "403", request=request, response=httpx.Response(403, request=request)
+        )
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN", "host-bearer")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _mint_ok_then_403)
+
+    factory = _make_auth_token_factory()
+    assert isinstance(factory, _InitialAuthTokenFactory)
+    factory.invalidate()
+    assert factory() == "minted-jwt"  # managed mint installed and serving
+
+    mint_factory = factory._fallback_factory
+    assert isinstance(mint_factory, _ManagedMintTokenFactory)
+    # The session outlives the minted JWT, and the edge 403s the re-mint.
+    mint_factory._cached_expires_at = time.time() - 1.0
+
+    assert factory() == "sdk-token"
+
+
 def test_mint_managed_owner_token_posts_binding_token_and_parses_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #4332

## Summary

A managed runner whose owner JWT fully expires (any idle session crossing the 60-minute token lifetime) re-mints with that expired JWT as its own proxy bearer, and the Databricks Apps edge answers 403. The mint path's 401/403 branch only latched `proxy_auth_failed` when no mint had *ever* succeeded, so this state set neither `declined` nor `proxy_auth_failed` — and `_RunnerDatabricksAuth.auth_flow` raised `httpx.RequestError("Databricks token refresh returned no token")` on every runner→server callback (events, policy evaluation, cost/status) for the remaining life of the process. Only a restart cleared it.

**ELI5:** the runner's hourly badge renewal uses its old badge as ID. Once the old badge expires, renewal is refused — and the runner had no rule for "renewal refused *after* it had worked before", so it kept presenting nothing forever instead of falling back to the credentials sitting on the machine.

```
before:                                        after:
mint 403 at expiry                             mint 403 at expiry
  └─ cached token expired → return None          └─ no still-valid cache → latch proxy_auth_failed
     (no latch set)                                 └─ _InitialAuthTokenFactory sees the latch
       └─ auth_flow: RequestError                      in the SAME call → re-resolves SDK/OIDC
          … forever, every callback                    └─ callback authenticates and proceeds
```

- `_ManagedMintTokenFactory.__call__`: latch `proxy_auth_failed` on a mint 401/403 whenever no still-valid cached token remains, not only before the first successful mint. Inside the refresh-skew window the still-valid cache is served without latching, as before (transient edge blips stay transient).
- `_InitialAuthTokenFactory.__call__`: consult `proxy_auth_failed` **after** invoking the fallback rather than before, so the request that hits the 403 re-resolves SDK/OIDC in the same call instead of failing once (a dropped forwarder item, per #4333) and only healing on the next.

This extends the pattern #4194 established for the construction-time expired-bearer case to the mid-session case. The relay-502 masking facet of the report was already fixed by #4154.

## Test Plan

- Two unit tests in `tests/runner/test_runner_entry.py`, written red-first against the unfixed code:
  - a timeline test (mint OK → 403 within the skew window serves the cache unlatch­ed → 403 at full expiry latches `proxy_auth_failed`, `declined` stays `False`) — previously the latch stayed unset;
  - a same-call re-resolve test through `_InitialAuthTokenFactory` — previously returned `None` forever.
- New e2e test `test_managed_runner_survives_mint_403_after_token_expiry` in `tests/e2e/test_managed_runner_http_auth.py`: real `omnigent server` subprocess with accounts auth behind a reverse-proxy stand-in for the Apps edge. Replays the full journey over real sockets — injected host bearer → bearer rejected → **real mint through the edge** → forced expiry → edge 403s the re-mint. Pre-fix this died with the exact production `RequestError`; post-fix the same callback 200s on the recovered credential with `proxy_auth_failed` latched.
- Full `tests/runner/test_runner_entry.py` (94 passed) and both e2e tests pass; all 8 other test files referencing the touched symbols were run, and their 4 failures reproduce identically on a pristine `main` checkout (pre-existing/environmental).
- `pre-commit` (ruff format/check, pyrefly, repo lints) fully green.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both unit tests and the e2e test were run against the unfixed code first and fail with the exact reported symptoms, so they pin this regression specifically.

## Changelog

Sessions that outlive their 60-minute runner bearer no longer permanently lose runner→server auth when the token re-mint is rejected — the runner now falls back to the machine's SDK/OIDC credential.
