### PR TITLE
chore(ci): add yaoharry and marktai to the maintainer list

### DIFF
--- a/.github/MAINTAINER
+++ b/.github/MAINTAINER
@@ -25,3 +25,6 @@ xq-yin
 hzub
 zhengwin
 ajayalfred
+yaoharry
+marktai
+arthivjkumar


### PR DESCRIPTION
## Related issue

N/A — chore, no associated issue.

## Summary

- Grants @yaoharry and @marktai maintainer status by appending them to
  `.github/MAINTAINER`, the single authoritative list.
- No other changes needed: every consumer (merge gate, security-scan skip,
  waiver checks, review SLA sweep, triage self-assign) reads this file at
  runtime.
- Appended rather than alphabetized, matching the existing convention for
  recent entries.

## Test Plan

- `node --test .github/workflows/areas.test.js` — passes (validates every
  `areas.json` owner is present in `.github/MAINTAINER`).
- `pre-commit run --files .github/MAINTAINER` — clean.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

`areas.test.js` already asserts the maintainer list stays consistent with
`areas.json`; ran it locally plus pre-commit on the changed file. The list is
plain text with no logic of its own, so no new tests.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

