### PR TITLE
fix(db): build conversation-search trgm indexes with CREATE INDEX CONCURRENTLY

### DIFF
--- a/omnigent/db/migrations/versions/d5e9f1a2b3c4_conversation_search_trgm_indexes.py
+++ b/omnigent/db/migrations/versions/d5e9f1a2b3c4_conversation_search_trgm_indexes.py
@@ -21,15 +21,21 @@ leaving ``title`` unindexed would let the planner fall back to scanning
 
 Postgres-only. SQLite (dev/tests) keeps its FTS5 virtual table and small tables,
 so the substring scan there is a non-issue; this migration is a no-op on any
-non-Postgres dialect. Plain ``CREATE INDEX`` (not ``CONCURRENTLY``) because the
-Alembic runner wraps every migration in a transaction, where ``CONCURRENTLY`` is
-illegal — matching every other index migration in this chain.
+non-Postgres dialect. The indexes are built with ``CREATE INDEX CONCURRENTLY``
+so a large ``conversation_items`` table never blocks writers for the duration of
+the GIN build. ``CONCURRENTLY`` is illegal inside a transaction block, so the
+builds run in Alembic's ``autocommit_block``, which commits the migration
+transaction up to that point — safe here because everything before the block is
+idempotent. A concurrent build that fails mid-flight leaves an INVALID index
+behind that ``IF NOT EXISTS`` would silently keep, so any such leftover is
+dropped before (re)creating each index.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "d5e9f1a2b3c4"
@@ -45,6 +51,29 @@ def _is_postgres() -> bool:
     return op.get_bind().dialect.name == "postgresql"
 
 
+def _drop_index_if_invalid(index_name: str) -> None:
+    """
+    Drop *index_name* if a previously failed ``CONCURRENTLY`` build left it
+    INVALID — ``IF NOT EXISTS`` would otherwise keep the unusable leftover.
+
+    :param index_name: Name of the index to check, e.g.
+        ``"ix_conversations_title_trgm"``.
+    """
+    invalid = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = :name AND NOT i.indisvalid"
+            ),
+            {"name": index_name},
+        )
+        .scalar()
+    )
+    if invalid:
+        op.execute(f"DROP INDEX {index_name}")
+
+
 def upgrade() -> None:
     """
     Enable ``pg_trgm`` and add GIN trigram indexes on the lowercased search
@@ -55,14 +84,19 @@ def upgrade() -> None:
     # IF NOT EXISTS so a deployment that already enabled the extension (or
     # pre-created an index) migrates cleanly.
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-    op.execute(
-        f"CREATE INDEX IF NOT EXISTS {_ITEMS_INDEX} "
-        "ON conversation_items USING gin (LOWER(search_text) gin_trgm_ops)"
-    )
-    op.execute(
-        f"CREATE INDEX IF NOT EXISTS {_TITLE_INDEX} "
-        "ON conversations USING gin (LOWER(title) gin_trgm_ops)"
-    )
+    # CONCURRENTLY cannot run inside a transaction block; the autocommit block
+    # commits the migration transaction so far and runs each statement in
+    # autocommit mode, letting writers proceed while the indexes build.
+    with op.get_context().autocommit_block():
+        for index_name, table, expression in (
+            (_ITEMS_INDEX, "conversation_items", "LOWER(search_text)"),
+            (_TITLE_INDEX, "conversations", "LOWER(title)"),
+        ):
+            _drop_index_if_invalid(index_name)
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+                f"ON {table} USING gin ({expression} gin_trgm_ops)"
+            )
 
 
 def downgrade() -> None:

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -406,9 +406,12 @@ def _run_migrations(engine: Engine, db_uri: str) -> None:
     config = _build_alembic_config(db_uri)
     # Pass a shared connection so Alembic operates within the same
     # engine (required for SQLite in-memory databases, and avoids
-    # creating a second connection pool).
+    # creating a second connection pool). The connection is handed over
+    # outside any transaction so Alembic owns transaction demarcation:
+    # a migration with an autocommit_block (CREATE INDEX CONCURRENTLY)
+    # cannot suspend an externally-begun transaction.
     with query_name_scope("omnigent.database.run_migrations"):
-        with engine.begin() as connection:
+        with engine.connect() as connection:
             config.attributes["connection"] = connection
             command.upgrade(config, "head")
         # Belt-and-suspenders: if a future migration is added but a

--- a/tests/db/test_migration_conversation_search_trgm_indexes.py
+++ b/tests/db/test_migration_conversation_search_trgm_indexes.py
@@ -118,7 +118,19 @@ def test_trgm_indexes_present_on_postgres(db_uri: str) -> None:
                 {"items": _ITEMS_INDEX, "title": _TITLE_INDEX},
             ).fetchall()
         )
+        invalid = conn.execute(
+            sa.text(
+                "SELECT c.relname FROM pg_index i "
+                "JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname IN (:items, :title) AND NOT i.indisvalid"
+            ),
+            {"items": _ITEMS_INDEX, "title": _TITLE_INDEX},
+        ).fetchall()
     assert set(defs) == {_ITEMS_INDEX, _TITLE_INDEX}, defs
     for definition in defs.values():
         lowered = definition.lower()
         assert "gin" in lowered and "gin_trgm_ops" in lowered and "lower(" in lowered, definition
+    # The indexes are built with CREATE INDEX CONCURRENTLY; a failed concurrent
+    # build leaves an INVALID (planner-ignored) index that would still pass the
+    # structural checks above, so assert both builds actually completed.
+    assert not invalid, invalid


### PR DESCRIPTION
## Related issue

N/A — operational hardening follow-up to #4502 (no linked issue).

## Summary

- Migration `d5e9f1a2b3c4` (revision ID unchanged, so already-migrated deployments are unaffected) now builds its two pg_trgm GIN indexes with `CREATE INDEX CONCURRENTLY` inside Alembic's `autocommit_block()`, so a large `conversation_items` table never blocks writers for the duration of the build.
- A concurrent build that fails mid-flight leaves an `INVALID` index that `IF NOT EXISTS` would silently keep (permanently ignored by the planner), so the migration drops any such leftover before (re)creating each index.
- `_run_migrations` now hands Alembic a non-transacted connection (`engine.connect()` instead of `engine.begin()`): `autocommit_block()` asserts when the surrounding transaction is externally owned. Alembic demarcates (and still commits) the migration run itself, so atomicity for every other migration is unchanged.

ELI5: building a Postgres index normally locks the table against writes until it finishes; `CONCURRENTLY` builds it in the background but is illegal inside a transaction. Alembic has a documented escape hatch (`autocommit_block`), but it only works when Alembic owns the transaction — so the runner stops pre-opening one.

```
before:  engine.begin() ──> alembic (external txn) ──> CREATE INDEX        (write-locks table)
after:   engine.connect() ─> alembic begins/commits ─> autocommit_block ──> CREATE INDEX CONCURRENTLY
```

## Test Plan

- `tests/db` SQLite lane: migration roundtrip + schema-init suites pass (37 passed).
- Postgres 16 (throwaway container), via the real `_run_migrations` path: fresh migrate emits exactly two `CREATE INDEX CONCURRENTLY` statements and both indexes land valid; re-run at head is a no-op; downgrade drops both; a simulated failed-build `INVALID` leftover is dropped and rebuilt valid.
- `tests/db/test_migration_conversation_search_trgm_indexes.py` passes in the Postgres lane; the Postgres test now also asserts `pg_index.indisvalid` for both indexes so a failed concurrent build can't masquerade as success.
- `pre-commit` green on all changed files.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Manual verification ran the four Postgres scenarios above (fresh migrate / idempotent re-run / downgrade / invalid-leftover recovery) against a real Postgres 16 through the production `_run_migrations` code path, capturing the emitted SQL to prove the `CONCURRENTLY` statements execute outside a transaction block.

## Changelog

The session-search index migration builds its Postgres indexes concurrently, so upgrades no longer block writes while the indexes build.
