### PR TITLE
fix(openai-agents): don't route an unpinned model to Databricks auth (#377)

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -500,7 +500,12 @@ def _get_openai_async_client(
             **retry_kwargs,
         )
 
-    allow_ambient_databricks = model is None or model.startswith("databricks-")
+    # An unpinned model is not a Databricks signal: it means "use the
+    # provider's default", which run_turn resolves from the model catalog.
+    # Treating it as Databricks-hosted sent credential-less OpenAI agents into
+    # ambient Databricks auth, surfacing an "install databricks-sdk" error at
+    # users who never configured Databricks.
+    allow_ambient_databricks = model is not None and model.startswith("databricks-")
 
     # An explicit Databricks profile is authoritative; model-service names
     # are opaque Unity Catalog identifiers such as catalog.schema.service.
@@ -552,8 +557,9 @@ def _get_openai_async_client(
     # Without an explicit profile, only legacy Databricks model names opt in
     # to ambient Databricks credentials.
     if not profile and not allow_ambient_databricks:
+        target = f"for model {model!r}" if model is not None else "and no model is pinned"
         raise ValueError(
-            f"No provider credentials were configured for model {model!r}. "
+            f"No provider credentials were configured {target}. "
             "Set OPENAI_API_KEY (and optionally OPENAI_BASE_URL), configure a "
             "Databricks profile, or use a 'databricks-' prefixed model name "
             "for legacy automatic Databricks routing."

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -1741,6 +1742,54 @@ def test_get_openai_client_model_service_without_provider_fails_loudly(monkeypat
 
     with pytest.raises(ValueError, match="No provider credentials"):
         _get_openai_async_client(model="production.agents.support_assistant")
+
+
+def test_get_openai_client_unpinned_model_does_not_route_to_databricks(monkeypatch):
+    """An unpinned model is not a Databricks signal.
+
+    Leaving the model unset means "use the provider default", not
+    "this is Databricks-hosted". Routing it to ambient Databricks auth
+    made a credential-less OpenAI agent fail with an "install
+    databricks-sdk" error instead of naming the missing OpenAI key.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="no model is pinned"):
+        _get_openai_async_client(model=None)
+
+
+def test_get_openai_client_databricks_model_still_uses_ambient_auth(monkeypatch):
+    """A ``databricks-`` model keeps the ambient Databricks fallback.
+
+    Guards the unpinned-model fix from over-reaching into the legacy
+    Databricks routing path.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    calls: list[str | None] = []
+
+    def _fake_resolve(profile=None, **kwargs):
+        calls.append(profile)
+        return httpx.BasicAuth("token", ""), "https://example.databricks.com"
+
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth", _fake_resolve
+    )
+
+    client = _get_openai_async_client(model="databricks-gpt-5-5")
+
+    assert calls == [None], "a 'databricks-' model must still resolve ambient Databricks auth"
+    assert "example.databricks.com" in str(client.base_url)
 
 
 def test_get_openai_client_invalid_profile_raises_auth_error(monkeypatch):

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1789,7 +1789,9 @@ def test_get_openai_client_databricks_model_still_uses_ambient_auth(monkeypatch)
     client = _get_openai_async_client(model="databricks-gpt-5-5")
 
     assert calls == [None], "a 'databricks-' model must still resolve ambient Databricks auth"
-    assert "example.databricks.com" in str(client.base_url)
+    assert (
+        str(client.base_url).rstrip("/") == "https://example.databricks.com/ai-gateway/openai/v1"
+    )
 
 
 def test_get_openai_client_invalid_profile_raises_auth_error(monkeypatch):


### PR DESCRIPTION
## Related issue

Closes #377

## Summary

`_get_openai_async_client` treated an **unpinned** model as Databricks-hosted:

```python
allow_ambient_databricks = model is None or model.startswith("databricks-")
```

So an `openai-agents` agent with no pinned model and no OpenAI credentials fell
through to the ambient Databricks fallback and failed with `The 'databricks-sdk'
package is required for Databricks authentication` (or `DatabricksAuthError` when
the SDK *is* installed) at users who never configured Databricks.

- An unpinned model means "use the provider's default", which `run_turn` already
  resolves from the model catalog. Gate the ambient Databricks fallback on a real
  Databricks signal instead: a `databricks-` model name or an explicit profile.
- Both Databricks paths are untouched, so real Databricks deployments resolve
  exactly as before. Only the no-signal case changes: it now raises the
  **existing** OpenAI-credentials `ValueError`, which names the real problem.
- Also rewords that error for the unpinned case, which previously read
  `for model None`.

**ELI5:** one line said "if nobody told me which model to use, assume Databricks."
That guess was wrong, so a plain GPT agent got sent to a Databricks login it never
asked for. Now only actual Databricks models go to Databricks.

```
              _get_openai_async_client(model=None), no OPENAI creds

  before                                   after
  ──────                                   ─────
  model is None                            model is None
      │                                        │
      ├─ "looks like Databricks"                ├─ no Databricks signal
      ▼                                        ▼
  ambient Databricks auth                  ValueError: No provider credentials
      ▼                                        were configured and no model is
  ImportError: 'databricks-sdk'                pinned. Set OPENAI_API_KEY ...
  is required   ← misleading                                ↑ actionable
```

Credit to @abhay-codes07, who diagnosed this root cause in #2411. That PR has
since gone stale against #3288 and gated the fallback on the *presence of
`~/.databrickscfg`*, which still misfires for anyone who has ever run
`databricks auth login`. This takes the narrower signal instead.

## Test Plan

`uv run pytest tests/inner/test_openai_agents_sdk_executor.py tests/inner/test_databricks_executor.py tests/spec/test_debby_example.py` → **135 passed**.

Two new unit tests:

- `test_get_openai_client_unpinned_model_does_not_route_to_databricks` — unpinned
  model, no creds → the OpenAI-credentials `ValueError`.
- `test_get_openai_client_databricks_model_still_uses_ambient_auth` — a
  `databricks-` model still resolves ambient Databricks auth (guards the fix from
  over-reaching).

**Verified the tests actually guard the fix**: reverting the one-line change while
keeping the tests makes `..._unpinned_model_does_not_route_to_databricks` fail
(`1 failed, 72 passed`); with the fix, `73 passed`.

**End-to-end on a clean install without the `databricks` extra** (throwaway venv +
`HOME`, no OpenAI or Databricks env), using a hand-written unpinned
`harness: openai-agents` spec:

```
# before
harness: openai-agents | model: None
ImportError: The 'databricks-sdk' package is required for Databricks authentication...

# after
harness: openai-agents | model: None
ValueError: No provider credentials were configured and no model is pinned.
Set OPENAI_API_KEY (and optionally OPENAI_BASE_URL), ...
```

Databricks paths re-checked by hand against a real `~/.databrickscfg`: explicit
`profile=` + unpinned model, and a `databricks-` model, both still route into
Databricks auth.

`ruff check` / `ruff format --check` clean.

## Demo

N/A — no UI surface; the behaviour change is the error text quoted above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts unit tests can't reach: a real install
*without* the `databricks` extra (to hit the `ImportError` arm rather than
`DatabricksAuthError`), and the two genuine Databricks routes against an actual
`~/.databrickscfg`. No secrets involved — the isolated run used an empty fake
`HOME` and no credentials, and the new tests stub `_resolve_databricks_auth`.

Scope note: production never reaches the changed branch today.
`runtime/workflow.py` always sets `HARNESS_OPENAI_AGENTS_MODEL` (spec → provider
default → catalog default), and `run_turn` resolves a catalog default when the
model is still `None`. This fixes direct-construction / hand-written unpinned
specs, and removes the footgun for future callers.

The original #377 report was Debby's `gpt` head, which was worked around in
`19c846db` by moving it to the `codex` harness (with a comment pointing at this
bug). That workaround is left in place — it works, `tests/spec/test_debby_example.py`
guards it, and flipping it back would be churn.

## Changelog

An `openai-agents` agent with no pinned model no longer fails with a confusing "install databricks-sdk" error when only OpenAI credentials are missing
