### PR TITLE
fix(host): exit after sustained connection-refused against a loopback server

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import functools
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Callable, Iterator, Mapping
@@ -278,14 +280,15 @@ def _url_is_loopback(url: str) -> bool:
     """Whether ``url``'s host is loopback (``127.0.0.1`` / ``localhost`` / ``::1``).
 
     Used to distinguish a daemon-spawned local server (no proxy in
-    front) from a remote deploy behind the Databricks Apps ingress, so
-    the reconnect heuristic only treats an abrupt ``no close frame`` as
-    a benign ingress recycle when there actually IS an ingress.
+    front) from a remote deploy behind the Databricks Apps ingress: the
+    reconnect loop treats an abrupt ``no close frame`` as a benign
+    ingress recycle only when there IS an ingress, and bounds
+    connection-refused retries only when the server is local.
 
     :param url: A server or ws:// URL, e.g. ``"ws://127.0.0.1:49175"``.
     :returns: ``True`` for a loopback host, ``False`` otherwise (incl.
         unparseable URLs — fail toward "remote", the safer default for
-        the recycle heuristic).
+        both reconnect heuristics).
     """
     from urllib.parse import urlparse
 
@@ -295,9 +298,37 @@ def _url_is_loopback(url: str) -> bool:
         return False
 
 
+def _connection_refused(exc: BaseException) -> bool:
+    """Whether *exc* means the target port actively refused the connection.
+
+    Dual-stack connects surface wrapped: asyncio combines per-address
+    failures into ``OSError("Multiple exceptions: ...")`` whose errno is
+    lost (only the ``[Errno N]`` texts survive), or an exception group.
+    A wrapped form counts only when every sub-error is itself refused.
+
+    :param exc: The exception a connect attempt raised.
+    :returns: ``True`` for a connection-refused failure, ``False``
+        otherwise (fail toward "not refused" — the loop keeps retrying).
+    """
+    # BaseExceptionGroup is a 3.11+ builtin (we require 3.12); ruff's pinned
+    # py310 target misflags it as undefined.
+    if isinstance(exc, BaseExceptionGroup):  # noqa: F821
+        return all(_connection_refused(sub) for sub in exc.exceptions)
+    if not isinstance(exc, OSError):
+        return False
+    if exc.errno is not None:
+        return exc.errno == errno.ECONNREFUSED
+    errnos = re.findall(r"\[Errno (\d+)\]", str(exc))
+    return bool(errnos) and all(int(n) == errno.ECONNREFUSED for n in errnos)
+
+
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 10.0
 _RECONNECT_JITTER = 0.5
+# Consecutive connection-refused failures against a loopback server before the
+# host exits (~5 minutes at the backoff cap). Refused on loopback means no
+# process listens on the port — the local server is gone, not unreachable.
+_LOOPBACK_REFUSED_FATAL_ATTEMPTS = 30
 
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
@@ -547,11 +578,13 @@ class HostConnectError(Exception):
 
     Raised when the WebSocket upgrade fails in a way that reconnecting
     can never fix — the Databricks Apps proxy bounced the connection to
-    a login page (wrong/absent workspace credentials), or the server
+    a login page (wrong/absent workspace credentials), the server
     returned a permanent ``4xx`` (unauthenticated, unauthorized, or a
-    build that predates the host API). The reconnect loop re-raises this
-    instead of backing off, so ``omnigent host`` exits with an
-    actionable message rather than looping silently forever.
+    build that predates the host API), or a loopback server refused a
+    sustained streak of connects (nothing listens — the local server is
+    gone). The reconnect loop re-raises this instead of backing off, so
+    ``omnigent host`` exits with an actionable message rather than
+    looping silently forever.
 
     The message is the full, user-facing explanation including the
     suggested fix; it is printed verbatim by :func:`run_host_process`.
@@ -757,6 +790,10 @@ class HostProcess:
         # reset by a successful upgrade. Gates the once-per-episode terminal
         # notice so a VPN outage doesn't spam stderr on every retry.
         self._auth_retry_streak = 0
+        # Consecutive connection-refused connect failures; reset by an accepted
+        # upgrade or any non-refused error. Fatal past a bounded streak only
+        # when the server URL is loopback (the local server is gone).
+        self._refused_streak = 0
         # Live tunnel connection, set by _serve_frames for the watcher
         # tasks (which outlive any single connection) to report on.
         self._ws: websockets.asyncio.client.ClientConnection | None = None
@@ -2382,6 +2419,9 @@ class HostProcess:
         disconnect. Ctrl-C / SIGTERM exit cleanly.
 
         :returns: None. Runs until the process is terminated.
+        :raises HostConnectError: On a permanent failure — auth /
+            authorization / outdated server, or a loopback server that
+            kept refusing connections (the local server is gone).
         """
         # Reap orphaned harness/tool grandchildren that reparent here when a
         # runner dies (this host is PID 1 in a container, or a subreaper
@@ -2405,7 +2445,7 @@ class HostProcess:
                     # server). Do NOT back off and retry — propagate so
                     # ``run_host_process`` can fail loud.
                     raise
-                except Exception as exc:  # noqa: BLE001 — reconnect loop
+                except Exception as exc:
                     if not isinstance(exc, InvalidURI):
                         # Any non-redirect failure (5xx bounce, network
                         # blip, mid-serve drop) breaks a login-redirect
@@ -2414,6 +2454,28 @@ class HostProcess:
                         # riding out a messy restart isn't killed by
                         # redirects accumulated across unrelated errors.
                         self._login_redirect_streak = 0
+                    # Refused on loopback is decisive: nothing listens on the
+                    # port and no network path can heal it, so bound the
+                    # retries. Remote refusals retry forever (outages recover).
+                    if _connection_refused(exc) and _url_is_loopback(self._server_url):
+                        self._refused_streak += 1
+                        if self._refused_streak >= _LOOPBACK_REFUSED_FATAL_ATTEMPTS:
+                            _logger.error(
+                                "Giving up: %s refused %d consecutive connection "
+                                "attempts — no server is listening there anymore. "
+                                "Exiting.",
+                                self._server_url,
+                                self._refused_streak,
+                            )
+                            raise HostConnectError(
+                                f"The server at {self._server_url} refused "
+                                f"{self._refused_streak} consecutive connection "
+                                "attempts — nothing is listening on that local "
+                                "address anymore. Start the server, then run "
+                                "`omnigent host` again."
+                            ) from exc
+                    else:
+                        self._refused_streak = 0
                     # Classify the disconnect to choose a reconnect cadence.
                     #
                     # 1012 "service restart" / 1001 "going away" are explicit
@@ -2536,6 +2598,7 @@ class HostProcess:
         self._ever_connected = True
         self._login_redirect_streak = 0
         self._auth_retry_streak = 0
+        self._refused_streak = 0
         try:
             await self._serve_frames(ws)
         finally:
@@ -2873,8 +2936,9 @@ def run_host_process(
     :param config_path: Optional path to ``config.yaml``.
         Defaults to ``~/.omnigent/config.yaml``.
     :raises SystemExit: With :data:`HOST_FATAL_EXIT_CODE` when the tunnel
-        fails permanently (auth / authorization / outdated server). The
-        actionable cause is printed to stderr first.
+        fails permanently (auth / authorization / outdated server, or a
+        loopback server that is gone). The actionable cause is printed
+        to stderr first.
     """
     host_log_path = configure_process_logging("host")
     # Initialize tracing so the host daemon exports its own spans

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import logging
 import subprocess
 import threading
@@ -3665,6 +3666,130 @@ async def test_run_reconnects_on_transient_upgrade_failure(
 
     # 2 = transient attempt + cancel attempt → it genuinely reconnected.
     assert spy.call_count == 2
+
+
+def _refused_exc() -> ConnectionRefusedError:
+    """A single-stack connection-refused, as asyncio raises it.
+
+    :returns: ``ConnectionRefusedError`` with the platform's errno set.
+    """
+    return ConnectionRefusedError(errno.ECONNREFUSED, "Connect call failed ('127.0.0.1', 5566)")
+
+
+def _dual_stack_refused_exc() -> OSError:
+    """The combined dual-stack refusal asyncio raises for ``localhost``.
+
+    ``create_connection`` folds the per-address failures into one
+    ``OSError`` whose errno is lost — only the per-address ``[Errno N]``
+    texts survive in the message.
+
+    :returns: ``OSError`` shaped like asyncio's combined failure.
+    """
+    e = errno.ECONNREFUSED
+    return OSError(
+        f"Multiple exceptions: [Errno {e}] Connect call failed ('::1', 5566, 0, 0), "
+        f"[Errno {e}] Connect call failed ('127.0.0.1', 5566)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("refused_exc", "server_url"),
+    [
+        (_refused_exc(), "http://127.0.0.1:5566"),
+        (_dual_stack_refused_exc(), "http://localhost:5566"),
+    ],
+    ids=["single-stack", "dual-stack-combined"],
+)
+async def test_loopback_host_exits_after_sustained_connection_refused(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    refused_exc: OSError,
+    server_url: str,
+) -> None:
+    """Persistent connection-refused against a loopback server exits the host.
+
+    A dead local server never comes back on its own, yet the reconnect
+    loop retried forever at the backoff cap — zombie hosts looped for
+    days against dead loopback ports. After a bounded refused streak the
+    host must log one clear ERROR and exit via the permanent-failure
+    path. Dual-stack refusals arrive as asyncio's combined ``OSError``
+    (errno lost) and must count exactly the same.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._LOOPBACK_REFUSED_FATAL_ATTEMPTS", 3)
+    spy = _ConnectSpy([refused_exc])
+    _patch_connect(monkeypatch, spy)
+    host = _host(server_url)
+
+    with caplog.at_level(logging.ERROR, logger="omnigent.host.connect"):
+        with pytest.raises(HostConnectError) as excinfo:
+            await host.run()
+
+    # Exactly the threshold — no premature death, no infinite loop.
+    assert spy.call_count == 3
+    # The fatal message names the dead address (printed by run_host_process).
+    assert server_url in str(excinfo.value)
+    # ONE clear ERROR explaining the exit, not one per retry.
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert server_url in errors[0].message
+    assert "no server is listening" in errors[0].message
+
+
+async def test_remote_host_retries_connection_refused_past_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection-refused against a REMOTE server never turns fatal.
+
+    A refusal from a remote endpoint can be an outage or a rolling
+    deploy — it recovers, so the host must keep retrying past the
+    loopback fatal threshold. Only loopback refusals prove the server
+    is gone for good.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._LOOPBACK_REFUSED_FATAL_ATTEMPTS", 3)
+    refused = _refused_exc()
+    # More refusals than the threshold, then a cancel to end the test.
+    spy = _ConnectSpy([refused, refused, refused, refused, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally: a fatal misfire would raise HostConnectError on
+    # the 3rd refusal (call_count 3) instead of reaching the cancel.
+    await host.run()
+
+    # 5 = 4 retried refusals (past the threshold of 3) + the ending cancel.
+    assert spy.call_count == 5
+
+
+async def test_accepted_connect_resets_loopback_refused_streak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful connect resets the loopback refused streak.
+
+    Only CONSECUTIVE refusals may kill the host: a streak interrupted by
+    a real connection (server came back, then died again) must start
+    counting from zero, not inherit pre-recovery refusals.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._LOOPBACK_REFUSED_FATAL_ATTEMPTS", 3)
+    # The accepted connect sends a real hello; skip its slow CLI probes —
+    # only the streak accounting is under test here.
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    refused = _refused_exc()
+    # 2 refusals (one short of fatal), an accepted upgrade (its tunnel
+    # drops on first recv), then refusals repeating until fatal.
+    spy = _ConnectSpy([refused, refused, None, refused])
+    _patch_connect(monkeypatch, spy)
+    host = _host("http://localhost:5566")
+
+    with pytest.raises(HostConnectError):
+        await host.run()
+
+    # 6 = 2 refusals + accepted connect + 3 FRESH refusals to reach the
+    # threshold. 5 would mean the accepted connect did not reset the
+    # streak (pre-recovery refusals were counted toward the exit).
+    assert spy.call_count == 6
 
 
 def test_run_host_process_exits_nonzero_on_fatal(


### PR DESCRIPTION
## Related issue

N/A — from a 72h host/runner log forensics pass: three zombie `omnigent host` processes had been reconnecting to dead loopback ports for 3–6 **days**, producing 43,947 disconnect warnings (95% of all tunnel-disconnect noise in the window), because the reconnect loop never gives up.

## Summary

- The host reconnect loop backs off to a 10s cap and retries forever; only permanent auth failures break out. For a **loopback** server that's the wrong contract: connection-refused means nothing listens on the port — the local server is gone, and no network path can ever heal it. The host becomes an immortal zombie (and they accumulate: 55 live host/server processes found on one dev machine).
- New `_connection_refused(exc)` classifier: `OSError` with `errno == ECONNREFUSED`; asyncio's errno-less dual-stack `OSError("Multiple exceptions: [Errno 61] …")` (all `[Errno N]` tokens must be ECONNREFUSED — verified empirically against a real dead port on websockets 14.2 / Py 3.12); `BaseExceptionGroup` counts only when every sub-error is refused.
- A consecutive-refusal streak (`_LOOPBACK_REFUSED_FATAL_ATTEMPTS = 30`, ≈5 minutes at the cap) is fatal **only when the server URL is loopback**: one clear ERROR, then `HostConnectError` through the existing fail-loud path (`run_host_process` → actionable stderr message + fatal exit code). Remote URLs are untouched and retry indefinitely so real network outages recover. The streak resets on any accepted upgrade or non-refused error.

ELI5: if your laptop's local server dies, the host used to knock on that door every 10 seconds forever. Now it knocks for 5 minutes, says "nobody lives here anymore," and leaves.

```
loopback refused ×30 (~5 min)  ->  ERROR + exit (fail-loud path)
loopback refused ×N, then server back  ->  streak resets, host reconnects
remote refused ×∞  ->  keeps retrying (unchanged; outages recover)
```

## Test Plan

```
python -m pytest tests/host/test_connect.py -q -k refused
```

- `test_loopback_host_exits_after_sustained_connection_refused[single-stack|dual-stack-combined]` — exits at exactly the threshold, URL in the fatal message, exactly one ERROR record.
- `test_remote_host_retries_connection_refused_past_threshold` — identical errors on a remote URL keep retrying past the threshold.
- `test_accepted_connect_resets_loopback_refused_streak` — refused×2 → accepted upgrade → refused×3 → fatal at the correct attempt, proving the reset.
- Full file: 112 passed (108 pre-existing + 4 new). Reuses the file's existing `_ConnectSpy` stubbed-websockets harness.

## Demo

N/A — non-visual (host process lifecycle).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dual-stack refused shape was reproduced against a genuinely dead port to confirm the classifier matches what asyncio/websockets actually raise (the production log lines' exact format).

## Changelog

`omnigent host` pointed at a local server that has exited now stops after ~5 minutes with a clear error instead of reconnecting forever.
