### PR TITLE
fix(harness): send harness-child logs to a file an operator can read

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -53,6 +53,7 @@ import math
 import os
 import secrets
 import shlex
+from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -76,6 +77,7 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.inner.os_env import OSEnvironment, create_os_environment
+from omnigent.process_logging import current_process_log_path, display_log_path
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +138,14 @@ if not math.isfinite(_PROMPT_TIMEOUT_SECONDS) or _PROMPT_TIMEOUT_SECONDS <= 0:
 
 # Idle timeout for the initial ACP handshake (initialize / session setup).
 _INIT_TIMEOUT_SECONDS = 30.0
+
+# Agent stderr kept for diagnostics: how many trailing lines to retain, how many
+# to quote in a turn error, and the per-line cap (a chatty CLI can emit one
+# enormous line, and the error goes in a UI toast).
+_STDERR_RING_LINES = 20
+_STDERR_QUOTED_LINES = 5
+_STDERR_LINE_LIMIT = 500
+_STDERR_QUOTED_LIMIT = 1000
 
 # ACP protocol version this executor targets (matches Goose 1.38 / Qwen).
 _PROTOCOL_VERSION = 1
@@ -289,6 +299,11 @@ class AcpExecutor(Executor):
         self._queue: asyncio.Queue[_AcpJsonObject] = asyncio.Queue()
         self._reader_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
+        # Last few agent stderr lines, attached to a startup failure. An agent
+        # that dies or stalls during the handshake usually explains why on
+        # stderr ("no API key", "unknown flag"), and that text is the whole
+        # diagnosis; without it the turn error names only the stalled RPC.
+        self._recent_stderr: deque[str] = deque(maxlen=_STDERR_RING_LINES)
         # Serializes stdin writes: run_turn (prompt / request replies) and the
         # adapter's interrupt_session() write from different tasks.
         self._write_lock = asyncio.Lock()
@@ -404,11 +419,33 @@ class AcpExecutor(Executor):
             )
             return binary, rest
 
+    def _startup_error_message(self, exc: BaseException) -> str:
+        """Describe a handshake failure, quoting the agent's own stderr.
+
+        ``str(exc)`` is empty for a bare ``TimeoutError``/``OSError``, so fall
+        back to the class name, then append what the agent printed — that text
+        ("no API key", "unknown flag") is usually the actual diagnosis. Also
+        names the log file so the full traceback is findable.
+        """
+        detail = str(exc) or type(exc).__name__
+        if self._recent_stderr:
+            tail = " | ".join(list(self._recent_stderr)[-_STDERR_QUOTED_LINES:])
+            # Cap here too, not just per line in the reader: this string ends up
+            # in a UI toast, and the ring can hold several long lines.
+            if len(tail) > _STDERR_QUOTED_LIMIT:
+                tail = tail[:_STDERR_QUOTED_LIMIT] + "...[truncated]"
+            detail = f"{detail}; {self._config.name} stderr: {tail}"
+        log_path = current_process_log_path()
+        if log_path is not None:
+            detail = f"{detail} (harness log: {display_log_path(log_path)})"
+        return detail
+
     async def _read_stderr(self) -> None:
         """Continuously drain the agent's stderr, logging each line at debug.
 
         Prevents a chatty CLI from filling the OS pipe buffer (~64 KiB) and
-        stalling the turn.
+        stalling the turn. Also retains the trailing lines so a startup failure
+        can quote what the agent said before it gave up.
         """
         assert self._proc and self._proc.stderr
         try:
@@ -418,6 +455,9 @@ class AcpExecutor(Executor):
                     break
                 line = raw_line.decode("utf-8", errors="replace").rstrip()
                 if line:
+                    if len(line) > _STDERR_LINE_LIMIT:
+                        line = line[:_STDERR_LINE_LIMIT] + "...[truncated]"
+                    self._recent_stderr.append(line)
                     logger.debug("acp[%s] stderr: %s", self._config.name, line)
         except asyncio.CancelledError:
             # Expected: close() cancels this reader task on teardown.
@@ -1057,7 +1097,7 @@ class AcpExecutor(Executor):
             await self._ensure_initialized()
             session_id = await self._ensure_session()
         except Exception as exc:  # noqa: BLE001
-            yield ExecutorError(message=str(exc), retryable=False)
+            yield ExecutorError(message=self._startup_error_message(exc), retryable=False)
             return
 
         # A fresh ACP session holds no prior context. Captured before the latch

--- a/omnigent/runtime/harnesses/_runner.py
+++ b/omnigent/runtime/harnesses/_runner.py
@@ -28,9 +28,14 @@ with four required arguments (plus one optional):
   It sends ``SIGTERM`` to this process when the parent disappears
   or the OS reparents the runner.
 
-The runner is intentionally minimal — import, factory call, state
-stash, uvicorn launch. All harness-specific behavior lives in the
-per-harness ``create_app()`` factory.
+The runner is intentionally minimal — configure logging, import,
+factory call, state stash, uvicorn launch. All harness-specific
+behavior lives in the per-harness ``create_app()`` factory.
+
+Logging is configured here rather than per harness so every harness
+child's logs land in a file an operator can read (see
+:func:`_configure_logging`); a child with no handler falls back to
+``logging.lastResort``, which drops everything below WARNING.
 
 See ``designs/SERVER_HARNESS_CONTRACT.md`` §Required harness
 package shape and §Process management.
@@ -387,6 +392,39 @@ def _create_uvicorn_config(
     sys.exit("runner: exactly one of --socket or --bind is required")
 
 
+def _configure_logging(harness: str, conversation_id: str) -> None:
+    """Point this harness child's logs at a file an operator can read.
+
+    Writes to ``OMNIGENT_PROCESS_LOG_FILE`` when the parent published one (the
+    runner's own log, so harness lines interleave with the spawn that caused
+    them), else a per-conversation file under ``logs/harness/``.
+
+    Best-effort: logging is diagnostics, so a read-only log dir must not stop a
+    harness from serving turns.
+    """
+    try:
+        from omnigent.process_logging import (
+            PROCESS_LOG_FILE_ENV_VAR,
+            configure_process_logging,
+            create_process_log_path,
+        )
+
+        # configure_process_logging picks up PROCESS_LOG_FILE itself; only when
+        # the parent published none do we allocate a per-conversation file.
+        log_path = None
+        if not os.environ.get(PROCESS_LOG_FILE_ENV_VAR):
+            log_path = create_process_log_path("harness", prefix=f"{harness}-{conversation_id}-")
+        configure_process_logging(
+            "harness",
+            log_path=log_path,
+            logger_names=("omnigent", "uvicorn"),
+        )
+    except Exception as exc:
+        # Never fatal, but never silent either: without this line a failure here
+        # looks exactly like the bug it fixes (no harness logs anywhere).
+        print(f"runner: could not configure harness logging: {exc!r}", file=sys.stderr)
+
+
 def main(argv: list[str] | None = None) -> None:
     """
     Runner entrypoint.
@@ -395,6 +433,13 @@ def main(argv: list[str] | None = None) -> None:
         the live process arguments. Tests pass an explicit list.
     """
     args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    # Attach a log handler before anything harness-specific runs. Without this
+    # the child has no handler at all, so logging falls back to lastResort:
+    # WARNING+ goes to the inherited stderr and every logger.debug/info/
+    # exception below WARNING is dropped. An agent CLI's own stderr (drained at
+    # debug) and an executor traceback then reach no file an operator can read.
+    _configure_logging(args.harness, args.conversation_id)
 
     # Initialize OTel tracing in the harness subprocess so ExecutorAdapter
     # can emit spans for agent turns, tool calls, and LLM interactions.

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -688,3 +688,68 @@ async def test_handshake_timeout_reports_a_non_blank_error(tmp_path: Path) -> No
     # Names the stalled call, not just the exception type.
     assert "session/new" in errors[0].message
     assert "Silent" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics: the agent's own stderr must reach the operator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_quotes_the_agents_stderr(tmp_path: Path) -> None:
+    """An agent that explains itself on stderr has that text in the turn error.
+
+    A stalled handshake names only the RPC that timed out. The reason usually
+    sits on the agent's stderr ("no API key"), which was drained at debug level
+    into a logger the harness child had no handler for — so it reached nobody.
+    """
+    agent_path = tmp_path / "noisy_agent.py"
+    agent_path.write_text(
+        "import sys, json, time\n"
+        "for line in sys.stdin:\n"
+        "    line = line.strip()\n"
+        "    if not line:\n"
+        "        continue\n"
+        "    msg = json.loads(line)\n"
+        "    if msg.get('method') == 'initialize':\n"
+        "        sys.stdout.write(json.dumps({'jsonrpc': '2.0', 'id': msg['id'],\n"
+        "            'result': {'protocolVersion': 1, 'agentCapabilities': {}}}) + '\\n')\n"
+        "        sys.stdout.flush()\n"
+        "    elif msg.get('method') == 'session/new':\n"
+        "        sys.stderr.write('ERROR: XAI_API_KEY not set\\n')\n"
+        "        sys.stderr.flush()\n"
+        "        time.sleep(3600)\n"
+    )
+    command = shlex.join([sys.executable, str(agent_path)])
+
+    ex = AcpExecutor(AcpAgentConfig(command=command, name="Grok"))
+    errors = []
+    with patch.object(acp_executor_module, "_INIT_TIMEOUT_SECONDS", 1.0):
+        try:
+            async for ev in ex.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                if isinstance(ev, ExecutorError):
+                    errors.append(ev)
+        finally:
+            await ex.close()
+
+    assert errors, "a stalled handshake must surface an ExecutorError"
+    assert "XAI_API_KEY not set" in errors[0].message
+
+
+def test_stderr_ring_is_bounded_and_lines_are_capped() -> None:
+    """A chatty agent can't grow the ring or put a huge line in a UI toast."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", name="A"))
+    for i in range(acp_executor_module._STDERR_RING_LINES * 3):
+        ex._recent_stderr.append(f"line{i}")
+    assert len(ex._recent_stderr) == acp_executor_module._STDERR_RING_LINES
+
+    ex._recent_stderr.clear()
+    ex._recent_stderr.append("x" * 10_000)
+    msg = ex._startup_error_message(TimeoutError())
+    assert len(msg) < 2_000, "a single huge stderr line must not dominate the error"
+
+
+def test_startup_error_names_the_exception_type_when_str_is_empty() -> None:
+    """No stderr and an empty ``str(exc)`` still yields something actionable."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", name="A"))
+    assert "TimeoutError" in ex._startup_error_message(TimeoutError())

--- a/tests/runtime/harnesses/test_runner.py
+++ b/tests/runtime/harnesses/test_runner.py
@@ -171,3 +171,77 @@ def test_create_uvicorn_config_for_tcp_bind() -> None:
 def test_create_uvicorn_config_requires_endpoint() -> None:
     with pytest.raises(SystemExit, match="exactly one of --socket or --bind"):
         _runner._create_uvicorn_config(FastAPI(), None, None)
+
+
+# ---------------------------------------------------------------------------
+# Log destination: a harness child's logs must land in a readable file
+# ---------------------------------------------------------------------------
+
+
+def test_configure_logging_writes_to_the_parents_log_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the runner published a log path, harness lines join that file.
+
+    Keeps a harness line next to the spawn that caused it, instead of in a
+    separate file an operator has to know to look for.
+    """
+    import logging
+
+    from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
+
+    parent_log = tmp_path / "runner.log"
+    monkeypatch.setenv(PROCESS_LOG_FILE_ENV_VAR, str(parent_log))
+    _reset_omnigent_log_handlers()
+
+    _runner._configure_logging("acp", "conv_abc")
+    logging.getLogger("omnigent.inner.acp_executor").warning("acp[Grok] boom")
+
+    assert "acp[Grok] boom" in parent_log.read_text()
+
+
+def test_configure_logging_falls_back_to_a_per_conversation_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no parent log path, the child still gets its own file."""
+    import logging
+
+    from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
+
+    monkeypatch.delenv(PROCESS_LOG_FILE_ENV_VAR, raising=False)
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    _reset_omnigent_log_handlers()
+
+    _runner._configure_logging("acp", "conv_xyz")
+    logging.getLogger("omnigent.inner.acp_executor").warning("acp[Grok] boom")
+
+    written = list((tmp_path / "logs" / "harness").glob("acp-conv_xyz-*.log"))
+    assert written, "expected a per-conversation harness log"
+    assert "acp[Grok] boom" in written[0].read_text()
+
+
+def test_configure_logging_survives_an_unwritable_log_dir(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Logging is diagnostics: a bad log dir must not stop a harness serving."""
+    from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
+
+    monkeypatch.delenv(PROCESS_LOG_FILE_ENV_VAR, raising=False)
+    # A file where the logs/ directory needs to be: mkdir raises underneath.
+    blocked = tmp_path / "data"
+    blocked.write_text("not a directory")
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(blocked))
+    _reset_omnigent_log_handlers()
+
+    _runner._configure_logging("acp", "conv_bad")  # must not raise
+
+
+def _reset_omnigent_log_handlers() -> None:
+    """Drop handlers a previous test attached, so each case asserts its own file."""
+    import logging
+
+    for name in ("", "omnigent", "uvicorn"):
+        logger = logging.getLogger(name)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()


### PR DESCRIPTION
## Related issue

Closes #4522

(The second half of #4281 — that issue's blank error is fixed by #4392 / #4362.
This is *why* diagnosing it needed stdio-level access to the agent instead of a
log file.)

## Summary

A harness subprocess's logs reached no file. `_runner.py` — the entrypoint every
harness boots through — never called `configure_process_logging`, so the child's
root logger had **no handler** and Python fell back to `logging.lastResort`
(level WARNING): everything below WARNING was dropped, and the survivor went to
whatever stderr it inherited rather than into the log tree.

Both ACP diagnostic paths sit below that line — the agent CLI's own stderr is
drained at `logger.debug`, and executor failures go through `logger.exception`
with no handler attached — so both vanished.

- **`_runner.main()` now configures logging before loading the harness app**, so
  this covers every harness rather than ACP alone. It reuses
  `OMNIGENT_PROCESS_LOG_FILE` when the parent published one (harness lines then
  interleave with the spawn that caused them — the child already inherits that
  var, it was just unused), else allocates
  `logs/harness/<harness>-<conversation>-<ts>.log`.
- **A failure to set up logging prints to stderr instead of raising.**
  Diagnostics must not stop a harness serving turns, but must not be silent
  either — a silent failure here is indistinguishable from the bug being fixed.
- **An ACP startup failure now quotes the agent's own stderr** plus the log path.
  The executor keeps the last 20 lines and appends the trailing few, following the
  `_recent_stderr` pattern `codex_executor` already uses. A stalled handshake
  named only the RPC that timed out; the reason is almost always what the agent
  printed.

```
before:  inner executor error: ACP agent 'Grok Build' did not answer session/new
         within 30s (command: 'grok agent stdio')

after:   inner executor error: ACP agent 'Grok Build' did not answer session/new
         within 30s (command: 'grok agent stdio'); Grok Build stderr: ERROR:
         XAI_API_KEY not set; cannot authenticate | hint: export XAI_API_KEY or
         run `grok login` (harness log: ~/.omnigent/logs/harness/acp-conv_ab12-…log)
```

Both the ring and the quoted tail are capped, so a chatty agent can't push an
enormous line into a UI toast.

<details>
<summary>ELI5 + flow</summary>

Omnigent runs each agent in a helper process. That process wrote its notes to a
logger with nowhere to write — like `print()` with stdout closed. When a turn
failed, the explanation had already been thrown away. Now the helper opens a log
file first, and an ACP failure repeats what the agent itself said.

```
before:  agent stderr ──debug──▶ logger (no handler) ──▶ ✗ dropped
         executor exc  ──ERROR──▶ logger (no handler) ──▶ ✗ dropped
                                            WARNING+ ──▶ inherited stdio (not the log tree)

after:   _runner.main() ──▶ configure_process_logging("harness")
              │                    │
              │      PROCESS_LOG_FILE set? ──yes──▶ the runner's own log
              │                    └────────no───▶ logs/harness/<h>-<conv>-<ts>.log
              ▼
         agent stderr ─┐
         executor exc  ─┴──▶ that file   +   last stderr lines quoted in the turn error
```
</details>

## Test Plan

New tests, each failing without the fix:

- `tests/runtime/harnesses/test_runner.py` — lines land in the parent's log file
  when one was published; fall back to a per-conversation file otherwise; an
  unwritable log dir does not raise.
- `tests/inner/test_acp_executor.py` — a stalled agent that printed to stderr has
  that text in the turn error; the ring is bounded and a huge line can't dominate
  the message; an empty `str(exc)` still names the exception type.

```
pytest tests/runtime/harnesses/test_runner.py tests/inner/test_acp_executor.py \
       tests/test_agent_spawn_env_canary.py          # 96 passed
```

Reverting just the two source files fails all 6 new tests (`AttributeError:
module ... has no attribute '_configure_logging'`, and the ACP error missing the
stderr text) — they pin the bug rather than describe it.

Regression sweep — 299 passed:

```
pytest tests/inner/test_acp_executor.py tests/runtime/harnesses/ \
       tests/test_agent_spawn_env_canary.py tests/inner/test_goose_executor.py
```

One failure, `test_process_manager.py::test_runner_subprocess_exits_when_spawning_parent_exits`,
reproduces identically with these changes stashed (and auto-reran twice) —
pre-existing flake, unrelated.

`ruff check` / `ruff format` clean; `pyrefly` 0 errors on both changed modules.

Manual, measured in an unconfigured child vs. a configured one:

```
# before: nothing below WARNING survives
log.debug("acp[Grok] stderr: FATAL: no API key found")   -> dropped
log.info("acp[Grok] handshake starting")                 -> dropped

# after (OMNIGENT_LOG_LEVEL=DEBUG), in logs/harness/acp-conv_x-….log:
DEBUG 08-10 17:32:18 inner.acp_executor | acp[Grok] stderr: FATAL: no API key found
ERROR 08-10 17:32:03 inner.acp_executor | acp[Grok] stdout reader error:
Traceback (most recent call last):
  ...
TimeoutError
```

Note the agent's stderr is at DEBUG, so it needs `OMNIGENT_LOG_LEVEL=DEBUG` to
reach the file; the executor traceback and the quoted stderr in the turn error
need no extra setting.

## Demo

N/A — backend/diagnostics change. The before/after operator-facing strings and
log output are quoted above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover both log destinations, the unwritable-dir degradation, and
the ACP error text including its caps. Manual verification was the measured
before/after above: driving a fake ACP agent that prints to stderr and then
stalls, confirming the text reaches both the turn error and the log file. Not
exercised: a real vendor CLI (needs live credentials), and the zygote-fork spawn
path, which already redirects child stdio to `PROCESS_LOG_FILE` and is unchanged
here.

## Changelog

Harness logs now go to a file under `~/.omnigent/logs/harness/` (or the runner's log), and a failing ACP turn quotes the agent's own error output instead of dropping it.
