### PR TITLE
fix(web): pre-warm and keep terminal surfaces alive across switches

### DIFF
--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -120,11 +120,15 @@ def test_right_panel_terminals_and_file_viewer(
         close_tab = rail.get_by_role("button", name="Close zsh · main", exact=True)
         expect(close_tab).to_be_visible(timeout=20_000)
         # The shell's xterm mounts in the rail and connects; the chat main
-        # column is not replaced.
+        # column is not replaced. Assert no VISIBLE main terminal surface:
+        # terminal-first sessions keep a hidden pre-warmed surface mounted
+        # (data-visible="false"), which is not a takeover.
         terminal_view = rail.get_by_test_id("terminal-view")
         expect(terminal_view.last).to_be_visible(timeout=20_000)
         expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
-        expect(page.get_by_test_id("main-terminal-view")).to_have_count(0)
+        expect(
+            page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
+        ).to_have_count(0)
         # The tab's x closes the shell — its xterm unmounts and the rail
         # falls back to the Shells list for the Files steps below.
         close_tab.click()

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -85,10 +85,13 @@ def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, s
 
     # The shell's xterm mounts INSIDE the rail (not the main column) and
     # connects. The chat surface is untouched — the composer stays visible.
+    # Assert no VISIBLE main terminal surface: terminal-first sessions keep
+    # a hidden pre-warmed surface mounted (data-visible="false"), which is
+    # not a takeover.
     terminal_view = rail.get_by_test_id("terminal-view")
     expect(terminal_view.last).to_be_visible(timeout=20_000)
     expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
-    expect(page.get_by_test_id("main-terminal-view")).to_have_count(0)
+    expect(page.locator('[data-testid="main-terminal-view"][data-visible="true"]')).to_have_count(0)
     expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
 
     # The tab's x closes the shell — its xterm unmounts and the rail falls

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -91,7 +91,9 @@ def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, s
     terminal_view = rail.get_by_test_id("terminal-view")
     expect(terminal_view.last).to_be_visible(timeout=20_000)
     expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
-    expect(page.locator('[data-testid="main-terminal-view"][data-visible="true"]')).to_have_count(0)
+    expect(page.locator('[data-testid="main-terminal-view"][data-visible="true"]')).to_have_count(
+        0
+    )
     expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
 
     # The tab's x closes the shell — its xterm unmounts and the rail falls

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -667,6 +667,16 @@ export class TerminalSession {
   }
 
   /**
+   * Give the terminal keyboard focus. The WS-open handler focuses
+   * automatically, but that call is a browser no-op while the surface is
+   * hidden (a pre-warmed attach behind the chat view), so the view calls
+   * this when the surface is revealed.
+   */
+  focus(): void {
+    this.term.focus();
+  }
+
+  /**
    * Update the terminal's code font (size + family) without reconnecting —
    * mirrors {@link setTheme}, mutating options in place. A new glyph size
    * changes the character-cell dimensions, so this re-fits the grid to the

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -27,6 +27,7 @@ const terminalSessionMock = vi.hoisted(() => ({
     onState: (state: ConnectionState) => void;
     dispose: ReturnType<typeof vi.fn>;
     setTheme: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
   }[],
 }));
 
@@ -37,6 +38,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
   TerminalSession: class {
     dispose = vi.fn();
     setTheme = vi.fn();
+    focus = vi.fn();
 
     constructor(
       _container: HTMLDivElement,
@@ -53,6 +55,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
         onState,
         dispose: this.dispose,
         setTheme: this.setTheme,
+        focus: this.focus,
       });
     }
   },
@@ -147,6 +150,41 @@ describe("control-mode transport", () => {
     expect(inst.url).not.toContain("transport");
     expect(inst.nativeSelection).toBe(false);
     expect(screen.getByTestId("terminal-selection-hint")).toBeInTheDocument();
+  });
+});
+
+describe("hidden pre-warmed surface", () => {
+  it("keeps one live session across an active flip and focuses on reveal", async () => {
+    // Mount hidden (a pre-warmed attach behind the chat view): the
+    // session dials immediately — that is the whole point of the
+    // pre-warm — but must not take focus away from the composer.
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />,
+    );
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    const inst = terminalSessionMock.instances[0];
+    expect(inst.focus).not.toHaveBeenCalled();
+
+    // Reveal: the SAME session is kept (no re-dial — a second instance
+    // here means the flip reconnected the WebSocket) and focused, since
+    // the WS-open auto-focus was a no-op while hidden.
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active />);
+    await waitFor(() => expect(inst.focus).toHaveBeenCalledTimes(1));
+    expect(terminalSessionMock.instances).toHaveLength(1);
+    expect(inst.dispose).not.toHaveBeenCalled();
+
+    // Hiding again neither disposes nor re-focuses.
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />);
+    expect(inst.dispose).not.toHaveBeenCalled();
+    expect(inst.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not focus on a plain active mount (WS-open handles it)", async () => {
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    // No reveal edge — the session's own WS-open focus owns this case;
+    // an extra explicit call would steal focus on every reconnect.
+    expect(terminalSessionMock.instances[0].focus).not.toHaveBeenCalled();
   });
 });
 
@@ -389,6 +427,50 @@ describe("automatic reconnect", () => {
       // Restore the default prototype getter for later tests.
       delete (document as { visibilityState?: unknown }).visibilityState;
     }
+  });
+
+  it("re-dials with a fresh budget when a hidden warm surface is revealed", async () => {
+    // A warm surface parked behind another session's view: the transport
+    // flaps with nobody watching and the background reconnect loop burns
+    // its whole budget.
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />,
+    );
+    await act(async () => {});
+    expect(terminalSessionMock.instances).toHaveLength(1);
+
+    for (const [, delay] of RECONNECT_BACKOFF_MS.entries()) {
+      closeNewest(1006);
+      // oxlint-disable-next-line no-await-in-loop
+      await elapse(delay);
+    }
+    closeNewest(1006);
+    await elapse(60_000);
+    const exhausted = RECONNECT_BACKOFF_MS.length + 1;
+    expect(terminalSessionMock.instances).toHaveLength(exhausted);
+
+    // Reveal: a user is now looking at the dead pane — that is the retry
+    // signal, same as a tab thaw. One fresh dial, budget restored.
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active />);
+    await act(async () => {});
+    expect(terminalSessionMock.instances).toHaveLength(exhausted + 1);
+  });
+
+  it("does not resurrect a deliberately closed terminal on reveal", async () => {
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active={false} />,
+    );
+    await act(async () => {});
+    closeNewest(4405);
+    await elapse(60_000);
+    expect(terminalSessionMock.instances).toHaveLength(1);
+
+    // The server ended this terminal on purpose; revealing the surface
+    // must keep the dead-end overlay, not loop on the same answer.
+    rerender(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" active />);
+    await act(async () => {});
+    expect(terminalSessionMock.instances).toHaveLength(1);
+    expect(screen.getByText("Bridge closed: code 4405")).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -82,6 +82,14 @@ interface TerminalViewProps {
    * behavior the UI renders for.
    */
   transport?: "control" | "pty";
+  /**
+   * False while the surface is mounted but hidden (a pre-warmed attach
+   * kept alive behind the chat view). The session stays connected either
+   * way; on the hidden→visible edge the terminal takes keyboard focus —
+   * the WS-open auto-focus is a browser no-op on a hidden element.
+   * Default true.
+   */
+  active?: boolean;
 }
 
 export function TerminalView({
@@ -94,6 +102,7 @@ export function TerminalView({
   onResume,
   resumePending = false,
   transport,
+  active = true,
 }: TerminalViewProps) {
   // Control mode: xterm owns the buffer + mouse, so plain drag selects and
   // the normal copy gesture works — no forced-selection modifier, no hint bar.
@@ -228,6 +237,30 @@ export function TerminalView({
   useEffect(() => {
     sessionRef.current?.setTheme(isDark);
   }, [isDark]);
+
+  // On the hidden→visible edge of a pre-warmed surface: focus the
+  // terminal (the session's WS-open focus is a no-op while the element is
+  // hidden — visibility:hidden elements aren't focusable), and if the
+  // transport dropped while the surface sat in the background — possibly
+  // exhausting the reconnect budget with nobody watching — retry
+  // immediately with a fresh budget. Reveal is a user signal, exactly
+  // like the visibilitychange redial for frozen tabs. Deliberate closes
+  // (4xxx) keep the dead-end overlay as ever.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const wasActiveRef = useRef(active);
+  useEffect(() => {
+    if (active && !wasActiveRef.current) {
+      sessionRef.current?.focus();
+      const current = stateRef.current;
+      if (current.kind === "closed" && isUnexpectedTerminalClose(current.code)) {
+        reconnectAttemptsRef.current = 0;
+        disposeActiveSession();
+        setConnectAttempt((attempt) => attempt + 1);
+      }
+    }
+    wasActiveRef.current = active;
+  }, [active, disposeActiveSession]);
 
   // Push code-font changes (Settings → Appearance) into the live session the
   // same way — xterm is a fixed-pixel widget, so it can't follow a CSS variable

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -29,7 +29,11 @@ import {
   shouldSendInitialPrompt,
   shouldShowAuthorBadge,
   shouldShowWorkingIndicator,
+  MAX_WARM_TERMINAL_SURFACES,
+  shouldMountTerminalSurface,
   shouldShowTerminalSurface,
+  updateWarmTerminalSurfaces,
+  type WarmTerminalEntry,
   splitSlashCommand,
   stripGatedSubagentRoutingChips,
   stripPendingElicitations,
@@ -121,6 +125,93 @@ describe("Terminal-first surface selection", () => {
     expect(
       shouldShowTerminalSurface("conv_regular", { isTerminalFirst: false, view: "terminal" }, true),
     ).toBe(false);
+  });
+
+  it("pre-warms the surface in chat view once a terminal is reachable", () => {
+    // Mounted (hidden) so the attach dials in the background and the
+    // first flip to Terminal is instant.
+    expect(
+      shouldMountTerminalSurface("conv_terminal", {
+        isTerminalFirst: true,
+        view: "chat",
+        terminalsAvailable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the surface mounted while the view is open even with no terminal", () => {
+    // The surface owns the "No terminals available" / reconnect states.
+    expect(
+      shouldMountTerminalSurface("conv_stopped", {
+        isTerminalFirst: true,
+        view: "terminal",
+        terminalsAvailable: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not pre-warm with no reachable terminal or for non-terminal-first sessions", () => {
+    // A hidden mount here would just dial a dead runner…
+    expect(
+      shouldMountTerminalSurface("conv_stopped", {
+        isTerminalFirst: true,
+        view: "chat",
+        terminalsAvailable: false,
+      }),
+    ).toBe(false);
+    // …and non-terminal-first sessions have no main terminal surface at all.
+    expect(
+      shouldMountTerminalSurface("conv_regular", {
+        isTerminalFirst: false,
+        view: "chat",
+        terminalsAvailable: true,
+      }),
+    ).toBe(false);
+    expect(shouldMountTerminalSurface(null, null)).toBe(false);
+  });
+});
+
+describe("Warm terminal-surface LRU", () => {
+  it("moves a revisited session to the most-recent end without duplicating it", () => {
+    const warmed = updateWarmTerminalSurfaces(
+      [
+        { conversationId: "conv_a", readOnly: false },
+        { conversationId: "conv_b", readOnly: false },
+      ],
+      "conv_a",
+      false,
+    );
+    expect(warmed.map((e) => e.conversationId)).toEqual(["conv_b", "conv_a"]);
+  });
+
+  it("evicts the least-recent session past the cap", () => {
+    const ids = Array.from({ length: MAX_WARM_TERMINAL_SURFACES + 1 }, (_, i) => `conv_${i}`);
+    let warmed: WarmTerminalEntry[] = [];
+    for (const id of ids) {
+      warmed = updateWarmTerminalSurfaces(warmed, id, false);
+    }
+    // The oldest fell out: its hidden surface unmounts and its attach is
+    // disposed, keeping the cache from accumulating a tmux attach for
+    // every session ever visited.
+    expect(warmed.map((e) => e.conversationId)).toEqual(ids.slice(1));
+    expect(warmed).toHaveLength(MAX_WARM_TERMINAL_SURFACES);
+  });
+
+  it("refreshes the readOnly snapshot for the re-inserted session only", () => {
+    // Permission hydrates late for the active session; a warm background
+    // session must keep the snapshot from when IT was active.
+    const warmed = updateWarmTerminalSurfaces(
+      [
+        { conversationId: "conv_a", readOnly: true },
+        { conversationId: "conv_b", readOnly: false },
+      ],
+      "conv_b",
+      true,
+    );
+    expect(warmed).toEqual([
+      { conversationId: "conv_a", readOnly: true },
+      { conversationId: "conv_b", readOnly: true },
+    ]);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1336,7 +1336,9 @@ interface SessionLayoutProps {
 function SessionLayout({ mainAgent }: SessionLayoutProps) {
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">
-      <div className="flex min-w-0 flex-1 flex-col">{mainAgent}</div>
+      {/* `relative`: positions MainAgentSurface's persistent terminal
+          overlay (absolute inset-0) against the main column. */}
+      <div className="relative flex min-w-0 flex-1 flex-col">{mainAgent}</div>
     </div>
   );
 }
@@ -1540,6 +1542,71 @@ export function shouldShowTerminalSurface(
 }
 
 /**
+ * Whether the terminal surface should be MOUNTED (kept alive), as opposed
+ * to shown. Broader than {@link shouldShowTerminalSurface}: once a
+ * terminal is reachable, the surface mounts hidden behind the chat view
+ * so the WS attach pre-warms in the background and survives Chat/Terminal
+ * flips — making both the first open and every return near-instant. With
+ * no reachable terminal the surface still mounts while the view is open
+ * (it owns the "No terminals available" / reconnect states), but a hidden
+ * mount would just dial a dead runner, so it stays unmounted.
+ */
+export function shouldMountTerminalSurface(
+  conversationId: string | null,
+  terminalFirst:
+    | {
+        isTerminalFirst: boolean;
+        view: "chat" | "terminal";
+        terminalsAvailable: boolean;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!conversationId || terminalFirst?.isTerminalFirst !== true) return false;
+  return terminalFirst.view === "terminal" || terminalFirst.terminalsAvailable;
+}
+
+/**
+ * One recently-viewed terminal-first session whose terminal surface stays
+ * mounted (hidden) after navigating away, so switching back re-reveals a
+ * live attach instead of re-dialing. ``readOnly`` is snapshotted from the
+ * session's own permission level while it was active — the current
+ * session's permissions must never leak onto a warm background surface.
+ */
+export interface WarmTerminalEntry {
+  conversationId: string;
+  readOnly: boolean;
+}
+
+/**
+ * How many sessions' terminal surfaces stay warm at once (the active one
+ * included). Each warm surface holds a WebSocket + a runner-side
+ * ``tmux attach``, a WebGL context (browsers cap those per page; losing
+ * one falls back to xterm's DOM renderer), and keeps parsing any output
+ * its TUI streams while hidden — so the cache is bounded rather than
+ * unbounded, but sized to cover a working set of sessions, not just a
+ * pair. Idle shells cost ~nothing in the background; the practical
+ * ceiling is many simultaneously *busy* TUIs.
+ */
+export const MAX_WARM_TERMINAL_SURFACES = 8;
+
+/**
+ * LRU update for the warm terminal-surface cache: move (or insert)
+ * *conversationId* at the most-recent end with the given *readOnly*
+ * snapshot, evicting the least-recent entry past
+ * {@link MAX_WARM_TERMINAL_SURFACES}. Pure — exported for direct unit
+ * testing.
+ */
+export function updateWarmTerminalSurfaces(
+  prev: WarmTerminalEntry[],
+  conversationId: string,
+  readOnly: boolean,
+): WarmTerminalEntry[] {
+  const rest = prev.filter((e) => e.conversationId !== conversationId);
+  return [...rest, { conversationId, readOnly }].slice(-MAX_WARM_TERMINAL_SURFACES);
+}
+
+/**
  * The conversation scroll surface + composer — the content of the
  * "Main Agent" tab (and also the standalone view on `/`).
  *
@@ -1605,8 +1672,9 @@ function MainAgentSurface({
   const showTerminal = shouldShowTerminalSurface(conversationId, terminalFirst, runnerOnline);
 
   // All hook calls below must run on every render regardless of
-  // `showTerminal` — Rules of Hooks. The early return for the terminal
-  // branch lives below, after every hook has run.
+  // `showTerminal` — Rules of Hooks. The single return at the bottom
+  // renders the persistent terminal overlay and, when the terminal view
+  // is closed, the chat surface beside it.
 
   // Single nav instance shared by hotkey + buttons (see useUserMessageNav).
   // System-message bubbles (`[System: ...]` notifications rendered via
@@ -1822,40 +1890,85 @@ function MainAgentSurface({
   // spinner suppresses it (that bubble owns the slot with its own animation).
   const showWorkingIndicator = shouldShowWorkingIndicator(showsWorking, bubbles);
 
-  if (showTerminal && conversationId) {
+  // Persistent terminal surfaces for terminal-first sessions. Each is
+  // mounted from the moment its terminal is reachable — not just when the
+  // view is open — and kept mounted as a visibility-toggled overlay, so
+  // the attach (WS dial through the host tunnel + a forked `tmux attach`
+  // + full repaint) pre-warms in the background and survives both
+  // Chat/Terminal flips AND session switches: a small LRU keeps the last
+  // few sessions' surfaces alive after navigating away, so coming back is
+  // near-instant instead of re-dialing from scratch. `invisible` (not
+  // display:none) keeps a hidden overlay's layout size, so FitAddon
+  // geometry stays correct and no resize churn hits tmux; hidden elements
+  // don't paint, hit-test, or take focus. The chat surface still unmounts
+  // while the terminal is shown — a heavy transcript shouldn't render
+  // behind a live terminal.
+  const mountTerminal = shouldMountTerminalSurface(conversationId, terminalFirst);
+  // Non-owners attach read-only: a shared PTY can't attribute input
+  // per-user, so only the owner may type. They drive the agent via the
+  // composer instead. Server enforces this too.
+  const terminalReadOnly = !isOwnerLevel(permissionLevel);
+  const [warmTerminals, setWarmTerminals] = useState<WarmTerminalEntry[]>([]);
+  useEffect(() => {
+    if (!mountTerminal || !conversationId) return;
+    setWarmTerminals((prev) => updateWarmTerminalSurfaces(prev, conversationId, terminalReadOnly));
+  }, [mountTerminal, conversationId, terminalReadOnly]);
+  // Render from a derived list that already includes the active session,
+  // so a fresh session's surface mounts in the same commit (the effect
+  // above persists it one commit later) and its readOnly snapshot tracks
+  // a late permission hydrate while it is the active session.
+  const renderedTerminals =
+    mountTerminal && conversationId
+      ? updateWarmTerminalSurfaces(warmTerminals, conversationId, terminalReadOnly)
+      : warmTerminals;
+  const terminalSurfaces = renderedTerminals.map((entry) => {
+    const isActive = mountTerminal && entry.conversationId === conversationId;
+    const isShown = isActive && showTerminal;
     return (
-      <>
+      <div
+        key={entry.conversationId}
+        className={cn("absolute inset-0 flex flex-col", !isShown && "invisible")}
+        aria-hidden={!isShown}
+      >
         <MainTerminalView
-          conversationId={conversationId}
-          initialTerminalKey={terminalFirst?.terminalViewKey}
-          onSurfaceElement={setTerminalSurfaceEl}
-          // Non-owners attach read-only: a shared PTY can't attribute
-          // input per-user, so only the owner may type. They drive the
-          // agent via the composer instead. Server enforces this too.
-          readOnly={!isOwnerLevel(permissionLevel)}
+          conversationId={entry.conversationId}
+          initialTerminalKey={isActive ? terminalFirst?.terminalViewKey : null}
+          visible={isShown}
+          onSurfaceElement={isActive ? setTerminalSurfaceEl : undefined}
+          readOnly={entry.readOnly}
         />
-        <ConnectionIndicator
-          liveness={liveness}
-          onShowReconnectHelp={onShowReconnectHelp}
-          surfaceFrontmost={surfaceFrontmost}
-        />
-      </>
+        {isShown && (
+          <ConnectionIndicator
+            liveness={liveness}
+            onShowReconnectHelp={onShowReconnectHelp}
+            surfaceFrontmost={surfaceFrontmost}
+          />
+        )}
+      </div>
     );
-  }
+  });
 
+  // Single return so both surfaces keep stable fragment positions across
+  // view flips — an early return would change the tree shape and remount
+  // the terminal overlays, disposing the live attaches they exist to
+  // preserve. The chat surface still unmounts entirely while the
+  // terminal is shown (a heavy transcript shouldn't render behind it).
   return (
     <>
-      {/* Wrapper div gives us a ref to scope the SelectionPopup to the
+      {terminalSurfaces}
+      {!showTerminal && (
+        <>
+          {/* Wrapper div gives us a ref to scope the SelectionPopup to the
           conversation area without requiring Conversation to forward refs. */}
-      <div
-        ref={setConversationEl}
-        className="@container/chat relative flex min-h-0 flex-1 overflow-hidden"
-      >
-        {/* chat-scroll-fade masks the viewport's top edge so scrolling
+          <div
+            ref={setConversationEl}
+            className="@container/chat relative flex min-h-0 flex-1 overflow-hidden"
+          >
+            {/* chat-scroll-fade masks the viewport's top edge so scrolling
             content dissolves into the canvas before reaching the
             ChatHeader overlay's controls (geometry in index.css). */}
-        <Conversation className="chat-scroll-fade flex-1">
-          {/* Override ConversationContent's default spacing so the thread keeps
+            <Conversation className="chat-scroll-fade flex-1">
+              {/* Override ConversationContent's default spacing so the thread keeps
               16px side gutters and consecutive agent turns read as one thread.
               The left inset grows *continuously* as the conversation area
               narrows: the centered column slides left with the area until its
@@ -1867,60 +1980,60 @@ function MainAgentSurface({
               ramp (1rem→1.5rem as the area crosses ~54rem) matches where the
               48rem column's auto-margins shrink past the clearance. md+ only:
               the rail is hidden on mobile, which keeps the plain 1rem gutter. */}
-          {/* Native scroll anchoring holds position across a history prepend —
+              {/* Native scroll anchoring holds position across a history prepend —
               the browser does it off the main thread, so it can't interrupt an
               in-flight scroll the way an imperative scrollTop write does. */}
-          <ConversationContent
-            scrollClassName="transcript-hide-native-scrollbar"
-            className={cn(
-              "chat-conversation-content mx-auto w-full gap-4 px-4 pt-20 pb-6",
-              "md:pl-[clamp(1rem,(54rem-100cqi)*0.5+1rem,1.5rem)]",
-              CHAT_COLUMN_WIDTH,
-            )}
-          >
-            {/* Scroll helpers — must live inside StickToBottom to access context. */}
-            <ScrollToBottomOnSend nonce={sendScrollNonce} />
-            <PreserveScrollDistanceOnResize />
-            <ConversationScrollRefBridge onScroller={setScroller} />
-            <HistoryAutoLoader scrollElement={scroller?.el ?? null} />
-            {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
-              // Cold launch: a centered spinner instead of the "ready to
-              // type" empty state (the create-then-send path uses the
-              // "row" variant). Two launch shapes land here: a
-              // terminal-first spin-up (gate on isTerminalFirst too —
-              // terminalStartingUp is set for non-terminal-first sessions
-              // as well) and a managed-sandbox launch, whose stage text
-              // renders in the same spot for ANY session type.
-              (terminalFirst?.isTerminalFirst && terminalFirst.terminalStartingUp) ||
-              sandboxLaunching ? (
-                <RunnerStartingIndicator variant="hero" />
-              ) : (
-                <ConversationEmptyState>
-                  <div className="space-y-1.5">
-                    <h3 className="text-2xl font-medium tracking-[-0.02em]">
-                      What should we work on?
-                    </h3>
-                    <p className="text-muted-foreground text-ui">
-                      {agentsError
-                        ? `Failed to load agents: ${agentsError instanceof Error ? agentsError.message : String(agentsError)}`
-                        : "Send a message to get started."}
-                    </p>
-                  </div>
-                </ConversationEmptyState>
-              )
-            ) : (
-              <>
-                {/* Older pages prepend here while their request is in flight. */}
-                {loadingMoreHistory && <HistoryLoadingIndicator />}
-                {streamBubbles.map((bubble, bubbleIndex) => (
-                  <BubbleView
-                    key={bubbleKey(bubble)}
-                    bubble={bubble}
-                    isLastAssistant={bubbleIndex === lastAssistantIndex}
-                    showsWorking={showsWorking && bubbleIndex === lastAssistantIndex}
-                  />
-                ))}
-                {/* Pending elicitation cards, floated to the bottom of the
+              <ConversationContent
+                scrollClassName="transcript-hide-native-scrollbar"
+                className={cn(
+                  "chat-conversation-content mx-auto w-full gap-4 px-4 pt-20 pb-6",
+                  "md:pl-[clamp(1rem,(54rem-100cqi)*0.5+1rem,1.5rem)]",
+                  CHAT_COLUMN_WIDTH,
+                )}
+              >
+                {/* Scroll helpers — must live inside StickToBottom to access context. */}
+                <ScrollToBottomOnSend nonce={sendScrollNonce} />
+                <PreserveScrollDistanceOnResize />
+                <ConversationScrollRefBridge onScroller={setScroller} />
+                <HistoryAutoLoader scrollElement={scroller?.el ?? null} />
+                {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
+                  // Cold launch: a centered spinner instead of the "ready to
+                  // type" empty state (the create-then-send path uses the
+                  // "row" variant). Two launch shapes land here: a
+                  // terminal-first spin-up (gate on isTerminalFirst too —
+                  // terminalStartingUp is set for non-terminal-first sessions
+                  // as well) and a managed-sandbox launch, whose stage text
+                  // renders in the same spot for ANY session type.
+                  (terminalFirst?.isTerminalFirst && terminalFirst.terminalStartingUp) ||
+                  sandboxLaunching ? (
+                    <RunnerStartingIndicator variant="hero" />
+                  ) : (
+                    <ConversationEmptyState>
+                      <div className="space-y-1.5">
+                        <h3 className="text-2xl font-medium tracking-[-0.02em]">
+                          What should we work on?
+                        </h3>
+                        <p className="text-muted-foreground text-ui">
+                          {agentsError
+                            ? `Failed to load agents: ${agentsError instanceof Error ? agentsError.message : String(agentsError)}`
+                            : "Send a message to get started."}
+                        </p>
+                      </div>
+                    </ConversationEmptyState>
+                  )
+                ) : (
+                  <>
+                    {/* Older pages prepend here while their request is in flight. */}
+                    {loadingMoreHistory && <HistoryLoadingIndicator />}
+                    {streamBubbles.map((bubble, bubbleIndex) => (
+                      <BubbleView
+                        key={bubbleKey(bubble)}
+                        bubble={bubble}
+                        isLastAssistant={bubbleIndex === lastAssistantIndex}
+                        showsWorking={showsWorking && bubbleIndex === lastAssistantIndex}
+                      />
+                    ))}
+                    {/* Pending elicitation cards, floated to the bottom of the
                     chat so an outstanding question stays in view (stick-to-
                     bottom) no matter how much text the agent streamed after
                     it. Wrapped in an assistant Message so each matches an
@@ -1929,143 +2042,145 @@ function MainAgentSurface({
                     the composer. Rendered ABOVE the Working… indicator so the
                     card sits closest to the prompt and the shimmer stays the
                     last thing in the flow. */}
-                {pendingElicitations.map((item) => (
-                  <Message
-                    key={item.elicitationId}
-                    from="assistant"
-                    className="max-w-full"
-                    data-testid="bottom-elicitation"
-                  >
-                    <MessageContent className="w-full">
-                      <ElicitationCard item={item} />
-                    </MessageContent>
-                  </Message>
-                ))}
-                {/* Working… shimmer, lit for the whole busy turn so the user
+                    {pendingElicitations.map((item) => (
+                      <Message
+                        key={item.elicitationId}
+                        from="assistant"
+                        className="max-w-full"
+                        data-testid="bottom-elicitation"
+                      >
+                        <MessageContent className="w-full">
+                          <ElicitationCard item={item} />
+                        </MessageContent>
+                      </Message>
+                    ))}
+                    {/* Working… shimmer, lit for the whole busy turn so the user
                     always sees the session is still going. Suppressed when the
                     last bubble is a compaction spinner — that bubble already
                     owns the "in-progress" slot. aria-hidden: the pinned pill
                     owns the single aria-live region (see WorkingStatusPin). */}
-                {showWorkingIndicator && <WorkingIndicator />}
-                {/* Terminal-first spin-up cue beneath the just-sent first
+                    {showWorkingIndicator && <WorkingIndicator />}
+                    {/* Terminal-first spin-up cue beneath the just-sent first
                     message: the prompt bubble renders immediately (no
                     runner-online send gate), but `showWorkingIndicator` stays
                     suppressed while the runner is offline, so without this the
                     user's message sits with no sign anything is happening.
                     Self-gates to null off the spin-up window; rendered only
                     when not already showing Working… so the two never stack. */}
-                {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
-                {/* MCP-server startup band (codex-native): renders while the
+                    {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
+                    {/* MCP-server startup band (codex-native): renders while the
                     harness boots its MCP servers and, after startup settles,
                     when servers failed or were cancelled. Independent of the
                     Working… shimmer — it is strictly more specific about why
                     the turn hasn't produced output yet. */}
-                <McpStartupIndicator />
-              </>
-            )}
-            {/* Frames the initially loaded turn at the top of the viewport and
+                    <McpStartupIndicator />
+                  </>
+                )}
+                {/* Frames the initially loaded turn at the top of the viewport and
                 keeps the pane scrollable so older history stays reachable.
                 Always mounted — including for an empty new conversation — so
                 a fast first send cannot become the captured initial anchor.
                 Last child so it measures everything above it. */}
-            <LatestTurnSpacer scrollElement={scroller?.el ?? null} />
-          </ConversationContent>
-          <ConversationScrollButton />
-          {/* Outside ConversationContent so it's pinned to the viewport, not the scroll. See WorkingStatusPin.
+                <LatestTurnSpacer scrollElement={scroller?.el ?? null} />
+              </ConversationContent>
+              <ConversationScrollButton />
+              {/* Outside ConversationContent so it's pinned to the viewport, not the scroll. See WorkingStatusPin.
               Suppressed in a sub-agent session: the composer's "Chatting with sub-agent …" tray owns this slot. */}
-          <WorkingStatusPin show={showWorkingIndicator} suppress={subAgentLabel != null} />
-          <UserMessageNavConnected
-            goPrev={nav.goPrev}
-            goNext={nav.goNext}
-            canPrev={nav.canPrev}
-            canNext={nav.canNext}
-            hidden={userMessageIds.length === 0}
-          />
-        </Conversation>
-        {/* Constant-height scrollbar. Sibling of Conversation for the same
+              <WorkingStatusPin show={showWorkingIndicator} suppress={subAgentLabel != null} />
+              <UserMessageNavConnected
+                goPrev={nav.goPrev}
+                goNext={nav.goNext}
+                canPrev={nav.canPrev}
+                canNext={nav.canNext}
+                hidden={userMessageIds.length === 0}
+              />
+            </Conversation>
+            {/* Constant-height scrollbar. Sibling of Conversation for the same
             reason as JumpToTopButton — outside the chat-scroll-fade mask, which
             would otherwise dissolve it against the header. */}
-        <TranscriptScrollbar scroller={scroller} />
-        {/* Hover the top edge to reveal a pill that loads all older history and
+            <TranscriptScrollbar scroller={scroller} />
+            {/* Hover the top edge to reveal a pill that loads all older history and
             scrolls to the first message. Rendered here (a wrapper sibling of
             Conversation) rather than inside it so it escapes the chat-scroll-fade
             mask and can sit right at the fade border. */}
-        <JumpToTopButton
-          containerEl={containerEl}
-          scroller={scroller}
-          hasMoreHistory={hasMoreHistory}
-        />
-        {/* Left-edge minimap: one tick per turn, scrolls independently, pages
+            <JumpToTopButton
+              containerEl={containerEl}
+              scroller={scroller}
+              hasMoreHistory={hasMoreHistory}
+            />
+            {/* Left-edge minimap: one tick per turn, scrolls independently, pages
             in older history on scroll-up. Sibling of Conversation for the same
             reason as JumpToTopButton — it escapes the chat-scroll-fade mask.
             Desktop-only: not mounted on mobile where the rail is hidden. */}
-        {!isMobileViewport && (
-          <TurnRail
-            turns={turns}
-            scroller={scroller}
-            hasMoreHistory={hasMoreHistory}
-            loadingMoreHistory={loadingMoreHistory}
+            {!isMobileViewport && (
+              <TurnRail
+                turns={turns}
+                scroller={scroller}
+                hasMoreHistory={hasMoreHistory}
+                loadingMoreHistory={loadingMoreHistory}
+              />
+            )}
+          </div>
+          {/* Floating reply button — scoped to the conversation container. */}
+          <SelectionPopup
+            containerRef={conversationRef}
+            onReply={(text) =>
+              setReplyQuotes((prev) => [
+                ...prev,
+                { id: `reply-quote-${nextReplyQuoteId.current++}`, text },
+              ])
+            }
           />
-        )}
-      </div>
-      {/* Floating reply button — scoped to the conversation container. */}
-      <SelectionPopup
-        containerRef={conversationRef}
-        onReply={(text) =>
-          setReplyQuotes((prev) => [
-            ...prev,
-            { id: `reply-quote-${nextReplyQuoteId.current++}`, text },
-          ])
-        }
-      />
 
-      <Composer
-        disabled={disabled}
-        status={status}
-        isWorking={isWorking}
-        onSend={handleSend}
-        onSendSlashCommand={handleSendSlashCommand}
-        onStop={onStop}
-        agents={agents}
-        selectedAgentId={selectedAgentId}
-        permissionLevel={permissionLevel}
-        readOnlyReason={readOnlyReason}
-        replyQuotes={replyQuotes}
-        onRemoveQuote={(i) => setReplyQuotes((prev) => prev.filter((_, idx) => idx !== i))}
-        onClearAllQuotes={() => setReplyQuotes([])}
-        effortLevels={effortLevels}
-        showEffort={showEffort}
-        showModels={showModels}
-        modelPickerKind={modelPickerKind}
-        codexModelOptions={codexModelOptions}
-        showCodexPlanMode={showCodexPlanMode}
-        showGoalControl={showGoalControl}
-        showClaudeGoalControl={showClaudeGoalControl}
-        showPollyCodexGoalControl={showPollyCodexGoalControl}
-        isTerminalFirst={isTerminalFirst}
-        isNativeWrapper={isNativeWrapper}
-        reconnectHint={liveness.kind === "runner_asleep" || liveness.kind === "host_asleep"}
-        sandboxAsleepHint={liveness.kind === "host_asleep"}
-        unreachable={
-          !sandboxLaunching &&
-          (liveness.kind === "host_offline" || liveness.kind === "local_stranded")
-        }
-        onShowReconnectHelp={onShowReconnectHelp}
-        costRoutingEligible={costRoutingEligible}
-        subagentRoutingEligible={subagentRoutingEligible}
-        subAgentLabel={subAgentLabel}
-        wrapperLabel={wrapperLabel}
-        onGrowthChange={publishComposerGrowth}
-      />
+          <Composer
+            disabled={disabled}
+            status={status}
+            isWorking={isWorking}
+            onSend={handleSend}
+            onSendSlashCommand={handleSendSlashCommand}
+            onStop={onStop}
+            agents={agents}
+            selectedAgentId={selectedAgentId}
+            permissionLevel={permissionLevel}
+            readOnlyReason={readOnlyReason}
+            replyQuotes={replyQuotes}
+            onRemoveQuote={(i) => setReplyQuotes((prev) => prev.filter((_, idx) => idx !== i))}
+            onClearAllQuotes={() => setReplyQuotes([])}
+            effortLevels={effortLevels}
+            showEffort={showEffort}
+            showModels={showModels}
+            modelPickerKind={modelPickerKind}
+            codexModelOptions={codexModelOptions}
+            showCodexPlanMode={showCodexPlanMode}
+            showGoalControl={showGoalControl}
+            showClaudeGoalControl={showClaudeGoalControl}
+            showPollyCodexGoalControl={showPollyCodexGoalControl}
+            isTerminalFirst={isTerminalFirst}
+            isNativeWrapper={isNativeWrapper}
+            reconnectHint={liveness.kind === "runner_asleep" || liveness.kind === "host_asleep"}
+            sandboxAsleepHint={liveness.kind === "host_asleep"}
+            unreachable={
+              !sandboxLaunching &&
+              (liveness.kind === "host_offline" || liveness.kind === "local_stranded")
+            }
+            onShowReconnectHelp={onShowReconnectHelp}
+            costRoutingEligible={costRoutingEligible}
+            subagentRoutingEligible={subagentRoutingEligible}
+            subAgentLabel={subAgentLabel}
+            wrapperLabel={wrapperLabel}
+            onGrowthChange={publishComposerGrowth}
+          />
 
-      {/* Chat/Terminal toggle for terminal-first sessions, reconnect-or-
+          {/* Chat/Terminal toggle for terminal-first sessions, reconnect-or-
           fork banner when unreachable, nothing otherwise. Sits below the
           composer so its position is consistent with the terminal view. */}
-      <ConnectionIndicator
-        liveness={liveness}
-        onShowReconnectHelp={onShowReconnectHelp}
-        surfaceFrontmost={surfaceFrontmost}
-      />
+          <ConnectionIndicator
+            liveness={liveness}
+            onShowReconnectHelp={onShowReconnectHelp}
+            surfaceFrontmost={surfaceFrontmost}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -279,3 +279,72 @@ describe("MainTerminalView — native wrapper sessions", () => {
     expect(setView).toHaveBeenCalledWith("chat");
   });
 });
+
+describe("MainTerminalView — persistent hidden mount", () => {
+  it("keeps the terminal mounted (same instance) across a hide/show flip", () => {
+    // ChatPage keeps this surface mounted as a hidden overlay while the
+    // user is in chat. A new data-instance after the round-trip means
+    // the flip tore down the xterm + WS it exists to preserve.
+    const { rerender } = renderView({ terminals: [REPL_TERMINAL] });
+    const view = screen.getByTestId("terminal-view");
+    const instance = view.getAttribute("data-instance");
+    expect(screen.getByTestId("main-terminal-view")).toHaveAttribute("data-visible", "true");
+
+    rerender(
+      <TerminalFirstContextProvider value={makeCtx(false)}>
+        <MainTerminalView
+          conversationId="conv_sdk"
+          initialTerminalKey={null}
+          visible={false}
+          readOnly={false}
+        />
+      </TerminalFirstContextProvider>,
+    );
+    expect(screen.getByTestId("main-terminal-view")).toHaveAttribute("data-visible", "false");
+    expect(screen.getByTestId("terminal-view").getAttribute("data-instance")).toBe(instance);
+
+    rerender(
+      <TerminalFirstContextProvider value={makeCtx(false)}>
+        <MainTerminalView
+          conversationId="conv_sdk"
+          initialTerminalKey={null}
+          visible
+          readOnly={false}
+        />
+      </TerminalFirstContextProvider>,
+    );
+    expect(screen.getByTestId("terminal-view").getAttribute("data-instance")).toBe(instance);
+  });
+
+  it("resets a shell selection to the agent terminal while hidden", () => {
+    // Open on a rail shell, then close the view (AppShell nulls the
+    // target key when the view closes). The old unmount-on-close forgot
+    // the shell selection, so reopening always showed the agent pane —
+    // the persistent mount must reproduce that.
+    const { rerender } = renderView({
+      terminals: [REPL_TERMINAL, BASH_SHELL],
+      initialTerminalKey: "terminal:terminal_bash_s1",
+    });
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_bash_s1",
+    );
+
+    rerender(
+      <TerminalFirstContextProvider value={makeCtx(false)}>
+        <MainTerminalView
+          conversationId="conv_sdk"
+          initialTerminalKey={null}
+          visible={false}
+          readOnly={false}
+        />
+      </TerminalFirstContextProvider>,
+    );
+    // The hidden background attach now targets the agent terminal — the
+    // pane the next open will actually show.
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_tui_main",
+    );
+  });
+});

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -32,6 +32,15 @@ interface MainTerminalViewProps {
    */
   initialTerminalKey?: string | null;
   /**
+   * False while the surface is mounted but hidden behind the chat view
+   * (the pre-warmed overlay in MainAgentSurface). The WS attach and
+   * xterm buffer stay alive so flipping to Terminal is instant; on the
+   * visible→hidden edge a user-shell selection resets to the agent
+   * terminal so the next open targets the agent pane, matching the old
+   * unmount-on-close behavior. Default true.
+   */
+  visible?: boolean;
+  /**
    * When true, attach every terminal (agent TUI and user shells)
    * read-only — the viewer can watch but not type. Set for non-owners:
    * a shared PTY's keystrokes carry no per-user identity, so only the
@@ -50,6 +59,7 @@ interface MainTerminalViewProps {
 export function MainTerminalView({
   conversationId,
   initialTerminalKey,
+  visible = true,
   readOnly = false,
   onSurfaceElement,
 }: MainTerminalViewProps) {
@@ -94,6 +104,17 @@ export function MainTerminalView({
     if (!stillValid) setActiveKey(terminalTabKey(agentTerminals[0] ?? terminals[0]));
   }, [terminals, agentTerminals, activeKey]);
 
+  // While hidden, drop a user-shell selection back to the agent terminal.
+  // The surface used to unmount on close (forgetting the selection), so
+  // reopening always showed the agent pane; the persistent pre-warmed
+  // mount must reproduce that, and it points the background attach at
+  // the pane the next open will actually show.
+  useEffect(() => {
+    if (visible || terminals.length === 0) return;
+    const fallback = agentTerminals[0] ?? terminals[0];
+    setActiveKey(terminalTabKey(fallback));
+  }, [visible, terminals, agentTerminals]);
+
   const activeTerminal = terminals.find((t) => terminalTabKey(t) === activeKey) ?? null;
   // A user shell opened from the rail takes over the pane chrome-free:
   // a single header row naming the shell plus a close X — no agent tab
@@ -127,6 +148,9 @@ export function MainTerminalView({
       // Exposed for e2e assertions that an expand targeted the right
       // terminal (not just that the view opened).
       data-active-terminal={activeKey}
+      // Distinguishes the revealed surface from the hidden pre-warmed
+      // mount for tests — both are in the DOM.
+      data-visible={visible}
       className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-14 pb-1.5"
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
@@ -172,6 +196,7 @@ export function MainTerminalView({
                     terminalId={activeTerminal.id}
                     readOnly={readOnly}
                     transport={activeTerminal.transport}
+                    active={visible}
                     onStateChange={(state) => {
                       setTerminalConnectionState(activeTerminal.id, state);
                     }}


### PR DESCRIPTION
## Related issue

N/A — found while dogfooding: the embedded terminal took seconds to load on every visit to the Terminal tab.

## Summary

Opening the Terminal tab rebuilt the whole stack on every visit — a new xterm + WebGL renderer, a WebSocket dialed through server → host tunnel → runner, a freshly forked `tmux attach`, and a full repaint — and flipping back to Chat tore it all down, so the cost repeated on every return. The same happened again after every session switch.

- The terminal surface is now a **persistent, visibility-toggled overlay**: it mounts *hidden* as soon as a terminal is reachable, so the attach **pre-warms in the background** and the first open is near-instant; Chat/Terminal flips just toggle visibility, keeping the WS + xterm buffer (and scrollback) alive.
- A small **LRU (8 sessions)** keeps recently-visited sessions' surfaces warm across session switches — `ChatPage` stays mounted across `/c/:id` changes, so switching back re-reveals a live attach. Each entry snapshots its own `readOnly` so permissions never leak between sessions.
- **Reveal-redial**: a warm hidden surface whose transport died in the background (possibly exhausting the reconnect budget with nobody watching) retries immediately with a fresh budget on reveal — same reasoning as the existing tab-thaw redial. Deliberate server closes (4xxx) keep the dead-end overlay and are never resurrected.

**ELI5:** instead of hanging up the phone every time you leave the terminal and re-dialing when you come back, the call stays connected on hold — and we place the call as soon as you enter the room, not when you pick up the receiver.

```
main column
├─ overlay conv_A  (visible)  ─ xterm ── WS ── tmux attach   ← active
├─ overlay conv_B  (hidden)   ─ xterm ── WS ── tmux attach   ← warm
├─ overlay conv_C  (hidden)   ─ xterm ── WS ── tmux attach   ← warm  (LRU cap 8)
└─ chat surface    (unmounted while terminal shown)
```

Mechanics worth knowing: hiding uses `visibility: hidden` (not `display: none`) so hidden overlays keep their layout size — FitAddon geometry stays correct and no resize churn hits tmux; hidden elements don't paint, hit-test, or take focus (the WS-open auto-focus is a browser no-op while hidden, so a pre-warm can't steal the composer's cursor — focus is applied explicitly on reveal). The e2e assertions that checked "no `main-terminal-view` exists" now assert "none is **visible**" via the new `data-visible` attribute — the hidden pre-warmed mount is not a takeover.

## Test Plan

- `npx vitest run src/pages/ChatPage.test.ts src/shell/MainTerminalView.test.tsx src/components/blocks/TerminalView.test.tsx` — 197 tests pass, including new coverage for: pre-warm mount gating (`shouldMountTerminalSurface`), same-session keep-alive across hide/show (no re-dial, focus on reveal only), LRU move-to-end/eviction/per-session `readOnly`, reveal-redial with a fresh budget, and no resurrect on deliberate close.
- Full web suite: 3 failing files are pre-existing/env-local (`scheduleText`, `streamdownCodeHighlight`, `NewChatDialog`) — none touch the changed code.
- `tsc -b`, `oxlint`, `prettier`, and `pre-commit run` all green.
- Manual verification against a live deployment (see below).

## Demo

N/A — the change is latency/lifecycle behavior with no new visuals. Verified live against a deployed server (Vite dev proxy → Databricks App): the Terminal tab connects near-instantly on first open, and Chat ↔ Terminal flips and session switches re-reveal the live terminal with scrollback intact instead of showing "Connecting…".

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified against a live deployed server through the authenticated dev proxy: first Terminal open is near-instant (pre-warmed), Chat ↔ Terminal flips are instant with scrollback intact, session switches within the warm window re-reveal live terminals, and a non-owner viewer still attaches read-only. E2E: the two `main-terminal-view` count-0 assertions were sharpened to "no *visible* main terminal surface" (`data-visible="true"`), which is the behavior they were actually pinning.

## Changelog

The embedded terminal connects in the background and stays connected across Chat/Terminal flips and recent-session switches, so opening it is near-instant instead of reconnecting every time.
