### PR TITLE
fix(web): spin modal action buttons while their work is in flight

### DIFF
--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -28,7 +28,7 @@ import httpx
 import pytest
 from playwright.sync_api import Page, Route, expect
 
-from tests.e2e_ui.conftest import configure_mock_llm
+from tests.e2e_ui.conftest import configure_mock_llm, seed_committed_turn
 
 # Unique marker so the copied-transcript assertion can't match
 # UI chrome or another test's message.
@@ -415,3 +415,80 @@ def test_clone_worktree_source_prefills_repo_and_validates_directory(
     assert "git" not in launch, (
         f"untouched worktree prefill must bind the existing worktree without git options: {launch}"
     )
+
+
+def test_clone_submit_spins_while_the_fork_is_in_flight(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Clone button shows a spinner (not just a fade) until the fork returns.
+
+    A fork waits on the server round trip, so a button that only greys out
+    reads as a hang and users re-click or close the dialog. Guards the
+    in-flight affordance end-to-end: the real dialog, the real fetch, and
+    the real ``Button`` loading overlay.
+
+    Determinism comes from holding the fork response rather than racing it:
+    the route handler parks the request without resolving it, so the
+    in-flight state stays up for as long as the assertions need, then the
+    captured route is released and the flow completes as usual. Catching a
+    naturally-fast fork mid-flight would be a coin flip.
+
+    The transcript is seeded straight into the store (the per-message "Fork
+    from here" action needs a committed assistant response to anchor on),
+    so this neither drives the LLM nor waits on a turn.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+
+    seed_committed_turn(
+        session_id,
+        prompt="ping",
+        reply="pong",
+        response_id="resp_spinner",
+    )
+
+    parked: list[Route] = []
+    # Returning without resolving parks the request in the browser and
+    # leaves the test's thread free to assert. The route is released below.
+    page.route(re.compile(r"/v1/sessions/[^/]+/fork"), parked.append)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    expect(assistant).to_be_visible(timeout=30_000)
+    assistant.hover()
+    page.get_by_test_id("fork-from-response").first.click()
+    expect(page.get_by_test_id("fork-session-dialog")).to_be_visible()
+
+    submit = page.get_by_test_id("fork-session-submit")
+    # Before the click: idle — enabled, no spinner. Without this the
+    # after-state below would also pass on a button that always spins.
+    expect(submit).to_be_enabled()
+    expect(submit).not_to_have_attribute("aria-busy", "true")
+    assert submit.locator("svg.animate-spin").count() == 0
+
+    submit.click()
+
+    # In flight: spinner up, button busy and click-proof so the fork can't
+    # be double-submitted.
+    expect(submit.locator("svg.animate-spin")).to_be_visible(timeout=10_000)
+    expect(submit).to_have_attribute("aria-busy", "true")
+    expect(submit).to_be_disabled()
+
+    # Releasing the fork completes the real flow — proving the spinner is a
+    # transient in-flight state and not a stuck button.
+    deadline = time.monotonic() + 10.0
+    while not parked and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert parked, "fork request never reached the route handler"
+    parked[0].continue_()
+
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})(conv_)?[0-9a-f]+"),
+        timeout=30_000,
+    )
+    expect(page.get_by_test_id("fork-session-dialog")).not_to_be_visible()

--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -452,9 +452,15 @@ def test_clone_submit_spins_while_the_fork_is_in_flight(
     )
 
     parked: list[Route] = []
+
     # Returning without resolving parks the request in the browser and
     # leaves the test's thread free to assert. The route is released below.
-    page.route(re.compile(r"/v1/sessions/[^/]+/fork"), parked.append)
+    # Must be a plain function, not ``parked.append``: Playwright stamps an
+    # attribute onto the handler it is given, which a builtin method rejects.
+    def park_fork(route: Route) -> None:
+        parked.append(route)
+
+    page.route(re.compile(r"/v1/sessions/[^/]+/fork"), park_fork)
 
     page.goto(f"{base_url}/c/{session_id}")
 

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -639,8 +639,13 @@ function AddPolicyDialog({
             >
               Cancel
             </Button>
-            <Button type="button" onClick={handleAdd} disabled={!selected || addPolicy.isPending}>
-              {addPolicy.isPending ? "Adding..." : "Add"}
+            <Button
+              type="button"
+              onClick={handleAdd}
+              loading={addPolicy.isPending}
+              disabled={!selected}
+            >
+              Add
             </Button>
           </div>
         </div>
@@ -1036,10 +1041,11 @@ function McpServerManagerDialog({
                 type="button"
                 size="sm"
                 onClick={handleSave}
-                disabled={saving || validateMcpForm(form) !== null}
+                loading={saving}
+                disabled={validateMcpForm(form) !== null}
               >
                 <SaveIcon className="size-3.5" />
-                {saving ? "Saving..." : "Save"}
+                Save
               </Button>
             </div>
           </div>

--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -242,7 +242,7 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
               </SelectContent>
             </Select>
           </div>
-          <Button type="submit" size="sm" disabled={!newUserId.trim() || grant.isPending}>
+          <Button type="submit" size="sm" loading={grant.isPending} disabled={!newUserId.trim()}>
             <UserPlusIcon className="mr-1 size-3.5" />
             Grant
           </Button>

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -2,7 +2,7 @@
 // host, and workspace pickers where the backend can persist those fields.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import { TriangleAlertIcon } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -545,10 +545,10 @@ export function CreateScheduledTaskDialog({
           </Button>
           <Button
             onClick={handleSubmit}
+            loading={mutationPending}
             disabled={!canSubmit}
             data-testid="create-scheduled-task-submit"
           >
-            {mutationPending && <Loader2Icon className="mr-1 size-4 animate-spin" />}
             {isEdit ? "Save changes" : "Create task"}
           </Button>
         </DialogFooter>

--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -329,8 +329,8 @@ export function MembersPage() {
             >
               Cancel
             </Button>
-            <Button onClick={() => void onCreateInvite()} disabled={pendingAction}>
-              {pendingAction ? "Creating…" : "Create invite"}
+            <Button onClick={() => void onCreateInvite()} loading={pendingAction}>
+              Create invite
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -419,9 +419,9 @@ export function MembersPage() {
             <Button
               variant="destructive"
               onClick={() => void onConfirmDelete()}
-              disabled={pendingAction}
+              loading={pendingAction}
             >
-              {pendingAction ? "Removing…" : "Remove"}
+              Remove
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -386,8 +386,9 @@ function AddDefaultPolicyDialog({
             </div>
           )}
           <div className="flex justify-end gap-2 pt-1">
-            <button
+            <Button
               type="button"
+              variant="outline"
               onClick={() => {
                 // With a policy selected, Cancel steps back to the list so the
                 // user can pick another; only close the dialog from the list.
@@ -399,18 +400,17 @@ function AddDefaultPolicyDialog({
                   onOpenChange(false);
                 }
               }}
-              className="rounded px-3 py-1.5 text-sm hover:bg-muted"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={handleAdd}
-              disabled={!selected || addPolicy.isPending}
-              className="rounded bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+              loading={addPolicy.isPending}
+              disabled={!selected}
             >
-              {addPolicy.isPending ? "Adding..." : "Add"}
-            </button>
+              Add
+            </Button>
           </div>
         </div>
       </DialogContent>
@@ -645,9 +645,9 @@ export function PoliciesPage() {
             <Button
               variant="destructive"
               onClick={() => void onConfirmDelete()}
-              disabled={pendingAction}
+              loading={pendingAction}
             >
-              {pendingAction ? "Removing..." : "Remove"}
+              Remove
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/shell/AddAgentDialog.tsx
+++ b/web/src/shell/AddAgentDialog.tsx
@@ -169,9 +169,10 @@ export function AddAgentDialog({
           <Button
             data-testid="add-agent-submit"
             onClick={handleAdd}
-            disabled={selectedAgent === null || !name.trim() || submitting}
+            loading={submitting}
+            disabled={selectedAgent === null || !name.trim()}
           >
-            {submitting ? "Adding…" : "Add"}
+            Add
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -235,6 +235,29 @@ describe("ForkSessionDialog", () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
   });
 
+  it("spins the submit button while the fork is in flight", async () => {
+    // The fork call can take seconds. Without the spinner the button only
+    // fades (disabled), which reads as a hang rather than work in progress.
+    type Fork = Awaited<ReturnType<typeof forkSession>>;
+    let settle: (value: Fork) => void = () => {};
+    forkSessionMock.mockReturnValue(
+      new Promise<Fork>((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    renderDialog();
+    const submit = screen.getByTestId("fork-session-submit");
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(submit).toHaveAttribute("aria-busy", "true"));
+    expect(submit).toBeDisabled();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+
+    settle({ id: "conv_fork" } as Fork);
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
+  });
+
   it("passes the truncation point through on a 'fork from here' and retitles the dialog", async () => {
     forkSessionMock.mockResolvedValue({
       id: "conv_fork",

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -857,15 +857,10 @@ export function ForkSessionForm({
         <Button
           data-testid="fork-session-submit"
           onClick={handleFork}
-          disabled={submitting || !canSubmit}
+          loading={submitting}
+          disabled={!canSubmit}
         >
-          {submitting
-            ? isCodingSource
-              ? "Starting…"
-              : "Cloning…"
-            : isCodingSource
-              ? "Clone & start"
-              : "Clone"}
+          {isCodingSource ? "Clone & start" : "Clone"}
         </Button>
       </DialogFooter>
     </>

--- a/web/src/shell/NewProjectButton.tsx
+++ b/web/src/shell/NewProjectButton.tsx
@@ -95,10 +95,11 @@ export function NewProjectButton({ onCreated }: { onCreated: (name: string) => v
             <Button
               type="button"
               data-testid="new-project-confirm"
-              disabled={createProject.isPending || name.trim() === ""}
+              loading={createProject.isPending}
+              disabled={name.trim() === ""}
               onClick={submit}
             >
-              {createProject.isPending ? "Creating…" : "Create"}
+              Create
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -473,9 +473,10 @@ export function ProjectSettingsDialog({
             <Button
               type="submit"
               data-testid="project-settings-save"
-              disabled={updateConfig.isPending || isLoading || loadFailed}
+              loading={updateConfig.isPending}
+              disabled={isLoading || loadFailed}
             >
-              {updateConfig.isPending ? "Saving…" : "Save"}
+              Save
             </Button>
           </DialogFooter>
         </form>

--- a/web/src/shell/ResumeWithDirectoryDialog.tsx
+++ b/web/src/shell/ResumeWithDirectoryDialog.tsx
@@ -417,10 +417,11 @@ export function ResumeWithDirectoryDialog({
             <DialogFooter>
               <Button
                 data-testid="resume-dir-bind-button"
-                disabled={!selectedHostId || !workspaceValid || submitting}
+                loading={submitting}
+                disabled={!selectedHostId || !workspaceValid}
                 onClick={handleBind}
               >
-                {submitting ? "Starting…" : "Start session"}
+                Start session
               </Button>
             </DialogFooter>
           </>

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -129,6 +129,7 @@ function openKebab() {
 beforeEach(() => {
   mocks.stop.mutate.mockReset();
   mocks.stop.reset.mockReset();
+  mocks.stop.isPending = false;
   mocks.runnerOnline.mockReset();
   mocks.runnerOnline.mockReturnValue(undefined);
 });
@@ -151,6 +152,21 @@ describe("sidebar Stop session item", () => {
     expect(mocks.stop.mutate).toHaveBeenCalledTimes(1);
     // Failure: the dialog stopped a different row's session.
     expect(mocks.stop.mutate.mock.calls[0][0]).toBe("conv_1");
+  });
+
+  it("spins the confirm button while the stop is in flight", () => {
+    // The stop can take seconds. Without the spinner the button only fades
+    // (disabled), which reads as a hang rather than work in progress.
+    mocks.stop.isPending = true;
+    mockConversations([HOST_SPAWNED]);
+    renderSidebar();
+    openKebab();
+    fireEvent.click(screen.getByTestId("stop-conversation"));
+
+    const confirm = screen.getByTestId("stop-session-confirm");
+    expect(confirm).toHaveAttribute("aria-busy", "true");
+    expect(confirm).toBeDisabled();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
   });
 
   it("clears a prior stop failure when the dialog is opened", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3752,10 +3752,11 @@ function ConversationRow({
             <Button
               type="button"
               variant="destructive"
+              data-testid="stop-session-confirm"
               onClick={() =>
                 stopSession.mutate(conversation.id, { onSuccess: () => setStopOpen(false) })
               }
-              disabled={stopSession.isPending}
+              loading={stopSession.isPending}
             >
               Stop session
             </Button>
@@ -4092,9 +4093,10 @@ function ProjectFolderMenu({
               <Button
                 type="submit"
                 data-testid="rename-project-confirm"
-                disabled={renameProject.isPending || renameValue.trim() === ""}
+                loading={renameProject.isPending}
+                disabled={renameValue.trim() === ""}
               >
-                {renameProject.isPending ? "Renaming…" : "Rename"}
+                Rename
               </Button>
             </DialogFooter>
           </form>
@@ -4139,7 +4141,7 @@ function ProjectFolderMenu({
             <Button
               type="button"
               variant="destructive"
-              disabled={deleteProject.isPending}
+              loading={deleteProject.isPending}
               onClick={() => {
                 deleteProject.mutate(
                   { id: projectId, name: projectName },
@@ -4152,7 +4154,7 @@ function ProjectFolderMenu({
                 );
               }}
             >
-              {deleteProject.isPending ? "Deleting…" : "Delete project"}
+              Delete project
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/shell/SwitchAgentDialog.tsx
+++ b/web/src/shell/SwitchAgentDialog.tsx
@@ -210,9 +210,10 @@ export function SwitchAgentDialog({
           <Button
             data-testid="switch-agent-submit"
             onClick={handleSwitch}
-            disabled={submitting || agentChoice === NONE_CHOSEN}
+            loading={submitting}
+            disabled={agentChoice === NONE_CHOSEN}
           >
-            {submitting ? "Switching…" : "Switch"}
+            Switch
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { useCreateHostDirectory, useHostFilesystem } from "@/hooks/useHostFilesystem";
 
 /**
@@ -596,7 +597,11 @@ export function WorkspacePicker({
               className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-30"
               data-testid="workspace-picker-new-folder-create"
             >
-              <CheckIcon className="size-4" />
+              {createDir.isPending ? (
+                <Spinner className="size-4" />
+              ) : (
+                <CheckIcon className="size-4" />
+              )}
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Related issue

Closes #4547

## Summary

Clicking the action button in the **Stop session** or **Clone session** modal only faded it (`disabled`), with no sign that work had started — a slow stop or a fork that waits on a directory pre-flight read as a hang, so people clicked again or closed the dialog.

`Button` already supported a centered spinner overlay via its `loading` prop (it keeps the label in flow but hidden, so the button doesn't resize). It just wasn't wired up at these call sites, which passed only `disabled`. This threads `loading` through every modal action button that does async work.

- **The reported two:** Stop session confirm (`Sidebar.tsx`), Clone / Clone & start (`ForkSessionDialog.tsx`).
- **The rest of the modals:** rename project, delete project, add agent, switch agent, resume-with-directory start, create project, project settings save, create scheduled task, grant permission, create invite, remove member, add policy (both the admin page and the per-session agent panel), remove policy, save MCP server, and the workspace picker's create-folder button.
- Drops the transient `"Renaming…"` / `"Deleting…"` label swaps — the spinner covers the label, so they were invisible, and a static label keeps the button width stable.
- Converts the two raw `<button>`s in the `PoliciesPage` add-policy dialog to the shared `Button` (the equivalent dialog in `AgentInfo` was already converted on `main`) so they can carry the spinner.

Deliberately **not** changed: modals that close immediately and report progress elsewhere — single and bulk session delete already show a `Deleting…` sidebar row — plus the per-row revoke buttons in the permissions modal, where any one mutation would spin every row at once.

## Test Plan

- New unit tests assert the in-flight state on the two reported buttons: `Sidebar.stop.test.tsx` (stop confirm) and `ForkSessionDialog.test.tsx` (clone submit) each check `aria-busy="true"`, `disabled`, and a visible `role="status"` spinner while the request is pending. The fork test was confirmed to **fail** against the pre-change code before the fix was restored.
- Full web suite green: `pnpm --dir web vitest run` → 279 passed / 1 skipped files.
  - `NewChatDialog.test.tsx` has 3 failures, but they reproduce identically on a clean `origin/main` worktree at `fc3fc268` — pre-existing, unrelated to this PR.
- `pre-commit run --files <changed>` clean (prettier, oxlint, tsc).
- **Live browser check** against a real local server + dev UI: stalled `POST /v1/sessions/*/events` so the stop stayed in flight, then inspected the Stop-session modal — `aria-busy=true`, button disabled, one visible `animate-spin` SVG, and the button box unchanged at 116.875 × 32 px (no reflow of the footer). Also opened the agent-info add-policy dialog to confirm the Cancel/Add pair still renders correctly.

## Demo

Before → after, on the **Stop session?** modal:

```
before                              after
┌──────────────────────────┐        ┌──────────────────────────┐
│ Stop session?            │        │ Stop session?            │
│ This terminates …        │        │ This terminates …        │
│                          │        │                          │
│      Cancel  [ Stop  ]   │        │      Cancel  [   ◜    ]  │
│               ^^^^^^^^   │        │               ^^^^^^^^   │
│         faded, inert —   │        │      spinner, same width │
│         looks hung       │        │      — clearly working   │
└──────────────────────────┘        └──────────────────────────┘
```

The label stays in the DOM (hidden) so the button keeps its exact width and the footer doesn't shift — measured at 116.875 px in both states.

To see it live: open a running session, sidebar row kebab → **Stop session**, and throttle or block `POST /v1/sessions/*/events` in devtools to hold the in-flight state open.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the two buttons named in the issue; the remaining call sites are the same one-line `loading={pending}` change against a `Button` whose loading behaviour is already covered by `components/ui/button.test.tsx`, and every affected dialog's existing suite still passes.

Manual verification was a live browser run (details in the Test Plan): a real server and dev UI with the stop request held open, asserting `aria-busy`, the visible spinner, and that the button's box does not change size.

No `tests/e2e_ui/**` test was added: asserting a transient spinner through Playwright means stalling the request mid-test, which is a flake source for a purely visual affordance. The jsdom tests pin the same contract deterministically.

## Changelog

Modal buttons like Stop session and Clone now show a spinner while the action is running, instead of just greying out.
