### PR TITLE
fix(codex): speak codex's model vocabulary on a CLI login

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -44,7 +44,7 @@ from omnigent.codex_model_vocabulary import (
 )
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
-from omnigent.model_fallbacks import CODEX_CATALOG_CLONE_SOURCE_SLUG
+from omnigent.model_fallbacks import CODEX_CATALOG_CLONE_SOURCE_SLUG, CODEX_DEFAULT_MODEL
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
 from omnigent.spec.types import RetryPolicy
 
@@ -3299,13 +3299,18 @@ class CodexExecutor(Executor):
         if self._model_provider_override is not None:
             model = None
         elif model is None:
-            provider_name = "databricks" if self._gateway_uses_databricks_profile else "openai"
-            resolution = await run_sync_on_thread(
-                model_catalog.resolve_catalog_model,
-                provider_name,
-                family="openai",
-            )
-            model = resolution.model_id
+            if self._gateway_uses_databricks_profile:
+                resolution = await run_sync_on_thread(
+                    model_catalog.resolve_catalog_model,
+                    "databricks",
+                    family="openai",
+                )
+                model = resolution.model_id
+            else:
+                # Codex's own login (ChatGPT account / API key), where codex is
+                # the vocabulary authority: the bundled OpenAI catalog's newest
+                # row is a bare family alias its backend rejects.
+                model = CODEX_DEFAULT_MODEL
         effective_cwd = (
             self._cwd or (self._os_env_spec.cwd if self._os_env_spec else None) or os.getcwd()
         )

--- a/omnigent/model_fallbacks.py
+++ b/omnigent/model_fallbacks.py
@@ -26,7 +26,12 @@ _CLAUDE_SUBSCRIPTION_MODELS = (
     "claude-haiku-4-5",
 )
 
-_CODEX_MODELS = ("gpt-5-6-sol", "gpt-5-6-luna", "gpt-5-6-terra", "gpt-5-5")
+#: Codex's own model slugs, which spell the version with a DOT
+#: (``gpt-5.6-sol``). These reach codex's ChatGPT-account backend directly, so
+#: the Databricks serving spelling (``databricks-gpt-5-6-sol``, hyphens only)
+#: is rejected here with a 400 — unlike the gateway catalogs below, which are
+#: correctly hyphenated. Ordered cheapest-safe default first.
+_CODEX_MODELS = ("gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.5")
 
 _STATIC_MODEL_FALLBACKS = {
     (SUBSCRIPTION_KIND, "claude"): StaticModelFallback(
@@ -56,6 +61,12 @@ _STATIC_MODEL_FALLBACKS = {
 def static_model_fallback(provider_kind: str, cli: str) -> StaticModelFallback | None:
     """Return the owned fallback for a provider kind and CLI, if registered."""
     return _STATIC_MODEL_FALLBACKS.get((provider_kind, cli))
+
+
+#: Codex's launch default when nothing else names a model. The bundled OpenAI
+#: catalog's newest row is a bare family alias (``gpt-5.6``) that codex rejects,
+#: so a codex launch defaults to a concrete variant from its own catalog.
+CODEX_DEFAULT_MODEL = _STATIC_MODEL_FALLBACKS[(SUBSCRIPTION_KIND, "codex")].model_ids[0]
 
 
 # ── Smart Routing ───────────────────────────────────────────────────────────

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from omnigent.codex_model_vocabulary import codex_spawn_model
 from omnigent.inner.codex_executor import (
     _TURN_EVENT_WARN_SECONDS,
     CodexExecutor,
@@ -36,6 +37,7 @@ from omnigent.inner.executor import (
     ToolCallStatus,
     TurnComplete,
 )
+from omnigent.model_fallbacks import CODEX_DEFAULT_MODEL
 
 
 def _run(coro):
@@ -419,7 +421,9 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertIsInstance(events[2], ToolCallComplete)
             self.assertIsInstance(events[3], TurnComplete)
             self.assertEqual(fake_session.calls[0]["system_prompt"], "Be helpful.")
-            self.assertEqual(fake_session.calls[0]["model"], "catalog-openai-openai-default")
+            # Codex's own login defaults from codex's catalog, not the generic
+            # OpenAI one, whose newest row is a family alias codex rejects.
+            self.assertEqual(fake_session.calls[0]["model"], CODEX_DEFAULT_MODEL)
             self.assertEqual(fake_session.calls[0]["tools"][0]["name"], "calculate")
 
         _run(_t())
@@ -3444,5 +3448,32 @@ def test_run_turn_cli_config_passes_no_model_to_thread_create():
         ):
             pass
         assert fake_session.calls[0]["model"] is None
+
+    _run(_t())
+
+
+def test_run_turn_defaults_to_a_codex_model_on_codexs_own_login():
+    """With no model anywhere, a codex-login turn gets a model codex accepts.
+
+    The bundled OpenAI catalog's newest row is the bare family alias
+    ``gpt-5.6``, which a ChatGPT-account backend rejects with a 400, so this
+    path must default from codex's own catalog instead.
+    """
+
+    async def _t():
+        fake_session = _FakeAppSession([[TurnComplete(response="done")]])
+        executor = CodexExecutor(
+            codex_path="/bin/echo",
+            app_session_factory=lambda **kwargs: fake_session,
+        )
+        async for _ in executor.run_turn(
+            [{"role": "user", "content": "hi", "session_id": "s1"}],
+            [],
+            "",
+        ):
+            pass
+        model = fake_session.calls[0]["model"]
+        assert model == CODEX_DEFAULT_MODEL
+        assert codex_spawn_model(model) == model, "not codex's own spelling"
 
     _run(_t())

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -12,6 +12,7 @@ Databricks credential mint is stubbed with the real
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -21,6 +22,7 @@ import pytest
 from cachetools import TTLCache
 
 import omnigent.model_catalog as model_catalog
+from omnigent.codex_model_vocabulary import codex_spawn_model
 from omnigent.model_catalog import (
     ModelEntry,
     ModelListing,
@@ -32,7 +34,7 @@ from omnigent.model_catalog import (
     resolve_model_provider,
     spec_harness,
 )
-from omnigent.model_fallbacks import static_model_fallback
+from omnigent.model_fallbacks import CODEX_DEFAULT_MODEL, static_model_fallback
 from omnigent.model_metadata import (
     ModelCapability,
     ModelCostTier,
@@ -953,10 +955,10 @@ def test_cli_config_listing_is_static_and_unverified(
     assert listing.source == "static"
     assert listing.verified is False
     assert [m.id for m in listing.models] == [
-        "gpt-5-6-sol",
-        "gpt-5-6-luna",
-        "gpt-5-6-terra",
-        "gpt-5-5",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+        "gpt-5.6-terra",
+        "gpt-5.5",
     ]
     # The note must say the CLI resolves the credential itself — this row
     # is a working worker, not a credentials preflight failure.
@@ -986,6 +988,39 @@ def test_static_model_fallbacks_document_ownership(
     assert fallback.owner
     assert fallback.provenance
     assert fallback.discovery_gap
+
+
+@pytest.mark.parametrize("provider_kind", ["subscription", "cli-config"])
+def test_codex_catalog_ids_are_spelled_the_way_codex_accepts(provider_kind: str) -> None:
+    """Codex's catalogs carry its dotted slugs, not the hyphenated serving ids.
+
+    Codex's own backend 400s on ``gpt-5-6-sol``; only ``gpt-5.6-sol`` reaches a
+    ChatGPT-account login. The two spellings still compare equal, so a routed
+    arm keeps matching either way.
+
+    :param provider_kind: The registered provider kind under test.
+    """
+    fallback = static_model_fallback(provider_kind, "codex")
+    assert fallback is not None
+    for model_id in fallback.model_ids:
+        assert not model_id.startswith("databricks-"), model_id
+        assert codex_spawn_model(model_id) == model_id, (
+            f"{model_id!r} is not codex's own spelling for itself"
+        )
+
+
+def test_codex_default_model_names_a_concrete_variant() -> None:
+    """The codex launch default is a tiered model, not a bare family alias.
+
+    The bundled OpenAI catalog's newest row is ``gpt-5.6``, which codex rejects
+    as a family name; a default must name a variant its backend serves.
+    """
+    fallback = static_model_fallback("subscription", "codex")
+    assert fallback is not None
+    assert CODEX_DEFAULT_MODEL in fallback.model_ids
+    assert codex_spawn_model(CODEX_DEFAULT_MODEL) == CODEX_DEFAULT_MODEL
+    # A bare family alias has no tier segment after the dotted version.
+    assert re.fullmatch(r"gpt-\d+\.\d+", CODEX_DEFAULT_MODEL) is None
 
 
 def test_cursor_listing_uses_live_cli_base_models(


### PR DESCRIPTION
## Related issue

Closes #4063

## Summary

Codex names its models with a **dotted** version (`gpt-5.6-sol`). Databricks serving names the same model with **hyphens only** (`databricks-gpt-5-6-sol`). Two places sent the Databricks spelling to codex's own backend, so every codex dispatch on a ChatGPT-account / API-key login failed at launch with a 400 — the default *and* every model the catalog offered.

- **The curated codex catalog carried the Databricks spelling.** `_CODEX_MODELS` in `model_fallbacks.py` backs both the `(subscription, codex)` and `(cli-config, codex)` fallbacks — the CLI-login paths — so picking any offered model was rejected. It now carries codex's own slugs. They still fold to the same comparable spelling via `comparable_model_id`, so routed-arm matching is unchanged.
- **The launch default resolved through the generic OpenAI catalog**, whose newest row is the bare family alias `gpt-5.6` that codex rejects as a family name. Only the Databricks-gateway branch consults that catalog now; a codex CLI login defaults to a concrete variant from codex's own catalog. The Databricks branch keeps its hyphenated ids, which are correct there.

### ELI5

Two dialects for one model name. The gateway says `gpt-5-6-sol`, codex says `gpt-5.6-sol`. We were speaking gateway to codex.

```
                        ┌─ Databricks gateway ──→ databricks-gpt-5-6-sol   ✅ (unchanged)
a codex launch needs ───┤
a model id              └─ codex's own login ───→ gpt-5.6-sol              ✅ (was gpt-5-6-sol / gpt-5.6 → 400)
```

### Where the regression came from

`_CODEX_MODELS` was moved into `model_fallbacks.py` and retyped in the Databricks spelling on the way. The list was also refreshed to the 5.6 generation in the same motion, which is why the spelling flip went unnoticed — and the neighbouring Claude list is legitimately hyphenated (`claude-opus-4-8`), so it looked consistent.

The bare-alias default is separate and older: a concrete `_OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4-mini"` was replaced with a generic "newest openai catalog row" lookup. That was fine when the newest row was a concrete model; it broke once the catalog gained a bare `gpt-5.6` family row.

Note `codex_model_vocabulary.py` already exists to translate between the two spellings — the static catalog path just never called it. The added tests assert `codex_spawn_model(id) == id` for every catalog entry, so the two can't drift apart again silently.

## Test Plan

- `pytest tests/test_model_catalog.py tests/inner/test_codex_executor.py tests/test_codex_model_vocabulary.py tests/inner/test_codex_model_catalog.py tests/inner/test_codex_harness.py tests/inner/test_codex_router_hook.py tests/server/test_smart_routing.py tests/test_model_override.py` → **624 passed**
- **Reverted each fix separately to confirm the new tests actually catch each defect**, rather than just passing alongside them:
  - hyphenated spelling restored → 5 tests fail (`assert 'gpt-5.6-sol' == 'gpt-5-6-sol'`)
  - default-resolution fix reverted, spelling left correct → the default test fails on its own, so the two defects are covered independently
- Smart routing green (198 passed): dotted and hyphenated ids still compare equal, so a routed arm keeps resolving.
- `dev/lint/lint_no_hardcoded_models.py` clean on both source files. Worth knowing for future edits: that lint only exempts model literals whose *every* load sits inside a `StaticModelFallback` record, so `CODEX_DEFAULT_MODEL` reads through `_STATIC_MODEL_FALLBACKS[...]` to keep the exemption (and the guardrail) intact.
- `pyrefly check omnigent/model_fallbacks.py omnigent/inner/codex_executor.py` → 0 errors.
- One existing assertion (`test_run_turn_delegates_to_app_server_session`) pinned the old `catalog-openai-openai-default` behaviour. It was encoding the bug, so it now asserts the codex default.

**Not verified live, and worth a smoke test before merge:** I have no ChatGPT-account login on this box, and my local `codex` is 0.144.3 vs 0.146.0 in the report, so I could not reproduce the 400→200 transition end to end. The id-level behaviour matches what the reporter verified by hand (`gpt-5.6-sol` accepted, `gpt-5-6-sol` and `gpt-5.6` rejected).

```console
$ omnigent run --harness codex -p "reply READY and stop"   # default; was 400 on 'gpt-5.6'
$ omnigent run --harness codex --model gpt-5.6-sol -p "reply READY and stop"  # now in the catalog
```

## Demo

N/A — non-visual model-id fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage on both defects, each verified to fail without its own fix. The live subscription-login path is the gap — see the note in the Test Plan.

## Changelog

Codex sessions on a ChatGPT-account or API-key login launch again, instead of failing with "model is not supported when using Codex with a ChatGPT account"

---

Overlaps with #4015 on the catalog spelling — @ColeMatthewBienek found that half first. That PR also carries ~25 unrelated files and is currently red; this one is scoped to the fix and adds the default-resolution half. Happy to close in its favour if they'd rather land theirs.
