### PR TITLE
chore(android): allow versionName to be set at build time

### DIFF
--- a/.github/workflows/android-bundle.yml
+++ b/.github/workflows/android-bundle.yml
@@ -11,6 +11,10 @@ on:
         description: "versionCode (must be higher than the last uploaded to Play; starts at 3)"
         required: true
         type: string
+      version-name:
+        description: "versionName shown to users (e.g. 0.2.0). Blank keeps the default in app/build.gradle.kts"
+        required: false
+        default: ""
       version-note:
         description: "Optional note appended to the artifact filename (e.g. rc1)"
         required: false
@@ -47,7 +51,10 @@ jobs:
           cache-read-only: false
 
       - name: Build release AAB
-        run: ./gradlew bundleRelease --no-daemon --console=plain -PversionCode=${{ github.event.inputs.version-code }}
+        run: |
+          ./gradlew bundleRelease --no-daemon --console=plain \
+            "-PversionCode=${{ inputs.version-code }}" \
+            "-PversionName=${{ inputs.version-name }}"
 
       - name: Verify artifact
         run: |

--- a/web/android/README.md
+++ b/web/android/README.md
@@ -179,12 +179,25 @@ keytool -genkeypair -v -keystore omnigent-upload.jks \
   -keyalg RSA -keysize 2048 -validity 10000 -alias omnigent-upload
 ```
 
-Build the Play-ready App Bundle (Play requires an `.aab`, not an APK); bump
-`versionCode` in `app/build.gradle.kts` before each upload:
+Build the Play-ready App Bundle (Play requires an `.aab`, not an APK):
 
 ```sh
 ./gradlew bundleRelease   # → app/build/outputs/bundle/release/app-release.aab
 ```
+
+### Versioning
+
+`versionCode` and `versionName` default to the values in
+`app/build.gradle.kts`, and either can be overridden at build time — no source
+edit needed for a one-off build:
+
+```sh
+./gradlew bundleRelease -PversionCode=10 -PversionName=0.2.0
+```
+
+Bump `versionCode` for every Play upload (Play rejects a reused code). The
+`Android Bundle` workflow takes both as `workflow_dispatch` inputs; leaving
+`version-name` blank keeps the checked-in default.
 
 ### Automated publishing (Gradle Play Publisher)
 
@@ -205,8 +218,7 @@ export PLAY_SERVICE_ACCOUNT_JSON=/path/to/play-credentials.json
 ```
 
 The publish tasks are inert when no credentials file is present, so ordinary
-builds are unaffected. Bump `versionCode` before each publish (Play rejects a
-reused code). Change the target track via `track.set(...)` in
+builds are unaffected. Change the target track via `track.set(...)` in
 `app/build.gradle.kts` (`internal` → `alpha` → `beta` → `production`).
 
 > Status: builds clean — `gradlew :app:assembleDebug :app:lintDebug` produces a

--- a/web/android/app/build.gradle.kts
+++ b/web/android/app/build.gradle.kts
@@ -30,6 +30,15 @@ fun signingValue(
 
 val storeFilePath = signingValue("storeFile", "OMNIGENT_KEYSTORE_FILE")
 
+// Version is overridable at build time so release builds can be stamped without
+// editing this file: ./gradlew bundleRelease -PversionCode=10 -PversionName=0.2.0
+// The defaults below apply to local and debug builds.
+fun buildProperty(key: String): String? =
+    (project.findProperty(key) as? String)?.takeIf { it.isNotBlank() }
+
+val appVersionCode = buildProperty("versionCode")?.toIntOrNull() ?: 9
+val appVersionName = buildProperty("versionName") ?: "0.1.3"
+
 android {
     namespace = "ai.omnigent.android"
     compileSdk = 36
@@ -38,8 +47,8 @@ android {
         applicationId = "ai.omnigent.android"
         minSdk = 28
         targetSdk = 36
-        versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 9
-        versionName = "0.1.3"
+        versionCode = appVersionCode
+        versionName = appVersionName
 
         // Instrumented (androidTest) runner — required for UI Automator / Espresso
         // screenshot tests. Mirrors the androidx.test stable line pinned below.


### PR DESCRIPTION
## Related issue

N/A — build configuration chore.

## Summary

- `versionCode` was already overridable with `-PversionCode=…`, but `versionName`
  was a hardcoded literal, so every release build required editing
  `app/build.gradle.kts` and committing the bump. Both are now overridable at
  build time, with the checked-in values as defaults.
- Added a `buildProperty()` helper that reads a Gradle property and treats blank
  as absent. This also fixes an existing rough edge: `-PversionCode=` with an
  empty value (what the CI workflow passes on PR-triggered runs, where the
  dispatch inputs are unset) was taken literally instead of falling back.
- Threaded a new optional `version-name` input through the `Android Bundle`
  workflow and quoted both `-P` args so an empty value stays a single token.
- Documented the override in `web/android/README.md` under a new "Versioning"
  heading, and removed the two now-stale "bump `versionCode` in
  `app/build.gradle.kts` before each upload" instructions.

Note: the repo's `Bump Version` workflow still only bumps the Python packages, so
the checked-in `versionName` default can drift from the release version. Folding
Android into `scripts/update_versions.py` is left for a follow-up.

## Test Plan

Verified the property plumbing at configuration time with a throwaway Gradle init
script that reflects into `android.defaultConfig` and prints the resolved values:

```sh
cd web/android
./gradlew -I /tmp/print-version.gradle.kts help -q                              # name=0.1.3     code=9
./gradlew -I /tmp/print-version.gradle.kts help -q \
  -PversionCode=42 -PversionName=9.9.9-rc1                                      # name=9.9.9-rc1 code=42
./gradlew -I /tmp/print-version.gradle.kts help -q "-PversionCode=" "-PversionName="  # name=0.1.3 code=9
```

All three matched expectations: defaults apply with no flags, overrides take
effect, and blank values fall back to the defaults (the CI PR-event path).
`pre-commit run --files …` passes; ktlint rewrapped the helper's signature.

## Demo

N/A — no user-visible surface; build configuration only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is Gradle build configuration, which the test suites do not cover.
Verified manually via the three `./gradlew` invocations above, asserting the
resolved `versionCode`/`versionName` for the default, overridden, and
blank-value cases. The existing `Android Bundle` workflow also runs
`bundleRelease` on PRs touching `web/android/**`, so this PR exercises the
blank-input path in CI.


