### PR TITLE
fix(runner): survive signal-handler registration failure instead of crash-looping

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1643,16 +1643,46 @@ def _install_signal_handlers(
             record_reason(f"received {signal.Signals(sig).name}")
         stop_event.set()
 
+    degraded = False
+
+    def _try_add_handler(sig: int, callback: Callable[..., None], *args: object) -> None:
+        """Register one handler; degrade instead of crashing the runner.
+
+        ``add_signal_handler`` raises RuntimeError when the loop's signal
+        wakeup fd is unusable — observed in zygote-forked runners whose
+        wakeup fd ended up in blocking mode ("the fd N must be in
+        non-blocking mode"), crash-looping every fork of the session.
+        Graceful-shutdown handlers are a nicety: a runner without them
+        still serves sessions and still exits via the parent-death
+        backstop, so warn once and continue instead of dying.
+
+        :param sig: Signal number to register.
+        :param callback: Handler invoked when the signal arrives.
+        :param args: Positional arguments passed to ``callback``.
+        :returns: None.
+        """
+        nonlocal degraded
+        if degraded:
+            return
+        try:
+            with contextlib.suppress(NotImplementedError):
+                loop.add_signal_handler(sig, callback, *args)
+        except RuntimeError:
+            degraded = True
+            _logger.warning(
+                "Signal handler registration failed; continuing without "
+                "graceful-shutdown signal handling",
+                exc_info=True,
+            )
+
     for sig in (signal.SIGINT, signal.SIGTERM):
-        with contextlib.suppress(NotImplementedError):
-            loop.add_signal_handler(sig, _handle_shutdown_signal, sig)
+        _try_add_handler(sig, _handle_shutdown_signal, sig)
     if adopted_event is not None:
         from omnigent.runner.identity import RUNNER_ADOPT_SIGNAL
 
         if RUNNER_ADOPT_SIGNAL is None:
             return
-        with contextlib.suppress(NotImplementedError):
-            loop.add_signal_handler(RUNNER_ADOPT_SIGNAL, adopted_event.set)
+        _try_add_handler(RUNNER_ADOPT_SIGNAL, adopted_event.set)
 
 
 def _install_crash_logging() -> None:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -23,6 +23,7 @@ from omnigent.runner._entry import (
     _agent_cache_dest,
     _InitialAuthTokenFactory,
     _install_crash_logging,
+    _install_signal_handlers,
     _load_runner_idle_timeout_s_from_config,
     _make_auth_token_factory,
     _make_managed_mint_factory,
@@ -2319,3 +2320,29 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
 
     assert dest == cache_root / "ag_abc123-v3"
+
+
+@pytest.mark.asyncio
+async def test_install_signal_handlers_degrades_when_wakeup_fd_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken signal wakeup fd must degrade, not crash the runner.
+
+    Zygote-forked runners crash-looped when the loop's wakeup fd came up
+    in blocking mode ("the fd 6 must be in non-blocking mode"): the
+    RuntimeError from ``add_signal_handler`` escaped ``main``. Handler
+    registration must warn and stop after the first failure instead.
+    """
+    loop = asyncio.get_running_loop()
+    attempts: list[int] = []
+
+    def _broken_add_signal_handler(sig: int, *args: Any) -> None:
+        attempts.append(sig)
+        raise RuntimeError("the fd 6 must be in non-blocking mode")
+
+    monkeypatch.setattr(loop, "add_signal_handler", _broken_add_signal_handler)
+
+    _install_signal_handlers(asyncio.Event())
+
+    # First failure marks the loop degraded; SIGTERM is skipped, not retried.
+    assert attempts == [signal.SIGINT]


### PR DESCRIPTION
## Related issue

N/A — from a 72h host/runner log forensics pass: two zygote-forked runners crash-looped five times each at session start (~1 min apart) with `CRIT … runner exiting: uncaught RuntimeError: the fd 6 must be in non-blocking mode`.

## Summary

- In zygote-forked runners, `loop.add_signal_handler` can raise `RuntimeError` when the event loop's signal wakeup fd is unusable (observed: the wakeup fd came up in **blocking** mode — `signal.set_wakeup_fd` refuses it). `_install_signal_handlers` suppressed only `NotImplementedError`, so the `RuntimeError` escaped `main()` and killed the fork — and the next fork of the same session hit it again, crash-looping session startup.
- Registration now degrades instead: the first failure logs one warning with the traceback and marks the loop degraded (remaining signals are skipped, not retried). Graceful-shutdown handlers are a nicety — a runner without them still serves sessions and still exits via the parent-death backstop — so their absence must never be fatal.
- Honest scoping: the underlying fd-flag clobber happens outside repo code (nothing in-tree calls `set_blocking`/`set_wakeup_fd`); this change makes registration non-fatal, which is the correct behavior regardless of the clobberer, and the warning's traceback preserves the evidence needed to root-cause it from field logs.

ELI5: the runner used to die on the spot if it couldn't set up its Ctrl-C handling — five times in a row per session. Now it shrugs, notes it in the log, and gets on with the actual work; shutdown still works through the parent-death watchdog.

## Test Plan

```
python -m pytest tests/runner/test_runner_entry.py -q -k "degrades or signal or crash_logging"
```

- New `test_install_signal_handlers_degrades_when_wakeup_fd_unusable`: a loop whose `add_signal_handler` raises the exact production `RuntimeError("the fd 6 must be in non-blocking mode")` — `_install_signal_handlers` returns normally and stops after the first attempt (SIGTERM skipped, not retried).
- Related entry-point tests re-run green (4 passed in the selected group).

## Demo

N/A — non-visual (runner process lifecycle).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The test injects the exact RuntimeError observed in production runner logs; the crash-loop itself requires the zygote fd-corruption environment, which is documented in the code comment for future root-causing.

## Changelog

Runners no longer crash-loop at session start when signal-handler registration fails; they log one warning and keep working.
