### PR TITLE
feat(omnidev): add --profile for supervising external Omnigent integrations

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -54,7 +54,7 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 
 Before Vite starts (and on a manual Vite restart), omnidev runs `pnpm install`
 in `web/` when needed — `node_modules/` is missing, or `package.json` /
-`package-lock.json` is newer than it — so a fresh checkout or a new dependency
+`pnpm-lock.yaml` is newer than it — so a fresh checkout or a new dependency
 doesn't make Vite fail its dependency scan. Output streams into the `vite` pane.
 
 Open the UI at the `ui` URL shown in the header (the Vite dev server).
@@ -219,3 +219,18 @@ and, on a terminal, prompts `Update omnigent now? [y/N]`; on yes it runs
 `omnidev update` in the foreground. Declining suppresses that same commit until
 a newer one lands. Set `OMNIGENT_NO_UPDATE_CHECK` in your environment if you want
 to silence omnigent's own separate notice.
+
+# External process profiles
+
+Integrations that embed the Omnigent server in another repository can reuse
+the supervisor without copying it:
+
+```bash
+omnidev --profile path/to/omnidev.toml
+```
+
+The profile supplies the server, optional host, Vite, and optional dependency
+preparation commands plus the backend and web directories. Command arguments
+may contain `{server_port}`, `{vite_port}`, `{vite_host}`, `{pod_dir}`, and
+`{repo_root}`. Environment variables from the launching integration are
+inherited; `OMNIGENT_URL` is set to the isolated backend as usual.

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -20,6 +20,7 @@ mod paths;
 mod pod;
 mod ports;
 mod process;
+mod profile;
 mod shellhook;
 mod state;
 mod supervisor;
@@ -97,6 +98,10 @@ enum Command {
 /// Flags for the default (no-subcommand) pod-supervisor run.
 #[derive(clap::Args, Debug)]
 struct RunArgs {
+    /// Process profile for an Omnigent integration with a different repository layout.
+    #[arg(long)]
+    profile: Option<PathBuf>,
+
     /// Force the backend server port (default: probe from 6767).
     #[arg(long)]
     server_port: Option<u16>,
@@ -180,7 +185,7 @@ fn main() -> Result<()> {
 /// running supervisor (the common case: server up, you run a command).
 fn run_omnigent(args: RunArgs, passthrough: Vec<String>) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let repo_root = paths::find_repo_root(&cwd)?;
+    let repo_root = paths::find_repo_root(&cwd, false)?;
     let pod_dir = match &args.pod_dir {
         Some(p) => p.clone(),
         None => paths::default_pod_dir(&repo_root)?,
@@ -208,7 +213,19 @@ fn run_omnigent(args: RunArgs, passthrough: Vec<String>) -> Result<()> {
 #[tokio::main]
 async fn run_supervisor(args: RunArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let repo_root = paths::find_repo_root(&cwd)?;
+    let repo_root = paths::find_repo_root(&cwd, args.profile.is_some())?;
+    let profile = args
+        .profile
+        .as_deref()
+        .map(|path| {
+            let path = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                repo_root.join(path)
+            };
+            profile::Profile::load(&path)
+        })
+        .transpose()?;
     let pod_dir = match &args.pod_dir {
         Some(p) => p.clone(),
         None => paths::default_pod_dir(&repo_root)?,
@@ -231,12 +248,13 @@ async fn run_supervisor(args: RunArgs) -> Result<()> {
     } else {
         Vec::new()
     };
-    let pod = Arc::new(Pod::create(
+    let pod = Arc::new(Pod::create_with_profile(
         repo_root,
         pod_dir,
         ports,
         args.vite_host,
         trusted_origins,
+        profile,
     )?);
 
     let shared = Shared::new(&pod);
@@ -246,7 +264,7 @@ async fn run_supervisor(args: RunArgs) -> Result<()> {
     // for the whole session.
     let _watcher = watcher::spawn(
         &pod.repo_root,
-        &pod.omnigent_dir(),
+        &pod.backend_dir(),
         shared.clone(),
         args.debug,
         cmd_tx.clone(),

--- a/dev/omnidev/src/paths.rs
+++ b/dev/omnidev/src/paths.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 /// The root is the first ancestor holding a `.jj/` or `.git/` marker — the VCS
 /// root. We then require `web/` and `omnigent/` to be present so we fail early
 /// on an unrelated repo rather than mid-spawn.
-pub fn find_repo_root(start: &Path) -> Result<PathBuf> {
+pub fn find_repo_root(start: &Path, external_profile: bool) -> Result<PathBuf> {
     let start = start
         .canonicalize()
         .with_context(|| format!("resolving start dir {}", start.display()))?;
@@ -18,7 +18,8 @@ pub fn find_repo_root(start: &Path) -> Result<PathBuf> {
     while let Some(dir) = cur {
         if dir.join(".jj").is_dir() || dir.join(".git").exists() {
             let root = dir.to_path_buf();
-            if !root.join("omnigent").is_dir() || !root.join("web").is_dir() {
+            if !external_profile && (!root.join("omnigent").is_dir() || !root.join("web").is_dir())
+            {
                 bail!(
                     "found a VCS root at {} but it lacks omnigent/ and web/ — \
                      run omnidev from inside an Omnigent checkout",

--- a/dev/omnidev/src/pod.rs
+++ b/dev/omnidev/src/pod.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::ports::Ports;
+use crate::profile::Profile;
 
 pub struct Pod {
     pub repo_root: PathBuf,
@@ -15,6 +16,7 @@ pub struct Pod {
     /// LAN origins to trust for device testing (`--trust-lan-origins`); empty
     /// otherwise. Fed to the server as `OMNIGENT_WS_ALLOWED_ORIGINS`.
     pub trusted_origins: Vec<String>,
+    pub profile: Option<Profile>,
 }
 
 impl Pod {
@@ -28,6 +30,17 @@ impl Pod {
         vite_host: String,
         trusted_origins: Vec<String>,
     ) -> Result<Pod> {
+        Self::create_with_profile(repo_root, dir, ports, vite_host, trusted_origins, None)
+    }
+
+    pub fn create_with_profile(
+        repo_root: PathBuf,
+        dir: PathBuf,
+        ports: Ports,
+        vite_host: String,
+        trusted_origins: Vec<String>,
+        profile: Option<Profile>,
+    ) -> Result<Pod> {
         for sub in ["data/omnigent", "artifacts", "logs", "config"] {
             let p = dir.join(sub);
             std::fs::create_dir_all(&p)
@@ -39,6 +52,7 @@ impl Pod {
             ports,
             vite_host,
             trusted_origins,
+            profile,
         };
         // Seed the pod's config from the developer's real one so it works out
         // of the box (keeps their providers). Best-effort: a copy failure just
@@ -87,14 +101,17 @@ impl Pod {
     }
 
     pub fn web_dir(&self) -> PathBuf {
-        self.repo_root.join("web")
+        self.repo_root.join(
+            self.profile
+                .as_ref()
+                .map(|profile| profile.web_dir.as_path())
+                .unwrap_or_else(|| Path::new("web")),
+        )
     }
 
-    /// Whether `web/` needs `pnpm install` before Vite can start: either
-    /// `node_modules/` is absent, or the lockfile / `package.json` is newer
-    /// than the installed tree (a dependency was added/changed since the last
-    /// install — the case that makes Vite's dependency scan fail).
-    pub fn needs_pnpm_install(&self) -> bool {
+    /// Whether web dependencies need preparation before Vite can start.
+    /// Profiles select their web directory and dependency manifests.
+    pub fn needs_web_prepare(&self) -> bool {
         let web = self.web_dir();
         let modules = web.join("node_modules");
         if !modules.is_dir() {
@@ -105,15 +122,42 @@ impl Pod {
             return true;
         };
         // Reinstall if either manifest is newer than node_modules.
-        [self.repo_root.join("pnpm-lock.yaml"), web.join("package.json")]
+        let manifests = self
+            .profile
+            .as_ref()
+            .map(|profile| {
+                profile
+                    .dependency_manifests
+                    .iter()
+                    .map(|path| web.join(path))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| {
+                vec![
+                    self.repo_root.join("pnpm-lock.yaml"),
+                    web.join("package.json"),
+                ]
+            });
+        manifests
             .into_iter()
             .filter_map(mtime)
             .any(|t| t > installed)
     }
 
     /// Directory to watch for backend source changes.
-    pub fn omnigent_dir(&self) -> PathBuf {
-        self.repo_root.join("omnigent")
+    pub fn backend_dir(&self) -> PathBuf {
+        self.repo_root.join(
+            self.profile
+                .as_ref()
+                .map(|profile| profile.backend_dir.as_path())
+                .unwrap_or_else(|| Path::new("omnigent")),
+        )
+    }
+
+    pub fn host_enabled(&self) -> bool {
+        self.profile
+            .as_ref()
+            .map_or(true, |profile| profile.host.is_some())
     }
 
     pub fn log_file(&self, name: &str) -> PathBuf {

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -15,6 +15,23 @@ pub struct ProcSpec {
 }
 
 impl ProcSpec {
+    fn from_profile(pod: &Pod, profile: &crate::profile::ProcessProfile) -> ProcSpec {
+        let expand = |value: &str| {
+            value
+                .replace("{server_port}", &pod.ports.server.to_string())
+                .replace("{vite_port}", &pod.ports.vite.to_string())
+                .replace("{vite_host}", &pod.vite_host)
+                .replace("{pod_dir}", &pod.dir.display().to_string())
+                .replace("{repo_root}", &pod.repo_root.display().to_string())
+        };
+        ProcSpec {
+            program: expand(&profile.command[0]),
+            args: profile.command[1..].iter().map(|arg| expand(arg)).collect(),
+            cwd: pod.repo_root.join(&profile.cwd),
+            extra_env: Vec::new(),
+        }
+    }
+
     fn omnigent_log_env() -> Vec<(String, String)> {
         // Child stderr is a pipe that omnidev reads into its process panes.
         // Let Omnigent's process logger mirror to that pipe despite it not
@@ -28,6 +45,9 @@ impl ProcSpec {
     /// `uv run --python <pinned> omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
     /// --database-uri <db> --artifact-location <dir>`, from the repo root.
     pub fn server(pod: &Pod) -> ProcSpec {
+        if let Some(profile) = &pod.profile {
+            return Self::from_profile(pod, &profile.server);
+        }
         ProcSpec {
             program: "uv".into(),
             args: vec![
@@ -54,6 +74,15 @@ impl ProcSpec {
     /// `uv run --python <pinned> omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
     /// from the repo root.
     pub fn host(pod: &Pod) -> ProcSpec {
+        if let Some(profile) = &pod.profile {
+            return Self::from_profile(
+                pod,
+                profile
+                    .host
+                    .as_ref()
+                    .expect("host is disabled for this profile"),
+            );
+        }
         ProcSpec {
             program: "uv".into(),
             args: vec![
@@ -73,7 +102,16 @@ impl ProcSpec {
 
     /// `pnpm install`, from `web/`. Run before Vite when deps are missing or
     /// stale so Vite's dependency scan doesn't fail on an unresolved import.
-    pub fn pnpm_install(pod: &Pod) -> ProcSpec {
+    pub fn web_prepare(pod: &Pod) -> ProcSpec {
+        if let Some(profile) = &pod.profile {
+            return Self::from_profile(
+                pod,
+                profile
+                    .prepare
+                    .as_ref()
+                    .expect("web prepare is disabled for this profile"),
+            );
+        }
         ProcSpec {
             program: "pnpm".into(),
             args: vec!["install".into()],
@@ -85,6 +123,9 @@ impl ProcSpec {
     /// `pnpm run dev -- --host <host> --port <p> --strictPort`, from `web/`.
     /// `OMNIGENT_URL` (in the pod env) points Vite's proxy at this pod's backend.
     pub fn vite(pod: &Pod) -> ProcSpec {
+        if let Some(profile) = &pod.profile {
+            return Self::from_profile(pod, &profile.vite);
+        }
         ProcSpec {
             program: "pnpm".into(),
             args: vec![
@@ -107,6 +148,7 @@ impl ProcSpec {
 mod tests {
     use super::*;
     use crate::ports::Ports;
+    use crate::profile::{ProcessProfile, Profile};
 
     #[test]
     fn vite_uses_configured_bind_host_but_backend_url_stays_loopback() {
@@ -175,6 +217,57 @@ mod tests {
                 Some("1")
             );
         }
+    }
+
+    #[test]
+    fn external_profile_expands_runtime_values() {
+        let repo = tempdir();
+        let pod_dir = tempdir();
+        let mut pod = Pod::create(
+            repo.clone(),
+            pod_dir.clone(),
+            Ports {
+                server: 19191,
+                vite: 19292,
+            },
+            "0.0.0.0".into(),
+            Vec::new(),
+        )
+        .unwrap();
+        let process = ProcessProfile {
+            command: vec![
+                "server".into(),
+                "--port={server_port}".into(),
+                "--ui={vite_port}".into(),
+                "--host={vite_host}".into(),
+                "--state={pod_dir}".into(),
+            ],
+            cwd: "service".into(),
+        };
+        pod.profile = Some(Profile {
+            server: process.clone(),
+            vite: process,
+            prepare: None,
+            host: None,
+            backend_dir: "service".into(),
+            web_dir: "ui".into(),
+            dependency_manifests: vec!["package.json".into()],
+        });
+
+        let spec = ProcSpec::server(&pod);
+
+        assert_eq!(spec.program, "server");
+        assert_eq!(
+            spec.args,
+            [
+                "--port=19191",
+                "--ui=19292",
+                "--host=0.0.0.0",
+                &format!("--state={}", pod_dir.display()),
+            ]
+        );
+        assert_eq!(spec.cwd, repo.join("service"));
+        assert!(!pod.host_enabled());
     }
 
     fn tempdir() -> std::path::PathBuf {

--- a/dev/omnidev/src/profile.rs
+++ b/dev/omnidev/src/profile.rs
@@ -1,0 +1,91 @@
+//! Optional process profile for supervising a non-OSS Omnigent integration.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProcessProfile {
+    /// Executable followed by its arguments. Runtime placeholders are expanded
+    /// immediately before the process is spawned.
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub cwd: PathBuf,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Profile {
+    pub server: ProcessProfile,
+    pub vite: ProcessProfile,
+    pub prepare: Option<ProcessProfile>,
+    pub host: Option<ProcessProfile>,
+    pub backend_dir: PathBuf,
+    pub web_dir: PathBuf,
+    #[serde(default = "default_dependency_manifests")]
+    pub dependency_manifests: Vec<PathBuf>,
+}
+
+fn default_dependency_manifests() -> Vec<PathBuf> {
+    vec![PathBuf::from("package.json")]
+}
+
+impl Profile {
+    pub fn load(path: &Path) -> Result<Profile> {
+        let source = fs::read_to_string(path)
+            .with_context(|| format!("reading omnidev profile {}", path.display()))?;
+        let profile: Profile = toml::from_str(&source)
+            .with_context(|| format!("parsing omnidev profile {}", path.display()))?;
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    fn validate(&self) -> Result<()> {
+        for (name, process) in [
+            ("server", Some(&self.server)),
+            ("vite", Some(&self.vite)),
+            ("prepare", self.prepare.as_ref()),
+            ("host", self.host.as_ref()),
+        ] {
+            if process.is_some_and(|p| p.command.is_empty()) {
+                bail!("omnidev profile process {name} has an empty command");
+            }
+        }
+        if self.backend_dir.is_absolute() || self.web_dir.is_absolute() {
+            bail!(
+                "omnidev profile backend_dir and web_dir must be relative to the repository root"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_external_profile() {
+        let profile: Profile = toml::from_str(
+            r#"
+backend_dir = "service"
+web_dir = "ui"
+
+[server]
+command = ["server", "--port", "{server_port}"]
+
+[vite]
+command = ["vite", "--port", "{vite_port}"]
+"#,
+        )
+        .unwrap();
+
+        profile.validate().unwrap();
+        assert!(profile.host.is_none());
+        assert_eq!(
+            profile.dependency_manifests,
+            [PathBuf::from("package.json")]
+        );
+    }
+}

--- a/dev/omnidev/src/supervisor.rs
+++ b/dev/omnidev/src/supervisor.rs
@@ -156,10 +156,12 @@ impl Supervisor {
 
     async fn start_backend(&mut self) {
         self.spawn(ProcId::Server);
-        if self.wait_healthy().await {
+        if self.pod.host_enabled() && self.wait_healthy().await {
             self.spawn(ProcId::Host);
-        } else {
+        } else if self.pod.host_enabled() {
             self.event("server did not become healthy; host not started");
+        } else {
+            self.set_status(ProcId::Host, ProcStatus::Stopped);
         }
     }
 
@@ -171,7 +173,9 @@ impl Supervisor {
         self.set_status(ProcId::Server, ProcStatus::Restarting);
         self.set_status(ProcId::Host, ProcStatus::Restarting);
         self.spawn(ProcId::Server);
-        if self.wait_healthy().await {
+        if !self.pod.host_enabled() {
+            self.set_status(ProcId::Host, ProcStatus::Stopped);
+        } else if self.wait_healthy().await {
             self.spawn(ProcId::Host);
         } else {
             self.event("server did not become healthy after restart");
@@ -272,23 +276,28 @@ impl Supervisor {
         });
     }
 
-    /// Run `pnpm install` to completion before Vite starts, but only when deps
-    /// are missing or stale — otherwise Vite's dependency scan fails on an
-    /// unresolved import (e.g. a dep added to package.json but not installed).
+    /// Prepare web dependencies before Vite starts, but only when they are
+    /// missing or stale. OSS uses `pnpm install`; profiles choose the command.
     /// Output streams into the Vite pane. A failed/absent install is logged but
     /// non-fatal: we still let Vite try, so a transient pnpm hiccup doesn't block
     /// the whole session.
     async fn prepare_vite(&self) {
-        if !self.pod.needs_pnpm_install() {
+        if self
+            .pod
+            .profile
+            .as_ref()
+            .is_some_and(|profile| profile.prepare.is_none())
+            || !self.pod.needs_web_prepare()
+        {
             return;
         }
         self.set_status(ProcId::Vite, ProcStatus::Starting);
         self.shared.lock().unwrap().log_proc(
             ProcId::Vite,
-            "web deps missing or stale — running pnpm install".into(),
+            "web deps missing or stale — preparing dependencies".into(),
         );
 
-        let spec = ProcSpec::pnpm_install(&self.pod);
+        let spec = ProcSpec::web_prepare(&self.pod);
         let mut cmd = Command::new(&spec.program);
         cmd.args(&spec.args)
             .current_dir(&spec.cwd)
@@ -301,10 +310,10 @@ impl Supervisor {
         let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
-                self.shared
-                    .lock()
-                    .unwrap()
-                    .log_proc(ProcId::Vite, format!("failed to run pnpm install: {e}"));
+                self.shared.lock().unwrap().log_proc(
+                    ProcId::Vite,
+                    format!("failed to prepare web dependencies: {e}"),
+                );
                 return;
             }
         };
@@ -327,17 +336,19 @@ impl Supervisor {
                     self.shared
                         .lock()
                         .unwrap()
-                        .log_proc(ProcId::Vite, format!("… pnpm install running ({secs}s)"));
+                        .log_proc(ProcId::Vite, format!("… dependency preparation running ({secs}s)"));
                 }
             }
         };
         match status {
             Ok(s) if s.success() => self.event(format!(
-                "pnpm install complete ({}s)",
+                "web dependency preparation complete ({}s)",
                 started.elapsed().as_secs()
             )),
-            Ok(s) => self.event(format!("pnpm install exited {s} — starting Vite anyway")),
-            Err(e) => self.event(format!("pnpm install wait error: {e}")),
+            Ok(s) => self.event(format!(
+                "web dependency preparation exited {s} — starting Vite anyway"
+            )),
+            Err(e) => self.event(format!("web dependency preparation wait error: {e}")),
         }
     }
 
@@ -427,6 +438,9 @@ impl Supervisor {
         match exit.id {
             ProcId::Server => self.start_backend_restart().await,
             ProcId::Host => {
+                if !self.pod.host_enabled() {
+                    return;
+                }
                 if self.wait_healthy().await {
                     self.spawn(ProcId::Host);
                 } else {

--- a/dev/omnidev/tests/pod_setup.rs
+++ b/dev/omnidev/tests/pod_setup.rs
@@ -17,6 +17,9 @@ mod pod;
 #[allow(dead_code)]
 #[path = "../src/ports.rs"]
 mod ports;
+#[allow(dead_code)]
+#[path = "../src/profile.rs"]
+mod profile;
 
 use pod::Pod;
 use ports::Ports;
@@ -30,7 +33,7 @@ fn finds_repo_root_from_subdir() {
     fs::create_dir_all(tmp.join("omnigent/server")).unwrap();
     fs::create_dir_all(tmp.join("web/src")).unwrap();
 
-    let root = paths::find_repo_root(&tmp.join("omnigent/server")).unwrap();
+    let root = paths::find_repo_root(&tmp.join("omnigent/server"), false).unwrap();
     assert_eq!(root, tmp.canonicalize().unwrap());
 }
 
@@ -39,7 +42,19 @@ fn finds_repo_root_from_subdir() {
 fn rejects_non_omnigent_project() {
     let tmp = tempdir();
     fs::create_dir_all(tmp.join(".git")).unwrap();
-    assert!(paths::find_repo_root(&tmp).is_err());
+    assert!(paths::find_repo_root(&tmp, false).is_err());
+}
+
+/// External profiles deliberately relax the OSS checkout layout check.
+#[test]
+fn external_profile_accepts_another_project_layout() {
+    let tmp = tempdir();
+    fs::create_dir_all(tmp.join(".git")).unwrap();
+    fs::create_dir_all(tmp.join("service")).unwrap();
+
+    let root = paths::find_repo_root(&tmp.join("service"), true).unwrap();
+
+    assert_eq!(root, tmp.canonicalize().unwrap());
 }
 
 /// Two different repo paths get distinct pod dirs; the same path is stable.
@@ -52,10 +67,9 @@ fn pod_dir_is_per_repo_and_stable() {
     assert_ne!(a1, b);
 }
 
-/// npm install is needed when node_modules is missing, and when a manifest is
-/// newer than it; not needed when node_modules is up to date.
+/// Dependency preparation is needed when node_modules is missing or stale.
 #[test]
-fn needs_npm_install_tracks_manifests() {
+fn needs_web_prepare_tracks_manifests() {
     let repo = tempdir();
     let web = repo.join("web");
     fs::create_dir_all(&web).unwrap();
@@ -70,20 +84,21 @@ fn needs_npm_install_tracks_manifests() {
         },
         vite_host: "127.0.0.1".into(),
         trusted_origins: Vec::new(),
+        profile: None,
     };
 
     // No node_modules yet → install needed.
-    assert!(pod.needs_npm_install());
+    assert!(pod.needs_web_prepare());
 
     // Fresh node_modules created after the manifest → up to date.
     fs::create_dir_all(web.join("node_modules")).unwrap();
-    assert!(!pod.needs_npm_install());
+    assert!(!pod.needs_web_prepare());
 
     // A manifest touched after node_modules → stale, install needed.
     // (Sleep briefly so the mtime is observably newer on coarse filesystems.)
     std::thread::sleep(std::time::Duration::from_millis(10));
-    fs::write(web.join("package-lock.json"), "{}").unwrap();
-    assert!(pod.needs_npm_install());
+    fs::write(repo.join("pnpm-lock.yaml"), "lockfileVersion: 1").unwrap();
+    assert!(pod.needs_web_prepare());
 }
 
 /// Ports probe to bindable values and persist/reuse across calls.
@@ -176,6 +191,7 @@ fn pod_with_trusted(trusted: Vec<String>) -> Pod {
         },
         vite_host: "0.0.0.0".into(),
         trusted_origins: trusted,
+        profile: None,
     }
 }
 


### PR DESCRIPTION
## Summary

omnidev assumes the OSS repo layout (an `omnigent/` backend + `web/` frontend rooted at the repo root). Add a `--profile <toml>` flag so it can supervise an Omnigent integration embedded in a repo with a different layout — e.g. a server, Vite UI, and compatibility host that live at arbitrary paths and are launched by custom commands.

The profile is a TOML file describing the server / vite / optional prepare / optional host process commands (with runtime placeholder expansion), the backend and web directories, and the dependency manifests to watch. When --profile is set, find_repo_root skips the OSS layout check (the integration's root need not contain omnigent/ + web/) and Pod is built via create_with_profile from the profile's process specs instead of the built-in OSS defaults.


## Test Plan

This is no-op change. .addition of `--profile` flag for omnidev command.



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable


