### PR TITLE
fix(web): keep panel resize working over the embedded browser

### DIFF
--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -1,5 +1,6 @@
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 import { BrowserPane } from "./BrowserPane";
 
 // supportsBrowser gates the whole pane. Force it true so the pane renders; the
@@ -265,5 +266,62 @@ describe("BrowserPane toolbar navigation + URL bar", () => {
         { force: true },
       ),
     );
+  });
+});
+
+describe("BrowserPane bounds vs the rail resize handle", () => {
+  /** Activate a view and give the measuring container a non-zero rect (jsdom
+   *  reports all-zero, which syncBounds rejects). */
+  async function renderMeasured(conversationId: string) {
+    let fireCreated: ((p: { conversationId: string }) => void) | undefined;
+    const bridge = installBridge({
+      onBrowserViewCreated: vi.fn((cb: (p: { conversationId: string }) => void) => {
+        fireCreated = cb;
+        return () => {};
+      }),
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 800,
+      y: 40,
+      left: 800,
+      top: 40,
+      right: 1200,
+      bottom: 640,
+      width: 400,
+      height: 600,
+      toJSON: () => ({}),
+    } as DOMRect);
+    render(<BrowserPane conversationId={conversationId} />);
+    await screen.findByRole("textbox", { name: /address bar/i });
+    act(() => fireCreated?.({ conversationId }));
+    await waitFor(() => expect(bridge.browserResize).toHaveBeenCalled());
+    return bridge;
+  }
+
+  function lastBounds(bridge: { browserResize: { mock: { calls: unknown[][] } } }) {
+    const calls = bridge.browserResize.mock.calls;
+    return calls[calls.length - 1][1] as { x: number; width: number };
+  }
+
+  it("insets the left edge so the resize handle is not covered by the native view", async () => {
+    const bridge = await renderMeasured("conv_inset");
+    const bounds = lastBounds(bridge);
+    // Container left is 800; the view must start to the RIGHT of it, leaving the
+    // handle strip hittable, and give back the same px in width.
+    expect(bounds.x).toBeGreaterThan(800);
+    expect(bounds.x + bounds.width).toBe(1200);
+  });
+
+  it("parks the view off-viewport while a drag runs and restores it on release", async () => {
+    const bridge = await renderMeasured("conv_drag");
+    const resting = lastBounds(bridge);
+
+    act(() => beginPanelDrag());
+    // Off the right edge of the viewport: the cursor can cross the rail without
+    // entering the view, so mousemove/mouseup keep reaching the window.
+    expect(lastBounds(bridge).x).toBeGreaterThanOrEqual(window.innerWidth);
+
+    act(() => endPanelDrag());
+    expect(lastBounds(bridge).x).toBe(resting.x);
   });
 });

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { supportsBrowser } from "@/lib/nativeBridge";
+import { isPanelDragging, onPanelDragChange } from "@/lib/panelDragBus";
 import { normalizeTypedUrl } from "@/lib/normalizeTypedUrl";
 import { cn } from "@/lib/utils";
 
@@ -36,6 +37,11 @@ interface Bounds {
   height: number;
   devicePixelRatio?: number;
 }
+
+/** Renderer px kept clear on the pane's left edge so the rail's resize handle
+ *  (a 4px strip at the same x) stays hittable instead of sitting under the
+ *  native view, which eats every mouse event in its rect. */
+const HANDLE_INSET_PX = 6;
 
 /** Result shape shared by the history-navigation bridge calls. */
 interface NavResult {
@@ -106,6 +112,9 @@ export interface BrowserPaneProps {
 export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const lastBoundsRef = useRef<Bounds | null>(null);
+  // Read synchronously by syncBounds (which the rAF loop calls), so a ref, not
+  // state: a re-render per drag frame would be wasted work.
+  const draggingRef = useRef(isPanelDragging());
   const browserSupported = supportsBrowser();
   // Whether a native view is attached for THIS conversation — drives when the
   // measuring placeholder mounts (no empty pane on an idle conversation).
@@ -250,15 +259,24 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // Measure the placeholder and push bounds to the main process. These are
   // renderer CSS pixels; the main process converts to WebContentsView DIPs
   // using the host zoom factor (they diverge after Cmd+/Cmd- zoom).
+  //
+  // Two adjustments keep the rail's resize handle usable. The native view
+  // swallows every mouse event inside its rect, so (1) the left edge is inset
+  // past the handle strip, else the handle is unhittable wherever the page
+  // paints; and (2) while a resize drag is live the view is parked off the right
+  // of the viewport, else the cursor crossing into it steals mousemove/mouseup
+  // and the drag never ends (a DOM overlay can't cover a non-DOM view).
   const syncBounds = useCallback(
     (force = false) => {
       const bridge = getBridge();
       if (!containerRef.current || !bridge?.browserResize) return;
       const rect = containerRef.current.getBoundingClientRect();
       const bounds: Bounds = {
-        x: Math.round(rect.left),
+        // Parked off the right edge for the duration of a drag; the width stays
+        // real so the page doesn't reflow to 0 and reflow back on release.
+        x: Math.round(draggingRef.current ? window.innerWidth : rect.left + HANDLE_INSET_PX),
         y: Math.round(rect.top),
-        width: Math.round(rect.width),
+        width: Math.round(rect.width - HANDLE_INSET_PX),
         height: Math.round(rect.height),
         devicePixelRatio: window.devicePixelRatio,
       };
@@ -333,6 +351,22 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
     };
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
+  }, [browserSupported, viewActive, syncBounds]);
+
+  // Park the view off-viewport while a panel resize drag runs, and restore it on
+  // release, so the drag's mouse stream stays with the app window.
+  useEffect(() => {
+    if (!browserSupported || !viewActive) return;
+    const unsubscribe = onPanelDragChange((dragging) => {
+      draggingRef.current = dragging;
+      syncBounds(true);
+    });
+    return () => {
+      unsubscribe();
+      // A drag that outlives this pane (tab switch mid-drag) must not leave the
+      // ref latched — the next mount reads the live bus value anyway.
+      draggingRef.current = false;
+    };
   }, [browserSupported, viewActive, syncBounds]);
 
   // Defense-in-depth against a hung rAF chain: ResizeObserver (size), window

--- a/web/src/hooks/useResizableColumn.ts
+++ b/web/src/hooks/useResizableColumn.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 
 export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth = 480) {
   const [width, setWidth] = useState(defaultWidth);
@@ -12,6 +13,7 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     dragging.current = true;
+    beginPanelDrag();
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, []);
@@ -25,6 +27,7 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
     function onMouseUp() {
       if (!dragging.current) return;
       dragging.current = false;
+      endPanelDrag();
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     }
@@ -35,6 +38,7 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
       window.removeEventListener("mouseup", onMouseUp);
       if (dragging.current) {
         dragging.current = false;
+        endPanelDrag();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -15,6 +15,7 @@
 // resizes are also persisted so a full page reload restores the width.
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 import { readPanelSizePreference, writePanelSizePreference } from "@/lib/panelSizePreferences";
 
 const DEFAULT_WIDTH_PX = 240; // matches the previous fixed `md:w-60`
@@ -105,6 +106,8 @@ export function useResizableCommentsPanel() {
   // the pointer stream keeps reaching the parent document. Without it, dragging
   // over a cross-origin/sandboxed iframe (e.g. the HTML preview) routes mousemove
   // /mouseup into the frame, the parent never sees mouseup, and the drag sticks.
+  // The native browser view isn't in the DOM and can't be covered, so the drag
+  // is announced too and that view detaches until release.
   const addDragOverlay = useCallback(() => {
     if (overlayRef.current || typeof document === "undefined") return;
     const el = document.createElement("div");
@@ -112,11 +115,14 @@ export function useResizableCommentsPanel() {
       "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;background:transparent;";
     document.body.appendChild(el);
     overlayRef.current = el;
+    beginPanelDrag();
   }, []);
 
   const removeDragOverlay = useCallback(() => {
-    overlayRef.current?.remove();
+    if (!overlayRef.current) return;
+    overlayRef.current.remove();
     overlayRef.current = null;
+    endPanelDrag();
   }, []);
 
   const [isDesktop, setIsDesktop] = useState(

--- a/web/src/hooks/useResizableInlinePanel.ts
+++ b/web/src/hooks/useResizableInlinePanel.ts
@@ -6,6 +6,7 @@
 // while the inline panel starts at a compact sidebar width.
 
 import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 
 const MIN_WIDTH_PX = 240;
@@ -183,6 +184,8 @@ export function useResizableInlinePanel(
   // the pointer stream keeps reaching the parent document. Without it, dragging
   // over a cross-origin/sandboxed iframe (e.g. the HTML preview) routes mousemove
   // /mouseup into the frame, the parent never sees mouseup, and the drag sticks.
+  // The native browser view isn't in the DOM and can't be covered, so the drag
+  // is announced too and that view detaches until release.
   const addDragOverlay = useCallback(() => {
     if (overlayRef.current || typeof document === "undefined") return;
     const el = document.createElement("div");
@@ -190,11 +193,14 @@ export function useResizableInlinePanel(
       "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;background:transparent;";
     document.body.appendChild(el);
     overlayRef.current = el;
+    beginPanelDrag();
   }, []);
 
   const removeDragOverlay = useCallback(() => {
-    overlayRef.current?.remove();
+    if (!overlayRef.current) return;
+    overlayRef.current.remove();
     overlayRef.current = null;
+    endPanelDrag();
   }, []);
 
   // Load the active session's saved width into the module store (and re-load

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 import { readPanelSizePreference, writePanelSizePreference } from "@/lib/panelSizePreferences";
 
 const MIN_WIDTH_PX = 320;
@@ -152,6 +153,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
       if (!open || !isDesktop) return;
       e.preventDefault();
       dragging.current = true;
+      beginPanelDrag();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
@@ -191,6 +193,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     function onMouseUp() {
       if (!dragging.current) return;
       dragging.current = false;
+      endPanelDrag();
       persistSharedWidth();
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -205,6 +208,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
       // via Escape while dragging).
       if (dragging.current) {
         dragging.current = false;
+        endPanelDrag();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }

--- a/web/src/hooks/useResizableSidebar.ts
+++ b/web/src/hooks/useResizableSidebar.ts
@@ -10,6 +10,7 @@
 // the sidebar — so the store is just a persisted, viewport-clamped width.
 
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { beginPanelDrag, endPanelDrag } from "@/lib/panelDragBus";
 import { readPanelSizePreference, writePanelSizePreference } from "@/lib/panelSizePreferences";
 
 // Default 320px (20rem) — wider than the old fixed ``md:w-64`` (256px) sidebar
@@ -107,6 +108,7 @@ export function useResizableSidebar() {
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     dragging.current = true;
+    beginPanelDrag();
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, []);
@@ -138,6 +140,7 @@ export function useResizableSidebar() {
     function onMouseUp() {
       if (!dragging.current) return;
       dragging.current = false;
+      endPanelDrag();
       persistWidth(storedWidth);
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -150,6 +153,7 @@ export function useResizableSidebar() {
       window.removeEventListener("mouseup", onMouseUp);
       if (dragging.current) {
         dragging.current = false;
+        endPanelDrag();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }

--- a/web/src/lib/panelDragBus.ts
+++ b/web/src/lib/panelDragBus.ts
@@ -1,0 +1,60 @@
+/**
+ * Broadcasts "a panel resize drag is in progress" so the embedded browser can
+ * step out of the way. The desktop browser page is a native WebContentsView
+ * painted over the DOM: once the cursor enters its rect, every mousemove and
+ * mouseup goes to the embedded page instead of the app window, so the drag
+ * never ends, the transparent drag overlay is never removed, and the whole UI
+ * becomes unclickable. A DOM overlay can't cover a view that isn't in the DOM,
+ * so the view detaches for the duration of the drag instead.
+ *
+ * Ref-counted: concurrent drags (or a StrictMode double-invoke) can't leave the
+ * view detached.
+ */
+
+type Listener = (dragging: boolean) => void;
+
+const listeners = new Set<Listener>();
+let depth = 0;
+
+function emit(): void {
+  const dragging = depth > 0;
+  for (const listener of listeners) {
+    try {
+      listener(dragging);
+    } catch (err) {
+      console.warn("[panel-drag] listener threw:", err);
+    }
+  }
+}
+
+/** Mark a resize drag as started. Pair with `endPanelDrag`. */
+export function beginPanelDrag(): void {
+  depth += 1;
+  if (depth === 1) emit();
+}
+
+/** Mark a resize drag as finished. Safe to call when no drag is active. */
+export function endPanelDrag(): void {
+  if (depth === 0) return;
+  depth -= 1;
+  if (depth === 0) emit();
+}
+
+/** Subscribe to drag start/stop; returns an unsubscribe. */
+export function onPanelDragChange(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Whether any resize drag is currently live. */
+export function isPanelDragging(): boolean {
+  return depth > 0;
+}
+
+/** Reset the ref count. Only for use in tests. */
+export function resetPanelDragForTesting(): void {
+  depth = 0;
+  listeners.clear();
+}


### PR DESCRIPTION
## Related issue

Closes #3981

## Summary

The desktop browser page is a native Electron `WebContentsView` painted *over* the DOM, so it consumes every mouse event inside its rect. That broke Workspace-rail resizing on the Browser tab in two escalating ways:

- **The handle was unhittable.** The rail's resize handle is a 4px strip at the rail's inner-left edge; the measured placeholder starts at the same x, so the native view painted over it everywhere below the toolbar. No way to start a resize at all while a page was loaded.
- **A drag that did start locked the whole app.** Starting from the thin uncovered band at tab-strip height and dragging right put the cursor inside the view's rect, so all further `mousemove`/`mouseup` went to the embedded page. The drag never ended, the transparent full-window drag overlay was never removed, and the app became completely unclickable with the cursor stuck as a resize beam. Only a reload recovered.

The existing anti-stick trick (a `z-index: 2147483647` overlay, added for the "iframe swallows mouseup" case) cannot help: it's a DOM element and the view isn't in the DOM.

**Fix, two parts in `BrowserPane`'s `syncBounds`:**

1. Inset the pushed bounds 6px on the left (`x + 6`, `width - 6`) so the view starts to the right of the handle strip. The view's right edge is unchanged.
2. While any panel resize drag is live, park the view at `x = window.innerWidth` (off-viewport) so the cursor can cross the rail without entering it. Width stays real, so the page doesn't reflow to 0 and back on release.

**Why this touches five hooks, not the one the issue named.** The issue blamed `useResizableInlinePanel`, but the root cause is "any drag whose cursor can cross a non-DOM view loses its `mouseup`" — and the sidebar, the push panels, the comments panel and the file column all have the same shape. Patching only the rail would leave those broken identically. So the drag signal lives in a small ref-counted bus (`web/src/lib/panelDragBus.ts`, 60 lines) that all five bracket their drags with, including the unmount-mid-drag cleanup paths so the count can't strand. 4 lines per hook.

<details>
<summary>ELI5 + diagram</summary>

The browser page isn't part of the web page — it's a separate native window the app parks exactly on top of a placeholder div. Anything the app draws underneath it (like a thin drag handle) is unreachable, and once your cursor is over it, the app stops hearing about your mouse. So: leave a few pixels of clearance at the edge where the handle lives, and slide the native window out of the way entirely while you're dragging.

```
BEFORE                              AFTER (resting)              AFTER (dragging)
┌─────────┬───────────────┐         ┌─────────┬─┬───────────┐    ┌─────────┬───────────┐
│         │▓ toolbar      │         │         │▓│ toolbar   │    │         │ toolbar   │
│  chat   │▓┌───────────┐ │         │  chat   │▓├───────────┤    │  chat   ├───────────┤ ┌────────┐
│         │▓│  native   │ │         │         │▓│  native   │    │         │  (empty)  │ │ native │
│         │▓│   view    │ │         │         │▓│   view    │    │         │           │ │  view  │
└─────────┴─┴───────────┴─┘         └─────────┴─┴───────────┘    └─────────┴───────────┘ └────────┘
           ▓ = 4px handle,                     ▓ = handle, now              view parked off-viewport;
             covered by the view                 clear of the view          mouseup reaches the window
```
</details>

## Test Plan

- **New unit tests** in `BrowserPane.test.tsx` asserting the bounds math: the pushed `x` is inset past the handle (right edge preserved), and the view parks off-viewport on `beginPanelDrag` then returns to its resting `x` on `endPanelDrag`.
- **Confirmed the tests catch the bug**: reverting just the two bounds expressions fails both (`expected 800 to be greater than 800`, `expected 800 to be greater than or equal to 1024`); restoring passes.
- **Full web suite**: 280 files / 5430 tests passed.
- `tsc --noEmit` clean; `pre-commit` clean on all 8 changed files (prettier, oxlint, tsc).

**Not yet verified on a real desktop build** — see Coverage notes. Manual verification on macOS is pending and I'll post the Demo recording once done.

Reviewer manual check (`just electron-dev`):
1. Browser tab → load a URL → grab the rail's left edge *over the page area*. Should show `col-resize` and drag.
2. Drag right past the page and release. Should end cleanly and the app stays clickable. The page blanks for the drag's duration (that's the parking) and snaps back on release.
3. Regression: with the Browser tab open, drag the left sidebar and the FileViewer comments panel — both should still work.

## Demo

Pending — recording on macOS to follow before merge (the change is only observable on a real Electron desktop build).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit tests cover the mechanism (the bounds pushed over IPC), which is where the bug lived, and they were verified to fail without the fix. What they can *not* cover is the actual native hit-test: whether a real cursor now reaches the handle, and whether a real drag's `mouseup` reaches the host window, depends on Electron's native view compositing and can't be exercised in jsdom. I developed this on a headless Linux box, so that half is genuinely unverified — synthetic events under Xvfb would not be faithful evidence about macOS compositing either. Manual verification on macOS is queued and I'll update this section plus the Demo before asking for merge.

One deliberate trade-off worth a reviewer's opinion: parking the view makes the page visibly disappear for the duration of a drag. The alternative that keeps it painted is `setIgnoreMouseEvents(true, { forward: true })` on the view while dragging, but that's more IPC surface and I'd want to confirm forwarding actually reaches the host window on all three platforms first. Happy to switch if the flicker is judged worse than the extra surface.

## Changelog

Resizing the Workspace rail now works while the embedded browser is open, and no longer locks the app mid-drag
