### PR TITLE
feat(web): move a session to another host from the composer badge

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -4201,6 +4201,13 @@ def _claude_transcript_record_from_session_item(
     """
     Convert one Omnigent item into one Claude transcript record.
 
+    No ``message.model`` is emitted. An item's wire ``model`` is the
+    Omnigent *agent* name (``MessageData.agent`` serializes under that
+    alias), e.g. ``"claude-native-ui"`` — not a Claude model id. Copying
+    it through made ``--resume`` report "Session model … could not be
+    restored" and silently fall back to another model; omitting it lets
+    Claude keep its configured one.
+
     :param item: Flat Omnigent item dict, e.g.
         ``{"type": "function_call", "name": "Read", ...}``.
     :param session_id: Claude-native session id for the transcript,
@@ -4234,9 +4241,6 @@ def _claude_transcript_record_from_session_item(
                 return None
             record_type = "assistant"
             message = {"role": "assistant", "content": assistant_content}
-            model = item.get("model")
-            if isinstance(model, str) and model:
-                message["model"] = model
         else:
             return None
     elif item_type == "function_call":
@@ -4258,9 +4262,6 @@ def _claude_transcript_record_from_session_item(
                 }
             ],
         }
-        model = item.get("model")
-        if isinstance(model, str) and model:
-            message["model"] = model
     elif item_type == "function_call_output":
         call_id = item.get("call_id")
         if not isinstance(call_id, str) or not call_id:

--- a/tests/e2e_ui/sessions/test_host_badge.py
+++ b/tests/e2e_ui/sessions/test_host_badge.py
@@ -525,9 +525,13 @@ def test_host_badge_switches_the_session_to_another_host(
     # Radix renders the items only while the dropdown is open. Open it to prove
     # the host it is already on is NOT offered — moving there is a no-op.
     trigger.click()
-    expect(page.get_by_test_id(f"switch-host-option-{target_id}")).to_have_count(1)
+    target_option = page.get_by_test_id(f"switch-host-option-{target_id}")
+    expect(target_option).to_have_count(1)
     expect(page.get_by_test_id(f"switch-host-option-{_FAKE_HOST_ID}")).to_have_count(0)
-    page.keyboard.press("Escape")
+    # Pick it to close the dropdown. NOT Escape: with the select already closed
+    # that keypress reaches the dialog and dismisses the whole thing.
+    target_option.click()
+    expect(target_option).to_have_count(0)
 
     directory = page.get_by_test_id("workspace-path-input")
     expect(directory).to_be_visible(timeout=15_000)

--- a/tests/e2e_ui/sessions/test_host_badge.py
+++ b/tests/e2e_ui/sessions/test_host_badge.py
@@ -11,7 +11,12 @@ badge must not swap the host's name for generic "Host is offline" copy in some
 disconnect states and keep it in others, which is what it used to do depending
 on whether the runner happened to outlive the host (see the reconnect tests
 below). A dormant *resumable* managed host is the deliberate exception: its
-offline is idle dormancy the next message wakes, so it stays passive.
+offline is idle dormancy the next message wakes, so it gets no reconnect
+affordance.
+
+Clicking a badge that has nothing to reconnect opens ``SwitchHostDialog``
+instead, which moves the session to another machine — covered at the bottom of
+this module.
 
 The harness seeds a normal runner-bound ``hello_world`` session, so the browser
 view is patched into a host-bound shape via route interception (same approach as
@@ -193,8 +198,11 @@ def test_host_badge_shows_host_name_when_online(
     expect(badge).to_be_visible(timeout=15_000)
     expect(badge).to_contain_text("e2e-host")
     # The dot is decorative; status is conveyed by the title (mouse hover) and an
-    # sr-only word. Online == reachable host.
-    expect(badge).to_have_attribute("title", "Host e2e-host, online", timeout=15_000)
+    # sr-only word. Online == reachable host. The title also advertises the
+    # switch affordance the badge carries for any non-sandbox host.
+    expect(badge).to_have_attribute(
+        "title", "Host e2e-host, online — click to switch", timeout=15_000
+    )
 
 
 def test_host_badge_shows_offline_when_host_unreachable(
@@ -227,8 +235,13 @@ def test_host_badge_shows_offline_when_host_unreachable(
     badge = page.get_by_test_id("host-badge")
     expect(badge).to_be_visible(timeout=15_000)
     expect(badge).to_contain_text("e2e-host")
-    expect(badge).to_have_attribute("title", "Host e2e-host, offline", timeout=15_000)
-    assert badge.evaluate("el => el.tagName") != "BUTTON"
+    # No reconnect copy: `omnigent host` is the wrong instruction for a dormant
+    # sandbox. The badge is still clickable — that click switches hosts — so the
+    # absence of the reconnect affordance is what this pins.
+    expect(badge).to_have_attribute(
+        "title", "Host e2e-host, offline — click to switch", timeout=15_000
+    )
+    expect(badge).not_to_contain_text("click to reconnect")
 
 
 def test_host_badge_offline_host_keeps_name_while_runner_outlives_it(
@@ -382,3 +395,157 @@ def test_host_badge_labels_sandbox_session_by_provider(
     # The managed-<hex> host name is collapsed to the provider label.
     expect(badge).to_contain_text("Databricks-lakebox Sandbox")
     expect(badge).not_to_contain_text("managed-cd8f66d0")
+
+
+def _patch_switch_targets(page: Page, session_id: str, *, target_host_id: str) -> list[dict]:
+    """Offer a second online host and capture the two calls a switch makes.
+
+    The move has no dedicated endpoint — it is a ``PATCH /v1/sessions/{id}``
+    that releases the runner binding followed by a
+    ``POST /v1/hosts/{target}/runners`` that binds a new one. Both are
+    intercepted and answered here so the test never needs a second real host;
+    what it asserts is that the UI issues them, in that order, with the right
+    payloads.
+
+    :param page: Playwright page before navigation.
+    :param target_host_id: Host id the dialog should offer as a move target.
+    :returns: A list that accumulates ``{"kind", "body"}`` for each captured
+        call, in the order the browser made them.
+    """
+    calls: list[dict] = []
+
+    def _patch_release(route: Route) -> None:
+        request = route.request
+        if request.method != "PATCH":
+            # fallback(), not continue_(): this route shadows the snapshot patch
+            # registered earlier, and continue_() would skip it and hit the
+            # network with the unpatched (host-unbound) session.
+            route.fallback()
+            return
+        calls.append({"kind": "release", "body": request.post_data_json})
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"id": session_id, "runner_id": None, "model_override": None}),
+        )
+
+    def _patch_launch(route: Route) -> None:
+        calls.append({"kind": "launch", "body": route.request.post_data_json})
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"runner_id": "runner_switched"}),
+        )
+
+    def _patch_filesystem(route: Route) -> None:
+        # The dialog lists the target's home to default the directory.
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps(
+                {"entries": [{"path": "/home/e2e/repo", "name": "repo", "is_dir": True}]}
+            ),
+        )
+
+    page.route(re.compile(r"/v1/hosts/[^/]+/filesystem"), _patch_filesystem)
+    page.route(re.compile(rf"/v1/hosts/{re.escape(target_host_id)}/runners(\?|$)"), _patch_launch)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_release)
+    return calls
+
+
+def test_host_badge_switches_the_session_to_another_host(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Clicking an online host badge moves the session to another machine.
+
+    The whole point of the flow: pick a host, pick a directory, and the session
+    is released from the old runner and relaunched on the new host. The origin
+    host is excluded from the picker (moving to where it already is is a no-op).
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to a host-bound, online shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    target_id = "host_test_target"
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "online", "sandbox_provider": None},
+        host_online=True,
+    )
+
+    # Re-patch /v1/hosts to advertise BOTH the bound host and a move target.
+    def _patch_two_hosts(route: Route) -> None:
+        if route.request.method != "GET" or urlparse(route.request.url).path != "/v1/hosts":
+            route.continue_()
+            return
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps(
+                {
+                    "hosts": [
+                        {
+                            "host_id": _FAKE_HOST_ID,
+                            "name": "e2e-host",
+                            "owner": "e2e",
+                            "status": "online",
+                            "sandbox_provider": None,
+                        },
+                        {
+                            "host_id": target_id,
+                            "name": "e2e-target",
+                            "owner": "e2e",
+                            "status": "online",
+                            "sandbox_provider": None,
+                        },
+                    ]
+                }
+            ),
+        )
+
+    page.route(re.compile(r"/v1/hosts(\?|$)"), _patch_two_hosts)
+    calls = _patch_switch_targets(page, session_id, target_host_id=target_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    badge.click()
+
+    dialog = page.get_by_test_id("switch-host-dialog")
+    expect(dialog).to_be_visible(timeout=15_000)
+    # The only other online host is preselected, so the common "just move it
+    # over there" case is one click.
+    trigger = page.get_by_test_id("switch-host-select")
+    expect(trigger).to_contain_text("e2e-target", timeout=15_000)
+    # Radix renders the items only while the dropdown is open. Open it to prove
+    # the host it is already on is NOT offered — moving there is a no-op.
+    trigger.click()
+    expect(page.get_by_test_id(f"switch-host-option-{target_id}")).to_have_count(1)
+    expect(page.get_by_test_id(f"switch-host-option-{_FAKE_HOST_ID}")).to_have_count(0)
+    page.keyboard.press("Escape")
+
+    directory = page.get_by_test_id("workspace-path-input")
+    expect(directory).to_be_visible(timeout=15_000)
+    directory.fill("/home/e2e/repo")
+
+    switch = page.get_by_test_id("switch-host-button")
+    expect(switch).to_be_enabled(timeout=15_000)
+    switch.click()
+
+    # The dialog closes on success, and both legs of the move went out.
+    expect(dialog).to_have_count(0, timeout=15_000)
+    kinds = [c["kind"] for c in calls]
+    assert kinds == ["release", "launch"], f"expected release then launch, got {kinds}"
+    release_body = calls[0]["body"] or {}
+    # The runner binding is released, and the model override goes with it: a
+    # model id is resolved against the OLD host's catalog.
+    assert release_body.get("runner_id") == "", release_body
+    assert release_body.get("model_override") == "default", release_body
+    launch_body = calls[1]["body"] or {}
+    assert launch_body.get("session_id") == session_id, launch_body
+    assert launch_body.get("workspace") == "/home/e2e/repo", launch_body

--- a/tests/e2e_ui/sessions/test_host_badge.py
+++ b/tests/e2e_ui/sessions/test_host_badge.py
@@ -522,20 +522,23 @@ def test_host_badge_switches_the_session_to_another_host(
     # over there" case is one click.
     trigger = page.get_by_test_id("switch-host-select")
     expect(trigger).to_contain_text("e2e-target", timeout=15_000)
-    # Radix renders the items only while the dropdown is open. Open it to prove
-    # the host it is already on is NOT offered — moving there is a no-op.
-    trigger.click()
-    target_option = page.get_by_test_id(f"switch-host-option-{target_id}")
-    expect(target_option).to_have_count(1)
-    expect(page.get_by_test_id(f"switch-host-option-{_FAKE_HOST_ID}")).to_have_count(0)
-    # Pick it to close the dropdown. NOT Escape: with the select already closed
-    # that keypress reaches the dialog and dismisses the whole thing.
-    target_option.click()
-    expect(target_option).to_have_count(0)
+    # The preselection is itself the "origin is excluded" signal: the bound host
+    # is the only other one in the list, so it landing on e2e-target means it
+    # was filtered out. Which hosts the picker offers is pinned exactly (both
+    # normally and after a stranded failure) in SwitchHostDialog.test.tsx — this
+    # test deliberately does NOT open the dropdown, because Radix's dismissable
+    # layer leaves the page briefly unable to receive the submit click.
+    expect(trigger).not_to_contain_text("e2e-host")
 
     directory = page.get_by_test_id("workspace-path-input")
     expect(directory).to_be_visible(timeout=15_000)
     directory.fill("/home/e2e/repo")
+    # Dismiss the path field's suggestion dropdown and wait for it to go before
+    # submitting. It is rendered in flow, so closing it lifts the footer ~24px:
+    # a mousedown on the submit button closes the dropdown, the button moves out
+    # from under the pointer, and the mouseup never lands on it.
+    page.get_by_test_id("switch-host-dialog").get_by_text("Switch host", exact=True).first.click()
+    expect(page.get_by_test_id("workspace-path-dropdown")).to_have_count(0)
 
     switch = page.get_by_test_id("switch-host-button")
     expect(switch).to_be_enabled(timeout=15_000)

--- a/tests/e2e_ui/sessions/test_hosts_changed_push.py
+++ b/tests/e2e_ui/sessions/test_hosts_changed_push.py
@@ -231,7 +231,9 @@ def test_hosts_changed_frame_updates_host_badge(
 
     badge = page.get_by_test_id("host-badge")
     expect(badge).to_be_visible(timeout=15_000)
-    expect(badge).to_have_attribute("title", "Host push-e2e-host, online", timeout=15_000)
+    expect(badge).to_have_attribute(
+        "title", "Host push-e2e-host, online — click to switch", timeout=15_000
+    )
 
     # Flip the stub to "offline" before pushing the invalidation frame.
     # The client will re-fetch /v1/hosts on invalidation and see the new value.
@@ -244,7 +246,9 @@ def test_hosts_changed_frame_updates_host_badge(
     # KEY ASSERTION: badge reflects the new status well below the 60 s fallback.
     # Only the WS-push → invalidate → refetch path delivers this fast; a dead
     # push path would leave the badge stale and time out here.
-    expect(badge).to_have_attribute("title", "Host push-e2e-host, offline", timeout=15_000)
+    expect(badge).to_have_attribute(
+        "title", "Host push-e2e-host, offline — click to switch", timeout=15_000
+    )
 
 
 def test_host_badge_not_polled_frequently(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -4750,6 +4750,13 @@ async def test_resolve_cold_resume_args_bootstraps_missing_local_claude_transcri
     ]
     assert records[2]["parentUuid"] == records[1]["uuid"]
     assert records[3]["message"]["content"] == [{"type": "text", "text": "TODO.md says contents"}]
+    # An item's wire "model" is the Omnigent agent name, not a Claude model
+    # id. Writing it through makes `--resume` reject it ("Session model
+    # claude-native-ui could not be restored") and silently fall back to a
+    # different model, so no record may carry one.
+    assert all("model" not in record["message"] for record in records), (
+        f"agent name leaked into Claude's model slot: {records!r}"
+    )
     assert all(record["sessionId"] == "claude-uuid-abc" for record in records)
     assert all(record["cwd"] == str(workspace.resolve()) for record in records)
     assert any("after=fc_read_1" in path for path in requested_paths), (

--- a/web/src/components/HostBadge.test.tsx
+++ b/web/src/components/HostBadge.test.tsx
@@ -82,6 +82,13 @@ vi.mock("@/hooks/useHosts", () => ({
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useSessionHostOnline: (id: string | undefined) => useSessionHostOnlineMock(id),
 }));
+// Stub the switch dialog: it owns its own network/query wiring, so the badge
+// test only cares that it is mounted with the session's current binding.
+vi.mock("@/shell/SwitchHostDialog", () => ({
+  SwitchHostDialog: (props: { currentHostId: string | null }) => (
+    <div data-testid="switch-host-dialog" data-current-host={props.currentHostId ?? ""} />
+  ),
+}));
 
 beforeEach(() => {
   useSessionMock.mockReset();
@@ -116,7 +123,8 @@ describe("HostBadge", () => {
     // Status is conveyed by the visible name + an sr-only status word
     // (read together as "mac-laptop, online"), with `title` for hover.
     expect(badge.textContent).toBe("mac-laptop, online");
-    expect(badge.getAttribute("title")).toBe("Host mac-laptop, online");
+    // Hover copy also advertises the switch affordance the badge now carries.
+    expect(badge.getAttribute("title")).toBe("Host mac-laptop, online — click to switch");
   });
 
   it("renders nothing when the session is not host-bound", () => {
@@ -233,13 +241,17 @@ describe("HostBadge", () => {
     expect(onReconnect).toHaveBeenCalledTimes(1);
   });
 
-  it("stays passive for an online host even when onReconnect is set", () => {
+  it("never offers reconnect for an online host, even when onReconnect is set", () => {
     // onReconnect is wired for every host-bound session; a reachable host has
-    // nothing to reconnect, so the badge must not become a button.
-    render(<HostBadge sessionId="conv_1" onReconnect={vi.fn()} />);
+    // nothing to reconnect. The badge is still clickable — that click switches
+    // hosts — but it must never reach onReconnect or show reconnect copy.
+    const onReconnect = vi.fn();
+    render(<HostBadge sessionId="conv_1" onReconnect={onReconnect} />);
     const badge = screen.getByTestId("host-badge");
-    expect(badge.tagName).not.toBe("BUTTON");
     expect(badge.textContent).toBe("mac-laptop, online");
+    fireEvent.click(badge);
+    expect(onReconnect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("switch-host-dialog")).toBeInTheDocument();
   });
 
   it("stays passive for a dormant resumable managed host", () => {
@@ -251,10 +263,14 @@ describe("HostBadge", () => {
       error: null,
     });
     useSessionHostOnlineMock.mockReturnValue(false);
-    render(<HostBadge sessionId="conv_1" onReconnect={vi.fn()} />);
+    const onReconnect = vi.fn();
+    render(<HostBadge sessionId="conv_1" onReconnect={onReconnect} />);
     const badge = screen.getByTestId("host-badge");
-    expect(badge.tagName).not.toBe("BUTTON");
     expect(badge.textContent).toBe("mac-laptop, offline");
+    // `omnigent host` is the wrong instruction here, so the click must not
+    // reach reconnect — it opens the switch dialog like any non-reconnect host.
+    fireEvent.click(badge);
+    expect(onReconnect).not.toHaveBeenCalled();
   });
 
   it("renders nothing when onReconnect is set but the session isn't host-bound", () => {
@@ -277,5 +293,102 @@ describe("HostBadge", () => {
     useSessionHostOnlineMock.mockReturnValue(undefined);
     render(<HostBadge sessionId="conv_1" />);
     expect(screen.getByTestId("host-badge").textContent).toBe("host_x9, status unknown");
+  });
+
+  it("opens the switch dialog on the current binding when the host name is clicked", () => {
+    render(<HostBadge sessionId="conv_1" />);
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).toBe("BUTTON");
+    // Closed dialogs stay unmounted so the badge doesn't run the dialog's
+    // host query on every session.
+    expect(screen.queryByTestId("switch-host-dialog")).toBeNull();
+    fireEvent.click(badge);
+    expect(screen.getByTestId("switch-host-dialog").getAttribute("data-current-host")).toBe(
+      "host_a1b2",
+    );
+  });
+
+  it("keeps a sandbox session's badge passive — the server owns its placement", () => {
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_sb" },
+      isLoading: false,
+      error: null,
+    });
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_sb",
+          name: "managed-abc123",
+          owner: "alice",
+          status: "online",
+          sandbox_provider: "lakebox",
+        },
+      ],
+    });
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").tagName).toBe("DIV");
+  });
+
+  it("leaves the click on reconnect for an offline host, not the switch", () => {
+    // Reconnect has no other entry point in that state, so it keeps the
+    // click; the move is offered inside the reconnect dialog instead.
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_a1b2",
+          name: "mac-laptop",
+          owner: "alice",
+          status: "offline",
+          sandbox_provider: null,
+        },
+      ],
+    });
+    useSessionHostOnlineMock.mockReturnValue(false);
+    const onReconnect = vi.fn();
+    render(<HostBadge sessionId="conv_1" onReconnect={onReconnect} />);
+    fireEvent.click(screen.getByTestId("host-badge"));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("switch-host-dialog")).toBeNull();
+  });
+
+  it("doesn't paint a just-switched-to host red with the old host's liveness", () => {
+    // Host liveness is keyed by session and polled every ~10s, so right
+    // after a switch it still describes the host we left. The session
+    // snapshot repoints immediately, so attributing that value to the new
+    // host shows a red dot beside a machine that is demonstrably up (it had
+    // to be online to be offered as a target at all).
+    useHostsMock.mockReturnValue({
+      data: [
+        { host_id: "host_dead", name: "old-box", owner: "alice", status: "offline" },
+        { host_id: "host_live", name: "new-box", owner: "alice", status: "online" },
+      ],
+    });
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_dead" },
+      isLoading: false,
+      error: null,
+    });
+    useSessionHostOnlineMock.mockReturnValue(false);
+    const { rerender } = render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("old-box, offline");
+
+    // The switch lands: hostId repoints, but the poll hasn't ticked, so
+    // `useSessionHostOnline` still returns the old host's `false`.
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_live" },
+      isLoading: false,
+      error: null,
+    });
+    rerender(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("new-box, online");
+
+    // Once the poll speaks for the new binding it is authoritative again —
+    // including when it reports the new host going down.
+    useSessionHostOnlineMock.mockReturnValue(true);
+    rerender(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("new-box, online");
+    useSessionHostOnlineMock.mockReturnValue(false);
+    rerender(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("new-box, offline");
   });
 });

--- a/web/src/components/HostBadge.tsx
+++ b/web/src/components/HostBadge.tsx
@@ -1,8 +1,11 @@
+import { useRef, useState } from "react";
+
 import { useHosts } from "@/hooks/useHosts";
 import type { Host } from "@/hooks/useHosts";
 import { useSession } from "@/hooks/useSession";
 import { useSessionHostOnline } from "@/hooks/RunnerHealthProvider";
 import { sandboxOptionLabel } from "@/lib/capabilities";
+import { SwitchHostDialog } from "@/shell/SwitchHostDialog";
 import { cn } from "@/lib/utils";
 
 export type HostBadgeStatus = "online" | "offline" | "unknown";
@@ -72,6 +75,12 @@ const RECONNECT_WORD = "offline — click to reconnect";
  * A dormant resumable managed host is excluded: its "offline" is idle
  * dormancy the next message wakes, not a disconnect to act on.
  *
+ * Otherwise the badge is a button that opens `SwitchHostDialog` to move the
+ * session to another machine. Reconnect keeps the click when it applies — it
+ * has no other entry point — and offers the move inside its own dialog
+ * instead. Server-managed sandbox hosts never offer it: the server owns
+ * their placement.
+ *
  * @param sessionId - The open conversation whose host to show.
  * @param onReconnect - Opens the reconnect help dialog. Wired by the caller
  *   for every host-bound session; the badge itself decides when a host is
@@ -84,6 +93,7 @@ export function HostBadge({
   sessionId: string;
   onReconnect?: () => void;
 }) {
+  const [switchOpen, setSwitchOpen] = useState(false);
   const { session } = useSession(sessionId);
   const hostId = session?.hostId ?? null;
   // Keep sandbox hosts so managed sessions resolve to a provider label.
@@ -93,14 +103,39 @@ export function HostBadge({
   const liveOnline = useSessionHostOnline(sessionId);
 
   const host = hostId ? hosts?.find((h) => h.host_id === hostId) : undefined;
+
+  // Host liveness is keyed by SESSION, not by host, and comes from a ~10s
+  // poll. A host switch repoints `hostId` as soon as the session snapshot
+  // refetches, but the map still holds the value polled against the host we
+  // just left — so moving off a dead host paints a red dot beside a machine
+  // that is demonstrably up until the next tick. Treat the value as stale
+  // from the moment the binding changes until the poll reports something
+  // different, which can only be an observation of the new host.
+  const bindingRef = useRef<{
+    hostId: string | null;
+    at: boolean | null | undefined;
+    stale: boolean;
+  }>({ hostId, at: liveOnline, stale: false });
+  if (bindingRef.current.hostId !== hostId) {
+    bindingRef.current = { hostId, at: liveOnline, stale: true };
+  } else if (bindingRef.current.stale && bindingRef.current.at !== liveOnline) {
+    bindingRef.current = { hostId, at: liveOnline, stale: false };
+  }
+  const livenessPredatesBinding = bindingRef.current.stale;
+
   // Prefer the live health signal. Both `false` (host down) and `null`
   // (the stream's "not host-bound" signal) are meaningful answers, so we
   // only fall back to the host record's stored status when liveness has
-  // not been observed yet (`undefined`). Falling back on `null` would let
-  // a stale record's "online" flash a green dot for a session the stream
-  // says is unbound — `null` must reach resolveHostBadge as "unknown".
+  // not been observed yet (`undefined`) or still describes the previous
+  // binding. Falling back on `null` would let a stale record's "online"
+  // flash a green dot for a session the stream says is unbound — `null`
+  // must reach resolveHostBadge as "unknown".
   const online =
-    liveOnline === undefined ? (host ? host.status === "online" : undefined) : liveOnline;
+    liveOnline === undefined || livenessPredatesBinding
+      ? host
+        ? host.status === "online"
+        : undefined
+      : liveOnline;
 
   const badge = resolveHostBadge({ hostId, host, online });
   if (!badge) return null;
@@ -140,15 +175,46 @@ export function HostBadge({
     );
   }
 
+  // Sandbox-backed hosts are provisioned (and relaunched) by the server, so a
+  // manual move isn't meaningful. An unresolved record — a shared session, or
+  // the list still loading — can't be confirmed non-sandbox, so it stays
+  // passive too rather than offering a switch that may not apply.
+  const canSwitch = host !== undefined && !host.sandbox_provider;
+  if (!canSwitch) {
+    return (
+      // No aria-label: on a non-interactive div it's announced unreliably and
+      // would only duplicate the sr-only text where it is honored.
+      <div
+        data-testid="host-badge"
+        className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground"
+        title={title}
+      >
+        {content}
+      </div>
+    );
+  }
+
   return (
-    // No aria-label: on a non-interactive div it's announced unreliably and
-    // would only duplicate the sr-only text where it is honored.
-    <div
-      data-testid="host-badge"
-      className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground"
-      title={title}
-    >
-      {content}
-    </div>
+    <>
+      <button
+        type="button"
+        data-testid="host-badge"
+        onClick={() => setSwitchOpen(true)}
+        className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        title={`${title} — click to switch`}
+      >
+        {content}
+      </button>
+      {/* Mounted only while open: the badge renders on every session, and a
+          closed dialog would still run its host query and workspace hooks. */}
+      {switchOpen && (
+        <SwitchHostDialog
+          open
+          onOpenChange={setSwitchOpen}
+          sessionId={sessionId}
+          currentHostId={hostId}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/hooks/useSessionLiveness.test.ts
+++ b/web/src/hooks/useSessionLiveness.test.ts
@@ -1,6 +1,11 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type LivenessRow, livenessRowFromSession, useSessionLiveness } from "./useSessionLiveness";
+import {
+  STARTING_GRACE_S,
+  type LivenessRow,
+  livenessRowFromSession,
+  useSessionLiveness,
+} from "./useSessionLiveness";
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import type { Session } from "@/lib/types";
 
@@ -42,7 +47,7 @@ function derive(
   runner: boolean | undefined,
   host: boolean | null | undefined,
   c: LivenessRow | null,
-  opts?: { turnActive?: boolean },
+  opts?: { turnActive?: boolean; launchedAt?: number | null },
 ) {
   runnerMock.mockReturnValue(runner);
   hostMock.mockReturnValue(host);
@@ -172,6 +177,49 @@ describe("useSessionLiveness — derivation truth table", () => {
     });
     expect(derive(false, false, conv({ host_id: null, kind: "sub_agent" }))).toEqual({
       kind: "runner_asleep",
+    });
+  });
+
+  describe("host-switch launch grace", () => {
+    it("starting while a just-launched runner has not registered yet", () => {
+      // A switch binds a runner on the new host, but nothing on the wire
+      // says so: the session is old (no created_at grace) and no turn is in
+      // flight. Steady-state with these inputs is runner_asleep, which
+      // renders NO indicator — the move would land on a silent empty chat.
+      expect(derive(false, true, conv({ host_id: "h2" }), { launchedAt: Date.now() })).toEqual({
+        kind: "starting",
+      });
+    });
+
+    it("applies even though a runner was previously online", () => {
+      // Deliberately not gated on "ever online": the whole point of a switch
+      // is that the old runner WAS up and is now gone, so the session
+      // genuinely re-enters cold boot. Same-mount rerender so the hook's
+      // ever-online ref carries the earlier `true`.
+      const c = conv({ host_id: "h2" });
+      hostMock.mockReturnValue(true);
+      runnerMock.mockReturnValue(true);
+      const launchedAt = Date.now();
+      const { result, rerender } = renderHook(
+        (props: { launchedAt: number | null }) =>
+          useSessionLiveness(SID, c, { launchedAt: props.launchedAt }),
+        { initialProps: { launchedAt: null as number | null } },
+      );
+      expect(result.current).toEqual({ kind: "online" });
+
+      runnerMock.mockReturnValue(false);
+      rerender({ launchedAt });
+      expect(result.current).toEqual({ kind: "starting" });
+    });
+
+    it("expires so a launch that never lands still reaches its real state", () => {
+      // The marker is a grace, not a latch — a runner that never registers
+      // must fall through to the actionable state instead of spinning
+      // forever.
+      const stale = Date.now() - (STARTING_GRACE_S + 1) * 1000;
+      expect(derive(false, true, conv({ host_id: "h2" }), { launchedAt: stale })).toEqual({
+        kind: "runner_asleep",
+      });
     });
   });
 

--- a/web/src/hooks/useSessionLiveness.ts
+++ b/web/src/hooks/useSessionLiveness.ts
@@ -190,12 +190,16 @@ function isOwner(conv: Pick<Conversation, "permission_level"> | null | undefined
  *   When the runner is down but the host is up, this upgrades the idle
  *   `runner_asleep` state to `starting` — the relaunch is happening now,
  *   so the user sees a "Connecting…" intermediate instead of a silent gap.
+ * @param opts.launchedAt Epoch ms when this client last asked a host to
+ *   launch a runner outside the send path (a host switch). Extends the
+ *   startup grace to that launch, so the move shows "Starting up…" rather
+ *   than an idle `runner_asleep` with no indicator at all.
  * @returns The single active liveness variant.
  */
 export function useSessionLiveness(
   sessionId: string | undefined,
   conv: LivenessRow | null | undefined,
-  opts?: { turnActive?: boolean },
+  opts?: { turnActive?: boolean; launchedAt?: number | null },
 ): SessionLiveness {
   const runnerOnline = useSessionRunnerOnline(sessionId);
   const hostOnline = useSessionHostOnline(sessionId);
@@ -241,6 +245,16 @@ export function useSessionLiveness(
     createdAt > 0 &&
     Date.now() / 1000 - createdAt < STARTING_GRACE_S
   ) {
+    return { kind: "starting" };
+  }
+
+  // 2'. Same grace for a runner this client just asked a host to launch
+  // outside the send path (a host switch). Deliberately NOT gated on
+  // `runnerEverOnline`: the point of a switch is that the previous runner
+  // WAS online and is now gone, so the session genuinely re-enters cold
+  // boot. Epoch ms, unlike `created_at`.
+  const launchedAt = opts?.launchedAt;
+  if (typeof launchedAt === "number" && Date.now() - launchedAt < STARTING_GRACE_S * 1000) {
     return { kind: "starting" };
   }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1080,8 +1080,12 @@ export function ChatPage() {
         kind: activeSession?.kind,
       }
     : livenessRowFromSession(activeSession);
+  // Host-switch launch marker; see the store field. Keeps this surface's
+  // liveness in step with AppShell's, which drives the startup spinner.
+  const runnerLaunchedAt = useChatStore((s) => s.runnerLaunchedAt);
   const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
     turnActive: status === "streaming",
+    launchedAt: runnerLaunchedAt,
   });
 
   // Browser tab title: "● Title" while the main session is working so

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -65,7 +65,11 @@ import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import { useChatStore } from "@/store/chatStore";
-import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
+import {
+  STARTING_GRACE_S,
+  livenessRowFromSession,
+  useSessionLiveness,
+} from "@/hooks/useSessionLiveness";
 import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { ChatHeader } from "./ChatHeader";
@@ -346,10 +350,13 @@ export function AppShell() {
   // `failed` session suppresses the terminal-startup spinner so a crashed
   // runner shows only the error banner, not a spinner that can never resolve.
   const sessionStatus = useChatStore((s) => s.sessionStatus);
+  // Set when this client launches a runner outside the send path (a host
+  // switch); extends the liveness startup grace so the move spins.
+  const runnerLaunchedAt = useChatStore((s) => s.runnerLaunchedAt);
   const liveness = useSessionLiveness(
     conversationId ?? undefined,
     activeConv ?? livenessRowFromSession(activeSession),
-    { turnActive: chatStatus === "streaming" },
+    { turnActive: chatStatus === "streaming", launchedAt: runnerLaunchedAt },
   );
   // Full agent object (mcp_servers + policies) for the header info icon.
   // react-query-cached, so this shares the fetch ChatPage's picker makes.
@@ -1254,9 +1261,14 @@ export function AppShell() {
   // local send lifecycle back to `idle` and the suppression re-engages.
   // `sessionStatus` (declared above) is set by both the live
   // `session.status:failed` push and the snapshot reload.
+  // A host switch tears down the old runner, which can push a lingering
+  // `failed` before the new one connects — so a just-requested launch lifts
+  // the failed-suppression exactly like an in-flight send does.
+  const launchPending =
+    runnerLaunchedAt !== null && Date.now() - runnerLaunchedAt < STARTING_GRACE_S * 1000;
   const terminalStartingUp =
     !terminalsAvailable &&
-    (sessionStatus !== "failed" || chatStatus === "streaming") &&
+    (sessionStatus !== "failed" || chatStatus === "streaming" || launchPending) &&
     (liveness.kind === "starting" || terminalPending);
   // A rail-opened shell (any open terminal key other than the agent's
   // own terminal) takes over the main view chrome-free:

--- a/web/src/shell/HostLabel.tsx
+++ b/web/src/shell/HostLabel.tsx
@@ -1,0 +1,40 @@
+import { MonitorCloudIcon, MonitorIcon } from "lucide-react";
+
+import type { Host } from "@/hooks/useHosts";
+
+/**
+ * Compact host row for a `<Select>` item — icon, name, and an
+ * online/offline pill.
+ *
+ * Its own module rather than a sibling dialog's export: the dialogs that
+ * render host pickers also reference each other (``ResumeWithDirectoryDialog``
+ * takes ``buildReconnectCommand`` from ``ReconnectSessionDialog``, which
+ * offers ``SwitchHostDialog``), so hanging the shared label off any one of
+ * them closes an import cycle.
+ *
+ * @param host - The host to render, e.g. ``{name: "mac-laptop", status:
+ *   "online"}``.
+ */
+export function HostLabel({ host }: { host: Host }) {
+  const isOnline = host.status === "online";
+  return (
+    <span className="flex items-center gap-2">
+      {host.name.toLowerCase().includes("cloud") ? (
+        <MonitorCloudIcon className="size-4 text-muted-foreground" />
+      ) : (
+        <MonitorIcon className="size-4 text-muted-foreground" />
+      )}
+      <span className="font-mono text-sm">{host.name}</span>
+      <span
+        className={`inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider ${
+          isOnline ? "text-green-600" : "text-muted-foreground"
+        }`}
+      >
+        <span
+          className={`inline-block size-1.5 rounded-full ${isOnline ? "bg-green-500" : "bg-muted-foreground"}`}
+        />
+        {host.status}
+      </span>
+    </span>
+  );
+}

--- a/web/src/shell/ReconnectSessionDialog.test.tsx
+++ b/web/src/shell/ReconnectSessionDialog.test.tsx
@@ -48,6 +48,17 @@ vi.mock("./ForkSessionDialog", () => ({
     </div>
   ),
 }));
+// The switch dialog owns its own host/filesystem queries; stub it so these
+// tests only pin whether this dialog offers it and with which session.
+vi.mock("./SwitchHostDialog", () => ({
+  SwitchHostDialog: (props: { sessionId: string; currentHostId: string | null }) => (
+    <div
+      data-testid="switch-host-dialog-stub"
+      data-session-id={props.sessionId}
+      data-current-host-id={props.currentHostId ?? ""}
+    />
+  ),
+}));
 
 afterEach(() => {
   cleanup();
@@ -165,6 +176,36 @@ describe("<ReconnectSessionDialog />", () => {
     // The clone form stays mounted (forceMount) but its panel is the
     // inactive one while the Reconnect tab is the default.
     expect(clonePanelState()).toBe("inactive");
+  });
+
+  it("offers the host switch to a host_offline owner and hands off to that dialog", () => {
+    // The composer badge no longer carries a switch link while offline, so
+    // this is the only way to escape a host that isn't coming back.
+    const { onOpenChange } = renderDialog({
+      state: "host_offline",
+      isOwner: true,
+      sourceHostId: "host_dead",
+    });
+    expect(screen.queryByTestId("switch-host-dialog-stub")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("reconnect-session-switch-host"));
+
+    // Handing off means this dialog closes as the switch one opens; the
+    // switch dialog is a sibling, so it survives that close.
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    const stub = screen.getByTestId("switch-host-dialog-stub");
+    expect(stub.getAttribute("data-session-id")).toBe("conv_abc123");
+    expect(stub.getAttribute("data-current-host-id")).toBe("host_dead");
+  });
+
+  it("withholds the host switch from a non-owner and from local_stranded", () => {
+    // Binding a runner on another machine isn't a viewer's call, and a
+    // local_stranded session has no host to move off of.
+    renderDialog({ state: "host_offline", isOwner: false });
+    expect(screen.queryByTestId("reconnect-session-switch-host")).toBeNull();
+    cleanup();
+    renderDialog({ state: "local_stranded", isOwner: true });
+    expect(screen.queryByTestId("reconnect-session-switch-host")).toBeNull();
   });
 
   it("defaults to the Clone tab for a host_offline non-owner", () => {

--- a/web/src/shell/ReconnectSessionDialog.tsx
+++ b/web/src/shell/ReconnectSessionDialog.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import {
   Dialog,
   DialogContent,
@@ -5,9 +7,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CliCommandBlock } from "./CliCommandBlock";
 import { ForkSessionForm } from "./ForkSessionDialog";
+import { SwitchHostDialog } from "./SwitchHostDialog";
 
 const CLAUDE_NATIVE_WRAPPER = "claude-code-native-ui";
 
@@ -138,6 +142,7 @@ export function ReconnectSessionDialog({
   sourceHostId?: string | null;
   sourceGitBranch?: string | null;
 }) {
+  const [switchOpen, setSwitchOpen] = useState(false);
   const isHostReconnect = state === "host_offline";
   // A non-owner can't reach the host machine to reconnect it, so the
   // CLI command is useless to them. Owners of both states, and anyone
@@ -153,61 +158,96 @@ export function ReconnectSessionDialog({
       : HOST_VIEWER_DESCRIPTION
     : RUN_DESCRIPTION;
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        data-testid="reconnect-session-dialog"
-        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
-      >
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          {/* The visible per-tab text lives inside the tab panels; this
-              keeps the dialog described for screen readers. */}
-          <DialogDescription className="sr-only">{description}</DialogDescription>
-        </DialogHeader>
-        {/* Uncontrolled tabs: DialogContent unmounts on close, so the
-            default re-applies on every open. */}
-        <Tabs
-          defaultValue={showCommand ? "reconnect" : "clone"}
-          className="flex min-h-0 flex-1 flex-col gap-4"
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          data-testid="reconnect-session-dialog"
+          className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
         >
-          <TabsList className="w-full">
-            <TabsTrigger value="reconnect" data-testid="reconnect-session-tab-reconnect">
-              Reconnect
-            </TabsTrigger>
-            <TabsTrigger value="clone" data-testid="reconnect-session-tab-clone">
-              Clone
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="reconnect" className="flex flex-col gap-4">
-            <p
-              className="text-ui text-muted-foreground"
-              data-testid="reconnect-session-description"
-            >
-              {description}
-            </p>
-            {showCommand && <CliCommandBlock command={command} testIdPrefix="reconnect-session" />}
-          </TabsContent>
-          {/* forceMount keeps the fork form's state (notably the
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            {/* The visible per-tab text lives inside the tab panels; this
+              keeps the dialog described for screen readers. */}
+            <DialogDescription className="sr-only">{description}</DialogDescription>
+          </DialogHeader>
+          {/* Uncontrolled tabs: DialogContent unmounts on close, so the
+            default re-applies on every open. */}
+          <Tabs
+            defaultValue={showCommand ? "reconnect" : "clone"}
+            className="flex min-h-0 flex-1 flex-col gap-4"
+          >
+            <TabsList className="w-full">
+              <TabsTrigger value="reconnect" data-testid="reconnect-session-tab-reconnect">
+                Reconnect
+              </TabsTrigger>
+              <TabsTrigger value="clone" data-testid="reconnect-session-tab-clone">
+                Clone
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="reconnect" className="flex flex-col gap-4">
+              <p
+                className="text-ui text-muted-foreground"
+                data-testid="reconnect-session-description"
+              >
+                {description}
+              </p>
+              {showCommand && (
+                <CliCommandBlock command={command} testIdPrefix="reconnect-session" />
+              )}
+              {/* Waiting on a machine that may not come back is a dead end, so
+                offer the move as the way out. Owners only — binding a runner
+                elsewhere is not something a viewer can do. */}
+              {isHostReconnect && isOwner && (
+                <div className="flex flex-col gap-2 border-t pt-4">
+                  <p className="text-ui text-muted-foreground">
+                    Can't bring that machine back? Move the session to another one instead.
+                  </p>
+                  <Button
+                    variant="outline"
+                    className="self-start"
+                    data-testid="reconnect-session-switch-host"
+                    onClick={() => {
+                      setSwitchOpen(true);
+                      onOpenChange(false);
+                    }}
+                  >
+                    Switch host
+                  </Button>
+                </div>
+              )}
+            </TabsContent>
+            {/* forceMount keeps the fork form's state (notably the
               created-fork ref after a failed launch) across tab switches —
               losing it would re-fork on retry. The explicit hidden class is
               required: `flex` would otherwise override the native [hidden]
               display:none that Radix puts on the inactive panel. */}
-          <TabsContent
-            value="clone"
-            forceMount
-            className="flex min-h-0 flex-1 flex-col gap-4 data-[state=inactive]:hidden"
-          >
-            <ForkSessionForm
-              sourceSessionId={conversationId}
-              sourceTitle={sourceTitle}
-              sourceWorkspace={sourceWorkspace}
-              sourceHostId={sourceHostId}
-              sourceGitBranch={sourceGitBranch}
-              onClose={() => onOpenChange(false)}
-            />
-          </TabsContent>
-        </Tabs>
-      </DialogContent>
-    </Dialog>
+            <TabsContent
+              value="clone"
+              forceMount
+              className="flex min-h-0 flex-1 flex-col gap-4 data-[state=inactive]:hidden"
+            >
+              <ForkSessionForm
+                sourceSessionId={conversationId}
+                sourceTitle={sourceTitle}
+                sourceWorkspace={sourceWorkspace}
+                sourceHostId={sourceHostId}
+                sourceGitBranch={sourceGitBranch}
+                onClose={() => onOpenChange(false)}
+              />
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+      {/* Sibling of the dialog above, not a child: the switch opens as the
+          reconnect dialog closes, and a child would unmount with it. */}
+      {switchOpen && (
+        <SwitchHostDialog
+          open
+          onOpenChange={setSwitchOpen}
+          sessionId={conversationId}
+          currentHostId={sourceHostId ?? null}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/shell/ResumeWithDirectoryDialog.tsx
+++ b/web/src/shell/ResumeWithDirectoryDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangleIcon, MonitorCloudIcon, GitBranchIcon, MonitorIcon } from "lucide-react";
+import { AlertTriangleIcon, GitBranchIcon } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -20,45 +20,18 @@ import {
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { WorkspacePathField } from "./WorkspacePathField";
 import { CliCommandBlock } from "./CliCommandBlock";
+import { HostLabel } from "./HostLabel";
 import { buildReconnectCommand } from "./ReconnectSessionDialog";
 import {
   isValidWorkspace,
   normalizeWorkspacePath,
   sessionsSharingDirectory,
 } from "./NewChatDialog";
-import { useHosts, type Host } from "@/hooks/useHosts";
+import { useHosts } from "@/hooks/useHosts";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { getSessionSlim, launchRunner } from "@/lib/sessionsApi";
-
-/**
- * Compact host label for the Select item — mirrors NewChatDialog's
- * HostOption (which is private to that module).
- */
-function HostLabel({ host }: { host: Host }) {
-  const isOnline = host.status === "online";
-  return (
-    <span className="flex items-center gap-2">
-      {host.name.toLowerCase().includes("cloud") ? (
-        <MonitorCloudIcon className="size-4 text-muted-foreground" />
-      ) : (
-        <MonitorIcon className="size-4 text-muted-foreground" />
-      )}
-      <span className="font-mono text-sm">{host.name}</span>
-      <span
-        className={`inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider ${
-          isOnline ? "text-green-600" : "text-muted-foreground"
-        }`}
-      >
-        <span
-          className={`inline-block size-1.5 rounded-full ${isOnline ? "bg-green-500" : "bg-muted-foreground"}`}
-        />
-        {host.status}
-      </span>
-    </span>
-  );
-}
 
 /**
  * Dialog surfaced when the user tries to chat with an unbound *coding*

--- a/web/src/shell/SwitchHostDialog.test.tsx
+++ b/web/src/shell/SwitchHostDialog.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { SwitchHostDialog } from "./SwitchHostDialog";
+import { useHosts } from "@/hooks/useHosts";
+import { useHostFilesystem } from "@/hooks/useHostFilesystem";
+import { launchRunner, updateSession } from "@/lib/sessionsApi";
+
+// Heavy children have their own suites; stub them so this one stays on the
+// dialog's two-call move and its recovery from a half-finished switch.
+vi.mock("./WorkspacePathField", () => ({
+  WorkspacePathField: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input
+      data-testid="mock-workspace-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock("./WorkspacePicker", () => ({
+  WorkspacePicker: () => <div data-testid="mock-workspace-picker" />,
+  homeFromEntries: () => null,
+  isNavigablePath: () => false,
+}));
+vi.mock("./HostLabel", () => ({
+  HostLabel: ({ host }: { host: { name: string } }) => <span>{host.name}</span>,
+}));
+vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+vi.mock("@/hooks/useHostFilesystem", () => ({ useHostFilesystem: vi.fn() }));
+vi.mock("@/hooks/useRecentWorkspaces", () => ({
+  useRecentWorkspaces: () => ({ recent: ["/Users/alice/repo"], addRecent: vi.fn() }),
+}));
+vi.mock("@/lib/sessionsApi", () => ({ launchRunner: vi.fn(), updateSession: vi.fn() }));
+// Radix Select uses a portal + pointer events jsdom can't drive; a native
+// <select> keeps the option list assertable.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: ReactNode;
+  }) => (
+    <select
+      data-testid="mock-host-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => children,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => children,
+  SelectItem: ({
+    value,
+    children,
+    "data-testid": testId,
+  }: {
+    value: string;
+    children: ReactNode;
+    "data-testid"?: string;
+  }) => (
+    <option value={value} data-testid={testId}>
+      {children}
+    </option>
+  ),
+}));
+
+const useHostsMock = vi.mocked(useHosts);
+const useHostFilesystemMock = vi.mocked(useHostFilesystem);
+const launchRunnerMock = vi.mocked(launchRunner);
+const updateSessionMock = vi.mocked(updateSession);
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <SwitchHostDialog open onOpenChange={() => {}} sessionId="conv_1" currentHostId="host_old" />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useHostsMock.mockReset();
+  useHostFilesystemMock.mockReset();
+  launchRunnerMock.mockReset();
+  updateSessionMock.mockReset();
+  useHostsMock.mockReturnValue({
+    data: [
+      { host_id: "host_old", name: "mac-laptop", owner: "alice", status: "online" },
+      { host_id: "host_new", name: "linux-box", owner: "alice", status: "online" },
+    ],
+  } as unknown as ReturnType<typeof useHosts>);
+  useHostFilesystemMock.mockReturnValue({
+    data: undefined,
+    isPlaceholderData: false,
+  } as unknown as ReturnType<typeof useHostFilesystem>);
+  updateSessionMock.mockResolvedValue({} as Awaited<ReturnType<typeof updateSession>>);
+  launchRunnerMock.mockResolvedValue({ runnerId: "runner_new" });
+});
+
+afterEach(() => cleanup());
+
+describe("SwitchHostDialog", () => {
+  it("releases the runner and the model override before launching on the new host", async () => {
+    renderDialog();
+
+    const button = await screen.findByTestId("switch-host-button");
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(button);
+
+    // The model id is resolved against the old host's catalog, so it has to
+    // go with the binding — otherwise the next turn asks the new host for a
+    // model it may not have. `silent` keeps the reset out of the transcript.
+    await waitFor(() => expect(updateSessionMock).toHaveBeenCalledTimes(1));
+    expect(updateSessionMock).toHaveBeenCalledWith("conv_1", {
+      runnerId: "",
+      modelOverride: null,
+      silent: true,
+    });
+    await waitFor(() => expect(launchRunnerMock).toHaveBeenCalledTimes(1));
+    expect(launchRunnerMock).toHaveBeenCalledWith("host_new", "conv_1", "/Users/alice/repo");
+    // The launch endpoint binds with `WHERE runner_id IS NULL`, so a launch
+    // that raced ahead of the release would be rejected outright.
+    expect(updateSessionMock.mock.invocationCallOrder[0]).toBeLessThan(
+      launchRunnerMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("offers the origin host again when the launch fails after the release", async () => {
+    launchRunnerMock.mockRejectedValue(new Error("host is offline"));
+    renderDialog();
+
+    // Moving to the host it is already on is a no-op, so the origin starts
+    // out of the list.
+    expect(screen.queryByTestId("switch-host-option-host_old")).toBeNull();
+    expect(screen.getByTestId("switch-host-option-host_new")).toBeInTheDocument();
+
+    const button = await screen.findByTestId("switch-host-button");
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(button);
+
+    // Released but not re-bound: the session is on no host at all, so the
+    // origin becomes a real target and the copy has to say what happened
+    // rather than read as two unrelated outages.
+    const error = await screen.findByTestId("switch-host-error");
+    expect(error.textContent).toContain("isn't running anywhere");
+    expect(error.textContent).toContain("host is offline");
+    expect(screen.getByTestId("switch-host-option-host_old")).toBeInTheDocument();
+  });
+});

--- a/web/src/shell/SwitchHostDialog.tsx
+++ b/web/src/shell/SwitchHostDialog.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertTriangleIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { WorkspacePicker, isNavigablePath, parentOf } from "./WorkspacePicker";
+import { WorkspacePathField } from "./WorkspacePathField";
+import { HostLabel } from "./HostLabel";
+import { isValidWorkspace, normalizeWorkspacePath } from "./NewChatDialog";
+import { useHosts } from "@/hooks/useHosts";
+import { useHostFilesystem } from "@/hooks/useHostFilesystem";
+import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
+import { launchRunner, updateSession } from "@/lib/sessionsApi";
+import { useChatStore } from "@/store/chatStore";
+
+/**
+ * Move an existing session onto a different host, from the composer's
+ * host badge (see ``HostBadge``).
+ *
+ * There is no single "switch host" endpoint — the move is the same two
+ * calls the CLI's daemon-launch path already makes:
+ *
+ * 1. ``PATCH /v1/sessions/{id}`` with ``runner_id: ""`` releases the
+ *    current runner binding. The launch endpoint binds atomically with
+ *    ``UPDATE … WHERE runner_id IS NULL``, so a bound session is
+ *    rejected until this clears it. The same call clears the model
+ *    override, which is bound to the old host's catalog.
+ * 2. ``POST /v1/hosts/{new}/runners`` validates the directory against
+ *    the agent's sandbox boundary, binds the runner, and repoints the
+ *    session's ``host_id``.
+ *
+ * A directory is always required: workspaces are per-machine, so the
+ * old path means nothing on the new host even when it reads the same.
+ *
+ * The first available host is selected on open and its directory
+ * defaulted, so the common "just move it over there" case is one click.
+ *
+ * Step 1 landing without step 2 (a dropped connection between them)
+ * leaves the session bound to nothing. The dialog stays open on that
+ * failure and puts the origin host back in the picker, so recovering —
+ * onward to the new host, or back to the old one — is the same click.
+ *
+ * @param open - Whether the dialog is visible.
+ * @param onOpenChange - Radix-controlled visibility setter.
+ * @param sessionId - The session to move, e.g. ``"conv_abc"``.
+ * @param currentHostId - The host it is bound to now; excluded from the
+ *   picker and used for the "different machine" warning.
+ */
+export function SwitchHostDialog({
+  open,
+  onOpenChange,
+  sessionId,
+  currentHostId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+  currentHostId: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const { data: hosts } = useHosts({ enabled: open });
+  const markRunnerLaunched = useChatStore((s) => s.markRunnerLaunched);
+
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+  const [workspace, setWorkspace] = useState("");
+  const [browsing, setBrowsing] = useState(false);
+  const [browseNonce, setBrowseNonce] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Set when step 1 succeeded but step 2 failed: the session is now
+  // unbound, so the retry copy has to say so rather than implying the
+  // old host is still serving it.
+  const [stranded, setStranded] = useState(false);
+
+  const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
+
+  // Pinned at mount — the badge mounts this dialog only while it is open.
+  // A successful switch repoints the session's host, so filtering on the
+  // live prop would drop the just-picked host out of its own list mid-
+  // submit and blank the select, which renders the chosen item's label.
+  const [originHostId] = useState(currentHostId);
+
+  // Only online hosts can accept a runner, and moving to the host the
+  // session is already on is a no-op — until a half-finished switch
+  // leaves it unbound, when the origin is a target like any other and
+  // moving back is the quickest way out.
+  const targetHosts = useMemo(
+    () =>
+      (hosts ?? []).filter(
+        (h) => h.status === "online" && (stranded || h.host_id !== originHostId),
+      ),
+    [hosts, originHostId, stranded],
+  );
+
+  // Land on a usable selection instead of an empty form: take the first
+  // available host as soon as the list arrives.
+  useEffect(() => {
+    if (open && selectedHostId === null && targetHosts.length > 0) {
+      setSelectedHostId(targetHosts[0].host_id);
+    }
+  }, [open, selectedHostId, targetHosts]);
+
+  // Home listing for the chosen host. Shares the picker's query key, so
+  // opening the browser afterwards costs no extra request.
+  const { data: homeListing, isPlaceholderData } = useHostFilesystem(
+    selectedHostId,
+    selectedHostId === null ? null : "",
+  );
+  // Entries share one parent, so the home listing's first entry resolves the
+  // host's absolute home directory.
+  const firstHomeEntry = homeListing && !isPlaceholderData ? homeListing.entries[0] : undefined;
+  const resolvedHome = firstHomeEntry ? parentOf(firstHomeEntry.path) : null;
+
+  // A path is meaningless on a machine it didn't come from, so clear the
+  // field whenever the target changes and let the default below refill it.
+  const prevHostId = useRef<string | null>(null);
+  const userEditedRef = useRef(false);
+  useEffect(() => {
+    if (prevHostId.current === selectedHostId) return;
+    prevHostId.current = selectedHostId;
+    setWorkspace("");
+    userEditedRef.current = false;
+  }, [selectedHostId]);
+
+  // Default the directory for the chosen host: the last workspace used
+  // there, else its home. Never overwrites typed text — a late-arriving
+  // home listing must not clobber what the user is entering.
+  useEffect(() => {
+    if (!open || selectedHostId === null || workspace !== "" || userEditedRef.current) return;
+    const preferred = recent[0] ?? resolvedHome;
+    if (preferred) setWorkspace(preferred);
+  }, [open, selectedHostId, workspace, recent, resolvedHome]);
+
+  function handleWorkspaceChange(next: string): void {
+    userEditedRef.current = true;
+    setWorkspace(next);
+  }
+
+  function handleOpenChange(next: boolean): void {
+    if (!next) {
+      setSelectedHostId(null);
+      setWorkspace("");
+      setBrowsing(false);
+      setError(null);
+      setStranded(false);
+      setSubmitting(false);
+      prevHostId.current = null;
+      userEditedRef.current = false;
+    }
+    onOpenChange(next);
+  }
+
+  const workspaceTrimmed = normalizeWorkspacePath(workspace) ?? "";
+  const workspaceValid = isValidWorkspace(workspace);
+
+  function commitWorkspacePath(path: string): void {
+    handleWorkspaceChange(path);
+    setBrowsing(true);
+    setBrowseNonce((n) => n + 1);
+  }
+
+  async function handleSwitch(): Promise<void> {
+    if (!selectedHostId || !workspaceValid) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Drop the model override alongside the runner binding. A model id is
+      // host-bound — the catalog depends on that machine's credentials — so
+      // carrying it over lands the next turn on "model may not exist or you
+      // may not have access to it". Cleared, the new runner resolves the
+      // harness default, which is by definition available there. `silent`
+      // keeps this off the transcript: it's part of the move, not a /model.
+      await updateSession(sessionId, { runnerId: "", modelOverride: null, silent: true });
+      // From here the session is unbound until the launch lands.
+      setStranded(true);
+      await launchRunner(selectedHostId, sessionId, workspaceTrimmed);
+      // The new runner is booting but nothing on the wire says so yet, and
+      // no turn is in flight to imply it — without this the session reads as
+      // idle and the move lands on a silent, empty chat.
+      markRunnerLaunched();
+      addRecent(workspaceTrimmed);
+      // Close before refreshing. The session refetch reports the new host,
+      // and keeping the dialog on screen for two round trips leaves it
+      // sitting in "Switching…" long after the move has landed.
+      handleOpenChange(false);
+      void queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't switch hosts. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const noTargets = hosts !== undefined && targetHosts.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="switch-host-dialog" className="flex flex-col gap-4 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Switch host</DialogTitle>
+          <DialogDescription>Move this session to another connected machine.</DialogDescription>
+        </DialogHeader>
+
+        {noTargets ? (
+          <p className="text-xs text-muted-foreground" data-testid="switch-host-no-targets">
+            No other hosts are online. Connect one with <code>omnigent host</code> and try again.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-muted-foreground">Host</span>
+              <Select value={selectedHostId ?? ""} onValueChange={(v) => setSelectedHostId(v)}>
+                <SelectTrigger className="w-full text-xs" data-testid="switch-host-select">
+                  <SelectValue placeholder="Select a host" />
+                </SelectTrigger>
+                <SelectContent>
+                  {targetHosts.map((host) => (
+                    <SelectItem
+                      key={host.host_id}
+                      value={host.host_id}
+                      data-testid={`switch-host-option-${host.host_id}`}
+                    >
+                      <HostLabel host={host} />
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-muted-foreground">Working directory</span>
+              {selectedHostId ? (
+                <>
+                  <WorkspacePathField
+                    hostId={selectedHostId}
+                    value={workspace}
+                    onChange={handleWorkspaceChange}
+                    onBrowse={() => setBrowsing((v) => !v)}
+                    onCommit={commitWorkspacePath}
+                    recent={recent}
+                    dropdownDisabled={browsing}
+                  />
+                  {browsing && (
+                    <WorkspacePicker
+                      key={browseNonce}
+                      hostId={selectedHostId}
+                      initialPath={isNavigablePath(workspaceTrimmed) ? workspaceTrimmed : undefined}
+                      onSelect={(path) => {
+                        handleWorkspaceChange(path);
+                        setBrowsing(false);
+                      }}
+                      onClose={() => setBrowsing(false)}
+                    />
+                  )}
+                  <p
+                    className="flex items-start gap-1.5 text-xs text-warning"
+                    data-testid="switch-host-warning"
+                  >
+                    <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+                    <span>
+                      Files don't move across hosts. Anything uncommitted stays on the old machine,
+                      and the agent picks up in this directory instead.
+                    </span>
+                  </p>
+                </>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Select a host to choose a directory.
+                </p>
+              )}
+            </div>
+
+            {/* A stranded failure reads as two separate outages — the old host
+                "stopped working" and the new one "wouldn't connect" — so lead
+                with the actual state and demote the server's reason to a
+                secondary line. */}
+            {error !== null && (
+              <div className="flex flex-col gap-1 text-xs" data-testid="switch-host-error">
+                {stranded ? (
+                  <>
+                    <span className="text-destructive">
+                      The session left its old host but didn't start on the new one, so it isn't
+                      running anywhere. Pick a host — including the one it came from — and try
+                      again.
+                    </span>
+                    <span className="text-muted-foreground">{error}</span>
+                  </>
+                ) : (
+                  <span className="text-destructive">{error}</span>
+                )}
+              </div>
+            )}
+
+            <DialogFooter>
+              {/* `loading` overlays a centered spinner and disables the
+                  button while holding its width — the shared affordance every
+                  other submit button here uses. */}
+              <Button
+                data-testid="switch-host-button"
+                disabled={!selectedHostId || !workspaceValid}
+                loading={submitting}
+                onClick={handleSwitch}
+              >
+                Switch host
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -531,6 +531,17 @@ export interface ChatState {
    */
   terminalPending: boolean;
   /**
+   * Epoch ms when this client last asked a host to launch a runner for the
+   * open session outside the send path — today, a host switch. The runner
+   * is coming up but nothing on the wire says so yet: the session is not
+   * newly created, so the liveness startup grace doesn't apply, and no turn
+   * is in flight, so it would otherwise read as idle `runner_asleep` and
+   * show nothing at all. Feeds `useSessionLiveness` as a `starting` nudge
+   * and self-expires after `STARTING_GRACE_S`. `null` when no such launch
+   * is outstanding.
+   */
+  runnerLaunchedAt: number | null;
+  /**
    * Users currently viewing this session (presence circles in the
    * chat header). Replaced wholesale by every `session.presence` SSE
    * event — the wire protocol is full-state, never deltas — and
@@ -701,6 +712,9 @@ export interface ChatState {
   addComposerAttachment: (attachment: ComposerAttachment) => void;
   /** Drain the queued composer attachments (called by the composer). */
   clearPendingComposerAttachments: () => void;
+  /** Stamp {@link ChatState.runnerLaunchedAt} now — call right after a
+   *  successful `launchRunner` for the open session. */
+  markRunnerLaunched: () => void;
   /**
    * Compact the active session's context. Posts a ``compact`` event to the
    * server, which summarises the conversation history in-place. No-ops when
@@ -1094,6 +1108,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   skills: [],
   codexModelOptions: [],
   terminalPending: false,
+  runnerLaunchedAt: null,
   viewers: [],
   sandboxStatus: null,
   mcpStartup: null,
@@ -1820,6 +1835,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // session's composer (which drains the store on mount). Same reset
         // discipline as ``viewers`` above.
         pendingComposerAttachments: [],
+        runnerLaunchedAt: null,
         sandboxStatus: null,
         mcpStartup: null,
         abortController: null,
@@ -1899,6 +1915,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   clearPendingComposerAttachments: () => set({ pendingComposerAttachments: [] }),
+
+  markRunnerLaunched: () => set({ runnerLaunchedAt: Date.now() }),
 
   compact: async () => {
     const { conversationId } = get();


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; this is a UX gap found while moving sessions between machines.

## Summary

The composer's host badge was passive: it named the machine a session was bound to and stopped there. Moving a session to another machine meant dropping to the CLI. Clicking the badge now opens a **Switch host** dialog that releases the current runner and launches one on the host + directory you pick.

There is no new endpoint — the move is the same two calls the CLI's daemon-launch path already makes:

```
PATCH /v1/sessions/{id}   runner_id: ""      release the binding (+ clear the model override)
POST  /v1/hosts/{new}/runners                validate the dir, bind, repoint host_id
```

Everything else here is a consequence of that sequence being visible in the UI for the first time:

- **A half-finished move strands the session.** If step 1 lands and step 2 fails, the session is bound to *nothing* — and the one host that could take it straight back was filtered out of the picker. It now says plainly that the session isn't running anywhere and puts the origin host back in the list, so recovering forward or back is the same click.
- **The model override is host-bound.** A model id is resolved against the old host's catalog, so carrying it over lands the next turn on "model may not exist or you may not have access to it". The release PATCH clears it.
- **A just-launched runner looked idle.** It hasn't registered and no turn is in flight, so liveness read as `runner_asleep`, which renders nothing — the move landed on a silent, empty chat. A launch marker extends the startup grace to cover it, and lifts the failed-status suppression that tearing down the old runner can trip.
- **Host liveness is keyed by session and polled (~10s)**, so right after a switch it still describes the host we *left* — painting a red dot next to a machine that is demonstrably up. A value known to predate the current binding now defers to the host record until the poll speaks for the new host.
- **Reconnect keeps the click** on a disconnected host, since it has no other entry point (the banner below the composer defers to the badge). The move is offered inside the reconnect dialog instead, for owners — waiting on a machine that may not come back is a dead end.

Also fixed, because a host switch is what exposed it: the synthesized Claude resume transcript was writing the Omnigent **agent name** into Claude Code's `message.model`. An item's wire `model` field is `MessageData.agent` under a serialization alias, not an LLM id — so any cold cross-machine resume (a switch, a fork) handed Claude `claude-native-ui` as a model. Claude reported *"Session model claude-native-ui could not be restored"* and silently continued on a different model than the one selected. The field is now omitted; there is no real model id to preserve.

```
item.model ("claude-native-ui")  ──copied──▶  message.model  ──▶  claude --resume
   = MessageData.agent alias                   = a Claude model id      ✗ rejected → silent fallback
```

## Test Plan

Automated:

- `web`: full suite green — **276 files / 4965 tests**, plus `tsc -b`, `oxlint --deny-warnings`, prettier.
- `tests/test_claude_native.py`: **171 passed**.
- Both new behaviours are mutation-tested — reverting the fix fails the test:
  - stranded recovery → `Unable to find switch-host-option-host_old`
  - transcript model → `'model': 'claude-native-ui'` on the assistant record
  - stale liveness → `'new-box, offline'` instead of `'new-box, online'`

Manual, against a live server with two connected hosts:

1. Moved a running session between two hosts from the badge; confirmed it rebinds and resumes in the chosen directory.
2. Verified the combined `PATCH {runner_id: "", model_override: "default", silent: true}` returns 200 and clears both fields (read back from the store).
3. Killed the target host mid-switch to hit the stranded path; confirmed the recovery copy and that the origin host reappears in the picker.
4. Confirmed the badge goes green immediately on landing, with no red interval.

## Demo

N/A — screen recording to follow; the reviewer-visible surface is the Switch host dialog opened from the composer's host badge.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit coverage: `SwitchHostDialog.test.tsx` (the two-call move with the model clear, and the stranded-failure recovery), `HostBadge.test.tsx` (opens on the current binding, sandbox stays passive, reconnect keeps the click, stale-liveness guard), `ReconnectSessionDialog.test.tsx` (the switch hand-off, and that it's withheld from non-owners and `local_stranded`), `useSessionLiveness.test.ts` (the launch grace, that it applies despite a prior online runner, and that it expires).

Manual verification covered the parts a unit test can't reach: a real two-host move, the live server's response to the combined PATCH, and the post-switch dot colour. Three upstream `HostBadge` tests asserted the badge was a passive `div` whenever it wasn't reconnectable; the badge is now clickable to switch, so they were updated to assert the intent they were actually protecting — that reconnect is never offered there.

## Changelog

Move a running session to another machine from the host badge in the composer.
