### PR TITLE
feat(desktop): merge the sidebar header into the macOS title-bar row

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -614,16 +614,75 @@ html:not(.dark) .conversations-sidebar:not(.is-peek) {
  * to the right of the sidebar keeps its normal top alignment. Inert in a
  * plain browser and on other platforms. */
 @media (min-width: 48rem) {
-  /* md+: matches the sidebar's own desktop breakpoint. */
+  /* md+: matches the sidebar's own desktop breakpoint.
+   *
+   * The sidebar now starts at the window's top edge rather than below the
+   * lights: its header row is TALL enough (h-12 = 3rem vs the 2.25rem strip) to
+   * hold the traffic lights inside itself, so the row doubles as the title bar
+   * instead of leaving an empty band of canvas above it. The rules below clear
+   * the lights' footprint within that row and drop the brand mark, which no
+   * longer has anywhere to sit. */
   [data-electron-mac] .conversations-sidebar {
-    margin-top: 2.25rem;
+    margin-top: 0;
+  }
+  /* The lights occupy the row's left end, so the action cluster (Collapse,
+   * Search, Settings) slides left to sit just right of them — the whole point
+   * of reclaiming this row. justify-content: flex-start overrides the row's
+   * justify-between, which would otherwise pin the cluster to the far right and
+   * leave a gap where the wordmark used to be. */
+  [data-electron-mac] .sidebar-header-row {
+    justify-content: flex-start;
+    /* ~5rem clears the three lights plus their inset; the row's own pl-4 is
+     * replaced (not added to) so the first button lands beside the green one. */
+    padding-left: 5rem;
+  }
+  /* No brand mark on the desktop shell: this row is the title bar now, and the
+   * lights own its left end. `display: none` rather than removing it from the
+   * JSX so the browser keeps the wordmark (and its home link) untouched. */
+  [data-electron-mac] .sidebar-brand {
+    display: none;
+  }
+  /* Mirror the visual order from the design: Collapse, Search, Settings —
+   * reading outward from the window controls. The DOM keeps Search → Settings →
+   * Collapse (tab order follows importance, and the collapse button swaps
+   * between two elements depending on peek state), so reorder visually rather
+   * than reshuffling the markup. */
+  [data-electron-mac] [data-testid="sidebar-header-actions"] {
+    /* Explicit flex ordering: the collapse/open toggle is the last child in the
+     * DOM and moves to the front here. */
+    & > *:last-child {
+      order: -1;
+    }
+    /* Align the buttons to the TRAFFIC LIGHTS, not to this row.
+     *
+     * The row is 3rem tall and centers its children, which lands them at y=24 —
+     * about 5px below the lights, a gap that reads as broken once the two sit
+     * side by side. The lights are drawn by macOS OUTSIDE the page (they are not
+     * in the DOM and don't appear in a page screenshot), so the web layer can't
+     * measure them; anchor instead to the 2.25rem title-bar strip whose height
+     * the drag-strip rule below already uses for exactly this band. Centering a
+     * 1.5rem button in that strip gives y=18, on the lights' centre line.
+     *
+     * flex-start + margin-top rather than a shorter row: the row's 3rem height
+     * is what gives the sidebar enough headroom to host the lights at all.
+     * Mirrors the .traffic-light-clearance pattern used for the chat header. */
+    align-self: flex-start;
+    /* (2.25rem strip − 1.5rem button) / 2 */
+    margin-top: 0.375rem;
+  }
+  /* The settings sidebar swaps the header row for a "Back" row, which would now
+   * sit under the traffic lights. Push it below them — it has no cluster to
+   * align beside the lights, so it clears them vertically instead. */
+  [data-electron-mac] .settings-sidebar-header {
+    padding-top: 2.75rem;
   }
 }
 /* The strip spans the top of the window but stops 20rem short of the right
  * edge, keeping the chat header's action cluster (share, panel toggles) and
  * devtools chrome clear of the drag region. Interactive elements that
  * overlap the strip elsewhere stay clickable via the blanket no-drag rule
- * below. */
+ * below — including the sidebar's own header buttons, which now live inside
+ * this strip's band since the sidebar starts at the window's top edge. */
 [data-electron-mac] .electron-drag-strip {
   position: absolute;
   inset: 0 20rem auto 0;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -616,59 +616,46 @@ html:not(.dark) .conversations-sidebar:not(.is-peek) {
 @media (min-width: 48rem) {
   /* md+: matches the sidebar's own desktop breakpoint.
    *
-   * The sidebar now starts at the window's top edge rather than below the
-   * lights: its header row is TALL enough (h-12 = 3rem vs the 2.25rem strip) to
-   * hold the traffic lights inside itself, so the row doubles as the title bar
-   * instead of leaving an empty band of canvas above it. The rules below clear
-   * the lights' footprint within that row and drop the brand mark, which no
-   * longer has anywhere to sit. */
+   * The sidebar starts at the window's top edge rather than below the lights, so
+   * no band of empty canvas sits above it. The title-bar row itself is NOT the
+   * sidebar's header row: the window furniture (lights + the Search/Settings/
+   * toggle cluster) is owned by AppShell and positioned over this top strip, so
+   * it stays put when the sidebar collapses or peeks. What remains here is to
+   * strip the sidebar's now-redundant header chrome — its wordmark and its own
+   * copy of the cluster — and reclaim the empty row. */
   [data-electron-mac] .conversations-sidebar {
     margin-top: 0;
   }
-  /* The lights occupy the row's left end, so the action cluster (Collapse,
-   * Search, Settings) slides left to sit just right of them — the whole point
-   * of reclaiming this row. justify-content: flex-start overrides the row's
-   * justify-between, which would otherwise pin the cluster to the far right and
-   * leave a gap where the wordmark used to be. */
-  [data-electron-mac] .sidebar-header-row {
-    justify-content: flex-start;
-    /* ~5rem clears the three lights plus their inset; the row's own pl-4 is
-     * replaced (not added to) so the first button lands beside the green one. */
-    padding-left: 5rem;
-  }
-  /* No brand mark on the desktop shell: this row is the title bar now, and the
-   * lights own its left end. `display: none` rather than removing it from the
-   * JSX so the browser keeps the wordmark (and its home link) untouched. */
+  /* No brand mark on the desktop shell: the lights own the window's top-left.
+   * `display: none` rather than removing it from the JSX so the browser keeps
+   * the wordmark (and its click-to-home link) untouched. */
   [data-electron-mac] .sidebar-brand {
     display: none;
   }
-  /* Mirror the visual order from the design: Collapse, Search, Settings —
-   * reading outward from the window controls. The DOM keeps Search → Settings →
-   * Collapse (tab order follows importance, and the collapse button swaps
-   * between two elements depending on peek state), so reorder visually rather
-   * than reshuffling the markup. */
-  [data-electron-mac] [data-testid="sidebar-header-actions"] {
-    /* Explicit flex ordering: the collapse/open toggle is the last child in the
-     * DOM and moves to the front here. */
-    & > *:last-child {
-      order: -1;
-    }
-    /* Align the buttons to the TRAFFIC LIGHTS, not to this row.
-     *
-     * The row is 3rem tall and centers its children, which lands them at y=24 —
-     * about 5px below the lights, a gap that reads as broken once the two sit
-     * side by side. The lights are drawn by macOS OUTSIDE the page (they are not
-     * in the DOM and don't appear in a page screenshot), so the web layer can't
-     * measure them; anchor instead to the 2.25rem title-bar strip whose height
-     * the drag-strip rule below already uses for exactly this band. Centering a
-     * 1.5rem button in that strip gives y=18, on the lights' centre line.
-     *
-     * flex-start + margin-top rather than a shorter row: the row's 3rem height
-     * is what gives the sidebar enough headroom to host the lights at all.
-     * Mirrors the .traffic-light-clearance pattern used for the chat header. */
-    align-self: flex-start;
-    /* (2.25rem strip − 1.5rem button) / 2 */
-    margin-top: 0.375rem;
+  /* The sidebar's own cluster is hidden here because an identical one renders in
+   * the title-bar strip (AppShell), where it survives the sidebar collapsing to
+   * w-0/inert and the peek card's inset-2 offset. Scoped to
+   * .conversations-sidebar so it can never match the AppShell copy. Hidden
+   * rather than removed from the JSX so every other platform keeps the
+   * in-sidebar cluster untouched. */
+  [data-electron-mac] .conversations-sidebar [data-testid="sidebar-header-actions"] {
+    display: none;
+  }
+  /* With both the wordmark and the cluster gone, the 3rem row is empty — it
+   * would leave the same dead band this change set out to reclaim. Collapse it
+   * to the title-bar strip's height so the session list starts right below the
+   * window furniture instead of 3rem down. */
+  [data-electron-mac] .sidebar-header-row {
+    height: 2.25rem;
+    padding: 0;
+  }
+  /* The chat header's own open-sidebar button is redundant here: the title-bar
+   * cluster's toggle is always present (collapsed included) and carries the same
+   * dwell-to-peek, so this one would be a second copy of the same control,
+   * sitting lower and out of line with the lights. Hidden only on the mac shell
+   * — everywhere else it is the ONLY way to reopen a collapsed sidebar. */
+  [data-electron-mac] .chat-header-sidebar-toggle {
+    display: none;
   }
   /* The settings sidebar swaps the header row for a "Back" row, which would now
    * sit under the traffic lights. Push it below them — it has no cluster to
@@ -688,6 +675,39 @@ html:not(.dark) .conversations-sidebar:not(.is-peek) {
   inset: 0 20rem auto 0;
   height: 2.25rem;
   -webkit-app-region: drag;
+}
+/* The title-bar cluster (Search/Settings/toggle), pinned beside the traffic
+ * lights and independent of the sidebar — that independence is the point: it
+ * holds this exact spot whether the sidebar is open, collapsed, or peeking.
+ *
+ * Sits ABOVE the drag strip in source order so it wins the same stacking
+ * context; the blanket no-drag rule below keeps its buttons clickable inside the
+ * drag band. Ordered Collapse, Search, Settings reading outward from the window
+ * controls, while the DOM keeps Search → Settings → toggle (tab order follows
+ * importance), so the toggle is reordered visually rather than in the markup.
+ *
+ * Geometry: left 5rem clears the three lights plus their inset. The buttons
+ * align to the LIGHTS, not to a text row — macOS paints them OUTSIDE the page
+ * (absent from the DOM and from page screenshots), so there is nothing to
+ * measure; anchor to the same 2.25rem strip the drag region uses and centre a
+ * 1.5rem button in it: (2.25rem − 1.5rem) / 2 = 0.375rem, landing y=18 on the
+ * lights' centre line. */
+[data-electron-mac] .electron-sidebar-header-actions {
+  position: absolute;
+  top: 0.375rem;
+  left: 5rem;
+  /* Above the sidebar, which is a positioned sibling at z-index 50 with an
+   * opaque gradient background — at any lower layer it paints straight over
+   * this cluster (the buttons still measure correctly in the DOM, which is why
+   * only a screenshot catches it). 51 clears the sidebar while staying under
+   * the mobile overlay/drawer layers. */
+  z-index: 51;
+  display: flex;
+  align-items: center;
+
+  & > * > *:last-child {
+    order: -1;
+  }
 }
 /* With the sidebar closed the chat header's left slot reaches the window
  * corner where the traffic lights float — drop just that slot below them,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -666,6 +666,16 @@ html:not(.dark) .conversations-sidebar:not(.is-peek) {
   [data-electron-mac] .conversations-sidebar.is-peek {
     top: 2.75rem;
   }
+  /* ...and once it floats down there, the header row it still carries is dead
+   * space. That row exists to reserve the title-bar strip for the lights and the
+   * icon cluster, which only applies to the DOCKED sidebar starting at y=0 — the
+   * peek card is already clear of all of it, so on mac the row is 2.25rem of
+   * empty canvas above the first entry (both the wordmark and the cluster inside
+   * it are hidden here). Drop it so the card's content lines up against its own
+   * top padding. */
+  [data-electron-mac] .conversations-sidebar.is-peek .sidebar-header-row {
+    display: none;
+  }
   /* The settings sidebar swaps the header row for a "Back" row, which would now
    * sit under the traffic lights. Push it below them — it has no cluster to
    * align beside the lights, so it clears them vertically instead. */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -657,6 +657,15 @@ html:not(.dark) .conversations-sidebar:not(.is-peek) {
   [data-electron-mac] .chat-header-sidebar-toggle {
     display: none;
   }
+  /* The peek card floats at inset-2 (8px from the top), which on this shell puts
+   * its first row level with the traffic lights and the title-bar cluster — the
+   * card slides up UNDER the window controls and collides with them. Drop its
+   * top edge below the 2.25rem strip so it floats in beneath the controls
+   * instead, keeping the same 0.5rem breathing room the other edges use.
+   * The docked sidebar is unaffected: only the floating card is offset. */
+  [data-electron-mac] .conversations-sidebar.is-peek {
+    top: 2.75rem;
+  }
   /* The settings sidebar swaps the header row for a "Back" row, which would now
    * sit under the traffic lights. Push it below them — it has no cluster to
    * align beside the lights, so it clears them vertically instead. */

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -442,6 +442,9 @@ describe("index.css electron-mac sidebar header", () => {
   const peekCardRule = cssSource.match(
     /\[data-electron-mac\] \.conversations-sidebar\.is-peek \{[^}]*\}/,
   )?.[0];
+  const peekHeaderRowRule = cssSource.match(
+    /\[data-electron-mac\] \.conversations-sidebar\.is-peek \.sidebar-header-row \{[^}]*\}/,
+  )?.[0];
 
   it("starts the sidebar at the window's top edge (no empty strip above it)", () => {
     // Was 2.25rem, which left the band of blank canvas this change removes.
@@ -504,6 +507,14 @@ describe("index.css electron-mac sidebar header", () => {
     expect(peekCardRule).toContain("top: 2.75rem");
   });
 
+  it("drops the header row inside the peek card", () => {
+    // The row reserves the title-bar strip for the lights and cluster, which
+    // only applies to the docked sidebar starting at y=0. The peek card already
+    // floats clear of all of it, so the row is 2.25rem of empty canvas above the
+    // first entry — the content should line up against the card's own padding.
+    expect(peekHeaderRowRule).toContain("display: none");
+  });
+
   it("aligns the cluster to the lights' centre line", () => {
     // The lights sit ~y=19. Centring a 1.5rem button in the 2.25rem title-bar
     // strip gives y=18: (2.25rem − 1.5rem) / 2 = 0.375rem.
@@ -527,17 +538,26 @@ describe("index.css electron-mac sidebar header", () => {
 
   it("keeps every header rule scoped to the desktop shell", () => {
     // A browser tab has no window controls to align to, so none of this may
-    // apply there. Each rule must carry the [data-electron-mac] scope.
-    for (const selector of [
+    // apply there. Every SELECTOR mentioning these classes must carry the
+    // [data-electron-mac] scope somewhere ahead of the class — not necessarily
+    // immediately before it, since some are qualified further (e.g.
+    // `[data-electron-mac] .conversations-sidebar.is-peek .sidebar-header-row`).
+    // Selectors are checked whole so a leaked unscoped rule still fails.
+    const selectorsInSource = [...cssSource.matchAll(/(^|\})\s*([^{}]+?)\s*\{/g)].map((m) => m[2]);
+    for (const cls of [
       ".sidebar-header-row",
       ".sidebar-brand",
       ".settings-sidebar-header",
       ".electron-sidebar-header-actions",
       ".chat-header-sidebar-toggle",
     ]) {
-      const occurrences = cssSource.split(selector).length - 1;
-      const scoped = cssSource.split(`[data-electron-mac] ${selector}`).length - 1;
-      expect(scoped, `${selector} must always be [data-electron-mac]-scoped`).toBe(occurrences);
+      const mentioning = selectorsInSource.filter((sel) => sel.includes(cls));
+      expect(mentioning.length, `${cls} should appear in at least one rule`).toBeGreaterThan(0);
+      for (const sel of mentioning) {
+        expect(sel, `${cls} must always be [data-electron-mac]-scoped`).toContain(
+          "[data-electron-mac]",
+        );
+      }
     }
   });
 });

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -407,3 +407,78 @@ describe("index.css text selection colors", () => {
     expect(cssSource).not.toContain(".dark ::selection");
   });
 });
+
+/* The macOS desktop shell's sidebar header shares the window's top strip with
+ * the OS traffic lights: no wordmark, and the action buttons sit beside the
+ * window controls. Asserted at the CSS level because the whole change is CSS —
+ * and because the lights are painted by macOS OUTSIDE the page, so no DOM test
+ * (and no page screenshot) can see them. These values ARE the alignment.
+ */
+describe("index.css electron-mac sidebar header", () => {
+  const sidebarRule = cssSource.match(
+    /\[data-electron-mac\] \.conversations-sidebar \{[^}]*\}/,
+  )?.[0];
+  const headerRowRule = cssSource.match(
+    /\[data-electron-mac\] \.sidebar-header-row \{[^}]*\}/,
+  )?.[0];
+  const brandRule = cssSource.match(/\[data-electron-mac\] \.sidebar-brand \{[^}]*\}/)?.[0];
+  const actionsRule = cssSource.match(
+    /\[data-electron-mac\] \[data-testid="sidebar-header-actions"\] \{(?:[^{}]|\{[^{}]*\})*\}/,
+  )?.[0];
+  const dragStripRule = cssSource.match(
+    /\[data-electron-mac\] \.electron-drag-strip \{[^}]*\}/,
+  )?.[0];
+  const settingsHeaderRule = cssSource.match(
+    /\[data-electron-mac\] \.settings-sidebar-header \{[^}]*\}/,
+  )?.[0];
+
+  it("starts the sidebar at the window's top edge (no empty strip above it)", () => {
+    // Was 2.25rem, which left the band of blank canvas this change removes: the
+    // 3rem header row is tall enough to host the lights itself.
+    expect(sidebarRule).toContain("margin-top: 0");
+  });
+
+  it("clears the traffic lights and left-aligns the action cluster", () => {
+    // justify-content must be overridden — the row's own justify-between would
+    // pin the buttons to the far right, leaving a gap where the wordmark was.
+    expect(headerRowRule).toContain("justify-content: flex-start");
+    expect(headerRowRule).toContain("padding-left: 5rem");
+  });
+
+  it("drops the brand mark, which has nowhere to sit in the title-bar row", () => {
+    expect(brandRule).toContain("display: none");
+  });
+
+  it("aligns the buttons to the lights' centre line, not the row's", () => {
+    // The row centres its children at y=24; the lights sit ~y=19. Centring a
+    // 1.5rem button in the 2.25rem title-bar strip gives y=18 instead:
+    // (2.25rem − 1.5rem) / 2 = 0.375rem.
+    expect(actionsRule).toContain("align-self: flex-start");
+    expect(actionsRule).toContain("margin-top: 0.375rem");
+    // Anchored to the SAME strip height the drag region uses, so the two can't
+    // drift apart if that band is ever retuned.
+    expect(dragStripRule).toContain("height: 2.25rem");
+  });
+
+  it("orders the cluster Collapse, Search, Settings left-to-right", () => {
+    // The DOM order is Search → Settings → Collapse (tab order follows
+    // importance), so the toggle is reordered visually rather than moved.
+    expect(actionsRule).toMatch(/&\s*>\s*\*:last-child\s*\{[^}]*order:\s*-1/);
+  });
+
+  it("pushes the settings sidebar's Back row below the lights", () => {
+    // /settings swaps the header row out entirely; without this its Back row
+    // would sit underneath the window controls.
+    expect(settingsHeaderRule).toContain("padding-top: 2.75rem");
+  });
+
+  it("keeps every header rule scoped to the desktop shell", () => {
+    // A browser tab has no window controls to align to, so none of this may
+    // apply there. Each rule must carry the [data-electron-mac] scope.
+    for (const selector of [".sidebar-header-row", ".sidebar-brand", ".settings-sidebar-header"]) {
+      const occurrences = cssSource.split(selector).length - 1;
+      const scoped = cssSource.split(`[data-electron-mac] ${selector}`).length - 1;
+      expect(scoped, `${selector} must always be [data-electron-mac]-scoped`).toBe(occurrences);
+    }
+  });
+});

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -439,6 +439,9 @@ describe("index.css electron-mac sidebar header", () => {
   const chatHeaderToggleRule = cssSource.match(
     /\[data-electron-mac\] \.chat-header-sidebar-toggle \{[^}]*\}/,
   )?.[0];
+  const peekCardRule = cssSource.match(
+    /\[data-electron-mac\] \.conversations-sidebar\.is-peek \{[^}]*\}/,
+  )?.[0];
 
   it("starts the sidebar at the window's top edge (no empty strip above it)", () => {
     // Was 2.25rem, which left the band of blank canvas this change removes.
@@ -491,6 +494,14 @@ describe("index.css electron-mac sidebar header", () => {
     // dwell-to-peek, so the chat header's copy would be a second, lower, offset
     // instance of one control.
     expect(chatHeaderToggleRule).toContain("display: none");
+  });
+
+  it("floats the peek card below the title-bar controls", () => {
+    // The card's own inset-2 would put its first row level with the lights and
+    // the icon cluster, so it slides up UNDER the window controls. Its top edge
+    // must clear the 2.25rem strip (2.75rem = strip + the same 0.5rem gap the
+    // card's other edges use).
+    expect(peekCardRule).toContain("top: 2.75rem");
   });
 
   it("aligns the cluster to the lights' centre line", () => {

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -408,11 +408,13 @@ describe("index.css text selection colors", () => {
   });
 });
 
-/* The macOS desktop shell's sidebar header shares the window's top strip with
- * the OS traffic lights: no wordmark, and the action buttons sit beside the
- * window controls. Asserted at the CSS level because the whole change is CSS —
- * and because the lights are painted by macOS OUTSIDE the page, so no DOM test
- * (and no page screenshot) can see them. These values ARE the alignment.
+/* On the macOS desktop shell the window's top strip carries the OS traffic
+ * lights plus the Search/Settings/toggle cluster, and the cluster is owned by
+ * AppShell rather than the sidebar so it holds that spot whether the sidebar is
+ * open, collapsed, or peeking. Asserted at the CSS level because the whole
+ * change is CSS — and because the lights are painted by macOS OUTSIDE the page,
+ * so no DOM test (and no page screenshot) can see them. These values ARE the
+ * alignment.
  */
 describe("index.css electron-mac sidebar header", () => {
   const sidebarRule = cssSource.match(
@@ -422,8 +424,11 @@ describe("index.css electron-mac sidebar header", () => {
     /\[data-electron-mac\] \.sidebar-header-row \{[^}]*\}/,
   )?.[0];
   const brandRule = cssSource.match(/\[data-electron-mac\] \.sidebar-brand \{[^}]*\}/)?.[0];
-  const actionsRule = cssSource.match(
-    /\[data-electron-mac\] \[data-testid="sidebar-header-actions"\] \{(?:[^{}]|\{[^{}]*\})*\}/,
+  const inSidebarActionsRule = cssSource.match(
+    /\[data-electron-mac\] \.conversations-sidebar \[data-testid="sidebar-header-actions"\] \{[^}]*\}/,
+  )?.[0];
+  const stripActionsRule = cssSource.match(
+    /\[data-electron-mac\] \.electron-sidebar-header-actions \{(?:[^{}]|\{[^{}]*\})*\}/,
   )?.[0];
   const dragStripRule = cssSource.match(
     /\[data-electron-mac\] \.electron-drag-strip \{[^}]*\}/,
@@ -431,39 +436,76 @@ describe("index.css electron-mac sidebar header", () => {
   const settingsHeaderRule = cssSource.match(
     /\[data-electron-mac\] \.settings-sidebar-header \{[^}]*\}/,
   )?.[0];
+  const chatHeaderToggleRule = cssSource.match(
+    /\[data-electron-mac\] \.chat-header-sidebar-toggle \{[^}]*\}/,
+  )?.[0];
 
   it("starts the sidebar at the window's top edge (no empty strip above it)", () => {
-    // Was 2.25rem, which left the band of blank canvas this change removes: the
-    // 3rem header row is tall enough to host the lights itself.
+    // Was 2.25rem, which left the band of blank canvas this change removes.
     expect(sidebarRule).toContain("margin-top: 0");
   });
 
-  it("clears the traffic lights and left-aligns the action cluster", () => {
-    // justify-content must be overridden — the row's own justify-between would
-    // pin the buttons to the far right, leaving a gap where the wordmark was.
-    expect(headerRowRule).toContain("justify-content: flex-start");
-    expect(headerRowRule).toContain("padding-left: 5rem");
-  });
-
-  it("drops the brand mark, which has nowhere to sit in the title-bar row", () => {
+  it("drops the brand mark, which has nowhere to sit beside the lights", () => {
     expect(brandRule).toContain("display: none");
   });
 
-  it("aligns the buttons to the lights' centre line, not the row's", () => {
-    // The row centres its children at y=24; the lights sit ~y=19. Centring a
-    // 1.5rem button in the 2.25rem title-bar strip gives y=18 instead:
-    // (2.25rem − 1.5rem) / 2 = 0.375rem.
-    expect(actionsRule).toContain("align-self: flex-start");
-    expect(actionsRule).toContain("margin-top: 0.375rem");
+  it("collapses the emptied header row instead of leaving a dead band", () => {
+    // Both the wordmark and the cluster are gone from this row on mac, so a
+    // 3rem row would reintroduce the empty strip this change set out to remove.
+    expect(headerRowRule).toContain("height: 2.25rem");
+  });
+
+  it("hides the sidebar's own cluster in favour of the title-bar copy", () => {
+    // The AppShell copy is the one that renders on mac; two visible clusters
+    // would be a duplicated control.
+    expect(inSidebarActionsRule).toContain("display: none");
+  });
+
+  it("scopes that hide to the sidebar so it cannot match the AppShell copy", () => {
+    // Without the .conversations-sidebar qualifier this selector would also hit
+    // the title-bar cluster and hide the icons entirely on mac.
+    expect(inSidebarActionsRule).toContain(".conversations-sidebar");
+  });
+
+  it("pins the title-bar cluster beside the lights, independent of the sidebar", () => {
+    // Positioned against the app shell, NOT inside the sidebar — that is what
+    // keeps the icons in place while the sidebar collapses (md:w-0 +
+    // overflow-hidden + inert) or peeks (floating card at inset-2).
+    expect(stripActionsRule).toContain("position: absolute");
+    // 5rem clears the three lights plus their inset.
+    expect(stripActionsRule).toContain("left: 5rem");
+  });
+
+  it("stacks the cluster above the sidebar so it is actually painted", () => {
+    // Regression guard: the sidebar is a positioned sibling at z-index 50 with
+    // an OPAQUE gradient background, so any lower layer leaves the buttons
+    // measuring correctly in the DOM while being invisible on screen — a bug no
+    // geometry assertion catches. Must clear 50.
+    const z = stripActionsRule?.match(/z-index:\s*(\d+)/)?.[1];
+    expect(z, "cluster needs an explicit z-index").toBeDefined();
+    expect(Number(z)).toBeGreaterThan(50);
+  });
+
+  it("hides the chat header's duplicate open-sidebar button", () => {
+    // The title-bar toggle is present in every state and carries the same
+    // dwell-to-peek, so the chat header's copy would be a second, lower, offset
+    // instance of one control.
+    expect(chatHeaderToggleRule).toContain("display: none");
+  });
+
+  it("aligns the cluster to the lights' centre line", () => {
+    // The lights sit ~y=19. Centring a 1.5rem button in the 2.25rem title-bar
+    // strip gives y=18: (2.25rem − 1.5rem) / 2 = 0.375rem.
+    expect(stripActionsRule).toContain("top: 0.375rem");
     // Anchored to the SAME strip height the drag region uses, so the two can't
     // drift apart if that band is ever retuned.
     expect(dragStripRule).toContain("height: 2.25rem");
   });
 
   it("orders the cluster Collapse, Search, Settings left-to-right", () => {
-    // The DOM order is Search → Settings → Collapse (tab order follows
+    // The DOM order is Search → Settings → toggle (tab order follows
     // importance), so the toggle is reordered visually rather than moved.
-    expect(actionsRule).toMatch(/&\s*>\s*\*:last-child\s*\{[^}]*order:\s*-1/);
+    expect(stripActionsRule).toMatch(/&\s*>\s*\*\s*>\s*\*:last-child\s*\{[^}]*order:\s*-1/);
   });
 
   it("pushes the settings sidebar's Back row below the lights", () => {
@@ -475,7 +517,13 @@ describe("index.css electron-mac sidebar header", () => {
   it("keeps every header rule scoped to the desktop shell", () => {
     // A browser tab has no window controls to align to, so none of this may
     // apply there. Each rule must carry the [data-electron-mac] scope.
-    for (const selector of [".sidebar-header-row", ".sidebar-brand", ".settings-sidebar-header"]) {
+    for (const selector of [
+      ".sidebar-header-row",
+      ".sidebar-brand",
+      ".settings-sidebar-header",
+      ".electron-sidebar-header-actions",
+      ".chat-header-sidebar-toggle",
+    ]) {
       const occurrences = cssSource.split(selector).length - 1;
       const scoped = cssSource.split(`[data-electron-mac] ${selector}`).length - 1;
       expect(scoped, `${selector} must always be [data-electron-mac]-scoped`).toBe(occurrences);

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -3,7 +3,7 @@ import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
 import type * as UseSessionModule from "@/hooks/useSession";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   MemoryRouter,
   Route,
@@ -61,9 +61,18 @@ vi.mock("@/hooks/useAgents", () => ({
 }));
 
 vi.mock("./Sidebar", () => ({
-  // Reflect the open prop so tests can assert sidebar collapse/expand.
-  Sidebar: ({ open }: { open: boolean }) => (
-    <div data-testid="sidebar" data-open={open ? "true" : "false"} />
+  // Reflect the open/peek props so tests can assert sidebar collapse/expand and
+  // whether it is peeking (a floating hover card rather than a docked panel).
+  // Rendered as aside.conversations-sidebar like the real one, so the
+  // peek-dismiss logic (which treats that selector as "inside the card") sees
+  // the same shape here as in the app.
+  Sidebar: ({ open, peek }: { open: boolean; peek?: boolean }) => (
+    <aside
+      className="conversations-sidebar"
+      data-testid="sidebar"
+      data-open={open ? "true" : "false"}
+      data-peek={peek ? "true" : "false"}
+    />
   ),
 }));
 vi.mock("./FilesPanel", () => ({
@@ -1234,6 +1243,41 @@ describe("Workspace rail maximize", () => {
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
     fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+  });
+
+  it("dismisses a peeking sidebar once the pointer moves elsewhere", async () => {
+    // The card closes itself on its own pointerleave, which only covers a peek
+    // armed from INSIDE it. Armed from the title-bar trigger (outside), a pointer
+    // that never crosses the card leaves it with no pointerenter and therefore no
+    // pointerleave, so the card used to sit open indefinitely.
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    renderShell("/c/conv_abc");
+
+    fireEvent.pointerEnter(screen.getByRole("button", { name: /open sidebar/i }));
+    await waitFor(() => expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "true"));
+
+    // Pointer over something that is not the card, the trigger, or a popper.
+    fireEvent.pointerMove(screen.getByTestId("url-params"));
+    await waitFor(() =>
+      expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "false"),
+    );
+  });
+
+  it("keeps peeking while the pointer is over the card itself", async () => {
+    // The other half: dismissal must not be so eager that moving onto the card —
+    // the entire point of peeking — closes it.
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    renderShell("/c/conv_abc");
+
+    fireEvent.pointerEnter(screen.getByRole("button", { name: /open sidebar/i }));
+    await waitFor(() => expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "true"));
+
+    fireEvent.pointerMove(screen.getByTestId("sidebar"));
+    await new Promise((resolve) => {
+      // Past the 200ms dismiss grace, so "still peeking" is a real result.
+      setTimeout(resolve, 350);
+    });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "true");
   });
 
   it("keeps the sidebar pinned open for the whole /settings visit", () => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -358,6 +358,19 @@ function renderShell(path: string, info?: ServerInfo) {
                   </>
                 }
               />
+              {/* The settings page itself renders inside the sidebar (its nav
+              replaces the session list), so the body here is irrelevant — what
+              matters is that the route is /settings, which is what AppShell
+              keys the sidebar pin off. */}
+              <Route
+                path="settings"
+                element={
+                  <>
+                    <div>settings</div>
+                    <LocationDisplay />
+                  </>
+                }
+              />
             </Route>
           </Routes>
         </MemoryRouter>
@@ -1172,6 +1185,47 @@ describe("Workspace rail maximize", () => {
     fireEvent.click(screen.getByRole("button", { name: "Exit full screen" }));
     expect(rail().className).toContain("md:shrink-0");
     expect(rail().className).not.toContain("md:absolute");
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+  });
+
+  it("pins the sidebar open on /settings so the Back row is reachable", () => {
+    // The settings nav replaces the session list INSIDE the sidebar, and its
+    // Back row is the only way off the page. Collapsed, that row is clipped and
+    // inert — the user is stranded with no visible exit. Entering /settings must
+    // therefore force the sidebar open.
+    mockConversations([]);
+    renderShell("/settings");
+
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+  });
+
+  it("refuses to collapse the sidebar while on /settings", () => {
+    // The hotkey (⌘⌥[) and command palette reach the toggle without going
+    // through the title-bar button, so the guard has to live in the handler, not
+    // just in what's rendered. Opening stays allowed; only collapsing is
+    // refused, because collapsing is what removes the exit.
+    mockConversations([]);
+    renderShell("/settings");
+
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+  });
+
+  it("does not restore a collapsed sidebar when /settings pins it open", () => {
+    // Deliberately one-way: the pin is NOT reversed on exit. Restoring a prior
+    // collapsed state would yank the sidebar away from someone who had just been
+    // using it, so a visible exit wins over a preserved preference. Asserted as
+    // "no stashed state to restore": once pinned, the ONLY way back to collapsed
+    // is the user's own toggle, which the /settings guard refuses — so the
+    // sidebar cannot silently re-collapse while the page is open.
+    mockConversations([]);
+    renderShell("/settings");
+
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+    // Repeated toggles all resolve to open while on the page.
+    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -284,6 +284,26 @@ function LocationDisplay() {
 }
 
 /**
+ * Route-change buttons standing in for the real Settings button and the
+ * sidebar's Back row, which live in components mocked out here. Navigation is
+ * what AppShell keys the /settings sidebar pin off, so the tests need a real
+ * router transition rather than a re-render.
+ */
+function NavProbe() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <button type="button" data-testid="nav-settings" onClick={() => navigate("/settings")}>
+        to-settings
+      </button>
+      <button type="button" data-testid="nav-home" onClick={() => navigate("/")}>
+        to-home
+      </button>
+    </div>
+  );
+}
+
+/**
  * Renders the current pathname (the `/c/:conversationId` segment) so a test
  * can detect an unwanted conversation switch — a redirect shows up as a
  * pathname change, which `LocationDisplay` (search params only) can't catch.
@@ -354,6 +374,7 @@ function renderShell(path: string, info?: ServerInfo) {
                   <>
                     <TerminalFirstViewProbe />
                     <ForkDialogProbe />
+                    <NavProbe />
                     <LocationDisplay />
                   </>
                 }
@@ -361,12 +382,15 @@ function renderShell(path: string, info?: ServerInfo) {
               {/* The settings page itself renders inside the sidebar (its nav
               replaces the session list), so the body here is irrelevant — what
               matters is that the route is /settings, which is what AppShell
-              keys the sidebar pin off. */}
+              keys the sidebar pin off. The nav-* links stand in for the real
+              Settings button and the sidebar's Back row, both of which live in
+              components mocked out here. */}
               <Route
                 path="settings"
                 element={
                   <>
                     <div>settings</div>
+                    <NavProbe />
                     <LocationDisplay />
                   </>
                 }
@@ -1208,24 +1232,54 @@ describe("Workspace rail maximize", () => {
     renderShell("/settings");
 
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
-    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 
-  it("does not restore a collapsed sidebar when /settings pins it open", () => {
-    // Deliberately one-way: the pin is NOT reversed on exit. Restoring a prior
-    // collapsed state would yank the sidebar away from someone who had just been
-    // using it, so a visible exit wins over a preserved preference. Asserted as
-    // "no stashed state to restore": once pinned, the ONLY way back to collapsed
-    // is the user's own toggle, which the /settings guard refuses — so the
-    // sidebar cannot silently re-collapse while the page is open.
+  it("keeps the sidebar pinned open for the whole /settings visit", () => {
+    // Repeated toggles all resolve to open while on the page: collapsing is what
+    // removes the only exit, so the guard refuses that direction throughout.
     mockConversations([]);
     renderShell("/settings");
 
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
-    // Repeated toggles all resolve to open while on the page.
-    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
-    fireEvent.keyDown(document, { key: "[", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+  });
+
+  it("restores a collapsed sidebar after leaving /settings", () => {
+    // A collapsed sidebar is a preference, and a trip to settings shouldn't
+    // silently undo it. The pin is only needed WHILE on the page — on the way out
+    // the title-bar toggle is back and Back is no longer the only exit — so
+    // restoring here cannot reintroduce the trap.
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    renderShell("/c/conv_abc");
+
+    // Collapsed going in (jsdom default).
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
+
+    // Into settings: pinned open despite the collapsed preference.
+    fireEvent.click(screen.getByTestId("nav-settings"));
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+
+    // Back out: the collapsed state the user chose is restored.
+    fireEvent.click(screen.getByTestId("nav-home"));
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
+  });
+
+  it("restores an open sidebar after leaving /settings", () => {
+    // The mirror case: someone who had it open keeps it open, so the restore is
+    // genuinely "put it back", not "always collapse".
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    renderShell("/c/conv_abc");
+
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+
+    fireEvent.click(screen.getByTestId("nav-settings"));
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
+    fireEvent.click(screen.getByTestId("nav-home"));
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -80,6 +80,7 @@ import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
+import { SidebarHeaderActions } from "./SidebarHeaderActions";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
 import {
@@ -938,6 +939,27 @@ export function AppShell() {
     setSidebarPeek(false);
   };
 
+  // Dwell-to-peek for the macOS title-bar toggle. ChatHeader owns this for its
+  // own collapsed-state button, but that button is hidden on the mac shell (the
+  // title-bar cluster replaces it), so the behaviour has to exist here too or
+  // dwell-to-peek would only work on a button the user can no longer see.
+  // Same 400ms as ChatHeader: a quick pass-over must not open the card.
+  const titleBarPeekTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelTitleBarPeek = useCallback(() => {
+    if (titleBarPeekTimer.current) {
+      clearTimeout(titleBarPeekTimer.current);
+      titleBarPeekTimer.current = null;
+    }
+  }, []);
+  const armTitleBarPeek = useCallback(() => {
+    cancelTitleBarPeek();
+    titleBarPeekTimer.current = setTimeout(() => {
+      setSidebarPeek(true);
+      setSidebarOpen(false);
+    }, 400);
+  }, [cancelTitleBarPeek]);
+  useEffect(() => cancelTitleBarPeek, [cancelTitleBarPeek]);
+
   // Toggle the workspace rail's full-screen (maximized) state. Entering
   // collapses the left sidebar (the maximized rail wants the full width) after
   // stashing its prior open-state; exiting restores that state. The sidebar
@@ -1365,6 +1387,39 @@ export function AppShell() {
           canvas for the traffic lights, and the strip is the window's one
           drag surface — content below and right stays fully clickable. */}
             {isMacElectronShell() && <div className="electron-drag-strip" aria-hidden="true" />}
+            {/* The Search/Settings/toggle cluster lives HERE on the macOS shell,
+          not in the sidebar, so the three icons hold one fixed position beside
+          the traffic lights no matter what the sidebar does. Inside the sidebar
+          they would be clipped and inert once it collapses (md:w-0 +
+          overflow-hidden + inert), and while peeking the floating card's
+          inset-2 would drag them off the lights' centre line. The sidebar's own
+          copy is hidden on mac by CSS; this one is positioned by
+          .electron-sidebar-header-actions in index.css. */}
+            {isMacElectronShell() && (
+              <div className="electron-sidebar-header-actions">
+                <SidebarHeaderActions
+                  expanded={sidebarOpen || sidebarPeek}
+                  onToggle={() => {
+                    // Mirrors the ⌘⌥[ hotkey: a peeking sidebar counts as open,
+                    // so toggling from peek pins it open rather than collapsing.
+                    if (sidebarOpen) {
+                      setSidebarOpen(false);
+                    } else {
+                      setSidebarOpen(true);
+                    }
+                    setSidebarPeek(false);
+                  }}
+                  onOpenSearch={() => setCommandPaletteOpen(true)}
+                  // Dwell-to-peek moves here with the button: on mac this cluster
+                  // replaces ChatHeader's collapsed-state toggle, which is where
+                  // peek was armed, so without this the affordance would vanish.
+                  // Only meaningful while collapsed — peeking or open, there is
+                  // nothing to peek at.
+                  onTogglePointerEnter={sidebarOpen || sidebarPeek ? undefined : armTitleBarPeek}
+                  onTogglePointerLeave={cancelTitleBarPeek}
+                />
+              </div>
+            )}
             {/* The server picker is NOT here: it lives at the bottom of the
           sidebar (SidebarServerPicker). This strip is shared with the chat
           header — which is taller and also anchored at top-0 — so a centered

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -81,6 +81,7 @@ import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
 import { SidebarHeaderActions } from "./SidebarHeaderActions";
+import { useSettingsRoute } from "./settingsNav";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
 import {
@@ -168,6 +169,25 @@ export function AppShell() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [sidebarOpen, setSidebarOpen] = useState(initialSidebarOpen);
   const [sidebarPeek, setSidebarPeek] = useState(false);
+
+  // The settings nav lives INSIDE the sidebar, and its "Back" row is the only
+  // way off the settings page. A collapsed sidebar therefore strands the user
+  // there — the row is still in the DOM but clipped and inert. So entering
+  // /settings pins the sidebar open (and drops any peek, which is a transient
+  // hover card, not somewhere to read a settings page from).
+  //
+  // Deliberately one-way: leaving /settings does NOT restore a prior collapsed
+  // state. Reversing the pin on exit would collapse the sidebar out from under
+  // someone who had just been using it, and the alternative — stashing the
+  // pre-settings state — resurrects a preference the user last expressed before
+  // a detour they may not associate with it. Visible exit beats preserved
+  // preference; the toggle is one click away on the way out.
+  const { inSettings } = useSettingsRoute();
+  useEffect(() => {
+    if (!inSettings) return;
+    setSidebarOpen(true);
+    setSidebarPeek(false);
+  }, [inSettings]);
 
   // Reads the same module-level store Sidebar drives, so the rail's ceiling
   // tracks the live sidebar width (including a drag) rather than a guess.
@@ -935,6 +955,15 @@ export function AppShell() {
   // cleared so we never leave `sidebarOpen` and `sidebarPeek` both true (a
   // floating-card layout the rest of the shell treats as a pushing panel).
   const toggleLeftSidebar = () => {
+    // On /settings the sidebar holds the only exit (the Back row), so collapsing
+    // it — by hotkey or command palette, the paths that bypass the hidden
+    // title-bar toggle — would strand the user on the page. Opening is still
+    // fine; only the collapse direction is refused.
+    if (inSettings) {
+      setSidebarOpen(true);
+      setSidebarPeek(false);
+      return;
+    }
     setSidebarOpen(!(sidebarOpen || sidebarPeek));
     setSidebarPeek(false);
   };
@@ -1395,7 +1424,14 @@ export function AppShell() {
           inset-2 would drag them off the lights' centre line. The sidebar's own
           copy is hidden on mac by CSS; this one is positioned by
           .electron-sidebar-header-actions in index.css. */}
-            {isMacElectronShell() && (
+            {/* Hidden on /settings: the settings nav replaces the session list
+          INSIDE the sidebar, and its "Back" row is the only way out. Leaving a
+          collapse toggle up here would let the user hide the one exit and strand
+          themselves on the settings page (the row exists but is clipped and
+          inert). So on /settings the sidebar is pinned open — see
+          forceSidebarOpenInSettings — and these controls step aside rather than
+          offer an action that would break the page. */}
+            {isMacElectronShell() && !inSettings && (
               <div className="electron-sidebar-header-actions">
                 <SidebarHeaderActions
                   expanded={sidebarOpen || sidebarPeek}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1008,6 +1008,68 @@ export function AppShell() {
   }, [cancelTitleBarPeek]);
   useEffect(() => cancelTitleBarPeek, [cancelTitleBarPeek]);
 
+  // Dismiss a peeking card when the pointer is clearly elsewhere.
+  //
+  // The card closes itself on its own pointerleave, which is enough when peek is
+  // armed from a button INSIDE it. The title-bar trigger sits outside, so a
+  // pointer that dwells there and then moves away without ever crossing the card
+  // leaves it with no pointerenter — and therefore no pointerleave — so nothing
+  // closes it and the card sits open indefinitely. Watch the document instead:
+  // once the pointer is over neither the card nor the trigger, dismiss on the
+  // same 200ms grace the card uses, so a wobble between the two doesn't.
+  //
+  // A click outside dismisses immediately: at that point the user has committed
+  // their attention elsewhere and waiting out a grace period just feels sticky.
+  const peekDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!sidebarPeek) return;
+    const cancel = () => {
+      if (peekDismissTimer.current) {
+        clearTimeout(peekDismissTimer.current);
+        peekDismissTimer.current = null;
+      }
+    };
+    // Anything the peek card legitimately spawns outside its own subtree (Radix
+    // menus, tooltips, dialogs) must not count as "outside", or opening a row's
+    // context menu would dismiss the card under it.
+    const insidePeekSurface = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) return false;
+      return !!target.closest(
+        [
+          "aside.conversations-sidebar",
+          ".electron-sidebar-header-actions",
+          "[data-radix-popper-content-wrapper]",
+          '[role="menu"]',
+          '[role="dialog"]',
+          '[role="tooltip"]',
+        ].join(","),
+      );
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (insidePeekSurface(e.target)) {
+        cancel();
+        return;
+      }
+      if (peekDismissTimer.current) return;
+      peekDismissTimer.current = setTimeout(() => {
+        peekDismissTimer.current = null;
+        setSidebarPeek(false);
+      }, 200);
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      if (insidePeekSurface(e.target)) return;
+      cancel();
+      setSidebarPeek(false);
+    };
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      cancel();
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, [sidebarPeek]);
+
   // Toggle the workspace rail's full-screen (maximized) state. Entering
   // collapses the left sidebar (the maximized rail wants the full width) after
   // stashing its prior open-state; exiting restores that state. The sidebar

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -174,19 +174,36 @@ export function AppShell() {
   // way off the settings page. A collapsed sidebar therefore strands the user
   // there — the row is still in the DOM but clipped and inert. So entering
   // /settings pins the sidebar open (and drops any peek, which is a transient
-  // hover card, not somewhere to read a settings page from).
+  // hover card, not somewhere to read a settings page from), and leaving it
+  // restores whatever the sidebar was before, so a collapsed sidebar stays a
+  // preference rather than being silently undone by a trip to settings.
   //
-  // Deliberately one-way: leaving /settings does NOT restore a prior collapsed
-  // state. Reversing the pin on exit would collapse the sidebar out from under
-  // someone who had just been using it, and the alternative — stashing the
-  // pre-settings state — resurrects a preference the user last expressed before
-  // a detour they may not associate with it. Visible exit beats preserved
-  // preference; the toggle is one click away on the way out.
+  // The pin is only needed WHILE on the page, so restoring on exit cannot
+  // reintroduce the trap: by then the title-bar toggle is back and the Back row
+  // is no longer the only way out. Mirrors sidebarOpenBeforeMaximizeRef, which
+  // stashes and restores the same state around the maximize flow.
   const { inSettings } = useSettingsRoute();
+  const sidebarOpenBeforeSettingsRef = useRef<boolean | null>(null);
   useEffect(() => {
-    if (!inSettings) return;
-    setSidebarOpen(true);
-    setSidebarPeek(false);
+    if (inSettings) {
+      // Stash inside the updater so it reads the CURRENT value rather than a
+      // closure captured before the pin, and so a re-render while already on
+      // /settings can't overwrite the stash with the pinned-open value.
+      setSidebarOpen((wasOpen) => {
+        if (sidebarOpenBeforeSettingsRef.current === null) {
+          sidebarOpenBeforeSettingsRef.current = wasOpen;
+        }
+        return true;
+      });
+      setSidebarPeek(false);
+      return;
+    }
+    // Leaving /settings: restore, then clear the stash so the next visit
+    // captures fresh state.
+    if (sidebarOpenBeforeSettingsRef.current !== null) {
+      setSidebarOpen(sidebarOpenBeforeSettingsRef.current);
+      sidebarOpenBeforeSettingsRef.current = null;
+    }
   }, [inSettings]);
 
   // Reads the same module-level store Sidebar drives, so the rail's ceiling
@@ -958,7 +975,9 @@ export function AppShell() {
     // On /settings the sidebar holds the only exit (the Back row), so collapsing
     // it — by hotkey or command palette, the paths that bypass the hidden
     // title-bar toggle — would strand the user on the page. Opening is still
-    // fine; only the collapse direction is refused.
+    // fine; only the collapse direction is refused. The pre-settings state stays
+    // stashed either way, so what the user had before the visit is still what
+    // gets restored on the way out.
     if (inSettings) {
       setSidebarOpen(true);
       setSidebarPeek(false);

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -252,7 +252,12 @@ export function ChatHeader({
                   cancelPeek();
                   onOpenSidebar(false);
                 }}
-                className="text-muted-foreground hover:text-foreground"
+                // chat-header-sidebar-toggle is hidden on the macOS shell, where
+                // the title-bar cluster carries an always-present toggle (with
+                // the same dwell-to-peek) and this would be a second, offset
+                // copy of it. Kept everywhere else, where it is the ONLY way to
+                // reopen a collapsed sidebar.
+                className="chat-header-sidebar-toggle text-muted-foreground hover:text-foreground"
                 onPointerEnter={onPeekSidebar}
                 onPointerLeave={cancelPeek}
               >

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -38,20 +38,17 @@ import {
   Maximize2Icon,
   Minimize2Icon,
   MoreHorizontalIcon,
-  PanelRightOpenIcon,
   PencilIcon,
   PinIcon,
   PinOffIcon,
   SearchIcon,
   Settings2Icon,
-  SettingsIcon,
   ShareIcon,
   SquareIcon,
   SquareCheckIcon,
   SquarePenIcon,
   Trash2Icon,
   XIcon,
-  PanelLeftOpenIcon,
 } from "lucide-react";
 import {
   DndContext,
@@ -69,6 +66,7 @@ import {
 } from "@dnd-kit/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
+import { SidebarHeaderActions } from "./SidebarHeaderActions";
 import omnigentWordmark from "@/assets/omnigent-wordmark.svg";
 import { Button } from "@/components/ui/button";
 import {
@@ -797,85 +795,17 @@ export function Sidebar({
                 className="h-[15px] w-auto shrink-0 translate-y-px dark:invert"
               />
             </Link>
-            <div className="flex items-center gap-1" data-testid="sidebar-header-actions">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Search"
-                    onClick={() => onOpenSearch?.()}
-                    className="size-6 text-muted-foreground hover:text-foreground"
-                    data-testid="sidebar-search-button"
-                  >
-                    <SearchIcon className="ui-icon" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Search</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    asChild
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Settings"
-                    className="size-6 text-muted-foreground hover:text-foreground"
-                  >
-                    {/* No onNavClick: on mobile, entering Settings keeps the
-                    drawer open and swaps it to the section list. */}
-                    <Link to="/settings" data-testid="settings-button">
-                      <SettingsIcon className="ui-icon" />
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Settings</TooltipContent>
-              </Tooltip>
-              {!peek ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label="Close sidebar"
-                      onClick={onClose}
-                      className="size-6 text-muted-foreground hover:text-foreground"
-                    >
-                      {/* panel-right-open while the sidebar IS open — this button
-                    only renders in the open state (ChatHeader's PanelLeftIcon
-                    covers the collapsed state). */}
-                      <PanelRightOpenIcon className="ui-icon" />
-                    </Button>
-                  </TooltipTrigger>
-                  {/* Bottom placement keeps the tooltip clear of the macOS
-                Electron shell's traffic lights at the window's top edge. */}
-                  <TooltipContent side="bottom">Collapse sidebar</TooltipContent>
-                </Tooltip>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label="Open sidebar"
-                      onClick={onOpen}
-                      className="size-6 text-muted-foreground hover:text-foreground"
-                    >
-                      {/* panel-right-open while the sidebar IS open — this button
-                    only renders in the open state (ChatHeader's PanelLeftIcon
-                    covers the collapsed state). */}
-                      <PanelLeftOpenIcon className="ui-icon" />
-                    </Button>
-                  </TooltipTrigger>
-                  {/* Bottom placement keeps the tooltip clear of the macOS
-                Electron shell's traffic lights at the window's top edge. */}
-                  <TooltipContent side="bottom">Open sidebar</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            {/* On the macOS shell this copy is hidden and an identical cluster
+            renders in the title-bar strip instead (see AppShell), so the icons
+            keep their place when the sidebar collapses or peeks. Everywhere
+            else this is the only copy. */}
+            <SidebarHeaderActions
+              expanded={!peek}
+              // onOpen is optional (the sidebar renders standalone in tests), so
+              // fall back to a no-op rather than widening the child's contract.
+              onToggle={peek ? () => onOpen?.() : onClose}
+              onOpenSearch={onOpenSearch}
+            />
           </div>
 
           <div className="flex flex-col gap-0 px-2 pt-2 pb-0" data-testid="sidebar-primary-nav">

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -772,7 +772,12 @@ export function Sidebar({
         <SettingsSidebarBody onNavClick={onNavClick} />
       ) : (
         <>
-          <div className="flex h-12 shrink-0 items-center justify-between pr-3 pl-4">
+          {/* sidebar-header-row is the hook for the macOS Electron shell, where
+          this row shares the window's top strip with the traffic lights: the
+          brand mark is dropped and the actions slide left to sit beside the
+          window controls (see the [data-electron-mac] rules in index.css).
+          Inert in a browser and on other platforms, which keep the row below. */}
+          <div className="sidebar-header-row flex h-12 shrink-0 items-center justify-between pr-3 pl-4">
             {/* Brand mark doubles as the "home" affordance: clicking it
             returns to `/`, the new-session composer. Without this there
             is no way back to the landing composer once you're inside a
@@ -782,7 +787,8 @@ export function Sidebar({
             <Link
               to="/"
               onClick={onNavClick}
-              className="rounded-none transition-opacity duration-200 ease-[var(--ease-otto)] hover:opacity-70"
+              data-testid="sidebar-brand"
+              className="sidebar-brand rounded-none transition-opacity duration-200 ease-[var(--ease-otto)] hover:opacity-70"
             >
               <img
                 src={omnigentWordmark}

--- a/web/src/shell/SidebarHeaderActions.tsx
+++ b/web/src/shell/SidebarHeaderActions.tsx
@@ -1,0 +1,118 @@
+import { PanelLeftOpenIcon, PanelRightOpenIcon, SearchIcon, SettingsIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Link } from "@/lib/routing";
+
+/**
+ * Search / Settings / sidebar-toggle cluster from the sidebar's header row.
+ *
+ * Extracted so it can render in TWO places without duplicating the markup:
+ * inside the sidebar (every browser and non-mac platform) and, on the macOS
+ * desktop shell, in the persistent title-bar strip. There it must survive the
+ * sidebar collapsing — the sidebar goes `md:w-0 md:overflow-hidden` and turns
+ * `inert`, so a cluster living inside it would be clipped and unclickable, and
+ * while peeking the card floats at `inset-2` and drags the cluster off the
+ * traffic lights' centre line. Hoisting it out of the sidebar is what keeps the
+ * three icons in one fixed place across open, collapsed, and peeking.
+ *
+ * Only the toggle's meaning changes with state: it collapses an open sidebar and
+ * opens a closed or peeking one, so the caller passes `expanded` and the icon
+ * and label follow from it.
+ */
+export function SidebarHeaderActions({
+  expanded,
+  onToggle,
+  onOpenSearch,
+  onSettingsClick,
+  onTogglePointerEnter,
+  onTogglePointerLeave,
+}: {
+  /**
+   * Whether the sidebar currently reads as open — `open || peek`. Drives the
+   * toggle only: expanded collapses, collapsed (or peeking) opens.
+   */
+  expanded: boolean;
+  /** Collapse an expanded sidebar, or open a collapsed/peeking one. */
+  onToggle: () => void;
+  /** Open the command palette (search). Optional so the cluster can render standalone. */
+  onOpenSearch?: () => void;
+  /**
+   * Extra handler for the Settings link. The in-sidebar copy passes nothing (on
+   * mobile, entering Settings keeps the drawer open and swaps it to the section
+   * list); navigation itself is the Link's job.
+   */
+  onSettingsClick?: () => void;
+  /**
+   * Dwell-to-peek hooks for the toggle. On the macOS shell this cluster replaces
+   * ChatHeader's collapsed-state button, which is where peek used to be armed,
+   * so the behaviour has to ride along with it or dwell-to-peek disappears.
+   */
+  onTogglePointerEnter?: () => void;
+  onTogglePointerLeave?: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-1" data-testid="sidebar-header-actions">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Search"
+            onClick={() => onOpenSearch?.()}
+            className="size-6 text-muted-foreground hover:text-foreground"
+            data-testid="sidebar-search-button"
+          >
+            <SearchIcon className="ui-icon" />
+          </Button>
+        </TooltipTrigger>
+        {/* Bottom placement keeps the tooltip clear of the macOS Electron
+        shell's traffic lights at the window's top edge. */}
+        <TooltipContent side="bottom">Search</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            asChild
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Settings"
+            className="size-6 text-muted-foreground hover:text-foreground"
+          >
+            <Link to="/settings" onClick={onSettingsClick} data-testid="settings-button">
+              <SettingsIcon className="ui-icon" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Settings</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={expanded ? "Close sidebar" : "Open sidebar"}
+            onClick={onToggle}
+            onPointerEnter={onTogglePointerEnter}
+            onPointerLeave={onTogglePointerLeave}
+            className="size-6 text-muted-foreground hover:text-foreground"
+          >
+            {/* panel-right-open reads as "push the panel away" while the sidebar
+            is open; panel-left-open as "bring it back" once it is collapsed or
+            merely peeking. */}
+            {expanded ? (
+              <PanelRightOpenIcon className="ui-icon" />
+            ) : (
+              <PanelLeftOpenIcon className="ui-icon" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {expanded ? "Collapse sidebar" : "Open sidebar"}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -211,7 +211,11 @@ export function SettingsSidebarBody({
 
   return (
     <>
-      <div className="px-3 pt-3">
+      {/* settings-sidebar-header carries the same traffic-light clearance the
+      home sidebar's header row gets: with the sidebar now starting at the
+      window's top edge on the macOS shell, this Back row would otherwise sit
+      underneath the window controls (see index.css). Inert elsewhere. */}
+      <div className="settings-sidebar-header px-3 pt-3">
         <Button
           asChild
           variant="ghost"


### PR DESCRIPTION
## Related issue

Closes #

<!-- Follow-up to #4551 (server picker → sidebar), which freed the title-bar
strip this PR reclaims. No separate issue tracks it; happy to file one. -->

## Summary

On the macOS shell the sidebar started `2.25rem` down, leaving a band of empty
canvas above it for the traffic lights to float over — so the window's
top-left held blank space, and the sidebar's own header (wordmark +
Search/Settings/Collapse) sat below it on a second row.

This reclaims that row. The header is already `3rem` tall — taller than the
`2.25rem` title-bar strip — so it can host the lights itself:

- the sidebar starts at the window's top edge (`margin-top: 0`), removing the
  empty strip;
- the brand mark is dropped, since the lights own the row's left end;
- the action cluster slides left to sit beside the window controls, ordered
  **Collapse, Search, Settings** outward from them.

```
before                                after
┌────────────────────────────────┐    ┌────────────────────────────────┐
│ ⬤⬤⬤                            │    │ ⬤⬤⬤  ▣ 🔍 ⚙                    │
│                                │    │                                │
│  ▤ Omnigent      🔍 ⚙ ▣        │    │  Sessions…                     │
│  Sessions…                     │    │                                │
└────────────────────────────────┘    └────────────────────────────────┘
  empty strip + wordmark row            lights share the header row
```

The buttons align to the **lights, not to the row**. The row centres its
children at `y=24` while the lights sit at `~y=19`, and `~5px` off reads as
broken once the two are side by side. macOS paints the lights *outside* the
page — they are not in the DOM and do not appear in a page screenshot — so
there is nothing to measure against; the rules anchor to the same `2.25rem`
strip height the drag region already uses, centring a `1.5rem` button in it at
`y=18`.

`/settings` swaps the header row out for its Back row, which would then sit
underneath the window controls, so that row gets vertical clearance instead.

All of it is scoped to `[data-electron-mac]`: a browser tab has no window
controls to align to and keeps today's wordmark row untouched.

## Test Plan

- `tsc -b` — clean
- `oxlint --deny-warnings` on changed files — clean
- `prettier --check` on changed files — clean
- `pnpm vitest run src/index.css.test.ts` — **49 pass** (7 new
  electron-mac header cases + the scoping assertion)

Verified in the desktop shell run from source: sidebar at `y=0`, wordmark
`display:none`, cluster at `x=80` ordered Collapse/Search/Settings, buttons at
`y=18` (on the lights' centre line). Toggling `data-electron-mac` off restores
the browser layout exactly (wordmark visible, `pl-4`, `space-between`, buttons
at `y=24`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The whole change is CSS, and the macOS traffic lights are invisible to any
DOM-level test (painted by the OS outside the page). So `index.css.test.ts`
asserts the **rules** rather than rendered geometry: that the sidebar's top
margin is zeroed, the brand is hidden, the cluster is left-aligned and
Collapse-first, and the settings Back row gets clearance — each **only** under
`[data-electron-mac]`. A dedicated scoping test fails if any of these rules
leaks out unscoped (verified it fails when the scope is removed), since a leak
would corrupt the browser layout that has no traffic lights to align to.

## Changelog

On the macOS desktop app, the sidebar header now shares the title-bar row with
the window controls — the empty strip above the sidebar and the redundant
wordmark row are gone, and the Collapse/Search/Settings buttons sit beside the
traffic lights.
