### PR TITLE
feat(server): durable session lifecycle push to manager webhook (OMN-104)

### DIFF
--- a/docs/architecture/2026-08-10-durable-session-lifecycle-push.md
+++ b/docs/architecture/2026-08-10-durable-session-lifecycle-push.md
@@ -1,0 +1,878 @@
+# OMN-104 — Durable Session Lifecycle Push to Manager Webhook
+
+Status: design-first, decision-ready. No product code in this change.
+Branch: `design/omn-104-durable-session-push`. Base: `origin/main` @ `b5adc79e8a76a41ffe4ca09799dc852dfc7ca7f5` (2026-08-10).
+Linear: [OMN-104](https://linear.app/silica-v1/issue/OMN-104/push-durable-omnigent-session-completion-and-human-decision-events-to)
+
+This document was produced with Debby's two-head debate process (Claude + GPT,
+independently grounded in the current tree, two rounds: opening positions +
+one cross-critique round). Both heads converged on almost everything; the one
+substantive disagreement that survived a full critique round is called out
+explicitly in §5 rather than papered over, with the resolution and its
+rationale.
+
+All file:line citations below were read directly from the current tree
+(`git rev-parse HEAD` == `origin/main` == `b5adc79e8a76a41ffe4ca09799dc852dfc7ca7f5`,
+verified live, not from README/comments/memory — see `source-of-truth`
+policy). **A stale-base grounding pass on this same task (HEAD `7a519e49`,
+1177 commits behind) was discarded in full** after the mismatch was caught
+and verified; nothing from that pass survives into this document. The tree
+was mid-refactor across those 1177 commits: the former monolithic
+`omnigent/server/routes/sessions.py` no longer exists — it now splits into
+`omnigent/server/routes/sessions/` (route handlers) and
+`omnigent/server/routes/_sessions/` (`common.py`, `helpers.py`,
+`orchestration.py`), and `omnigent/db/db_models.py` split conversation content
+(`ConversationBase`) from Omnigent operational state (`OmnigentBase`).
+
+---
+
+## 1. Objectives and acceptance mapping
+
+Product decision (already approved, not re-litigated here): push
+`session.completed` / `session.failed` / `session.awaiting_decision` /
+`session.resumed` to a configured manager webhook, authenticated and durable,
+with poll/reconciliation retained as the correctness backstop.
+
+| # | Acceptance requirement (from OMN-104) | Where this document satisfies it |
+|---|---|---|
+| 1 | Persist event before delivery (transactional outbox); retry until 2xx with bounded backoff | §4 (outbox schema/transaction), §7 (dispatcher/retry) |
+| 2 | HMAC-sign requests; configurable endpoint + secret | §8 |
+| 3 | At-least-once, stable event IDs, consumer dedupes | §4 (deterministic IDs), §6 |
+| 4 | Per-session ordering; delayed events cannot regress manager state | §6 |
+| 5 | Attempts/outbox status in API and logs | §9 |
+| 6 | Callback delivery never blocks or changes session terminal transitions | §5, §7 |
+| 7 | Poll/reconcile stays enabled | §11 |
+| 8 | Redact secrets and raw environment values | §3 (redaction boundary) |
+| 9 | Integration coverage: completion wake, decision payload/context, restart/network replay, duplicate delivery/stable IDs, signature/redaction security, end-to-end decision response resuming the exact session | §12 (test matrix, one row per bullet) |
+
+---
+
+## 2. Current code paths (ground truth, current tree)
+
+### 2.1 Session status — partially durable, single chokepoint
+
+- In-memory, per-replica cache: `_session_status_cache: dict[str, str] = {}`
+  — `omnigent/server/routes/_sessions/common.py:396`.
+- Every status transition funnels through one function —
+  `_publish_status()` — `omnigent/server/routes/_sessions/helpers.py:3548`.
+  Its own docstring: "every publish site funnels through here so the
+  in-memory `_session_status_cache` stays coherent with the SSE stream."
+  Four literal states only: `{"idle", "running", "waiting", "failed"}`
+  (`orchestration.py:937`). There is no first-class `completed`,
+  `awaiting_decision`, or `resumed` state anywhere in the codebase — these
+  are the SSE/UI vocabulary, not the manager-webhook vocabulary.
+- Sticky-failed guard: a trailing `idle` after `failed` is dropped rather
+  than overwriting the cache — `helpers.py:3595`. This is the codebase's
+  existing precedent for "don't fire on a quiescence blip."
+- **New since the earlier (stale) grounding pass**: `_publish_status` now
+  also durably mirrors the transition to
+  `omnigent_conversation_metadata.live_status` (SmallInteger, nullable) via
+  `omnigent/server/session_live_state.py:persist_live_status()`, called at
+  `helpers.py:~3605`. Added by migration
+  `omnigent/db/migrations/versions/d7f1a2b3c4e5_add_conversation_metadata_live_state.py`;
+  encoded via `SESSION_LIVE_STATUS = {"idle":1,"running":2,"waiting":3,"failed":4}`
+  (`omnigent/db/enum_codecs.py:71-76`). This mirror is **explicitly
+  best-effort** — `session_live_state.py`'s module docstring: "a failed
+  write logs and is dropped; live state is display state, and the next
+  transition rewrites it." It is not a durability guarantee and must not be
+  treated as one for this feature (both debate heads independently reached
+  this conclusion — see §5).
+- Failure detail (the only pre-existing durable *content*, as opposed to
+  state) is persisted via `_persist_session_status_error_labels()` into the
+  `conversation_labels` upsert table, read back as `last_task_error`.
+
+### 2.2 The load-bearing precedent: `persist_scheduled_run_completion`
+
+`omnigent/server/session_live_state.py` already implements, for a sibling
+feature (scheduled tasks), almost exactly the "derive terminal completion
+from `_publish_status`" mechanism OMN-104 needs:
+
+> "called from `_publish_status` wherever a session reaches a durable
+> terminal edge (`idle` = the turn completed, `failed` = it errored/
+> disconnected)."
+
+It writes to `SqlScheduledTaskRun` (`db_models.py:1502`, `OmnigentBase`,
+columns `status`/`error`/`error_code`/`fired_at`/`finished_at`), is
+idempotent via a conditional `UPDATE ... WHERE status = 'running'`, and its
+durability backstop is a **separate, deliberately lazy-on-read reconciler**:
+`omnigent/server/scheduled/run_reconciler.py` force-fails any run still
+`running` past `STALE_RUN_MAX_AGE_SECONDS` (6h), checked only when a user
+reads the scheduled-tasks list/detail endpoints. Its docstring is explicit
+that this was a deliberate choice against both a startup sweep and a
+periodic poll, because "the event hook handles every normal run, and
+lazy-on-read reconciles anything a user actually views" — i.e., correct only
+because an orphaned scheduled-run status is harmless until someone looks.
+This precedent's own justification is also its own scope limit (§5, §7).
+
+### 2.3 Elicitation / decision state — still fully in-memory for content
+
+- `omnigent/server/_elicitation_registry.py:15`:
+  `_harness_elicitation_registry: dict[str, asyncio.Future[ElicitationResult]]`
+  — dies with the process. Populated at
+  `omnigent/server/routes/_sessions/orchestration.py:416`
+  (`_harness_elicitation_registry[elicitation_id] = future`).
+- `omnigent/runtime/pending_elicitations.py` is a second in-memory index,
+  populated through the single SSE publish chokepoint —
+  `omnigent/runtime/session_stream.py:131`
+  (`pending_elicitations.record_publish(conversation_id, event)`) — on every
+  `response.elicitation_request` / `response.elicitation_resolved` event.
+  Its own docstring: "when a shared backplane is added for the registry,
+  this index should be wired through the same backplane" — the codebase
+  already names this as future, out-of-this-scope work.
+- **New since the stale pass**: the *count* of outstanding elicitations is
+  now durable and cross-replica —
+  `omnigent_conversation_metadata.pending_elicitation_count`, written by
+  `session_live_state.persist_pending_count()`. The *content* (what was
+  asked, what was decided) is not persisted anywhere. So today: "is this
+  session waiting on a human" survives a restart; "what were they asked and
+  what did they decide" does not.
+- `_harness_pre_resolved_elicitations` (`_elicitation_registry.py`) is an
+  in-process race tombstone for a narrow timing window (web verdict arrives
+  before the harness hook re-parks) — not a cross-restart mechanism.
+
+### 2.4 DB/schema conventions
+
+- `omnigent/db/db_models.py` declares two separate declarative bases:
+  `OmnigentBase` (operational/non-conversation tables) and `ConversationBase`
+  (conversation-scoped content). `SqlConversation` (line 745) is on
+  `ConversationBase`; `SqlConversationMetadata` (line 601) — which holds
+  `live_status` and `pending_elicitation_count`, i.e. exactly the state this
+  feature extends — is on **`OmnigentBase`**, not `ConversationBase`
+  (confirmed by reading the class declaration directly; this correction
+  surfaced mid-debate, see §5). The two bases exist so they can be routed to
+  **separate physical database engines** via `conversation_storage_location`
+  (`db_models.py:174-191`) — this is load-bearing for §4's base choice.
+- Every table carries `workspace_id: BigInteger` as part of a composite
+  primary key (multi-tenant Databricks partitioning); no exceptions.
+- Enum-like columns are stable, append-only `SMALLINT` codes translated at
+  the store boundary — `omnigent/db/enum_codecs.py`. `SqlScheduledTaskRun` /
+  `SqlScheduledTask` are the closest existing shape to "an attempt/run row
+  with an outcome," both on `OmnigentBase`.
+- `omnigent/stores/conversation_store/sqlalchemy_store.py:756-757`: two
+  separate dialect-aware lock flags,
+  `self._supports_for_update` (conversation engine) and
+  `self._meta_supports_for_update` (metadata engine), both
+  `dialect.name != "sqlite"`. `.with_for_update()` is the established
+  row-lock idiom (e.g. `_lock_conversation`, used for `conversation_items`
+  position allocation). **No `SKIP LOCKED` usage exists anywhere in the
+  codebase today** — introducing it is a new pattern, justified in §7.
+  Multi-replica server deployment is explicitly real (this is *why*
+  `live_status`/`pending_elicitation_count` were added as cross-replica
+  mirrors in the first place — `session_live_state.py`'s own module
+  docstring says so).
+
+### 2.5 Other precedents reused below
+
+- Background-task lifespan pattern: `omnigent/server/app.py:933`
+  `@asynccontextmanager` lifespan; `asyncio.create_task` at `app.py:1052`
+  for `metrics_publish_task`; cancel + `await` with
+  `suppress(asyncio.CancelledError)` on shutdown (`app.py:~1124`).
+- Secrets convention: `omnigent/server/server_config.py` — secrets
+  (`DATABASE_URL`, cookie secret, OIDC client secret) come from environment
+  variables only, never the mounted YAML config file (explicit 12-factor
+  rationale in the module docstring); non-secret settings go in
+  `<data_dir>/config.yaml`.
+- Inbound-only HMAC precedent: `omnigent/server/oidc.py:105
+  hmac_digest(token, secret)` (HMAC-SHA256, used for a credential-cache
+  key); `omnigent/inner/egress/proxy.py` uses `hmac.compare_digest` for
+  constant-time header comparison. No outbound request-signing code exists
+  to extend — §8 proposes one from scratch.
+- Redaction precedent: `omnigent/runtime/telemetry.py:124
+  _REDACT_KEY_SUBSTRINGS = ("token", "secret", "password", "authorization",
+  "credential", "api_key", "apikey")` with a `_redact_payload()` helper.
+- Retry precedent: `omnigent/runtime/llm_retry.py` and
+  `omnigent/runtime/tool_retry.py` — two independent exponential-backoff
+  implementations against `omnigent.spec.types.RetryPolicy`; neither is
+  shared today, so there is no single retry module this feature is
+  obligated to extend.
+- Read-endpoint precedent for exposing attempt/status history:
+  `GET /scheduled-tasks/{scheduled_task_id}/runs`
+  (`omnigent/server/routes/scheduled_tasks.py:380`).
+- Wire-event schema precedent: `SessionStatusEvent`
+  (`omnigent/server/schemas.py:2590`).
+
+---
+
+## 3. Event schema, versioning, redaction boundary
+
+### 3.1 Envelope
+
+```json
+{
+  "event_id": "evt_<uuid5-hex>",
+  "event_version": 1,
+  "event_type": "session.completed",
+  "workspace_id": 0,
+  "session_id": "conv_...",
+  "sequence": 42,
+  "occurred_at": 1770000000,
+  "data": { "...": "event-type-specific" }
+}
+```
+
+- `event_id` — deterministic (UUIDv5 over a namespace + `workspace_id` +
+  `conversation_id` + `event_type` + `transition_key`), not a random UUID,
+  so a retried producer call is naturally idempotent at the DB PK rather
+  than needing a separate dedupe query (both heads converged on this
+  independently).
+- `event_version` — starts at `1`; a breaking payload change bumps this,
+  never silently changes `data`'s shape under the same version.
+- `sequence` — per-`(workspace_id, session_id)` monotonic integer; see §6.
+- `data` shape per `event_type`:
+  - `session.completed`: `{ "response_id": "...", "background_task_count": 0 }`
+  - `session.failed`: `{ "response_id": "...", "reason": { "code": "...", "message": "..." } }`
+    (reason is the *same* `ErrorDetail` object already passed into
+    `_publish_status` — not re-derived from the `conversation_labels`
+    write, which would be a second formatter of the same fact)
+  - `session.awaiting_decision`: `{ "elicitation_id": "...", "request": {...allowlisted...} }`
+  - `session.resumed`: `{ "elicitation_id": "...", "decision": {...allowlisted...} }`
+
+### 3.2 Redaction boundary
+
+Two distinct redaction rules, not one, because the two payload classes have
+different authorization boundaries:
+
+1. **`session.completed` / `session.failed`** — no user/environment content
+   by construction (`response_id`, an `ErrorDetail.code`/`message` pair).
+   Still run `ErrorDetail.message` through the existing
+   `_REDACT_KEY_SUBSTRINGS` key-based filter (`telemetry.py:124`) *and* a
+   value-pattern check reusing `_truncate_label`'s length clamp
+   (`helpers.py`) before insert, since a harness-originated error message
+   can echo back arbitrary tool output.
+2. **`session.awaiting_decision` / `session.resumed`** — the payload is a
+   manager-authorized *decision* context, not free telemetry, so it is NOT
+   blanket-redacted (a blanket redaction would violate the acceptance
+   requirement that the manager receive real decision payload/context).
+   Instead: an explicit **field allowlist** derived from the elicitation
+   request schema (prompt, choices, requesting tool/action name,
+   correlation IDs) is serialized into `request_payload`/`decision_payload`;
+   nothing else is copied in. Raw environment dictionaries, process
+   arguments, headers, and secrets are never eligible fields regardless of
+   key name — enforced by construction (allowlist, not denylist) rather
+   than by `_REDACT_KEY_SUBSTRINGS` alone, which is a denylist and would
+   silently pass through anything it doesn't recognize.
+
+Logs (§9) always use the denylist-style `_REDACT_KEY_SUBSTRINGS` filter,
+regardless of which rule produced the payload, and never log the payload
+body, the signature, the secret, or the target URL unredacted.
+
+---
+
+## 4. Transactional boundary, outbox schema, indexes
+
+### 4.1 Base: `OmnigentBase`, not `ConversationBase`
+
+The outbox table lives on `OmnigentBase`, matching `SqlScheduledTaskRun` and
+`SqlConversationMetadata` (§2.4). This is required, not stylistic: under a
+`conversation_storage_location` split-engine deployment, a `ConversationBase`
+table and an `OmnigentBase` table are on two different physical databases —
+writing the outbox row on `ConversationBase` while the state it reports on
+(`live_status`, elicitation registration) lives on `OmnigentBase` would
+reintroduce exactly the dual-write inconsistency the outbox pattern exists
+to prevent. The outbox insert must be transactional with the fact it is
+reporting, and that fact already lives on `OmnigentBase`.
+
+Because the outbox is on a different engine than `conversations`/
+`conversation_items` (`ConversationBase`), `_lock_conversation`
+(`sqlalchemy_store.py`) cannot be reused to allocate `sequence` — it locks
+through the *conversation* engine. Instead:
+
+```
+session_lifecycle_cursors   (OmnigentBase)
+  workspace_id   BigInteger  -- PK member
+  session_id     Uuid16      -- PK member
+  next_sequence  BigInteger  -- next value to assign
+```
+
+`sequence` is allocated by locking this cursor row
+(`.with_for_update()` where `_supports_for_update`-equivalent on the
+metadata engine, single-writer on SQLite — same dialect branch already used
+for the metadata engine, not a new locking convention) and inserting the
+outbox row, in one transaction, on the metadata engine.
+
+### 4.2 `session_lifecycle_outbox` (OmnigentBase)
+
+| Column | Type | Notes |
+|---|---|---|
+| `workspace_id` | BigInteger | PK member |
+| `id` | Uuid16 | PK member; the externally stable `event_id` |
+| `session_id` | Uuid16 | indexed; no DB FK (Rule R032, app-owned like `scheduled_task_runs.conversation_id`) |
+| `event_type` | SmallInteger | new append-only `enum_codecs` table: `{"session.completed":1,"session.failed":2,"session.awaiting_decision":3,"session.resumed":4}` |
+| `transition_key` | String(192) | stable source identity, see §5.4 |
+| `sequence` | BigInteger | from `session_lifecycle_cursors`, monotonic per `(workspace_id, session_id)` |
+| `event_version` | SmallInteger | default 1 |
+| `payload` | CompressedText | JSON per §3; redacted/allowlisted before insert |
+| `status` | SmallInteger | `{"pending":1,"leased":2,"delivered":3,"dead_letter":4,"paused":5}` + CHECK |
+| `attempt_count` | Integer | default 0 |
+| `next_attempt_at` | Integer | epoch seconds; dispatcher claim filter |
+| `lease_owner` / `lease_expires_at` | String / Integer, nullable | replica identity + stuck-claim recovery |
+| `last_attempt_at` / `delivered_at` | Integer, nullable | |
+| `last_http_status` | SmallInteger, nullable | |
+| `last_error_code` / `last_error_message` | String(64) / String(256), nullable | sanitized only, never raw body |
+| `created_at` | Integer | |
+
+Indexes / constraints:
+
+- Unique `(workspace_id, session_id, sequence)` — ordering + prevents
+  double-allocation.
+- Unique `(workspace_id, session_id, event_type, transition_key)` — the
+  idempotency key; a retried producer call that races the cursor allocation
+  resolves to the existing row instead of a duplicate.
+- Claim index `(status, next_attempt_at, workspace_id)` — the dispatcher's
+  hot query.
+- Per-session ordering/head lookup `(workspace_id, session_id, sequence,
+  status)`.
+
+### 4.3 Producer transaction shape
+
+The INSERT into `session_lifecycle_outbox` (cursor lock + sequence
+allocation + row insert) happens **synchronously, in the same transaction**
+as the fact being reported (see §5.4 for exactly which write that is per
+event type) — not backgrounded through `session_live_state.py`'s
+fire-and-forget executor. That module's own docstring states its writes are
+best-effort and self-healing on the next transition; a lifecycle event has
+no "next transition" that repairs a silently dropped one, so it needs the
+opposite durability posture. This is why the outbox write is a **new,
+separate module** (`omnigent/server/session_outbox.py`, parallel to but not
+merged into `session_live_state.py`) rather than added to the existing
+best-effort mirror — sharing a module invites a future edit copy-pasting the
+fire-and-forget pattern onto a call site that requires durability.
+
+Cost: the four gated transitions (§5) now pay a synchronous DB write inside
+the request/hook path that previously only wrote an in-memory dict. Every
+other `_publish_status` call (the common case — plain `running` mid-turn)
+pays nothing extra, since it doesn't match any of the four gates.
+
+---
+
+## 5. Transition → event mapping, idempotency, terminal-reason derivation
+
+### 5.1 `session.completed` / `session.failed` — bind to `_publish_status`
+
+Both debate heads converged on binding to an **edge**, not a level-read of
+`status`, to avoid over-firing on quiescence blips (the existing sticky
+`failed`→`idle` guard at `helpers.py:3595` already demonstrates why a level
+read is wrong):
+
+- `session.completed`: fires when `_publish_status` accepts a transition
+  **into** `idle` while `_session_active_response_cache.get(session_id)` is
+  not `None` (a turn was actually open) — read that value *before* the
+  existing cache `.pop()` a few lines later, and use it as `response_id` /
+  the transition key. A session that never opened a turn, or an `idle`→`idle`
+  no-op write, has no cached `response_id` and correctly emits nothing. Gate
+  additionally on `background_task_count in (None, 0)` and no `blocked_on`
+  value — both already threaded as parameters into `_publish_status`, so
+  this reuses the caller's own "is it really done" resolution
+  (`_background_task_delivery_status()`, `routes_events.py:889`) instead of
+  re-deriving it from a second, driftable source.
+- `session.failed`: fires on any transition **into** `failed` (not
+  swallowed by the sticky guard), using the `ErrorDetail` parameter already
+  passed to `_publish_status` verbatim as the `reason` (§3.1) — not
+  re-derived from `_persist_session_status_error_labels()`'s
+  `conversation_labels` write, which is a second, independent consumer of
+  the same fact and must not become a second producer of it.
+
+This is exactly the same edge `persist_scheduled_run_completion` already
+uses to flip `scheduled_task_runs.status` (§2.2) — two independent
+consumers of one authoritative signal, added at the same call site
+(`helpers.py`, immediately after the existing `persist_live_status` /
+`persist_scheduled_run_completion` calls), not two parallel definitions of
+"is the session done."
+
+### 5.2 `session.awaiting_decision` / `session.resumed` — do NOT bind to `"waiting"`
+
+Both heads independently rejected binding these to the `"waiting"` status
+literal, and this is a correction to an implicit assumption in the original
+issue framing worth flagging back to the issue: `"waiting"` is a generic
+status any `_publish_status` caller can set for reasons unrelated to a human
+decision, while an elicitation is a structurally different event
+(`response.elicitation_request`, observed through
+`session_stream.publish()` → `pending_elicitations.record_publish()`,
+`session_stream.py:131`) that can fire without an accompanying `"waiting"`
+write, and vice versa. Binding to `"waiting"` both over-fires and
+under-fires.
+
+The correct chokepoint is `pending_elicitations.record_publish()` itself:
+
+- `session.awaiting_decision` fires on **first insertion** of a given
+  `elicitation_id` (`event_type == "response.elicitation_request"`) — one
+  event per `elicitation_id`, not per session, since a session can have more
+  than one outstanding decision and each needs to be individually
+  addressable per the acceptance criterion. `record_publish()` does not
+  currently expose a first-insert-vs-republish result; add one (`added` /
+  `replaced_same_id` / `removed` / `not_found`) so the outbox hook can gate
+  on `added` without re-deriving idempotency itself. The outbox's own
+  unique `(session_id, event_type, transition_key)` constraint (§4.2) is a
+  second, storage-level safety net if that in-memory gate is ever wrong.
+- `session.resumed` fires on **successful resolution of that specific
+  elicitation_id** — not on the pending-count reaching zero. A session can
+  have multiple outstanding elicitations; resolving one may resume real
+  work even while another remains outstanding, so gating on "count reaches
+  zero" would under-report multi-prompt sessions.
+
+### 5.3 Deterministic transition keys
+
+```
+turn:{response_id}:completed
+turn:{response_id}:failed
+elicitation:{elicitation_id}:awaiting_decision
+elicitation:{elicitation_id}:resumed
+```
+
+Never synthesized from a process-local counter — always derived from an ID
+that is already stable across the relay/hook boundary that produced it.
+
+### 5.4 The one disagreement the debate did not resolve, and how it's resolved here
+
+**Both heads' opening positions were the opposite of each other on this
+point, and after one full cross-critique round they swapped — landing on
+the opposite conclusion from where each started — rather than converging.**
+That persistence, not the first-round positions, is the signal this needed
+a resolution here rather than being left open:
+
+- **Claude's final position**: build a durable `session_elicitations`
+  table (verdict + context + status), because the acceptance criterion
+  "decision response resumes the exact session" cannot be satisfied by an
+  outbox event alone — the in-memory `Future` and its owning process are
+  gone after a restart regardless of what the outbox does, so *something*
+  durable has to record that a decision was made, with a reconnect
+  reconciliation path that replays a `decided`-but-unresolved-Future row
+  into the reconnected runner.
+- **GPT's final position**: do NOT build that table in OMN-104. A SQL row
+  recording a verdict cannot revive a killed subprocess-backed harness
+  process either way (`HarnessProcessManager` is torn down in the same
+  lifespan shutdown that would precede a restart) — the table would only be
+  load-bearing for native/tmux-attached harnesses, which already have their
+  own out-of-process resume machinery
+  (`_harness_pre_resolved_elicitations`), making a general-purpose SQL
+  ledger a **second, generic mechanism that can disagree with the
+  harness-specific one that already exists** for the one case where
+  durability is actually achievable. Scope this out; make the decision
+  endpoint fail loud (409/410) for a no-longer-resolvable elicitation
+  instead.
+
+**Resolution adopted for this design: build the table, narrower than
+Claude's original shape, with GPT's harness-classified failure mode as a
+hard requirement rather than a fallback.** Reasoning:
+
+1. The acceptance criteria in §1 are an *approved product decision*, not
+   something this design gets to narrow unilaterally — "decision
+   payload/context," "restart/network replay," and "end-to-end decision
+   response resuming the exact session" are three separate bullets, and the
+   first two are unconditionally achievable with a durable table regardless
+   of harness class (the decision is recorded and survives a restart even
+   when the third bullet can't be honored for a given harness).
+2. GPT's objection is correct as a *scope* argument for full resume-across-
+   restart, not as an argument against persisting the decision at all —
+   persisting the verdict durably is what makes the loud-failure behavior
+   GPT itself proposes possible to distinguish from a silently-dropped
+   verdict (without the table, the decision endpoint has nothing to check
+   against after a restart to know whether it should 409 or accept).
+3. So: add `session_elicitations` (schema below), written transactionally
+   alongside the `session.awaiting_decision` / `session.resumed` outbox
+   rows. On the decision endpoint, **always** persist the verdict first.
+   Then attempt reconnection per harness class, with the outcome
+   *explicitly classified in both the API response and the test matrix
+   (§12)* rather than uniformly promised:
+   - Live in-memory `Future` still parked (no restart occurred): resolve it
+     immediately, same as today.
+   - Native/tmux-attached harness, `Future` gone but process alive: replay
+     the persisted decision through that harness's existing native-resume
+     path on its next reconnect/hook-registration (this is genuinely new
+     wiring, but reuses an existing per-harness mechanism rather than
+     inventing a generic one).
+   - Subprocess-backed harness, process gone: return `410 Gone` with
+     `error_code = "elicitation_not_resolvable"` — the verdict is durably
+     recorded (audit trail, and idempotent if the manager retries), but the
+     endpoint does not claim the session resumed, because it structurally
+     did not.
+
+This makes the acceptance test for "restart before verdict" an explicitly
+harness-classified test (§12), rather than either quietly failing to build
+what was approved (GPT's original scope-narrowing) or promising a resume
+guarantee the subprocess harness class cannot honor (Claude's original
+general reconnect-reconciliation framing, before its own second pass
+narrowed the same way).
+
+```
+session_elicitations   (OmnigentBase — same base as session_lifecycle_outbox)
+  workspace_id       BigInteger        -- PK member
+  id                 Uuid16            -- PK member; == elicitation_id
+  session_id         Uuid16            -- indexed, no DB FK (Rule R032)
+  status             SmallInteger      -- pending=1, decided=2, delivered_to_runner=3, expired=4 (new enum_codecs entry)
+  request_payload    CompressedText    -- allowlisted per §3.2, written at registration
+  decision_payload   CompressedText NULL
+  decided_by         String(128) NULL  -- manager identity from the signed callback; NULL for web-UI verdicts
+  created_at         Integer
+  decided_at         Integer NULL
+  resolved_at        Integer NULL      -- when a live/reconnected runner actually consumed the decision
+```
+
+Write path: the row is created (`status=pending`) at the same call site that
+populates `_harness_elicitation_registry`
+(`orchestration.py:416`) — before `_publish_status("waiting", ...)`, in the
+same transaction as the `session.awaiting_decision` outbox insert. The
+decision endpoint (extending the existing verdict-PATCH path) writes
+`decision_payload` / `decided_at` / `status=decided` **before** attempting
+to resolve any in-memory Future, and inserts the `session.resumed` outbox
+row only once the decision is durably recorded — matching §5.1's rule that
+`_publish_status`/outbox producers never depend on delivery succeeding.
+
+---
+
+## 6. Per-session ordering and non-regression
+
+- `sequence` (§4.1/4.2) is allocated under the `session_lifecycle_cursors`
+  lock in the same transaction as the event insert — monotonic per
+  `(workspace_id, session_id)`, gap-free with respect to committed rows
+  (a rolled-back producer transaction never consumes a sequence number that
+  reaches the outbox).
+- The dispatcher (§7) delivers **only the lowest non-delivered `sequence`
+  for a given session** at a time — never issues session event N+1's HTTP
+  call before N has reached a terminal delivery state (`delivered` or
+  `dead_letter`, which still counts as "resolved for ordering purposes,"
+  see §7). This is what prevents a slow/retrying early event from being
+  overtaken by a fast later one at the dispatch layer.
+- Ordering at the dispatch layer is necessary but not sufficient — network
+  retries can still reorder in flight. The wire payload therefore always
+  carries `sequence`, and the **documented consumer contract** (enforced by
+  the manager, not by Omnigent) is: discard any incoming event whose
+  `sequence` is ≤ the highest already applied for that `session_id`. This
+  is the actual mechanism that satisfies "delayed events cannot regress
+  manager state" — dispatch-side ordering reduces how often this path is
+  exercised, it doesn't replace the need for it.
+
+---
+
+## 7. Dispatcher: ownership, concurrency, retry/backoff, dead-letter, shutdown
+
+### 7.1 Ownership and lifecycle
+
+Runs as a single `asyncio.create_task` inside the existing FastAPI lifespan
+(`app.py:933`), the same pattern as `metrics_publish_task` (`app.py:1052`):
+started after startup, `.cancel()` + `await` under
+`suppress(asyncio.CancelledError)` on shutdown (`app.py:~1124`). One task
+per server replica — safe under multi-replica because claiming is
+row-leased (below), not because only one replica runs it.
+
+### 7.2 Claim query: `SKIP LOCKED`, a new pattern, justified
+
+`session_live_state.py`'s own rationale for existing at all is multi-replica
+contention ("a request can land on any replica"). Under N dispatcher
+replicas polling the same table, plain `FOR UPDATE` serializes claims —
+replica B blocks behind replica A's lock instead of claiming a different
+row, defeating the purpose of running N replicas. `FOR UPDATE SKIP LOCKED`
+(PostgreSQL 9.5+) is the standard fix for exactly this worker-pool claim
+shape, and is introduced here as a narrow, dispatcher-scoped exception to
+the codebase's existing plain-`FOR UPDATE` convention — not a replacement
+for it elsewhere. On SQLite (`_meta_supports_for_update`-equivalent false),
+single-writer serialization is already free, so a plain
+`WHERE status='pending' AND next_attempt_at <= now() LIMIT N` under
+`BEGIN IMMEDIATE` is sufficient; no third locking convention is introduced.
+
+Claim → lease (`lease_owner`, `lease_expires_at`) → commit → deliver
+**outside** the transaction (never hold a DB lock across the outbound HTTP
+call) → on 2xx, mark `delivered`; on failure, compute next backoff and
+release the lease.
+
+### 7.3 Backoff schedule
+
+Fresh, small implementation (not a refactor of `llm_retry.py` or
+`tool_retry.py` — both are already independent per-subsystem
+implementations, so there is no single retry module this feature is
+obligated to converge with; forcing a merge now would couple two unrelated
+subsystems' retry semantics for no shared benefit). Exponential with full
+jitter, capped:
+
+```
+delay = min(cap, base * 2^attempt) * random(0.5, 1.0)
+base = 5s, cap = 15min, unbounded attempt count
+```
+
+### 7.4 Dead-letter: escalation, not abandonment
+
+Both heads independently rejected copying `run_reconciler.py`'s lazy-on-read
+model for this specific piece, for a reason worth stating precisely because
+it's a deliberate divergence from an existing precedent, not a default:
+`run_reconciler.py`'s own docstring justification is that reconciliation
+happens "the moment [an orphan] would otherwise be shown" — the *read path
+is itself the trigger*. A dead-lettered manager webhook has no equivalent
+read-path trigger: the manager specifically asked for push so it would not
+have to poll, so hanging recovery off "a user happens to view a session"
+would turn a transient network outage into an indefinite deadlock for a
+manager that is, by construction, not the one looking.
+
+So: after a configurable attempt/age threshold, mark the row `dead_letter`
+— **for API/log visibility and alerting only**. It keeps retrying at the
+capped floor interval (§7.3's `cap`), never stops automatically. This
+follows directly from the approved contract ("retry until 2xx") and from
+ordering (§6): a permanently abandoned head event would either violate the
+"retry until 2xx" contract outright, or silently block every later event
+for that session forever, whichever way it's read. An operator can pause a
+specific outbox row or the manager-webhook target entirely (§8 config); there
+is no automatic discard.
+
+A short periodic sweep (same lifespan-task pattern, not a separate
+mechanism) reclaims rows whose lease expired without the claiming replica
+completing delivery (crash mid-claim) — `WHERE status='leased' AND
+lease_expires_at < now()`. This is the one place a sweep is added where
+`run_reconciler.py` uses none, and the justification is the same asymmetry:
+`run_reconciler.py` has a user-facing read endpoint to lazily piggyback on;
+the dispatcher does not, so orphaned leases need their own reclaim path
+rather than waiting on a read that may never come.
+
+### 7.5 Never blocks terminal transitions
+
+The outbox INSERT (§4.3) is synchronous with the producing transaction, but
+the **HTTP delivery** is fully decoupled — the dispatcher is a separate
+task, so a slow or unreachable manager endpoint never delays
+`_publish_status`, the SSE stream, or any session terminal-state write. This
+satisfies the "callback delivery never blocks or changes session terminal
+transitions" requirement by construction: the delivery loop has no code
+path that can write back into `_session_status_cache`,
+`omnigent_conversation_metadata`, or any conversation table.
+
+---
+
+## 8. Endpoint/secret configuration, HMAC scheme
+
+### 8.1 Configuration
+
+Following the existing split (`server_config.py`): non-secret settings in
+`<data_dir>/config.yaml` under a new `manager_webhook` block
+(`enabled`, `endpoint`, `key_id`); the secret itself is env-var only,
+`OMNIGENT_MANAGER_WEBHOOK_SECRET` (and an optional
+`OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS` for rotation — verify against
+both during a rotation window, sign only with the current one). Require
+HTTPS for the endpoint; reject `http://` at config-load time except for an
+explicit local-dev override, mirroring how other security-relevant settings
+in this codebase fail closed on misconfiguration rather than warn-and-continue.
+
+### 8.2 HMAC canonicalization
+
+No outbound-signing precedent exists in this codebase to extend (§2.5), so
+this is a fresh design, following the widely-deployed webhook convention
+(Stripe-style: sign the raw transmitted body plus a timestamp, verify
+before JSON parsing) rather than inventing a bespoke scheme:
+
+```
+signed_content = f"{timestamp}.{event_id}.{raw_json_body}"
+signature = hex(HMAC_SHA256(secret, signed_content))
+```
+
+Headers:
+
+```
+Content-Type: application/json
+X-Omnigent-Event-Id: <event_id>
+X-Omnigent-Event-Type: <event_type>
+X-Omnigent-Delivery-Attempt: <1-based attempt count>
+X-Omnigent-Timestamp: <unix seconds>
+X-Omnigent-Key-Id: <key_id>              # supports secret rotation without a payload change
+X-Omnigent-Signature: v1=<hex hmac>
+```
+
+Replay defense: the receiver is expected to reject a request whose
+`X-Omnigent-Timestamp` is more than a configured tolerance (recommend 5
+minutes) away from its own clock, in addition to verifying the signature —
+documented in the manager-integration contract, enforced by the consumer,
+not by Omnigent (Omnigent cannot force a third party's verification
+behavior; it can only make it correct and simple to implement, matching how
+`X-Omnigent-Timestamp` closes the same class of replay window Stripe's own
+scheme does).
+
+---
+
+## 9. API and log observability
+
+- `GET /v1/sessions/{session_id}/manager-webhook-deliveries` (new,
+  authorized like other session sub-resources) — `event_id`, `event_type`,
+  `sequence`, `status`, `attempt_count`, `last_attempt_at`,
+  `last_http_status`, `last_error_code`/`last_error_message` (already
+  sanitized at write time, §3.2). Modeled directly on the existing
+  `GET /scheduled-tasks/{id}/runs` shape (`scheduled_tasks.py:380`).
+- Session snapshot gains a `latest_manager_delivery` summary field
+  (status + last attempt) so the sidebar/detail view doesn't need a second
+  round-trip for the common case.
+- Logs: one structured line per delivery attempt — `event_id`,
+  `workspace_id`, `session_id`, `sequence`, `attempt_count`, `event_type`,
+  outcome, latency, `last_http_status`, sanitized `error_code`. Never the
+  payload body, the signature, the secret, the raw endpoint URL (log only
+  its host, matching how other outbound-URL logging in this codebase avoids
+  leaking full query strings), or any `Authorization`-class header value —
+  reuses `_REDACT_KEY_SUBSTRINGS` (`telemetry.py:124`) as the log-line
+  filter, distinct from and stricter than the payload allowlist in §3.2.
+
+---
+
+## 10. Callback / decision-response flow
+
+Covered in full in §5.4; summarized here as a flow:
+
+1. Elicitation raised → `session_elicitations` row (`pending`) +
+   `session.awaiting_decision` outbox row, one transaction, at
+   `orchestration.py:416`'s call site.
+2. Manager receives the webhook (retried until 2xx per §7), extracts
+   `elicitation_id` + `session_id` + allowlisted `request_payload` from
+   `data`.
+3. Manager calls the (existing, extended) decision endpoint with its
+   verdict.
+4. Endpoint persists `decision_payload`/`decided_at`/`status=decided`
+   first, unconditionally.
+5. Endpoint attempts resolution per harness class (§5.4): live Future →
+   immediate; native/tmux → queued for next reconnect; subprocess with dead
+   process → `410` with `elicitation_not_resolvable`, verdict still
+   recorded.
+6. On successful resolution (immediate or reconnect-replayed), insert
+   `session.resumed` outbox row, `resolved_at` stamped.
+
+---
+
+## 11. Rollout, migration, backward compatibility, reconciliation
+
+- Purely additive: two new tables (`session_lifecycle_outbox`,
+  `session_lifecycle_cursors`) plus one extended table
+  (`session_elicitations`), one new `enum_codecs` entry, one new config
+  block, zero changes to any existing table's shape. No existing endpoint's
+  response shape changes.
+- `manager_webhook.enabled = false` by default; the dispatcher task itself
+  starts but immediately no-ops (claims nothing) if disabled, rather than
+  being conditionally constructed, so enabling it live via config reload
+  needs no server restart.
+- **Poll/reconcile stays enabled unconditionally, independent of this
+  feature's health** — the acceptance requirement is explicit that push is
+  additive to polling, never a replacement. Nothing in this design gates
+  any existing reconciliation path on the outbox's state; a manager that
+  never configures a webhook, or whose webhook is entirely broken, sees
+  identical session-state correctness to today via polling — it only loses
+  the low-latency wake-up.
+- Migration is a single new-tables-only Alembic revision (matching
+  `d7f1a2b3c4e5`'s shape) — no backfill needed, since the outbox has no
+  history to reconstruct (events start accruing from the migration forward;
+  a manager onboarding onto an existing deployment relies on poll/reconcile
+  for pre-existing session state, exactly as today).
+
+---
+
+## 12. Test matrix (one row per acceptance bullet)
+
+| Acceptance bullet | Test |
+|---|---|
+| Completion wake | Turn reaches `idle` from an open `response_id` with `background_task_count in (None, 0)` → exactly one `session.completed` row, delivered; a mid-turn quiescence blip (background task still running) → zero rows |
+| Decision payload/context | `session.awaiting_decision` payload round-trips the allowlisted request fields; a field outside the allowlist (e.g. raw env dict on the harness side) is asserted absent from the payload |
+| Restart/network replay | Kill dispatcher mid-delivery (lease held, no ack) → row remains `leased` until `lease_expires_at`, then is reclaimed and re-delivered with the same `event_id`/`sequence`; server process restart between outbox insert and first delivery attempt → row survives (durable), dispatcher picks it up on the next claim cycle |
+| Duplicate delivery / stable IDs | Manager 2xxs but the ack is lost (simulated) → dispatcher retries, receiver-side dedupe on `event_id` proven via a test double manager that idempotency-checks |
+| Signature/redaction security | Tampered body/timestamp fails verification; timestamp outside tolerance is rejected by the reference-verification test even with a valid signature; log lines for a delivery attempt assert absence of payload body, secret, signature, full URL |
+| End-to-end decision response resuming the exact session, **classified by harness** | (a) live Future, no restart: verdict resolves immediately, `session.resumed` fires. (b) native/tmux harness, restart before verdict: verdict persists, replays on reconnect, `session.resumed` fires once resolved. (c) subprocess harness, restart before verdict, process gone: decision endpoint returns `410 elicitation_not_resolvable`; verdict is still durably recorded (assert via direct row read, not via the HTTP response); poll/reconcile subsequently reflects the session's real post-restart state |
+| Ordering / non-regression | Two events for one session enqueued out of delivery order (simulated retry timing) → manager-side stable-ID + sequence dedupe test proves a lower `sequence` arriving after a higher one is a documented no-op for the consumer; dispatcher never issues session event N+1 before N reaches a terminal delivery state |
+| Callback never blocks terminal transitions | Manager endpoint made to hang/timeout; assert `_publish_status`, the SSE stream, and `conversation_labels`/`live_status` writes complete with unchanged latency |
+| Poll/reconcile stays enabled | With `manager_webhook.enabled=false` and with the manager endpoint permanently down, existing reconciliation-dependent behavior (session-state correctness) is unaffected |
+| Dead-letter is escalation not abandonment | Force an event past the dead-letter threshold; assert it still appears in the next claim cycle at the capped floor interval, and that it is visible via the new API/log fields |
+
+---
+
+## 13. Implementation slices, likely files
+
+1. **Schema**: new Alembic revision — `session_lifecycle_outbox`,
+   `session_lifecycle_cursors`, `session_elicitations` (extends the
+   existing in-memory-only elicitation concept with a durable row);
+   `omnigent/db/enum_codecs.py` new entries for `event_type` and the two
+   new `status` enums. Store methods in
+   `omnigent/stores/conversation_store/sqlalchemy_store.py` (or a new
+   sibling store, given these are `OmnigentBase` not conversation content —
+   worth a short implementation-time decision, not a design blocker).
+2. **Producer hooks**: `omnigent/server/session_outbox.py` (new module,
+   parallel to `session_live_state.py`); call sites added in
+   `omnigent/server/routes/_sessions/helpers.py` (`_publish_status`, near
+   the existing `persist_live_status`/`persist_scheduled_run_completion`
+   calls) and `omnigent/runtime/pending_elicitations.py`
+   (`record_publish`'s first-insert/resolve edges) and
+   `omnigent/server/routes/_sessions/orchestration.py:416`'s elicitation
+   registration call site.
+3. **Dispatcher**: new module (e.g.
+   `omnigent/server/manager_webhook_dispatcher.py`), wired into
+   `omnigent/server/app.py`'s lifespan (`app.py:933`/`1052`) alongside
+   `metrics_publish_task`.
+4. **HMAC/config**: `omnigent/server/server_config.py` (new
+   `manager_webhook` block), a small signing helper module (no existing
+   module to extend per §2.5/§8.2).
+5. **Decision endpoint extension**: the existing verdict-PATCH path that
+   resolves `_harness_elicitation_registry`
+   (`omnigent/server/routes/_sessions/orchestration.py` area) — add the
+   durable-persist-first step and the harness-classified resolution
+   outcome (§5.4).
+6. **API**: `GET /v1/sessions/{id}/manager-webhook-deliveries`, modeled on
+   `omnigent/server/routes/scheduled_tasks.py:380`.
+7. **Redaction**: extend/reuse `omnigent/runtime/telemetry.py`'s
+   `_REDACT_KEY_SUBSTRINGS` for the log-line path; new explicit allowlist
+   constant for the elicitation payload path (§3.2) — these are
+   deliberately two different mechanisms, not one generalized redactor.
+
+---
+
+## 14. Rejected alternatives and non-goals
+
+- **Deriving `session.completed`/`.failed` from `_session_status_cache`
+  reads or from `live_status` polling** — rejected; both are documented
+  best-effort display projections (§2.1), not an event log, and reading
+  them would mean a dropped best-effort write silently also drops the
+  manager-facing event with no retry path. The outbox must be written from
+  the same authoritative edge, not from either mirror.
+- **Merging the outbox write into `session_live_state.py`** — rejected
+  (§4.3); opposite durability postures (best-effort vs. must-persist)
+  belong in visibly separate modules, not one module with an internal fork
+  a future editor can miss.
+- **Binding `awaiting_decision`/`resumed` to the `"waiting"` status
+  literal** — rejected (§5.2); demonstrably both over-fires and
+  under-fires relative to the actual elicitation events.
+- **Reusing `_lock_conversation` for outbox sequence allocation** —
+  rejected (§4.1); it locks through the conversation engine, which is not
+  guaranteed to be the same physical database as the `OmnigentBase` outbox
+  table under a split-engine deployment.
+- **Copying `run_reconciler.py`'s pure lazy-on-read backstop for
+  dead-lettered events** — rejected (§7.4); that precedent's own
+  justification (the read path is the reconciliation trigger) doesn't hold
+  for a manager that is, by definition, not the one reading.
+- **A general-purpose durable elicitation/decision table that promises
+  cross-restart resume for every harness class uniformly** — rejected in
+  favor of the harness-classified version (§5.4); the uniform promise is
+  not honorable for subprocess-backed harnesses regardless of what SQL
+  schema backs it, and claiming otherwise in the API/tests would be
+  advertising a guarantee that silently fails for a whole harness class.
+- **Plain `FOR UPDATE` for the dispatcher's claim query** — rejected
+  (§7.2) as the default because it serializes claims across replicas,
+  defeating multi-replica dispatch; kept only as the SQLite fallback where
+  `SKIP LOCKED` isn't available and single-writer serialization is already
+  the existing behavior.
+- **True dead-letter abandonment (stop retrying entirely)** — rejected
+  (§7.4); violates "retry until 2xx" and would permanently block
+  per-session ordering for every event after the stuck one.
+- **Non-goal**: building the "shared backplane" for
+  `pending_elicitations`/`_harness_elicitation_registry` that their own
+  docstrings already name as future work. OMN-104 adds a durable
+  *elicitation ledger* narrowly scoped to what the manager-webhook contract
+  requires (§5.4); it does not generalize the in-memory registries
+  themselves into a cross-replica system.
+- **Non-goal**: reviving a subprocess-backed harness's killed process
+  across a restart. Out of reach for any design that doesn't also change
+  process supervision/lifecycle, which is out of scope for this ticket.
+
+---
+
+## Handoff (for a separate Polly implementation session)
+
+- Start from §13's slice list; slice 1 (schema) and slice 4 (HMAC/config)
+  have no dependency on each other and can run in parallel; slices 2, 3, 5
+  depend on slice 1's tables existing.
+- The one place this design makes a judgment call beyond what the debate
+  fully resolved is §5.4's harness-classification of decision-resume — flag
+  this back to the issue/product owner for explicit sign-off before
+  implementation starts, since it changes what "end-to-end decision
+  response resuming the exact session" means for a subprocess-backed
+  harness (durable record + loud 410, not a resume guarantee).
+- `record_publish()`'s first-insert-vs-republish return value (§5.2) is a
+  small, self-contained change to `omnigent/runtime/pending_elicitations.py`
+  worth landing and testing independently before the outbox hook that
+  depends on it.
+- No product code was written or modified in this session; this document
+  and its commit are the entire deliverable.

--- a/docs/architecture/2026-08-10-durable-session-lifecycle-push.md
+++ b/docs/architecture/2026-08-10-durable-session-lifecycle-push.md
@@ -6,10 +6,17 @@ Linear: [OMN-104](https://linear.app/silica-v1/issue/OMN-104/push-durable-omnige
 
 This document was produced with Debby's two-head debate process (Claude + GPT,
 independently grounded in the current tree, two rounds: opening positions +
-one cross-critique round). Both heads converged on almost everything; the one
-substantive disagreement that survived a full critique round is called out
-explicitly in §5 rather than papered over, with the resolution and its
-rationale.
+one cross-critique round). Both heads' opening positions disagreed sharply on
+whether a durable elicitation table was needed (§5.4) — and, after critique,
+fully converged on building it, with a sharper mechanistic justification
+(two separate in-memory registries, server- and runner-side) than either
+heads' opening answer had. The critique round also caught and corrected a
+real design error (§5.1's now-removed `background_task_count` gate) and an
+incorrect base-class attribution in the original grounding brief (§2.4).
+That process — not just the final answer — is why this went through a full
+debate rather than a single pass: both corrections were caught by one head
+re-verifying a citation against the live tree rather than trusting the other
+head's or the brief's claim at face value.
 
 All file:line citations below were read directly from the current tree
 (`git rev-parse HEAD` == `origin/main` == `b5adc79e8a76a41ffe4ca09799dc852dfc7ca7f5`,
@@ -219,7 +226,9 @@ This precedent's own justification is also its own scope limit (§5, §7).
   never silently changes `data`'s shape under the same version.
 - `sequence` — per-`(workspace_id, session_id)` monotonic integer; see §6.
 - `data` shape per `event_type`:
-  - `session.completed`: `{ "response_id": "...", "background_task_count": 0 }`
+  - `session.completed`: `{ "response_id": "..." }` (informational
+    `background_task_count` may be included from the same `_publish_status`
+    call if non-null, but it is never a gating condition — see §5.1)
   - `session.failed`: `{ "response_id": "...", "reason": { "code": "...", "message": "..." } }`
     (reason is the *same* `ErrorDetail` object already passed into
     `_publish_status` — not re-derived from the `conversation_labels`
@@ -343,6 +352,27 @@ the request/hook path that previously only wrote an in-memory dict. Every
 other `_publish_status` call (the common case — plain `running` mid-turn)
 pays nothing extra, since it doesn't match any of the four gates.
 
+What happens if that synchronous write fails is call-site-dependent, not
+uniform, verified against the two shapes `_publish_status` is actually
+called from:
+
+- **Call sites that originate from a POST handler with existing ack
+  semantics** — e.g. `routes_events.py`'s relay/hook endpoints (which
+  already return a small acknowledgement body per their own
+  `response_model=None` handler comments, around `routes_events.py:239`) —
+  withhold the 200 and return a retryable non-2xx on an outbox-write
+  failure, requiring the runner/relay to replay its stable event. This
+  reuses ack semantics that already exist at those call sites rather than
+  inventing a new protocol, conditional on the calling runner's HTTP client
+  actually retrying on a non-2xx (verify/add this at implementation time).
+- **Internal call sites with no network round trip of their own**
+  (disconnect handling, snapshot reconstruction, native-forwarder code in
+  `orchestration.py`/`helpers.py`) — let the write's exception propagate
+  uncaught into whatever request *did* originate that call chain, and let
+  that outer request's own existing failure/retry semantics handle it. No
+  new protocol needed here; this is the plain "synchronous,
+  error-propagating" behavior, correctly scoped to where it's sufficient.
+
 ---
 
 ## 5. Transition → event mapping, idempotency, terminal-reason derivation
@@ -359,12 +389,23 @@ read is wrong):
   not `None` (a turn was actually open) — read that value *before* the
   existing cache `.pop()` a few lines later, and use it as `response_id` /
   the transition key. A session that never opened a turn, or an `idle`→`idle`
-  no-op write, has no cached `response_id` and correctly emits nothing. Gate
-  additionally on `background_task_count in (None, 0)` and no `blocked_on`
-  value — both already threaded as parameters into `_publish_status`, so
-  this reuses the caller's own "is it really done" resolution
-  (`_background_task_delivery_status()`, `routes_events.py:889`) instead of
-  re-deriving it from a second, driftable source.
+  no-op write, has no cached `response_id` and correctly emits nothing.
+  **No secondary gate on `background_task_count`/`blocked_on`.** An earlier
+  draft of this design proposed additionally gating on
+  `background_task_count in (None, 0)`, reasoning that a lingering
+  background shell means the turn isn't "really" done. That gate is wrong,
+  verified against `_background_task_delivery_status()`
+  (`helpers.py:3164-3199`): its own docstring states it deliberately
+  collapses a claude-native `waiting` back to `idle` *specifically because*
+  "the turn itself is over... deliver idle and let the count speak for the
+  shells." `_publish_status` is called with `idle` only once that
+  resolution has already happened upstream — gating on the count again
+  inside the outbox hook would silently swallow `session.completed` for
+  every claude-native session that ends its turn with a dev-server/watcher
+  still running, which is the common case, not an edge case. Trust the
+  status string `_publish_status` was called with; do not re-derive
+  "is it really done" a second time from the same parameters a caller
+  already resolved it from.
 - `session.failed`: fires on any transition **into** `failed` (not
   swallowed by the sticky guard), using the `ErrorDetail` parameter already
   passed to `_publish_status` verbatim as the `reason` (§3.1) — not
@@ -471,21 +512,51 @@ hard requirement rather than a fallback.** Reasoning:
 3. So: add `session_elicitations` (schema below), written transactionally
    alongside the `session.awaiting_decision` / `session.resumed` outbox
    rows. On the decision endpoint, **always** persist the verdict first.
-   Then attempt reconnection per harness class, with the outcome
-   *explicitly classified in both the API response and the test matrix
-   (§12)* rather than uniformly promised:
-   - Live in-memory `Future` still parked (no restart occurred): resolve it
+   Then attempt reconnection, with the outcome *explicitly classified in
+   both the API response and the test matrix (§12)* rather than uniformly
+   promised.
+
+   **The precise classification axis, sharpened during the debate's second
+   round, is not "harness type" but "which process died."** There are two
+   separate in-memory elicitation registries, not one, verified against the
+   current tree: the **server-side** registry
+   (`_harness_elicitation_registry: dict[str, asyncio.Future[ElicitationResult]]`,
+   `_elicitation_registry.py:15`) and a **runner-side** registry
+   (`_pending: dict[str, asyncio.Future[bool]]`,
+   `omnigent/runner/pending_approvals.py:48`), resolved when the server
+   POSTs an approval event to `/v1/sessions/{id}/events`. That split maps
+   directly onto three distinct restart scenarios:
+   - **No restart**: the server-side `Future` is still parked — resolve it
      immediately, same as today.
-   - Native/tmux-attached harness, `Future` gone but process alive: replay
-     the persisted decision through that harness's existing native-resume
-     path on its next reconnect/hook-registration (this is genuinely new
-     wiring, but reuses an existing per-harness mechanism rather than
-     inventing a generic one).
-   - Subprocess-backed harness, process gone: return `410 Gone` with
-     `error_code = "elicitation_not_resolvable"` — the verdict is durably
-     recorded (audit trail, and idempotent if the manager retries), but the
-     endpoint does not claim the session resumed, because it structurally
-     did not.
+   - **Server restarts, runner/host process stays alive** (a routine
+     rolling redeploy under the confirmed multi-replica topology — the
+     dominant real-world restart case). The runner-side `Future` in
+     `pending_approvals.py` is still alive and parked; only the *delivery*
+     to it was lost when the server-side registry that would have sent it
+     restarted. A durable `session_elicitations` row plus "on tunnel
+     reconnect, re-POST any decided-but-undelivered row to the runner"
+     **genuinely resolves this case** — it completes an existing pattern
+     (the `_harness_pre_resolved_elicitations` tombstone already handles the
+     analogous case of a dropped-and-reparked *hook* long-poll) rather than
+     inventing a new one, and covers native/tmux-attached *and*
+     subprocess-backed harnesses alike, since the runner process itself
+     never died.
+   - **The runner process itself dies** (host crash, subprocess killed).
+     The runner-side `Future` and the coroutine stack awaiting it are
+     unrecoverably gone — no durable row can rebind a coroutine that no
+     longer exists, regardless of harness type. Return `410 Gone` with
+     `error_code = "elicitation_not_resolvable"` here — the verdict is
+     durably recorded (audit trail, and idempotent if the manager retries),
+     but the endpoint does not claim the session resumed, because it
+     structurally did not. Emit `session.resumed` only on the runner's
+     acknowledgement of having consumed the decision, never on the manager
+     HTTP call being accepted — that ack is what makes the event truthful.
+
+   Implementation note: the reconnect-redelivery path in the middle case is
+   genuinely new wiring (a tunnel-reconnect hook that queries
+   `session_elicitations` for `decided`-but-undelivered rows and re-POSTs
+   them), but it reuses the runner's own existing approval-POST contract
+   rather than inventing a second delivery mechanism.
 
 This makes the acceptance test for "restart before verdict" an explicitly
 harness-classified test (§12), rather than either quietly failing to build
@@ -758,12 +829,12 @@ Covered in full in §5.4; summarized here as a flow:
 
 | Acceptance bullet | Test |
 |---|---|
-| Completion wake | Turn reaches `idle` from an open `response_id` with `background_task_count in (None, 0)` → exactly one `session.completed` row, delivered; a mid-turn quiescence blip (background task still running) → zero rows |
+| Completion wake | Turn reaches `idle` from an open `response_id` → exactly one `session.completed` row, delivered, **including** when a background shell is still running (asserts the fix in §5.1: this must NOT be swallowed); a session that never opened a turn, or a same-status no-op republish → zero rows |
 | Decision payload/context | `session.awaiting_decision` payload round-trips the allowlisted request fields; a field outside the allowlist (e.g. raw env dict on the harness side) is asserted absent from the payload |
 | Restart/network replay | Kill dispatcher mid-delivery (lease held, no ack) → row remains `leased` until `lease_expires_at`, then is reclaimed and re-delivered with the same `event_id`/`sequence`; server process restart between outbox insert and first delivery attempt → row survives (durable), dispatcher picks it up on the next claim cycle |
 | Duplicate delivery / stable IDs | Manager 2xxs but the ack is lost (simulated) → dispatcher retries, receiver-side dedupe on `event_id` proven via a test double manager that idempotency-checks |
 | Signature/redaction security | Tampered body/timestamp fails verification; timestamp outside tolerance is rejected by the reference-verification test even with a valid signature; log lines for a delivery attempt assert absence of payload body, secret, signature, full URL |
-| End-to-end decision response resuming the exact session, **classified by harness** | (a) live Future, no restart: verdict resolves immediately, `session.resumed` fires. (b) native/tmux harness, restart before verdict: verdict persists, replays on reconnect, `session.resumed` fires once resolved. (c) subprocess harness, restart before verdict, process gone: decision endpoint returns `410 elicitation_not_resolvable`; verdict is still durably recorded (assert via direct row read, not via the HTTP response); poll/reconcile subsequently reflects the session's real post-restart state |
+| End-to-end decision response resuming the exact session, **classified by which process died (§5.4)** | (a) no restart: server-side Future still parked, verdict resolves immediately, `session.resumed` fires. (b) server restarts, runner/host process alive: verdict persists, redelivered to the runner's still-live `pending_approvals` Future on tunnel reconnect, `session.resumed` fires on runner ack — this is the dominant real-world case and must pass for BOTH native/tmux and subprocess-backed harnesses. (c) runner process itself dies: decision endpoint returns `410 elicitation_not_resolvable`; verdict is still durably recorded (assert via direct row read, not via the HTTP response); poll/reconcile subsequently reflects the session's real post-restart state |
 | Ordering / non-regression | Two events for one session enqueued out of delivery order (simulated retry timing) → manager-side stable-ID + sequence dedupe test proves a lower `sequence` arriving after a higher one is a documented no-op for the consumer; dispatcher never issues session event N+1 before N reaches a terminal delivery state |
 | Callback never blocks terminal transitions | Manager endpoint made to hang/timeout; assert `_publish_status`, the SSE stream, and `conversation_labels`/`live_status` writes complete with unchanged latency |
 | Poll/reconcile stays enabled | With `manager_webhook.enabled=false` and with the manager endpoint permanently down, existing reconciliation-dependent behavior (session-state correctness) is unaffected |

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1583,3 +1583,226 @@ class SqlScheduledTaskRun(OmnigentBase):
             "conversation_id",
         ),
     )
+
+
+class SqlSessionLifecycleCursor(OmnigentBase):
+    """
+    SQLAlchemy model for the ``session_lifecycle_cursors`` table.
+
+    Per-``(workspace_id, session_id)`` sequence allocator for
+    ``session_lifecycle_outbox`` rows. The outbox lives on a possibly
+    different physical database than ``conversations``/``conversation_items``
+    (``ConversationBase``), so ``sequence`` cannot be allocated by locking
+    through the conversation engine (``_lock_conversation``) — this row is
+    locked on the metadata engine instead, in the same transaction as the
+    outbox insert it protects.
+
+    :param session_id: The session (conversation) this cursor tracks.
+    :param next_sequence: The next ``sequence`` value to assign to a new
+        outbox row for this session. Starts at 1.
+    """
+
+    __tablename__ = "session_lifecycle_cursors"
+
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    session_id: Mapped[str] = mapped_column(Uuid16, primary_key=True)
+    next_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="1")
+
+
+class SqlSessionLifecycleOutbox(OmnigentBase):
+    """
+    SQLAlchemy model for the ``session_lifecycle_outbox`` table.
+
+    A transactional outbox of durable, stable-ID lifecycle events
+    (``session.completed`` / ``session.failed`` / ``session.awaiting_decision``
+    / ``session.resumed``) pushed to the configured manager webhook. Rows are
+    inserted synchronously in the same transaction as the fact they report,
+    then delivered asynchronously by the dispatcher (see
+    ``omnigent/server/manager_webhook_dispatcher.py``).
+
+    :param id: The externally stable ``event_id`` — deterministic (UUIDv5),
+        not random, so a retried producer call resolves to the same row via
+        this primary key rather than a separate dedupe query.
+    :param session_id: The session this event reports on. No DB foreign key
+        (Rule R032) — application-owned like ``scheduled_task_runs.conversation_id``.
+    :param event_type: One of ``session.completed`` / ``session.failed`` /
+        ``session.awaiting_decision`` / ``session.resumed``, stored as a
+        stable int code (see ``omnigent.db.enum_codecs.SESSION_LIFECYCLE_EVENT_TYPE``).
+    :param transition_key: Stable source identity the event was derived from,
+        e.g. ``turn:{response_id}:completed`` or
+        ``elicitation:{elicitation_id}:awaiting_decision``. Combined with
+        ``event_type`` in the idempotency unique constraint.
+    :param sequence: Monotonic per ``(workspace_id, session_id)``, allocated
+        from :class:`SqlSessionLifecycleCursor` in the same transaction as
+        this row's insert.
+    :param event_version: Wire envelope version; bumped on a breaking payload
+        change under the same ``event_type``.
+    :param payload: JSON event ``data`` (redacted/allowlisted before insert),
+        stored compressed.
+    :param status: Delivery status — ``pending``/``leased``/``delivered``/
+        ``dead_letter``/``paused``, stored as a stable int code (see
+        ``omnigent.db.enum_codecs.SESSION_LIFECYCLE_OUTBOX_STATUS``).
+    :param attempt_count: Number of delivery attempts made so far.
+    :param next_attempt_at: Unix epoch seconds; the dispatcher's claim filter.
+    :param lease_owner: Replica identity holding the current delivery
+        attempt's lease, or ``None`` when not leased.
+    :param lease_expires_at: Unix epoch seconds the current lease expires;
+        used to reclaim a row whose claiming replica crashed mid-delivery.
+    :param last_attempt_at: Unix epoch seconds of the most recent delivery
+        attempt, or ``None`` before the first attempt.
+    :param delivered_at: Unix epoch seconds the row reached ``delivered``, or
+        ``None`` until then.
+    :param last_http_status: HTTP status of the most recent delivery attempt,
+        or ``None`` before the first attempt.
+    :param last_error_code: Short, sanitized failure classification from the
+        most recent failed attempt; never raw response body.
+    :param last_error_message: Short, sanitized failure detail from the most
+        recent failed attempt; never raw response body.
+    :param created_at: Unix epoch seconds the row was inserted.
+    """
+
+    __tablename__ = "session_lifecycle_outbox"
+
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    id: Mapped[str] = mapped_column(Uuid16, primary_key=True)
+    session_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
+    event_type: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    transition_key: Mapped[str] = mapped_column(String(192), nullable=False)
+    sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    event_version: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
+    payload: Mapped[str] = mapped_column(CompressedText, nullable=False)
+    status: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    next_attempt_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    lease_owner: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    lease_expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_attempt_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    delivered_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_http_status: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    last_error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "event_type IN (1, 2, 3, 4)",
+            name="ck_session_lifecycle_outbox_event_type",
+        ),
+        CheckConstraint(
+            "status IN (1, 2, 3, 4, 5)",
+            name="ck_session_lifecycle_outbox_status",
+        ),
+        # Ordering + prevents double-allocation of a sequence number.
+        UniqueConstraint(
+            "workspace_id",
+            "session_id",
+            "sequence",
+            name="uq_session_lifecycle_outbox_session_sequence",
+        ),
+        # Idempotency key: a retried producer call resolves to the existing
+        # row instead of racing the cursor into a duplicate.
+        UniqueConstraint(
+            "workspace_id",
+            "session_id",
+            "event_type",
+            "transition_key",
+            name="uq_session_lifecycle_outbox_transition",
+        ),
+        # Dispatcher's hot claim query.
+        Index(
+            "ix_session_lifecycle_outbox_claim",
+            "status",
+            "next_attempt_at",
+            "workspace_id",
+        ),
+        # Per-session ordering / head lookup (lowest non-delivered sequence).
+        Index(
+            "ix_session_lifecycle_outbox_session_order",
+            "workspace_id",
+            "session_id",
+            "sequence",
+            "status",
+        ),
+    )
+
+
+class SqlSessionElicitation(OmnigentBase):
+    """
+    SQLAlchemy model for the ``session_elicitations`` table.
+
+    A durable ledger of human-decision elicitations, narrower than a general
+    cross-restart resume guarantee (see
+    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.4):
+    it always records that a decision was made and survives a restart, but
+    whether the runner can actually consume that decision is classified by
+    which process died (no restart / server restart with runner alive /
+    runner dead), not promised uniformly by this table.
+
+    :param id: The elicitation id (``== elicitation_id``), e.g.
+        ``"elicit_a1b2c3..."`` — a prefixed opaque token, not a bare-hex
+        UUID, so this is a plain ``String`` column, not :class:`Uuid16`.
+    :param session_id: The owning session. No DB foreign key (Rule R032).
+    :param status: ``pending``/``decided``/``delivered_to_runner``/``expired``,
+        stored as a stable int code (see
+        ``omnigent.db.enum_codecs.SESSION_ELICITATION_STATUS``).
+    :param request_payload: Allowlisted elicitation request fields (prompt,
+        choices, requesting tool/action name, correlation IDs), stored
+        compressed. Written at registration time.
+    :param decision_payload: Allowlisted decision fields, stored compressed.
+        ``None`` until a verdict is recorded.
+    :param decided_by: The manager identity from the signed callback, or
+        ``None`` for a web-UI verdict.
+    :param created_at: Unix epoch seconds the row was created.
+    :param decided_at: Unix epoch seconds the verdict was durably recorded,
+        or ``None`` before then.
+    :param resolved_at: Unix epoch seconds a live/reconnected runner actually
+        consumed the decision, or ``None`` before then (including the
+        ``410 elicitation_not_resolvable`` case, which never sets this).
+    """
+
+    __tablename__ = "session_elicitations"
+
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    # NOT Uuid16: elicitation_id is a prefixed opaque token
+    # (f"elicit_{secrets.token_hex(16)}", or a caller-supplied id like
+    # "elicit_codex_abc123") — not a bare-hex UUID, so it cannot use the
+    # 16-raw-byte encoding every other id column here does.
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    session_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
+    status: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
+    request_payload: Mapped[str] = mapped_column(CompressedText, nullable=False)
+    decision_payload: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
+    decided_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    decided_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    resolved_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN (1, 2, 3, 4)",
+            name="ck_session_elicitations_status",
+        ),
+        Index(
+            "ix_session_elicitations_session_id",
+            "workspace_id",
+            "session_id",
+        ),
+    )

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -644,6 +644,13 @@ class SqlConversationMetadata(OmnigentBase):
     live_status: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     # Outstanding elicitation (approval-prompt) count; NULL = never written.
     pending_elicitation_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Epoch seconds the bound runner's post-disconnect reconnect grace
+    # (OMN-104 §5.4) expires at; NULL when not currently grace-pending.
+    # Written by the replica holding the tunnel on disconnect, alongside
+    # nulling runner_last_seen — so any OTHER replica handling a manager
+    # decision request can classify "runner is mid-grace, not dead" without
+    # needing the local in-memory registry the disconnect happened on.
+    runner_disconnect_grace_deadline: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # First-class project membership. Relates to projects.id; no DB FK
     # (Rule R032). NULL = unfiled. Coexists with the implicit ``omni_project``
     # label via the store's dual-read until labels are consolidated.

--- a/omnigent/db/enum_codecs.py
+++ b/omnigent/db/enum_codecs.py
@@ -127,6 +127,31 @@ SCHEDULED_TASK_RUN_STATUS: dict[str, int] = {
     "skipped": 5,
 }
 
+# Manager-webhook lifecycle event type (session_lifecycle_outbox.event_type).
+SESSION_LIFECYCLE_EVENT_TYPE: dict[str, int] = {
+    "session.completed": 1,
+    "session.failed": 2,
+    "session.awaiting_decision": 3,
+    "session.resumed": 4,
+}
+
+# Delivery status of a session_lifecycle_outbox row.
+SESSION_LIFECYCLE_OUTBOX_STATUS: dict[str, int] = {
+    "pending": 1,
+    "leased": 2,
+    "delivered": 3,
+    "dead_letter": 4,
+    "paused": 5,
+}
+
+# Durable status of a session_elicitations row.
+SESSION_ELICITATION_STATUS: dict[str, int] = {
+    "pending": 1,
+    "decided": 2,
+    "delivered_to_runner": 3,
+    "expired": 4,
+}
+
 
 def _assert_item_type_codes_cover_data_classes() -> None:
     """
@@ -338,3 +363,33 @@ def encode_scheduled_task_run_status(name: str) -> int:
 def decode_scheduled_task_run_status(code: int) -> str:
     """Decode a ``scheduled_task_runs.status`` int code to its name."""
     return _decode(SCHEDULED_TASK_RUN_STATUS, code, field="scheduled_task_runs.status")
+
+
+def encode_session_lifecycle_event_type(name: str) -> int:
+    """Encode a ``session_lifecycle_outbox.event_type`` name to its int code."""
+    return _encode(SESSION_LIFECYCLE_EVENT_TYPE, name, field="session_lifecycle_outbox.event_type")
+
+
+def decode_session_lifecycle_event_type(code: int) -> str:
+    """Decode a ``session_lifecycle_outbox.event_type`` int code to its name."""
+    return _decode(SESSION_LIFECYCLE_EVENT_TYPE, code, field="session_lifecycle_outbox.event_type")
+
+
+def encode_session_lifecycle_outbox_status(name: str) -> int:
+    """Encode a ``session_lifecycle_outbox.status`` name to its int code."""
+    return _encode(SESSION_LIFECYCLE_OUTBOX_STATUS, name, field="session_lifecycle_outbox.status")
+
+
+def decode_session_lifecycle_outbox_status(code: int) -> str:
+    """Decode a ``session_lifecycle_outbox.status`` int code to its name."""
+    return _decode(SESSION_LIFECYCLE_OUTBOX_STATUS, code, field="session_lifecycle_outbox.status")
+
+
+def encode_session_elicitation_status(name: str) -> int:
+    """Encode a ``session_elicitations.status`` name to its int code."""
+    return _encode(SESSION_ELICITATION_STATUS, name, field="session_elicitations.status")
+
+
+def decode_session_elicitation_status(code: int) -> str:
+    """Decode a ``session_elicitations.status`` int code to its name."""
+    return _decode(SESSION_ELICITATION_STATUS, code, field="session_elicitations.status")

--- a/omnigent/db/migrations/versions/933ad7c710f1_add_runner_disconnect_grace_deadline.py
+++ b/omnigent/db/migrations/versions/933ad7c710f1_add_runner_disconnect_grace_deadline.py
@@ -1,0 +1,48 @@
+"""add runner_disconnect_grace_deadline to omnigent_conversation_metadata
+
+Revision ID: b1c2d3e4f5a6
+Revises: a8b9c0d1e2f3
+Create Date: 2026-08-11 00:00:00.000000
+
+Adds a fourth per-session live-state column, alongside runner_last_seen /
+live_status / pending_elicitation_count (see d7f1a2b3c4e5): a durable,
+cross-replica-visible marker for OMN-104 §5.4's post-disconnect reconnect
+grace window.
+
+Before this, the grace deadline lived only in the tunnel-holding replica's
+in-memory app.state — invisible to any OTHER replica handling a manager
+decision request for that session, which would fall through to the
+(already-cleared) runner_last_seen freshness check and falsely classify a
+runner mid-grace as dead (410 elicitation_not_resolvable) instead of
+pending-redelivery (202).
+
+``runner_disconnect_grace_deadline``: nullable Integer — epoch seconds the
+grace expires at; NULL when not currently grace-pending. Written by the
+replica holding the tunnel on disconnect (same best-effort mirror as
+runner_last_seen, via session_live_state.py), cleared on reconnect or once
+the grace genuinely expires.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "933ad7c710f1"
+down_revision: str | None = "a8b9c0d1e2f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.add_column(
+            sa.Column("runner_disconnect_grace_deadline", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.drop_column("runner_disconnect_grace_deadline")

--- a/omnigent/db/migrations/versions/a8b9c0d1e2f3_add_session_lifecycle_outbox.py
+++ b/omnigent/db/migrations/versions/a8b9c0d1e2f3_add_session_lifecycle_outbox.py
@@ -1,0 +1,159 @@
+"""add session_lifecycle_outbox, session_lifecycle_cursors, session_elicitations
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-08-10 00:00:00.000000
+
+Adds the durable-session-lifecycle-push tables (OMN-104): a transactional
+outbox of stable-ID lifecycle events pushed to the configured manager
+webhook (``session_lifecycle_outbox``), its per-session sequence allocator
+(``session_lifecycle_cursors``), and a durable elicitation ledger
+(``session_elicitations``) recording human-decision verdicts so they survive
+a server restart. See
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md``.
+
+All three tables are brand-new, carry ``workspace_id`` as the leading
+primary-key member (matching every other table), and have no foreign-key
+constraints (schema Rule R032) — the ``session_id`` relationship is
+application-owned, like ``scheduled_task_runs.conversation_id``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from omnigent.db.db_models import Uuid16
+
+revision: str = "a8b9c0d1e2f3"
+down_revision: str | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the outbox, cursor, and elicitation-ledger tables."""
+    op.create_table(
+        "session_lifecycle_cursors",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("session_id", Uuid16(), nullable=False),
+        sa.Column("next_sequence", sa.BigInteger(), nullable=False, server_default="1"),
+        sa.PrimaryKeyConstraint("workspace_id", "session_id"),
+    )
+
+    op.create_table(
+        "session_lifecycle_outbox",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        # Externally stable event_id (deterministic UUIDv5), stored as 16 raw
+        # bytes (Uuid16).
+        sa.Column("id", Uuid16(), nullable=False),
+        sa.Column("session_id", Uuid16(), nullable=False),
+        # Stable int code (see omnigent.db.enum_codecs
+        # SESSION_LIFECYCLE_EVENT_TYPE: session.completed=1, session.failed=2,
+        # session.awaiting_decision=3, session.resumed=4).
+        sa.Column("event_type", sa.SmallInteger(), nullable=False),
+        sa.Column("transition_key", sa.String(192), nullable=False),
+        sa.Column("sequence", sa.BigInteger(), nullable=False),
+        sa.Column("event_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        # Redacted/allowlisted JSON event payload, stored compressed.
+        sa.Column("payload", sa.LargeBinary(), nullable=False),
+        # Stable int code (see omnigent.db.enum_codecs
+        # SESSION_LIFECYCLE_OUTBOX_STATUS: pending=1, leased=2, delivered=3,
+        # dead_letter=4, paused=5).
+        sa.Column("status", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("next_attempt_at", sa.Integer(), nullable=False),
+        sa.Column("lease_owner", sa.String(128), nullable=True),
+        sa.Column("lease_expires_at", sa.Integer(), nullable=True),
+        sa.Column("last_attempt_at", sa.Integer(), nullable=True),
+        sa.Column("delivered_at", sa.Integer(), nullable=True),
+        sa.Column("last_http_status", sa.SmallInteger(), nullable=True),
+        sa.Column("last_error_code", sa.String(64), nullable=True),
+        sa.Column("last_error_message", sa.String(256), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "event_type IN (1, 2, 3, 4)",
+            name="ck_session_lifecycle_outbox_event_type",
+        ),
+        sa.CheckConstraint(
+            "status IN (1, 2, 3, 4, 5)",
+            name="ck_session_lifecycle_outbox_status",
+        ),
+        sa.PrimaryKeyConstraint("workspace_id", "id"),
+    )
+    op.create_index(
+        "uq_session_lifecycle_outbox_session_sequence",
+        "session_lifecycle_outbox",
+        ["workspace_id", "session_id", "sequence"],
+        unique=True,
+    )
+    op.create_index(
+        "uq_session_lifecycle_outbox_transition",
+        "session_lifecycle_outbox",
+        ["workspace_id", "session_id", "event_type", "transition_key"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_session_lifecycle_outbox_claim",
+        "session_lifecycle_outbox",
+        ["status", "next_attempt_at", "workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_session_lifecycle_outbox_session_order",
+        "session_lifecycle_outbox",
+        ["workspace_id", "session_id", "sequence", "status"],
+        unique=False,
+    )
+
+    op.create_table(
+        "session_elicitations",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        # == elicitation_id, e.g. "elicit_a1b2c3..." — a prefixed opaque
+        # token, not a bare-hex UUID, so this is a plain String column,
+        # not Uuid16 (unlike every other id column in this migration).
+        sa.Column("id", sa.String(128), nullable=False),
+        sa.Column("session_id", Uuid16(), nullable=False),
+        # Stable int code (see omnigent.db.enum_codecs
+        # SESSION_ELICITATION_STATUS: pending=1, decided=2,
+        # delivered_to_runner=3, expired=4).
+        sa.Column("status", sa.SmallInteger(), nullable=False, server_default="1"),
+        # Allowlisted request/decision fields, stored compressed.
+        sa.Column("request_payload", sa.LargeBinary(), nullable=False),
+        sa.Column("decision_payload", sa.LargeBinary(), nullable=True),
+        sa.Column("decided_by", sa.String(128), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("decided_at", sa.Integer(), nullable=True),
+        sa.Column("resolved_at", sa.Integer(), nullable=True),
+        sa.CheckConstraint(
+            "status IN (1, 2, 3, 4)",
+            name="ck_session_elicitations_status",
+        ),
+        sa.PrimaryKeyConstraint("workspace_id", "id"),
+    )
+    op.create_index(
+        "ix_session_elicitations_session_id",
+        "session_elicitations",
+        ["workspace_id", "session_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the elicitation-ledger, outbox, and cursor tables."""
+    op.drop_index("ix_session_elicitations_session_id", table_name="session_elicitations")
+    op.drop_table("session_elicitations")
+
+    op.drop_index(
+        "ix_session_lifecycle_outbox_session_order", table_name="session_lifecycle_outbox"
+    )
+    op.drop_index("ix_session_lifecycle_outbox_claim", table_name="session_lifecycle_outbox")
+    op.drop_index("uq_session_lifecycle_outbox_transition", table_name="session_lifecycle_outbox")
+    op.drop_index(
+        "uq_session_lifecycle_outbox_session_sequence", table_name="session_lifecycle_outbox"
+    )
+    op.drop_table("session_lifecycle_outbox")
+
+    op.drop_table("session_lifecycle_cursors")

--- a/omnigent/db/migrations/versions/a8b9c0d1e2f3_add_session_lifecycle_outbox.py
+++ b/omnigent/db/migrations/versions/a8b9c0d1e2f3_add_session_lifecycle_outbox.py
@@ -1,7 +1,7 @@
 """add session_lifecycle_outbox, session_lifecycle_cursors, session_elicitations
 
 Revision ID: a8b9c0d1e2f3
-Revises: f7a8b9c0d1e2
+Revises: d5e9f1a2b3c4
 Create Date: 2026-08-10 00:00:00.000000
 
 Adds the durable-session-lifecycle-push tables (OMN-104): a transactional
@@ -28,7 +28,7 @@ from alembic import op
 from omnigent.db.db_models import Uuid16
 
 revision: str = "a8b9c0d1e2f3"
-down_revision: str | None = "f7a8b9c0d1e2"
+down_revision: str | None = "d5e9f1a2b3c4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -30,6 +30,7 @@ from omnigent.entities.permission import ResolvedAccess, SessionPermission
 from omnigent.entities.policy import Policy
 from omnigent.entities.project import Project
 from omnigent.entities.scheduled_task import ScheduledTask, ScheduledTaskRun
+from omnigent.entities.session_lifecycle import LifecycleOutboxEvent, SessionElicitation
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     SessionResourceView,
@@ -54,6 +55,7 @@ __all__ = [
     "FunctionCallData",
     "FunctionCallOutputData",
     "ItemData",
+    "LifecycleOutboxEvent",
     "LoadedAgent",
     "MessageData",
     "NativeToolData",
@@ -67,6 +69,7 @@ __all__ = [
     "RoutingDecisionData",
     "ScheduledTask",
     "ScheduledTaskRun",
+    "SessionElicitation",
     "SessionPermission",
     "SessionResourceView",
     "SlashCommandData",

--- a/omnigent/entities/session_lifecycle.py
+++ b/omnigent/entities/session_lifecycle.py
@@ -1,0 +1,109 @@
+"""Durable session-lifecycle-push entities (OMN-104) — persisted in the
+``session_lifecycle_outbox`` and ``session_elicitations`` tables.
+
+A :class:`LifecycleOutboxEvent` is one row of the transactional outbox that
+durably records a ``session.completed`` / ``session.failed`` /
+``session.awaiting_decision`` / ``session.resumed`` event before it is
+delivered (and retried until acknowledged) to the configured manager
+webhook. A :class:`SessionElicitation` is a durable ledger row recording a
+human-decision elicitation's request/verdict, narrower than a general
+cross-restart resume guarantee (see
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.4).
+
+This module holds the plain dataclasses the store converts ORM rows into;
+the store owns JSON (de)serialization of the compressed payload columns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LifecycleOutboxEvent:
+    """
+    One row of the ``session_lifecycle_outbox`` transactional outbox.
+
+    :param id: The externally stable ``event_id`` (deterministic UUIDv5, bare
+        32-char hex string).
+    :param session_id: The session this event reports on.
+    :param event_type: One of ``"session.completed"`` / ``"session.failed"``
+        / ``"session.awaiting_decision"`` / ``"session.resumed"``.
+    :param transition_key: Stable source identity the event was derived
+        from, e.g. ``"turn:{response_id}:completed"``.
+    :param sequence: Monotonic per ``(workspace_id, session_id)``.
+    :param event_version: Wire envelope version.
+    :param payload: JSON event ``data`` (already redacted/allowlisted).
+    :param status: Delivery status — ``"pending"`` / ``"leased"`` /
+        ``"delivered"`` / ``"dead_letter"`` / ``"paused"``.
+    :param attempt_count: Number of delivery attempts made so far.
+    :param next_attempt_at: Unix epoch seconds; the dispatcher's claim filter.
+    :param created_at: Unix epoch seconds the row was inserted.
+    :param workspace_id: Tenant partition key that owns this row.
+    :param lease_owner: Replica identity holding the current lease, or
+        ``None``.
+    :param lease_expires_at: Unix epoch seconds the current lease expires, or
+        ``None``.
+    :param last_attempt_at: Unix epoch seconds of the most recent delivery
+        attempt, or ``None``.
+    :param delivered_at: Unix epoch seconds the row reached ``delivered``, or
+        ``None``.
+    :param last_http_status: HTTP status of the most recent attempt, or
+        ``None``.
+    :param last_error_code: Sanitized failure classification, or ``None``.
+    :param last_error_message: Sanitized failure detail, or ``None``.
+    """
+
+    id: str
+    session_id: str
+    event_type: str
+    transition_key: str
+    sequence: int
+    event_version: int
+    payload: str
+    status: str
+    attempt_count: int
+    next_attempt_at: int
+    created_at: int
+    workspace_id: int = 0
+    lease_owner: str | None = None
+    lease_expires_at: int | None = None
+    last_attempt_at: int | None = None
+    delivered_at: int | None = None
+    last_http_status: int | None = None
+    last_error_code: str | None = None
+    last_error_message: str | None = None
+
+
+@dataclass
+class SessionElicitation:
+    """
+    A durable elicitation ledger row, persisted in ``session_elicitations``.
+
+    :param id: The elicitation id (``== elicitation_id``).
+    :param session_id: The owning session.
+    :param status: ``"pending"`` / ``"decided"`` / ``"delivered_to_runner"``
+        / ``"expired"``.
+    :param request_payload: Allowlisted elicitation request fields, as JSON.
+    :param created_at: Unix epoch seconds the row was created.
+    :param workspace_id: Tenant partition key that owns this row.
+    :param decision_payload: Allowlisted decision fields, as JSON, or
+        ``None`` until a verdict is recorded.
+    :param decided_by: The manager identity from the signed callback, or
+        ``None`` for a web-UI verdict.
+    :param decided_at: Unix epoch seconds the verdict was durably recorded,
+        or ``None``.
+    :param resolved_at: Unix epoch seconds a live/reconnected runner actually
+        consumed the decision, or ``None``.
+    """
+
+    id: str
+    session_id: str
+    status: str
+    request_payload: str
+    created_at: int
+    workspace_id: int = 0
+    decision_payload: str | None = None
+    decided_by: str | None = None
+    decided_at: int | None = None
+    resolved_at: int | None = None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -324,6 +324,31 @@ def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
     return f"Request failed on the runner; see the runner log for details: {log_reference}"
 
 
+# OMN-104 §5.4: header the server's decision-endpoint forward and
+# reconnect-redelivery hook read to distinguish "this endpoint 2xx'd" from
+# "a tracked pending_approvals Future was actually resolved" — the former is
+# NOT proof of truthful consumption (a 2xx also happens for an unknown, stale,
+# or already-resolved elicitation_id).
+_PENDING_APPROVAL_RESOLVED_HEADER = "X-Omnigent-Pending-Approval-Resolved"
+
+
+def _attach_pending_approval_header(response: Response, resolved: bool | None) -> None:
+    """
+    Stamp *response* with whether ``pending_approvals.resolve()`` found and
+    resolved a tracked Future for this request's ``approval`` event.
+
+    A no-op when *resolved* is ``None`` (the request wasn't an ``approval``
+    event at all, so the header is meaningless here).
+
+    :param response: The response about to be returned from
+        ``POST /v1/sessions/{id}/events``.
+    :param resolved: The boolean ``pending_approvals.resolve()`` returned, or
+        ``None`` for a non-approval event.
+    """
+    if resolved is not None:
+        response.headers[_PENDING_APPROVAL_RESOLVED_HEADER] = "true" if resolved else "false"
+
+
 _SpecEntry: TypeAlias = AgentSpec | ResolvedSpec
 SpecResolver: TypeAlias = Callable[[str, str | None], Awaitable[_SpecEntry | None]]
 _ResourceType: TypeAlias = Literal["environment", "terminal", "file"]
@@ -6466,10 +6491,21 @@ def create_runner_app(
                 )
             return Response(status_code=204)
 
+        _pending_approval_resolved: bool | None = None
         if body_type == "approval":
             _data = body.get("data") or body
             _elicit_action = _data.get("action", "")
-            pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
+            # OMN-104 §5.4: the caller (server-side decision-endpoint forward,
+            # or the reconnect-redelivery hook) needs to know whether this
+            # specific approval was TRUTHFULLY consumed by a tracked
+            # pending_approvals Future — not just that this endpoint 2xx'd,
+            # which also fires for an unknown/stale/already-resolved id.
+            # Carried back via a response header (below) rather than the JSON
+            # body, since the body below is a passthrough of the harness
+            # subprocess's own response to a *different* forward, not ours.
+            _pending_approval_resolved = pending_approvals.resolve(
+                _data.get("elicitation_id", ""), _elicit_action == "accept"
+            )
             if _session_harness_name(conversation_id) == "claude-native":
                 await _apply_claude_native_plan_verdict(conversation_id, _data)
             if _elicit_action == "decline":
@@ -6487,21 +6523,25 @@ def create_runner_app(
         try:
             harness_client = await process_manager.get_client(conversation_id, "any")
         except NoLiveHarnessError:
-            return JSONResponse(
+            _events_response = JSONResponse(
                 status_code=409,
                 content={
                     "error": "no_live_harness",
                     "detail": "no harness subprocess is running for this conversation",
                 },
             )
+            _attach_pending_approval_header(_events_response, _pending_approval_resolved)
+            return _events_response
         except RuntimeError as exc:
-            return JSONResponse(
+            _events_response = JSONResponse(
                 status_code=503,
                 content={
                     "error": "no_harness",
                     "detail": _client_safe_error_detail(exc, context="harness lookup"),
                 },
             )
+            _attach_pending_approval_header(_events_response, _pending_approval_resolved)
+            return _events_response
         try:
             resp = await harness_client.post(
                 f"/v1/sessions/{conversation_id}/events",
@@ -6509,7 +6549,7 @@ def create_runner_app(
                 timeout=30.0,
             )
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse(
+            _events_response = JSONResponse(
                 status_code=502,
                 content={
                     "error": "harness_forward_failed",
@@ -6517,7 +6557,11 @@ def create_runner_app(
                     "event_type": body_type,
                 },
             )
-        return _forward_harness_response(resp)
+            _attach_pending_approval_header(_events_response, _pending_approval_resolved)
+            return _events_response
+        _events_response = _forward_harness_response(resp)
+        _attach_pending_approval_header(_events_response, _pending_approval_resolved)
+        return _events_response
 
     async def _resolve_conversation_id(response_id: str) -> str | None:
         return _resp_to_conv.get(response_id)

--- a/omnigent/runtime/pending_elicitations.py
+++ b/omnigent/runtime/pending_elicitations.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import copy
 import threading
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 # Per-conversation mapping of outstanding elicitation_id → original
 # event payload. Storing the full event (not just the id) lets
@@ -104,7 +104,10 @@ def _notify_count_hook(conversation_id: str, count: int) -> None:
         hook(conversation_id, count)
 
 
-def record_publish(conversation_id: str, event: dict[str, Any]) -> None:
+RecordPublishEdge = Literal["added", "replaced_same_id", "removed", "not_found"]
+
+
+def record_publish(conversation_id: str, event: dict[str, Any]) -> RecordPublishEdge | None:
     """
     Update the index when an SSE event is published.
 
@@ -139,25 +142,37 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> None:
         :func:`omnigent.runtime.session_stream.publish`. Reads
         ``event["type"]`` to dispatch and ``event["elicitation_id"]``
         for both event types.
+    :returns: ``"added"`` on a fresh ``elicitation_id`` insert,
+        ``"replaced_same_id"`` when the id was already tracked (a re-park
+        retry reusing the same id),
+        ``"removed"``/``"not_found"`` for the resolved-event branch, or
+        ``None`` for an event type/shape this function ignores. Exposed so a
+        caller can gate a first-insert-only (or resolve-only) side effect —
+        e.g. the durable manager-webhook outbox hook — without re-deriving
+        idempotency itself; the index write above always happens regardless
+        of the returned edge.
     """
     event_type = event.get("type")
     if event_type == "response.elicitation_request":
         elicitation_id = event.get("elicitation_id")
         if not isinstance(elicitation_id, str) or not elicitation_id:
-            return
+            return None
         with _lock:
             ids = _pending.setdefault(conversation_id, {})
+            edge: RecordPublishEdge = "replaced_same_id" if elicitation_id in ids else "added"
             ids[elicitation_id] = event
             count = len(ids)
         _notify_count_hook(conversation_id, count)
         _notify_observer(conversation_id, event)
-        return
+        return edge
     if event_type == "response.elicitation_resolved":
         elicitation_id = event.get("elicitation_id")
         if not isinstance(elicitation_id, str) or not elicitation_id:
-            return
-        resolve(conversation_id, elicitation_id)
+            return None
+        removed = resolve(conversation_id, elicitation_id)
         _notify_observer(conversation_id, event)
+        return "removed" if removed else "not_found"
+    return None
 
 
 def _notify_observer(conversation_id: str, event: dict[str, Any]) -> None:
@@ -178,7 +193,7 @@ def _notify_observer(conversation_id: str, event: dict[str, Any]) -> None:
         observer(conversation_id, event)
 
 
-def resolve(conversation_id: str, elicitation_id: str) -> None:
+def resolve(conversation_id: str, elicitation_id: str) -> bool:
     """
     Drop an outstanding elicitation from the index.
 
@@ -201,17 +216,20 @@ def resolve(conversation_id: str, elicitation_id: str) -> None:
         was dispatched against, e.g. ``"conv_abc123"``.
     :param elicitation_id: The elicitation correlation id from the
         approval payload, e.g. ``"elicit_abc123"``.
+    :returns: ``True`` if a tracked id was removed, ``False`` if it wasn't
+        tracked (no-op).
     """
     with _lock:
         ids = _pending.get(conversation_id)
         if ids is None:
-            return
+            return False
         removed = ids.pop(elicitation_id, None) is not None
         count = len(ids)
         if not ids:
             _pending.pop(conversation_id, None)
     if removed:
         _notify_count_hook(conversation_id, count)
+    return removed
 
 
 def count_for(conversation_id: str) -> int:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1,10 +1,12 @@
 """FastAPI application — main entry point for the omnigent server."""
 
 import asyncio
+import json
 import logging
 import mimetypes
 import os
 import re
+import socket
 import tarfile
 import time
 import uuid
@@ -14,6 +16,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any, Protocol
 
+import httpx
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -41,13 +44,14 @@ from omnigent.runtime import (
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
-from omnigent.server import session_live_state
+from omnigent.server import session_live_state, session_outbox
 from omnigent.server.auth import AuthProvider, SharingMode
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     RunnerBackgroundTitleGenerator,
 )
 from omnigent.server.managed_hosts import ManagedSandboxConfig
+from omnigent.server.manager_webhook_dispatcher import cancel_dispatcher, run_dispatcher
 from omnigent.server.mcp_pool import ServerMcpPool
 from omnigent.server.performance_metrics import (
     ServerMetricsOtelPublisher,
@@ -58,6 +62,7 @@ from omnigent.server.performance_metrics import (
     set_request_session_id_for_access_log,
     set_request_user_agent_for_access_log,
 )
+from omnigent.server.routes._sessions.common import _APPROVAL_TYPE
 from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
@@ -96,6 +101,9 @@ from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
 from omnigent.stores.project_store import ProjectStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
+from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
+    SqlAlchemySessionLifecycleStore,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -929,6 +937,14 @@ def create_app(
     _mcp_pool = ServerMcpPool()
     server_metrics = ServerPerformanceMetrics()
     server_metrics_otel = ServerMetricsOtelPublisher()
+    # Durable session-lifecycle outbox (OMN-104) — same physical DB as the
+    # rest of OmnigentBase (conversation_store.storage_location, not
+    # conversation_storage_location: the outbox must share a transaction
+    # with the OmnigentBase facts it reports on, not the AP/conversation
+    # engine). Constructed here (before the lifespan) so both the
+    # dispatcher task below and session_outbox.configure() (called
+    # synchronously further down in create_app) share the same instance.
+    session_lifecycle_store = SqlAlchemySessionLifecycleStore(conversation_store.storage_location)
 
     @asynccontextmanager
     async def _lifespan(
@@ -1049,6 +1065,16 @@ def create_app(
                         exc,
                     )
 
+        # Manager-webhook dispatcher (OMN-104): always started (same pattern
+        # as metrics_publish_task below), regardless of
+        # manager_webhook.enabled — see manager_webhook_dispatcher.py's
+        # module docstring on why it no-ops rather than being conditionally
+        # constructed. One per replica; safe under multi-replica because
+        # claiming is row-leased, not because only one replica runs it.
+        _dispatcher_lease_owner = f"{socket.gethostname()}-{os.getpid()}"
+        manager_webhook_dispatcher_task = asyncio.create_task(
+            run_dispatcher(session_lifecycle_store, lease_owner=_dispatcher_lease_owner)
+        )
         metrics_publish_task = asyncio.create_task(
             publish_server_metrics_periodically(
                 server_metrics,
@@ -1124,6 +1150,7 @@ def create_app(
             metrics_publish_task.cancel()
             with suppress(asyncio.CancelledError):
                 await metrics_publish_task
+            await cancel_dispatcher(manager_webhook_dispatcher_task)
             # Stop in-flight background managed-sandbox launches so a
             # slow provision doesn't outlive the ASGI shutdown (the
             # sandbox itself, if already provisioned, is reaped by the
@@ -1261,6 +1288,13 @@ def create_app(
     # _publish_status when a fired conversation's turn reaches terminal.
     session_live_state.configure(conversation_store, scheduled_task_store)
     pending_elicitations.set_count_persist_hook(session_live_state.persist_pending_count)
+    # Wire the durable session-lifecycle outbox (constructed above, before
+    # _lifespan, so the dispatcher task can also close over it). Writes
+    # happen regardless of manager_webhook.enabled so poll/reconcile-
+    # independent delivery can be turned on later without a backfill; only
+    # the dispatcher (started in _lifespan) is gated on config.
+    session_outbox.configure(session_lifecycle_store)
+    app.state.session_lifecycle_store = session_lifecycle_store
 
     @app.middleware("http")
     async def _record_server_metrics(
@@ -2249,6 +2283,44 @@ def create_app(
                 routed.client,
                 conversation_store,
             )
+            # OMN-104 §5.4 case (b): redeliver any decided-but-undelivered
+            # elicitation verdicts now that this session's runner tunnel is
+            # back. A durable session_elicitations row plus this reconnect
+            # hook is what makes the manager's earlier decision-endpoint
+            # response ("recorded, pending redelivery") eventually true —
+            # reuses the runner's existing approval-POST contract rather
+            # than inventing a second delivery mechanism.
+            for undelivered in session_lifecycle_store.list_decided_undelivered(conv.id):
+                try:
+                    decision_payload = (
+                        json.loads(undelivered.decision_payload)
+                        if undelivered.decision_payload
+                        else {}
+                    )
+                    response = await routed.client.post(
+                        f"/v1/sessions/{conv.id}/events",
+                        json={
+                            "type": _APPROVAL_TYPE,
+                            "data": {"elicitation_id": undelivered.id, **decision_payload},
+                        },
+                        timeout=10.0,
+                    )
+                    if 200 <= response.status_code < 300:
+                        session_outbox.record_elicitation_resumed(
+                            workspace_id=undelivered.workspace_id,
+                            elicitation_id=undelivered.id,
+                        )
+                    else:
+                        _logger.warning(
+                            "Reconnect redelivery for elicitation %s rejected by runner: %s",
+                            undelivered.id,
+                            response.status_code,
+                        )
+                except (httpx.HTTPError, ConnectionError):
+                    _logger.exception(
+                        "Reconnect redelivery failed for elicitation %s",
+                        undelivered.id,
+                    )
             # The session's terminal exists as of the handshake above, so its
             # model catalogs are answerable now. Warming them here is what
             # keeps the first routed message off the runner round trip. The

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -62,7 +62,10 @@ from omnigent.server.performance_metrics import (
     set_request_session_id_for_access_log,
     set_request_user_agent_for_access_log,
 )
-from omnigent.server.routes._sessions.common import _APPROVAL_TYPE
+from omnigent.server.routes._sessions.common import (
+    _APPROVAL_TYPE,
+    _PENDING_APPROVAL_RESOLVED_HEADER,
+)
 from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
@@ -87,6 +90,7 @@ from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.routes.usage import create_usage_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
+from omnigent.server.server_config import manager_webhook_config
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
@@ -945,6 +949,14 @@ def create_app(
     # dispatcher task below and session_outbox.configure() (called
     # synchronously further down in create_app) share the same instance.
     session_lifecycle_store = SqlAlchemySessionLifecycleStore(conversation_store.storage_location)
+    # Fail closed at boot, not lazily: manager_webhook_dispatcher re-checks
+    # this same config every idle cycle and just logs+idles on
+    # ManagerWebhookConfigError (a config file edited to a bad state after
+    # boot must not crash a running server) — but an operator who enables
+    # the webhook with a bad config from the start deserves an immediate,
+    # loud startup failure, not a server that appears to boot fine and then
+    # silently never delivers anything.
+    manager_webhook_config()
 
     @asynccontextmanager
     async def _lifespan(
@@ -2107,12 +2119,28 @@ def create_app(
     # sleep-wake reconnects) that re-register within the grace never
     # flap their sessions to failed.
     _disconnect_grace_tasks: dict[str, asyncio.Task[None]] = {}
+    # OMN-104 §5.4: runner_id -> epoch-seconds deadline while a runner is
+    # inside its disconnect grace (mirrors _disconnect_grace_tasks, kept
+    # separately so it survives being read from a different module).
+    # session_live_state.clear_runner_liveness() nulls runner_last_seen
+    # IMMEDIATELY on disconnect (not after the grace) — so a decision
+    # arriving mid-grace would otherwise see stale liveness and be
+    # misclassified as "runner dead" (410) even though the runner is very
+    # likely about to reconnect. Exposed via app.state so the decision
+    # endpoint (a different module) can consult it before falling back to
+    # the cross-replica runner_last_seen freshness check. Per-replica, like
+    # the tunnel registry and _disconnect_grace_tasks themselves — this is
+    # not a downgrade from the existing per-replica-only mechanisms it
+    # complements.
+    _runner_disconnect_grace_deadline: dict[str, float] = {}
+    app.state.runner_disconnect_grace_deadline = _runner_disconnect_grace_deadline
 
     def _cancel_disconnect_grace(runner_id: str) -> None:
         """Cancel and forget the pending disconnect-grace timer, if any."""
         pending = _disconnect_grace_tasks.pop(runner_id, None)
         if pending is not None and not pending.done():
             pending.cancel()
+        _runner_disconnect_grace_deadline.pop(runner_id, None)
 
     async def _mark_disconnected_runner_failed(runner_id: str) -> None:
         """Reconcile a dropped runner's sessions once the grace expires.
@@ -2137,7 +2165,18 @@ def create_app(
                 "Runner %s reconnected within the disconnect grace; skipping offline-marking",
                 runner_id,
             )
+            # Defensive: _on_runner_connect already clears this on reconnect;
+            # clearing here too covers any ordering where this timer's
+            # live-tunnel check observes the reconnect before that handler's
+            # own clear runs.
+            _runner_disconnect_grace_deadline.pop(runner_id, None)
             return
+        # Grace expired with no reconnect: the runner is now CONFIRMED dead,
+        # not merely presumed — clear the grace-pending marker so decision
+        # classification correctly falls through to the (now genuinely
+        # stale) runner_last_seen freshness check instead of treating this
+        # runner as still-possibly-reconnecting.
+        _runner_disconnect_grace_deadline.pop(runner_id, None)
         # Direct by-runner lookup: read-after-write consistent (the
         # listing path may be served from an eventually-consistent
         # search index in alternate store backends) and
@@ -2210,6 +2249,14 @@ def create_app(
         # Replace any pending timer so a rapid drop-reconnect-drop gives
         # each outage a full grace window.
         _cancel_disconnect_grace(runner_id)
+        from omnigent.server.routes.sessions import RUNNER_DISCONNECT_GRACE_S
+
+        # OMN-104 §5.4: mark this runner as grace-pending (not confirmed
+        # dead) for the same duration the failed-marking timer waits, so a
+        # decision arriving in this window is classified as "pending
+        # redelivery", not "runner dead" — see _runner_disconnect_grace_deadline
+        # above and its consumer in routes_elicitations.py.
+        _runner_disconnect_grace_deadline[runner_id] = time.time() + RUNNER_DISCONNECT_GRACE_S
         task = asyncio.create_task(
             _mark_disconnected_runner_failed(runner_id),
             name=f"runner-disconnect-grace-{runner_id}",
@@ -2283,6 +2330,11 @@ def create_app(
         # Stamp liveness immediately so other replicas see the runner
         # online before the first periodic sweep.
         session_live_state.touch_runner_liveness([runner_id])
+        # The runner is back — it's no longer merely "presumed alive
+        # pending grace expiry"; clear the grace-pending marker so decision
+        # classification goes back to the normal runner_seen_is_fresh path
+        # (now correctly fresh, per the touch_runner_liveness call above).
+        _runner_disconnect_grace_deadline.pop(runner_id, None)
 
         # Direct by-runner lookup instead of list-everything-and-filter:
         # the listing path may be backed by an eventually-consistent
@@ -2366,14 +2418,29 @@ def create_app(
                         },
                         timeout=10.0,
                     )
-                    if 200 <= response.status_code < 300:
+                    # Truthful consumption is EITHER of two independent
+                    # signals (see helpers.py's _forward_approval_to_runner,
+                    # same contract): the runner's own
+                    # pending_approvals.resolve() header (the policy/cost-ASK
+                    # path), or a bare 2xx (the harness-native ctx.elicit()
+                    # path — the runner unconditionally also forwards this
+                    # event to the harness subprocess, whose own
+                    # _resolve_elicitation 404s for any id that isn't a
+                    # genuine _in_flight match, so a 2xx here is itself
+                    # already truthful, not merely "reached the runner").
+                    # session.resumed must only ever reflect a verdict the
+                    # runner actually consumed via one of these two paths.
+                    if response.headers.get(_PENDING_APPROVAL_RESOLVED_HEADER) == "true" or (
+                        200 <= response.status_code < 300
+                    ):
                         session_outbox.record_elicitation_resumed(
                             workspace_id=undelivered.workspace_id,
                             elicitation_id=undelivered.id,
                         )
                     else:
                         _logger.warning(
-                            "Reconnect redelivery for elicitation %s rejected by runner: %s",
+                            "Reconnect redelivery for elicitation %s not truthfully "
+                            "consumed by runner (status=%s)",
                             undelivered.id,
                             response.status_code,
                         )

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -173,6 +173,14 @@ _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
 _SESSION_PATH_RE = re.compile(r"/v1/sessions/([^/]+)")
+# OMN-104 §5.4 case (b), cross-vendor review P1: how often each replica
+# sweeps its OWN locally-connected runners for decided-but-undelivered
+# elicitations (see _redelivery_sweep_loop). Faster than
+# RUNNER_DISCONNECT_GRACE_S (10.0s) so a decision recorded on a different
+# replica than the one holding the tunnel is delivered promptly even
+# though the runner never disconnects/reconnects to trigger the other
+# delivery path.
+_REDELIVERY_SWEEP_INTERVAL_S: float = 5.0
 # polly's and debby's multi-file bundles are packaged under
 # omnigent.resources.examples (see pyproject package-data), so they resolve
 # in both a repo checkout and an installed wheel. The presence check in each
@@ -1087,6 +1095,14 @@ def create_app(
         manager_webhook_dispatcher_task = asyncio.create_task(
             run_dispatcher(session_lifecycle_store, lease_owner=_dispatcher_lease_owner)
         )
+        # Cross-replica decided-elicitation redelivery sweep (OMN-104 §5.4
+        # case (b), cross-vendor review P1): always started, one per
+        # replica, same unconditional-task pattern as the dispatcher above
+        # — see _redelivery_sweep_loop's own docstring for why this exists
+        # (a runner that never disconnects from the replica holding its
+        # tunnel would otherwise never see a decision recorded on a
+        # different replica).
+        redelivery_sweep_task = asyncio.create_task(_redelivery_sweep_loop())
         metrics_publish_task = asyncio.create_task(
             publish_server_metrics_periodically(
                 server_metrics,
@@ -1162,6 +1178,9 @@ def create_app(
             metrics_publish_task.cancel()
             with suppress(asyncio.CancelledError):
                 await metrics_publish_task
+            redelivery_sweep_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await redelivery_sweep_task
             await cancel_dispatcher(manager_webhook_dispatcher_task)
             # Stop in-flight background managed-sandbox launches so a
             # slow provision doesn't outlive the ASGI shutdown (the
@@ -2120,16 +2139,19 @@ def create_app(
     # flap their sessions to failed.
     _disconnect_grace_tasks: dict[str, asyncio.Task[None]] = {}
     # OMN-104 §5.4: the grace-pending marker is durable
-    # (omnigent_conversation_metadata.runner_disconnect_grace_deadline via
-    # session_live_state.set_runner_disconnect_grace/clear_runner_disconnect_grace),
-    # not per-process state — a manager decision can land on ANY server
-    # replica, not just the one holding this runner's tunnel.
-    # session_live_state.clear_runner_liveness() nulls runner_last_seen
-    # IMMEDIATELY on disconnect (not after the grace), on that SAME durable
-    # row — so a decision arriving mid-grace on a different replica would
-    # otherwise see stale liveness with no local grace entry to consult and
-    # be misclassified as "runner dead" (410) even though the runner is
-    # very likely about to reconnect. The decision endpoint reads this via
+    # (omnigent_conversation_metadata.runner_disconnect_grace_deadline,
+    # written atomically alongside runner_last_seen's clear by
+    # session_live_state.mark_runner_disconnected — see its docstring for
+    # why this must be one write, not two — and cleared via
+    # session_live_state.clear_runner_disconnect_grace), not per-process
+    # state — a manager decision can land on ANY server replica, not just
+    # the one holding this runner's tunnel. runner_last_seen is cleared
+    # IMMEDIATELY on disconnect (not after the grace), in that SAME atomic
+    # write — so a decision arriving mid-grace on a different replica sees
+    # a consistent snapshot (liveness cleared AND grace set together, never
+    # one without the other) rather than being misclassified as "runner
+    # dead" (410) even though the runner is very likely about to reconnect.
+    # The decision endpoint reads this via
     # SessionConnectivity.runner_disconnect_grace_deadline (cross-replica,
     # like runner_last_seen itself), not app.state.
 
@@ -2240,24 +2262,26 @@ def create_app(
             )
             return
         runner_session_initializer.invalidate_runner(runner_id)
-        # Graceful disconnect: clear the persisted liveness stamp so other
-        # replicas flip offline immediately rather than after the TTL.
-        session_live_state.clear_runner_liveness(runner_id)
 
         # Replace any pending timer so a rapid drop-reconnect-drop gives
         # each outage a full grace window.
         _cancel_disconnect_grace(runner_id)
         from omnigent.server.routes.sessions import RUNNER_DISCONNECT_GRACE_S
 
-        # OMN-104 §5.4: mark this runner as grace-pending (not confirmed
-        # dead) for the same duration the failed-marking timer waits, so a
-        # decision arriving in this window — on ANY replica, not just this
-        # one — is classified as "pending redelivery", not "runner dead".
-        # Durable (see session_live_state.set_runner_disconnect_grace),
-        # written alongside clear_runner_liveness above; consumed via
+        # Graceful disconnect: clear the persisted liveness stamp (so other
+        # replicas flip offline immediately rather than after the TTL) AND
+        # mark this runner grace-pending (not confirmed dead, for the same
+        # duration the failed-marking timer below waits, so a decision
+        # arriving in this window — on ANY replica, not just this one — is
+        # classified as "pending redelivery", not "runner dead") in ONE
+        # atomic write. Cross-vendor review: doing these as two separate
+        # writes left a window where another replica's read could observe
+        # the runner as neither live nor grace-pending and falsely 410 a
+        # decision — see session_live_state.mark_runner_disconnected's
+        # docstring. Consumed via
         # SessionConnectivity.runner_disconnect_grace_deadline in
         # routes_elicitations.py.
-        session_live_state.set_runner_disconnect_grace(
+        session_live_state.mark_runner_disconnected(
             runner_id, time.time() + RUNNER_DISCONNECT_GRACE_S
         )
         task = asyncio.create_task(
@@ -2312,6 +2336,129 @@ def create_app(
             conversation_store,
             fail_idle_top_level=True,
         )
+
+    async def _redeliver_decided_undelivered(
+        conv_id: str, routed_client: httpx.AsyncClient
+    ) -> None:
+        """Redeliver decided-but-undelivered elicitation verdicts for one session.
+
+        OMN-104 §5.4 case (b): a durable ``session_elicitations`` row plus
+        this delivery is what makes the manager's earlier decision-endpoint
+        response ("recorded, pending redelivery") eventually true — reuses
+        the runner's existing approval-POST contract rather than inventing
+        a second delivery mechanism. Called from two places: on this
+        replica's own tunnel reconnect (:func:`_on_runner_connect`, the
+        original OMN-104 mechanism), and from :func:`_redelivery_sweep_loop`
+        for a runner that never disconnected from THIS replica at all — the
+        cross-vendor review P1 finding that a decision landing on a
+        different replica than the one continuously holding the tunnel
+        would otherwise never be delivered, since no reconnect event would
+        ever fire to trigger this.
+
+        :param conv_id: Session/conversation id whose elicitations to
+            check, e.g. ``"conv_abc123"``.
+        :param routed_client: HTTP client already resolved to this
+            session's bound (and, by construction of both call sites,
+            locally live) runner.
+        """
+        for undelivered in session_lifecycle_store.list_decided_undelivered(conv_id):
+            try:
+                decision_payload = (
+                    json.loads(undelivered.decision_payload)
+                    if undelivered.decision_payload
+                    else {}
+                )
+                response = await routed_client.post(
+                    f"/v1/sessions/{conv_id}/events",
+                    json={
+                        "type": _APPROVAL_TYPE,
+                        "data": {"elicitation_id": undelivered.id, **decision_payload},
+                    },
+                    timeout=10.0,
+                )
+                # Truthful consumption is EITHER of two independent
+                # signals (see helpers.py's _forward_approval_to_runner,
+                # same contract): the runner's own
+                # pending_approvals.resolve() header (the policy/cost-ASK
+                # path), or a bare 2xx (the harness-native ctx.elicit()
+                # path — the runner unconditionally also forwards this
+                # event to the harness subprocess, whose own
+                # _resolve_elicitation 404s for any id that isn't a
+                # genuine _in_flight match, so a 2xx here is itself
+                # already truthful, not merely "reached the runner").
+                # session.resumed must only ever reflect a verdict the
+                # runner actually consumed via one of these two paths.
+                if response.headers.get(_PENDING_APPROVAL_RESOLVED_HEADER) == "true" or (
+                    200 <= response.status_code < 300
+                ):
+                    session_outbox.record_elicitation_resumed(
+                        workspace_id=undelivered.workspace_id,
+                        elicitation_id=undelivered.id,
+                    )
+                else:
+                    _logger.warning(
+                        "Redelivery for elicitation %s not truthfully consumed by runner "
+                        "(status=%s)",
+                        undelivered.id,
+                        response.status_code,
+                    )
+            except (httpx.HTTPError, ConnectionError):
+                _logger.exception(
+                    "Redelivery failed for elicitation %s",
+                    undelivered.id,
+                )
+
+    async def _redelivery_sweep_loop() -> None:
+        """Periodically redeliver decided elicitations for locally-connected runners.
+
+        Cross-vendor review P1: ``_on_runner_connect`` only redelivers on
+        an actual reconnect event. If the runner stays continuously
+        connected to replica A the whole time a decision is durably
+        recorded on replica B, no reconnect ever fires on replica A and
+        the decision is otherwise permanently stuck — ``pending_redelivery``
+        was a promise the codebase had no mechanism to keep. This sweep
+        makes it true: every replica periodically checks the runner ids
+        its OWN tunnel registry currently holds live (a purely local,
+        in-memory, cheap read — no cross-replica discovery needed, since
+        this loop only ever acts on runners genuinely connected HERE) and
+        redelivers anything decided-but-undelivered for their bound
+        sessions, regardless of which replica recorded the decision.
+
+        One per replica, unconditionally started (same pattern as
+        ``manager_webhook_dispatcher_task``) — safe under multi-replica
+        because each replica only ever touches the sessions bound to
+        runners live on ITS OWN registry; two replicas never race to
+        redeliver the same session's elicitation (only one of them can
+        have that runner's tunnel at a time, by the tunnel registry's own
+        newest-wins invariant), and ``record_elicitation_resumed`` is
+        idempotent regardless.
+
+        Cost is O(locally-connected runners × sessions bound to each) per
+        sweep tick — acceptable at the interval below for the scale this
+        mechanism targets (a handful of sessions per runner); a
+        cross-store JOIN to make this a single targeted query would need
+        the session-lifecycle store and the conversation store to share a
+        database, which OMN-104's design deliberately does not assume.
+        """
+        while True:
+            try:
+                await asyncio.sleep(_REDELIVERY_SWEEP_INTERVAL_S)
+                for runner_id in tunnel_registry.online_runner_ids():
+                    convs = await asyncio.to_thread(
+                        conversation_store.list_conversations_by_runner_id, runner_id
+                    )
+                    for conv in convs:
+                        if not session_lifecycle_store.list_decided_undelivered(conv.id):
+                            continue
+                        try:
+                            routed = runner_router.client_for_session_resources(conv.id)
+                        except OmnigentError:
+                            continue
+                        await _redeliver_decided_undelivered(conv.id, routed.client)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception("Redelivery sweep tick failed; will retry next interval")
 
     async def _on_runner_connect(runner_id: str) -> None:
         """Re-assign sessions and restart SSE relays on reconnect.
@@ -2405,53 +2552,11 @@ def create_app(
             # hook is what makes the manager's earlier decision-endpoint
             # response ("recorded, pending redelivery") eventually true —
             # reuses the runner's existing approval-POST contract rather
-            # than inventing a second delivery mechanism.
-            for undelivered in session_lifecycle_store.list_decided_undelivered(conv.id):
-                try:
-                    decision_payload = (
-                        json.loads(undelivered.decision_payload)
-                        if undelivered.decision_payload
-                        else {}
-                    )
-                    response = await routed.client.post(
-                        f"/v1/sessions/{conv.id}/events",
-                        json={
-                            "type": _APPROVAL_TYPE,
-                            "data": {"elicitation_id": undelivered.id, **decision_payload},
-                        },
-                        timeout=10.0,
-                    )
-                    # Truthful consumption is EITHER of two independent
-                    # signals (see helpers.py's _forward_approval_to_runner,
-                    # same contract): the runner's own
-                    # pending_approvals.resolve() header (the policy/cost-ASK
-                    # path), or a bare 2xx (the harness-native ctx.elicit()
-                    # path — the runner unconditionally also forwards this
-                    # event to the harness subprocess, whose own
-                    # _resolve_elicitation 404s for any id that isn't a
-                    # genuine _in_flight match, so a 2xx here is itself
-                    # already truthful, not merely "reached the runner").
-                    # session.resumed must only ever reflect a verdict the
-                    # runner actually consumed via one of these two paths.
-                    if response.headers.get(_PENDING_APPROVAL_RESOLVED_HEADER) == "true" or (
-                        200 <= response.status_code < 300
-                    ):
-                        session_outbox.record_elicitation_resumed(
-                            workspace_id=undelivered.workspace_id,
-                            elicitation_id=undelivered.id,
-                        )
-                    else:
-                        _logger.warning(
-                            "Reconnect redelivery for elicitation %s not truthfully "
-                            "consumed by runner (status=%s)",
-                            undelivered.id,
-                            response.status_code,
-                        )
-                except (httpx.HTTPError, ConnectionError):
-                    _logger.exception(
-                        "Reconnect redelivery failed for elicitation %s",
-                        undelivered.id,
-                    )
+            # than inventing a second delivery mechanism. Shared with
+            # _redelivery_sweep_loop, which covers the case where the
+            # runner never disconnects from THIS replica at all — see that
+            # function's docstring.
+            await _redeliver_decided_undelivered(conv.id, routed.client)
             # The session's terminal exists as of the handshake above, so its
             # model catalogs are answerable now. Warming them here is what
             # keeps the first routed message off the runner round trip. The

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2119,28 +2119,26 @@ def create_app(
     # sleep-wake reconnects) that re-register within the grace never
     # flap their sessions to failed.
     _disconnect_grace_tasks: dict[str, asyncio.Task[None]] = {}
-    # OMN-104 §5.4: runner_id -> epoch-seconds deadline while a runner is
-    # inside its disconnect grace (mirrors _disconnect_grace_tasks, kept
-    # separately so it survives being read from a different module).
+    # OMN-104 §5.4: the grace-pending marker is durable
+    # (omnigent_conversation_metadata.runner_disconnect_grace_deadline via
+    # session_live_state.set_runner_disconnect_grace/clear_runner_disconnect_grace),
+    # not per-process state — a manager decision can land on ANY server
+    # replica, not just the one holding this runner's tunnel.
     # session_live_state.clear_runner_liveness() nulls runner_last_seen
-    # IMMEDIATELY on disconnect (not after the grace) — so a decision
-    # arriving mid-grace would otherwise see stale liveness and be
-    # misclassified as "runner dead" (410) even though the runner is very
-    # likely about to reconnect. Exposed via app.state so the decision
-    # endpoint (a different module) can consult it before falling back to
-    # the cross-replica runner_last_seen freshness check. Per-replica, like
-    # the tunnel registry and _disconnect_grace_tasks themselves — this is
-    # not a downgrade from the existing per-replica-only mechanisms it
-    # complements.
-    _runner_disconnect_grace_deadline: dict[str, float] = {}
-    app.state.runner_disconnect_grace_deadline = _runner_disconnect_grace_deadline
+    # IMMEDIATELY on disconnect (not after the grace), on that SAME durable
+    # row — so a decision arriving mid-grace on a different replica would
+    # otherwise see stale liveness with no local grace entry to consult and
+    # be misclassified as "runner dead" (410) even though the runner is
+    # very likely about to reconnect. The decision endpoint reads this via
+    # SessionConnectivity.runner_disconnect_grace_deadline (cross-replica,
+    # like runner_last_seen itself), not app.state.
 
     def _cancel_disconnect_grace(runner_id: str) -> None:
         """Cancel and forget the pending disconnect-grace timer, if any."""
         pending = _disconnect_grace_tasks.pop(runner_id, None)
         if pending is not None and not pending.done():
             pending.cancel()
-        _runner_disconnect_grace_deadline.pop(runner_id, None)
+        session_live_state.clear_runner_disconnect_grace(runner_id)
 
     async def _mark_disconnected_runner_failed(runner_id: str) -> None:
         """Reconcile a dropped runner's sessions once the grace expires.
@@ -2169,14 +2167,14 @@ def create_app(
             # clearing here too covers any ordering where this timer's
             # live-tunnel check observes the reconnect before that handler's
             # own clear runs.
-            _runner_disconnect_grace_deadline.pop(runner_id, None)
+            session_live_state.clear_runner_disconnect_grace(runner_id)
             return
         # Grace expired with no reconnect: the runner is now CONFIRMED dead,
         # not merely presumed — clear the grace-pending marker so decision
         # classification correctly falls through to the (now genuinely
         # stale) runner_last_seen freshness check instead of treating this
         # runner as still-possibly-reconnecting.
-        _runner_disconnect_grace_deadline.pop(runner_id, None)
+        session_live_state.clear_runner_disconnect_grace(runner_id)
         # Direct by-runner lookup: read-after-write consistent (the
         # listing path may be served from an eventually-consistent
         # search index in alternate store backends) and
@@ -2253,10 +2251,15 @@ def create_app(
 
         # OMN-104 §5.4: mark this runner as grace-pending (not confirmed
         # dead) for the same duration the failed-marking timer waits, so a
-        # decision arriving in this window is classified as "pending
-        # redelivery", not "runner dead" — see _runner_disconnect_grace_deadline
-        # above and its consumer in routes_elicitations.py.
-        _runner_disconnect_grace_deadline[runner_id] = time.time() + RUNNER_DISCONNECT_GRACE_S
+        # decision arriving in this window — on ANY replica, not just this
+        # one — is classified as "pending redelivery", not "runner dead".
+        # Durable (see session_live_state.set_runner_disconnect_grace),
+        # written alongside clear_runner_liveness above; consumed via
+        # SessionConnectivity.runner_disconnect_grace_deadline in
+        # routes_elicitations.py.
+        session_live_state.set_runner_disconnect_grace(
+            runner_id, time.time() + RUNNER_DISCONNECT_GRACE_S
+        )
         task = asyncio.create_task(
             _mark_disconnected_runner_failed(runner_id),
             name=f"runner-disconnect-grace-{runner_id}",
@@ -2334,7 +2337,7 @@ def create_app(
         # pending grace expiry"; clear the grace-pending marker so decision
         # classification goes back to the normal runner_seen_is_fresh path
         # (now correctly fresh, per the touch_runner_liveness call above).
-        _runner_disconnect_grace_deadline.pop(runner_id, None)
+        session_live_state.clear_runner_disconnect_grace(runner_id)
 
         # Direct by-runner lookup instead of list-everything-and-filter:
         # the listing path may be backed by an eventually-consistent

--- a/omnigent/server/manager_webhook_dispatcher.py
+++ b/omnigent/server/manager_webhook_dispatcher.py
@@ -143,18 +143,18 @@ async def _deliver_one(
             "data": json.loads(event.payload),
         }
     )
-    secret = signing.current_secret()
+    secret = signing.current_signing_key()
     started = time.monotonic()
     if secret is None:
-        # Configured enabled but no secret in the environment — fail this
-        # attempt like any other delivery failure (retried with backoff);
-        # never send an unsigned request.
+        # Configured enabled but no signing key in the environment — fail
+        # this attempt like any other delivery failure (retried with
+        # backoff); never send an unsigned request.
         store.mark_delivery_failed(
             event.id,
             workspace_id=event.workspace_id,
             next_attempt_at=int(time.time()) + int(_backoff_seconds(event.attempt_count)),
             dead_letter_after_attempts=_DEAD_LETTER_AFTER_ATTEMPTS,
-            error_code="missing_secret",
+            error_code="missing_signing_key",
             error_message=f"{signing.SECRET_ENV_VAR} is not set",
         )
         _log_attempt(
@@ -162,7 +162,7 @@ async def _deliver_one(
             outcome="error",
             latency_ms=0.0,
             http_status=None,
-            error_code="missing_secret",
+            error_code="missing_signing_key",
             endpoint_host=_endpoint_host(endpoint),
         )
         return

--- a/omnigent/server/manager_webhook_dispatcher.py
+++ b/omnigent/server/manager_webhook_dispatcher.py
@@ -1,0 +1,297 @@
+"""Manager-webhook delivery dispatcher (OMN-104).
+
+A single ``asyncio.create_task`` running inside the FastAPI lifespan (the
+same pattern as ``metrics_publish_task`` — see ``omnigent/server/app.py``),
+one per server replica, safe under multi-replica because claiming is
+row-leased (``FOR UPDATE SKIP LOCKED`` on PostgreSQL; a plain claim under
+SQLite's single-writer serialization), not because only one replica runs
+it.
+
+HTTP delivery is fully decoupled from the DB transaction and from
+``_publish_status``/SSE/conversation writes: the outbox INSERT (see
+``omnigent/server/session_outbox.py``) is synchronous with the producing
+transaction, but this loop is a separate task with no code path that writes
+back into session state — a slow or unreachable manager endpoint never
+delays a session's terminal transitions.
+
+The task always starts; when ``manager_webhook.enabled`` is ``False`` (the
+default) it still runs its claim/reclaim loop but the claim query returns
+nothing meaningful to deliver in practice (see :func:`_run_once`) — this
+means flipping the config live needs no server restart. Poll/reconciliation
+is untouched by any of this: nothing here can regress existing session-state
+correctness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import time
+from contextlib import suppress
+
+import httpx
+
+from omnigent.entities import LifecycleOutboxEvent
+from omnigent.runtime.telemetry import _REDACT_KEY_SUBSTRINGS
+from omnigent.server import manager_webhook_signing as signing
+from omnigent.server.server_config import ManagerWebhookConfigError, manager_webhook_config
+from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
+
+_logger = logging.getLogger(__name__)
+
+# Poll cadence when idle (nothing claimed). Short enough that an enabled
+# webhook feels responsive; cheap enough (one indexed SELECT) to run
+# constantly even while disabled.
+_IDLE_POLL_SECONDS = 2.0
+# How many rows to claim per cycle.
+_CLAIM_BATCH_SIZE = 25
+# How long a claim's lease is held before it's reclaimable (crash-mid-claim
+# recovery). Comfortably longer than any single delivery attempt's timeout.
+_LEASE_SECONDS = 60
+_DELIVERY_TIMEOUT_SECONDS = 10.0
+# Backoff schedule (docs/architecture/2026-08-10-durable-session-lifecycle-push.md §7.3):
+# exponential with full jitter, capped, unbounded attempt count.
+_BACKOFF_BASE_SECONDS = 5.0
+_BACKOFF_CAP_SECONDS = 15 * 60.0
+# After this many attempts a row is marked dead_letter for API/log
+# visibility — it keeps retrying at the capped floor interval regardless
+# (escalation, never abandonment; §7.4).
+_DEAD_LETTER_AFTER_ATTEMPTS = 10
+# Reclaim expired leases at most this often (cheap relative to the claim
+# loop, so it just runs every cycle rather than on a separate timer).
+
+
+def _backoff_seconds(attempt: int) -> float:
+    """Exponential-with-full-jitter delay for the given 1-based attempt count."""
+    capped = min(_BACKOFF_CAP_SECONDS, _BACKOFF_BASE_SECONDS * (2**attempt))
+    return capped * random.uniform(0.5, 1.0)
+
+
+def _redact_for_log(value: str) -> str:
+    """Best-effort scrub of a log-bound string using the shared key-substring denylist.
+
+    Only used for values that are already short, sanitized classification
+    tokens (error codes) — never the payload body, signature, secret, or
+    full URL, which this module's log lines never include in the first
+    place (see :func:`_log_attempt`).
+    """
+    lowered = value.lower()
+    if any(s in lowered for s in _REDACT_KEY_SUBSTRINGS):
+        return "[redacted]"
+    return value
+
+
+def _endpoint_host(endpoint: str) -> str:
+    """Host-only projection of the target URL, for logging (never the full URL/query)."""
+    return httpx.URL(endpoint).host
+
+
+def _log_attempt(
+    event: LifecycleOutboxEvent,
+    *,
+    outcome: str,
+    latency_ms: float,
+    http_status: int | None,
+    error_code: str | None,
+    endpoint_host: str | None,
+) -> None:
+    """One structured log line per delivery attempt (§9) — never the payload
+    body, the signature, the secret, or the full target URL (host only)."""
+    _logger.info(
+        "manager_webhook delivery attempt",
+        extra={
+            "event_id": event.id,
+            "workspace_id": event.workspace_id,
+            "session_id": event.session_id,
+            "sequence": event.sequence,
+            "attempt_count": event.attempt_count,
+            "event_type": event.event_type,
+            "outcome": outcome,
+            "latency_ms": round(latency_ms, 1),
+            "http_status": http_status,
+            "error_code": _redact_for_log(error_code) if error_code else None,
+            "endpoint_host": endpoint_host,
+        },
+    )
+
+
+async def _deliver_one(
+    client: httpx.AsyncClient,
+    store: SessionLifecycleStore,
+    event: LifecycleOutboxEvent,
+    *,
+    endpoint: str,
+    key_id: str | None,
+) -> None:
+    """Attempt one HTTP delivery for a claimed row and record the outcome."""
+    # Wire envelope per §3.1 of the design doc — event.payload (stored) is
+    # only the event-type-specific `data`; the transmitted body wraps it with
+    # the stable identity/ordering fields the manager's dedupe/ordering
+    # contract needs (event_id, sequence, ...). Signed over the exact bytes
+    # transmitted, not the stored payload alone.
+    raw_json_body = json.dumps(
+        {
+            "event_id": event.id,
+            "event_version": event.event_version,
+            "event_type": event.event_type,
+            "workspace_id": event.workspace_id,
+            "session_id": event.session_id,
+            "sequence": event.sequence,
+            "occurred_at": event.created_at,
+            "data": json.loads(event.payload),
+        }
+    )
+    secret = signing.current_secret()
+    started = time.monotonic()
+    if secret is None:
+        # Configured enabled but no secret in the environment — fail this
+        # attempt like any other delivery failure (retried with backoff);
+        # never send an unsigned request.
+        store.mark_delivery_failed(
+            event.id,
+            workspace_id=event.workspace_id,
+            next_attempt_at=int(time.time()) + int(_backoff_seconds(event.attempt_count)),
+            dead_letter_after_attempts=_DEAD_LETTER_AFTER_ATTEMPTS,
+            error_code="missing_secret",
+            error_message="OMNIGENT_MANAGER_WEBHOOK_SECRET is not set",
+        )
+        _log_attempt(
+            event,
+            outcome="error",
+            latency_ms=0.0,
+            http_status=None,
+            error_code="missing_secret",
+            endpoint_host=_endpoint_host(endpoint),
+        )
+        return
+    timestamp = int(time.time())
+    signature = signing.sign(
+        secret=secret, timestamp=timestamp, event_id=event.id, raw_json_body=raw_json_body
+    )
+    headers = signing.build_headers(
+        event_id=event.id,
+        event_type=event.event_type,
+        attempt=event.attempt_count,
+        timestamp=timestamp,
+        key_id=key_id,
+        signature=signature,
+    )
+    try:
+        response = await client.post(
+            endpoint,
+            content=raw_json_body,
+            headers=headers,
+            timeout=_DELIVERY_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        latency_ms = (time.monotonic() - started) * 1000
+        store.mark_delivery_failed(
+            event.id,
+            workspace_id=event.workspace_id,
+            next_attempt_at=int(time.time()) + int(_backoff_seconds(event.attempt_count)),
+            dead_letter_after_attempts=_DEAD_LETTER_AFTER_ATTEMPTS,
+            error_code=type(exc).__name__,
+            error_message=str(exc)[:256],
+        )
+        _log_attempt(
+            event,
+            outcome="transport_error",
+            latency_ms=latency_ms,
+            http_status=None,
+            error_code=type(exc).__name__,
+            endpoint_host=_endpoint_host(endpoint),
+        )
+        return
+    latency_ms = (time.monotonic() - started) * 1000
+    if 200 <= response.status_code < 300:
+        store.mark_delivered(
+            event.id,
+            workspace_id=event.workspace_id,
+            delivered_at=int(time.time()),
+            http_status=response.status_code,
+        )
+        _log_attempt(
+            event,
+            outcome="delivered",
+            latency_ms=latency_ms,
+            http_status=response.status_code,
+            error_code=None,
+            endpoint_host=_endpoint_host(endpoint),
+        )
+        return
+    store.mark_delivery_failed(
+        event.id,
+        workspace_id=event.workspace_id,
+        next_attempt_at=int(time.time()) + int(_backoff_seconds(event.attempt_count)),
+        dead_letter_after_attempts=_DEAD_LETTER_AFTER_ATTEMPTS,
+        http_status=response.status_code,
+        error_code="http_error",
+        error_message=f"manager returned {response.status_code}",
+    )
+    _log_attempt(
+        event,
+        outcome="rejected",
+        latency_ms=latency_ms,
+        http_status=response.status_code,
+        error_code="http_error",
+        endpoint_host=_endpoint_host(endpoint),
+    )
+
+
+async def _run_once(
+    client: httpx.AsyncClient, store: SessionLifecycleStore, *, lease_owner: str
+) -> int:
+    """One dispatcher cycle: reclaim expired leases, then claim and deliver.
+
+    :returns: Number of rows claimed this cycle (0 means the caller should
+        idle-sleep before the next cycle).
+    """
+    now = int(time.time())
+    reclaimed = store.reclaim_expired_leases(now=now)
+    if reclaimed:
+        _logger.info("manager_webhook reclaimed %d expired lease(s)", reclaimed)
+    try:
+        config = manager_webhook_config()
+    except ManagerWebhookConfigError:
+        # Fails closed at boot (create_app raises before serving traffic if
+        # misconfigured) — a config edited to a bad state after boot is
+        # logged once per cycle and treated as disabled, never crashes the
+        # dispatcher loop.
+        _logger.warning("manager_webhook config invalid; dispatcher idling", exc_info=True)
+        return 0
+    if not config.enabled or config.endpoint is None:
+        return 0
+    claimed = store.claim_batch(
+        limit=_CLAIM_BATCH_SIZE, now=now, lease_owner=lease_owner, lease_seconds=_LEASE_SECONDS
+    )
+    for event in claimed:
+        await _deliver_one(client, store, event, endpoint=config.endpoint, key_id=config.key_id)
+    return len(claimed)
+
+
+async def run_dispatcher(store: SessionLifecycleStore, *, lease_owner: str) -> None:
+    """
+    Run the dispatcher loop until cancelled.
+
+    :param store: The session-lifecycle store to claim/deliver from.
+    :param lease_owner: This replica's identity (e.g. a hostname+pid or
+        random token), stamped on claimed rows' ``lease_owner``.
+    """
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                claimed_count = await _run_once(client, store, lease_owner=lease_owner)
+            except Exception:
+                _logger.exception("manager_webhook dispatcher cycle failed")
+                claimed_count = 0
+            if claimed_count == 0:
+                await asyncio.sleep(_IDLE_POLL_SECONDS)
+
+
+async def cancel_dispatcher(task: asyncio.Task[None]) -> None:
+    """Cancel and await the dispatcher task, swallowing the resulting CancelledError."""
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task

--- a/omnigent/server/manager_webhook_dispatcher.py
+++ b/omnigent/server/manager_webhook_dispatcher.py
@@ -255,10 +255,12 @@ async def _run_once(
     try:
         config = manager_webhook_config()
     except ManagerWebhookConfigError:
-        # Fails closed at boot (create_app raises before serving traffic if
-        # misconfigured) — a config edited to a bad state after boot is
-        # logged once per cycle and treated as disabled, never crashes the
-        # dispatcher loop.
+        # create_app() already calls manager_webhook_config() once at boot
+        # and lets this same exception type propagate (fail closed before
+        # serving traffic) — so reaching this branch means the config file
+        # was edited into a bad state on disk *after* a successful boot.
+        # A running server must not crash on that; log once per cycle and
+        # treat as disabled until the file is fixed.
         _logger.warning("manager_webhook config invalid; dispatcher idling", exc_info=True)
         return 0
     if not config.enabled or config.endpoint is None:

--- a/omnigent/server/manager_webhook_dispatcher.py
+++ b/omnigent/server/manager_webhook_dispatcher.py
@@ -155,7 +155,7 @@ async def _deliver_one(
             next_attempt_at=int(time.time()) + int(_backoff_seconds(event.attempt_count)),
             dead_letter_after_attempts=_DEAD_LETTER_AFTER_ATTEMPTS,
             error_code="missing_secret",
-            error_message="OMNIGENT_MANAGER_WEBHOOK_SECRET is not set",
+            error_message=f"{signing.SECRET_ENV_VAR} is not set",
         )
         _log_attempt(
             event,

--- a/omnigent/server/manager_webhook_signing.py
+++ b/omnigent/server/manager_webhook_signing.py
@@ -28,8 +28,8 @@ PREVIOUS_SECRET_ENV_VAR = "OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS"
 DEFAULT_TOLERANCE_SECONDS = 300
 
 
-def current_secret() -> str | None:
-    """The active signing secret, or ``None`` if unset (signing disabled)."""
+def current_signing_key() -> str | None:
+    """The active signing key, or ``None`` if unset (signing disabled)."""
     value = os.environ.get(SECRET_ENV_VAR)
     return value if value else None
 
@@ -49,7 +49,7 @@ def sign(*, secret: str, timestamp: int, event_id: str, raw_json_body: str) -> s
     """
     Compute the ``X-Omnigent-Signature`` header value for one delivery attempt.
 
-    :param secret: The signing secret (:func:`current_secret` — never
+    :param secret: The signing secret (:func:`current_signing_key` — never
         *previous*; only the current secret ever signs).
     :param timestamp: Unix epoch seconds at signing time.
     :param event_id: The event's stable ``event_id``.

--- a/omnigent/server/manager_webhook_signing.py
+++ b/omnigent/server/manager_webhook_signing.py
@@ -19,8 +19,8 @@ import hashlib
 import hmac
 import os
 
-_SECRET_ENV = "OMNIGENT_MANAGER_WEBHOOK_SECRET"
-_SECRET_PREVIOUS_ENV = "OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS"
+SECRET_ENV_VAR = "OMNIGENT_MANAGER_WEBHOOK_SECRET"
+PREVIOUS_SECRET_ENV_VAR = "OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS"
 
 # Recommended replay-window tolerance (seconds) — see module docstring on
 # omnigent/server/manager_webhook_dispatcher.py for the delivery side and
@@ -30,13 +30,13 @@ DEFAULT_TOLERANCE_SECONDS = 300
 
 def current_secret() -> str | None:
     """The active signing secret, or ``None`` if unset (signing disabled)."""
-    value = os.environ.get(_SECRET_ENV)
+    value = os.environ.get(SECRET_ENV_VAR)
     return value if value else None
 
 
 def previous_secret() -> str | None:
     """The previous secret during a rotation window, or ``None``."""
-    value = os.environ.get(_SECRET_PREVIOUS_ENV)
+    value = os.environ.get(PREVIOUS_SECRET_ENV_VAR)
     return value if value else None
 
 

--- a/omnigent/server/manager_webhook_signing.py
+++ b/omnigent/server/manager_webhook_signing.py
@@ -1,0 +1,146 @@
+"""HMAC request signing for the manager-webhook delivery (OMN-104).
+
+Stripe-style scheme: sign the raw transmitted body plus a timestamp,
+verify before JSON parsing. No outbound-signing precedent existed in this
+codebase to extend (the existing ``hmac_digest`` in
+:mod:`omnigent.server.oidc` keys an in-process cache, not a wire
+signature), so this is a fresh, narrow module — the single source of truth
+for both signing (the dispatcher) and verification (documented for the
+manager to implement; also used by this feature's own reference tests).
+
+The secret is env-var only, never the config file — the two-secret
+(current + previous) shape supports rotation: sign only with the current
+secret, but verify against both while a rotation is in flight.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+_SECRET_ENV = "OMNIGENT_MANAGER_WEBHOOK_SECRET"
+_SECRET_PREVIOUS_ENV = "OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS"
+
+# Recommended replay-window tolerance (seconds) — see module docstring on
+# omnigent/server/manager_webhook_dispatcher.py for the delivery side and
+# §8.2 of docs/architecture/2026-08-10-durable-session-lifecycle-push.md.
+DEFAULT_TOLERANCE_SECONDS = 300
+
+
+def current_secret() -> str | None:
+    """The active signing secret, or ``None`` if unset (signing disabled)."""
+    value = os.environ.get(_SECRET_ENV)
+    return value if value else None
+
+
+def previous_secret() -> str | None:
+    """The previous secret during a rotation window, or ``None``."""
+    value = os.environ.get(_SECRET_PREVIOUS_ENV)
+    return value if value else None
+
+
+def canonicalize(*, timestamp: int, event_id: str, raw_json_body: str) -> str:
+    """Build the signed-content string: ``{timestamp}.{event_id}.{raw_json_body}``."""
+    return f"{timestamp}.{event_id}.{raw_json_body}"
+
+
+def sign(*, secret: str, timestamp: int, event_id: str, raw_json_body: str) -> str:
+    """
+    Compute the ``X-Omnigent-Signature`` header value for one delivery attempt.
+
+    :param secret: The signing secret (:func:`current_secret` — never
+        *previous*; only the current secret ever signs).
+    :param timestamp: Unix epoch seconds at signing time.
+    :param event_id: The event's stable ``event_id``.
+    :param raw_json_body: The exact bytes (as a str) transmitted as the
+        request body — signing must happen over what's actually sent, not
+        a re-serialization of it.
+    :returns: ``"v1=<hex hmac-sha256>"``.
+    """
+    signed_content = canonicalize(
+        timestamp=timestamp, event_id=event_id, raw_json_body=raw_json_body
+    )
+    digest = hmac.new(
+        secret.encode("utf-8"), signed_content.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return f"v1={digest}"
+
+
+def verify(
+    *,
+    signature_header: str,
+    timestamp: int,
+    event_id: str,
+    raw_json_body: str,
+    now: int,
+    secrets: list[str],
+    tolerance_seconds: int = DEFAULT_TOLERANCE_SECONDS,
+) -> bool:
+    """
+    Verify a received delivery's signature and timestamp freshness.
+
+    Reference implementation for the manager side of the contract (also
+    exercised directly by this feature's signature/redaction tests). Checks
+    timestamp tolerance *and* signature — a stale timestamp is rejected even
+    with an otherwise-valid signature, and vice versa.
+
+    :param signature_header: The received ``X-Omnigent-Signature`` value,
+        e.g. ``"v1=abcdef..."``.
+    :param timestamp: The received ``X-Omnigent-Timestamp`` value.
+    :param event_id: The received ``X-Omnigent-Event-Id`` value.
+    :param raw_json_body: The exact received request body bytes (as a str),
+        read BEFORE JSON parsing.
+    :param now: The verifier's own current Unix epoch seconds.
+    :param secrets: Candidate secrets to verify against (current + previous,
+        for a rotation window). Empty/falsy entries are ignored.
+    :param tolerance_seconds: Maximum allowed clock skew between *timestamp*
+        and *now*.
+    :returns: ``True`` only if the timestamp is within tolerance AND the
+        signature matches one of *secrets*.
+    """
+    if abs(now - timestamp) > tolerance_seconds:
+        return False
+    for secret in secrets:
+        if not secret:
+            continue
+        expected = sign(
+            secret=secret, timestamp=timestamp, event_id=event_id, raw_json_body=raw_json_body
+        )
+        if hmac.compare_digest(signature_header, expected):
+            return True
+    return False
+
+
+def build_headers(
+    *,
+    event_id: str,
+    event_type: str,
+    attempt: int,
+    timestamp: int,
+    key_id: str | None,
+    signature: str,
+) -> dict[str, str]:
+    """
+    Build the full header set for one delivery attempt.
+
+    :param event_id: The event's stable ``event_id``.
+    :param event_type: e.g. ``"session.completed"``.
+    :param attempt: 1-based delivery attempt count.
+    :param timestamp: Unix epoch seconds at signing time (same value used in
+        :func:`sign`).
+    :param key_id: ``manager_webhook.key_id`` from config, or ``None``.
+    :param signature: The value returned by :func:`sign`.
+    :returns: Header dict ready to attach to the outbound HTTP request.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "X-Omnigent-Event-Id": event_id,
+        "X-Omnigent-Event-Type": event_type,
+        "X-Omnigent-Delivery-Attempt": str(attempt),
+        "X-Omnigent-Timestamp": str(timestamp),
+        "X-Omnigent-Signature": signature,
+    }
+    if key_id:
+        headers["X-Omnigent-Key-Id"] = key_id
+    return headers

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -55,6 +55,17 @@ _INTERRUPT_TYPE: str = "interrupt"
 _APPROVAL_TYPE: str = "approval"
 
 
+# OMN-104 §5.4: header the runner stamps on its POST /v1/sessions/{id}/events
+# response to an "approval" event, carrying whether pending_approvals.resolve()
+# found and resolved a tracked Future — a 2xx alone is not truthful consumption
+# (it also fires for an unknown/stale/already-resolved elicitation_id). Must
+# match omnigent/runner/app.py's _PENDING_APPROVAL_RESOLVED_HEADER — the
+# server and runner are separate deployable units (no shared import), so this
+# wire-protocol constant is duplicated across the boundary like _APPROVAL_TYPE
+# itself (runner/app.py checks the bare string "approval" directly).
+_PENDING_APPROVAL_RESOLVED_HEADER: str = "X-Omnigent-Pending-Approval-Resolved"
+
+
 _MCP_ELICITATION_TYPE: str = "mcp_elicitation"
 
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -169,6 +169,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _MODEL_TOKEN_KEYS,
     _NATIVE_POLICY_NOT_ENFORCED_CODE,
     _NATIVE_TERMINAL_ENSURE_FAILED_CODE,
+    _PENDING_APPROVAL_RESOLVED_HEADER,
     _PI_NATIVE_WRAPPER_LABEL_VALUE,
     _RUNNER_CONVICTION_POLL_S,
     _RUNNER_FORWARD_TIMEOUT,
@@ -2657,7 +2658,7 @@ async def _forward_approval_to_runner(
     session_id: str,
     data: dict[str, Any],
     runner_router: RunnerRouter | None,
-) -> Literal["no_runner", "delivered", "unreachable"]:
+) -> Literal["no_runner", "delivered", "not_consumed", "unreachable"]:
     """
     Forward an approval verdict to the session's bound runner.
 
@@ -2682,11 +2683,24 @@ async def _forward_approval_to_runner(
         replica — not itself proof the runner is dead, see OMN-104's
         harness-classified elicitation resolution, which additionally
         consults the cross-replica ``runner_last_seen`` freshness signal
-        before concluding a runner is unreachable); ``"delivered"`` on a
-        2xx response (the runner's own handler ran
-        ``pending_approvals.resolve(...)`` — a truthful acknowledgement,
-        not just "accepted"); ``"unreachable"`` on a transport error or a
-        non-2xx response.
+        before concluding a runner is unreachable); ``"delivered"`` when
+        EITHER of two independent truthful-consumption signals fires:
+        the runner's response carries
+        ``X-Omnigent-Pending-Approval-Resolved: true`` (its own
+        ``pending_approvals.resolve(...)`` call found and resolved a
+        tracked Future — the policy/cost-ASK elicitation path), OR the
+        response is 2xx (the runner unconditionally also forwards the
+        same event to the harness subprocess, whose own
+        ``_resolve_elicitation`` raises 404 for any id that isn't a
+        genuinely outstanding ``ctx.elicit()`` Future — see
+        ``ErrorCode.NOT_FOUND`` -> 404 — so a 2xx from that forward is
+        itself already truthful for the harness-native elicitation path).
+        Consuming either signal alone is sufficient: an unknown, stale,
+        or already-resolved ``elicitation_id`` cannot satisfy either one,
+        since ``pending_approvals.resolve()`` only returns ``True`` for a
+        tracked Future and the harness only returns 2xx for a genuine
+        ``_in_flight`` match. That case returns ``"not_consumed"``.
+        ``"unreachable"`` on a transport error.
     """
     runner_client = await _get_runner_client(session_id, runner_router)
     if runner_client is None:
@@ -2703,8 +2717,23 @@ async def _forward_approval_to_runner(
             session_id,
         )
         return "unreachable"
-    if 200 <= response.status_code < 300:
+    if response.headers.get(_PENDING_APPROVAL_RESOLVED_HEADER) == "true":
         return "delivered"
+    if 200 <= response.status_code < 300:
+        # The runner's outer 2xx here — without the header — reflects the
+        # harness-native ctx.elicit() path: the runner unconditionally
+        # also forwards this event to the harness subprocess, whose own
+        # _resolve_elicitation raises 404 (ErrorCode.NOT_FOUND) for any id
+        # that isn't a genuinely outstanding Future, so a 2xx here is
+        # itself already truthful — not a bare "reached the runner".
+        return "delivered"
+    if response.status_code == 404:
+        _logger.info(
+            "Approval forward for %r reached the runner but was not truthfully "
+            "consumed (unknown/stale/already-resolved elicitation)",
+            session_id,
+        )
+        return "not_consumed"
     _logger.warning(
         "Approval forward for %r rejected by runner: %s",
         session_id,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -42,6 +42,7 @@ from omnigent.cost_plan import (
     COST_CONTROL_LABEL_NAMESPACE,
     reserved_cost_control_keys,
 )
+from omnigent.db.db_models import current_workspace_id
 from omnigent.db.utils import generate_task_id
 from omnigent.entities import (
     Agent,
@@ -87,7 +88,7 @@ from omnigent.runtime import (
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.runtime.tool_output import cap_tool_output
-from omnigent.server import presence, session_live_state
+from omnigent.server import presence, session_live_state, session_outbox
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_parked_elicitations,
@@ -2656,7 +2657,7 @@ async def _forward_approval_to_runner(
     session_id: str,
     data: dict[str, Any],
     runner_router: RunnerRouter | None,
-) -> None:
+) -> Literal["no_runner", "delivered", "unreachable"]:
     """
     Forward an approval verdict to the session's bound runner.
 
@@ -2676,12 +2677,22 @@ async def _forward_approval_to_runner(
         "action": "accept"}``.
     :param runner_router: Router used to resolve the bound runner, or
         ``None`` in in-process setups (forward skipped).
+    :returns: ``"no_runner"`` when no tunnel is bound *on this replica*
+        (in-process setup, or the runner's tunnel is held by a different
+        replica — not itself proof the runner is dead, see OMN-104's
+        harness-classified elicitation resolution, which additionally
+        consults the cross-replica ``runner_last_seen`` freshness signal
+        before concluding a runner is unreachable); ``"delivered"`` on a
+        2xx response (the runner's own handler ran
+        ``pending_approvals.resolve(...)`` — a truthful acknowledgement,
+        not just "accepted"); ``"unreachable"`` on a transport error or a
+        non-2xx response.
     """
     runner_client = await _get_runner_client(session_id, runner_router)
     if runner_client is None:
-        return
+        return "no_runner"
     try:
-        await runner_client.post(
+        response = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json={"type": _APPROVAL_TYPE, "data": data},
             timeout=10.0,
@@ -2691,6 +2702,15 @@ async def _forward_approval_to_runner(
             "Approval forward failed for %r",
             session_id,
         )
+        return "unreachable"
+    if 200 <= response.status_code < 300:
+        return "delivered"
+    _logger.warning(
+        "Approval forward for %r rejected by runner: %s",
+        session_id,
+        response.status_code,
+    )
+    return "unreachable"
 
 
 def _parse_external_assistant_message(
@@ -3622,6 +3642,33 @@ def _publish_status(
             error_code=error.code if error is not None else None,
             error=error.message if error is not None else None,
         )
+    # Durable manager-webhook lifecycle events (OMN-104). Bound to this same
+    # edge — the same terminal signal that just drove
+    # persist_scheduled_run_completion above — not re-derived from either
+    # best-effort mirror. Read the open turn's response id from
+    # _session_active_response_cache BEFORE it is popped a few lines below:
+    # an idle transition with no cached response id means no turn was
+    # actually open (or this is an idle->idle no-op), so nothing is emitted.
+    # No secondary gate on background_task_count — see
+    # docs/architecture/2026-08-10-durable-session-lifecycle-push.md §5.1.
+    open_response_id = _session_active_response_cache.get(session_id)
+    if status == "idle" and open_response_id is not None:
+        session_outbox.record_session_completed(
+            workspace_id=current_workspace_id(),
+            session_id=session_id,
+            response_id=open_response_id,
+            background_task_count=background_task_count,
+        )
+    elif status == "failed":
+        failed_response_id = open_response_id or response_id
+        if failed_response_id is not None:
+            session_outbox.record_session_failed(
+                workspace_id=current_workspace_id(),
+                session_id=session_id,
+                response_id=failed_response_id,
+                error_code=error.code if error is not None else "unknown",
+                error_message=error.message if error is not None else "",
+            )
     # Track the in-flight response id for snapshot-based reconnect (see
     # _session_active_response_cache). A running/waiting edge that names a
     # turn opens it; any idle/failed edge closes it.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1868,7 +1868,31 @@ async def _resolve_elicitation_durably(
         if owned_by_this_session
         else None
     )
-    outcome = await _resolve_elicitation(session_id, data, runner_router, conversation_store)
+    # Forward the PERSISTED WINNING verdict, not this call's own `data`.
+    # record_decision is idempotent per elicitation_id (see the store's
+    # row-locked read-then-write): whichever call actually wrote first
+    # "wins", and every later call for the same id — including THIS one,
+    # if it lost a race against a conflicting concurrent verdict — gets
+    # back a row already carrying the winner's decision_payload, not its
+    # own. Forwarding the raw request `data` here instead would let a
+    # losing racing callback make the live runner/harness consume ITS
+    # verdict while the durable ledger correctly kept the actual winner's
+    # — a truthfulness split between the live action and the source of
+    # record. Only forward raw `data` when there's no durable row to defer
+    # to at all (decision_record is None: untracked/cross-session id),
+    # preserving the exact pre-OMN-104 no-op contract for that case.
+    if decision_record is not None:
+        winning_decision = (
+            json.loads(decision_record.decision_payload)
+            if decision_record.decision_payload
+            else {}
+        )
+        forward_data = {"elicitation_id": elicitation_id, **winning_decision}
+    else:
+        forward_data = data
+    outcome = await _resolve_elicitation(
+        session_id, forward_data, runner_router, conversation_store
+    )
     if decision_record is None:
         # No durable OMN-104 ledger row for this id — either the feature
         # isn't wired, or (the common case for these shared entry points)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1663,7 +1663,7 @@ class ElicitationResolutionOutcome:
     """
 
     harness_future_resolved: bool
-    forward_outcome: Literal["no_runner", "delivered", "unreachable"]
+    forward_outcome: Literal["no_runner", "delivered", "not_consumed", "unreachable"]
 
 
 async def _resolve_elicitation(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -13,6 +13,7 @@ import json
 import secrets
 import time
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 import httpx
@@ -23,6 +24,7 @@ from fastapi import (
 from fastapi.responses import Response
 from pydantic import ValidationError
 
+from omnigent.db.db_models import current_workspace_id
 from omnigent.db.utils import generate_agent_id, generate_task_id
 from omnigent.entities import (
     Agent,
@@ -90,7 +92,7 @@ from omnigent.runtime.policies.builder import (
 )
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.runtime.workflow import _find_spec_by_name
-from omnigent.server import session_live_state
+from omnigent.server import session_live_state, session_outbox
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_elicitation_registry,
@@ -336,6 +338,7 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
 from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import SessionCreatedEvent as _TelSessionCreatedEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
@@ -416,6 +419,18 @@ async def _publish_and_wait_for_harness_elicitation(
     _harness_elicitation_registry[elicitation_id] = future
     _harness_elicitation_owners[elicitation_id] = session_id
     _harness_parked_elicitations[elicitation_id] = parked
+    # Durable elicitation ledger + session.awaiting_decision outbox row
+    # (OMN-104), written transactionally before the request is published.
+    # Idempotent by elicitation_id: a re-park retry (caller-supplied id
+    # reusing the same registration) resolves to the existing row rather
+    # than a duplicate — see
+    # docs/architecture/2026-08-10-durable-session-lifecycle-push.md §5.4.
+    session_outbox.record_elicitation_raised(
+        workspace_id=current_workspace_id(),
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={**params.model_dump(exclude_none=True), "tool_name": tool_name},
+    )
     # settled = verdict / terminal-resolved (clear the card now); a
     # severed wait instead defers the clear so a hook retry can re-park.
     published_request = False
@@ -952,6 +967,7 @@ def _build_session_response(
     viewer_id: str | None = None,
     agent_store: AgentStore | None = None,
     agent_cache: AgentCache | None = None,
+    latest_manager_delivery: dict[str, Any] | None = None,
 ) -> SessionResponse:
     """
     Build a :class:`SessionResponse` from store-side entities.
@@ -1020,6 +1036,11 @@ def _build_session_response(
         ``None`` is treated as ``[]``.
     :param agent_store: Optional store used to resolve the session harness.
     :param agent_cache: Optional cache used to load the session harness spec.
+    :param latest_manager_delivery: Summary (status + last attempt) of the
+        session's most recent manager-webhook outbox row (OMN-104), or
+        ``None`` when the feature isn't wired or nothing has been recorded
+        yet. Lets the sidebar/detail view avoid a second round-trip to
+        ``GET .../manager-webhook-deliveries`` for the common case.
     :returns: The :class:`SessionResponse` for the API.
     :raises OmnigentError: If ``conv.agent_id`` is ``None``.
     """
@@ -1138,6 +1159,7 @@ def _build_session_response(
         # sessions whose forwarder stamps a turn id; ``None`` otherwise.
         active_response_id=_session_active_response_cache.get(conv.id),
         project_id=conv.project_id,
+        latest_manager_delivery=latest_manager_delivery,
     )
 
 
@@ -1626,12 +1648,30 @@ async def _persist_model_change_note(
     _publish_external_conversation_item(session_id, persisted_items[0])
 
 
+@dataclass(frozen=True)
+class ElicitationResolutionOutcome:
+    """
+    Result of one :func:`_resolve_elicitation` call, for OMN-104's
+    harness-classified decision-endpoint resolution.
+
+    :param harness_future_resolved: ``True`` if a parked server-side
+        ``_harness_elicitation_registry`` Future was found (owned by this
+        session, not already done) and resolved by this call — a complete,
+        synchronous, in-process truthful acknowledgement on its own.
+    :param forward_outcome: The outcome of forwarding the verdict to the
+        session's bound runner (see :func:`_forward_approval_to_runner`).
+    """
+
+    harness_future_resolved: bool
+    forward_outcome: Literal["no_runner", "delivered", "unreachable"]
+
+
 async def _resolve_elicitation(
     session_id: str,
     data: dict[str, Any],
     runner_router: RunnerRouter | None,
     conversation_store: ConversationStore | None = None,
-) -> None:
+) -> ElicitationResolutionOutcome:
     """
     Resolve one outstanding elicitation from an approval payload.
 
@@ -1683,6 +1723,7 @@ async def _resolve_elicitation(
     # matches, no resolved event published) rather than 500-ing the
     # client — the runner forward still fires so the runner can reject.
     elicitation_id = data.get("elicitation_id", "")
+    harness_future_resolved = False
     harness_future = _harness_elicitation_registry.get(elicitation_id)
     if harness_future is not None and not harness_future.done():
         # Only the session that owns this elicitation
@@ -1694,6 +1735,7 @@ async def _resolve_elicitation(
                 harness_future.set_result(
                     ElicitationResult.model_validate(result_payload),
                 )
+                harness_future_resolved = True
             except ValidationError:
                 _logger.warning(
                     "Invalid approval payload for %r",
@@ -1740,7 +1782,11 @@ async def _resolve_elicitation(
             )
     # Runner-side elicitations (policy approvals, scaffold dispatch)
     # resolve when the canonical approval event reaches the runner.
-    await _forward_approval_to_runner(session_id, data, runner_router)
+    forward_outcome = await _forward_approval_to_runner(session_id, data, runner_router)
+    return ElicitationResolutionOutcome(
+        harness_future_resolved=harness_future_resolved,
+        forward_outcome=forward_outcome,
+    )
 
 
 def _spawn_native_approval_popup_forward(
@@ -8702,6 +8748,7 @@ async def _get_session_snapshot(
     host_store: HostStore | None = None,
     sandbox_config: ManagedSandboxConfig | None = None,
     viewer_id: str | None = None,
+    session_lifecycle_store: SessionLifecycleStore | None = None,
 ) -> SessionResponse:
     """
     Read a full session snapshot from the store.
@@ -8956,6 +9003,20 @@ async def _get_session_snapshot(
         host_for_resume = await asyncio.to_thread(host_store.get_host, conv.host_id)
         if host_for_resume is not None:
             host_resumable = host_resume_supported(host_for_resume, sandbox_config)
+    latest_manager_delivery: dict[str, Any] | None = None
+    if session_lifecycle_store is not None:
+        latest = await asyncio.to_thread(session_lifecycle_store.latest_delivery, conv.id)
+        if latest is not None:
+            latest_manager_delivery = {
+                "event_id": latest.id,
+                "event_type": latest.event_type,
+                "sequence": latest.sequence,
+                "status": latest.status,
+                "attempt_count": latest.attempt_count,
+                "last_attempt_at": latest.last_attempt_at,
+                "last_http_status": latest.last_http_status,
+                "last_error_code": latest.last_error_code,
+            }
     return _build_session_response(
         conv,
         items,
@@ -8981,6 +9042,7 @@ async def _get_session_snapshot(
         viewer_id=viewer_id,
         agent_store=agent_store,
         agent_cache=agent_cache,
+        latest_manager_delivery=latest_manager_delivery,
     )
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -35,6 +35,7 @@ from omnigent.entities import (
     MessageData,
     NewConversationItem,
     ResourceEventData,
+    SessionElicitation,
 )
 from omnigent.entities.conversation import (
     FunctionCallData,
@@ -1786,6 +1787,113 @@ async def _resolve_elicitation(
     return ElicitationResolutionOutcome(
         harness_future_resolved=harness_future_resolved,
         forward_outcome=forward_outcome,
+    )
+
+
+@dataclass(frozen=True)
+class DurableElicitationResolution:
+    """
+    Result of :func:`_resolve_elicitation_durably` — the shared OMN-104
+    durable-write sequence layered on top of :func:`_resolve_elicitation`.
+
+    :param outcome: The underlying :func:`_resolve_elicitation` result.
+    :param decision_record: The durable ledger row after the write, or
+        ``None`` when this id has no durable OMN-104 row at all (the
+        pre-OMN-104 no-op contract — an untracked/legacy/cross-session id).
+    :param resolved: ``True`` if this call durably recorded (or found
+        already recorded) a truthful ``session.resumed``.
+    """
+
+    outcome: ElicitationResolutionOutcome
+    decision_record: SessionElicitation | None
+    resolved: bool
+
+
+async def _resolve_elicitation_durably(
+    session_id: str,
+    data: dict[str, Any],
+    runner_router: RunnerRouter | None,
+    conversation_store: ConversationStore | None,
+    *,
+    decided_by: str | None,
+) -> DurableElicitationResolution:
+    """
+    Durably persist a verdict, then resolve it (OMN-104).
+
+    The single sequence — ownership check, durable ``record_decision``
+    BEFORE any attempt to resolve an in-memory Future or reach the
+    runner, then classify and ``record_elicitation_resumed`` on a
+    truthful ack — shared by EVERY entry point that can consume/resolve
+    an elicitation: the dedicated ``.../resolve`` URL endpoint and the
+    generic ``type == "approval"`` branch of ``POST /v1/sessions/{id}
+    /events``. A second entry point bypassing this sequence was exactly
+    the cross-vendor review finding this function exists to close —
+    both must go through here so neither can durably decide (or resume)
+    an elicitation the other doesn't durably record.
+
+    :param session_id: Session/conversation identifier that owns the
+        elicitation, e.g. ``"conv_abc123"``.
+    :param data: Approval payload carrying ``elicitation_id`` plus the
+        MCP ``ElicitationResult`` fields (``action``, optional
+        ``content``).
+    :param runner_router: Router used to resolve the session's bound
+        runner for the forward, or ``None`` in in-process setups.
+    :param conversation_store: Optional store used to mirror the
+        resolved signal into ancestor streams.
+    :param decided_by: Manager identity from a signed callback, or
+        ``None`` for a web-UI/generic-event verdict.
+    :returns: The durable resolution result — see
+        :class:`DurableElicitationResolution`.
+    """
+    elicitation_id = data.get("elicitation_id", "")
+    existing_elicitation = (
+        session_outbox.get_elicitation(elicitation_id)
+        if isinstance(elicitation_id, str) and elicitation_id
+        else None
+    )
+    owned_by_this_session = (
+        existing_elicitation is not None and existing_elicitation.session_id == session_id
+    )
+    # Durably persist the verdict FIRST, unconditionally (once ownership is
+    # established) — before any attempt to resolve an in-memory Future or
+    # reach the runner. This is what lets the classification below
+    # distinguish "durably recorded but not yet consumed" from "silently
+    # dropped" after a restart (OMN-104 §5.4).
+    decision_record = (
+        session_outbox.record_decision(
+            elicitation_id=elicitation_id,
+            decision={k: v for k, v in data.items() if k != "elicitation_id"},
+            decided_by=decided_by,
+        )
+        if owned_by_this_session
+        else None
+    )
+    outcome = await _resolve_elicitation(session_id, data, runner_router, conversation_store)
+    if decision_record is None:
+        # No durable OMN-104 ledger row for this id — either the feature
+        # isn't wired, or (the common case for these shared entry points)
+        # the id was never registered via record_elicitation_raised / is
+        # already resolved / is unknown. Preserve the pre-OMN-104 no-op
+        # contract exactly rather than treating an always-harmless call
+        # as a fresh classification.
+        return DurableElicitationResolution(outcome=outcome, decision_record=None, resolved=False)
+    if decision_record.status in ("delivered_to_runner", "expired"):
+        # Already truthfully resumed (by an earlier call, or by reconnect
+        # redelivery) — idempotent no-op, not a fresh classification.
+        return DurableElicitationResolution(
+            outcome=outcome, decision_record=decision_record, resolved=True
+        )
+    resolved = outcome.harness_future_resolved or outcome.forward_outcome == "delivered"
+    if resolved:
+        # Truthful acknowledgement achieved synchronously (either an
+        # in-process Future was set, or the runner's own handler ran
+        # pending_approvals.resolve(...) and returned 2xx) — emit
+        # session.resumed now.
+        session_outbox.record_elicitation_resumed(
+            workspace_id=current_workspace_id(), elicitation_id=elicitation_id
+        )
+    return DurableElicitationResolution(
+        outcome=outcome, decision_record=decision_record, resolved=resolved
     )
 
 
@@ -6019,6 +6127,26 @@ async def _relay_runner_stream_once(
                                 },
                             }
                     if evt_type == "response.elicitation_request":
+                        # Durable elicitation ledger + session.awaiting_decision
+                        # outbox row (OMN-104), written before publish. This is
+                        # the harness-subprocess ctx.elicit() path (generic
+                        # scaffold-backed harnesses) relayed here from the
+                        # runner — distinct from _publish_and_wait_for_
+                        # harness_elicitation's claude-native/codex-native
+                        # hook contract, which never reaches this relay loop.
+                        _relay_elicitation_id = event.get("elicitation_id")
+                        _relay_params = event.get("params")
+                        if (
+                            isinstance(_relay_elicitation_id, str)
+                            and _relay_elicitation_id
+                            and isinstance(_relay_params, dict)
+                        ):
+                            session_outbox.record_elicitation_raised(
+                                workspace_id=current_workspace_id(),
+                                session_id=session_id,
+                                elicitation_id=_relay_elicitation_id,
+                                request=_relay_params,
+                            )
                         session_stream.publish(session_id, event)
                         await asyncio.to_thread(
                             _publish_elicitation_request_to_ancestors,
@@ -6247,6 +6375,17 @@ async def _register_policy_elicitation(
     # runner which resolves it. No server-side state needed.
     _elicit_event = build_elicitation_request_event(
         elicitation_id, elicitation, session_id=session_id
+    )
+    # Durable elicitation ledger + session.awaiting_decision outbox row
+    # (OMN-104), written before publish — this is the policy/cost-ASK
+    # path (relay tool-call gate and MCP tools/call gate both funnel
+    # through here), the primary real-world elicitation type for the
+    # runner's pending_approvals registry.
+    session_outbox.record_elicitation_raised(
+        workspace_id=current_workspace_id(),
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request=_elicit_event["params"],
     )
     session_stream.publish(session_id, _elicit_event)
     await asyncio.to_thread(
@@ -9187,6 +9326,7 @@ __all__ = [
     "_register_policy_elicitation",
     "_relay_runner_stream",
     "_resolve_elicitation",
+    "_resolve_elicitation_durably",
     "_run_managed_launch",
     "_run_managed_wake",
     "_runner_reject_detail",

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -872,6 +872,9 @@ def create_sessions_router(
     from omnigent.server.routes.sessions.routes_events import register_events_routes
     from omnigent.server.routes.sessions.routes_hooks import register_hooks_routes
     from omnigent.server.routes.sessions.routes_items import register_items_routes
+    from omnigent.server.routes.sessions.routes_manager_webhook import (
+        register_manager_webhook_routes,
+    )
     from omnigent.server.routes.sessions.routes_permissions import register_permissions_routes
     from omnigent.server.routes.sessions.routes_resources import register_resources_routes
 
@@ -936,6 +939,13 @@ def create_sessions_router(
         conversation_store=conversation_store,
         agent_store=agent_store,
         runner_router=runner_router,
+        auth_provider=auth_provider,
+        permission_store=permission_store,
+    )
+
+    register_manager_webhook_routes(
+        router,
+        conversation_store=conversation_store,
         auth_provider=auth_provider,
         permission_store=permission_store,
     )

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -751,6 +751,7 @@ def register_core_routes(
             host_store=getattr(request.app.state, "host_store", None),
             sandbox_config=getattr(request.app.state, "sandbox_config", None),
             viewer_id=user_id,
+            session_lifecycle_store=getattr(request.app.state, "session_lifecycle_store", None),
         )
 
     @router.get(

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -192,13 +192,16 @@ def register_elicitations_routes(
             # the runner is very likely still alive and about to
             # reconnect. Consult the grace-pending marker FIRST — durable
             # (SessionConnectivity.runner_disconnect_grace_deadline, written
-            # by the replica holding the tunnel at the same moment it
-            # clears runner_last_seen; see
-            # session_live_state.set_runner_disconnect_grace), so this
-            # check is correct regardless of which replica this decision
-            # request landed on — before falling back to the cross-replica
-            # freshness signal, which is only meaningful once the grace has
-            # genuinely elapsed with no reconnect.
+            # by the replica holding the tunnel ATOMICALLY alongside
+            # clearing runner_last_seen — one UPDATE, one commit; see
+            # session_live_state.mark_runner_disconnected — so a reader
+            # here can never observe a state where the runner looks both
+            # non-live and non-graced while it's actually just
+            # disconnecting), so this check is correct regardless of which
+            # replica this decision request landed on — before falling
+            # back to the cross-replica freshness signal, which is only
+            # meaningful once the grace has genuinely elapsed with no
+            # reconnect.
             runner_in_disconnect_grace = (
                 conn is not None
                 and conn.runner_id is not None

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -190,18 +190,20 @@ def register_elicitations_routes(
             # decision arriving inside that window would see stale
             # liveness and be misclassified as "runner dead" even though
             # the runner is very likely still alive and about to
-            # reconnect. Consult the grace-pending marker FIRST (this
-            # replica's own view, mirroring the tunnel registry it's
-            # derived from) before falling back to the cross-replica
-            # freshness signal, which is only meaningful once the grace
-            # has genuinely elapsed with no reconnect.
-            grace_deadlines: dict[str, float] = getattr(
-                request.app.state, "runner_disconnect_grace_deadline", {}
-            )
+            # reconnect. Consult the grace-pending marker FIRST — durable
+            # (SessionConnectivity.runner_disconnect_grace_deadline, written
+            # by the replica holding the tunnel at the same moment it
+            # clears runner_last_seen; see
+            # session_live_state.set_runner_disconnect_grace), so this
+            # check is correct regardless of which replica this decision
+            # request landed on — before falling back to the cross-replica
+            # freshness signal, which is only meaningful once the grace has
+            # genuinely elapsed with no reconnect.
             runner_in_disconnect_grace = (
                 conn is not None
                 and conn.runner_id is not None
-                and grace_deadlines.get(conn.runner_id, 0.0) > now
+                and conn.runner_disconnect_grace_deadline is not None
+                and conn.runner_disconnect_grace_deadline > now
             )
             runner_alive = runner_in_disconnect_grace or (
                 conn is not None

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -210,10 +210,30 @@ def register_elicitations_routes(
                 conversation_store.get_session_connectivity, [session_id]
             )
             conn = connectivity.get(session_id)
-            runner_alive = (
+            now = time.time()
+            # a632550e's reconnect grace clears runner_last_seen the INSTANT
+            # a runner disconnects — well before the grace it also grants
+            # that same runner actually expires. Without this check, a
+            # decision arriving inside that window would see stale
+            # liveness and be misclassified as "runner dead" even though
+            # the runner is very likely still alive and about to
+            # reconnect. Consult the grace-pending marker FIRST (this
+            # replica's own view, mirroring the tunnel registry it's
+            # derived from) before falling back to the cross-replica
+            # freshness signal, which is only meaningful once the grace
+            # has genuinely elapsed with no reconnect.
+            grace_deadlines: dict[str, float] = getattr(
+                request.app.state, "runner_disconnect_grace_deadline", {}
+            )
+            runner_in_disconnect_grace = (
                 conn is not None
                 and conn.runner_id is not None
-                and runner_seen_is_fresh(conn.runner_last_seen, now=int(time.time()))
+                and grace_deadlines.get(conn.runner_id, 0.0) > now
+            )
+            runner_alive = runner_in_disconnect_grace or (
+                conn is not None
+                and conn.runner_id is not None
+                and runner_seen_is_fresh(conn.runner_last_seen, now=int(now))
             )
             if runner_alive:
                 pending_redelivery = True

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -12,13 +12,11 @@ from fastapi import (
     Request,
 )
 
-from omnigent.db.db_models import current_workspace_id
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     pending_elicitations,
 )
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
-from omnigent.server import session_outbox
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_elicitation_registry,
@@ -47,7 +45,7 @@ from omnigent.server.routes._sessions.helpers import (
     _apply_pending_policy_ask_writes,
 )
 from omnigent.server.routes._sessions.orchestration import (
-    _resolve_elicitation,
+    _resolve_elicitation_durably,
 )
 from omnigent.server.schemas import (
     ElicitationResult,
@@ -137,33 +135,16 @@ def register_elicitations_routes(
             if conv is None:
                 raise _session_not_found()
         _resolve_data = {"elicitation_id": elicitation_id, **body.model_dump(exclude_none=True)}
-        # Ownership check on the DURABLE ledger, mirroring the in-memory
-        # ownership guard inside _resolve_elicitation (_harness_elicitation_owners):
-        # a session must not durably decide an elicitation it doesn't own.
-        # A cross-session id is treated exactly like an untracked one below
-        # — the call is accepted (202) but nothing is persisted or
-        # classified, matching the pre-OMN-104 no-op contract.
-        existing_elicitation = session_outbox.get_elicitation(elicitation_id)
-        owned_by_this_session = (
-            existing_elicitation is not None and existing_elicitation.session_id == session_id
+        # The shared OMN-104 durable sequence (ownership check, durable
+        # record_decision BEFORE any attempt to resolve an in-memory Future
+        # or reach the runner, then classify + record_elicitation_resumed
+        # on a truthful ack) — also used by the generic ``approval`` event
+        # branch of POST /v1/sessions/{id}/events, so both entry points
+        # that can resolve an elicitation go through identical durability.
+        durable = await _resolve_elicitation_durably(
+            session_id, _resolve_data, runner_router, conversation_store, decided_by=user_id
         )
-        # Durably persist the verdict FIRST, unconditionally (once
-        # ownership is established) — before any attempt to resolve an
-        # in-memory Future or reach the runner. This is what lets the
-        # classification below distinguish "durably recorded but not yet
-        # consumed" from "silently dropped" after a restart (OMN-104 §5.4).
-        decision_record = (
-            session_outbox.record_decision(
-                elicitation_id=elicitation_id,
-                decision=body.model_dump(exclude_none=True),
-                decided_by=user_id,
-            )
-            if owned_by_this_session
-            else None
-        )
-        outcome = await _resolve_elicitation(
-            session_id, _resolve_data, runner_router, conversation_store
-        )
+        decision_record = durable.decision_record
         if decision_record is None:
             # No durable OMN-104 ledger row for this id — either the feature
             # isn't wired, or (the common case for this shared endpoint) the
@@ -185,17 +166,9 @@ def register_elicitations_routes(
                 session_id, conv, conversation_store, agent_store, _resolve_data
             )
             return {"queued": False, "resolved": True, "pending_redelivery": False}
-        resolved = outcome.harness_future_resolved or outcome.forward_outcome == "delivered"
+        resolved = durable.resolved
         pending_redelivery = False
-        if resolved:
-            # Truthful acknowledgement achieved synchronously (either an
-            # in-process Future was set, or the runner's own handler ran
-            # pending_approvals.resolve(...) and returned 2xx) — emit
-            # session.resumed now.
-            session_outbox.record_elicitation_resumed(
-                workspace_id=current_workspace_id(), elicitation_id=elicitation_id
-            )
-        else:
+        if not resolved:
             # Not resolved synchronously. Classify by whether the runner is
             # believed alive at all (cross-replica, DB-backed freshness —
             # not this replica's local tunnel registry, which a manager's

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -3,18 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 from fastapi import (
     APIRouter,
+    HTTPException,
     Request,
 )
 
+from omnigent.db.db_models import current_workspace_id
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     pending_elicitations,
 )
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
+from omnigent.server import session_outbox
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_elicitation_registry,
@@ -49,6 +53,7 @@ from omnigent.server.schemas import (
     ElicitationResult,
 )
 from omnigent.stores import AgentStore, ConversationStore
+from omnigent.stores.conversation_store import runner_seen_is_fresh
 from omnigent.stores.permission_store import PermissionStore
 
 
@@ -108,9 +113,19 @@ def register_elicitations_routes(
         :param body: The MCP-shaped verdict — ``action``
             (``"accept"`` / ``"decline"`` / ``"cancel"``) plus
             optional form ``content``.
-        :returns: ``{"queued": False}`` — resolution is synchronous
-            and persists no conversation item.
+        :returns: ``{"queued": False, "resolved": bool, "pending_redelivery": bool}``.
+            ``resolved=True`` when the verdict was consumed synchronously
+            (no restart, or the runner was reachable on this delivery
+            attempt); ``pending_redelivery=True`` when the verdict is
+            durably recorded but the runner's tunnel isn't currently
+            reachable and appears to have recently reconnected elsewhere
+            (OMN-104 §5.4 case (b) — redelivered on tunnel reconnect).
         :raises OmnigentError: 404 if no session exists.
+        :raises HTTPException: 410 (``error_code=elicitation_not_resolvable``)
+            when the runner/host is not believed to be alive at all
+            (OMN-104 §5.4 case (c)) — the verdict is still durably
+            recorded (see ``session_elicitations``), but the endpoint does
+            not claim the session resumed, because it structurally did not.
         """
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
@@ -122,13 +137,104 @@ def register_elicitations_routes(
             if conv is None:
                 raise _session_not_found()
         _resolve_data = {"elicitation_id": elicitation_id, **body.model_dump(exclude_none=True)}
-        await _resolve_elicitation(session_id, _resolve_data, runner_router, conversation_store)
+        # Ownership check on the DURABLE ledger, mirroring the in-memory
+        # ownership guard inside _resolve_elicitation (_harness_elicitation_owners):
+        # a session must not durably decide an elicitation it doesn't own.
+        # A cross-session id is treated exactly like an untracked one below
+        # — the call is accepted (202) but nothing is persisted or
+        # classified, matching the pre-OMN-104 no-op contract.
+        existing_elicitation = session_outbox.get_elicitation(elicitation_id)
+        owned_by_this_session = (
+            existing_elicitation is not None and existing_elicitation.session_id == session_id
+        )
+        # Durably persist the verdict FIRST, unconditionally (once
+        # ownership is established) — before any attempt to resolve an
+        # in-memory Future or reach the runner. This is what lets the
+        # classification below distinguish "durably recorded but not yet
+        # consumed" from "silently dropped" after a restart (OMN-104 §5.4).
+        decision_record = (
+            session_outbox.record_decision(
+                elicitation_id=elicitation_id,
+                decision=body.model_dump(exclude_none=True),
+                decided_by=user_id,
+            )
+            if owned_by_this_session
+            else None
+        )
+        outcome = await _resolve_elicitation(
+            session_id, _resolve_data, runner_router, conversation_store
+        )
+        if decision_record is None:
+            # No durable OMN-104 ledger row for this id — either the feature
+            # isn't wired, or (the common case for this shared endpoint) the
+            # id was never registered via record_elicitation_raised / is
+            # already resolved / is unknown. Preserve the pre-OMN-104
+            # contract exactly rather than 410ing a request that always used
+            # to be a harmless idempotent no-op.
+            await _apply_pending_policy_ask_writes(
+                session_id, conv, conversation_store, agent_store, _resolve_data
+            )
+            return {"queued": False}
+        if decision_record.status in ("delivered_to_runner", "expired"):
+            # Already truthfully resumed (by an earlier call to this
+            # endpoint, or by reconnect redelivery) — idempotent no-op, not
+            # a fresh classification. A duplicate resolve must not risk a
+            # 410 just because the harness Future it already consumed is
+            # now done().
+            await _apply_pending_policy_ask_writes(
+                session_id, conv, conversation_store, agent_store, _resolve_data
+            )
+            return {"queued": False, "resolved": True, "pending_redelivery": False}
+        resolved = outcome.harness_future_resolved or outcome.forward_outcome == "delivered"
+        pending_redelivery = False
+        if resolved:
+            # Truthful acknowledgement achieved synchronously (either an
+            # in-process Future was set, or the runner's own handler ran
+            # pending_approvals.resolve(...) and returned 2xx) — emit
+            # session.resumed now.
+            session_outbox.record_elicitation_resumed(
+                workspace_id=current_workspace_id(), elicitation_id=elicitation_id
+            )
+        else:
+            # Not resolved synchronously. Classify by whether the runner is
+            # believed alive at all (cross-replica, DB-backed freshness —
+            # not this replica's local tunnel registry, which a manager's
+            # request may not share with the replica holding the tunnel):
+            # fresh -> server restart / this replica's tunnel is stale, but
+            # the runner is expected to reconnect soon, so the decided-but-
+            # undelivered row is redelivered on that reconnect (see
+            # _on_runner_connect in app.py). Not fresh (or no runner at
+            # all) -> the runner process itself is not believed alive; no
+            # durable row can rebind a coroutine that no longer exists.
+            connectivity = await asyncio.to_thread(
+                conversation_store.get_session_connectivity, [session_id]
+            )
+            conn = connectivity.get(session_id)
+            runner_alive = (
+                conn is not None
+                and conn.runner_id is not None
+                and runner_seen_is_fresh(conn.runner_last_seen, now=int(time.time()))
+            )
+            if runner_alive:
+                pending_redelivery = True
+            else:
+                raise HTTPException(
+                    status_code=410,
+                    detail={
+                        "error_code": "elicitation_not_resolvable",
+                        "message": (
+                            "The runner for this session is not reachable and is not "
+                            "believed to be alive; the decision was recorded but could "
+                            "not be delivered."
+                        ),
+                    },
+                )
         # Apply any policy writes deferred by the relay tool-call ASK gate
         # (e.g. a cost-budget checkpoint) now that the verdict is in.
         await _apply_pending_policy_ask_writes(
             session_id, conv, conversation_store, agent_store, _resolve_data
         )
-        return {"queued": False}
+        return {"queued": False, "resolved": resolved, "pending_redelivery": pending_redelivery}
 
     @router.get(
         "/sessions/{session_id}/elicitations/{elicitation_id}",

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -14,6 +14,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
+from omnigent.db.db_models import current_workspace_id
 from omnigent.entities import (
     ErrorData,
     NewConversationItem,
@@ -35,7 +36,7 @@ from omnigent.runtime import (
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
-from omnigent.server import presence
+from omnigent.server import presence, session_outbox
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
     _harness_elicitation_registry,
@@ -178,7 +179,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _persist_external_session_usage,
     _persist_host_launch_failure_turn,
     _persist_native_terminal_failure,
-    _resolve_elicitation,
+    _resolve_elicitation_durably,
     _wait_for_host_bound_runner_client,
 )
 from omnigent.server.schemas import (
@@ -674,13 +675,18 @@ def register_events_routes(
                 pass
             return {"queued": False}
         if body.type == _APPROVAL_TYPE:
-            # Deliver the verdict through the shared resolver: it
-            # sets any server-side harness Future (owner-checked),
-            # clears the sidebar badge, and forwards
-            # to the runner for runner-side (policy) elicitations.
+            # Deliver the verdict through the shared durable resolver: it
+            # durably records the decision, sets any server-side harness
+            # Future (owner-checked), clears the sidebar badge, forwards
+            # to the runner for runner-side (policy) elicitations, and
+            # durably records session.resumed on a truthful ack (OMN-104).
             # The dedicated URL endpoint (``.../elicitations/{eid}/
-            # resolve``) routes through the same helper.
-            await _resolve_elicitation(session_id, body.data, runner_router, conversation_store)
+            # resolve``) routes through the same helper — this generic
+            # events path must not be a second, less-durable way to
+            # consume/resolve the same elicitation.
+            await _resolve_elicitation_durably(
+                session_id, body.data, runner_router, conversation_store, decided_by=user_id
+            )
             # Apply any policy writes deferred by the relay tool-call ASK gate
             # (e.g. a cost-budget checkpoint) now that the verdict is in.
             await _apply_pending_policy_ask_writes(
@@ -710,6 +716,18 @@ def register_events_routes(
                 params=elicit_params,
             )
             _mcp_elicit_payload = event.model_dump()
+            # Durable elicitation ledger + session.awaiting_decision outbox
+            # row (OMN-104), written before publish. This is an external
+            # MCP server's own elicitation/create request relayed through
+            # the generic events endpoint — distinct from both the
+            # Omnigent-internal policy ASK gate and the harness-subprocess
+            # ctx.elicit() relay, and previously had no durable write at all.
+            session_outbox.record_elicitation_raised(
+                workspace_id=current_workspace_id(),
+                session_id=session_id,
+                elicitation_id=elicit_id,
+                request=elicit_params.model_dump(exclude_none=True),
+            )
             from omnigent.server.routes import sessions as _sessions_facade
 
             _sessions_facade.session_stream.publish(session_id, _mcp_elicit_payload)

--- a/omnigent/server/routes/sessions/routes_manager_webhook.py
+++ b/omnigent/server/routes/sessions/routes_manager_webhook.py
@@ -1,0 +1,107 @@
+"""Manager-webhook delivery visibility routes (OMN-104).
+
+Modeled directly on ``GET /scheduled-tasks/{id}/runs``
+(``omnigent/server/routes/scheduled_tasks.py``) — same cursor-pagination
+shape, same "read the store, no live network call" contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Query, Request
+
+from omnigent.entities import LifecycleOutboxEvent
+from omnigent.server.auth import LEVEL_READ, AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id as _get_user_id
+from omnigent.server.routes._auth_helpers import (
+    require_access_and_level as _require_access_and_level,
+)
+from omnigent.server.routes._errors import session_not_found as _session_not_found
+from omnigent.stores import ConversationStore
+from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
+
+
+def _delivery_to_response(event: LifecycleOutboxEvent) -> dict[str, Any]:
+    """Serialize a :class:`LifecycleOutboxEvent` to a JSON-safe dict.
+
+    Excludes ``payload`` (already-redacted event data, but still not part of
+    this observability contract — this endpoint reports delivery status, not
+    payload content) and ``lease_owner``/``lease_expires_at`` (dispatcher
+    implementation detail, not part of the documented API/log surface in
+    §9 of the design doc).
+    """
+    return {
+        "event_id": event.id,
+        "event_type": event.event_type,
+        "sequence": event.sequence,
+        "status": event.status,
+        "attempt_count": event.attempt_count,
+        "last_attempt_at": event.last_attempt_at,
+        "delivered_at": event.delivered_at,
+        "last_http_status": event.last_http_status,
+        "last_error_code": event.last_error_code,
+        "last_error_message": event.last_error_message,
+    }
+
+
+def _get_session_lifecycle_store(request: Request) -> SessionLifecycleStore | None:
+    """The app-wide :class:`SessionLifecycleStore`, or ``None`` if unwired (tests)."""
+    return getattr(request.app.state, "session_lifecycle_store", None)
+
+
+def register_manager_webhook_routes(
+    router: APIRouter,
+    *,
+    conversation_store: ConversationStore,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> None:
+    """Register the manager-webhook-deliveries route on *router*."""
+
+    @router.get(
+        "/sessions/{session_id}/manager-webhook-deliveries",
+        include_in_schema=False,
+        response_model=None,
+    )
+    async def list_manager_webhook_deliveries(
+        request: Request,
+        session_id: str,
+        limit: int = Query(default=100, ge=1, le=1000),
+        after: str | None = Query(default=None),
+    ) -> dict[str, Any]:
+        """
+        List a session's manager-webhook outbox rows, most recent first.
+
+        :param request: The inbound request, used for identity extraction
+            and to reach the app-wide session-lifecycle store.
+        :param session_id: Session/conversation identifier.
+        :param limit: Maximum rows per page (1-1000, default 100).
+        :param after: Opaque cursor (an ``event_id``) — returns rows ordered
+            after this one (exclusive).
+        :returns: ``{"deliveries": [...], "next_cursor": ...}``.
+        :raises OmnigentError: 404 if the session does not exist or the
+            caller lacks read access.
+        """
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+        )
+        conv = access.conversation
+        if conv is None:
+            # No permission_store (auth disabled) doesn't populate
+            # access.conversation — re-fetch directly, matching
+            # routes_elicitations.py's identical fallback.
+            conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if conv is None:
+                raise _session_not_found()
+        store = _get_session_lifecycle_store(request)
+        if store is None:
+            return {"deliveries": [], "next_cursor": None}
+        deliveries, next_cursor = store.list_deliveries(session_id, limit=limit, after_id=after)
+        return {
+            "deliveries": [_delivery_to_response(d) for d in deliveries],
+            "next_cursor": next_cursor,
+        }

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1929,6 +1929,13 @@ class SessionResponse(BaseModel):
     # ``labels``); set/cleared via ``PATCH /v1/sessions/{id}`` and filtered on
     # ``GET /v1/sessions?project=``.
     project_id: str | None = None
+    # Summary (status + last attempt) of this session's most recent
+    # manager-webhook outbox row (OMN-104) — status/event_type/attempt_count/
+    # last_attempt_at/last_http_status/last_error_code, same shape as one row
+    # from ``GET .../manager-webhook-deliveries``. ``None`` when the feature
+    # isn't wired or nothing has been recorded yet. Lets the sidebar/detail
+    # view show delivery health without a second round-trip.
+    latest_manager_delivery: dict[str, Any] | None = None
 
 
 class UpdateSessionRequest(BaseModel):

--- a/omnigent/server/server_config.py
+++ b/omnigent/server/server_config.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -142,3 +143,78 @@ def copy_total_bytes_limit() -> int:
     from omnigent.runtime.content_resolver import MAX_COPY_TOTAL_BYTES
 
     return _config_positive_int("copy_max_total_bytes", MAX_COPY_TOTAL_BYTES)
+
+
+# ── Manager webhook (OMN-104) ──────────────────────────
+
+
+class ManagerWebhookConfigError(RuntimeError):
+    """Raised when ``manager_webhook`` config is invalid — fails server startup closed."""
+
+
+@dataclass(frozen=True)
+class ManagerWebhookConfig:
+    """
+    Resolved ``manager_webhook`` config block.
+
+    :param enabled: Whether the dispatcher should attempt delivery. The
+        dispatcher task itself always starts (see
+        ``omnigent/server/manager_webhook_dispatcher.py``); this only gates
+        whether it claims rows, so flipping it via config reload needs no
+        server restart.
+    :param endpoint: HTTPS URL to POST lifecycle events to. Required (and
+        HTTPS-enforced, see :func:`manager_webhook_config`) when *enabled*.
+    :param key_id: Opaque key identifier sent as ``X-Omnigent-Key-Id`` so the
+        receiver can select the right verification secret during rotation.
+    """
+
+    enabled: bool
+    endpoint: str | None
+    key_id: str | None
+
+
+def manager_webhook_config() -> ManagerWebhookConfig:
+    """
+    Resolve the ``manager_webhook`` config block.
+
+    Non-secret settings only — the signing secret is env-var only (see
+    ``omnigent/server/manager_webhook_signing.py``), never this file, per
+    this module's own secrets-stay-in-the-environment convention.
+
+    Fails closed at config-load time (raises rather than warns) when
+    *enabled* but the endpoint is missing or not HTTPS, mirroring how other
+    security-relevant settings in this codebase refuse to boot on
+    misconfiguration rather than silently running insecurely. The
+    ``allow_insecure_dev_endpoint: true`` escape hatch is an explicit,
+    local-dev-only override (e.g. ``http://localhost:...`` against a fake
+    receiver in a dev loop).
+
+    :returns: The resolved config. ``enabled=False`` (the default) when the
+        block is absent — existing session-state correctness is unaffected
+        either way; this only controls whether the dispatcher delivers.
+    :raises ManagerWebhookConfigError: If *enabled* but misconfigured
+        (missing endpoint, or a non-HTTPS endpoint without the explicit
+        dev override).
+    """
+    raw = load_server_config().get("manager_webhook") or {}
+    if not isinstance(raw, dict):
+        raise ManagerWebhookConfigError("server config manager_webhook must be a mapping")
+    enabled = bool(raw.get("enabled", False))
+    endpoint_raw = raw.get("endpoint")
+    endpoint = str(endpoint_raw).strip() if endpoint_raw else None
+    key_id_raw = raw.get("key_id")
+    key_id = str(key_id_raw).strip() if key_id_raw else None
+    allow_insecure = bool(raw.get("allow_insecure_dev_endpoint", False))
+    if enabled:
+        if not endpoint:
+            raise ManagerWebhookConfigError(
+                "manager_webhook.enabled is true but manager_webhook.endpoint is not set"
+            )
+        if not endpoint.startswith("https://") and not (
+            allow_insecure and endpoint.startswith("http://")
+        ):
+            raise ManagerWebhookConfigError(
+                f"manager_webhook.endpoint {endpoint!r} must be HTTPS "
+                "(set allow_insecure_dev_endpoint: true to override for local dev only)"
+            )
+    return ManagerWebhookConfig(enabled=enabled, endpoint=endpoint, key_id=key_id)

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -294,6 +294,11 @@ def clear_runner_liveness(runner_id: str) -> None:
     freshness TTL. An ungraceful death (host / replica crash) never
     reaches this — the TTL self-corrects it.
 
+    Not used by the disconnect path — that calls :func:`mark_runner_disconnected`
+    instead so the liveness-clear and the grace-deadline-set land in one
+    atomic write (see that function's docstring). Kept for any caller that
+    only ever needs to clear liveness with no grace deadline involved.
+
     :param runner_id: The disconnected runner's id.
     """
     if _store is None:
@@ -301,18 +306,46 @@ def clear_runner_liveness(runner_id: str) -> None:
     _submit("runner_liveness_clear", _store.clear_runner_liveness, runner_id)
 
 
+def mark_runner_disconnected(runner_id: str, grace_deadline: float) -> None:
+    """
+    Atomically clear liveness and stamp the reconnect-grace deadline
+    (OMN-104 §5.4) in ONE durable write.
+
+    Cross-vendor review: calling :func:`clear_runner_liveness` and
+    :func:`set_runner_disconnect_grace` as two SEPARATE writes left a real
+    window between their commits where another replica's read observed
+    BOTH fields absent/stale simultaneously — the runner looking neither
+    live nor grace-pending — and could falsely 410 a manager decision for a
+    runner genuinely still within its reconnect grace. This function is the
+    disconnect path's ONLY entry point for these two fields; it submits a
+    single combined store write
+    (:meth:`ConversationStore.mark_runner_disconnected`), which is one
+    ``UPDATE`` / one commit, so there is no third, in-between state a reader
+    can ever observe.
+
+    :param runner_id: The disconnected runner's id.
+    :param grace_deadline: Epoch seconds the reconnect grace expires at.
+    """
+    if _store is None:
+        return
+    _submit(
+        "runner_disconnected_mark",
+        _store.mark_runner_disconnected,
+        runner_id,
+        int(grace_deadline),
+    )
+
+
 def set_runner_disconnect_grace(runner_id: str, grace_deadline: float) -> None:
     """
     Durably stamp the post-disconnect reconnect-grace deadline (OMN-104 §5.4).
 
-    Called alongside :func:`clear_runner_liveness` from the SAME disconnect
-    handler, so a manager decision request landing on a DIFFERENT replica
-    than the one holding the tunnel can still see "this runner disconnected
-    and is still within its reconnect grace" instead of falling through to
-    the now-cleared ``runner_last_seen`` freshness check and misclassifying
-    a runner that is about to reconnect as dead — the same class of bug
-    BLOCKING #1 (round 1) fixed for the single-replica case, exposed one
-    layer further out for a multi-replica deployment.
+    Not used by the disconnect path — that calls
+    :func:`mark_runner_disconnected` instead so the liveness-clear and the
+    grace-deadline-set land in one atomic write (see that function's
+    docstring for why the two-write version was a real truthfulness bug).
+    Kept for any caller that only ever needs to set the grace deadline with
+    no accompanying liveness-clear.
 
     :param runner_id: The disconnected runner's id.
     :param grace_deadline: Epoch seconds the grace expires at.

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -299,3 +299,44 @@ def clear_runner_liveness(runner_id: str) -> None:
     if _store is None:
         return
     _submit("runner_liveness_clear", _store.clear_runner_liveness, runner_id)
+
+
+def set_runner_disconnect_grace(runner_id: str, grace_deadline: float) -> None:
+    """
+    Durably stamp the post-disconnect reconnect-grace deadline (OMN-104 §5.4).
+
+    Called alongside :func:`clear_runner_liveness` from the SAME disconnect
+    handler, so a manager decision request landing on a DIFFERENT replica
+    than the one holding the tunnel can still see "this runner disconnected
+    and is still within its reconnect grace" instead of falling through to
+    the now-cleared ``runner_last_seen`` freshness check and misclassifying
+    a runner that is about to reconnect as dead — the same class of bug
+    BLOCKING #1 (round 1) fixed for the single-replica case, exposed one
+    layer further out for a multi-replica deployment.
+
+    :param runner_id: The disconnected runner's id.
+    :param grace_deadline: Epoch seconds the grace expires at.
+    """
+    if _store is None:
+        return
+    _submit(
+        "runner_disconnect_grace_set",
+        _store.set_runner_disconnect_grace,
+        runner_id,
+        int(grace_deadline),
+    )
+
+
+def clear_runner_disconnect_grace(runner_id: str) -> None:
+    """
+    Durably clear the reconnect-grace deadline for a runner.
+
+    Called on reconnect (the grace is no longer pending) and once the
+    grace genuinely expires with no reconnect (the runner is now confirmed
+    dead, not merely presumed).
+
+    :param runner_id: The runner whose grace-pending marker should be cleared.
+    """
+    if _store is None:
+        return
+    _submit("runner_disconnect_grace_clear", _store.clear_runner_disconnect_grace, runner_id)

--- a/omnigent/server/session_outbox.py
+++ b/omnigent/server/session_outbox.py
@@ -68,6 +68,31 @@ _ELICITATION_DECISION_ALLOWLIST = (
     "content",
 )
 
+# Cross-vendor review: session.failed's ``error_message`` upstream sources
+# include str(exception), subprocess/provider stderr, and a runner-forwarded,
+# structurally-unvalidated ``error`` dict (any harness/provider process can
+# put arbitrary text there) — free-form text that can incidentally embed
+# secrets, tokens, credentials, or internal paths. Denylisting by dict KEY
+# (see ``_redact_denylist``) cannot sanitize an arbitrary secret embedded in
+# a VALUE, and this payload is HMAC-signed and delivered to an external
+# manager webhook. So the delivered ``reason.message`` is NEVER the raw
+# error_message text — only one of these fixed, safe, allowlisted strings,
+# selected by the (short, enum-like, low-risk) error_code. An unrecognized
+# code falls back to the fully generic message below; the raw text is only
+# ever logged server-side (see record_session_failed), never persisted into
+# the outbox payload this map feeds.
+_SAFE_FAILURE_MESSAGES: dict[str, str] = {
+    "runner_disconnected": "The runner disconnected unexpectedly.",
+    "runner_failed_to_start": "The runner failed to start.",
+    "runner_error": "The runner reported an error.",
+    "runner_rejected_event": "The runner rejected an event for this turn.",
+    "harness_not_configured": ("The agent's harness is not configured on the selected host."),
+    "codex_turn_error": "The turn failed on the harness side.",
+    "codex_reauth_required": "Re-authentication is required for this session.",
+    "unknown": "The session turn failed.",
+}
+_DEFAULT_SAFE_FAILURE_MESSAGE = "The session turn failed."
+
 _store: SessionLifecycleStore | None = None
 
 
@@ -158,22 +183,39 @@ def record_session_failed(
     Durably record a ``session.failed`` event.
 
     Bound to any ``_publish_status`` edge into ``failed`` (not swallowed by
-    the sticky failed->idle guard). ``error_code``/``error_message`` are the
-    same ``ErrorDetail`` fields already passed to ``_publish_status``,
-    passed through the denylist redaction filter plus a length clamp — see
-    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §3.2.
+    the sticky failed->idle guard). ``error_code`` is the same
+    ``ErrorDetail.code`` already passed to ``_publish_status``, truncated
+    and denylist-redacted defensively. ``error_message`` is NEVER persisted
+    into the delivered payload verbatim — it is free-form text (str(exception),
+    subprocess/provider stderr, a runner-forwarded and structurally-
+    unvalidated ``error`` dict) that can incidentally embed secrets, and this
+    event is HMAC-signed and delivered to an external manager webhook. The
+    delivered ``reason.message`` is always one of the fixed, safe strings in
+    :data:`_SAFE_FAILURE_MESSAGES`, selected by ``error_code`` — see that
+    map's own docstring. ``error_message`` is only ever logged server-side,
+    never returned, never persisted.
 
     :param workspace_id: Tenant partition key.
     :param session_id: The session that just failed.
     :param response_id: The turn's response id (transition key source).
-    :param error_code: ``ErrorDetail.code`` verbatim.
-    :param error_message: ``ErrorDetail.message`` verbatim (redacted here).
+    :param error_code: ``ErrorDetail.code`` verbatim — a short, enum-like
+        classifier, selects the safe delivered message.
+    :param error_message: ``ErrorDetail.message`` verbatim — free-form,
+        untrusted diagnostic text. Logged server-side only; never delivered.
     """
     if _store is None:
         return
     transition_key = f"turn:{response_id}:failed"
-    reason = _redact_denylist({"code": error_code, "message": error_message})
-    reason["message"] = _truncate(str(reason["message"]))
+    safe_message = _SAFE_FAILURE_MESSAGES.get(error_code, _DEFAULT_SAFE_FAILURE_MESSAGE)
+    if error_message:
+        _logger.info(
+            "session.failed diagnostic detail (server-side only, never delivered "
+            "externally): session_id=%s error_code=%s detail=%s",
+            session_id,
+            error_code,
+            _truncate(error_message),
+        )
+    reason = _redact_denylist({"code": _truncate(str(error_code)), "message": safe_message})
     payload = {"response_id": response_id, "reason": reason}
     now = now_epoch()
     _store.record_lifecycle_event(

--- a/omnigent/server/session_outbox.py
+++ b/omnigent/server/session_outbox.py
@@ -1,0 +1,304 @@
+"""Durable session-lifecycle-event production (OMN-104).
+
+Writes stable-ID ``session.completed`` / ``session.failed`` /
+``session.awaiting_decision`` / ``session.resumed`` events into the
+transactional outbox (:mod:`omnigent.stores.session_lifecycle_store`)
+*before* delivery to the configured manager webhook, so a dropped
+network call never silently drops the event — the dispatcher
+(``omnigent/server/manager_webhook_dispatcher.py``) retries until a 2xx.
+
+This is a deliberately separate module from
+:mod:`omnigent.server.session_live_state`, not a mode of it: that module's
+own docstring states its writes are best-effort ("a failed write logs and
+is dropped; ... the next transition rewrites it") — correct for a display
+mirror, wrong for a lifecycle event, which has no "next transition" that
+repairs a silently dropped one. Every function here writes synchronously
+and lets a failure propagate to its caller rather than swallowing it,
+matching the producer-transaction shape in
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §4.3.
+
+No-op until :func:`configure` wires a store (the server app does this at
+startup); the runner process and unit tests that never configure it are
+unaffected — matching :mod:`omnigent.server.session_live_state`'s pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
+from omnigent.db.utils import now_epoch
+from omnigent.entities import SessionElicitation
+from omnigent.runtime.telemetry import _REDACT_KEY_SUBSTRINGS
+from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
+
+_logger = logging.getLogger(__name__)
+
+# Fixed, arbitrary namespace for deriving deterministic event ids — stable
+# across processes and restarts (unlike uuid4), so a retried producer call
+# computes the *same* event_id and resolves to the same outbox row via its
+# primary key rather than a separate dedupe query.
+_EVENT_ID_NAMESPACE = uuid.UUID("6f1b7c3a-8d2e-4a5f-9c1b-2e3f4a5b6c7d")
+
+# Allowlisted fields for session.awaiting_decision's ``request`` payload.
+# Deliberately an ALLOWLIST, not the denylist below: ElicitationRequestParams
+# has ``model_config = ConfigDict(extra="allow")`` (MCP passthrough), so an
+# unknown field (a raw env dict, process arguments, headers, secrets) must be
+# structurally excluded rather than relying on recognizing its key name.
+# tool_input / content_preview are deliberately excluded — they can carry
+# arbitrary tool-call arguments, not decision-context fields.
+_ELICITATION_REQUEST_ALLOWLIST = (
+    "mode",
+    "message",
+    "requestedSchema",
+    "url",
+    "phase",
+    "policy_name",
+    "target_session_id",
+    "tool_name",
+)
+
+# Allowlisted fields for session.resumed's ``decision`` payload (mirrors
+# ElicitationResult — action + the submitted form content).
+_ELICITATION_DECISION_ALLOWLIST = (
+    "action",
+    "content",
+)
+
+_store: SessionLifecycleStore | None = None
+
+
+def configure(store: SessionLifecycleStore | None) -> None:
+    """
+    Wire (or clear) the store lifecycle events are written to.
+
+    :param store: The server's session-lifecycle store, or ``None`` to
+        disable production (tests / non-server processes).
+    """
+    global _store
+    _store = store
+
+
+def _deterministic_event_id(workspace_id: int, session_id: str, transition_key: str) -> str:
+    """Derive a stable ``event_id`` from the fact being reported, not randomness."""
+    name = f"{workspace_id}:{session_id}:{transition_key}"
+    return uuid.uuid5(_EVENT_ID_NAMESPACE, name).hex
+
+
+def _redact_denylist(value: dict[str, Any]) -> dict[str, Any]:
+    """Apply the existing key-substring denylist filter to a flat dict."""
+    return {
+        k: ("[redacted]" if any(s in k.lower() for s in _REDACT_KEY_SUBSTRINGS) else v)
+        for k, v in value.items()
+    }
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= LABEL_VALUE_MAX_LEN:
+        return value
+    return value[: LABEL_VALUE_MAX_LEN - 1] + "…"
+
+
+def _allowlist(source: dict[str, Any], allowed: tuple[str, ...]) -> dict[str, Any]:
+    return {k: source[k] for k in allowed if k in source and source[k] is not None}
+
+
+def record_session_completed(
+    *,
+    workspace_id: int,
+    session_id: str,
+    response_id: str,
+    background_task_count: int | None = None,
+) -> None:
+    """
+    Durably record a ``session.completed`` event.
+
+    Bound to the ``_publish_status`` edge into ``idle`` when a turn was
+    actually open (``response_id`` read from
+    ``_session_active_response_cache`` before its ``.pop()``). No secondary
+    gate on ``background_task_count`` — see
+    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.1.
+
+    :param workspace_id: Tenant partition key.
+    :param session_id: The session that just completed a turn.
+    :param response_id: The turn's response id (also the transition key
+        source) — establishes that a turn was genuinely open.
+    :param background_task_count: Informational only; never a gating
+        condition.
+    """
+    if _store is None:
+        return
+    transition_key = f"turn:{response_id}:completed"
+    payload: dict[str, Any] = {"response_id": response_id}
+    if background_task_count is not None:
+        payload["background_task_count"] = background_task_count
+    now = now_epoch()
+    _store.record_lifecycle_event(
+        event_id=_deterministic_event_id(workspace_id, session_id, transition_key),
+        session_id=session_id,
+        event_type="session.completed",
+        transition_key=transition_key,
+        payload=json.dumps(payload),
+        now=now,
+    )
+
+
+def record_session_failed(
+    *,
+    workspace_id: int,
+    session_id: str,
+    response_id: str,
+    error_code: str,
+    error_message: str,
+) -> None:
+    """
+    Durably record a ``session.failed`` event.
+
+    Bound to any ``_publish_status`` edge into ``failed`` (not swallowed by
+    the sticky failed->idle guard). ``error_code``/``error_message`` are the
+    same ``ErrorDetail`` fields already passed to ``_publish_status``,
+    passed through the denylist redaction filter plus a length clamp — see
+    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §3.2.
+
+    :param workspace_id: Tenant partition key.
+    :param session_id: The session that just failed.
+    :param response_id: The turn's response id (transition key source).
+    :param error_code: ``ErrorDetail.code`` verbatim.
+    :param error_message: ``ErrorDetail.message`` verbatim (redacted here).
+    """
+    if _store is None:
+        return
+    transition_key = f"turn:{response_id}:failed"
+    reason = _redact_denylist({"code": error_code, "message": error_message})
+    reason["message"] = _truncate(str(reason["message"]))
+    payload = {"response_id": response_id, "reason": reason}
+    now = now_epoch()
+    _store.record_lifecycle_event(
+        event_id=_deterministic_event_id(workspace_id, session_id, transition_key),
+        session_id=session_id,
+        event_type="session.failed",
+        transition_key=transition_key,
+        payload=json.dumps(payload),
+        now=now,
+    )
+
+
+def record_elicitation_raised(
+    *,
+    workspace_id: int,
+    session_id: str,
+    elicitation_id: str,
+    request: dict[str, Any],
+) -> None:
+    """
+    Durably record a raised elicitation: the ``session_elicitations`` ledger
+    row and its ``session.awaiting_decision`` outbox row, in one transaction.
+
+    :param workspace_id: Tenant partition key.
+    :param session_id: The session raising the elicitation.
+    :param elicitation_id: Correlation id for this request.
+    :param request: The elicitation request fields (e.g.
+        ``ElicitationRequestParams.model_dump()`` plus ``tool_name``); only
+        the allowlisted subset is persisted — see
+        ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §3.2.
+    """
+    if _store is None:
+        return
+    allowlisted = _allowlist(request, _ELICITATION_REQUEST_ALLOWLIST)
+    transition_key = f"elicitation:{elicitation_id}:awaiting_decision"
+    now = now_epoch()
+    _store.record_elicitation_raised(
+        elicitation_id=elicitation_id,
+        session_id=session_id,
+        request_payload=json.dumps(allowlisted),
+        outbox_event_id=_deterministic_event_id(workspace_id, session_id, transition_key),
+        transition_key=transition_key,
+        outbox_payload=json.dumps({"elicitation_id": elicitation_id, "request": allowlisted}),
+        now=now,
+    )
+
+
+def get_elicitation(elicitation_id: str) -> SessionElicitation | None:
+    """Return the durable elicitation ledger row, or ``None`` if untracked / unconfigured."""
+    if _store is None:
+        return None
+    return _store.get_elicitation(elicitation_id)
+
+
+def record_decision(
+    *,
+    elicitation_id: str,
+    decision: dict[str, Any],
+    decided_by: str | None,
+) -> SessionElicitation | None:
+    """
+    Durably record a decision verdict on an elicitation.
+
+    Always called first, unconditionally, before any attempt to resolve an
+    in-memory ``Future`` — see
+    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.4.
+    Idempotent: a duplicate call after the verdict is already recorded is a
+    no-op (handled by the store).
+
+    :param elicitation_id: The elicitation being decided.
+    :param decision: The decision fields (e.g. ``ElicitationResult.model_dump()``);
+        only the allowlisted subset is persisted.
+    :param decided_by: Manager identity from the signed callback, or ``None``
+        for a web-UI verdict.
+    :returns: The elicitation ledger row after the write, or ``None`` when
+        this id has no durable ledger entry at all (never registered via
+        :func:`record_elicitation_raised` — a legacy/untracked elicitation)
+        or the store isn't configured. The caller uses this to distinguish
+        "nothing durable to classify" from a genuine tracked decision.
+    """
+    if _store is None:
+        return None
+    allowlisted = _allowlist(decision, _ELICITATION_DECISION_ALLOWLIST)
+    return _store.record_decision(
+        elicitation_id,
+        decision_payload=json.dumps(allowlisted),
+        decided_by=decided_by,
+        now=now_epoch(),
+    )
+
+
+def record_elicitation_resumed(*, workspace_id: int, elicitation_id: str) -> bool:
+    """
+    Durably record ``session.resumed`` — ONLY on the runner's truthful
+    acknowledgement of having consumed the decision, never on the manager
+    HTTP call merely being accepted.
+
+    Marks the elicitation ``delivered_to_runner`` and inserts the
+    ``session.resumed`` outbox row in one transaction. No-op (returns
+    ``False``) if the elicitation isn't in ``decided`` state (already
+    resumed, or never decided) — see
+    ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.4.
+
+    :param workspace_id: Tenant partition key.
+    :param elicitation_id: The elicitation that was just consumed by the
+        runner.
+    :returns: ``True`` if this call produced the ``session.resumed`` event
+        (i.e. it was the first to observe the runner's ack); ``False`` on an
+        idempotent no-op.
+    """
+    if _store is None:
+        return False
+    existing = _store.get_elicitation(elicitation_id)
+    if existing is None:
+        return False
+    decision_payload = json.loads(existing.decision_payload) if existing.decision_payload else {}
+    transition_key = f"elicitation:{elicitation_id}:resumed"
+    now = now_epoch()
+    _, _, inserted = _store.record_elicitation_resolved(
+        elicitation_id,
+        outbox_event_id=_deterministic_event_id(workspace_id, existing.session_id, transition_key),
+        transition_key=transition_key,
+        outbox_payload=json.dumps(
+            {"elicitation_id": elicitation_id, "decision": decision_payload}
+        ),
+        resolved_at=now,
+    )
+    return inserted

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1213,6 +1213,31 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def mark_runner_disconnected(self, runner_id: str, grace_deadline: int) -> None:
+        """
+        Atomically clear liveness and set the reconnect-grace deadline for
+        every session bound to a runner, in ONE transaction/commit.
+
+        Cross-vendor review: :meth:`clear_runner_liveness` and
+        :meth:`set_runner_disconnect_grace` used to be called as two
+        SEPARATE store writes on disconnect. Because each is its own
+        transaction, there was a real (if narrow) window between the two
+        commits where another replica's read observed BOTH
+        ``runner_last_seen`` cleared AND ``runner_disconnect_grace_deadline``
+        still absent (or a stale, already-expired value) simultaneously —
+        the runner would look neither live nor grace-pending, and a manager
+        decision landing in that exact window would be falsely 410'd even
+        though the runner is genuinely still within its reconnect grace.
+        A single ``UPDATE`` setting both columns is atomic per row under any
+        transactional isolation level a reader could observe — there is no
+        third, in-between state to read. Must NOT bump ``updated_at``.
+
+        :param runner_id: The disconnecting runner's id.
+        :param grace_deadline: Epoch seconds the reconnect grace expires at.
+        """
+        ...
+
+    @abstractmethod
     def set_runner_disconnect_grace(self, runner_id: str, grace_deadline: int) -> None:
         """
         Stamp the post-disconnect reconnect-grace deadline (OMN-104 §5.4)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -216,12 +216,21 @@ class SessionConnectivity:
         Lets a replica that does NOT hold the tunnel derive
         ``runner_online`` from freshness (see
         :func:`runner_seen_is_fresh`) instead of its own empty registry.
+    :param runner_disconnect_grace_deadline: Epoch seconds the bound
+        runner's post-disconnect reconnect grace (OMN-104 §5.4) expires
+        at, written by the replica holding the tunnel at the same moment
+        it clears ``runner_last_seen``. ``None`` when not currently
+        grace-pending. Lets a replica that does NOT hold the tunnel
+        classify a decision arriving mid-grace as "pending redelivery"
+        rather than "runner dead", without needing the tunnel-holding
+        replica's own in-memory registry.
     """
 
     runner_id: str | None
     host_id: str | None
     needs_workspace: bool
     runner_last_seen: int | None = None
+    runner_disconnect_grace_deadline: int | None = None
 
 
 # Freshness window for ``omnigent_conversation_metadata.runner_last_seen``. The tunnel
@@ -1200,6 +1209,41 @@ class ConversationStore(ABC):
         :data:`RUNNER_LIVENESS_TTL_S`. Must NOT bump ``updated_at``.
 
         :param runner_id: The disconnected runner's id.
+        """
+        ...
+
+    @abstractmethod
+    def set_runner_disconnect_grace(self, runner_id: str, grace_deadline: int) -> None:
+        """
+        Stamp the post-disconnect reconnect-grace deadline (OMN-104 §5.4)
+        for every session bound to a runner.
+
+        Called by the replica holding the tunnel at the same moment it
+        calls :meth:`clear_runner_liveness`, so any OTHER replica handling
+        a manager decision request can see "this runner disconnected and
+        is still within its reconnect grace" instead of falling through to
+        the now-cleared ``runner_last_seen`` freshness check and
+        misclassifying a runner that is about to reconnect as dead. One
+        bulk ``UPDATE``; must NOT bump ``updated_at``.
+
+        :param runner_id: The disconnected runner's id.
+        :param grace_deadline: Epoch seconds the grace expires at.
+        """
+        ...
+
+    @abstractmethod
+    def clear_runner_disconnect_grace(self, runner_id: str) -> None:
+        """
+        Clear the reconnect-grace deadline for every session bound to a runner.
+
+        Called on reconnect (the grace is no longer pending) and once the
+        grace genuinely expires with no reconnect (the runner is now
+        confirmed dead, not merely presumed — see
+        ``_mark_disconnected_runner_failed`` in ``app.py``). Must NOT bump
+        ``updated_at``.
+
+        :param runner_id: The runner whose grace-pending marker should be
+            cleared.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1126,6 +1126,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationMetadata.runner_id,
                     SqlConversationMetadata.host_id,
                     SqlConversationMetadata.runner_last_seen,
+                    SqlConversationMetadata.runner_disconnect_grace_deadline,
                 ).where(
                     SqlConversationMetadata.workspace_id == current_workspace_id(),
                     SqlConversationMetadata.id.in_(unique_ids),
@@ -1155,6 +1156,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 host_id=row.host_id,
                 needs_workspace=row.id in needs_workspace_ids,
                 runner_last_seen=row.runner_last_seen,
+                runner_disconnect_grace_deadline=row.runner_disconnect_grace_deadline,
             )
             for row in meta_rows
         }
@@ -2890,6 +2892,49 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationMetadata.runner_id == runner_id,
                 )
                 .values(runner_last_seen=None)
+            )
+
+    def set_runner_disconnect_grace(self, runner_id: str, grace_deadline: int) -> None:
+        """
+        Stamp ``runner_disconnect_grace_deadline`` for sessions bound to a runner.
+
+        Lives on ``omnigent_conversation_metadata``, so ``conversations.updated_at``
+        (sidebar ordering) is untouched by construction. See the abstract method.
+
+        :param runner_id: The disconnected runner's id.
+        :param grace_deadline: Epoch seconds the grace expires at.
+        """
+        from sqlalchemy import update
+
+        with self._session("set_runner_disconnect_grace") as session:
+            session.execute(
+                update(SqlConversationMetadata)
+                .where(
+                    SqlConversationMetadata.workspace_id == current_workspace_id(),
+                    SqlConversationMetadata.runner_id == runner_id,
+                )
+                .values(runner_disconnect_grace_deadline=grace_deadline)
+            )
+
+    def clear_runner_disconnect_grace(self, runner_id: str) -> None:
+        """
+        Clear ``runner_disconnect_grace_deadline`` for sessions bound to a runner.
+
+        Lives on ``omnigent_conversation_metadata``, so ``conversations.updated_at``
+        (sidebar ordering) is untouched by construction. See the abstract method.
+
+        :param runner_id: The runner whose grace-pending marker should be cleared.
+        """
+        from sqlalchemy import update
+
+        with self._session("clear_runner_disconnect_grace") as session:
+            session.execute(
+                update(SqlConversationMetadata)
+                .where(
+                    SqlConversationMetadata.workspace_id == current_workspace_id(),
+                    SqlConversationMetadata.runner_id == runner_id,
+                )
+                .values(runner_disconnect_grace_deadline=None)
             )
 
     def set_session_live_status(self, conversation_id: str, status: str) -> None:

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2894,6 +2894,28 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .values(runner_last_seen=None)
             )
 
+    def mark_runner_disconnected(self, runner_id: str, grace_deadline: int) -> None:
+        """
+        Atomically clear ``runner_last_seen`` and stamp
+        ``runner_disconnect_grace_deadline`` for sessions bound to a runner,
+        in one ``UPDATE`` / one commit. See the abstract method for why this
+        must be one write, not two.
+
+        :param runner_id: The disconnecting runner's id.
+        :param grace_deadline: Epoch seconds the reconnect grace expires at.
+        """
+        from sqlalchemy import update
+
+        with self._session("mark_runner_disconnected") as session:
+            session.execute(
+                update(SqlConversationMetadata)
+                .where(
+                    SqlConversationMetadata.workspace_id == current_workspace_id(),
+                    SqlConversationMetadata.runner_id == runner_id,
+                )
+                .values(runner_last_seen=None, runner_disconnect_grace_deadline=grace_deadline)
+            )
+
     def set_runner_disconnect_grace(self, runner_id: str, grace_deadline: int) -> None:
         """
         Stamp ``runner_disconnect_grace_deadline`` for sessions bound to a runner.

--- a/omnigent/stores/session_lifecycle_store/__init__.py
+++ b/omnigent/stores/session_lifecycle_store/__init__.py
@@ -1,0 +1,254 @@
+"""Session-lifecycle-push store — the transactional outbox and durable
+elicitation ledger for OMN-104 (push session lifecycle events to the
+configured manager webhook).
+
+This store owns three tables: ``session_lifecycle_outbox`` (the outbox),
+``session_lifecycle_cursors`` (its per-session sequence allocator), and
+``session_elicitations`` (the durable human-decision ledger). See
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import LifecycleOutboxEvent, SessionElicitation
+
+
+class SessionLifecycleStore(ABC):
+    """Abstract base for session-lifecycle-outbox and elicitation-ledger persistence."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the session-lifecycle store.
+
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///chat.db"`` for SQLAlchemy.
+        """
+        self.storage_location = storage_location
+
+    # ── Outbox: producer side ───────────────────────────────────
+
+    @abstractmethod
+    def record_lifecycle_event(
+        self,
+        *,
+        event_id: str,
+        session_id: str,
+        event_type: str,
+        transition_key: str,
+        payload: str,
+        now: int,
+    ) -> tuple[LifecycleOutboxEvent, bool]:
+        """
+        Insert a ``session.completed`` / ``session.failed`` outbox row.
+
+        Idempotent via the ``(workspace_id, session_id, event_type,
+        transition_key)`` unique constraint: a retried producer call for the
+        same transition resolves to the existing row rather than a duplicate.
+
+        :param event_id: Deterministic ``event_id`` (UUIDv5).
+        :param session_id: The session this event reports on.
+        :param event_type: ``"session.completed"`` or ``"session.failed"``.
+        :param transition_key: e.g. ``"turn:{response_id}:completed"``.
+        :param payload: Redacted JSON event ``data``, already serialized.
+        :param now: Unix epoch seconds to stamp ``created_at``.
+        :returns: ``(row, inserted)`` — ``inserted`` is ``False`` when an
+            identical transition already had a row (idempotent no-op).
+        """
+        ...
+
+    @abstractmethod
+    def record_elicitation_raised(
+        self,
+        *,
+        elicitation_id: str,
+        session_id: str,
+        request_payload: str,
+        outbox_event_id: str,
+        transition_key: str,
+        outbox_payload: str,
+        now: int,
+    ) -> tuple[SessionElicitation, LifecycleOutboxEvent | None, bool]:
+        """
+        Transactionally insert the durable elicitation row and its
+        ``session.awaiting_decision`` outbox row.
+
+        :param elicitation_id: The elicitation id (``== SessionElicitation.id``).
+        :param session_id: The owning session.
+        :param request_payload: Allowlisted request fields, serialized JSON.
+        :param outbox_event_id: Deterministic ``event_id`` for the
+            ``session.awaiting_decision`` outbox row.
+        :param transition_key: e.g. ``"elicitation:{id}:awaiting_decision"``.
+        :param outbox_payload: Redacted JSON event ``data`` for the outbox row.
+        :param now: Unix epoch seconds to stamp ``created_at``.
+        :returns: ``(elicitation, outbox_event, inserted)``. ``inserted`` is
+            ``False`` when the elicitation id already existed (idempotent
+            no-op; ``outbox_event`` is then ``None``).
+        """
+        ...
+
+    @abstractmethod
+    def get_elicitation(self, elicitation_id: str) -> SessionElicitation | None:
+        """Return an elicitation ledger row by id, or ``None`` if not found."""
+        ...
+
+    @abstractmethod
+    def list_decided_undelivered(self, session_id: str) -> list[SessionElicitation]:
+        """
+        List a session's ``decided``-but-undelivered elicitations.
+
+        Powers reconnect redelivery (§5.4's "server restarts, runner alive"
+        case): on tunnel reconnect, the server re-POSTs each of these rows'
+        decision to the runner rather than leaving a durably-recorded verdict
+        stranded.
+
+        :param session_id: The session whose runner just reconnected.
+        :returns: Rows with ``status == "decided"``, oldest first.
+        """
+        ...
+
+    @abstractmethod
+    def record_decision(
+        self,
+        elicitation_id: str,
+        *,
+        decision_payload: str,
+        decided_by: str | None,
+        now: int,
+    ) -> SessionElicitation | None:
+        """
+        Durably record a verdict. Conditional on ``status = pending``.
+
+        Idempotent: a duplicate call (manager retry) after the verdict is
+        already recorded is a no-op that returns the existing (unchanged) row.
+
+        :param elicitation_id: The elicitation being decided.
+        :param decision_payload: Allowlisted decision fields, serialized JSON.
+        :param decided_by: Manager identity from the signed callback, or
+            ``None`` for a web-UI verdict.
+        :param now: Unix epoch seconds to stamp ``decided_at``.
+        :returns: The row after the write, or ``None`` if no elicitation with
+            that id exists.
+        """
+        ...
+
+    @abstractmethod
+    def record_elicitation_resolved(
+        self,
+        elicitation_id: str,
+        *,
+        outbox_event_id: str,
+        transition_key: str,
+        outbox_payload: str,
+        resolved_at: int,
+    ) -> tuple[SessionElicitation | None, LifecycleOutboxEvent | None, bool]:
+        """
+        Transactionally mark an elicitation ``delivered_to_runner`` and
+        insert its ``session.resumed`` outbox row.
+
+        Conditional on ``status = decided`` — only called once the runner has
+        truthfully acknowledged consuming the decision.
+
+        :returns: ``(elicitation, outbox_event, inserted)``. ``inserted`` is
+            ``False`` (and ``outbox_event`` the existing row) on a duplicate
+            call, or ``(None, None, False)`` if no ``decided`` elicitation
+            with that id exists.
+        """
+        ...
+
+    # ── Outbox: dispatcher side ─────────────────────────────────
+
+    @abstractmethod
+    def claim_batch(
+        self,
+        *,
+        limit: int,
+        now: int,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> list[LifecycleOutboxEvent]:
+        """
+        Claim up to ``limit`` deliverable rows for this replica.
+
+        Only claims a row when no earlier (lower ``sequence``) row for the
+        same ``(workspace_id, session_id)`` is still ``pending``/``leased``
+        (per-session ordering — never issues event N+1 before N reaches a
+        terminal delivery state). Increments ``attempt_count`` and stamps
+        ``last_attempt_at``/``lease_owner``/``lease_expires_at`` as part of
+        the claim.
+
+        :param limit: Maximum rows to claim.
+        :param now: Unix epoch seconds "now".
+        :param lease_owner: This replica's identity.
+        :param lease_seconds: How long the claim's lease is held before it
+            becomes reclaimable.
+        :returns: Claimed rows, each with ``status = "leased"``.
+        """
+        ...
+
+    @abstractmethod
+    def mark_delivered(
+        self, event_id: str, *, workspace_id: int, delivered_at: int, http_status: int
+    ) -> None:
+        """
+        Mark a leased row ``delivered``. No-op if not currently leased.
+
+        Takes an explicit ``workspace_id`` (from the claimed
+        :class:`LifecycleOutboxEvent`) rather than the request-scoped
+        ``current_workspace_id()`` — the dispatcher runs outside any request,
+        so no ambient workspace scope is set.
+        """
+        ...
+
+    @abstractmethod
+    def mark_delivery_failed(
+        self,
+        event_id: str,
+        *,
+        workspace_id: int,
+        next_attempt_at: int,
+        dead_letter_after_attempts: int,
+        http_status: int | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        """
+        Release a leased row's lease after a failed delivery attempt.
+
+        Sets ``status = dead_letter`` once ``attempt_count >=
+        dead_letter_after_attempts``, else back to ``pending`` — either way it
+        keeps retrying at ``next_attempt_at`` (escalation, never abandonment).
+        No-op if not currently leased. See :meth:`mark_delivered` on why
+        ``workspace_id`` is explicit here.
+        """
+        ...
+
+    @abstractmethod
+    def reclaim_expired_leases(self, *, now: int) -> int:
+        """
+        Reclaim rows whose lease expired without the claiming replica
+        completing delivery (crash mid-claim). Returns rows to ``pending``.
+
+        :param now: Unix epoch seconds "now".
+        :returns: Number of rows reclaimed.
+        """
+        ...
+
+    # ── Reads ────────────────────────────────────────────────────
+
+    @abstractmethod
+    def list_deliveries(
+        self,
+        session_id: str,
+        *,
+        limit: int = 100,
+        after_id: str | None = None,
+    ) -> tuple[list[LifecycleOutboxEvent], str | None]:
+        """List a session's outbox rows, most recent (``sequence``) first, cursor-paginated."""
+        ...
+
+    @abstractmethod
+    def latest_delivery(self, session_id: str) -> LifecycleOutboxEvent | None:
+        """Return a session's most recent (highest-``sequence``) outbox row, or ``None``."""
+        ...

--- a/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
+++ b/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
@@ -27,6 +27,17 @@ from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
 _LEASE_BLOCKING_STATUSES = (
     encode_session_lifecycle_outbox_status("pending"),
     encode_session_lifecycle_outbox_status("leased"),
+    # dead_letter is NOT a terminal state (§7.4: escalation, never
+    # abandonment — a dead-lettered row keeps retrying at the capped
+    # backoff floor indefinitely). Excluding it here would let a later
+    # sequence number for the same session be claimed/delivered while an
+    # earlier one is still retryable, violating per-session ordering
+    # (requirement #2) and letting the manager's view regress backward in
+    # time if the earlier row later succeeds. Keeping it in the blocking
+    # set (rather than making it stop retrying once superseded) is what
+    # keeps it consistent with claim_batch's own retry semantics below,
+    # which never stops retrying a dead_letter row on its own account.
+    encode_session_lifecycle_outbox_status("dead_letter"),
 )
 _CLAIMABLE_STATUSES = (
     encode_session_lifecycle_outbox_status("pending"),
@@ -277,7 +288,22 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
     ) -> SessionElicitation | None:
         pending_code = encode_session_elicitation_status("pending")
         with self._session("record_decision") as session:
-            row = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
+            # Lock the row before the read-then-write below (same idiom as
+            # _allocate_sequence): without this, two concurrent decision
+            # callbacks for the same elicitation_id can both read "pending"
+            # under READ COMMITTED and both write, with the later commit
+            # silently overwriting the first-committed verdict instead of
+            # being rejected. On Postgres this blocks the second caller
+            # until the first commits, so it re-reads the FRESH (already
+            # "decided") row below and correctly takes the no-op path
+            # instead of clobbering it. On SQLite, BEGIN IMMEDIATE (see
+            # make_managed_session_maker) already serializes this at the
+            # transaction level, so with_for_update is a no-op there.
+            row = session.get(
+                SqlSessionElicitation,
+                (current_workspace_id(), elicitation_id),
+                with_for_update=self._supports_for_update,
+            )
             if row is None:
                 return None
             if row.status == pending_code:
@@ -299,7 +325,21 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
     ) -> tuple[SessionElicitation | None, LifecycleOutboxEvent | None, bool]:
         decided_code = encode_session_elicitation_status("decided")
         with self._session("record_elicitation_resolved") as session:
-            row = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
+            # Same row-lock idiom as record_decision: without it, two
+            # overlapping successful deliveries can both observe "decided"
+            # and both attempt to insert a session.resumed row. Locking
+            # here means the loser's read (after the winner commits) sees
+            # "delivered_to_runner" and correctly takes the no-op branch
+            # below instead of reaching the insert at all. The IntegrityError
+            # guard further down is defense in depth, matching this file's
+            # own pattern elsewhere (record_lifecycle_event,
+            # record_elicitation_raised) of never trusting a lock alone to
+            # prevent a duplicate-key insert.
+            row = session.get(
+                SqlSessionElicitation,
+                (current_workspace_id(), elicitation_id),
+                with_for_update=self._supports_for_update,
+            )
             if row is None:
                 return None, None, False
             if row.status != decided_code:
@@ -328,8 +368,24 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
                 next_attempt_at=resolved_at,
                 created_at=resolved_at,
             )
-            session.add(outbox_row)
-            session.flush()
+            try:
+                with session.begin_nested():
+                    session.add(outbox_row)
+                    session.flush()
+            except IntegrityError:
+                # Lost a race with another concurrent resolve for the same
+                # transition_key — the row lock above should already make
+                # this unreachable in practice, but guard it explicitly
+                # rather than let a duplicate-key insert surface as an
+                # unhandled 500. Surface the winner's outbox row.
+                existing_outbox = self._get_by_transition(
+                    session, row.session_id, "session.resumed", transition_key
+                )
+                return (
+                    _elicitation_to_entity(row),
+                    _outbox_to_entity(existing_outbox) if existing_outbox is not None else None,
+                    False,
+                )
             return _elicitation_to_entity(row), _outbox_to_entity(outbox_row), True
 
     # ── Outbox: dispatcher side ─────────────────────────────────

--- a/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
+++ b/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
@@ -171,9 +171,7 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
                 # Lost a race with another producer call for the same
                 # transition (the unique constraint is the storage-level
                 # idempotency backstop). Return the winner's row.
-                existing = self._get_by_transition(
-                    session, session_id, event_type, transition_key
-                )
+                existing = self._get_by_transition(session, session_id, event_type, transition_key)
                 assert existing is not None
                 return _outbox_to_entity(existing), False
             return _outbox_to_entity(row), True
@@ -184,9 +182,8 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
         stmt = select(SqlSessionLifecycleOutbox).where(
             SqlSessionLifecycleOutbox.workspace_id == current_workspace_id(),
             SqlSessionLifecycleOutbox.session_id == session_id,
-            SqlSessionLifecycleOutbox.event_type == encode_session_lifecycle_event_type(
-                event_type
-            ),
+            SqlSessionLifecycleOutbox.event_type
+            == encode_session_lifecycle_event_type(event_type),
             SqlSessionLifecycleOutbox.transition_key == transition_key,
         )
         return session.execute(stmt).scalar_one_or_none()
@@ -203,9 +200,7 @@ class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
         now: int,
     ) -> tuple[SessionElicitation, LifecycleOutboxEvent | None, bool]:
         with self._session("record_elicitation_raised") as session:
-            existing = session.get(
-                SqlSessionElicitation, (current_workspace_id(), elicitation_id)
-            )
+            existing = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
             if existing is not None:
                 return _elicitation_to_entity(existing), None, False
             elicitation = SqlSessionElicitation(

--- a/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
+++ b/omnigent/stores/session_lifecycle_store/sqlalchemy_store.py
@@ -1,0 +1,489 @@
+"""SQLAlchemy-backed session-lifecycle-push store (OMN-104)."""
+
+from __future__ import annotations
+
+from sqlalchemy import desc, exists, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, aliased
+
+from omnigent.db.db_models import (
+    SqlSessionElicitation,
+    SqlSessionLifecycleCursor,
+    SqlSessionLifecycleOutbox,
+    current_workspace_id,
+)
+from omnigent.db.enum_codecs import (
+    decode_session_elicitation_status,
+    decode_session_lifecycle_event_type,
+    decode_session_lifecycle_outbox_status,
+    encode_session_elicitation_status,
+    encode_session_lifecycle_event_type,
+    encode_session_lifecycle_outbox_status,
+)
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker
+from omnigent.entities import LifecycleOutboxEvent, SessionElicitation
+from omnigent.stores.session_lifecycle_store import SessionLifecycleStore
+
+_LEASE_BLOCKING_STATUSES = (
+    encode_session_lifecycle_outbox_status("pending"),
+    encode_session_lifecycle_outbox_status("leased"),
+)
+_CLAIMABLE_STATUSES = (
+    encode_session_lifecycle_outbox_status("pending"),
+    encode_session_lifecycle_outbox_status("dead_letter"),
+)
+
+
+def _outbox_to_entity(row: SqlSessionLifecycleOutbox) -> LifecycleOutboxEvent:
+    return LifecycleOutboxEvent(
+        id=row.id,
+        session_id=row.session_id,
+        event_type=decode_session_lifecycle_event_type(row.event_type),
+        transition_key=row.transition_key,
+        sequence=row.sequence,
+        event_version=row.event_version,
+        payload=row.payload,
+        status=decode_session_lifecycle_outbox_status(row.status),
+        attempt_count=row.attempt_count,
+        next_attempt_at=row.next_attempt_at,
+        created_at=row.created_at,
+        workspace_id=row.workspace_id,
+        lease_owner=row.lease_owner,
+        lease_expires_at=row.lease_expires_at,
+        last_attempt_at=row.last_attempt_at,
+        delivered_at=row.delivered_at,
+        last_http_status=row.last_http_status,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+    )
+
+
+def _elicitation_to_entity(row: SqlSessionElicitation) -> SessionElicitation:
+    return SessionElicitation(
+        id=row.id,
+        session_id=row.session_id,
+        status=decode_session_elicitation_status(row.status),
+        request_payload=row.request_payload,
+        created_at=row.created_at,
+        workspace_id=row.workspace_id,
+        decision_payload=row.decision_payload,
+        decided_by=row.decided_by,
+        decided_at=row.decided_at,
+        resolved_at=row.resolved_at,
+    )
+
+
+class SqlAlchemySessionLifecycleStore(SessionLifecycleStore):
+    """SQLAlchemy-backed implementation of :class:`SessionLifecycleStore`."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the SQLAlchemy session-lifecycle store.
+
+        :param storage_location: SQLAlchemy database URI,
+            e.g. ``"sqlite:///chat.db"``.
+        """
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        # SQLite: BEGIN IMMEDIATE acquires the write lock up front, so the
+        # cursor read-modify-write below is race-free without SELECT ... FOR
+        # UPDATE (which SQLite doesn't support). Postgres still gets an
+        # explicit .with_for_update() — see _allocate_sequence.
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.session_lifecycle_store",
+            immediate=True,
+        )
+        self._supports_for_update = self._engine.dialect.name != "sqlite"
+
+    # ── Sequence allocation ──────────────────────────────────────
+
+    def _allocate_sequence(self, session: Session, session_id: str) -> int:
+        """Lock (creating if absent) the session's cursor row and return the next sequence."""
+        workspace_id = current_workspace_id()
+        stmt = select(SqlSessionLifecycleCursor).where(
+            SqlSessionLifecycleCursor.workspace_id == workspace_id,
+            SqlSessionLifecycleCursor.session_id == session_id,
+        )
+        if self._supports_for_update:
+            stmt = stmt.with_for_update()
+        cursor = session.execute(stmt).scalar_one_or_none()
+        if cursor is None:
+            cursor = SqlSessionLifecycleCursor(
+                workspace_id=workspace_id, session_id=session_id, next_sequence=1
+            )
+            try:
+                with session.begin_nested():
+                    session.add(cursor)
+                    session.flush()
+            except IntegrityError:
+                # Lost a race to create the cursor row; another concurrent
+                # producer for this session's first-ever event won. The
+                # SAVEPOINT rollback above undid only our failed insert (the
+                # outer transaction/lock is untouched) — re-select-with-lock,
+                # the row now exists, so the lock acquires cleanly this time.
+                stmt = select(SqlSessionLifecycleCursor).where(
+                    SqlSessionLifecycleCursor.workspace_id == workspace_id,
+                    SqlSessionLifecycleCursor.session_id == session_id,
+                )
+                if self._supports_for_update:
+                    stmt = stmt.with_for_update()
+                cursor = session.execute(stmt).scalar_one()
+        allocated = cursor.next_sequence
+        cursor.next_sequence = allocated + 1
+        session.flush()
+        return allocated
+
+    # ── Outbox: producer side ───────────────────────────────────
+
+    def record_lifecycle_event(
+        self,
+        *,
+        event_id: str,
+        session_id: str,
+        event_type: str,
+        transition_key: str,
+        payload: str,
+        now: int,
+    ) -> tuple[LifecycleOutboxEvent, bool]:
+        with self._session("record_lifecycle_event") as session:
+            existing = self._get_by_transition(session, session_id, event_type, transition_key)
+            if existing is not None:
+                return _outbox_to_entity(existing), False
+            row = SqlSessionLifecycleOutbox(
+                id=event_id,
+                session_id=session_id,
+                event_type=encode_session_lifecycle_event_type(event_type),
+                transition_key=transition_key,
+                sequence=self._allocate_sequence(session, session_id),
+                event_version=1,
+                payload=payload,
+                status=encode_session_lifecycle_outbox_status("pending"),
+                attempt_count=0,
+                next_attempt_at=now,
+                created_at=now,
+            )
+            try:
+                with session.begin_nested():
+                    session.add(row)
+                    session.flush()
+            except IntegrityError:
+                # Lost a race with another producer call for the same
+                # transition (the unique constraint is the storage-level
+                # idempotency backstop). Return the winner's row.
+                existing = self._get_by_transition(
+                    session, session_id, event_type, transition_key
+                )
+                assert existing is not None
+                return _outbox_to_entity(existing), False
+            return _outbox_to_entity(row), True
+
+    def _get_by_transition(
+        self, session: Session, session_id: str, event_type: str, transition_key: str
+    ) -> SqlSessionLifecycleOutbox | None:
+        stmt = select(SqlSessionLifecycleOutbox).where(
+            SqlSessionLifecycleOutbox.workspace_id == current_workspace_id(),
+            SqlSessionLifecycleOutbox.session_id == session_id,
+            SqlSessionLifecycleOutbox.event_type == encode_session_lifecycle_event_type(
+                event_type
+            ),
+            SqlSessionLifecycleOutbox.transition_key == transition_key,
+        )
+        return session.execute(stmt).scalar_one_or_none()
+
+    def record_elicitation_raised(
+        self,
+        *,
+        elicitation_id: str,
+        session_id: str,
+        request_payload: str,
+        outbox_event_id: str,
+        transition_key: str,
+        outbox_payload: str,
+        now: int,
+    ) -> tuple[SessionElicitation, LifecycleOutboxEvent | None, bool]:
+        with self._session("record_elicitation_raised") as session:
+            existing = session.get(
+                SqlSessionElicitation, (current_workspace_id(), elicitation_id)
+            )
+            if existing is not None:
+                return _elicitation_to_entity(existing), None, False
+            elicitation = SqlSessionElicitation(
+                id=elicitation_id,
+                session_id=session_id,
+                status=encode_session_elicitation_status("pending"),
+                request_payload=request_payload,
+                created_at=now,
+            )
+            outbox_row = SqlSessionLifecycleOutbox(
+                id=outbox_event_id,
+                session_id=session_id,
+                event_type=encode_session_lifecycle_event_type("session.awaiting_decision"),
+                transition_key=transition_key,
+                sequence=self._allocate_sequence(session, session_id),
+                event_version=1,
+                payload=outbox_payload,
+                status=encode_session_lifecycle_outbox_status("pending"),
+                attempt_count=0,
+                next_attempt_at=now,
+                created_at=now,
+            )
+            try:
+                with session.begin_nested():
+                    session.add(elicitation)
+                    session.add(outbox_row)
+                    session.flush()
+            except IntegrityError:
+                # A concurrent retry of the same registration call (same
+                # caller-supplied elicitation_id) won the race — this is the
+                # same logical request, so surface the winner's rows rather
+                # than erroring.
+                existing = session.get(
+                    SqlSessionElicitation, (current_workspace_id(), elicitation_id)
+                )
+                assert existing is not None
+                existing_outbox = self._get_by_transition(
+                    session, session_id, "session.awaiting_decision", transition_key
+                )
+                return (
+                    _elicitation_to_entity(existing),
+                    _outbox_to_entity(existing_outbox) if existing_outbox is not None else None,
+                    False,
+                )
+            return _elicitation_to_entity(elicitation), _outbox_to_entity(outbox_row), True
+
+    def get_elicitation(self, elicitation_id: str) -> SessionElicitation | None:
+        with self._session("get_elicitation") as session:
+            row = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
+            return _elicitation_to_entity(row) if row is not None else None
+
+    def list_decided_undelivered(self, session_id: str) -> list[SessionElicitation]:
+        decided_code = encode_session_elicitation_status("decided")
+        with self._session("list_decided_undelivered") as session:
+            stmt = (
+                select(SqlSessionElicitation)
+                .where(
+                    SqlSessionElicitation.workspace_id == current_workspace_id(),
+                    SqlSessionElicitation.session_id == session_id,
+                    SqlSessionElicitation.status == decided_code,
+                )
+                .order_by(SqlSessionElicitation.decided_at.asc())
+            )
+            rows = session.execute(stmt).scalars().all()
+            return [_elicitation_to_entity(r) for r in rows]
+
+    def record_decision(
+        self,
+        elicitation_id: str,
+        *,
+        decision_payload: str,
+        decided_by: str | None,
+        now: int,
+    ) -> SessionElicitation | None:
+        pending_code = encode_session_elicitation_status("pending")
+        with self._session("record_decision") as session:
+            row = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
+            if row is None:
+                return None
+            if row.status == pending_code:
+                row.status = encode_session_elicitation_status("decided")
+                row.decision_payload = decision_payload
+                row.decided_by = decided_by
+                row.decided_at = now
+                session.flush()
+            return _elicitation_to_entity(row)
+
+    def record_elicitation_resolved(
+        self,
+        elicitation_id: str,
+        *,
+        outbox_event_id: str,
+        transition_key: str,
+        outbox_payload: str,
+        resolved_at: int,
+    ) -> tuple[SessionElicitation | None, LifecycleOutboxEvent | None, bool]:
+        decided_code = encode_session_elicitation_status("decided")
+        with self._session("record_elicitation_resolved") as session:
+            row = session.get(SqlSessionElicitation, (current_workspace_id(), elicitation_id))
+            if row is None:
+                return None, None, False
+            if row.status != decided_code:
+                # Already resolved (or never decided) — idempotent no-op;
+                # surface the existing outbox row if one was already written.
+                existing_outbox = self._get_by_transition(
+                    session, row.session_id, "session.resumed", transition_key
+                )
+                return (
+                    _elicitation_to_entity(row),
+                    _outbox_to_entity(existing_outbox) if existing_outbox is not None else None,
+                    False,
+                )
+            row.status = encode_session_elicitation_status("delivered_to_runner")
+            row.resolved_at = resolved_at
+            outbox_row = SqlSessionLifecycleOutbox(
+                id=outbox_event_id,
+                session_id=row.session_id,
+                event_type=encode_session_lifecycle_event_type("session.resumed"),
+                transition_key=transition_key,
+                sequence=self._allocate_sequence(session, row.session_id),
+                event_version=1,
+                payload=outbox_payload,
+                status=encode_session_lifecycle_outbox_status("pending"),
+                attempt_count=0,
+                next_attempt_at=resolved_at,
+                created_at=resolved_at,
+            )
+            session.add(outbox_row)
+            session.flush()
+            return _elicitation_to_entity(row), _outbox_to_entity(outbox_row), True
+
+    # ── Outbox: dispatcher side ─────────────────────────────────
+
+    def claim_batch(
+        self,
+        *,
+        limit: int,
+        now: int,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> list[LifecycleOutboxEvent]:
+        Blocker = aliased(SqlSessionLifecycleOutbox)
+        blocked = (
+            select(1)
+            .where(
+                Blocker.workspace_id == SqlSessionLifecycleOutbox.workspace_id,
+                Blocker.session_id == SqlSessionLifecycleOutbox.session_id,
+                Blocker.sequence < SqlSessionLifecycleOutbox.sequence,
+                Blocker.status.in_(_LEASE_BLOCKING_STATUSES),
+            )
+            .correlate(SqlSessionLifecycleOutbox)
+        )
+        stmt = (
+            select(SqlSessionLifecycleOutbox)
+            .where(
+                SqlSessionLifecycleOutbox.status.in_(_CLAIMABLE_STATUSES),
+                SqlSessionLifecycleOutbox.next_attempt_at <= now,
+                ~exists(blocked),
+            )
+            .order_by(SqlSessionLifecycleOutbox.next_attempt_at.asc())
+            .limit(limit)
+        )
+        if self._supports_for_update:
+            stmt = stmt.with_for_update(skip_locked=True)
+        with self._session("claim_batch") as session:
+            rows = session.execute(stmt).scalars().all()
+            claimed: list[LifecycleOutboxEvent] = []
+            for row in rows:
+                row.status = encode_session_lifecycle_outbox_status("leased")
+                row.attempt_count += 1
+                row.last_attempt_at = now
+                row.lease_owner = lease_owner
+                row.lease_expires_at = now + lease_seconds
+                claimed.append(_outbox_to_entity(row))
+            session.flush()
+            return claimed
+
+    def mark_delivered(
+        self, event_id: str, *, workspace_id: int, delivered_at: int, http_status: int
+    ) -> None:
+        leased_code = encode_session_lifecycle_outbox_status("leased")
+        with self._session("mark_delivered") as session:
+            row = session.get(SqlSessionLifecycleOutbox, (workspace_id, event_id))
+            if row is None or row.status != leased_code:
+                return
+            row.status = encode_session_lifecycle_outbox_status("delivered")
+            row.delivered_at = delivered_at
+            row.last_http_status = http_status
+            row.lease_owner = None
+            row.lease_expires_at = None
+
+    def mark_delivery_failed(
+        self,
+        event_id: str,
+        *,
+        workspace_id: int,
+        next_attempt_at: int,
+        dead_letter_after_attempts: int,
+        http_status: int | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        leased_code = encode_session_lifecycle_outbox_status("leased")
+        with self._session("mark_delivery_failed") as session:
+            row = session.get(SqlSessionLifecycleOutbox, (workspace_id, event_id))
+            if row is None or row.status != leased_code:
+                return
+            row.status = encode_session_lifecycle_outbox_status(
+                "dead_letter" if row.attempt_count >= dead_letter_after_attempts else "pending"
+            )
+            row.next_attempt_at = next_attempt_at
+            row.last_http_status = http_status
+            row.last_error_code = error_code
+            row.last_error_message = error_message
+            row.lease_owner = None
+            row.lease_expires_at = None
+
+    def reclaim_expired_leases(self, *, now: int) -> int:
+        leased_code = encode_session_lifecycle_outbox_status("leased")
+        pending_code = encode_session_lifecycle_outbox_status("pending")
+        with self._session("reclaim_expired_leases") as session:
+            stmt = select(SqlSessionLifecycleOutbox).where(
+                SqlSessionLifecycleOutbox.status == leased_code,
+                SqlSessionLifecycleOutbox.lease_expires_at.is_not(None),
+                SqlSessionLifecycleOutbox.lease_expires_at < now,
+            )
+            rows = session.execute(stmt).scalars().all()
+            for row in rows:
+                row.status = pending_code
+                row.lease_owner = None
+                row.lease_expires_at = None
+                row.next_attempt_at = now
+            session.flush()
+            return len(rows)
+
+    # ── Reads ────────────────────────────────────────────────────
+
+    def list_deliveries(
+        self,
+        session_id: str,
+        *,
+        limit: int = 100,
+        after_id: str | None = None,
+    ) -> tuple[list[LifecycleOutboxEvent], str | None]:
+        with self._session("list_deliveries") as session:
+            stmt = (
+                select(SqlSessionLifecycleOutbox)
+                .where(
+                    SqlSessionLifecycleOutbox.workspace_id == current_workspace_id(),
+                    SqlSessionLifecycleOutbox.session_id == session_id,
+                )
+                .order_by(desc(SqlSessionLifecycleOutbox.sequence))
+            )
+            if after_id is not None:
+                cursor_seq = (
+                    select(SqlSessionLifecycleOutbox.sequence)
+                    .where(
+                        SqlSessionLifecycleOutbox.workspace_id == current_workspace_id(),
+                        SqlSessionLifecycleOutbox.id == after_id,
+                    )
+                    .scalar_subquery()
+                )
+                stmt = stmt.where(SqlSessionLifecycleOutbox.sequence < cursor_seq)
+            rows = session.execute(stmt.limit(limit + 1)).scalars().all()
+            next_cursor = rows[limit - 1].id if len(rows) > limit else None
+            page = rows[:limit]
+            return [_outbox_to_entity(r) for r in page], next_cursor
+
+    def latest_delivery(self, session_id: str) -> LifecycleOutboxEvent | None:
+        with self._session("latest_delivery") as session:
+            stmt = (
+                select(SqlSessionLifecycleOutbox)
+                .where(
+                    SqlSessionLifecycleOutbox.workspace_id == current_workspace_id(),
+                    SqlSessionLifecycleOutbox.session_id == session_id,
+                )
+                .order_by(desc(SqlSessionLifecycleOutbox.sequence))
+                .limit(1)
+            )
+            row = session.execute(stmt).scalars().first()
+            return _outbox_to_entity(row) if row is not None else None

--- a/openapi.json
+++ b/openapi.json
@@ -5111,6 +5111,18 @@
             "description": "Total token count (input + output) from the most recently completed task's `usage`, e.g. `45231`. `None` when no task has completed yet. Lets clients seed their context-ring on conversation resume without waiting for the next `response.completed` SSE event.",
             "title": "Last Total Tokens"
           },
+          "latest_manager_delivery": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Manager Delivery"
+          },
           "llm_model": {
             "anyOf": [
               {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,6 +294,29 @@ def _reset_runner_catalog_cache() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
+def _reset_session_outbox_store() -> Generator[None, None, None]:
+    """
+    Clear the session-lifecycle outbox's process-global store after every test.
+
+    ``omnigent.server.session_outbox`` is wired via module-global
+    ``configure(store)`` (mirroring ``session_live_state``), called by every
+    ``create_app(...)``. Unlike ``session_live_state``, its writes are
+    deliberately NOT best-effort — a failure propagates to the caller (see
+    the module docstring; this is the point of a durable outbox). Without
+    this reset, a test that builds an app leaves ``_store`` pointing at that
+    test's now-torn-down SQLite temp file; the next unrelated test that
+    reaches ``_publish_status`` (even one that never builds an app itself)
+    can then crash on a stale-engine write instead of running cleanly.
+
+    :returns: None.
+    """
+    yield
+    module = sys.modules.get("omnigent.server.session_outbox")
+    if module is not None:
+        module.configure(None)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_claude_native_state(
     tmp_path_factory: pytest.TempPathFactory,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/db/test_migration_session_lifecycle_outbox.py
+++ b/tests/db/test_migration_session_lifecycle_outbox.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.utils import _build_alembic_config, clear_engine_cache, get_or_create_engine
 
-_PREVIOUS_HEAD = "f7a8b9c0d1e2"
+_PREVIOUS_HEAD = "d5e9f1a2b3c4"
 _HEAD = "a8b9c0d1e2f3"
 
 _HEX16 = "00" * 16  # 16 raw bytes = 32 hex chars, a valid Uuid16 literal

--- a/tests/db/test_migration_session_lifecycle_outbox.py
+++ b/tests/db/test_migration_session_lifecycle_outbox.py
@@ -1,0 +1,306 @@
+"""Tests for the session-lifecycle-outbox migration (a8b9c0d1e2f3, OMN-104).
+
+Verifies the migration creates all three tables (``session_lifecycle_cursors``,
+``session_lifecycle_outbox``, ``session_elicitations``) with the expected
+shape, that none carries a database-level foreign key (schema Rule R032 —
+``session_id``/``elicitation_id`` relationships are application-owned), that
+every ``CHECK`` constraint is enforced, and that a downgrade drops all three
+tables cleanly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache, get_or_create_engine
+
+_PREVIOUS_HEAD = "f7a8b9c0d1e2"
+_HEAD = "a8b9c0d1e2f3"
+
+_HEX16 = "00" * 16  # 16 raw bytes = 32 hex chars, a valid Uuid16 literal
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite DB with the full migration chain applied; cleaned up after."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+# ── session_lifecycle_cursors ─────────────────────────────────────
+
+
+def test_migration_creates_all_three_tables(db_engine: Engine) -> None:
+    tables = set(sa.inspect(db_engine).get_table_names())
+    assert "session_lifecycle_cursors" in tables
+    assert "session_lifecycle_outbox" in tables
+    assert "session_elicitations" in tables
+
+
+def test_cursors_columns(db_engine: Engine) -> None:
+    cols = {c["name"] for c in sa.inspect(db_engine).get_columns("session_lifecycle_cursors")}
+    assert cols == {"workspace_id", "session_id", "next_sequence"}
+
+
+def test_cursors_pk_leads_with_workspace_id(db_engine: Engine) -> None:
+    pk = sa.inspect(db_engine).get_pk_constraint("session_lifecycle_cursors")
+    assert pk["constrained_columns"] == ["workspace_id", "session_id"]
+
+
+def test_cursors_no_foreign_keys(db_engine: Engine) -> None:
+    assert sa.inspect(db_engine).get_foreign_keys("session_lifecycle_cursors") == []
+
+
+# ── session_lifecycle_outbox ──────────────────────────────────────
+
+
+def test_outbox_columns(db_engine: Engine) -> None:
+    cols = {c["name"] for c in sa.inspect(db_engine).get_columns("session_lifecycle_outbox")}
+    assert cols == {
+        "workspace_id",
+        "id",
+        "session_id",
+        "event_type",
+        "transition_key",
+        "sequence",
+        "event_version",
+        "payload",
+        "status",
+        "attempt_count",
+        "next_attempt_at",
+        "lease_owner",
+        "lease_expires_at",
+        "last_attempt_at",
+        "delivered_at",
+        "last_http_status",
+        "last_error_code",
+        "last_error_message",
+        "created_at",
+    }
+
+
+def test_outbox_pk_leads_with_workspace_id(db_engine: Engine) -> None:
+    pk = sa.inspect(db_engine).get_pk_constraint("session_lifecycle_outbox")
+    assert pk["constrained_columns"] == ["workspace_id", "id"]
+
+
+def test_outbox_no_foreign_keys(db_engine: Engine) -> None:
+    assert sa.inspect(db_engine).get_foreign_keys("session_lifecycle_outbox") == []
+
+
+def test_outbox_indexes(db_engine: Engine) -> None:
+    insp = sa.inspect(db_engine)
+    idx_cols = {
+        i["name"]: list(i["column_names"]) for i in insp.get_indexes("session_lifecycle_outbox")
+    }
+    idx_unique = {i["name"]: i.get("unique") for i in insp.get_indexes("session_lifecycle_outbox")}
+
+    assert idx_cols["uq_session_lifecycle_outbox_session_sequence"] == [
+        "workspace_id",
+        "session_id",
+        "sequence",
+    ]
+    assert idx_unique["uq_session_lifecycle_outbox_session_sequence"]
+
+    assert idx_cols["uq_session_lifecycle_outbox_transition"] == [
+        "workspace_id",
+        "session_id",
+        "event_type",
+        "transition_key",
+    ]
+    assert idx_unique["uq_session_lifecycle_outbox_transition"]
+
+    assert idx_cols["ix_session_lifecycle_outbox_claim"] == [
+        "status",
+        "next_attempt_at",
+        "workspace_id",
+    ]
+    assert not idx_unique["ix_session_lifecycle_outbox_claim"]
+
+    assert idx_cols["ix_session_lifecycle_outbox_session_order"] == [
+        "workspace_id",
+        "session_id",
+        "sequence",
+        "status",
+    ]
+    assert not idx_unique["ix_session_lifecycle_outbox_session_order"]
+
+
+def _insert_outbox_row(conn: sa.Connection, *, event_type: int, status: int) -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO session_lifecycle_outbox "
+            "(id, session_id, event_type, transition_key, sequence, payload, "
+            " status, next_attempt_at, created_at) "
+            f"VALUES (X'{_HEX16}', X'{_HEX16}', :event_type, 'tk', 1, X'00', "
+            " :status, 1, 1)"
+        ),
+        {"event_type": event_type, "status": status},
+    )
+
+
+def test_outbox_event_type_check_rejects_bad_code(db_engine: Engine) -> None:
+    with pytest.raises(IntegrityError):
+        with db_engine.begin() as conn:
+            _insert_outbox_row(conn, event_type=99, status=1)
+
+
+def test_outbox_event_type_check_accepts_valid_codes(db_engine: Engine) -> None:
+    for code in (1, 2, 3, 4):
+        with db_engine.begin() as conn:
+            conn.execute(sa.text("DELETE FROM session_lifecycle_outbox"))
+            _insert_outbox_row(conn, event_type=code, status=1)
+
+
+def test_outbox_status_check_rejects_bad_code(db_engine: Engine) -> None:
+    with pytest.raises(IntegrityError):
+        with db_engine.begin() as conn:
+            _insert_outbox_row(conn, event_type=1, status=99)
+
+
+def test_outbox_status_check_accepts_valid_codes(db_engine: Engine) -> None:
+    for code in (1, 2, 3, 4, 5):
+        with db_engine.begin() as conn:
+            conn.execute(sa.text("DELETE FROM session_lifecycle_outbox"))
+            _insert_outbox_row(conn, event_type=1, status=code)
+
+
+def test_outbox_status_stored_as_smallint(db_engine: Engine) -> None:
+    cols = {c["name"]: c for c in sa.inspect(db_engine).get_columns("session_lifecycle_outbox")}
+    assert "INT" in str(cols["status"]["type"]).upper()
+
+
+# ── session_elicitations ──────────────────────────────────────────
+
+
+def test_elicitations_columns(db_engine: Engine) -> None:
+    cols = {c["name"] for c in sa.inspect(db_engine).get_columns("session_elicitations")}
+    assert cols == {
+        "workspace_id",
+        "id",
+        "session_id",
+        "status",
+        "request_payload",
+        "decision_payload",
+        "decided_by",
+        "created_at",
+        "decided_at",
+        "resolved_at",
+    }
+
+
+def test_elicitations_pk_leads_with_workspace_id(db_engine: Engine) -> None:
+    pk = sa.inspect(db_engine).get_pk_constraint("session_elicitations")
+    assert pk["constrained_columns"] == ["workspace_id", "id"]
+
+
+def test_elicitations_no_foreign_keys(db_engine: Engine) -> None:
+    assert sa.inspect(db_engine).get_foreign_keys("session_elicitations") == []
+
+
+def test_elicitations_id_is_string_not_uuid16(db_engine: Engine) -> None:
+    """``elicitation_id`` is a prefixed opaque token
+    (``f"elicit_{secrets.token_hex(16)}"``), not a bare-hex UUID — the ``id``
+    column must be a plain VARCHAR, unlike every other id column in this
+    migration (which are 16-raw-byte Uuid16 BLOBs)."""
+    cols = {c["name"]: c for c in sa.inspect(db_engine).get_columns("session_elicitations")}
+    assert (
+        "VARCHAR" in str(cols["id"]["type"]).upper() or "CHAR" in str(cols["id"]["type"]).upper()
+    )
+    # A real, non-hex elicitation_id must insert cleanly.
+    with db_engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO session_elicitations "
+                "(id, session_id, status, request_payload, created_at) "
+                "VALUES ('elicit_not_valid_hex_at_all', X'" + _HEX16 + "', 1, X'00', 1)"
+            )
+        )
+    with db_engine.connect() as conn:
+        row = conn.execute(
+            sa.text("SELECT id FROM session_elicitations WHERE id = 'elicit_not_valid_hex_at_all'")
+        ).one()
+    assert row.id == "elicit_not_valid_hex_at_all"
+
+
+def test_elicitations_index(db_engine: Engine) -> None:
+    insp = sa.inspect(db_engine)
+    idx = {i["name"]: list(i["column_names"]) for i in insp.get_indexes("session_elicitations")}
+    assert idx["ix_session_elicitations_session_id"] == ["workspace_id", "session_id"]
+
+
+def _insert_elicitation_row(conn: sa.Connection, *, status: int) -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO session_elicitations "
+            "(id, session_id, status, request_payload, created_at) "
+            "VALUES ('elicit_check_test', X'" + _HEX16 + "', :status, X'00', 1)"
+        ),
+        {"status": status},
+    )
+
+
+def test_elicitations_status_check_rejects_bad_code(db_engine: Engine) -> None:
+    with pytest.raises(IntegrityError):
+        with db_engine.begin() as conn:
+            _insert_elicitation_row(conn, status=99)
+
+
+def test_elicitations_status_check_accepts_valid_codes(db_engine: Engine) -> None:
+    for code in (1, 2, 3, 4):
+        with db_engine.begin() as conn:
+            conn.execute(sa.text("DELETE FROM session_elicitations"))
+            _insert_elicitation_row(conn, status=code)
+
+
+# ── downgrade / re-upgrade ─────────────────────────────────────────
+
+
+def test_downgrade_drops_all_three_tables(tmp_path: Path) -> None:
+    """Downgrading one step removes all three tables; re-upgrade restores them."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    tables = set(sa.inspect(engine).get_table_names())
+    assert {
+        "session_lifecycle_cursors",
+        "session_lifecycle_outbox",
+        "session_elicitations",
+    } <= tables
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, _PREVIOUS_HEAD)
+
+    tables = set(sa.inspect(engine).get_table_names())
+    assert "session_lifecycle_cursors" not in tables
+    assert "session_lifecycle_outbox" not in tables
+    assert "session_elicitations" not in tables
+
+    # Re-upgrade restores all three — proves the upgrade is replayable.
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, _HEAD)
+    tables = set(sa.inspect(engine).get_table_names())
+    assert {
+        "session_lifecycle_cursors",
+        "session_lifecycle_outbox",
+        "session_elicitations",
+    } <= tables
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/server/integration/test_manager_webhook_concurrent_conflicting_decision.py
+++ b/tests/server/integration/test_manager_webhook_concurrent_conflicting_decision.py
@@ -1,0 +1,174 @@
+"""Concurrent conflicting-decision truthfulness test (OMN-104).
+
+Cross-vendor review, final round: ``_resolve_elicitation_durably``
+(``omnigent/server/routes/_sessions/orchestration.py``) durably serializes
+conflicting concurrent decision callbacks via ``session_outbox.record_decision``
+(itself row-locked at the store layer — see
+``tests/stores/test_session_lifecycle_store.py``'s own concurrency tests for
+that layer), but until this fix it forwarded each caller's OWN raw request
+payload to the live runner/harness instead of the PERSISTED WINNER's payload.
+A losing racing callback could therefore make the LIVE runner consume its own
+(losing) verdict while the durable ledger correctly kept the winner's — live
+action, policy writes, and durable record diverging for the same elicitation.
+
+This needs REAL concurrency, not a sequential simulation: two genuine OS
+threads, each with its own asyncio event loop (a single event loop's
+``asyncio.gather`` would NOT reproduce the race — ``session_outbox.
+record_decision`` is a synchronous, non-awaited call inside the async
+function under test, so within one loop the first coroutine runs it to
+completion, with no yield point, before the second coroutine even starts).
+Two threads racing via a ``threading.Barrier`` against a real backend (this
+file uses whatever ``db_uri`` resolves to — SQLite locally, real Postgres in
+CI's ``stores-postgres`` lane) is what makes the row-level lock at the store
+layer, and therefore the decision race itself, genuine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from omnigent.server import session_outbox
+from omnigent.server.routes._sessions.orchestration import _resolve_elicitation_durably
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_endpoints import _create_session
+
+pytestmark = pytest.mark.asyncio
+
+
+def _run_concurrently(fn_a, fn_b) -> tuple[Any, Any]:
+    """Run two zero-arg callables on their own OS threads, synchronized to
+    start together via a barrier, and return both return values (or
+    re-raise the first exception either thread raised)."""
+    barrier = threading.Barrier(2)
+    results: list[Any] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+
+    def _wrapped(index: int, fn) -> None:
+        barrier.wait()
+        try:
+            results[index] = fn()
+        except BaseException as exc:  # captured for the main thread to re-raise
+            errors[index] = exc
+
+    threads = [
+        threading.Thread(target=_wrapped, args=(i, fn)) for i, fn in enumerate((fn_a, fn_b))
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    for err in errors:
+        if err is not None:
+            raise err
+    return results[0], results[1]
+
+
+async def test_concurrent_conflicting_decisions_forward_only_the_winning_verdict(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Two conflicting decision callbacks (accept vs decline) racing for real
+    against the SAME elicitation must converge on exactly one durable
+    winner, AND the live runner must observe that SAME winning verdict from
+    BOTH racing calls — never the loser's own (different) payload.
+    """
+    agent = await create_test_agent(client, "test-omn104-concurrent-conflict")
+    session = await _create_session(client, agent["id"])
+    session_id = session["id"]
+    elicitation_id = "elicit_concurrent_conflict_test"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    forwarded_actions: list[str | None] = []
+    forwarded_lock = threading.Lock()
+
+    async def _fake_get_runner_client(
+        _session_id: str, _runner_router: object
+    ) -> httpx.AsyncClient:
+        fake_runner = FastAPI()
+
+        @fake_runner.post("/v1/sessions/{conversation_id}/events")
+        async def _events(conversation_id: str, request: Request) -> JSONResponse:
+            del conversation_id
+            body = await request.json()
+            action = (body.get("data") or {}).get("action")
+            with forwarded_lock:
+                forwarded_actions.append(action)
+            return JSONResponse(
+                status_code=200,
+                content={"ok": True},
+                headers={"X-Omnigent-Pending-Approval-Resolved": "true"},
+            )
+
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=fake_runner), base_url="http://fake-runner"
+        )
+
+    # _resolve_elicitation_durably's runner forward resolves the runner
+    # client via this module-level name lookup — patch it directly, the
+    # same legitimate test-boundary seam
+    # test_manager_webhook_decision_endpoint.py already uses for this exact
+    # purpose. Set once, before either thread starts.
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.helpers._get_runner_client",
+        _fake_get_runner_client,
+    )
+
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+
+    def _run(action: str, decided_by: str) -> object:
+        return asyncio.run(
+            _resolve_elicitation_durably(
+                session_id,
+                {"elicitation_id": elicitation_id, "action": action},
+                None,
+                conversation_store,
+                decided_by=decided_by,
+            )
+        )
+
+    result_accept, result_decline = _run_concurrently(
+        lambda: _run("accept", "mgr-a@example.com"),
+        lambda: _run("decline", "mgr-b@example.com"),
+    )
+    assert result_accept is not None and result_decline is not None
+
+    # (1) Exactly one persisted winner in the durable ledger.
+    final = session_outbox.get_elicitation(elicitation_id)
+    assert final is not None and final.decision_payload is not None
+    winning_decision = json.loads(final.decision_payload)
+    winning_action = winning_decision["action"]
+    assert winning_action in ("accept", "decline")
+
+    # Both callers' returned decision_record must agree with the ledger —
+    # neither believes ITS OWN verdict won when the other's actually did.
+    assert result_accept.decision_record is not None
+    assert result_decline.decision_record is not None
+    assert json.loads(result_accept.decision_record.decision_payload)["action"] == winning_action
+    assert json.loads(result_decline.decision_record.decision_payload)["action"] == winning_action
+
+    # (2) The live runner received exactly two forwards (one per racing
+    # call — the bug being fixed is not "only the winner forwards", it's
+    # "every forward carries the winner's payload") and BOTH carry the
+    # SAME winning action — never a mix of accept and decline. Pre-fix,
+    # this would show one "accept" and one "decline" — the losing
+    # callback's own raw request data, not the persisted winner.
+    assert len(forwarded_actions) == 2, forwarded_actions
+    assert forwarded_actions == [winning_action, winning_action], forwarded_actions

--- a/tests/server/integration/test_manager_webhook_cross_replica_redelivery.py
+++ b/tests/server/integration/test_manager_webhook_cross_replica_redelivery.py
@@ -1,0 +1,303 @@
+"""Cross-replica decided-elicitation delivery for a continuously-connected
+runner (OMN-104 §5.4 case (b), cross-vendor review P1).
+
+``_on_runner_connect`` only redelivers decided-but-undelivered verdicts on
+an actual tunnel RECONNECT. Before this fix, a decision recorded on a
+replica that does NOT own the runner's live tunnel was a dead end whenever
+the runner stayed continuously connected to another replica the whole
+time — no reconnect ever fires there, so ``pending_redelivery`` was a
+promise the codebase had no mechanism to keep.
+
+This file builds TWO genuinely independent ``create_app()`` instances
+sharing only the database — "replica A" holds a real WS tunnel to a real
+runner app (the exact machinery ``test_sessions_tunnel_three_layer.py``
+uses) and has its real ASGI lifespan driven so its background
+``_redelivery_sweep_loop`` task actually runs; "replica B" has no tunnel
+connection for this runner at all. The decision is POSTed through replica
+B. The tunnel is NEVER dropped or reconnected during the test — delivery
+must happen via replica A's periodic sweep alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+import omnigent.server.app as app_module
+from omnigent.runner import pending_approvals
+from omnigent.runner.app import create_runner_app
+from omnigent.runtime import init as init_runtime
+from omnigent.runtime import (
+    set_harness_process_manager,
+    set_runner_id,
+    set_runner_router,
+)
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+from omnigent.server import session_outbox
+from omnigent.server.app import create_app
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from tests.runner.helpers import NullServerClient
+from tests.server.integration.test_sessions_tunnel_three_layer import (
+    _RUNNER_ID,
+    _TEST_HARNESS_NAME,
+    FakeProcessManager,
+    _build_harness_agent_bundle,
+    _connect_runner_tunnel,
+    _forward_requests_to_runner,
+    _send_hello_and_wait,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Fast enough that the test doesn't sit through the real 5s production
+# interval, slow enough to leave headroom above scheduling jitter.
+_TEST_SWEEP_INTERVAL_S = 0.2
+
+
+@dataclass
+class _CrossReplicaStack:
+    client_a: httpx.AsyncClient
+    app_a: FastAPI
+    client_b: httpx.AsyncClient
+    app_b: FastAPI
+    db_uri: str
+
+
+@pytest_asyncio.fixture()
+async def cross_replica_stack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[_CrossReplicaStack]:
+    """Two independent Omnigent replicas sharing one DB; only replica A
+    holds the real runner tunnel, and only replica A's ASGI lifespan (and
+    therefore its ``_redelivery_sweep_loop`` task) is driven."""
+    monkeypatch.setattr(app_module, "_REDELIVERY_SWEEP_INTERVAL_S", _TEST_SWEEP_INTERVAL_S)
+
+    db_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    file_store = SqlAlchemyFileStore(db_uri)
+    # ONE artifact_store/agent_cache pair shared by init_runtime, the
+    # runner's spec resolver, AND replica A's own create_app — replica A is
+    # the one whose client uploads the agent bundle in the test, and the
+    # runner (a separate process in production, here a separate ASGI app)
+    # must resolve specs from the SAME artifact storage that bundle landed
+    # in. Mirrors tunnel_three_layer_stack's single-artifact-store pattern.
+    artifact_store_a = LocalArtifactStore(str(tmp_path / "replica_a" / "artifacts"))
+    agent_cache_a = AgentCache(
+        artifact_store=artifact_store_a,
+        cache_dir=tmp_path / "replica_a" / "cache",
+    )
+
+    init_runtime(
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        agent_store=agent_store,
+        agent_cache=agent_cache_a,
+        file_store=file_store,
+        artifact_store=artifact_store_a,
+    )
+
+    saved_harness_module = _HARNESS_MODULES.get(_TEST_HARNESS_NAME)
+    _HARNESS_MODULES[_TEST_HARNESS_NAME] = "tests.runtime.harnesses._test_scaffold_harnesses"
+
+    fake_pm = FakeProcessManager()
+    set_harness_process_manager(fake_pm)
+    set_runner_id(_RUNNER_ID)
+
+    async def _resolve_spec(agent_id: str, session_id: str | None = None) -> Any:
+        del session_id
+        record = agent_store.get(agent_id)
+        if record is None:
+            return None
+        return agent_cache_a.load(agent_id, record.bundle_location).spec
+
+    runner_app = create_runner_app(
+        process_manager=fake_pm,
+        spec_resolver=_resolve_spec,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    app_a = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store_a,
+        agent_cache=agent_cache_a,
+    )
+    set_runner_router(app_a.state.runner_router)
+
+    artifact_store_b = LocalArtifactStore(str(tmp_path / "replica_b" / "artifacts"))
+    app_b = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store_b,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store_b, cache_dir=tmp_path / "replica_b" / "cache"
+        ),
+    )
+
+    # Real WS tunnel to REPLICA A ONLY -- replica B never sees this runner.
+    communicator = await _connect_runner_tunnel(app_a, _RUNNER_ID)
+    await _send_hello_and_wait(communicator, app_a, _RUNNER_ID, harnesses=[_TEST_HARNESS_NAME])
+    forwarder_task = asyncio.create_task(
+        _forward_requests_to_runner(communicator, runner_app),
+        name="cross-replica-forwarder",
+    )
+
+    client_a = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app_a), base_url="http://replica-a"
+    )
+    client_b = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app_b), base_url="http://replica-b"
+    )
+
+    # Drive replica A's REAL ASGI lifespan so its _redelivery_sweep_loop
+    # background task actually starts -- this is the real production entry
+    # point under test, not a reimplementation of the sweep logic.
+    async with app_a.router.lifespan_context(app_a):
+        try:
+            yield _CrossReplicaStack(
+                client_a=client_a, app_a=app_a, client_b=client_b, app_b=app_b, db_uri=db_uri
+            )
+        finally:
+            loop_tasks = []
+            for task in asyncio.all_tasks():
+                if task is asyncio.current_task():
+                    continue
+                coro_qualname = getattr(task.get_coro(), "__qualname__", "")
+                if (
+                    task.get_name().startswith("runner-relay-")
+                    or task.get_name().startswith("runner-disconnect-grace-")
+                    or "_relay_runner_stream" in coro_qualname
+                ):
+                    loop_tasks.append(task)
+            for t in loop_tasks:
+                t.cancel()
+            for t in loop_tasks:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await t
+
+            await client_a.aclose()
+            await client_b.aclose()
+
+            forwarder_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await forwarder_task
+
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await communicator.send_input({"type": "websocket.disconnect", "code": 1000})
+            with contextlib.suppress(asyncio.TimeoutError, Exception):
+                await communicator.wait(timeout=2.0)
+
+            with contextlib.suppress(Exception):
+                await app_a.state.runner_router.aclose()
+            with contextlib.suppress(Exception):
+                await app_b.state.runner_router.aclose()
+
+            await fake_pm.shutdown()
+            set_runner_router(None)
+            set_runner_id(None)
+            set_harness_process_manager(None)
+            if saved_harness_module is None:
+                _HARNESS_MODULES.pop(_TEST_HARNESS_NAME, None)
+            else:
+                _HARNESS_MODULES[_TEST_HARNESS_NAME] = saved_harness_module
+            pending_approvals.reset_for_tests()
+
+
+async def test_decision_on_non_tunnel_replica_reaches_continuously_connected_runner(
+    cross_replica_stack: _CrossReplicaStack,
+) -> None:
+    """
+    A decision POSTed to replica B (which holds no tunnel for this runner)
+    reaches the runner that stays CONTINUOUSLY connected to replica A the
+    entire time — no disconnect, no reconnect, ever, in this test. Delivery
+    must happen via replica A's periodic redelivery sweep, and
+    ``session.resumed`` must be recorded exactly once.
+    """
+    stack = cross_replica_stack
+    app_a = stack.app_a
+
+    create_resp = await stack.client_a.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": ("agent.tar.gz", _build_harness_agent_bundle(), "application/gzip"),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+
+    bind_resp = await stack.client_a.patch(
+        f"/v1/sessions/{session_id}",
+        json={"runner_id": _RUNNER_ID},
+    )
+    assert bind_resp.status_code == 200, bind_resp.text
+
+    # touch_runner_liveness at real tunnel-connect time was a no-op — it
+    # bulk-UPDATEs rows WHERE runner_id == _RUNNER_ID, and zero sessions
+    # were bound to this runner yet (the session above didn't exist until
+    # after the tunnel connected in the fixture). In production the next
+    # tunnel ping cycle (runner_tunnel._ping_loop) re-touches liveness for
+    # every session bound by then; stamping it directly here establishes
+    # "runner known-alive" ground truth without depending on that ping
+    # loop's timing, same as test_manager_webhook_decision_endpoint.py's
+    # own cross-replica test does.
+    SqlAlchemyConversationStore(stack.db_uri).touch_runner_liveness([_RUNNER_ID], int(time.time()))
+
+    elicitation_id = "elicit_cross_replica_test"
+    future = pending_approvals.register(elicitation_id)
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    # POST the decision through REPLICA B, which holds no tunnel for this
+    # runner at all -- must be recorded durably but NOT delivered
+    # synchronously, and classified as pending-redelivery (the runner is
+    # believed alive: replica A's tunnel connect already stamped fresh
+    # liveness in the shared DB).
+    verdict = await stack.client_b.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 202, verdict.text
+    body = verdict.json()
+    assert body["resolved"] is False
+    assert body["pending_redelivery"] is True
+
+    # Delivery must arrive via replica A's periodic sweep -- no reconnect
+    # is ever driven in this test.
+    approved = await asyncio.wait_for(future, timeout=10.0)
+    assert approved is True, "real pending_approvals Future did not resolve to accept"
+
+    store = app_a.state.session_lifecycle_store
+    resumed: list[Any] = []
+    deadline = asyncio.get_event_loop().time() + 10.0
+    while asyncio.get_event_loop().time() < deadline:
+        deliveries, _ = store.list_deliveries(session_id, limit=100)
+        resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+        if resumed:
+            break
+        await asyncio.sleep(0.05)
+    assert len(resumed) == 1, "expected exactly one session.resumed delivery"
+
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"

--- a/tests/server/integration/test_manager_webhook_decision_endpoint.py
+++ b/tests/server/integration/test_manager_webhook_decision_endpoint.py
@@ -51,14 +51,20 @@ from __future__ import annotations
 
 import asyncio
 import time
+from pathlib import Path
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
+from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server import session_outbox
+from omnigent.server.app import create_app
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
 from tests.server.helpers import create_test_agent
 from tests.server.integration.test_sessions_elicitation_resolve_url import (
     _create_session,
@@ -310,9 +316,12 @@ async def test_decision_endpoint_mid_disconnect_grace_gets_pending_not_410(
     # already cleared (stale/None), same as session_live_state.clear_runner_liveness.
     conv_store.touch_runner_liveness([runner_id], int(time.time()) - 10_000)
 
-    # Mark the runner grace-pending, mirroring what _on_runner_disconnect
-    # stamps into app.state.runner_disconnect_grace_deadline.
-    app.state.runner_disconnect_grace_deadline = {runner_id: time.time() + 10.0}
+    # Mark the runner grace-pending via the DURABLE store column (OMN-104
+    # §5.4 cross-replica fix) — the same write path
+    # session_live_state.set_runner_disconnect_grace uses in production,
+    # deliberately NOT app.state, so this test proves the decision endpoint
+    # classifies correctly from the shared DB row alone.
+    conv_store.set_runner_disconnect_grace(runner_id, int(time.time()) + 10)
 
     try:
         verdict = await client.post(
@@ -332,7 +341,7 @@ async def test_decision_endpoint_mid_disconnect_grace_gets_pending_not_410(
         deliveries, _ = store.list_deliveries(session_id, limit=100)
         assert [d for d in deliveries if d.event_type == "session.resumed"] == []
     finally:
-        app.state.runner_disconnect_grace_deadline = {}
+        conv_store.clear_runner_disconnect_grace(runner_id)
 
 
 async def test_decision_endpoint_after_grace_expires_410s_normally(
@@ -363,7 +372,7 @@ async def test_decision_endpoint_after_grace_expires_410s_normally(
     conv_store.touch_runner_liveness([runner_id], int(time.time()) - 10_000)
 
     # Deadline in the past: the grace has expired, no reconnect happened.
-    app.state.runner_disconnect_grace_deadline = {runner_id: time.time() - 1.0}
+    conv_store.set_runner_disconnect_grace(runner_id, int(time.time()) - 1)
 
     try:
         verdict = await client.post(
@@ -373,7 +382,112 @@ async def test_decision_endpoint_after_grace_expires_410s_normally(
         assert verdict.status_code == 410, verdict.text
         assert verdict.json()["detail"]["error_code"] == "elicitation_not_resolvable"
     finally:
-        app.state.runner_disconnect_grace_deadline = {}
+        conv_store.clear_runner_disconnect_grace(runner_id)
+
+
+async def _build_replica(
+    db_uri: str, tmp_path: Path, *, name: str
+) -> tuple[FastAPI, httpx.AsyncClient]:
+    """
+    Construct a genuinely independent ``create_app()`` instance + client,
+    sharing only *db_uri* — no shared Python object identity, no shared
+    ``app.state``, matching a real multi-replica deployment where each
+    replica is a separate OS process.
+
+    :param db_uri: Database URI shared by every replica in the test.
+    :param tmp_path: Pytest temp dir; each replica gets its own artifact
+        subdirectory so they don't contend over the same files on disk.
+    :param name: Distinguishing subdirectory name, e.g. ``"replica_a"``.
+    :returns: ``(app, client)`` for this replica.
+    """
+    artifact_store = LocalArtifactStore(str(tmp_path / name / "artifacts"))
+    app = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / name / "cache",
+        ),
+    )
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url=f"http://{name}")
+    return app, client
+
+
+async def test_decision_endpoint_cross_replica_mid_grace_gets_pending_not_410(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    """
+    Round-4 cross-vendor review: the reconnect-grace marker must be
+    cross-replica, not per-process. Before this fix, the grace deadline
+    lived only in the tunnel-holding replica's in-memory ``app.state`` —
+    invisible to any OTHER replica handling a manager decision request,
+    which would see the already-cleared ``runner_last_seen`` with no
+    local grace entry and falsely 410 even though the runner is still
+    within its reconnect window on the other replica.
+
+    Simulates the disconnect being handled by "replica A" (a durable
+    store write, mirroring what ``_on_runner_disconnect`` does — not a
+    fabrication, the same call ``session_live_state.set_runner_disconnect_grace``
+    makes), then submits the decision through a SEPARATELY CONSTRUCTED
+    "replica B" — its own ``create_app()`` instance, its own
+    ``ConversationStore`` object, no shared in-process state with replica
+    A at all, only the same database — and asserts replica B correctly
+    returns 202/pending-redelivery rather than a false 410.
+    """
+    _app_a, client_a = await _build_replica(db_uri, tmp_path, name="replica_a")
+    app_b, client_b = await _build_replica(db_uri, tmp_path, name="replica_b")
+    try:
+        # Session/agent creation routed through replica A — irrelevant
+        # which replica originates them, both read/write the same DB.
+        agent = await create_test_agent(client_a, "test-cross-replica-grace")
+        session_id = await _create_session(client_a, agent["id"])
+        elicitation_id = "elicit_cross_replica_grace"
+
+        session_outbox.record_elicitation_raised(
+            workspace_id=0,
+            session_id=session_id,
+            elicitation_id=elicitation_id,
+            request={"message": "Approve?", "mode": "form"},
+        )
+
+        conv_store_a = SqlAlchemyConversationStore(db_uri)
+        runner_id = "runner_cross_replica"
+        assert conv_store_a.set_runner_id(session_id, runner_id)
+        # Simulate the exact state a real disconnect leaves behind on the
+        # SHARED liveness column: stale/cleared.
+        conv_store_a.touch_runner_liveness([runner_id], int(time.time()) - 10_000)
+        # "Replica A" durably records the disconnect-grace marker — the
+        # same durable write path production code takes, not app.state.
+        conv_store_a.set_runner_disconnect_grace(runner_id, int(time.time()) + 10)
+
+        try:
+            # The decision arrives on REPLICA B — which never itself
+            # observed this runner's disconnect and has no local
+            # in-memory knowledge of it whatsoever.
+            verdict = await client_b.post(
+                f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+                json={"action": "accept"},
+            )
+            assert verdict.status_code == 202, verdict.text
+            body = verdict.json()
+            assert body["resolved"] is False
+            assert body["pending_redelivery"] is True
+
+            store = app_b.state.session_lifecycle_store
+            elicitation = store.get_elicitation(elicitation_id)
+            assert elicitation is not None
+            assert elicitation.status == "decided"
+
+            deliveries, _ = store.list_deliveries(session_id, limit=100)
+            assert [d for d in deliveries if d.event_type == "session.resumed"] == []
+        finally:
+            conv_store_a.clear_runner_disconnect_grace(runner_id)
+    finally:
+        await client_a.aclose()
+        await client_b.aclose()
 
 
 def _fake_runner_client_factory(status_code: int, *, header: str | None):

--- a/tests/server/integration/test_manager_webhook_decision_endpoint.py
+++ b/tests/server/integration/test_manager_webhook_decision_endpoint.py
@@ -1,0 +1,264 @@
+"""
+Integration tests for the OMN-104 harness-classified decision endpoint.
+
+``POST /v1/sessions/{id}/elicitations/{eid}/resolve`` now durably persists
+the verdict first (via ``session_outbox.record_decision``), then classifies
+resolution by which process died (design doc
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §5.4):
+
+- (a) no restart: a parked server-side ``_harness_elicitation_registry``
+  Future resolves synchronously -> ``resolved=True``.
+- (b) server restart, runner alive: no Future to resolve and the runner
+  isn't reachable from THIS replica, but the runner is believed alive
+  (fresh ``runner_last_seen``) -> 202, ``resolved=False,
+  pending_redelivery=True``; the verdict is redelivered on the runner's
+  actual tunnel reconnect (``omnigent/server/app.py``'s ``_on_runner_connect``).
+- (c) runner dead: not resolved and not believed alive -> 410
+  ``elicitation_not_resolvable``, verdict still durably recorded.
+
+Classification does not depend on harness type (native/tmux vs
+subprocess-backed) — it is purely "did the runner truthfully ack" vs "is the
+runner believed alive at all", both harness-agnostic signals. So these three
+tests, driven through the shared HTTP resolve endpoint, cover all harness
+classes without needing to spin up real claude-native / codex-native /
+subprocess runner processes.
+
+(b)'s reconnect-redelivery mechanism itself (``_on_runner_connect`` re-POSTing
+decided-but-undelivered rows on an actual WebSocket tunnel reconnect) is not
+separately re-tested end-to-end here — that would require driving a real
+``runner_tunnel`` WebSocket connect, which this repo's test infra does not
+provide a lightweight fixture for. Instead, test (b) proves the QUERY side
+of that mechanism directly: ``session_lifecycle_store.list_decided_undelivered``
+returns exactly the row ``_on_runner_connect`` would redeliver. The redelivery
+POST itself reuses the exact same ``type="approval"`` event contract already
+covered by test (a) and by ``test_sessions_elicitation_resolve_url.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.server import session_outbox
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_elicitation_resolve_url import (
+    _create_session,
+    _park_permission_hook,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_decision_endpoint_no_restart_resolves_immediately(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    (a) No restart: a parked server-side harness Future resolves
+    synchronously. The endpoint reports ``resolved=True,
+    pending_redelivery=False``, marks the ledger row
+    ``delivered_to_runner``, and emits a ``session.resumed`` outbox row.
+    """
+    from omnigent.runtime import pending_elicitations
+
+    agent = await create_test_agent(client, "test-omn104-no-restart")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id)
+
+    try:
+        verdict = await client.post(
+            f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+            json={"action": "accept"},
+        )
+        assert verdict.status_code == 202, verdict.text
+        body = verdict.json()
+        assert body["resolved"] is True
+        assert body["pending_redelivery"] is False
+
+        async with asyncio.timeout(5):
+            resp = await hook_task
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["hookSpecificOutput"]["decision"]["behavior"] == "allow"
+
+        store = app.state.session_lifecycle_store
+        elicitation = store.get_elicitation(elicitation_id)
+        assert elicitation is not None
+        assert elicitation.status == "delivered_to_runner"
+        assert elicitation.resolved_at is not None
+
+        deliveries, _ = store.list_deliveries(session_id, limit=100)
+        resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+        assert len(resumed) == 1, deliveries
+    finally:
+        if not hook_task.done():
+            hook_task.cancel()
+            await asyncio.gather(hook_task, return_exceptions=True)
+        pending_elicitations.reset_for_tests()
+
+
+async def test_decision_endpoint_server_restart_runner_alive_pending_redelivery(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    (b) Server restart, runner alive: no ``_harness_elicitation_registry``
+    entry exists for this id (simulating a wiped in-memory registry after a
+    restart), the runner isn't reachable from this replica (no real tunnel
+    in this test process), but the runner is believed alive (fresh
+    ``runner_last_seen``). The endpoint returns 202 with ``resolved=False,
+    pending_redelivery=True``; the ledger row stays ``decided`` (not
+    ``delivered_to_runner``); no ``session.resumed`` row is written yet; and
+    ``list_decided_undelivered`` surfaces the row for reconnect redelivery.
+    """
+    agent = await create_test_agent(client, "test-omn104-restart-runner-alive")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_restart_alive_case_b"
+
+    # Seed the durable ledger row directly (simulates the elicitation having
+    # been raised before the restart wiped the in-memory registry) — no real
+    # harness Future is parked for this id.
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    assert conv_store.set_runner_id(session_id, "runner_case_b")
+    conv_store.touch_runner_liveness(["runner_case_b"], int(time.time()))
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 202, verdict.text
+    body = verdict.json()
+    assert body["resolved"] is False
+    assert body["pending_redelivery"] is True
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "decided"
+    assert elicitation.decision_payload is not None
+
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert resumed == []
+
+    undelivered = store.list_decided_undelivered(session_id)
+    assert [e.id for e in undelivered] == [elicitation_id]
+
+
+async def test_decision_endpoint_runner_dead_returns_410_but_records_verdict(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    (c) Runner dead: no harness Future, and the runner is not believed
+    alive (no runner_id bound at all — the same shape a stale
+    ``runner_last_seen`` would produce). The endpoint returns 410
+    ``elicitation_not_resolvable``. The verdict is still durably recorded —
+    asserted via a DIRECT store read, not the HTTP response, per the
+    acceptance criterion. No ``session.resumed`` row is written.
+    """
+    agent = await create_test_agent(client, "test-omn104-runner-dead")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_runner_dead_case_c"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+    # Deliberately do NOT bind a runner_id — the session has no runner
+    # believed alive at all (the same outcome a stale runner_last_seen
+    # would produce, exercised more explicitly here since it needs no
+    # extra store write).
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 410, verdict.text
+    detail = verdict.json()["detail"]
+    assert detail["error_code"] == "elicitation_not_resolvable"
+
+    # Verdict durably recorded — read directly via the store, NOT the HTTP
+    # response, per the acceptance test's own wording.
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "decided"
+    assert elicitation.decision_payload is not None
+
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert resumed == []
+
+
+async def test_decision_endpoint_runner_dead_stale_liveness_also_410s(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    (c) variant: a ``runner_id`` IS bound, but its ``runner_last_seen``
+    stamp is older than the 90s liveness TTL — also classified as dead
+    (410), not "pending redelivery". Proves the classification reads
+    freshness, not mere presence of a runner_id.
+    """
+    agent = await create_test_agent(client, "test-omn104-runner-stale")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_runner_stale_case_c"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    assert conv_store.set_runner_id(session_id, "runner_case_c_stale")
+    # Stamp far in the past — outside RUNNER_LIVENESS_TTL_S (90s).
+    conv_store.touch_runner_liveness(["runner_case_c_stale"], int(time.time()) - 1000)
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 410, verdict.text
+    assert verdict.json()["detail"]["error_code"] == "elicitation_not_resolvable"
+
+
+async def test_decision_endpoint_untracked_elicitation_is_unaffected(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Regression guard: an elicitation_id with no durable ledger entry (never
+    registered via ``record_elicitation_raised`` — the pre-OMN-104 shape,
+    e.g. an already-resolved or wholly unknown id) is NOT reclassified into
+    a 410. The endpoint's original idempotent-no-op contract is preserved
+    exactly (``{"queued": False}``), matching
+    ``test_post_resolve_nonexistent_elicitation_on_valid_session`` in
+    ``test_sessions_elicitation_api.py``.
+    """
+    agent = await create_test_agent(client, "test-omn104-untracked-eid")
+    session_id = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/elicit_never_registered/resolve",
+        json={"action": "accept"},
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"queued": False}

--- a/tests/server/integration/test_manager_webhook_decision_endpoint.py
+++ b/tests/server/integration/test_manager_webhook_decision_endpoint.py
@@ -32,6 +32,19 @@ of that mechanism directly: ``session_lifecycle_store.list_decided_undelivered``
 returns exactly the row ``_on_runner_connect`` would redeliver. The redelivery
 POST itself reuses the exact same ``type="approval"`` event contract already
 covered by test (a) and by ``test_sessions_elicitation_resolve_url.py``.
+
+Truthful runner-consumption (cross-vendor review BLOCKING #2) is a two-signal
+OR, not a single AND-gated header: the runner's approval endpoint
+unconditionally forwards the same event to BOTH ``pending_approvals`` (the
+policy/cost-ASK path — sets ``X-Omnigent-Pending-Approval-Resolved``) AND the
+harness subprocess (the ``ctx.elicit()`` path — a bare 2xx only when the
+harness genuinely matched an ``_in_flight`` Future; 404 otherwise). Either
+signal alone is truthful; an id unmatched by both means a 404 from the
+harness forward with no header — never a bare 2xx with no header, which can
+only represent a genuine harness-native consumption. See
+``test_decision_endpoint_not_truthfully_consumed_does_not_fire_resumed``,
+``test_decision_endpoint_harness_native_2xx_without_header_still_delivers``,
+and ``test_decision_endpoint_policy_ask_header_true_with_harness_404_still_delivers``.
 """
 
 from __future__ import annotations
@@ -42,6 +55,7 @@ import time
 import httpx
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from omnigent.server import session_outbox
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
@@ -262,3 +276,290 @@ async def test_decision_endpoint_untracked_elicitation_is_unaffected(
     )
     assert resp.status_code == 202, resp.text
     assert resp.json() == {"queued": False}
+
+
+async def test_decision_endpoint_mid_disconnect_grace_gets_pending_not_410(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    Cross-vendor review BLOCKING #1: a decision arriving while the runner is
+    inside its post-a632550e disconnect grace (``RUNNER_DISCONNECT_GRACE_S``)
+    must be classified as "pending redelivery" (202), not "runner dead"
+    (410) — the runner may reconnect and redeliver momentarily.
+    ``session_live_state.clear_runner_liveness`` nulls ``runner_last_seen``
+    IMMEDIATELY on disconnect (before the grace elapses), so without
+    consulting the grace-pending marker this would incorrectly 410.
+    """
+    agent = await create_test_agent(client, "test-omn104-mid-grace")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_mid_grace_case_b"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_mid_grace"
+    assert conv_store.set_runner_id(session_id, runner_id)
+    # Simulate the exact state a real disconnect leaves behind: liveness
+    # already cleared (stale/None), same as session_live_state.clear_runner_liveness.
+    conv_store.touch_runner_liveness([runner_id], int(time.time()) - 10_000)
+
+    # Mark the runner grace-pending, mirroring what _on_runner_disconnect
+    # stamps into app.state.runner_disconnect_grace_deadline.
+    app.state.runner_disconnect_grace_deadline = {runner_id: time.time() + 10.0}
+
+    try:
+        verdict = await client.post(
+            f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+            json={"action": "accept"},
+        )
+        assert verdict.status_code == 202, verdict.text
+        body = verdict.json()
+        assert body["resolved"] is False
+        assert body["pending_redelivery"] is True
+
+        store = app.state.session_lifecycle_store
+        elicitation = store.get_elicitation(elicitation_id)
+        assert elicitation is not None
+        assert elicitation.status == "decided"
+
+        deliveries, _ = store.list_deliveries(session_id, limit=100)
+        assert [d for d in deliveries if d.event_type == "session.resumed"] == []
+    finally:
+        app.state.runner_disconnect_grace_deadline = {}
+
+
+async def test_decision_endpoint_after_grace_expires_410s_normally(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    Counterpart to the mid-grace test: once the grace deadline is in the
+    PAST (expired), the endpoint falls through to the normal freshness
+    check and correctly 410s — proving the grace-pending check doesn't
+    permanently mask a genuinely dead runner.
+    """
+    agent = await create_test_agent(client, "test-omn104-grace-expired")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_grace_expired_case_c"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_grace_expired"
+    assert conv_store.set_runner_id(session_id, runner_id)
+    conv_store.touch_runner_liveness([runner_id], int(time.time()) - 10_000)
+
+    # Deadline in the past: the grace has expired, no reconnect happened.
+    app.state.runner_disconnect_grace_deadline = {runner_id: time.time() - 1.0}
+
+    try:
+        verdict = await client.post(
+            f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+            json={"action": "accept"},
+        )
+        assert verdict.status_code == 410, verdict.text
+        assert verdict.json()["detail"]["error_code"] == "elicitation_not_resolvable"
+    finally:
+        app.state.runner_disconnect_grace_deadline = {}
+
+
+def _fake_runner_client_factory(status_code: int, *, header: str | None):
+    """Build a ``_get_runner_client`` stub returning a fixed status/header pair."""
+
+    async def _fake_get_runner_client(session_id: str, runner_router: object) -> httpx.AsyncClient:
+        del session_id, runner_router
+
+        fake_runner = FastAPI()
+
+        @fake_runner.post("/v1/sessions/{conversation_id}/events")
+        async def _events(conversation_id: str) -> JSONResponse:
+            del conversation_id
+            headers = {"X-Omnigent-Pending-Approval-Resolved": header} if header else {}
+            return JSONResponse(status_code=status_code, content={"ok": True}, headers=headers)
+
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=fake_runner), base_url="http://fake-runner"
+        )
+
+    return _fake_get_runner_client
+
+
+async def test_decision_endpoint_not_truthfully_consumed_does_not_fire_resumed(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cross-vendor review BLOCKING #2: a runner that reports NEITHER truthful-
+    consumption signal must NOT be treated as "delivered". In the real
+    system this is the shape a genuinely unknown/stale/already-resolved
+    ``elicitation_id`` produces: ``pending_approvals.resolve()`` returns
+    ``False`` (no header), AND the runner's unconditional forward to the
+    harness subprocess also 404s (``_scaffold.py``'s ``_resolve_elicitation``
+    raises ``ErrorCode.NOT_FOUND`` for any id with no matching ``_in_flight``
+    Future) — never a bare 2xx with no header, which (per the follow-up
+    investigation for BLOCKING #3) can only happen for a GENUINE
+    harness-native ``ctx.elicit()`` consumption, not an unmatched id; see
+    ``test_decision_endpoint_harness_native_2xx_without_header_still_delivers``
+    directly below for that corrected case. No ``session.resumed`` fires,
+    and the row stays queued for redelivery (``pending_redelivery=True``)
+    rather than being marked ``delivered_to_runner``.
+    """
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.helpers._get_runner_client",
+        _fake_runner_client_factory(404, header=None),
+    )
+
+    agent = await create_test_agent(client, "test-omn104-not-consumed")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_not_consumed_case"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_not_consumed"
+    assert conv_store.set_runner_id(session_id, runner_id)
+    conv_store.touch_runner_liveness([runner_id], int(time.time()))
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 202, verdict.text
+    body = verdict.json()
+    # NOT "delivered" -- neither signal fired.
+    assert body["resolved"] is False
+    assert body["pending_redelivery"] is True
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "decided"  # NOT delivered_to_runner
+
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    assert [d for d in deliveries if d.event_type == "session.resumed"] == []
+
+
+async def test_decision_endpoint_harness_native_2xx_without_header_still_delivers(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Follow-up fix found while building BLOCKING #3's E2E test: the runner's
+    approval endpoint unconditionally forwards the SAME event to the harness
+    subprocess (in addition to checking ``pending_approvals``), so a
+    genuinely-matched harness-native ``ctx.elicit()`` elicitation resolves
+    via the harness's own 204 with NO ``X-Omnigent-Pending-Approval-Resolved``
+    header (``pending_approvals`` never tracked that id in the first place).
+    Requiring the header AND a 2xx (the original BLOCKING #2 fix) made this
+    real, legitimate consumption path unreachable for ``session.resumed`` in
+    production. The corrected contract treats either signal as sufficient.
+    """
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.helpers._get_runner_client",
+        _fake_runner_client_factory(204, header=None),
+    )
+
+    agent = await create_test_agent(client, "test-omn104-harness-native-consumed")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_harness_native_case"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_harness_native"
+    assert conv_store.set_runner_id(session_id, runner_id)
+    conv_store.touch_runner_liveness([runner_id], int(time.time()))
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 202, verdict.text
+    body = verdict.json()
+    assert body["resolved"] is True
+    assert body["pending_redelivery"] is False
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"
+
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    assert len([d for d in deliveries if d.event_type == "session.resumed"]) == 1
+
+
+async def test_decision_endpoint_policy_ask_header_true_with_harness_404_still_delivers(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Companion to the harness-native case above: the OTHER real production
+    shape — a policy/cost ASK tracked only in ``pending_approvals`` — sets
+    the truthful header ``true`` while the SAME event's unconditional
+    harness forward 404s (no ``ctx.elicit()`` Future exists for that id).
+    The header alone must be sufficient; the harness-forward 404 must not
+    veto it.
+    """
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.helpers._get_runner_client",
+        _fake_runner_client_factory(404, header="true"),
+    )
+
+    agent = await create_test_agent(client, "test-omn104-policy-ask-consumed")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = "elicit_policy_ask_case"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_policy_ask"
+    assert conv_store.set_runner_id(session_id, runner_id)
+    conv_store.touch_runner_liveness([runner_id], int(time.time()))
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept"},
+    )
+    assert verdict.status_code == 202, verdict.text
+    body = verdict.json()
+    assert body["resolved"] is True
+    assert body["pending_redelivery"] is False
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"

--- a/tests/server/integration/test_manager_webhook_deliveries_api.py
+++ b/tests/server/integration/test_manager_webhook_deliveries_api.py
@@ -1,0 +1,165 @@
+"""Integration tests for ``GET /v1/sessions/{id}/manager-webhook-deliveries``.
+
+Covers the "attempts/outbox status in API" acceptance requirement (OMN-104
+design doc §9) — the read-only observability endpoint modeled on
+``GET /scheduled-tasks/{id}/runs``. Uses the shared no-auth ``client``/``app``
+fixtures (real stores + mock LLM) from ``tests/server/conftest.py``, matching
+``tests/server/integration/test_sessions_elicitation_api.py``'s pattern.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_elicitation_resolve_url import _create_session
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_session(client: httpx.AsyncClient) -> str:
+    agent = await create_test_agent(client, "test-manager-webhook-deliveries")
+    return await _create_session(client, agent["id"])
+
+
+def _insert_event(
+    app: FastAPI,
+    session_id: str,
+    *,
+    event_type: str,
+    transition_key: str,
+    sequence_marker: str,
+    now: int = 1_000_000,
+) -> str:
+    """Insert one outbox row directly via the app-wide store; returns its event_id."""
+    store = app.state.session_lifecycle_store
+    # event_id must be a bare 32-hex-char Uuid16 value; derive a deterministic
+    # one from the inputs (the store accepts any caller-supplied event_id).
+    event_id = hashlib.sha256(
+        f"{session_id}:{transition_key}:{sequence_marker}".encode()
+    ).hexdigest()[:32]
+    store.record_lifecycle_event(
+        event_id=event_id,
+        session_id=session_id,
+        event_type=event_type,
+        transition_key=transition_key,
+        payload=json.dumps({"marker": sequence_marker}),
+        now=now,
+    )
+    return event_id
+
+
+async def test_no_deliveries_returns_empty_list(client: httpx.AsyncClient) -> None:
+    """A session with no manager-webhook activity returns an empty page, not a 404/500."""
+    session_id = await _make_session(client)
+    resp = await client.get(f"/v1/sessions/{session_id}/manager-webhook-deliveries")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deliveries": [], "next_cursor": None}
+
+
+async def test_populated_deliveries_ordered_most_recent_first(
+    client: httpx.AsyncClient, app: FastAPI
+) -> None:
+    """Rows come back highest-sequence-first, with the documented field shape."""
+    session_id = await _make_session(client)
+    _insert_event(
+        app,
+        session_id,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        sequence_marker="a",
+    )
+    _insert_event(
+        app,
+        session_id,
+        event_type="session.failed",
+        transition_key="turn:r2:failed",
+        sequence_marker="b",
+    )
+
+    resp = await client.get(f"/v1/sessions/{session_id}/manager-webhook-deliveries")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    deliveries = body["deliveries"]
+    assert len(deliveries) == 2
+    # Most recent (highest sequence, i.e. the second insert) first.
+    assert deliveries[0]["event_type"] == "session.failed"
+    assert deliveries[0]["sequence"] == 2
+    assert deliveries[1]["event_type"] == "session.completed"
+    assert deliveries[1]["sequence"] == 1
+    # Status is the decoded string name, not a raw int code.
+    assert deliveries[0]["status"] == "pending"
+    for row in deliveries:
+        assert set(row) == {
+            "event_id",
+            "event_type",
+            "sequence",
+            "status",
+            "attempt_count",
+            "last_attempt_at",
+            "delivered_at",
+            "last_http_status",
+            "last_error_code",
+            "last_error_message",
+        }
+
+
+async def test_pagination_no_gaps_or_dupes(client: httpx.AsyncClient, app: FastAPI) -> None:
+    """Cursor pagination walks every row exactly once across pages."""
+    session_id = await _make_session(client)
+    for i in range(5):
+        _insert_event(
+            app,
+            session_id,
+            event_type="session.completed",
+            transition_key=f"turn:r{i}:completed",
+            sequence_marker=str(i),
+        )
+
+    seen_sequences: list[int] = []
+    cursor: str | None = None
+    for _ in range(10):  # bounded loop guard
+        params = {"limit": 2}
+        if cursor is not None:
+            params["after"] = cursor
+        resp = await client.get(
+            f"/v1/sessions/{session_id}/manager-webhook-deliveries", params=params
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        seen_sequences.extend(d["sequence"] for d in body["deliveries"])
+        cursor = body["next_cursor"]
+        if cursor is None:
+            break
+    else:
+        pytest.fail("pagination did not terminate within 10 pages")
+
+    assert sorted(seen_sequences) == [1, 2, 3, 4, 5]
+    assert len(seen_sequences) == len(set(seen_sequences))
+
+
+async def test_nonexistent_session_returns_404(client: httpx.AsyncClient) -> None:
+    """A session id that doesn't exist 404s rather than 500ing or returning an empty page."""
+    resp = await client.get("/v1/sessions/conv_does_not_exist/manager-webhook-deliveries")
+    assert resp.status_code == 404, resp.text
+
+
+async def test_store_unwired_degrades_gracefully() -> None:
+    """``_get_session_lifecycle_store`` returns ``None`` (not an error) off a bare Request-like
+    app.state that never had the store attached — the route's own getattr fallback."""
+    from omnigent.server.routes.sessions.routes_manager_webhook import (
+        _get_session_lifecycle_store,
+    )
+
+    class _FakeState:
+        pass
+
+    class _FakeRequest:
+        app = type("_FakeApp", (), {"state": _FakeState()})()
+
+    assert _get_session_lifecycle_store(_FakeRequest()) is None  # type: ignore[arg-type]

--- a/tests/server/integration/test_manager_webhook_dispatcher.py
+++ b/tests/server/integration/test_manager_webhook_dispatcher.py
@@ -1,0 +1,546 @@
+"""Integration tests for the manager-webhook dispatcher (OMN-104).
+
+Exercises ``omnigent.server.manager_webhook_dispatcher`` against a real
+SQLite-backed :class:`SqlAlchemySessionLifecycleStore` and a tiny real
+FastAPI "fake manager" app reached via ``httpx.ASGITransport`` — no mocking
+libraries. ``ASGITransport`` routes the dispatcher's real ``httpx.AsyncClient``
+calls into an in-process ASGI app with no actual socket, the same technique
+``test_scheduled_tasks_routes.py`` uses for testing HTTP surfaces.
+
+One row per docs/architecture/2026-08-10-durable-session-lifecycle-push.md
+§12 test-matrix bullet that concerns the dispatcher specifically (producer-
+side rows — completion wake, decision payload allowlist — are covered by
+other test files).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+import httpx
+import pytest
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+
+from omnigent.server import manager_webhook_dispatcher as dispatcher
+from omnigent.server import manager_webhook_signing as signing
+from omnigent.server.server_config import ManagerWebhookConfig
+from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
+    SqlAlchemySessionLifecycleStore,
+)
+
+# asyncio_mode = "auto" (pyproject.toml) auto-collects async def tests as
+# asyncio tests without a marker; no module-level pytestmark here since this
+# file also has a plain sync test (test_hex_id_helper_is_deterministic).
+
+_ENDPOINT = "https://fake-manager.test/webhook"
+_SECRET = "test-webhook-secret"
+
+
+def _hex_id(seed: str) -> str:
+    """Deterministic bare 32-char hex id (Uuid16 columns) from a readable seed."""
+    return hashlib.sha256(seed.encode()).hexdigest()[:32]
+
+
+@dataclass
+class FakeManagerState:
+    """Mutable per-test behavior for the fake manager app."""
+
+    fail_times: int = 0
+    always_fail: bool = False
+    verify_signature: bool = True
+    received: list[dict] = field(default_factory=list)
+    received_headers: list[dict] = field(default_factory=list)
+    seen_event_ids: set[str] = field(default_factory=set)
+    duplicate_event_ids: set[str] = field(default_factory=set)
+    call_count: int = 0
+    hang_seconds: float | None = None
+
+
+def _build_fake_manager(state: FakeManagerState) -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/webhook")
+    async def webhook(
+        request: Request,
+        x_omnigent_event_id: str = Header(...),
+        x_omnigent_timestamp: str = Header(...),
+        x_omnigent_signature: str = Header(...),
+    ) -> JSONResponse:
+        state.call_count += 1
+        raw_body = await request.body()
+        raw_json_body = raw_body.decode("utf-8")
+        if state.hang_seconds is not None:
+            await asyncio.sleep(state.hang_seconds)
+        if state.verify_signature:
+            ok = signing.verify(
+                signature_header=x_omnigent_signature,
+                timestamp=int(x_omnigent_timestamp),
+                event_id=x_omnigent_event_id,
+                raw_json_body=raw_json_body,
+                now=int(time.time()),
+                secrets=[_SECRET],
+            )
+            if not ok:
+                return JSONResponse(status_code=401, content={"error": "bad signature"})
+        state.received.append(json.loads(raw_json_body))
+        state.received_headers.append(dict(request.headers))
+        duplicate = x_omnigent_event_id in state.seen_event_ids
+        if duplicate:
+            state.duplicate_event_ids.add(x_omnigent_event_id)
+        state.seen_event_ids.add(x_omnigent_event_id)
+        if state.always_fail:
+            return JSONResponse(status_code=500, content={"error": "always fails"})
+        if state.fail_times > 0:
+            state.fail_times -= 1
+            return JSONResponse(status_code=500, content={"error": "transient"})
+        return JSONResponse(status_code=200, content={"duplicate": duplicate})
+
+    return app
+
+
+@pytest.fixture()
+def state() -> FakeManagerState:
+    return FakeManagerState()
+
+
+@pytest.fixture()
+async def client(state: FakeManagerState) -> AsyncIterator[httpx.AsyncClient]:
+    app = _build_fake_manager(state)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport) as c:
+        yield c
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
+    return SqlAlchemySessionLifecycleStore(db_uri)
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", _SECRET)
+
+
+def _enable_dispatch(monkeypatch: pytest.MonkeyPatch, *, endpoint: str = _ENDPOINT) -> None:
+    """Point manager_webhook_config() at our fake manager without touching disk config.
+
+    Legitimate test-boundary stub of config *resolution* (not of the
+    dispatcher/signing code under test) — avoids cross-test env/file leakage
+    under parallel test workers.
+    """
+    monkeypatch.setattr(
+        dispatcher,
+        "manager_webhook_config",
+        lambda: ManagerWebhookConfig(enabled=True, endpoint=endpoint, key_id="k1"),
+    )
+
+
+def _insert_event(
+    store: SqlAlchemySessionLifecycleStore,
+    *,
+    session_id: str,
+    transition_key: str,
+    event_id: str | None = None,
+) -> str:
+    eid = event_id or _hex_id(f"evt:{session_id}:{transition_key}")
+    now = int(time.time())
+    event, _inserted = store.record_lifecycle_event(
+        event_id=eid,
+        session_id=session_id,
+        event_type="session.completed",
+        transition_key=transition_key,
+        payload=json.dumps({"response_id": transition_key}),
+        now=now,
+    )
+    return event.id
+
+
+# ── 1. Delivered on first attempt ───────────────────────────────
+
+
+async def test_delivered_on_first_attempt(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    session_id = _hex_id("session-1")
+    event_id = _insert_event(store, session_id=session_id, transition_key="turn:r1:completed")
+
+    claimed_count = await dispatcher._run_once(client, store, lease_owner="replica-1")
+
+    assert claimed_count == 1
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.id == event_id
+    assert row.status == "delivered"
+    assert row.last_http_status == 200
+    assert state.call_count == 1
+
+
+# ── 2. Retry then succeed ───────────────────────────────────────
+
+
+async def test_retry_then_succeed(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    state.fail_times = 2
+    session_id = _hex_id("session-2")
+    _insert_event(store, session_id=session_id, transition_key="turn:r2:completed")
+
+    # Bypass real backoff wait: pass an artificially advanced `now` to
+    # claim_batch each cycle (backoff caps at 15 minutes, so +1 day is always
+    # past any possible next_attempt_at) instead of sleeping real time.
+    far_future = int(time.time()) + 86_400
+    for _ in range(5):
+        claimed = store.claim_batch(
+            limit=10, now=far_future, lease_owner="replica-1", lease_seconds=60
+        )
+        if not claimed:
+            break
+        for event in claimed:
+            await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+        far_future += 86_400
+        row = store.latest_delivery(session_id)
+        assert row is not None
+        if row.status == "delivered":
+            break
+
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.status == "delivered"
+    assert row.attempt_count == 3  # 2 failures + 1 success
+    assert state.call_count == 3
+
+
+# ── 3. Dead-letter escalation, never abandonment ────────────────
+
+
+async def test_dead_letter_is_escalation_not_abandonment(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    state.always_fail = True
+    session_id = _hex_id("session-3")
+    event_id = _insert_event(store, session_id=session_id, transition_key="turn:r3:completed")
+
+    far_future = int(time.time())
+    row = None
+    for _ in range(dispatcher._DEAD_LETTER_AFTER_ATTEMPTS + 2):
+        far_future += 86_400
+        claimed = store.claim_batch(
+            limit=10, now=far_future, lease_owner="replica-1", lease_seconds=60
+        )
+        assert claimed, "dead-lettered row must remain claimable (escalation, not abandonment)"
+        for event in claimed:
+            await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+        row = store.latest_delivery(session_id)
+        assert row is not None
+        if row.status == "dead_letter":
+            break
+
+    assert row is not None
+    assert row.status == "dead_letter"
+    assert row.attempt_count >= dispatcher._DEAD_LETTER_AFTER_ATTEMPTS
+
+    # Visible via the read API/store with its dead_letter status — "visible
+    # via the new API/log fields", not silently dropped.
+    deliveries, _cursor = store.list_deliveries(session_id, limit=10)
+    assert any(d.id == event_id and d.status == "dead_letter" for d in deliveries)
+
+    # One more cycle past next_attempt_at: still claimed and retried at the
+    # capped floor interval — proves it never stops trying.
+    far_future += 86_400
+    claimed_again = store.claim_batch(
+        limit=10, now=far_future, lease_owner="replica-1", lease_seconds=60
+    )
+    assert len(claimed_again) == 1
+    assert claimed_again[0].id == event_id
+    attempts_before = claimed_again[0].attempt_count
+    for event in claimed_again:
+        await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+    row_after = store.latest_delivery(session_id)
+    assert row_after is not None
+    assert row_after.attempt_count == attempts_before  # already incremented by claim
+    assert row_after.status == "dead_letter"
+
+
+# ── 4. Ordering / non-regression ────────────────────────────────
+
+
+async def test_ordering_never_issues_n_plus_1_before_n_terminal(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    session_id = _hex_id("session-4")
+    _insert_event(store, session_id=session_id, transition_key="turn:r4a:completed")
+    _insert_event(store, session_id=session_id, transition_key="turn:r4b:failed")
+
+    deliveries, _c = store.list_deliveries(session_id, limit=10)
+    by_seq = sorted(deliveries, key=lambda d: d.sequence)
+    assert [d.sequence for d in by_seq] == [1, 2]
+
+    # First cycle: only sequence 1 is claimable (claim_batch's own blocking
+    # subquery refuses to return sequence 2 while sequence 1 is pending).
+    claimed_count = await dispatcher._run_once(client, store, lease_owner="replica-1")
+    assert claimed_count == 1
+    deliveries, _c = store.list_deliveries(session_id, limit=10)
+    by_seq = sorted(deliveries, key=lambda d: d.sequence)
+    assert by_seq[0].status == "delivered"
+    assert by_seq[1].status == "pending"  # sequence 2 never attempted yet
+    assert state.call_count == 1
+
+    # Wire payload always carries `sequence` (manager-side dedupe-by-sequence
+    # contract).
+    assert "sequence" in state.received[0]
+    assert state.received[0]["sequence"] == 1
+
+    # Second cycle: sequence 1 is now delivered (terminal) -> sequence 2
+    # becomes claimable.
+    claimed_count_2 = await dispatcher._run_once(client, store, lease_owner="replica-1")
+    assert claimed_count_2 == 1
+    deliveries, _c = store.list_deliveries(session_id, limit=10)
+    by_seq = sorted(deliveries, key=lambda d: d.sequence)
+    assert by_seq[0].status == "delivered"
+    assert by_seq[1].status == "delivered"
+    assert state.received[1]["sequence"] == 2
+
+
+# ── 5. Duplicate delivery / stable event IDs ────────────────────
+
+
+async def test_duplicate_delivery_stable_event_ids(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+) -> None:
+    session_id = _hex_id("session-5")
+    transition_key = "turn:r5:completed"
+    # A retried producer call for the identical transition resolves to the
+    # SAME row (same event_id), not a duplicate — this is what bounds the
+    # dispatcher to ever scheduling exactly one delivery per logical event.
+    id_a = _insert_event(store, session_id=session_id, transition_key=transition_key)
+    id_b = _insert_event(store, session_id=session_id, transition_key=transition_key)
+    assert id_a == id_b
+    deliveries, _c = store.list_deliveries(session_id, limit=10)
+    assert len(deliveries) == 1
+
+    # Receiver-side dedupe: simulate "manager 2xx'd but the ack was lost" by
+    # POSTing the identical signed payload twice directly against the fake
+    # manager. Its own seen_event_ids tracking must recognize the replay.
+    now = int(time.time())
+    body = json.dumps({"event_id": id_a, "sequence": 1, "event_type": "session.completed"})
+    signature = signing.sign(secret=_SECRET, timestamp=now, event_id=id_a, raw_json_body=body)
+    headers = signing.build_headers(
+        event_id=id_a,
+        event_type="session.completed",
+        attempt=1,
+        timestamp=now,
+        key_id="k1",
+        signature=signature,
+    )
+    resp1 = await client.post(_ENDPOINT, content=body, headers=headers)
+    resp2 = await client.post(_ENDPOINT, content=body, headers=headers)
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json()["duplicate"] is False
+    assert resp2.json()["duplicate"] is True
+    assert id_a in state.duplicate_event_ids
+    assert len(state.seen_event_ids) == 1
+
+
+# ── 6. HMAC signature required and verified ─────────────────────
+
+
+async def test_hmac_headers_present_and_verified(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+    state: FakeManagerState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    session_id = _hex_id("session-6")
+    _insert_event(store, session_id=session_id, transition_key="turn:r6:completed")
+
+    claimed_count = await dispatcher._run_once(client, store, lease_owner="replica-1")
+
+    assert claimed_count == 1
+    assert store.latest_delivery(session_id).status == "delivered"  # type: ignore[union-attr]
+    assert len(state.received_headers) == 1
+    headers = state.received_headers[0]
+    assert "x-omnigent-signature" in headers
+    assert headers["x-omnigent-signature"].startswith("v1=")
+    assert "x-omnigent-event-id" in headers
+    assert "x-omnigent-timestamp" in headers
+    assert headers["x-omnigent-delivery-attempt"] == "1"
+    assert headers["x-omnigent-key-id"] == "k1"
+
+    # An invalid signature is rejected by the (independently-implemented)
+    # verification reference, proving the scheme round-trips end to end.
+    state.received.clear()
+    state.verify_signature = True
+    tampered_body = json.dumps({"tampered": True})
+    bad_headers = dict(headers)
+    resp = await client.post(_ENDPOINT, content=tampered_body, headers=bad_headers)
+    assert resp.status_code == 401
+
+
+# ── 7. Reclaim expired lease -> redelivered with same identity ─
+
+
+async def test_reclaim_expired_lease_redelivers_same_identity(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    session_id = _hex_id("session-7")
+    event_id = _insert_event(store, session_id=session_id, transition_key="turn:r7:completed")
+
+    now = int(time.time())
+    # Simulate "dispatcher killed mid-delivery": claim but never complete.
+    claimed = store.claim_batch(limit=10, now=now, lease_owner="replica-dead", lease_seconds=1)
+    assert len(claimed) == 1
+    original_sequence = claimed[0].sequence
+    assert claimed[0].id == event_id
+
+    # Still leased -> invisible to a fresh claim while the lease is live.
+    still_leased = store.claim_batch(limit=10, now=now, lease_owner="replica-2", lease_seconds=60)
+    assert still_leased == []
+
+    # Lease expires -> reclaimed back to pending.
+    reclaimed_count = store.reclaim_expired_leases(now=now + 3600)
+    assert reclaimed_count == 1
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.status == "pending"
+    assert row.lease_owner is None
+
+    # A live (not-yet-expired) lease is NOT reclaimed.
+    claimed_2 = store.claim_batch(
+        limit=10, now=now + 3601, lease_owner="replica-3", lease_seconds=3600
+    )
+    assert len(claimed_2) == 1
+    assert store.reclaim_expired_leases(now=now + 3601) == 0
+
+    # Redelivered with the SAME event_id/sequence — identity preserved.
+    assert claimed_2[0].id == event_id
+    assert claimed_2[0].sequence == original_sequence
+
+
+# ── 8. manager_webhook.enabled=false -> dispatcher claims nothing ─
+
+
+async def test_disabled_config_claims_nothing(
+    store: SqlAlchemySessionLifecycleStore,
+    client: httpx.AsyncClient,
+) -> None:
+    # No monkeypatch: default config is enabled=False.
+    session_id = _hex_id("session-8")
+    _insert_event(store, session_id=session_id, transition_key="turn:r8:completed")
+
+    claimed_count = await dispatcher._run_once(client, store, lease_owner="replica-1")
+
+    assert claimed_count == 0
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.status == "pending"
+    assert row.attempt_count == 0
+
+
+# ── 9. Endpoint permanently down ────────────────────────────────
+
+
+async def test_endpoint_down_releases_lease_and_retries(
+    store: SqlAlchemySessionLifecycleStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_dispatch(monkeypatch)
+    session_id = _hex_id("session-9")
+    _insert_event(store, session_id=session_id, transition_key="turn:r9:completed")
+
+    async def _always_down(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    down_transport = httpx.MockTransport(_always_down)
+    async with httpx.AsyncClient(transport=down_transport) as down_client:
+        claimed_count = await dispatcher._run_once(down_client, store, lease_owner="replica-1")
+
+    assert claimed_count == 1
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.status == "pending"  # released the lease, not stuck in "leased"
+    assert row.attempt_count == 1
+    assert row.last_error_code == "ConnectError"
+
+
+# ── 10. Callback never blocks (dispatcher-side bounded timeout) ─
+
+
+async def test_delivery_attempt_carries_a_bounded_timeout(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Proves the dispatcher's own delivery attempt is bounded by
+    _DELIVERY_TIMEOUT_SECONDS rather than able to hang forever on an
+    unresponsive manager.
+
+    This sandbox's httpx/anyio socket layer does not honor
+    ``asyncio.wait_for``-based cancellation around a genuinely-hanging
+    server (verified empirically: a real TCP listener that accepts the
+    connection and never writes a response defeats both httpx's own
+    ``timeout=`` kwarg AND an outer ``asyncio.wait_for`` in this
+    environment — an infra/sandbox limitation, not a product one), so a
+    true end-to-end "manager hangs, dispatcher must not hang" test cannot
+    run reliably here without risking a wedged CI job. Instead this proves
+    the same guarantee two ways that don't depend on that transport
+    behavior: (1) the exact bounded value is wired into the real HTTP call,
+    and (2) a manager that responds well within budget doesn't trigger any
+    extra unbounded wait in the delivery path. The producer-side half of
+    "callback never blocks" (that _publish_status itself never makes a
+    network call at all) is covered by test_session_outbox.py, not here.
+    """
+    import inspect
+
+    source = inspect.getsource(dispatcher._deliver_one)
+    assert "timeout=_DELIVERY_TIMEOUT_SECONDS" in source
+    assert dispatcher._DELIVERY_TIMEOUT_SECONDS <= 30.0  # sane, bounded budget
+
+    slow_state = FakeManagerState()
+    slow_state.hang_seconds = 1.0  # well within the 10s budget
+    app = _build_fake_manager(slow_state)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app)) as fast_client:
+        session_id = _hex_id("session-10")
+        _insert_event(store, session_id=session_id, transition_key="turn:r10:completed")
+        event = store.claim_batch(
+            limit=1, now=int(time.time()), lease_owner="replica-1", lease_seconds=60
+        )[0]
+        started = time.monotonic()
+        await dispatcher._deliver_one(fast_client, store, event, endpoint=_ENDPOINT, key_id="k1")
+        elapsed = time.monotonic() - started
+    assert elapsed < 5.0  # no unbounded wait added on top of the manager's own delay
+    row = store.latest_delivery(session_id)
+    assert row is not None
+    assert row.status == "delivered"
+
+
+def test_hex_id_helper_is_deterministic() -> None:
+    """Sanity-check the test module's own id helper (not product code)."""
+    assert _hex_id("x") == _hex_id("x")
+    assert len(_hex_id("x")) == 32
+    assert _hex_id("x") != _hex_id("y")
+    uuid.UUID(bytes=bytes.fromhex(_hex_id("x")))  # round-trips as 16 raw bytes

--- a/tests/server/integration/test_manager_webhook_dispatcher.py
+++ b/tests/server/integration/test_manager_webhook_dispatcher.py
@@ -124,7 +124,7 @@ def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
 
 
 @pytest.fixture(autouse=True)
-def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+def _webhook_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(signing.SECRET_ENV_VAR, _SECRET)
 
 

--- a/tests/server/integration/test_manager_webhook_dispatcher.py
+++ b/tests/server/integration/test_manager_webhook_dispatcher.py
@@ -125,7 +125,7 @@ def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
 
 @pytest.fixture(autouse=True)
 def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv(signing.SECRET_ENV_VAR, _SECRET)
 
 
 def _enable_dispatch(monkeypatch: pytest.MonkeyPatch, *, endpoint: str = _ENDPOINT) -> None:

--- a/tests/server/integration/test_manager_webhook_elicitation_origin_durability.py
+++ b/tests/server/integration/test_manager_webhook_elicitation_origin_durability.py
@@ -1,0 +1,207 @@
+"""Durability coverage for every elicitation-origin call site (OMN-104).
+
+Independent cross-vendor review (round 2) found that OMN-104's durable
+outbox writes were wired into only ONE of several code paths that raise or
+resolve an elicitation:
+
+* ``_publish_and_wait_for_harness_elicitation`` (claude-native/codex-native
+  permission hooks) already called ``session_outbox.record_elicitation_raised``
+  — covered by other test files.
+* ``_register_policy_elicitation`` (the relay tool-call ASK gate AND the MCP
+  ``tools/call`` ASK gate both funnel through this one function) had NO
+  durable write at all.
+* The generic ``POST /v1/sessions/{id}/events``'s ``mcp_elicitation`` branch
+  (an external MCP server's own ``elicitation/create`` relayed through) had
+  NO durable write at all.
+* The generic ``POST /v1/sessions/{id}/events``'s ``approval`` branch called
+  ``_resolve_elicitation`` directly but never ``record_decision`` /
+  ``record_elicitation_resumed`` — a second, less-obvious entry point that
+  could resolve an elicitation while the durable ledger stayed stuck at
+  ``pending`` and no ``session.resumed`` ever fired.
+
+This file drives each of those gaps through the REAL HTTP endpoint (not the
+internal function directly) and asserts on the durable
+``session_lifecycle_store`` state, closing the coverage gap the review found.
+The remaining origin — harness-subprocess ``ctx.elicit()`` relayed via
+``_relay_runner_stream_once`` — requires the real WS-tunnel machinery and is
+covered separately in
+``tests/server/integration/test_manager_webhook_reconnect_redelivery_e2e.py``'s
+sibling file for that mechanism.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_endpoints import (
+    _COST_GUARD_SOFT_GUARDRAILS,
+    _create_session,
+    _evaluate_tool,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_relay_tool_call_ask_durably_records_awaiting_decision(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    The relay tool-call ASK gate (``_evaluate_tool_call_policy`` ->
+    ``_register_policy_elicitation``) durably records the elicitation and a
+    ``session.awaiting_decision`` outbox row BEFORE the SSE event publishes —
+    previously this path had no durable write at all. The MCP ``tools/call``
+    ASK gate shares this exact same ``_register_policy_elicitation`` function
+    body, so this single real-HTTP exercise covers both entry points.
+    """
+    agent = await create_test_agent(client, guardrails=_COST_GUARD_SOFT_GUARDRAILS)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_session_usage", "data": {"cumulative_cost_usd": 0.1}},
+    )
+    assert resp.status_code == 202, resp.text
+
+    verdict = await _evaluate_tool(client, sid)
+    assert verdict["verdict"] == "pending", verdict
+    eid = verdict["elicitation_id"]
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(eid)
+    assert elicitation is not None
+    assert elicitation.status == "pending"
+    assert elicitation.session_id == sid
+
+    deliveries, _ = store.list_deliveries(sid, limit=100)
+    awaiting = [d for d in deliveries if d.event_type == "session.awaiting_decision"]
+    assert len(awaiting) == 1, deliveries
+
+
+async def test_mcp_elicitation_event_durably_records_awaiting_decision(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    The generic events endpoint's ``mcp_elicitation`` branch (an external
+    MCP server's own ``elicitation/create`` relayed through
+    ``routes_events.py``) durably records the elicitation and a
+    ``session.awaiting_decision`` outbox row — previously this path had no
+    durable write at all, distinct from both the internal policy ASK gate
+    and the harness-subprocess ``ctx.elicit()`` relay.
+    """
+    agent = await create_test_agent(client, "test-mcp-elicit-durability")
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    publish = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "mcp_elicitation",
+            "data": {
+                "message": "MCP server asks: proceed with deletion?",
+                "requestedSchema": {
+                    "type": "object",
+                    "properties": {"confirm": {"type": "boolean"}},
+                },
+            },
+        },
+    )
+    assert publish.status_code == 202, publish.text
+    eid = publish.json()["elicitation_id"]
+    assert isinstance(eid, str) and eid
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(eid)
+    assert elicitation is not None
+    assert elicitation.status == "pending"
+    assert elicitation.session_id == sid
+
+    deliveries, _ = store.list_deliveries(sid, limit=100)
+    awaiting = [d for d in deliveries if d.event_type == "session.awaiting_decision"]
+    assert len(awaiting) == 1, deliveries
+
+
+async def test_generic_events_approval_path_durably_resumes(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The generic ``POST /v1/sessions/{id}/events`` ``approval`` branch —
+    NOT the dedicated ``.../elicitations/{eid}/resolve`` URL endpoint —
+    durably records the decision AND ``session.resumed`` on a truthful
+    runner ack. Previously this branch called ``_resolve_elicitation``
+    directly with no durable write at all: a client using this generic
+    path could consume an elicitation while the ledger stayed stuck at
+    ``pending`` and no ``session.resumed`` ever fired.
+    """
+
+    async def _fake_get_runner_client(session_id: str, runner_router: object) -> httpx.AsyncClient:
+        del session_id, runner_router
+        fake_runner = FastAPI()
+
+        @fake_runner.post("/v1/sessions/{conversation_id}/events")
+        async def _events(conversation_id: str) -> JSONResponse:
+            del conversation_id
+            return JSONResponse(
+                status_code=200,
+                content={"ok": True},
+                headers={"X-Omnigent-Pending-Approval-Resolved": "true"},
+            )
+
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=fake_runner), base_url="http://fake-runner"
+        )
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.helpers._get_runner_client",
+        _fake_get_runner_client,
+    )
+
+    agent = await create_test_agent(client, guardrails=_COST_GUARD_SOFT_GUARDRAILS)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_session_usage", "data": {"cumulative_cost_usd": 0.1}},
+    )
+    assert resp.status_code == 202, resp.text
+
+    verdict = await _evaluate_tool(client, sid)
+    assert verdict["verdict"] == "pending", verdict
+    eid = verdict["elicitation_id"]
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    runner_id = "runner_generic_events_approval"
+    assert conv_store.set_runner_id(sid, runner_id)
+    conv_store.touch_runner_liveness([runner_id], int(time.time()))
+
+    # POST the verdict to the GENERIC events endpoint, NOT the dedicated
+    # resolve URL — this is the exact path the review found bypassed
+    # durability.
+    approve = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "approval", "data": {"elicitation_id": eid, "action": "accept"}},
+    )
+    assert approve.status_code == 202, approve.text
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(eid)
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"
+    assert elicitation.decision_payload is not None
+
+    deliveries, _ = store.list_deliveries(sid, limit=100)
+    resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert len(resumed) == 1, deliveries

--- a/tests/server/integration/test_manager_webhook_reconnect_redelivery_e2e.py
+++ b/tests/server/integration/test_manager_webhook_reconnect_redelivery_e2e.py
@@ -1,0 +1,262 @@
+"""True end-to-end reconnect-redelivery test for OMN-104 (cross-vendor review BLOCKING #3).
+
+``test_manager_webhook_decision_endpoint.py``'s case (b) test only proves the
+QUERY side of ``_on_runner_connect``'s reconnect-redelivery loop
+(``session_lifecycle_store.list_decided_undelivered`` returns the row the
+hook would redeliver) — it never drives an actual WebSocket tunnel
+disconnect/reconnect, never exercises the real
+``omnigent.runner.pending_approvals`` registry, and never observes a real
+``session.resumed`` outbox row produced by a genuine runner acknowledgement.
+This file closes that gap using the same real WS-tunnel machinery as
+``test_sessions_tunnel_three_layer.py`` (``tunnel_three_layer_stack``,
+``_connect_runner_tunnel``, ``_send_hello_and_wait``,
+``_forward_requests_to_runner``) — no mocking library, no fake runner stub.
+
+Unlike ``test_on_runner_connect_restarts_relay_via_router`` (which stubs the
+router resolver and ``_ensure_runner_relay`` so it can assert on hook
+plumbing in isolation), these tests deliberately do NOT stub anything on the
+redelivery path: the reconnect-redelivery POST must reach the REAL runner
+app's ``/v1/sessions/{id}/events`` handler so ``pending_approvals.resolve()``
+runs for real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from typing import Any
+
+import pytest
+from asgiref.testing import ApplicationCommunicator
+from fastapi import FastAPI
+
+from omnigent.runner import pending_approvals
+from omnigent.runner.app import create_runner_app
+from omnigent.server import session_outbox
+from tests.runner.helpers import NullServerClient
+from tests.server.integration.test_sessions_tunnel_three_layer import (
+    _RUNNER_ID,
+    _TEST_HARNESS_NAME,
+    _build_harness_agent_bundle,
+    _connect_runner_tunnel,
+    _forward_requests_to_runner,
+    _send_hello_and_wait,
+    _TunnelStack,
+    tunnel_three_layer_stack,  # noqa: F401 — re-exported fixture
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_bound_session(stack: _TunnelStack) -> str:
+    """Create a session and bind it to ``_RUNNER_ID`` via a real PATCH."""
+    create_resp = await stack.ap_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_harness_agent_bundle(),
+                "application/gzip",
+            ),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+
+    bind_resp = await stack.ap_client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"runner_id": _RUNNER_ID},
+    )
+    assert bind_resp.status_code == 200, bind_resp.text
+    return session_id
+
+
+async def _drop_and_reconnect_tunnel(
+    stack: _TunnelStack,
+) -> tuple[ApplicationCommunicator, asyncio.Task[None]]:
+    """Deregister ``_RUNNER_ID``'s tunnel and reconnect it for real.
+
+    This is the production trigger for ``_on_runner_connect`` — the same
+    choreography ``test_on_runner_connect_restarts_relay_via_router`` uses,
+    minus the resolver/relay stubs, so the redelivery loop's HTTP POST
+    actually lands on the fresh runner app spun up here.
+
+    :returns: The new communicator and its forwarder task, both owned by
+        the caller for teardown.
+    """
+    from omnigent.server.routes.sessions import _runner_relay_tasks
+
+    ap_app = stack.ap_app
+    fake_pm = stack.fake_pm
+
+    ap_app.state.tunnel_registry.deregister(_RUNNER_ID)
+
+    async def _relays_cleared() -> None:
+        while any(not h.task.done() for h in _runner_relay_tasks.values()):
+            await asyncio.sleep(0.01)
+
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(_relays_cleared(), timeout=2.0)
+
+    new_communicator = await _connect_runner_tunnel(ap_app, _RUNNER_ID)
+    await _send_hello_and_wait(
+        new_communicator,
+        ap_app,
+        _RUNNER_ID,
+        harnesses=[_TEST_HARNESS_NAME],
+    )
+
+    async def _resolve_spec(agent_id: str) -> Any:
+        del agent_id
+        return None
+
+    new_runner_app = create_runner_app(
+        process_manager=fake_pm,  # type: ignore[arg-type]
+        spec_resolver=_resolve_spec,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    new_forwarder_task = asyncio.create_task(
+        _forward_requests_to_runner(new_communicator, new_runner_app),
+        name="tunnel-redelivery-e2e-forwarder",
+    )
+    return new_communicator, new_forwarder_task
+
+
+async def _teardown_reconnect(
+    communicator: ApplicationCommunicator | None, forwarder_task: asyncio.Task[None] | None
+) -> None:
+    if forwarder_task is not None:
+        forwarder_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await forwarder_task
+    if communicator is not None:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await communicator.send_input({"type": "websocket.disconnect", "code": 1000})
+        with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+            await communicator.wait(timeout=2.0)
+
+
+async def _session_resumed_rows(app: FastAPI, session_id: str) -> list[Any]:
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    return [d for d in deliveries if d.event_type == "session.resumed"]
+
+
+async def test_reconnect_redelivers_policy_ask_and_fires_resumed(
+    tunnel_three_layer_stack: _TunnelStack,  # noqa: F811
+) -> None:
+    """
+    Policy/cost-ASK shape: a real ``pending_approvals`` Future registered on
+    the runner is genuinely resolved by the reconnect-redelivery POST, and
+    the durable ledger observes a real ``session.resumed``.
+
+    No harness turn is in flight for this session (no message was ever
+    sent), so the SAME redelivery event's unconditional harness-subprocess
+    forward will 404 (``_scaffold.py``'s ``_resolve_elicitation`` finds no
+    matching ``_in_flight`` entry) — that is the expected, real-world shape
+    of a policy/cost ASK, not a test artifact. The
+    ``X-Omnigent-Pending-Approval-Resolved: true`` header alone must be
+    sufficient (the fix this test exists to prove).
+    """
+    stack = tunnel_three_layer_stack
+    ap_app = stack.ap_app
+    session_id = await _create_bound_session(stack)
+    elicitation_id = "elicit_e2e_policy_ask"
+
+    future = pending_approvals.register(elicitation_id)
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+    session_outbox.record_decision(
+        elicitation_id=elicitation_id,
+        decision={"action": "accept"},
+        decided_by=None,
+    )
+
+    store = ap_app.state.session_lifecycle_store
+    assert [e.id for e in store.list_decided_undelivered(session_id)] == [elicitation_id]
+
+    communicator: ApplicationCommunicator | None = None
+    forwarder_task: asyncio.Task[None] | None = None
+    try:
+        communicator, forwarder_task = await _drop_and_reconnect_tunnel(stack)
+
+        approved = await asyncio.wait_for(future, timeout=5.0)
+        assert approved is True, "real pending_approvals Future did not resolve to accept"
+
+        resumed: list[Any] = []
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            resumed = await _session_resumed_rows(ap_app, session_id)
+            if resumed:
+                break
+            await asyncio.sleep(0.05)
+        assert resumed, "session.resumed did not fire after real reconnect redelivery"
+
+        elicitation = store.get_elicitation(elicitation_id)
+        assert elicitation is not None
+        assert elicitation.status == "delivered_to_runner"
+        assert elicitation.resolved_at is not None
+    finally:
+        await _teardown_reconnect(communicator, forwarder_task)
+        pending_approvals.reset_for_tests()
+
+
+async def test_reconnect_does_not_resume_untracked_elicitation(
+    tunnel_three_layer_stack: _TunnelStack,  # noqa: F811
+) -> None:
+    """
+    Counterpart: an elicitation_id tracked by NEITHER registry (no
+    ``pending_approvals`` Future registered, no harness turn in flight) must
+    not fire ``session.resumed`` on reconnect — the real runner's
+    unconditional harness-forward genuinely 404s and
+    ``pending_approvals.resolve()`` genuinely returns ``False``, so neither
+    truthful-consumption signal is present.
+    """
+    stack = tunnel_three_layer_stack
+    ap_app = stack.ap_app
+    session_id = await _create_bound_session(stack)
+    elicitation_id = "elicit_e2e_untracked"
+
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=session_id,
+        elicitation_id=elicitation_id,
+        request={"message": "Approve?", "mode": "form"},
+    )
+    session_outbox.record_decision(
+        elicitation_id=elicitation_id,
+        decision={"action": "accept"},
+        decided_by=None,
+    )
+
+    store = ap_app.state.session_lifecycle_store
+    assert [e.id for e in store.list_decided_undelivered(session_id)] == [elicitation_id]
+
+    communicator: ApplicationCommunicator | None = None
+    forwarder_task: asyncio.Task[None] | None = None
+    try:
+        communicator, forwarder_task = await _drop_and_reconnect_tunnel(stack)
+
+        # Give the reconnect hook a real window to (incorrectly) resume —
+        # a fixed sleep is appropriate here since we're proving a negative
+        # (nothing happens), not racing a positive signal.
+        await asyncio.sleep(1.0)
+
+        resumed = await _session_resumed_rows(ap_app, session_id)
+        assert resumed == [], (
+            "session.resumed fired for an elicitation truthfully consumed by nobody"
+        )
+
+        elicitation = store.get_elicitation(elicitation_id)
+        assert elicitation is not None
+        assert elicitation.status == "decided"
+    finally:
+        await _teardown_reconnect(communicator, forwarder_task)
+        pending_approvals.reset_for_tests()

--- a/tests/server/integration/test_manager_webhook_relay_elicitation_durability.py
+++ b/tests/server/integration/test_manager_webhook_relay_elicitation_durability.py
@@ -1,0 +1,136 @@
+"""Durability coverage for the runner-relay ``ctx.elicit()`` branch (OMN-104).
+
+The last of the elicitation-origin gaps cross-vendor review (round 2) found:
+``_relay_runner_stream_once`` (``omnigent/server/routes/_sessions/orchestration.py``)
+is a long-lived background task that opens ``GET /v1/sessions/{id}/stream`` on the
+RUNNER and relays every event it reads onto the local ``session_stream.publish`` on
+the SERVER side. A harness subprocess's own ``ctx.elicit()`` call (generic
+scaffold-backed harnesses) emits ``response.elicitation_request`` on its own stream,
+which the runner forwards, which this relay loop picks up — a code path distinct
+from both the internal policy ASK gate and an external MCP server's
+``elicitation/create`` (both covered in
+``test_manager_webhook_elicitation_origin_durability.py``), and distinct from the
+claude-native/codex-native permission-hook contract (which never reaches this relay
+loop at all).
+
+Driving this end to end through a REAL harness subprocess turn (harness ->
+runner's own internal event-queue plumbing -> runner's ``GET /stream`` -> this
+relay) was attempted first and abandoned: the harness genuinely calls
+``ctx.elicit()`` and parks correctly, but nothing from that turn — not even the
+routine turn-lifecycle envelope events — ever reaches the AP-side relay in that
+test wiring, which is a pre-existing test-infrastructure gap in getting a fake
+in-process harness's SSE output through the runner's own internal queue
+(``_publish_event`` / ``_session_event_queues``, both closures private to
+``create_runner_app``, not reachable from a test without touching product code),
+not something this OMN-104 change introduced or could fix. The general
+harness -> runner -> AP relay pipeline itself is already proven end-to-end for
+ordinary turn events by ``test_native_session_happy_path_via_ws_tunnel`` and
+friends in ``test_sessions_tunnel_three_layer.py``.
+
+This file instead drives ``_relay_runner_stream_once`` directly (the real,
+unmodified function under test — not a mock of it) against a REAL HTTP
+``GET /v1/sessions/{id}/stream`` endpoint that emits genuine SSE bytes in the
+runner's exact wire format (``data: {json}\\n\\n``, see
+``omnigent/runner/app.py``'s ``stream_session``/``_event_generator``), carrying a
+real ``ElicitationRequestEvent``. This isolates the one thing OMN-104 actually
+changed in this function (the durable write on the ``response.elicitation_request``
+branch) from the separate, pre-existing question of how an event gets from a live
+harness subprocess into the runner's own queue in the first place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+from omnigent.server.routes._sessions.orchestration import _relay_runner_stream_once
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_endpoints import _create_session
+
+pytestmark = pytest.mark.asyncio
+
+
+def _build_fake_runner_stream_app(elicitation_id: str) -> FastAPI:
+    """A minimal runner stand-in serving one real SSE stream.
+
+    Mirrors ``omnigent/runner/app.py``'s ``stream_session`` wire format exactly
+    (heartbeat frame first, then event frames, then ``[DONE]``) so
+    ``_relay_runner_stream_once``'s real parsing loop (``resp.aiter_text()`` +
+    ``"\\n\\n"``-delimited ``data:`` frames) exercises the same bytes it would
+    read from a real runner.
+    """
+    app = FastAPI()
+
+    @app.get("/v1/sessions/{session_id}/stream")
+    async def stream(session_id: str) -> StreamingResponse:
+        del session_id
+
+        async def _gen():
+            yield b'data: {"type": "session.heartbeat"}\n\n'
+            event = {
+                "type": "response.elicitation_request",
+                "elicitation_id": elicitation_id,
+                "method": "elicitation/create",
+                "params": {
+                    "mode": "form",
+                    "message": "harness asks: proceed?",
+                    "requestedSchema": {"type": "object"},
+                },
+            }
+            yield ("data: " + json.dumps(event) + "\n\n").encode("utf-8")
+            yield b"data: [DONE]\n\n"
+
+        return StreamingResponse(_gen(), media_type="text/event-stream")
+
+    return app
+
+
+async def test_relay_ctx_elicit_durably_records_awaiting_decision(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    ``_relay_runner_stream_once`` durably records the elicitation ledger row
+    and a ``session.awaiting_decision`` outbox event when it relays a real
+    ``response.elicitation_request`` frame read over real HTTP SSE — the
+    harness-subprocess ``ctx.elicit()`` origin, previously the only
+    elicitation-origin path with no durable write at all.
+    """
+    agent = await create_test_agent(client, "test-relay-elicit-durability")
+    session = await _create_session(client, agent["id"])
+    session_id = session["id"]
+    elicitation_id = "elicit_relay_ctx_test"
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    fake_runner = _build_fake_runner_stream_app(elicitation_id)
+    runner_client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=fake_runner), base_url="http://fake-runner"
+    )
+    try:
+        ready = asyncio.Event()
+        # The real function under test: connects, parses real SSE bytes, and
+        # (via this PR's fix) durably records the raised elicitation before
+        # returning at [DONE].
+        await asyncio.wait_for(
+            _relay_runner_stream_once(session_id, runner_client, conv_store, ready=ready),
+            timeout=10.0,
+        )
+    finally:
+        await runner_client.aclose()
+
+    store = app.state.session_lifecycle_store
+    elicitation = store.get_elicitation(elicitation_id)
+    assert elicitation is not None
+    assert elicitation.status == "pending"
+    assert elicitation.session_id == session_id
+
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    awaiting = [d for d in deliveries if d.event_type == "session.awaiting_decision"]
+    assert len(awaiting) == 1, deliveries

--- a/tests/server/integration/test_sessions_elicitation_api.py
+++ b/tests/server/integration/test_sessions_elicitation_api.py
@@ -193,12 +193,17 @@ async def test_post_resolve_already_resolved_is_idempotent(
             _ = await hook_task
 
         # Second resolve — the Future is already done; should still 202.
+        # OMN-104: the durable elicitation ledger already transitioned to
+        # delivered_to_runner on the first resolve, so this is the
+        # already-resumed idempotent no-op branch — "resolved": True,
+        # not a fresh classification (and not a 410, even though the
+        # harness Future it already consumed is now done()).
         second = await client.post(
             f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
             json={"action": "decline"},
         )
         assert second.status_code == 202, second.text
-        assert second.json() == {"queued": False}
+        assert second.json() == {"queued": False, "resolved": True, "pending_redelivery": False}
     finally:
         if not hook_task.done():
             hook_task.cancel()

--- a/tests/server/integration/test_sessions_manager_webhook_lifecycle.py
+++ b/tests/server/integration/test_sessions_manager_webhook_lifecycle.py
@@ -135,6 +135,12 @@ async def test_session_failed_fires_and_is_not_swallowed_by_sticky_guard(
     ``session.failed`` outbox row carrying the failure reason. (The sticky
     failed->idle guard in ``_publish_status`` only swallows a TRAILING
     idle after failed — it must not swallow the failed transition itself.)
+
+    Cross-vendor review: the delivered ``reason.message`` is a fixed, safe
+    string selected by ``error_code`` (here ``codex_turn_error``, from this
+    route's own classification of a failed ``external_session_status``
+    with ``output`` set) — never the raw ``output`` text verbatim. See
+    ``session_outbox.record_session_failed``'s docstring.
     """
     agent = await create_test_agent(client, "test-omn104-failed-not-swallowed")
     session_id = await _create_session(client, agent["id"])
@@ -152,7 +158,9 @@ async def test_session_failed_fires_and_is_not_swallowed_by_sticky_guard(
     deliveries, _ = store.list_deliveries(session_id, limit=100)
     failed = [d for d in deliveries if d.event_type == "session.failed"]
     assert len(failed) == 1, deliveries
-    assert "the turn errored out" in failed[0].payload
+    assert "the turn errored out" not in failed[0].payload
+    assert '"code": "codex_turn_error"' in failed[0].payload
+    assert '"message": "The turn failed on the harness side."' in failed[0].payload
     assert '"response_id": "resp_fail_1"' in failed[0].payload
 
 

--- a/tests/server/integration/test_sessions_manager_webhook_lifecycle.py
+++ b/tests/server/integration/test_sessions_manager_webhook_lifecycle.py
@@ -1,0 +1,214 @@
+"""
+Integration tests for OMN-104's producer hooks, exercised through the real
+session/turn lifecycle (not by calling ``session_outbox`` functions
+directly — that unit-level coverage lives in ``test_session_outbox.py``).
+
+Drives ``_publish_status`` via the same ``POST /v1/sessions/{id}/events``
+``external_session_status`` mechanism the claude-native forwarder uses (see
+``test_post_external_session_status_publishes_session_status`` in
+``test_sessions_endpoints.py`` for the established pattern), and asserts on
+the resulting ``session_lifecycle_outbox`` rows via
+``app.state.session_lifecycle_store``.
+
+Covers the design doc's "Completion wake" and "Poll/reconcile stays
+enabled" acceptance-test rows (§12).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_elicitation_resolve_url import _create_session
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _post_status(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    status: str,
+    response_id: str | None = None,
+    background_task_count: int | None = None,
+    output: str | None = None,
+) -> httpx.Response:
+    data: dict[str, object] = {"status": status}
+    if response_id is not None:
+        data["response_id"] = response_id
+    if background_task_count is not None:
+        data["background_task_count"] = background_task_count
+    if output is not None:
+        data["output"] = output
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+    )
+    assert resp.status_code in (200, 202), resp.text
+    return resp
+
+
+async def test_completion_wake_fires_with_background_shell_still_running(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A turn reaching ``idle`` from an open ``response_id`` fires exactly one
+    ``session.completed`` outbox row — INCLUDING when
+    ``background_task_count`` is positive (a background shell/dev-server
+    still running). Proves the previously-considered secondary gate on
+    ``background_task_count`` was correctly NOT reintroduced (design doc
+    §5.1): gating on it again here would silently swallow
+    ``session.completed`` for every claude-native session that ends its
+    turn with a shell still running, which is the common case.
+    """
+    agent = await create_test_agent(client, "test-omn104-completion-bg-shell")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="running", response_id="resp_bg_1")
+    await _post_status(
+        client,
+        session_id,
+        status="idle",
+        response_id="resp_bg_1",
+        background_task_count=3,
+    )
+
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    completed = [d for d in deliveries if d.event_type == "session.completed"]
+    assert len(completed) == 1, deliveries
+    assert '"response_id": "resp_bg_1"' in completed[0].payload
+
+
+async def test_completion_wake_zero_rows_when_turn_never_opened(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    An ``idle`` transition with no preceding open ``response_id`` emits
+    zero ``session.completed`` rows.
+    """
+    agent = await create_test_agent(client, "test-omn104-completion-never-opened")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="idle")
+
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    completed = [d for d in deliveries if d.event_type == "session.completed"]
+    assert completed == []
+
+
+async def test_completion_wake_zero_rows_on_same_status_no_op_republish(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A second ``idle`` republish (already idle, no newly-open turn) is a
+    no-op: exactly one ``session.completed`` row exists after the FIRST
+    ``running``->``idle`` transition, and the second ``idle``->``idle``
+    republish adds no second row (the cached open ``response_id`` was
+    already cleared by the first transition).
+    """
+    agent = await create_test_agent(client, "test-omn104-completion-noop-republish")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="running", response_id="resp_noop_1")
+    await _post_status(client, session_id, status="idle", response_id="resp_noop_1")
+    await _post_status(client, session_id, status="idle")
+
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    completed = [d for d in deliveries if d.event_type == "session.completed"]
+    assert len(completed) == 1, deliveries
+
+
+async def test_session_failed_fires_and_is_not_swallowed_by_sticky_guard(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A ``running`` -> ``failed`` transition fires exactly one
+    ``session.failed`` outbox row carrying the failure reason. (The sticky
+    failed->idle guard in ``_publish_status`` only swallows a TRAILING
+    idle after failed — it must not swallow the failed transition itself.)
+    """
+    agent = await create_test_agent(client, "test-omn104-failed-not-swallowed")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="running", response_id="resp_fail_1")
+    await _post_status(
+        client,
+        session_id,
+        status="failed",
+        response_id="resp_fail_1",
+        output="the turn errored out",
+    )
+
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    failed = [d for d in deliveries if d.event_type == "session.failed"]
+    assert len(failed) == 1, deliveries
+    assert "the turn errored out" in failed[0].payload
+    assert '"response_id": "resp_fail_1"' in failed[0].payload
+
+
+async def test_sticky_failed_guard_still_drops_trailing_idle_and_no_completed_row(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    The PRE-EXISTING sticky failed->idle guard (unrelated to OMN-104, but
+    load-bearing for it: §5.1 binds session.completed to this same
+    ``_publish_status`` call) still drops a trailing idle after failed —
+    and, since that transition never reaches the outbox hook at all
+    (early return), no spurious ``session.completed`` row is produced for
+    a session that ended in failure.
+    """
+    agent = await create_test_agent(client, "test-omn104-sticky-guard-no-completed")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="running", response_id="resp_sticky_1")
+    await _post_status(
+        client, session_id, status="failed", response_id="resp_sticky_1", output="boom"
+    )
+    # Trailing quiescence idle (e.g. PTY-activity watcher) — must be
+    # swallowed by the sticky guard, not treated as a fresh completion.
+    await _post_status(client, session_id, status="idle")
+
+    store = app.state.session_lifecycle_store
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    completed = [d for d in deliveries if d.event_type == "session.completed"]
+    failed = [d for d in deliveries if d.event_type == "session.failed"]
+    assert completed == [], deliveries
+    assert len(failed) == 1, deliveries
+
+
+async def test_manager_webhook_disabled_leaves_existing_status_read_path_unchanged(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Poll/reconcile stays correct with ``manager_webhook.enabled=false``
+    (the default; no config file exists in this test environment): this
+    feature is purely additive — driving the exact same turn-completion
+    flow as the other tests here still updates the PRE-EXISTING
+    ``_session_status_cache`` / list-endpoint ``status`` field exactly as
+    it did before this feature existed. The new outbox write is a NEW
+    side effect layered on the same authoritative edge, not a replacement
+    of the old one.
+    """
+    agent = await create_test_agent(client, "test-omn104-poll-reconcile-unaffected")
+    session_id = await _create_session(client, agent["id"])
+
+    await _post_status(client, session_id, status="running", response_id="resp_poll_1")
+    list_resp = await client.get("/v1/sessions")
+    item = next(s for s in list_resp.json()["data"] if s["id"] == session_id)
+    assert item["status"] == "running"
+
+    await _post_status(client, session_id, status="idle", response_id="resp_poll_1")
+    list_resp = await client.get("/v1/sessions")
+    item = next(s for s in list_resp.json()["data"] if s["id"] == session_id)
+    assert item["status"] == "idle"

--- a/tests/server/test_manager_webhook_dispatcher_logging.py
+++ b/tests/server/test_manager_webhook_dispatcher_logging.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from omnigent.server import manager_webhook_dispatcher as dispatcher
+from omnigent.server import manager_webhook_signing as signing
 from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
     SqlAlchemySessionLifecycleStore,
 )
@@ -41,7 +42,7 @@ def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
 
 @pytest.fixture(autouse=True)
 def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv(signing.SECRET_ENV_VAR, _SECRET)
 
 
 def _insert_event(store: SqlAlchemySessionLifecycleStore, *, session_id: str) -> str:
@@ -180,7 +181,7 @@ async def test_missing_secret_log_is_redacted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The "missing secret" error path (never signs/sends) still logs cleanly."""
-    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv(signing.SECRET_ENV_VAR, raising=False)
     session_id = _hex_id("session-c")
     event_id = _insert_event(store, session_id=session_id)
     app = _build_fake_manager(always_fail=False)

--- a/tests/server/test_manager_webhook_dispatcher_logging.py
+++ b/tests/server/test_manager_webhook_dispatcher_logging.py
@@ -41,7 +41,7 @@ def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
 
 
 @pytest.fixture(autouse=True)
-def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+def _webhook_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(signing.SECRET_ENV_VAR, _SECRET)
 
 

--- a/tests/server/test_manager_webhook_dispatcher_logging.py
+++ b/tests/server/test_manager_webhook_dispatcher_logging.py
@@ -1,0 +1,198 @@
+"""Log-redaction tests for the manager-webhook dispatcher (OMN-104).
+
+Covers the acceptance-test row "log lines for a delivery attempt assert
+absence of payload body, secret, signature, full URL" (design doc §12,
+§9). Reuses the fake-manager-via-``httpx.ASGITransport`` technique from
+``tests/server/integration/test_manager_webhook_dispatcher.py`` — a real
+in-process FastAPI app, no mocking libraries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from omnigent.server import manager_webhook_dispatcher as dispatcher
+from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
+    SqlAlchemySessionLifecycleStore,
+)
+
+_SECRET = "test-webhook-secret-marker-XYZ789"
+_PAYLOAD_MARKER = "MARKER_PAYLOAD_CONTENT_12345"
+_URL_PATH_MARKER = "very-specific-path-marker"
+_ENDPOINT = f"https://fake-manager.test/webhook/{_URL_PATH_MARKER}"
+
+
+def _hex_id(seed: str) -> str:
+    return hashlib.sha256(seed.encode()).hexdigest()[:32]
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
+    return SqlAlchemySessionLifecycleStore(db_uri)
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", _SECRET)
+
+
+def _insert_event(store: SqlAlchemySessionLifecycleStore, *, session_id: str) -> str:
+    event, _inserted = store.record_lifecycle_event(
+        event_id=_hex_id(f"evt:{session_id}"),
+        session_id=session_id,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        payload=json.dumps({"response_id": "r1", "marker": _PAYLOAD_MARKER}),
+        now=int(time.time()),
+    )
+    return event.id
+
+
+def _build_fake_manager(*, always_fail: bool) -> FastAPI:
+    app = FastAPI()
+
+    @app.post(f"/webhook/{_URL_PATH_MARKER}")
+    async def webhook() -> JSONResponse:
+        if always_fail:
+            return JSONResponse(status_code=500, content={"error": "fail"})
+        return JSONResponse(status_code=200, content={})
+
+    return app
+
+
+def _assert_log_records_are_clean(records: list[logging.LogRecord]) -> None:
+    assert records, "expected at least one manager_webhook_dispatcher log record"
+    for record in records:
+        message = record.getMessage()
+        # No payload body content.
+        assert _PAYLOAD_MARKER not in message
+        # No secret.
+        assert _SECRET not in message
+        # No full URL / path — only the bare host may appear (via the
+        # dedicated endpoint_host field).
+        assert _URL_PATH_MARKER not in message
+        assert _ENDPOINT not in message
+        # extra={...} fields land as record attributes — check those too,
+        # not just the formatted message.
+        for key, value in record.__dict__.items():
+            if not isinstance(value, str):
+                continue
+            assert _PAYLOAD_MARKER not in value, f"payload leaked via {key!r}"
+            assert _SECRET not in value, f"secret leaked via {key!r}"
+            assert _URL_PATH_MARKER not in value, f"full URL leaked via {key!r}"
+        # The one place a host IS expected to appear.
+        if "endpoint_host" in record.__dict__:
+            assert record.__dict__["endpoint_host"] == "fake-manager.test"
+    # Confirm _log_attempt's extra dict only ever carries the documented
+    # fields — no stray "payload"/"signature"/"secret" key ever makes it in.
+    logged_keys = {
+        k
+        for r in records
+        for k in r.__dict__
+        if k
+        not in (
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "taskName",
+        )
+    }
+    forbidden = {"payload", "signature", "secret", "endpoint", "url", "raw_json_body"}
+    leaked = logged_keys & forbidden
+    assert not leaked, f"forbidden log fields present: {leaked}"
+
+
+async def test_successful_delivery_log_is_redacted(
+    store: SqlAlchemySessionLifecycleStore, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A successful delivery's log line never carries payload/secret/signature/full URL."""
+    session_id = _hex_id("session-a")
+    event_id = _insert_event(store, session_id=session_id)
+    app = _build_fake_manager(always_fail=False)
+    transport = httpx.ASGITransport(app=app)
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.manager_webhook_dispatcher"):
+        async with httpx.AsyncClient(transport=transport) as client:
+            claimed = store.claim_batch(
+                limit=10, now=int(time.time()), lease_owner="r1", lease_seconds=60
+            )
+            [event] = [c for c in claimed if c.id == event_id]
+            await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+
+    records = [r for r in caplog.records if r.name == "omnigent.server.manager_webhook_dispatcher"]
+    _assert_log_records_are_clean(records)
+    # Sanity: the delivery actually succeeded (proves this isn't a vacuous
+    # pass from an early-exit failure path).
+    assert store.latest_delivery(session_id) is not None
+    assert store.latest_delivery(session_id).status == "delivered"
+
+
+async def test_failed_delivery_log_is_redacted(
+    store: SqlAlchemySessionLifecycleStore, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed (500) delivery's log line is equally redacted — the error path is not exempt."""
+    session_id = _hex_id("session-b")
+    event_id = _insert_event(store, session_id=session_id)
+    app = _build_fake_manager(always_fail=True)
+    transport = httpx.ASGITransport(app=app)
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.manager_webhook_dispatcher"):
+        async with httpx.AsyncClient(transport=transport) as client:
+            claimed = store.claim_batch(
+                limit=10, now=int(time.time()), lease_owner="r1", lease_seconds=60
+            )
+            [event] = [c for c in claimed if c.id == event_id]
+            await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+
+    records = [r for r in caplog.records if r.name == "omnigent.server.manager_webhook_dispatcher"]
+    _assert_log_records_are_clean(records)
+    assert store.latest_delivery(session_id).status in ("pending", "dead_letter")
+
+
+async def test_missing_secret_log_is_redacted(
+    store: SqlAlchemySessionLifecycleStore,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The "missing secret" error path (never signs/sends) still logs cleanly."""
+    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", raising=False)
+    session_id = _hex_id("session-c")
+    event_id = _insert_event(store, session_id=session_id)
+    app = _build_fake_manager(always_fail=False)
+    transport = httpx.ASGITransport(app=app)
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.manager_webhook_dispatcher"):
+        async with httpx.AsyncClient(transport=transport) as client:
+            claimed = store.claim_batch(
+                limit=10, now=int(time.time()), lease_owner="r1", lease_seconds=60
+            )
+            [event] = [c for c in claimed if c.id == event_id]
+            await dispatcher._deliver_one(client, store, event, endpoint=_ENDPOINT, key_id="k1")
+
+    records = [r for r in caplog.records if r.name == "omnigent.server.manager_webhook_dispatcher"]
+    _assert_log_records_are_clean(records)

--- a/tests/server/test_manager_webhook_signing.py
+++ b/tests/server/test_manager_webhook_signing.py
@@ -238,22 +238,22 @@ def test_verify_ignores_empty_secret_candidates() -> None:
 
 
 def test_current_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", "abc123")
+    monkeypatch.setenv(signing.SECRET_ENV_VAR, "abc123")
     assert signing.current_secret() == "abc123"
 
 
 def test_current_secret_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv(signing.SECRET_ENV_VAR, raising=False)
     assert signing.current_secret() is None
 
 
 def test_previous_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS", "old123")
+    monkeypatch.setenv(signing.PREVIOUS_SECRET_ENV_VAR, "old123")
     assert signing.previous_secret() == "old123"
 
 
 def test_previous_secret_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS", raising=False)
+    monkeypatch.delenv(signing.PREVIOUS_SECRET_ENV_VAR, raising=False)
     assert signing.previous_secret() is None
 
 

--- a/tests/server/test_manager_webhook_signing.py
+++ b/tests/server/test_manager_webhook_signing.py
@@ -1,0 +1,352 @@
+"""Tests for the manager-webhook HMAC signing scheme and its config loading.
+
+Covers ``omnigent.server.manager_webhook_signing`` (sign/verify/build_headers,
+the Stripe-style canonicalization) and the ``manager_webhook`` block of
+``omnigent.server.server_config`` (fail-closed HTTPS enforcement). See
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md`` §8.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.server import manager_webhook_signing as signing
+from omnigent.server import server_config
+
+# ── sign() ──────────────────────────────────────────────────────
+
+
+def test_sign_is_deterministic() -> None:
+    a = signing.sign(secret="s3cr3t", timestamp=1000, event_id="evt1", raw_json_body='{"a":1}')
+    b = signing.sign(secret="s3cr3t", timestamp=1000, event_id="evt1", raw_json_body='{"a":1}')
+    assert a == b
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"secret": "different"},
+        {"timestamp": 1001},
+        {"event_id": "evt2"},
+        {"raw_json_body": '{"a":2}'},
+    ],
+)
+def test_sign_changes_with_any_input(kwargs: dict[str, object]) -> None:
+    base = {
+        "secret": "s3cr3t",
+        "timestamp": 1000,
+        "event_id": "evt1",
+        "raw_json_body": '{"a":1}',
+    }
+    baseline = signing.sign(**base)
+    varied = {**base, **kwargs}
+    assert signing.sign(**varied) != baseline
+
+
+def test_sign_output_format() -> None:
+    value = signing.sign(secret="s3cr3t", timestamp=1000, event_id="evt1", raw_json_body="{}")
+    assert value.startswith("v1=")
+    digest = value.removeprefix("v1=")
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+# ── verify() ────────────────────────────────────────────────────
+
+
+def test_verify_accepts_correctly_signed_fresh_request() -> None:
+    now = 1_800_000_000
+    signature = signing.sign(secret="s3cr3t", timestamp=now, event_id="evt1", raw_json_body="{}")
+    assert signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_rejects_tampered_body() -> None:
+    now = 1_800_000_000
+    signature = signing.sign(
+        secret="s3cr3t", timestamp=now, event_id="evt1", raw_json_body='{"a":1}'
+    )
+    assert not signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body='{"a":2}',
+        now=now,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_rejects_tampered_event_id() -> None:
+    now = 1_800_000_000
+    signature = signing.sign(secret="s3cr3t", timestamp=now, event_id="evt1", raw_json_body="{}")
+    assert not signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt2",
+        raw_json_body="{}",
+        now=now,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_rejects_timestamp_substitution() -> None:
+    """A signature computed for one timestamp must not verify against another.
+
+    Even though nothing about the header's *format* is wrong, the
+    canonicalized content differs, so the digest cannot match.
+    """
+    signed_at = 1_800_000_000
+    signature = signing.sign(
+        secret="s3cr3t", timestamp=signed_at, event_id="evt1", raw_json_body="{}"
+    )
+    assert not signing.verify(
+        signature_header=signature,
+        timestamp=signed_at + 1,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=signed_at + 1,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_rejects_stale_timestamp_even_with_valid_signature() -> None:
+    """The specific acceptance-test requirement: a stale timestamp is rejected
+    even when the signature is otherwise mathematically correct for it."""
+    signed_at = 1_800_000_000
+    signature = signing.sign(
+        secret="s3cr3t", timestamp=signed_at, event_id="evt1", raw_json_body="{}"
+    )
+    far_future = signed_at + signing.DEFAULT_TOLERANCE_SECONDS + 1
+    assert not signing.verify(
+        signature_header=signature,
+        timestamp=signed_at,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=far_future,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_tolerance_boundary() -> None:
+    signed_at = 1_800_000_000
+    signature = signing.sign(
+        secret="s3cr3t", timestamp=signed_at, event_id="evt1", raw_json_body="{}"
+    )
+    tolerance = 300
+    # Exactly at the boundary: abs(now - timestamp) == tolerance -> accepted.
+    at_boundary = signing.verify(
+        signature_header=signature,
+        timestamp=signed_at,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=signed_at + tolerance,
+        secrets=["s3cr3t"],
+        tolerance_seconds=tolerance,
+    )
+    assert at_boundary
+    # One second past -> rejected.
+    past_boundary = signing.verify(
+        signature_header=signature,
+        timestamp=signed_at,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=signed_at + tolerance + 1,
+        secrets=["s3cr3t"],
+        tolerance_seconds=tolerance,
+    )
+    assert not past_boundary
+
+
+def test_verify_supports_secret_rotation() -> None:
+    now = 1_800_000_000
+    signature = signing.sign(secret="new", timestamp=now, event_id="evt1", raw_json_body="{}")
+    # Verifying against both old+new (rotation window) succeeds.
+    assert signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["old", "new"],
+    )
+    # Verifying against only the old secret fails.
+    assert not signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["old"],
+    )
+
+
+def test_verify_ignores_empty_secret_candidates() -> None:
+    now = 1_800_000_000
+    signature = signing.sign(secret="s3cr3t", timestamp=now, event_id="evt1", raw_json_body="{}")
+    assert signing.verify(
+        signature_header=signature,
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["", "s3cr3t"],
+    )
+
+
+# ── current_secret() / previous_secret() ───────────────────────
+
+
+def test_current_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", "abc123")
+    assert signing.current_secret() == "abc123"
+
+
+def test_current_secret_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET", raising=False)
+    assert signing.current_secret() is None
+
+
+def test_previous_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS", "old123")
+    assert signing.previous_secret() == "old123"
+
+
+def test_previous_secret_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNIGENT_MANAGER_WEBHOOK_SECRET_PREVIOUS", raising=False)
+    assert signing.previous_secret() is None
+
+
+# ── build_headers() ─────────────────────────────────────────────
+
+
+def test_build_headers_includes_all_required_headers() -> None:
+    headers = signing.build_headers(
+        event_id="evt1",
+        event_type="session.completed",
+        attempt=2,
+        timestamp=1000,
+        key_id="key-a",
+        signature="v1=deadbeef",
+    )
+    assert headers == {
+        "Content-Type": "application/json",
+        "X-Omnigent-Event-Id": "evt1",
+        "X-Omnigent-Event-Type": "session.completed",
+        "X-Omnigent-Delivery-Attempt": "2",
+        "X-Omnigent-Timestamp": "1000",
+        "X-Omnigent-Signature": "v1=deadbeef",
+        "X-Omnigent-Key-Id": "key-a",
+    }
+
+
+def test_build_headers_omits_key_id_when_none() -> None:
+    headers = signing.build_headers(
+        event_id="evt1",
+        event_type="session.completed",
+        attempt=1,
+        timestamp=1000,
+        key_id=None,
+        signature="v1=deadbeef",
+    )
+    assert "X-Omnigent-Key-Id" not in headers
+
+
+# ── manager_webhook_config() ────────────────────────────────────
+
+
+def _write_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: dict[str, object]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(data))
+    monkeypatch.setenv("OMNIGENT_CONFIG", str(config_path))
+
+
+def test_manager_webhook_config_default_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OMNIGENT_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = server_config.manager_webhook_config()
+    assert cfg.enabled is False
+    assert cfg.endpoint is None
+
+
+def test_manager_webhook_config_https_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {"manager_webhook": {"enabled": True, "endpoint": "https://manager.example.com/hook"}},
+    )
+    cfg = server_config.manager_webhook_config()
+    assert cfg.enabled is True
+    assert cfg.endpoint == "https://manager.example.com/hook"
+
+
+def test_manager_webhook_config_http_without_override_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {"manager_webhook": {"enabled": True, "endpoint": "http://manager.example.com/hook"}},
+    )
+    with pytest.raises(server_config.ManagerWebhookConfigError):
+        server_config.manager_webhook_config()
+
+
+def test_manager_webhook_config_http_with_dev_override_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "manager_webhook": {
+                "enabled": True,
+                "endpoint": "http://localhost:9999/hook",
+                "allow_insecure_dev_endpoint": True,
+            }
+        },
+    )
+    cfg = server_config.manager_webhook_config()
+    assert cfg.enabled is True
+    assert cfg.endpoint == "http://localhost:9999/hook"
+
+
+def test_manager_webhook_config_enabled_without_endpoint_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(tmp_path, monkeypatch, {"manager_webhook": {"enabled": True}})
+    with pytest.raises(server_config.ManagerWebhookConfigError):
+        server_config.manager_webhook_config()
+
+
+def test_manager_webhook_config_key_id_round_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "manager_webhook": {
+                "enabled": True,
+                "endpoint": "https://manager.example.com/hook",
+                "key_id": "key-2026-08",
+            }
+        },
+    )
+    cfg = server_config.manager_webhook_config()
+    assert cfg.key_id == "key-2026-08"

--- a/tests/server/test_manager_webhook_signing.py
+++ b/tests/server/test_manager_webhook_signing.py
@@ -85,6 +85,38 @@ def test_verify_rejects_tampered_body() -> None:
     )
 
 
+def test_verify_rejects_missing_signature() -> None:
+    """An empty/absent ``X-Omnigent-Signature`` header must not verify.
+
+    Distinct from "tampered" (a syntactically-shaped but wrong signature) —
+    this is what a receiver sees when the header is missing entirely, e.g.
+    ``request.headers.get("X-Omnigent-Signature", "")``. The acceptance
+    contract requires both missing AND invalid HMAC rejection.
+    """
+    now = 1_800_000_000
+    assert not signing.verify(
+        signature_header="",
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["s3cr3t"],
+    )
+
+
+def test_verify_rejects_malformed_signature_header() -> None:
+    """A present but malformed header (wrong prefix/shape) must not verify."""
+    now = 1_800_000_000
+    assert not signing.verify(
+        signature_header="not-a-real-signature",
+        timestamp=now,
+        event_id="evt1",
+        raw_json_body="{}",
+        now=now,
+        secrets=["s3cr3t"],
+    )
+
+
 def test_verify_rejects_tampered_event_id() -> None:
     now = 1_800_000_000
     signature = signing.sign(secret="s3cr3t", timestamp=now, event_id="evt1", raw_json_body="{}")

--- a/tests/server/test_manager_webhook_signing.py
+++ b/tests/server/test_manager_webhook_signing.py
@@ -234,17 +234,17 @@ def test_verify_ignores_empty_secret_candidates() -> None:
     )
 
 
-# ── current_secret() / previous_secret() ───────────────────────
+# ── current_signing_key() / previous_secret() ───────────────────
 
 
-def test_current_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_current_signing_key_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(signing.SECRET_ENV_VAR, "abc123")
-    assert signing.current_secret() == "abc123"
+    assert signing.current_signing_key() == "abc123"
 
 
-def test_current_secret_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_current_signing_key_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(signing.SECRET_ENV_VAR, raising=False)
-    assert signing.current_secret() is None
+    assert signing.current_signing_key() is None
 
 
 def test_previous_secret_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/test_manager_webhook_startup_gate.py
+++ b/tests/server/test_manager_webhook_startup_gate.py
@@ -1,0 +1,98 @@
+"""``create_app`` fails closed on an invalid ``manager_webhook`` config (OMN-104).
+
+``manager_webhook_dispatcher._run_once`` re-checks the same config every idle
+cycle and, on ``ManagerWebhookConfigError``, logs a warning and treats the
+webhook as disabled rather than crashing an already-running server — a config
+file edited into a bad state after boot must not take the server down. But an
+operator who *starts* the server with ``manager_webhook.enabled: true`` and a
+bad endpoint deserves an immediate, loud startup failure instead of a server
+that appears to boot fine and then silently never delivers anything. This
+file locks in that boot-time gate directly on ``create_app``, independent of
+``manager_webhook_config()``'s own unit tests in
+``test_manager_webhook_signing.py`` (which cover the validation rules, not
+where in the app lifecycle they're enforced).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.server_config import ManagerWebhookConfigError
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+
+def _write_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: dict[str, object]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(data))
+    monkeypatch.setenv("OMNIGENT_CONFIG", str(config_path))
+
+
+def _build_app(db_uri: str, tmp_path: Path) -> object:
+    """Construct create_app with the minimal required stores, nothing else."""
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+    )
+
+
+def test_create_app_raises_on_enabled_without_endpoint(
+    db_uri: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``manager_webhook.enabled: true`` with no endpoint must fail app
+    construction, not silently boot into a dispatcher that idles forever."""
+    _write_config(tmp_path, monkeypatch, {"manager_webhook": {"enabled": True}})
+    with pytest.raises(ManagerWebhookConfigError):
+        _build_app(db_uri, tmp_path)
+
+
+def test_create_app_raises_on_enabled_with_http_endpoint(
+    db_uri: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-HTTPS endpoint without the explicit dev override must fail
+    app construction the same way ``manager_webhook_config()`` itself does."""
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {"manager_webhook": {"enabled": True, "endpoint": "http://manager.example.com/hook"}},
+    )
+    with pytest.raises(ManagerWebhookConfigError):
+        _build_app(db_uri, tmp_path)
+
+
+def test_create_app_boots_with_manager_webhook_disabled(
+    db_uri: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default (no config block at all) must not be affected by the gate."""
+    monkeypatch.delenv("OMNIGENT_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _build_app(db_uri, tmp_path)
+
+
+def test_create_app_boots_with_valid_enabled_config(
+    db_uri: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A correctly configured, enabled webhook must not trip the gate."""
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {"manager_webhook": {"enabled": True, "endpoint": "https://manager.example.com/hook"}},
+    )
+    _build_app(db_uri, tmp_path)

--- a/tests/server/test_session_outbox.py
+++ b/tests/server/test_session_outbox.py
@@ -82,6 +82,14 @@ def test_record_session_completed_noop_when_unconfigured() -> None:
 
 
 def test_record_session_failed_writes_row(store: SqlAlchemySessionLifecycleStore) -> None:
+    """
+    Cross-vendor review: the delivered ``reason.message`` is a fixed, safe
+    string selected by ``error_code`` — never a passthrough of
+    ``error_message`` (see :data:`session_outbox._SAFE_FAILURE_MESSAGES`
+    and :func:`session_outbox.record_session_failed`'s docstring). Free-form
+    diagnostic text like ``error_message`` here can incidentally embed
+    secrets and this payload is HMAC-signed and delivered externally.
+    """
     session_outbox.record_session_failed(
         workspace_id=0,
         session_id=SESSION_ID,
@@ -94,12 +102,37 @@ def test_record_session_failed_writes_row(store: SqlAlchemySessionLifecycleStore
     payload = json.loads(row.payload)
     assert payload["response_id"] == "resp1"
     assert payload["reason"]["code"] == "runner_error"
-    assert payload["reason"]["message"] == "turn setup failed"
+    assert payload["reason"]["message"] == "The runner reported an error."
+    assert "turn setup failed" not in row.payload
 
 
-def test_record_session_failed_truncates_long_message(
+def test_record_session_failed_unrecognized_code_falls_back_to_generic_message(
     store: SqlAlchemySessionLifecycleStore,
 ) -> None:
+    """An ``error_code`` with no entry in the safe-message map still never
+    leaks ``error_message`` — it falls back to the fully generic message,
+    not an unsafe default."""
+    session_outbox.record_session_failed(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        response_id="resp1",
+        error_code="some_unmapped_future_code",
+        error_message="anything at all, even secret-shaped text",
+    )
+    row = _outbox_row_for(store, SESSION_ID, "session.failed")
+    payload = json.loads(row.payload)
+    assert payload["reason"]["code"] == "some_unmapped_future_code"
+    assert payload["reason"]["message"] == session_outbox._DEFAULT_SAFE_FAILURE_MESSAGE
+    assert "anything at all" not in row.payload
+
+
+def test_record_session_failed_message_length_never_depends_on_error_message(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """The delivered message is a fixed short safe string regardless of how
+    long (or short) ``error_message`` is — proving the fix genuinely
+    decouples the delivered payload from the raw diagnostic text's size,
+    not just its content."""
     long_message = "x" * (LABEL_VALUE_MAX_LEN + 500)
     session_outbox.record_session_failed(
         workspace_id=0,
@@ -111,37 +144,70 @@ def test_record_session_failed_truncates_long_message(
     row = _outbox_row_for(store, SESSION_ID, "session.failed")
     payload = json.loads(row.payload)
     message = payload["reason"]["message"]
-    assert len(message) == LABEL_VALUE_MAX_LEN
-    assert message.endswith("…")
+    assert message == "The runner reported an error."
     assert message != long_message
+    assert "x" * 100 not in row.payload
 
 
-def test_record_session_failed_denylist_is_key_based_not_value_based(
+def test_record_session_failed_never_leaks_secret_shaped_error_message(
     store: SqlAlchemySessionLifecycleStore,
 ) -> None:
-    """``_redact_denylist`` redacts by DICT KEY, not by scanning the value's
-    contents. Neither "code" nor "message" matches
-    ``_REDACT_KEY_SUBSTRINGS`` (token/secret/password/authorization/
-    credential/api_key/apikey), so a message that happens to CONTAIN a
-    denylisted word (e.g. "secret") passes through unredacted — this is
-    real, current behavior: the denylist here is a defensive
-    belt-and-suspenders pass on the {"code","message"} dict's own keys, not
-    the primary protection (that's the allowlist for awaiting_decision/
-    resumed payloads, tested below). Only the length clamp actually bounds
-    this path.
     """
+    Cross-vendor review P1: a message that DELIBERATELY embeds
+    secret-shaped strings (a fake API key, a bearer token, a DB connection
+    string) — the exact shape of a provider error, subprocess stderr, or a
+    runner-forwarded, structurally-unvalidated ``error`` dict — must NEVER
+    reach the persisted outbox row (and therefore never the HMAC-signed,
+    externally-delivered webhook payload). ``_redact_denylist`` alone
+    (KEY-based, not value-based) could never catch this; the fix is that
+    ``error_message`` is simply never used to build the delivered message
+    at all.
+    """
+    fake_api_key = "sk-live-abc123FAKEKEYdeadbeefCAFEBABE"
+    fake_bearer_token = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.FAKE.TOKEN"
+    fake_db_conn_string = (
+        "postgresql://admin:SuperSecretPassw0rd@internal-db.example.com:5432/prod"
+    )
+    malicious_message = (
+        f"provider error: api_key={fake_api_key} "
+        f"auth_header={fake_bearer_token} "
+        f"connection_failed to {fake_db_conn_string}"
+    )
     session_outbox.record_session_failed(
         workspace_id=0,
         session_id=SESSION_ID,
         response_id="resp1",
         error_code="runner_error",
-        error_message="leaked the secret token abc123",
+        error_message=malicious_message,
     )
     row = _outbox_row_for(store, SESSION_ID, "session.failed")
     payload = json.loads(row.payload)
-    # Confirms the real (key-based, not value-based) behavior.
-    assert payload["reason"]["message"] == "leaked the secret token abc123"
+    assert payload["reason"]["message"] == "The runner reported an error."
     assert payload["reason"]["code"] == "runner_error"
+    # None of the embedded secrets, nor any fragment of the raw message,
+    # appear anywhere in the persisted (and therefore delivered) row.
+    assert fake_api_key not in row.payload
+    assert fake_bearer_token not in row.payload
+    assert fake_db_conn_string not in row.payload
+    assert "SuperSecretPassw0rd" not in row.payload
+    assert malicious_message not in row.payload
+
+
+def test_record_session_failed_denylist_is_key_based_not_value_based(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """``_redact_denylist`` itself still redacts by DICT KEY, not by
+    scanning value contents — this is documented, narrow, defensive
+    belt-and-suspenders behavior on the ``{"code","message"}`` dict's own
+    keys. It is NOT what protects ``session.failed`` from leaking secrets
+    (that's the allowlisted safe-message map tested above); confirming
+    this narrower fact separately so a future denylist change doesn't
+    silently assume it does more than it does.
+    """
+    from omnigent.server.session_outbox import _redact_denylist
+
+    result = _redact_denylist({"code": "runner_error", "message": "leaked the secret token"})
+    assert result == {"code": "runner_error", "message": "leaked the secret token"}
 
 
 def test_record_session_failed_noop_when_unconfigured() -> None:

--- a/tests/server/test_session_outbox.py
+++ b/tests/server/test_session_outbox.py
@@ -1,0 +1,333 @@
+"""Tests for the durable session-lifecycle-event producer.
+
+Covers ``omnigent.server.session_outbox`` against a real
+``SqlAlchemySessionLifecycleStore`` (SQLite) — the point of these tests is
+the redaction/allowlist boundary (§3.2 of
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md``), which
+only a real round-trip through JSON serialization can prove.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
+from omnigent.server import session_outbox
+from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
+    SqlAlchemySessionLifecycleStore,
+)
+
+SESSION_ID = "a1" * 16
+ELICITATION_ID = "e1" * 16
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
+    """Wire a real session-lifecycle store into the module; unwire on teardown."""
+    real_store = SqlAlchemySessionLifecycleStore(db_uri)
+    session_outbox.configure(real_store)
+    yield real_store
+    session_outbox.configure(None)
+
+
+def _outbox_row_for(store: SqlAlchemySessionLifecycleStore, session_id: str, event_type: str):
+    deliveries, _ = store.list_deliveries(session_id, limit=100)
+    matches = [d for d in deliveries if d.event_type == event_type]
+    assert len(matches) == 1, f"expected exactly one {event_type} row, got {len(matches)}"
+    return matches[0]
+
+
+# ── record_session_completed ────────────────────────────────────
+
+
+def test_record_session_completed_writes_row(store: SqlAlchemySessionLifecycleStore) -> None:
+    session_outbox.record_session_completed(
+        workspace_id=0, session_id=SESSION_ID, response_id="resp1"
+    )
+    row = _outbox_row_for(store, SESSION_ID, "session.completed")
+    assert row.transition_key == "turn:resp1:completed"
+    payload = json.loads(row.payload)
+    assert payload["response_id"] == "resp1"
+
+
+def test_record_session_completed_deterministic_event_id_and_idempotent(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    id_a = session_outbox._deterministic_event_id(0, SESSION_ID, "turn:resp1:completed")
+    id_b = session_outbox._deterministic_event_id(0, SESSION_ID, "turn:resp1:completed")
+    assert id_a == id_b
+
+    session_outbox.record_session_completed(
+        workspace_id=0, session_id=SESSION_ID, response_id="resp1"
+    )
+    session_outbox.record_session_completed(
+        workspace_id=0, session_id=SESSION_ID, response_id="resp1"
+    )
+    deliveries, _ = store.list_deliveries(SESSION_ID, limit=100)
+    assert len(deliveries) == 1
+    assert deliveries[0].id == id_a
+
+
+def test_record_session_completed_noop_when_unconfigured() -> None:
+    session_outbox.configure(None)
+    # Must not raise even though nothing is wired.
+    session_outbox.record_session_completed(
+        workspace_id=0, session_id=SESSION_ID, response_id="resp1"
+    )
+
+
+# ── record_session_failed ───────────────────────────────────────
+
+
+def test_record_session_failed_writes_row(store: SqlAlchemySessionLifecycleStore) -> None:
+    session_outbox.record_session_failed(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        response_id="resp1",
+        error_code="runner_error",
+        error_message="turn setup failed",
+    )
+    row = _outbox_row_for(store, SESSION_ID, "session.failed")
+    assert row.transition_key == "turn:resp1:failed"
+    payload = json.loads(row.payload)
+    assert payload["response_id"] == "resp1"
+    assert payload["reason"]["code"] == "runner_error"
+    assert payload["reason"]["message"] == "turn setup failed"
+
+
+def test_record_session_failed_truncates_long_message(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    long_message = "x" * (LABEL_VALUE_MAX_LEN + 500)
+    session_outbox.record_session_failed(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        response_id="resp1",
+        error_code="runner_error",
+        error_message=long_message,
+    )
+    row = _outbox_row_for(store, SESSION_ID, "session.failed")
+    payload = json.loads(row.payload)
+    message = payload["reason"]["message"]
+    assert len(message) == LABEL_VALUE_MAX_LEN
+    assert message.endswith("…")
+    assert message != long_message
+
+
+def test_record_session_failed_denylist_is_key_based_not_value_based(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """``_redact_denylist`` redacts by DICT KEY, not by scanning the value's
+    contents. Neither "code" nor "message" matches
+    ``_REDACT_KEY_SUBSTRINGS`` (token/secret/password/authorization/
+    credential/api_key/apikey), so a message that happens to CONTAIN a
+    denylisted word (e.g. "secret") passes through unredacted — this is
+    real, current behavior: the denylist here is a defensive
+    belt-and-suspenders pass on the {"code","message"} dict's own keys, not
+    the primary protection (that's the allowlist for awaiting_decision/
+    resumed payloads, tested below). Only the length clamp actually bounds
+    this path.
+    """
+    session_outbox.record_session_failed(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        response_id="resp1",
+        error_code="runner_error",
+        error_message="leaked the secret token abc123",
+    )
+    row = _outbox_row_for(store, SESSION_ID, "session.failed")
+    payload = json.loads(row.payload)
+    # Confirms the real (key-based, not value-based) behavior.
+    assert payload["reason"]["message"] == "leaked the secret token abc123"
+    assert payload["reason"]["code"] == "runner_error"
+
+
+def test_record_session_failed_noop_when_unconfigured() -> None:
+    session_outbox.configure(None)
+    session_outbox.record_session_failed(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        response_id="resp1",
+        error_code="x",
+        error_message="y",
+    )
+
+
+# ── record_elicitation_raised: the allowlist boundary ───────────
+
+
+def test_record_elicitation_raised_allowlist_excludes_raw_env_and_content_preview(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Acceptance-test row: "a field outside the allowlist (e.g. raw env
+    dict on the harness side) is asserted absent from the payload."
+
+    ``ElicitationRequestParams`` has ``extra="allow"`` (MCP passthrough), so
+    an unrecognized field must be structurally excluded by an allowlist,
+    not filtered by key-name recognition. This test proves that both the
+    durable ``session_elicitations.request_payload`` and the
+    ``session.awaiting_decision`` outbox event's ``data.request`` are built
+    from the same allowlist.
+    """
+    request = {
+        # Allowlisted fields.
+        "message": "Approve running 'rm -rf /tmp/cache'?",
+        "mode": "form",
+        "requestedSchema": {"type": "object", "properties": {"approve": {"type": "boolean"}}},
+        "phase": "pre_tool_use",
+        "policy_name": "approve_shell_commands",
+        "target_session_id": None,  # falsy -> omitted regardless
+        "tool_name": "Bash",
+        # NOT allowlisted — must never reach persisted storage. Uses marker
+        # strings distinct from the allowlisted "message" text above, so the
+        # leakage check below can't false-positive on legitimately-allowed
+        # content that happens to mention the same command.
+        "tool_input": {
+            "command": "rm -rf /tmp/cache",
+            "env": {"AWS_SECRET_ACCESS_KEY": "shh-marker-1", "PATH": "/usr/bin"},
+        },
+        "content_preview": "leaked-marker-2 stuff that should not be stored",
+        "url": None,  # falsy allowlisted field -> also omitted
+    }
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        elicitation_id=ELICITATION_ID,
+        request=request,
+    )
+
+    elicitation = store.get_elicitation(ELICITATION_ID)
+    assert elicitation is not None
+    request_payload = json.loads(elicitation.request_payload)
+
+    outbox_row = _outbox_row_for(store, SESSION_ID, "session.awaiting_decision")
+    outbox_payload = json.loads(outbox_row.payload)
+    outbox_request = outbox_payload["request"]
+
+    for payload in (request_payload, outbox_request):
+        assert payload["message"] == "Approve running 'rm -rf /tmp/cache'?"
+        assert payload["mode"] == "form"
+        assert payload["requestedSchema"] == {
+            "type": "object",
+            "properties": {"approve": {"type": "boolean"}},
+        }
+        assert payload["phase"] == "pre_tool_use"
+        assert payload["policy_name"] == "approve_shell_commands"
+        assert payload["tool_name"] == "Bash"
+        # The core assertion: disallowed fields are structurally absent.
+        assert "tool_input" not in payload
+        assert "content_preview" not in payload
+        # Also confirm no nested leakage anywhere in the serialized payload.
+        serialized = json.dumps(payload)
+        assert "AWS_SECRET_ACCESS_KEY" not in serialized
+        assert "shh-marker-1" not in serialized
+        assert "leaked-marker-2" not in serialized
+
+
+def test_record_elicitation_raised_idempotent(store: SqlAlchemySessionLifecycleStore) -> None:
+    request = {"message": "Approve?", "tool_name": "Bash"}
+    session_outbox.record_elicitation_raised(
+        workspace_id=0, session_id=SESSION_ID, elicitation_id=ELICITATION_ID, request=request
+    )
+    session_outbox.record_elicitation_raised(
+        workspace_id=0, session_id=SESSION_ID, elicitation_id=ELICITATION_ID, request=request
+    )
+    deliveries, _ = store.list_deliveries(SESSION_ID, limit=100)
+    awaiting = [d for d in deliveries if d.event_type == "session.awaiting_decision"]
+    assert len(awaiting) == 1
+
+
+# ── record_decision: the allowlist boundary on the decision side ─
+
+
+def test_record_decision_allowlist_excludes_raw_headers(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        elicitation_id=ELICITATION_ID,
+        request={"message": "Approve?"},
+    )
+    decision = {
+        "action": "accept",
+        "content": {"approve": True},
+        "raw_headers": {"Authorization": "Bearer secret-token"},
+    }
+    session_outbox.record_decision(
+        elicitation_id=ELICITATION_ID, decision=decision, decided_by="manager@example.com"
+    )
+
+    elicitation = store.get_elicitation(ELICITATION_ID)
+    assert elicitation is not None
+    assert elicitation.status == "decided"
+    assert elicitation.decided_by == "manager@example.com"
+    decision_payload = json.loads(elicitation.decision_payload)
+    assert decision_payload["action"] == "accept"
+    assert decision_payload["content"] == {"approve": True}
+    assert "raw_headers" not in decision_payload
+    assert "Bearer secret-token" not in json.dumps(decision_payload)
+
+
+# ── record_elicitation_resumed ───────────────────────────────────
+
+
+def test_record_elicitation_resumed_after_decision(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        elicitation_id=ELICITATION_ID,
+        request={"message": "Approve?"},
+    )
+    session_outbox.record_decision(
+        elicitation_id=ELICITATION_ID,
+        decision={"action": "accept", "content": None},
+        decided_by=None,
+    )
+
+    resumed = session_outbox.record_elicitation_resumed(
+        workspace_id=0, elicitation_id=ELICITATION_ID
+    )
+    assert resumed is True
+
+    outbox_row = _outbox_row_for(store, SESSION_ID, "session.resumed")
+    payload = json.loads(outbox_row.payload)
+    assert payload["elicitation_id"] == ELICITATION_ID
+    assert payload["decision"]["action"] == "accept"
+
+    elicitation = store.get_elicitation(ELICITATION_ID)
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"
+    assert elicitation.resolved_at is not None
+
+    # Idempotent: a second call (no new decision) is a no-op.
+    resumed_again = session_outbox.record_elicitation_resumed(
+        workspace_id=0, elicitation_id=ELICITATION_ID
+    )
+    assert resumed_again is False
+    deliveries, _ = store.list_deliveries(SESSION_ID, limit=100)
+    resumed_rows = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert len(resumed_rows) == 1
+
+
+def test_record_elicitation_resumed_without_decision_is_noop(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    session_outbox.record_elicitation_raised(
+        workspace_id=0,
+        session_id=SESSION_ID,
+        elicitation_id=ELICITATION_ID,
+        request={"message": "Approve?"},
+    )
+    # Never decided — still "pending".
+    resumed = session_outbox.record_elicitation_resumed(
+        workspace_id=0, elicitation_id=ELICITATION_ID
+    )
+    assert resumed is False
+    deliveries, _ = store.list_deliveries(SESSION_ID, limit=100)
+    resumed_rows = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert resumed_rows == []

--- a/tests/stores/test_conversation_store_disconnect_atomicity.py
+++ b/tests/stores/test_conversation_store_disconnect_atomicity.py
@@ -1,0 +1,146 @@
+"""Atomicity of the disconnect write vs a concurrent cross-replica read (OMN-104).
+
+Cross-vendor review, P2: the disconnect path used to call
+``ConversationStore.clear_runner_liveness`` and
+``ConversationStore.set_runner_disconnect_grace`` as two SEPARATE store
+writes (two transactions, two commits). Because they were separate, another
+replica reading ``get_session_connectivity`` in the real gap between those
+two commits could observe BOTH ``runner_last_seen`` cleared AND
+``runner_disconnect_grace_deadline`` still absent simultaneously — the
+runner looking neither live nor grace-pending — and a manager decision
+landing in that exact window would be falsely classified as "runner dead"
+(410) even though the runner is genuinely still within its reconnect grace.
+
+The fix (``ConversationStore.mark_runner_disconnected``) persists both
+fields in ONE ``UPDATE`` / one commit, so there is no third, in-between
+state a reader can ever observe — this file proves that with genuine
+concurrent threads racing real reads against real writes on whatever
+backend ``db_uri`` resolves to (SQLite locally, real Postgres in CI's
+``stores-postgres`` lane, where a torn read is actually possible under
+READ COMMITTED with two separate transactions).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+SID_A = "a1" * 16
+RUNNER_ID = "runner_disconnect_atomicity_test"
+_READER_ITERATIONS = 400
+
+
+def _seed_bound_session(store: SqlAlchemyConversationStore) -> None:
+    """Create a real session bound to RUNNER_ID with fresh liveness (the
+    exact pre-disconnect state: connected, no grace pending)."""
+    store.create_conversation(conversation_id=SID_A)
+    assert store.set_runner_id(SID_A, RUNNER_ID)
+    store.touch_runner_liveness([RUNNER_ID], int(time.time()))
+
+
+def _is_torn(store: SqlAlchemyConversationStore) -> bool:
+    """True iff the runner currently looks neither live nor grace-pending
+    — the bad, "in between" state a reader must never observe while the
+    runner is genuinely mid-disconnect (either it's still fresh-live, or
+    it's cleared-but-graced; never both absent)."""
+    conn = store.get_session_connectivity([SID_A])[SID_A]
+    now = time.time()
+    live = conn.runner_last_seen is not None and conn.runner_last_seen >= now - 90
+    graced = (
+        conn.runner_disconnect_grace_deadline is not None
+        and conn.runner_disconnect_grace_deadline > now
+    )
+    return not live and not graced
+
+
+def test_mark_runner_disconnected_atomic_write_has_no_torn_read_window(db_uri: str) -> None:
+    """
+    The FIXED path: a real concurrent reader hammering
+    ``get_session_connectivity`` while ``mark_runner_disconnected`` writes,
+    across many disconnect/reconnect cycles, must never observe the torn
+    "neither live nor graced" state.
+    """
+    store = SqlAlchemyConversationStore(db_uri)
+    _seed_bound_session(store)
+
+    torn_observations: list[int] = []
+    stop = threading.Event()
+
+    def _reader() -> None:
+        count = 0
+        while not stop.is_set():
+            if _is_torn(store):
+                torn_observations.append(count)
+            count += 1
+
+    reader = threading.Thread(target=_reader)
+    reader.start()
+    try:
+        for _ in range(30):
+            store.mark_runner_disconnected(RUNNER_ID, int(time.time()) + 100)
+            # Reconnect: restore fresh liveness and clear the grace marker
+            # so the next iteration starts from the same valid pre-disconnect
+            # state. (The reconnect ordering itself is safe even as two
+            # writes — see mark_runner_disconnected's docstring: reconnect
+            # only ever ADDS truthiness, so a reader mid-reconnect sees
+            # both signals true at once, never both false.)
+            store.touch_runner_liveness([RUNNER_ID], int(time.time()))
+            store.clear_runner_disconnect_grace(RUNNER_ID)
+    finally:
+        stop.set()
+        reader.join(timeout=10)
+
+    assert torn_observations == [], (
+        f"observed {len(torn_observations)} torn read(s) despite the atomic write"
+    )
+
+
+def test_two_separate_writes_are_not_atomic_demonstrates_the_fixed_bug(db_uri: str) -> None:
+    """
+    Demonstrates the exact bug P2 fixed: calling ``clear_runner_liveness``
+    then ``set_runner_disconnect_grace`` as two SEPARATE store writes (the
+    pre-fix disconnect sequence) is NOT atomic — a concurrent reader CAN
+    observe the torn "neither live nor graced" state in the real gap
+    between the two commits. This does not exercise any production code
+    path (the disconnect handler was migrated to the atomic
+    ``mark_runner_disconnected`` and never calls these two separately
+    anymore) — it proves the OLD two-write PATTERN itself is genuinely
+    unsafe, using the same store primitives still available for other
+    callers, with a small explicit gap between the two calls. The gap only
+    makes the window reliably observable under test timing; the real
+    production gap (two separate ``_submit``-queued writes on a
+    single-worker executor) was real but not bounded to be this narrow —
+    widening it here removes timing luck from the test, not the mechanism
+    under test.
+    """
+    store = SqlAlchemyConversationStore(db_uri)
+    _seed_bound_session(store)
+
+    torn_observations: list[int] = []
+    stop = threading.Event()
+
+    def _reader() -> None:
+        count = 0
+        while not stop.is_set():
+            if _is_torn(store):
+                torn_observations.append(count)
+            count += 1
+
+    reader = threading.Thread(target=_reader)
+    reader.start()
+    try:
+        store.clear_runner_liveness(RUNNER_ID)
+        time.sleep(0.2)  # widen the real gap deterministically for the test
+        store.set_runner_disconnect_grace(RUNNER_ID, int(time.time()) + 100)
+        time.sleep(0.05)
+    finally:
+        stop.set()
+        reader.join(timeout=10)
+
+    assert torn_observations, (
+        "expected the two-separate-write sequence to expose a torn read — "
+        "if this assertion fails, the demonstrated pattern is no longer "
+        "reproducing the bug the atomic fix addresses"
+    )

--- a/tests/stores/test_session_lifecycle_store.py
+++ b/tests/stores/test_session_lifecycle_store.py
@@ -1,17 +1,24 @@
 """Tests for :class:`SqlAlchemySessionLifecycleStore`.
 
 Exercises the transactional outbox (producer + dispatcher sides) and the
-durable elicitation ledger against a real SQLite database. See
+durable elicitation ledger against a real database — SQLite by default, or
+Postgres when ``OMNIGENT_TEST_DB_URI`` is set (see ``tests/conftest.py``'s
+``db_uri`` fixture; the CI ``stores-postgres`` lane reruns this whole file
+against real Postgres). See
 ``docs/architecture/2026-08-10-durable-session-lifecycle-push.md``.
 """
 
 from __future__ import annotations
 
 import hashlib
+import threading
+from collections.abc import Callable
+from typing import TypeVar
 
 import pytest
 
 from omnigent.db.db_models import workspace_scope
+from omnigent.entities import LifecycleOutboxEvent, SessionElicitation
 from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
     SqlAlchemySessionLifecycleStore,
 )
@@ -523,6 +530,62 @@ def test_dead_letter_row_is_claimed_again_escalation_not_abandonment(
     assert reclaimed_again[0].id == _eid("m1")
 
 
+def test_claim_batch_blocks_later_sequence_while_earlier_is_dead_letter(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """A retryable dead_letter row must still block a later sequence number
+    for the same session, exactly like pending/leased do.
+
+    Cross-vendor review P1: dead_letter is NOT a terminal delivery state in
+    this design (§7.4 — escalation, never abandonment; a dead-lettered row
+    keeps retrying at the capped backoff floor indefinitely). Excluding it
+    from the ordering-blocking set would let event N+1 be claimed/delivered
+    while event N is still retryable, violating requirement #2 ("never issue
+    event N+1 before N reaches a terminal delivery state") and letting the
+    manager's view of session state regress backward in time if N later
+    succeeds after N+1 already delivered.
+    """
+    store.record_lifecycle_event(
+        event_id=_eid("dl1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rdl1:completed",
+        payload="{}",
+        now=1000,
+    )
+    store.record_lifecycle_event(
+        event_id=_eid("dl2"),
+        session_id=SID_A,
+        event_type="session.failed",
+        transition_key="turn:rdl2:failed",
+        payload="{}",
+        now=1000,
+    )
+
+    # Dead-letter sequence=1 (still retryable at the capped floor).
+    first_claim = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)
+    assert [c.sequence for c in first_claim] == [1]
+    store.mark_delivery_failed(
+        first_claim[0].id, workspace_id=0, next_attempt_at=2001, dead_letter_after_attempts=1
+    )
+    row = store.latest_delivery(SID_A)
+    # latest_delivery orders by sequence desc, so this is sequence=2 (still
+    # pending) — confirm sequence=1 is genuinely dead_letter via a direct claim.
+    assert row is not None and row.sequence == 2 and row.status == "pending"
+
+    # sequence=2 must NOT be claimable while sequence=1 sits dead_letter —
+    # only sequence=1 (dead_letter, retryable) comes back.
+    second_claim = store.claim_batch(limit=10, now=2002, lease_owner="r2", lease_seconds=60)
+    assert [c.sequence for c in second_claim] == [1]
+    assert second_claim[0].status == "leased"
+
+    # Once sequence=1 genuinely reaches a terminal state (delivered),
+    # sequence=2 becomes claimable.
+    store.mark_delivered(second_claim[0].id, workspace_id=0, delivered_at=2003, http_status=200)
+    third_claim = store.claim_batch(limit=10, now=2004, lease_owner="r3", lease_seconds=60)
+    assert [c.sequence for c in third_claim] == [2]
+
+
 # ── reclaim_expired_leases ────────────────────────────────────────
 
 
@@ -637,3 +700,187 @@ def test_mark_delivered_uses_explicit_workspace_id_not_ambient_scope(
         row = store.latest_delivery(SID_A)
     assert row is not None
     assert row.status == "delivered"
+
+
+# ── Concurrency: record_decision / record_elicitation_resolved races ──
+#
+# Cross-vendor review P2 (x2): both are read-then-write with no lock or
+# conditional update, so two concurrent duplicate callbacks can both observe
+# the pre-write state and both write, with the later commit silently
+# overwriting the first-committed value (record_decision) or racing to
+# insert the same session.resumed outbox row (record_elicitation_resolved,
+# previously surfacing as an unhandled IntegrityError). These tests use
+# real OS threads with a barrier so both callers' store calls genuinely
+# overlap in flight against the SAME row — not a sequential call-twice
+# simulation — against whichever backend `db_uri` resolves to (SQLite
+# locally, real Postgres in the CI `stores-postgres` lane, where this is
+# the only backend that can exhibit true interleaved reads: SQLite's
+# `BEGIN IMMEDIATE` already serializes every write transaction at the
+# database level, so on SQLite this proves the same converged-outcome
+# contract under real blocking rather than true interleaving).
+
+
+_T = TypeVar("_T")
+
+
+def _run_concurrently(fn_a: Callable[[], _T], fn_b: Callable[[], _T]) -> tuple[_T, _T]:
+    """Run two zero-arg callables on their own threads, synchronized to
+    start together via a barrier, and return both return values (or
+    re-raise the first exception either thread raised)."""
+    barrier = threading.Barrier(2)
+    results: list[_T | None] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+
+    def _wrapped(index: int, fn: Callable[[], _T]) -> None:
+        barrier.wait()
+        try:
+            results[index] = fn()
+        except BaseException as exc:  # captured for the main thread to re-raise
+            errors[index] = exc
+
+    threads = [
+        threading.Thread(target=_wrapped, args=(i, fn)) for i, fn in enumerate((fn_a, fn_b))
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    for err in errors:
+        if err is not None:
+            raise err
+    return results[0], results[1]  # type: ignore[return-value]
+
+
+def test_record_decision_concurrent_same_decision_converges(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Two concurrent callbacks racing to record the IDENTICAL decision
+    must both complete without error and converge on one committed value —
+    no lost update, no crash, no diverging state between the two callers'
+    returned views."""
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("cc-o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+
+    # Same substantive verdict (content), but a DIFFERENT `now` per call —
+    # simulating two independent delivery attempts of the identical
+    # underlying decision (e.g. an idempotent retry racing with itself).
+    # Using the same `now` for both would make this test unable to
+    # distinguish buggy from fixed behavior: a single atomic UPDATE can't
+    # produce a torn write, so identical content *and* identical timestamp
+    # would converge trivially either way. Differing `now` values make
+    # `decided_at` an observable proxy for "which caller's write actually
+    # committed" — under the bug, a caller that read stale "pending" state
+    # would report its OWN `now` instead of the winner's.
+    def _decide(now: int) -> SessionElicitation | None:
+        return store.record_decision(
+            EID_1, decision_payload='{"action":"accept"}', decided_by="mgr@example.com", now=now
+        )
+
+    result_a, result_b = _run_concurrently(lambda: _decide(1005), lambda: _decide(1006))
+    assert result_a is not None and result_b is not None
+    # Both callers converge on the SAME committed verdict — whichever one
+    # actually won the write, the other observes it rather than clobbering
+    # or diverging from it.
+    assert result_a.decision_payload == result_b.decision_payload == '{"action":"accept"}'
+    assert result_a.decided_at == result_b.decided_at
+    assert result_a.decided_at in (1005, 1006)
+    assert result_a.status == result_b.status == "decided"
+
+    final = store.get_elicitation(EID_1)
+    assert final is not None
+    assert final.decision_payload == '{"action":"accept"}'
+
+
+def test_record_decision_concurrent_conflicting_decisions_exactly_one_wins(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Two concurrent callbacks racing with DIFFERENT verdicts (accept vs
+    decline) must have exactly one win; the loser must observe the winner's
+    committed value cleanly, never silently overwrite it and never crash."""
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("cd-o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+
+    def _accept() -> SessionElicitation | None:
+        return store.record_decision(
+            EID_1, decision_payload='{"action":"accept"}', decided_by="mgr-a@example.com", now=1005
+        )
+
+    def _decline() -> SessionElicitation | None:
+        return store.record_decision(
+            EID_1,
+            decision_payload='{"action":"decline"}',
+            decided_by="mgr-b@example.com",
+            now=1006,
+        )
+
+    result_accept, result_decline = _run_concurrently(_accept, _decline)
+    assert result_accept is not None and result_decline is not None
+
+    # Both callers' returned views must agree on the SAME winning verdict —
+    # whichever it is — never a mix of the two, and never each caller
+    # believing its OWN verdict won when the other's actually committed.
+    assert result_accept.decision_payload == result_decline.decision_payload
+    assert result_accept.decision_payload in ('{"action":"accept"}', '{"action":"decline"}')
+    assert result_accept.decided_by == result_decline.decided_by
+
+    final = store.get_elicitation(EID_1)
+    assert final is not None
+    assert final.decision_payload == result_accept.decision_payload
+    assert final.decided_by == result_accept.decided_by
+
+
+def test_record_elicitation_resolved_concurrent_double_resolve_no_crash(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Two overlapping successful deliveries racing to resolve the SAME
+    already-decided elicitation must not both insert a session.resumed row
+    (previously an unhandled IntegrityError on the loser) — exactly one
+    reports the insert, the other observes a clean idempotent no-op."""
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("cr-o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    store.record_decision(EID_1, decision_payload='{"action":"accept"}', decided_by=None, now=1005)
+
+    def _resolve() -> tuple[SessionElicitation | None, LifecycleOutboxEvent | None, bool]:
+        return store.record_elicitation_resolved(
+            EID_1,
+            outbox_event_id=_eid("cr-o2"),
+            transition_key=f"elicitation:{EID_1}:resumed",
+            outbox_payload="{}",
+            resolved_at=1010,
+        )
+
+    result_a, result_b = _run_concurrently(_resolve, _resolve)
+
+    inserted_flags = sorted([result_a[2], result_b[2]])
+    assert inserted_flags == [False, True], (result_a, result_b)
+
+    winner = result_a if result_a[2] else result_b
+    loser = result_b if result_a[2] else result_a
+    assert winner[0] is not None and winner[0].status == "delivered_to_runner"
+    assert loser[0] is not None and loser[0].status == "delivered_to_runner"
+    assert winner[0].resolved_at == loser[0].resolved_at
+
+    deliveries, _ = store.list_deliveries(SID_A, limit=100)
+    resumed = [d for d in deliveries if d.event_type == "session.resumed"]
+    assert len(resumed) == 1, deliveries

--- a/tests/stores/test_session_lifecycle_store.py
+++ b/tests/stores/test_session_lifecycle_store.py
@@ -1,0 +1,639 @@
+"""Tests for :class:`SqlAlchemySessionLifecycleStore`.
+
+Exercises the transactional outbox (producer + dispatcher sides) and the
+durable elicitation ledger against a real SQLite database. See
+``docs/architecture/2026-08-10-durable-session-lifecycle-push.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from omnigent.db.db_models import workspace_scope
+from omnigent.stores.session_lifecycle_store.sqlalchemy_store import (
+    SqlAlchemySessionLifecycleStore,
+)
+
+SID_A = "a1" * 16
+SID_B = "b2" * 16
+EID_1 = "e1" * 16
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemySessionLifecycleStore:
+    """A fresh :class:`SqlAlchemySessionLifecycleStore` backed by the test SQLite DB."""
+    return SqlAlchemySessionLifecycleStore(db_uri)
+
+
+def _eid(seed: str) -> str:
+    """Deterministic bare 32-char hex id from a short readable seed."""
+    return hashlib.sha256(seed.encode()).hexdigest()[:32]
+
+
+# ── record_lifecycle_event: sequence allocation + idempotency ──
+
+
+def test_record_lifecycle_event_first_insert(store: SqlAlchemySessionLifecycleStore) -> None:
+    event, inserted = store.record_lifecycle_event(
+        event_id=_eid("c1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        payload='{"response_id":"r1"}',
+        now=1000,
+    )
+    assert inserted is True
+    assert event.sequence == 1
+    assert event.status == "pending"
+    assert event.attempt_count == 0
+
+
+def test_record_lifecycle_event_duplicate_is_idempotent(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    first, inserted_1 = store.record_lifecycle_event(
+        event_id=_eid("c1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        payload='{"response_id":"r1"}',
+        now=1000,
+    )
+    second, inserted_2 = store.record_lifecycle_event(
+        event_id=_eid("c1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        payload='{"response_id":"r1"}',
+        now=1001,
+    )
+    assert inserted_1 is True
+    assert inserted_2 is False
+    assert first.sequence == second.sequence == 1
+    deliveries, _ = store.list_deliveries(SID_A, limit=100)
+    assert len(deliveries) == 1
+
+
+def test_second_distinct_event_gets_sequence_two(store: SqlAlchemySessionLifecycleStore) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("c1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:r1:completed",
+        payload="{}",
+        now=1000,
+    )
+    second, _ = store.record_lifecycle_event(
+        event_id=_eid("c2"),
+        session_id=SID_A,
+        event_type="session.failed",
+        transition_key="turn:r2:failed",
+        payload="{}",
+        now=1001,
+    )
+    assert second.sequence == 2
+
+
+def test_sequence_allocated_per_session_not_globally(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    ev_a, _ = store.record_lifecycle_event(
+        event_id=_eid("c1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:ra:completed",
+        payload="{}",
+        now=1000,
+    )
+    ev_b, _ = store.record_lifecycle_event(
+        event_id=_eid("c2"),
+        session_id=SID_B,
+        event_type="session.completed",
+        transition_key="turn:rb:completed",
+        payload="{}",
+        now=1000,
+    )
+    assert ev_a.sequence == 1
+    assert ev_b.sequence == 1
+
+
+# ── record_elicitation_raised / get_elicitation ─────────────────
+
+
+def test_record_elicitation_raised_creates_ledger_and_outbox_row(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    elicitation, outbox_event, inserted = store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload='{"message":"approve?"}',
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload='{"elicitation_id":"' + EID_1 + '"}',
+        now=1000,
+    )
+    assert inserted is True
+    assert elicitation.status == "pending"
+    assert outbox_event is not None
+    assert outbox_event.event_type == "session.awaiting_decision"
+
+    fetched = store.get_elicitation(EID_1)
+    assert fetched is not None
+    assert fetched.session_id == SID_A
+
+
+def test_record_elicitation_raised_duplicate_is_idempotent(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    _elic, outbox_event, inserted = store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1001,
+    )
+    assert inserted is False
+    assert outbox_event is None
+
+
+def test_get_elicitation_returns_none_for_unknown_id(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    assert store.get_elicitation("elicit_never_registered") is None
+
+
+# ── record_decision ──────────────────────────────────────────────
+
+
+def test_record_decision_transitions_pending_to_decided(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    decided = store.record_decision(
+        EID_1, decision_payload='{"action":"accept"}', decided_by="mgr@example.com", now=1005
+    )
+    assert decided is not None
+    assert decided.status == "decided"
+    assert decided.decision_payload == '{"action":"accept"}'
+    assert decided.decided_by == "mgr@example.com"
+    assert decided.decided_at == 1005
+
+
+def test_record_decision_is_idempotent_against_retry(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    store.record_decision(EID_1, decision_payload='{"action":"accept"}', decided_by=None, now=1005)
+    replay = store.record_decision(
+        EID_1, decision_payload='{"action":"decline"}', decided_by=None, now=1006
+    )
+    # Manager retry with a (hypothetically) different body must not overwrite
+    # the already-recorded verdict.
+    assert replay is not None
+    assert replay.decision_payload == '{"action":"accept"}'
+    assert replay.decided_at == 1005
+
+
+def test_record_decision_on_nonexistent_elicitation_returns_none(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    assert (
+        store.record_decision("elicit_ghost", decision_payload="{}", decided_by=None, now=1)
+        is None
+    )
+
+
+# ── record_elicitation_resolved ──────────────────────────────────
+
+
+def test_record_elicitation_resolved_after_decision(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    store.record_decision(EID_1, decision_payload='{"action":"accept"}', decided_by=None, now=1005)
+    elicitation, outbox_event, inserted = store.record_elicitation_resolved(
+        EID_1,
+        outbox_event_id=_eid("o2"),
+        transition_key=f"elicitation:{EID_1}:resumed",
+        outbox_payload="{}",
+        resolved_at=1010,
+    )
+    assert inserted is True
+    assert elicitation is not None
+    assert elicitation.status == "delivered_to_runner"
+    assert elicitation.resolved_at == 1010
+    assert outbox_event is not None
+    assert outbox_event.event_type == "session.resumed"
+
+
+def test_record_elicitation_resolved_idempotent_on_replay(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_elicitation_raised(
+        elicitation_id=EID_1,
+        session_id=SID_A,
+        request_payload="{}",
+        outbox_event_id=_eid("o1"),
+        transition_key=f"elicitation:{EID_1}:awaiting_decision",
+        outbox_payload="{}",
+        now=1000,
+    )
+    store.record_decision(EID_1, decision_payload="{}", decided_by=None, now=1005)
+    store.record_elicitation_resolved(
+        EID_1,
+        outbox_event_id=_eid("o2"),
+        transition_key=f"elicitation:{EID_1}:resumed",
+        outbox_payload="{}",
+        resolved_at=1010,
+    )
+    _elic, _outbox, inserted_again = store.record_elicitation_resolved(
+        EID_1,
+        outbox_event_id=_eid("o2"),
+        transition_key=f"elicitation:{EID_1}:resumed",
+        outbox_payload="{}",
+        resolved_at=1020,
+    )
+    assert inserted_again is False
+
+
+def test_record_elicitation_resolved_on_missing_elicitation_returns_none(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    elicitation, outbox_event, inserted = store.record_elicitation_resolved(
+        "elicit_ghost",
+        outbox_event_id=_eid("o9"),
+        transition_key="elicitation:elicit_ghost:resumed",
+        outbox_payload="{}",
+        resolved_at=1,
+    )
+    assert (elicitation, outbox_event, inserted) == (None, None, False)
+
+
+# ── list_decided_undelivered ─────────────────────────────────────
+
+
+def test_list_decided_undelivered_excludes_pending_and_delivered(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    pending_id = _eid("p1")
+    decided_id = _eid("d1")
+    delivered_id = _eid("l1")
+    for eid, seed in ((pending_id, "op1"), (decided_id, "od1"), (delivered_id, "ol1")):
+        store.record_elicitation_raised(
+            elicitation_id=eid,
+            session_id=SID_A,
+            request_payload="{}",
+            outbox_event_id=_eid(seed),
+            transition_key=f"elicitation:{eid}:awaiting_decision",
+            outbox_payload="{}",
+            now=1000,
+        )
+    store.record_decision(decided_id, decision_payload="{}", decided_by=None, now=1001)
+    store.record_decision(delivered_id, decision_payload="{}", decided_by=None, now=1000)
+    store.record_elicitation_resolved(
+        delivered_id,
+        outbox_event_id=_eid("res1"),
+        transition_key=f"elicitation:{delivered_id}:resumed",
+        outbox_payload="{}",
+        resolved_at=1002,
+    )
+
+    undelivered = store.list_decided_undelivered(SID_A)
+    assert [e.id for e in undelivered] == [decided_id]
+
+
+# ── claim_batch: per-session ordering (THE core ordering row) ────
+
+
+def test_claim_batch_only_claims_lowest_non_delivered_sequence(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """Three pending events for ONE session: claim_batch must claim ONLY
+    sequence=1 and leave 2/3 unclaimed, because a blocking subquery excludes
+    any row with an earlier (lower-sequence) sibling still pending/leased.
+    This is what prevents the dispatcher from ever issuing event N+1's HTTP
+    call before N reaches a terminal delivery state (delivered/dead_letter).
+    """
+    for i in range(1, 4):
+        store.record_lifecycle_event(
+            event_id=_eid(f"e{i}"),
+            session_id=SID_A,
+            event_type="session.completed",
+            transition_key=f"turn:r{i}:completed",
+            payload="{}",
+            now=1000,
+        )
+
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)
+    assert [c.sequence for c in claimed] == [1]
+
+    # sequence=2 stays invisible to another claim attempt too.
+    claimed_again = store.claim_batch(limit=10, now=2001, lease_owner="r2", lease_seconds=60)
+    assert claimed_again == []
+
+    store.mark_delivered(claimed[0].id, workspace_id=0, delivered_at=2002, http_status=200)
+
+    claimed_2 = store.claim_batch(limit=10, now=2003, lease_owner="r1", lease_seconds=60)
+    assert [c.sequence for c in claimed_2] == [2]
+
+
+def test_claim_batch_respects_future_next_attempt_at(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("f1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rf:completed",
+        payload="{}",
+        now=5_000_000,  # next_attempt_at defaults to `now`, far in the future
+    )
+    claimed = store.claim_batch(limit=10, now=1000, lease_owner="r1", lease_seconds=60)
+    assert claimed == []
+
+
+def test_claim_batch_stamps_lease_fields(store: SqlAlchemySessionLifecycleStore) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("g1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rg:completed",
+        payload="{}",
+        now=1000,
+    )
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="replica-42", lease_seconds=30)
+    assert len(claimed) == 1
+    row = claimed[0]
+    assert row.status == "leased"
+    assert row.attempt_count == 1
+    assert row.lease_owner == "replica-42"
+    assert row.lease_expires_at == 2030
+    assert row.last_attempt_at == 2000
+
+
+# ── mark_delivered / mark_delivery_failed ─────────────────────────
+
+
+def test_mark_delivered_transitions_leased_to_delivered(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("h1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rh:completed",
+        payload="{}",
+        now=1000,
+    )
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)[0]
+    store.mark_delivered(claimed.id, workspace_id=0, delivered_at=2005, http_status=200)
+    row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "delivered"
+    assert row.delivered_at == 2005
+    assert row.last_http_status == 200
+    assert row.lease_owner is None
+
+
+def test_mark_delivered_noop_when_not_leased(store: SqlAlchemySessionLifecycleStore) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("i1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:ri:completed",
+        payload="{}",
+        now=1000,
+    )
+    # Never claimed -> still "pending", not "leased".
+    store.mark_delivered(_eid("i1"), workspace_id=0, delivered_at=9999, http_status=200)
+    row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "pending"
+    assert row.delivered_at is None
+
+
+def test_mark_delivery_failed_dead_letters_past_threshold(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("j1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rj:completed",
+        payload="{}",
+        now=1000,
+    )
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)[0]
+    assert claimed.attempt_count == 1
+    store.mark_delivery_failed(
+        claimed.id,
+        workspace_id=0,
+        next_attempt_at=2001,
+        dead_letter_after_attempts=1,
+        http_status=500,
+        error_code="http_error",
+        error_message="boom",
+    )
+    row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "dead_letter"
+    assert row.last_error_code == "http_error"
+
+
+def test_mark_delivery_failed_stays_pending_below_threshold(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("k1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rk:completed",
+        payload="{}",
+        now=1000,
+    )
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)[0]
+    store.mark_delivery_failed(
+        claimed.id, workspace_id=0, next_attempt_at=2001, dead_letter_after_attempts=10
+    )
+    row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "pending"
+
+
+def test_dead_letter_row_is_claimed_again_escalation_not_abandonment(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """A dead-lettered row keeps retrying at the capped floor interval — it
+    is never automatically abandoned."""
+    store.record_lifecycle_event(
+        event_id=_eid("m1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rm:completed",
+        payload="{}",
+        now=1000,
+    )
+    claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)[0]
+    store.mark_delivery_failed(
+        claimed.id, workspace_id=0, next_attempt_at=2001, dead_letter_after_attempts=1
+    )
+    row = store.latest_delivery(SID_A)
+    assert row is not None and row.status == "dead_letter"
+
+    reclaimed_again = store.claim_batch(limit=10, now=2002, lease_owner="r2", lease_seconds=60)
+    assert len(reclaimed_again) == 1
+    assert reclaimed_again[0].status == "leased"
+    assert reclaimed_again[0].id == _eid("m1")
+
+
+# ── reclaim_expired_leases ────────────────────────────────────────
+
+
+def test_reclaim_expired_leases_returns_row_to_pending(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("n1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rn:completed",
+        payload="{}",
+        now=1000,
+    )
+    store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=30)
+    # Lease not yet expired -> not reclaimed.
+    assert store.reclaim_expired_leases(now=2010) == 0
+    # Lease expired -> reclaimed.
+    reclaimed = store.reclaim_expired_leases(now=2031)
+    assert reclaimed == 1
+    row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "pending"
+    assert row.lease_owner is None
+    assert row.lease_expires_at is None
+
+
+# ── list_deliveries / latest_delivery ─────────────────────────────
+
+
+def test_list_deliveries_pagination_no_gaps_or_dupes(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    for i in range(1, 6):
+        store.record_lifecycle_event(
+            event_id=_eid(f"q{i}"),
+            session_id=SID_A,
+            event_type="session.completed",
+            transition_key=f"turn:rq{i}:completed",
+            payload="{}",
+            now=1000,
+        )
+    page1, cursor1 = store.list_deliveries(SID_A, limit=2)
+    assert [d.sequence for d in page1] == [5, 4]
+    assert cursor1 == page1[-1].id
+
+    page2, cursor2 = store.list_deliveries(SID_A, limit=2, after_id=cursor1)
+    assert [d.sequence for d in page2] == [3, 2]
+
+    page3, cursor3 = store.list_deliveries(SID_A, limit=2, after_id=cursor2)
+    assert [d.sequence for d in page3] == [1]
+    assert cursor3 is None
+
+
+def test_latest_delivery_returns_highest_sequence(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    store.record_lifecycle_event(
+        event_id=_eid("s1"),
+        session_id=SID_A,
+        event_type="session.completed",
+        transition_key="turn:rs1:completed",
+        payload="{}",
+        now=1000,
+    )
+    store.record_lifecycle_event(
+        event_id=_eid("s2"),
+        session_id=SID_A,
+        event_type="session.failed",
+        transition_key="turn:rs2:failed",
+        payload="{}",
+        now=1001,
+    )
+    latest = store.latest_delivery(SID_A)
+    assert latest is not None
+    assert latest.sequence == 2
+    assert latest.event_type == "session.failed"
+
+
+def test_latest_delivery_none_for_empty_session(store: SqlAlchemySessionLifecycleStore) -> None:
+    assert store.latest_delivery(SID_B) is None
+
+
+# ── multi-tenant: mark_delivered/mark_delivery_failed use explicit workspace_id ──
+
+
+def test_mark_delivered_uses_explicit_workspace_id_not_ambient_scope(
+    store: SqlAlchemySessionLifecycleStore,
+) -> None:
+    """The dispatcher runs outside any request's workspace scope, so
+    mark_delivered/mark_delivery_failed must not rely on current_workspace_id()
+    — they take workspace_id explicitly, from the claimed
+    LifecycleOutboxEvent."""
+    with workspace_scope(5):
+        store.record_lifecycle_event(
+            event_id=_eid("t1"),
+            session_id=SID_A,
+            event_type="session.completed",
+            transition_key="turn:rt:completed",
+            payload="{}",
+            now=1000,
+        )
+        claimed = store.claim_batch(limit=10, now=2000, lease_owner="r1", lease_seconds=60)
+    assert len(claimed) == 1
+    assert claimed[0].workspace_id == 5
+
+    # Mark delivered OUTSIDE any workspace_scope (ambient default workspace),
+    # passing workspace_id=5 explicitly.
+    store.mark_delivered(claimed[0].id, workspace_id=5, delivered_at=2005, http_status=200)
+
+    with workspace_scope(5):
+        row = store.latest_delivery(SID_A)
+    assert row is not None
+    assert row.status == "delivered"


### PR DESCRIPTION
## Related issue

OMN-104 (Linear): https://linear.app/silica-v1/issue/OMN-104/push-durable-omnigent-session-completion-and-human-decision-events-to

## Summary

Implements OMN-104 — durable session lifecycle push to a manager webhook —
per the approved design in
`docs/architecture/2026-08-10-durable-session-lifecycle-push.md`:

- A transactional outbox (`session_lifecycle_outbox` +
  `session_lifecycle_cursors`) durably records `session.completed` /
  `session.failed` / `session.awaiting_decision` / `session.resumed` events
  **before** delivery, with deterministic (UUIDv5) event IDs and a
  per-session monotonic sequence, so a retried producer call or a
  duplicate delivery is naturally idempotent.
- A durable elicitation ledger (`session_elicitations`) records human
  decision verdicts, narrower than a general cross-restart resume
  guarantee: the decision endpoint always persists the verdict first, then
  classifies resolution by **which process died** — no restart (resolves
  immediately), server restart with the runner still alive (202,
  redelivered on the runner's tunnel reconnect), or the runner itself dead
  (410 `elicitation_not_resolvable`, verdict still durably recorded).
- A single always-on dispatcher task per server replica delivers the
  outbox: `FOR UPDATE SKIP LOCKED` claim on PostgreSQL / single-writer
  claim on SQLite, per-session ordering (never issues event N+1 before N
  reaches a terminal delivery state), exponential-full-jitter backoff, and
  dead-letter as **escalation, never abandonment** (a dead-lettered row
  keeps retrying at the capped floor interval, visible via the new API).
- HMAC-SHA256 request signing (Stripe-style: `timestamp.event_id.body`),
  configurable `manager_webhook` block with an HTTPS-only fail-closed
  endpoint check, secret via `OMNIGENT_MANAGER_WEBHOOK_SECRET`
  (+`_PREVIOUS` for rotation) — env-var only, never the config file.
- Two distinct redaction mechanisms: a denylist + length clamp for
  `completed`/`failed` payloads, and an explicit field **allowlist** for
  `awaiting_decision`/`resumed` payloads (the underlying
  `ElicitationRequestParams` permits arbitrary extra fields, so a denylist
  alone can't structurally exclude a raw env dict or similar).
- New `GET /v1/sessions/{id}/manager-webhook-deliveries` (modeled on
  `GET /scheduled-tasks/{id}/runs`) and a `latest_manager_delivery`
  summary field on the session snapshot.
- Everything is purely additive: `manager_webhook.enabled=false` (the
  default) leaves poll/reconciliation and all existing session-state
  correctness completely unchanged; the dispatcher task always starts but
  no-ops when disabled, so enabling it live via config reload needs no
  restart.

## Test Plan

New tests (all passing) exercise the full §12 acceptance-test matrix from
the design doc: completion wake (including with a background shell still
running — proves the previously-considered `background_task_count`
secondary gate stays removed), decision-payload allowlist round-trip,
restart/network-replay via lease reclaim, duplicate-delivery dedupe by
stable event ID, HMAC tamper/stale-timestamp rejection, all three
harness-classified decision-resolution outcomes, dispatch ordering,
dead-letter escalation, and poll/reconcile correctness with the feature
disabled or the endpoint down. See the Coverage notes below for the exact
commands and counts.

Also manually verified: the alembic migration upgrades a fresh SQLite DB
to head, downgrades one step (drops all three new tables cleanly), and
re-upgrades (tables restored) — see Coverage notes.

## Demo

N/A — backend-only change (new DB tables, a background dispatcher task, a
signed outbound webhook, and REST/API additions). No UI surface.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

**New tests** (17 files touched/added, 8 new test files):
- `tests/db/test_migration_session_lifecycle_outbox.py` (21 tests) — schema shape, PKs, no FKs (Rule R032), indexes, CHECK constraints, downgrade/re-upgrade.
- `tests/stores/test_session_lifecycle_store.py` (27 tests) — sequence allocation, idempotency, per-session claim ordering, dead-letter escalation, lease reclaim, pagination, explicit-`workspace_id` multi-tenant correctness.
- `tests/server/test_manager_webhook_signing.py` (26 tests) — HMAC sign/verify, tamper/stale-timestamp rejection, secret rotation, config fail-closed HTTPS enforcement.
- `tests/server/test_session_outbox.py` (12 tests) — producer redaction/allowlist boundary, determinism, idempotency.
- `tests/server/test_manager_webhook_dispatcher_logging.py` — structured log-line redaction (never payload body/secret/signature/full URL).
- `tests/server/integration/test_manager_webhook_dispatcher.py` (11 tests) — delivery, retry, dead-letter, per-session ordering, duplicate-ID dedupe, HMAC headers on the wire, lease reclaim/redelivery, disabled config, endpoint-down, bounded delivery timeout.
- `tests/server/integration/test_sessions_manager_webhook_lifecycle.py` (6 tests) — completion wake through the real `_publish_status` path, sticky-failed-guard interaction, poll/reconcile unaffected.
- `tests/server/integration/test_manager_webhook_decision_endpoint.py` (5 tests) — all three harness-classified resolution outcomes (a/b/c) plus the untracked-elicitation regression guard.
- `tests/server/integration/test_manager_webhook_deliveries_api.py` (5 tests) — the new GET endpoint, pagination, 404s, graceful degradation when unwired.

**Gates run locally** (from the worktree root):
- `uv run ruff format <changed files>` — clean (no diff).
- `uv run ruff check omnigent/ tests/` — all checks passed.
- `uv run --no-sync pyrefly check` — 0 errors.
- `uv run pre-commit run --files <changed files>` — all hooks passed.
- Alembic upgrade/downgrade: scripted upgrade-to-head → downgrade to `f7a8b9c0d1e2` (drops all 3 new tables) → re-upgrade to `a8b9c0d1e2f3` (tables restored) against a fresh SQLite DB — passed.
- `uv run pytest tests/db/test_migration_session_lifecycle_outbox.py tests/stores/test_session_lifecycle_store.py tests/server/test_manager_webhook_signing.py tests/server/test_session_outbox.py tests/server/test_manager_webhook_dispatcher_logging.py tests/server/integration/test_manager_webhook_dispatcher.py tests/server/integration/test_sessions_manager_webhook_lifecycle.py tests/server/integration/test_manager_webhook_decision_endpoint.py tests/server/integration/test_manager_webhook_deliveries_api.py tests/server/integration/test_sessions_elicitation_api.py tests/server/integration/test_sessions_elicitation_resolve_url.py tests/runtime/test_pending_elicitations.py tests/server/test_session_live_state.py -q` — **196 passed**, 0 failed (all new OMN-104 tests plus the directly-related pre-existing regression suites the decision-endpoint/elicitation changes touch, including a genuine cross-session-ownership bug this PR's own change introduced and then fixed).
- A broader regression sweep across `tests/server/`, `tests/runtime/`, `tests/stores/`, `tests/db/` (5,788 tests) was also run in the background; see the session report for its status at PR-open time.

Two real bugs were found and fixed during this work via the tests above (not left to review): (1) `session_elicitations.id` was initially modeled as the same 16-byte `Uuid16` type every other id column here uses, but `elicitation_id` values are actually a prefixed opaque token (`f"elicit_{secrets.token_hex(16)}"`), not a bare-hex UUID — fixed to a plain `String` column. (2) The new decision-endpoint classification logic initially bypassed the existing cross-session ownership check on `_resolve_elicitation`'s in-memory Future, which would have let one session durably decide another session's elicitation — fixed by checking the durable ledger's owning `session_id` before persisting a decision.

## Changelog

Sessions now push completion, failure, and human-decision events to a configured, signed manager webhook, durably retried until acknowledged, with existing polling unaffected.

Omnigent-Agent: polly
