### PR TITLE
feat(llms): add Novita AI as an OpenAI-compatible provider

### DIFF
--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -57,6 +57,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "openrouter": "https://openrouter.ai/api/v1",
         "ollama": "http://localhost:11434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
+        "novita": "https://api.novita.ai/openai/v1",
     }
 
     if provider in openai_compat_providers:

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -29,6 +29,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
+    "novita": "https://api.novita.ai/openai/v1",
 }
 
 _DEFAULT_PROVIDER = "openai"

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -160,6 +160,7 @@ _CATALOG_PROVIDER_FAMILY: dict[str, str] = {
     "mistral": OPENAI_FAMILY,
     "together_ai": OPENAI_FAMILY,
     "fireworks_ai": OPENAI_FAMILY,
+    "novita": OPENAI_FAMILY,
 }
 
 
@@ -194,6 +195,7 @@ _KEY_PROVIDER_ENDPOINT: dict[str, _VendorEndpoint] = {
     "mistral": _VendorEndpoint("https://api.mistral.ai/v1", CHAT_WIRE_API),
     "together_ai": _VendorEndpoint("https://api.together.xyz/v1", CHAT_WIRE_API),
     "fireworks_ai": _VendorEndpoint("https://api.fireworks.ai/inference/v1", CHAT_WIRE_API),
+    "novita": _VendorEndpoint("https://api.novita.ai/openai/v1", CHAT_WIRE_API),
 }
 
 


### PR DESCRIPTION
## Related issue

Closes #4524

## Summary

`PROVIDER_ENV_VARS["novita"]` (`NOVITA_API_KEY`) has existed since the initial commit for onboarding credential detection, but Novita was never wired into routing, the adapter registry, or the setup provider menu. This adds it alongside the other OpenAI-compatible vendors (Groq, DeepSeek, xAI, Moonshot):

- `omnigent/llms/routing.py`: `PROVIDER_CONFIGS["novita"]` so `novita/<model>` resolves through the existing `OpenAICompatibleAdapter`.
- `omnigent/llms/adapters/__init__.py`: added to `openai_compat_providers`.
- `omnigent/onboarding/configure_models.py`: added to `_CATALOG_PROVIDER_FAMILY` / `_KEY_PROVIDER_ENDPOINT` so `omnigent setup`'s "Other provider" flow offers Novita and points it at `https://api.novita.ai/openai/v1` instead of the generic OpenAI default.

## Test Plan

- `uv run pytest tests/llms/test_routing.py tests/llms/test_init_lazy_imports.py` — 28 passed.
- `uv run pytest tests/cli/` (onboarding/configure_models coverage) — passed.
- Manually verified a live call routed through `novita/<model>` against `https://api.novita.ai/openai/v1` resolves and returns a completion via the `OpenAICompatibleAdapter`.

## Demo

N/A (no UI change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new provider is a dict-entry addition following the exact pattern already exercised by existing parametrized tests in `tests/llms/test_routing.py` for the other OpenAI-compatible vendors, so no new test cases were needed. Manually verified with a live call against Novita's endpoint (see Test Plan).

## Changelog

`omnigent setup` now offers Novita AI as a provider, and `novita/<model>` is a valid model identifier
