### PR TITLE
fix(search): correlate the session content-search subquery

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2390,13 +2390,20 @@ class SqlAlchemyConversationStore(ConversationStore):
             if search_query:
                 pattern = f"%{search_query.lower()}%"
                 title_match = func.lower(SqlConversation.title).like(pattern)
-                content_match = SqlConversation.id.in_(
+                # Correlated EXISTS rather than ``id IN (SELECT ...)``: the IN
+                # form is uncorrelated, so the match set is built for the WHOLE
+                # workspace before the outer query discards every row the caller
+                # cannot see. Correlating on conversation_id keeps each probe on
+                # the (workspace_id, conversation_id) index and lets it stop at
+                # the first matching item per conversation.
+                content_match = (
                     select(SqlConversationItem.conversation_id)
                     .where(
                         SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == SqlConversation.id,
                         func.lower(SqlConversationItem.search_text).like(pattern),
                     )
-                    .distinct()
+                    .exists()
                 )
                 stmt = stmt.where(or_(title_match, content_match))
             if project is not None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1414,6 +1414,48 @@ def test_list_conversations_no_search_skips_statement_timeout(
     assert not any("statement_timeout" in s.lower() for s in statements), statements
 
 
+def test_list_conversations_search_content_match_is_correlated(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    The content-search predicate is a correlated ``EXISTS``, not an
+    uncorrelated ``id IN (SELECT DISTINCT ...)``.
+
+    The IN form materializes the match set for the entire workspace before the
+    outer query discards the rows the caller cannot see, so on a large
+    ``conversation_items`` table it scans everything regardless of how few
+    conversations the caller can actually access. Correlating on
+    ``conversation_id`` keeps each probe on the
+    ``(workspace_id, conversation_id)`` index. Asserted on the emitted SQL
+    because the difference is a query-plan property, not an observable result
+    difference — the two forms return identical rows.
+    """
+    conv = conversation_store.create_conversation()
+    conversation_store.append(
+        conv.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_corr1",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "fix the deployment pipeline"}],
+                ),
+            ),
+        ],
+    )
+
+    statements = _captured_sql(
+        conversation_store,
+        lambda: conversation_store.list_conversations(search_query="deployment"),
+    )
+    select_sql = " ".join(s for s in statements if "conversation_items" in s).lower()
+    assert "exists" in select_sql, select_sql
+    assert "conversation_items.conversation_id = conversations.id" in select_sql, select_sql
+    # The uncorrelated form is what this guards against.
+    assert "distinct conversation_items.conversation_id" not in select_sql, select_sql
+
+
 def test_list_conversations_search_snippet_uses_earliest_match(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; follow-up to #4502, diagnosed against the deployed instance. -->

## Summary

Session search still returned nothing on the deployed app after #4502 added the `pg_trgm` indexes. Root-caused against the live database: the index was applied and being used — it just wasn't the bottleneck.

The content-search predicate is **uncorrelated**:

```sql
conversations.id IN (SELECT DISTINCT conversation_id
                     FROM conversation_items
                     WHERE workspace_id = ? AND lower(search_text) LIKE ?)
```

Postgres must materialize that match set for the **entire workspace** before the outer query discards every row the caller can't see. So the cost scales with total workspace size, not with what the user can actually access — in the observed request, 3.16 M items scanned to serve a user who can see 432 conversations.

This changes it to a correlated `EXISTS`, so each probe rides the existing `(workspace_id, conversation_id)` index and stops at the first matching item per conversation. Results are identical — the two forms match exactly the same rows.

The `pg_trgm` index is **kept**; this is complementary, not a revert.

### ELI5

Search was reading every message in the workspace, then throwing away everything you're not allowed to see — like searching every book in the library when you only ever needed the 432 on your own shelf. Now it looks only at your conversations, and stops at the first hit in each.

```
before:  scan all 3.16M items ─▶ de-duplicate ─▶ intersect with your 432 ─▶ (>15s, killed)
after:   for each of your 432 conversations ─▶ index probe, stop at first hit ─▶ 2.36s
```

## Test Plan

Diagnosed and measured **against the deployed database** (3.16 M `conversation_items` / 12 GB; trigram index 2.2 GB vs 456 MB `shared_buffers`):

| variant | result |
|---|---|
| current `id IN (SELECT DISTINCT …)` | killed at 15 s (`statement_timeout`) |
| add permission scope to that subquery | still killed at 15 s — planner still leads with the trigram scan |
| **correlated `EXISTS` (this PR)** | **2.36 s**, cold cache |

The `EXISTS` plan confirms the intended shape:

```
SubPlan 1
  -> Index Scan using ix_conversation_items_conversation_id_position
       Index Cond: ((workspace_id = 0) AND (conversation_id = c.id))
       Filter: (lower(search_text) ~~ '%claude%'::text)
       Rows Removed by Filter: 15        <- stops at first match
Execution Time: 2358.999 ms
```

Automated:

- `tests/stores/test_conversation_store.py` — **181 passed / 1 skipped** on SQLite; **13 passed** for the search subset against real Postgres 16.
- New `test_list_conversations_search_content_match_is_correlated` asserts the emitted SQL uses a correlated `EXISTS` and not the uncorrelated `DISTINCT` form. Asserted on SQL because the two forms are result-identical — the difference is a plan property, so a behavioural test cannot catch a regression here.

```bash
python3 -m pytest tests/stores/test_conversation_store.py -k search
docker run -d --name pg -e POSTGRES_PASSWORD=pg -p 55434:5432 postgres:16
export OMNIGENT_TEST_DB_URI="postgresql+psycopg://postgres:pg@localhost:55434/postgres"
python3 -m pytest tests/stores/test_conversation_store.py -k search
```

## Demo

N/A — no visual change. Search returns results instead of timing out; behaviour and ordering are otherwise unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the plan/timing comparison against the deployed database above — the regression only reproduces at production scale (3.16 M rows), which no test fixture recreates. Automated coverage is the existing search-behaviour tests (proving results are unchanged) plus the new SQL-shape assertion (proving the query stays correlated).

Worth noting separately: `last_autoanalyze` on `conversation_items` predates the trigram index, so the planner has no statistics for the `lower(search_text)` expression and estimates a flat ~317 rows for every pattern. Running `ANALYZE conversation_items` is still worthwhile, but this fix no longer depends on the estimate.

## Changelog

Session search now returns results instead of timing out on large workspaces.
