### PR TITLE
fix(host): keep CLAUDE_CODE_USE_GATEWAY / ENABLE_TOOL_SEARCH in the r…

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -456,6 +456,11 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # auth, which fails for non-AWS proxies. Same rationale as
         # CLAUDE_CODE_USE_BEDROCK above. Safe to propagate: not a secret.
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        # Non-secret Claude Code flags the native-claude provider path reads from
+        # os.environ. If stripped, the runner re-adds CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1,
+        # which turns off MCP tool search and loads every tool schema eagerly.
+        "CLAUDE_CODE_USE_GATEWAY",
+        "ENABLE_TOOL_SEARCH",
         # Kubernetes config path. A filesystem path (typically
         # ``~/.kube/config``), not a bearer secret — the file *contains*
         # cluster certs/tokens but the env var is just a path string,

--- a/tests/cli/test_host_daemon_env.py
+++ b/tests/cli/test_host_daemon_env.py
@@ -94,3 +94,45 @@ def test_runner_env_explicit_proxy_passthrough_remains_available() -> None:
         name: _PROXY_ENV[name] for name in explicit_names
     }
     assert (set(_PROXY_ENV) - explicit_names).isdisjoint(env)
+
+
+_CLAUDE_TOOL_SEARCH_ENV: Final = {
+    "CLAUDE_CODE_USE_GATEWAY": "1",
+    "ENABLE_TOOL_SEARCH": "true",
+}
+
+
+@pytest.mark.parametrize("server_url", [None, _REMOTE_SERVER_URL])
+def test_host_daemon_env_preserves_claude_tool_search_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    server_url: str | None,
+) -> None:
+    """USE_GATEWAY / ENABLE_TOOL_SEARCH reach the daemon in both modes (Gate 1)."""
+    # Given
+    for name, value in _CLAUDE_TOOL_SEARCH_ENV.items():
+        monkeypatch.setenv(name, value)
+
+    # When
+    env = _build_host_daemon_env(server_url=server_url)
+
+    # Then
+    assert {name: env.get(name) for name in _CLAUDE_TOOL_SEARCH_ENV} == _CLAUDE_TOOL_SEARCH_ENV
+
+
+def test_runner_env_preserves_claude_tool_search_flags() -> None:
+    """USE_GATEWAY / ENABLE_TOOL_SEARCH reach the runner subprocess (Gate 2)."""
+    # Given
+    base_env = {"PATH": "/usr/bin", **_CLAUDE_TOOL_SEARCH_ENV}
+
+    # When
+    env = _build_runner_env(
+        base_env,
+        server_url=_REMOTE_SERVER_URL,
+        runner_id="runner_tool_search",
+        binding_token="binding-tool-search",
+        workspace="/tmp/workspace",
+        parent_pid=12345,
+    )
+
+    # Then
+    assert {name: env.get(name) for name in _CLAUDE_TOOL_SEARCH_ENV} == _CLAUDE_TOOL_SEARCH_ENV


### PR DESCRIPTION
A launcher sets CLAUDE_CODE_USE_GATEWAY=1 and ENABLE_TOOL_SEARCH=true in its process env so the native-claude harness keeps MCP tool search on (schemas load on demand). But the host daemon env (`_build_host_daemon_env`) and the runner env (`_build_runner_env`) are both built from `_RUNNER_ENV_ALLOWLIST`, and neither var was on it — so they were stripped at daemon spawn and never reached the runner process.

The native-claude provider path (`_provider_config_for_native_claude`, `_ucode_config_for_profile`, `_bedrock_config_for_native_claude`) reads CLAUDE_CODE_USE_GATEWAY from os.environ to decide whether to set CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1. With it stripped, the runner saw it absent, re-added the disable flag, and Claude Code turned tool search off — loading every MCP tool schema eagerly (~88k tokens for ~190 MCP tools at startup instead of on demand).

Add both non-secret boolean flags to `_RUNNER_ENV_ALLOWLIST`, beside the existing CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_SKIP_BEDROCK_AUTH flags (same category). The single allowlist is consulted by both gates, so the vars now survive daemon spawn and runner spawn and reach the guard.

Tests: assert both vars survive `_build_host_daemon_env` (local + remote) and `_build_runner_env`. They fail before this change and pass after.

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo
<img width="734" height="359" alt="Screenshot 2026-08-10 at 3 31 57 PM" src="https://github.com/user-attachments/assets/bde25365-f3e4-49bd-9a01-fe1bbb3529ad" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
