### PR TITLE
fix(databricks): normalize generated app uv.lock to public PyPI

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -406,6 +406,32 @@ def run_uv_lock(src: Path) -> None:
         env=env,
         check=True,
     )
+    _normalize_generated_lock(src / "uv.lock")
+
+
+def _normalize_generated_lock(lock_path: Path) -> None:
+    """Rewrite any non-public registry/wheel URLs in the generated lock.
+
+    A machine-level uv config with ``default = true`` overrides
+    ``--index-url``, so uv can bake a private mirror host into the
+    lock's ``registry`` and direct ``url`` entries. Those are not
+    resolvable from the Databricks Apps build runtime. Reuse the repo's
+    canonical normalizer to rewrite them back to public PyPI so the
+    deployed lock is always fetchable.
+
+    :param lock_path: The generated ``src/uv.lock`` to normalize in place.
+    """
+    sys.path.insert(0, str(_repo_root() / "scripts"))
+    try:
+        from normalize_uv_lock_registry import non_canonical_entries, normalize_text
+    finally:
+        sys.path.pop(0)
+
+    original = lock_path.read_text()
+    if not non_canonical_entries(original):
+        return
+    lock_path.write_text(normalize_text(original))
+    _log(f"normalized proxy URLs in {lock_path.name} to public PyPI")
 
 
 def write_uv_dependency_files(


### PR DESCRIPTION
## Related issue

Closes #4534

## Summary

- `deploy.py` generates `deploy/databricks/src/uv.lock` at deploy time. A
  machine-level uv config with `default = true` overrides the `--index-url` this
  script passes, so uv can bake a private mirror host into the lock's `registry`
  and direct wheel/sdist URLs — hosts the Databricks Apps build runtime can't
  resolve, so the app fails at install with a 404 on the first wheel.
- Normalize the generated lock in place after `uv lock`, reusing the repo's
  existing `scripts/normalize_uv_lock_registry.py` (the same normalizer the
  committed-`uv.lock` pre-commit hook runs). No-op when already canonical.

## Test Plan

- Unit: loaded `deploy.py`, fed `_normalize_generated_lock` a lock containing a
  private-mirror `registry` source and a `/packages/` wheel URL — both rewritten
  to `pypi.org` / `files.pythonhosted.org`; an already-canonical lock is a
  byte-for-byte no-op.
- `uv run --no-sync pytest -q tests/test_normalize_uv_lock_registry.py` — 19
  passed (the reused normalizer).
- `uv run --no-sync ruff check` + `ruff format --check` + `pre-commit run
  --files deploy/databricks/deploy.py` — all pass.

## Demo

N/A — deploy-tooling fix, no UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The rewrite logic itself is the repo's existing
`scripts/normalize_uv_lock_registry.py`, covered by
`tests/test_normalize_uv_lock_registry.py` (19 tests). This PR only wires that
normalizer into `run_uv_lock`; the wiring was verified manually against a lock
carrying a mirror `registry` source and a `/packages/` wheel URL (rewritten) and
an already-canonical lock (no-op). `deploy.py` has no unit-test harness today, so
no automated test is added for the one-line call site.
