### PR TITLE
fix(ios): land Databricks workspaces on /omnigent and hide the workspace chrome

### DIFF
--- a/web/electron/src/workspace-chrome.js
+++ b/web/electron/src/workspace-chrome.js
@@ -2,6 +2,11 @@
 // Omnigent SPA. Kept in its own Electron-free module so the injection logic is
 // unit-testable (test/workspace-chrome.test.js calls applyWorkspaceChromeHideCss
 // with a fake webContents) without requiring main.js, which boots the app.
+//
+// The mobile shells carry the same logic in
+// web/android/.../WorkspaceChromeScript.kt and
+// web/ios/Omnigent/WorkspaceChromeScript.swift. Keep the CSS identical in all
+// three so a fix in one shell isn't silently missing from the others.
 
 /**
  * CSS that hides the Databricks workspace navigation chrome.

--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -24,11 +24,13 @@
 		B10000000000000000000012 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* SafariView.swift */; };
 		B10000000000000000000015 /* ManagedConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000015 /* ManagedConfiguration.swift */; };
 		B10000000000000000000016 /* ManagedConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000016 /* ManagedConfigurationProvider.swift */; };
+		B10000000000000000000017 /* WorkspaceChromeScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* WorkspaceChromeScript.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B10000000000000000000013 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000013 /* PrivacyInfo.xcprivacy */; };
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
 		B20000000000000000000002 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* SettingsStoreTests.swift */; };
+		B20000000000000000000008 /* WorkspaceChromeScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* WorkspaceChromeScriptTests.swift */; };
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
 		B20000000000000000000004 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* DeepLinkTests.swift */; };
 		B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */; };
@@ -67,6 +69,7 @@
 		A10000000000000000000006 /* ServerURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURL.swift; sourceTree = "<group>"; };
 		A10000000000000000000014 /* DeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		A10000000000000000000007 /* WorkspaceURLExpander.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpander.swift; sourceTree = "<group>"; };
+		A10000000000000000000017 /* WorkspaceChromeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceChromeScript.swift; sourceTree = "<group>"; };
 		A10000000000000000000008 /* NativeNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000009 /* WebShellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebShellView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000A /* WebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModel.swift; sourceTree = "<group>"; };
@@ -87,6 +90,7 @@
 		A20000000000000000000004 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderRedirectTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000007 /* ManagedConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfigurationTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000008 /* WorkspaceChromeScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceChromeScriptTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* MockHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPServer.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
@@ -154,6 +158,7 @@
 				A10000000000000000000006 /* ServerURL.swift */,
 				A10000000000000000000014 /* DeepLink.swift */,
 				A10000000000000000000007 /* WorkspaceURLExpander.swift */,
+				A10000000000000000000017 /* WorkspaceChromeScript.swift */,
 				A10000000000000000000008 /* NativeNotificationManager.swift */,
 				A10000000000000000000009 /* WebShellView.swift */,
 				A1000000000000000000000A /* WebViewModel.swift */,
@@ -180,6 +185,7 @@
 				A20000000000000000000004 /* DeepLinkTests.swift */,
 				A20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift */,
 				A20000000000000000000007 /* ManagedConfigurationTests.swift */,
+				A20000000000000000000008 /* WorkspaceChromeScriptTests.swift */,
 				A20000000000000000000006 /* MockHTTPServer.swift */,
 			);
 			path = OmnigentTests;
@@ -343,6 +349,7 @@
 				B10000000000000000000006 /* ServerURL.swift in Sources */,
 				B10000000000000000000014 /* DeepLink.swift in Sources */,
 				B10000000000000000000007 /* WorkspaceURLExpander.swift in Sources */,
+				B10000000000000000000017 /* WorkspaceChromeScript.swift in Sources */,
 				B10000000000000000000008 /* NativeNotificationManager.swift in Sources */,
 				B10000000000000000000009 /* WebShellView.swift in Sources */,
 				B1000000000000000000000A /* WebViewModel.swift in Sources */,
@@ -365,6 +372,7 @@
 				B20000000000000000000004 /* DeepLinkTests.swift in Sources */,
 				B20000000000000000000005 /* WorkspaceURLExpanderRedirectTests.swift in Sources */,
 				B20000000000000000000007 /* ManagedConfigurationTests.swift in Sources */,
+				B20000000000000000000008 /* WorkspaceChromeScriptTests.swift in Sources */,
 				B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/web/ios/Omnigent/AppRootView.swift
+++ b/web/ios/Omnigent/AppRootView.swift
@@ -42,7 +42,7 @@ struct AppRootView: View {
           // Record the CLEAN server URL (no /c/<id>) — the conversation path
           // lives only in the load URL, never in recents, so a later deep link
           // resolves against an un-polluted server identity.
-          loadSucceeded: { _ in
+          loadSucceeded: {
             settings.rememberRecentServer(serverURL)
           }
         )
@@ -190,7 +190,7 @@ extension AppRootView {
 
   /// Consent was given for an unknown server — discover the workspace mount
   /// (the only network request, AFTER consent), then switch. The origin is
-  /// unchanged by the probe (it only appends `/ml/omnigents` under it), so the
+  /// unchanged by the probe (it only appends the SPA mount path under it), so the
   /// consent decision stands. Recording the server happens on load success
   /// (loadSucceeded), so a server that fails to load isn't remembered.
   private func confirmUnknownDeepLink() {
@@ -214,7 +214,8 @@ extension AppRootView {
   }
 
   /// Join a basename-less SPA path (`/c/<id>`) onto a server URL that may carry
-  /// a workspace mount (`/ml/omnigents`). The path lives UNDER the mount, so it
+  /// a workspace mount (`WorkspaceURLExpander.workspaceUIPath`). The path lives
+  /// UNDER the mount, so it
   /// is string-concatenated (not URL-resolved, which would anchor against the
   /// origin and drop the mount) — mirroring the desktop's `resolveServerPath`.
   private func conversationURL(for serverURL: URL, path: String) -> URL {

--- a/web/ios/Omnigent/DeepLink.swift
+++ b/web/ios/Omnigent/DeepLink.swift
@@ -9,7 +9,7 @@ import Foundation
 /// conversation by the SPA's own `/c/:id` route. It carries no `http`/`https` —
 /// the scheme is inferred with the same rule the setup page and desktop use
 /// (`http` for loopback, `https` for a remote host), so a deep link and a pasted
-/// URL never disagree on scheme. The Databricks workspace mount (`/ml/omnigents`)
+/// URL never disagree on scheme. The Databricks workspace mount
 /// is deliberately NOT in the link; it is server-determined and discovered by
 /// `WorkspaceURLExpander` (after consent, for an unknown server).
 ///

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -7,7 +7,7 @@ struct OmnigentWebView: UIViewRepresentable {
   @ObservedObject var model: WebViewModel
   @ObservedObject var settings: SettingsStore
   let loadFailed: (URL, String) -> Void
-  let loadSucceeded: (URL) -> Void
+  let loadSucceeded: () -> Void
 
   func makeCoordinator() -> Coordinator {
     Coordinator(self)
@@ -267,8 +267,18 @@ struct OmnigentWebView: UIViewRepresentable {
   {
     var parent: OmnigentWebView
     private weak var webView: WKWebView?
+    /// The server this web view is pinned to; nil before the first load. Doubles as
+    /// the identity `updateUIView` compares against, so a re-render only reloads
+    /// when SwiftUI hands over a different server.
     private(set) var pinnedURL: URL?
-    private var pinnedOrigin: String?
+    /// Derived, never stored: a cached copy would be one more thing to keep in sync
+    /// with `pinnedURL`.
+    private var pinnedOrigin: String? { pinnedURL?.omnigentOrigin }
+    /// Bare-root → mount bounces since the last app page loaded; see
+    /// `workspaceRootBounceTarget` for why they're capped.
+    private var rootBounces = 0
+    private static let maxRootBounces = 1
+    private var urlObservation: NSKeyValueObservation?
 
     init(_ parent: OmnigentWebView) {
       self.parent = parent
@@ -276,11 +286,55 @@ struct OmnigentWebView: UIViewRepresentable {
 
     func attach(_ webView: WKWebView) {
       self.webView = webView
+      // In-page navigation: the SPA swapped the URL with pushState / replaceState,
+      // or the user moved through history. No page is loaded, so no navigation
+      // delegate callback runs — KVO on `url` is the only way to observe the user
+      // routing client-side back to the workspace root.
+      urlObservation = webView.observe(\.url) { [weak self] _, _ in
+        Task { @MainActor in
+          guard let self, let webView = self.webView else { return }
+          self.bounceIfWorkspaceRoot(webView)
+        }
+      }
     }
 
     func detach() {
       parent.model.cancelServerSwitcherWatchdog()
+      urlObservation = nil
       webView = nil
+    }
+
+    /// Send a landing on the bare Databricks workspace root to the SPA mount. The
+    /// root serves the Databricks landing page, so leaving the user there hides the
+    /// app and lets them wander into another workspace app with no way back.
+    private func bounceIfWorkspaceRoot(_ webView: WKWebView) {
+      guard let url = webView.url, url.omnigentOrigin == pinnedOrigin,
+        let target = workspaceRootBounceTarget(for: url)
+      else {
+        return
+      }
+      bounce(webView, to: target)
+    }
+
+    /// The mount URL to bounce to when `url` is a bare Databricks workspace root, or
+    /// nil when there's nothing to do.
+    ///
+    /// Budgeted, and spent by the caller that acts on it: a workspace that answers
+    /// the mount with a redirect back to the root (e.g. it isn't enabled there)
+    /// would otherwise loop forever. One bounce per app page load, so a failed
+    /// bounce leaves the user on the root and `didFinish` re-arms the budget as soon
+    /// as an app page loads.
+    private func workspaceRootBounceTarget(for url: URL) -> URL? {
+      guard let target = WorkspaceURLExpander.workspaceUIURL(forBareRoot: url) else { return nil }
+      guard rootBounces < Self.maxRootBounces else { return nil }
+      rootBounces += 1
+      return target
+    }
+
+    /// Posted, never loaded inline: a load issued while WebKit is committing a
+    /// navigation can be dropped.
+    private func bounce(_ webView: WKWebView, to target: URL) {
+      DispatchQueue.main.async { webView.load(URLRequest(url: target)) }
     }
 
     // A left-edge swipe drives the web app's sidebar as an interactive drawer.
@@ -322,7 +376,9 @@ struct OmnigentWebView: UIViewRepresentable {
 
     func load(_ url: URL, in webView: WKWebView) {
       pinnedURL = url
-      pinnedOrigin = url.omnigentOrigin
+      // A new pin is a new server: the previous one's exhausted bounce budget must
+      // not suppress the first bounce here.
+      rootBounces = 0
       publishModelChanges { model in
         model.currentURL = url
         model.serverSwitcherHidden = true
@@ -385,16 +441,35 @@ struct OmnigentWebView: UIViewRepresentable {
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
       parent.model.currentURL = webView.url ?? parent.model.currentURL
+      // Workspace roots are caught here too, not only in decidePolicyFor: that
+      // callback is skipped for loads the shell starts itself, and the Databricks
+      // login chain hands the session back with a form POST landing on the root.
+      // didCommit sees every committed main-frame load.
+      bounceIfWorkspaceRoot(webView)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
       parent.model.isLoading = false
       parent.model.currentURL = webView.url ?? parent.model.currentURL
-      if webView.url?.path.starts(with: WorkspaceURLExpander.workspaceUIPath) == true {
-        injectWorkspaceChromeCSS(webView)
+      // A page other than the bare root finished loading, so the last bounce (if
+      // any) got us somewhere: re-arm the budget for the next landing on the root.
+      // Deliberately loose — an auth page also re-arms, which at worst costs one
+      // extra bounce attempt rather than stranding the user on the root.
+      if let url = webView.url, url.omnigentOrigin == pinnedOrigin,
+        WorkspaceURLExpander.workspaceUIURL(forBareRoot: url) == nil
+      {
+        rootBounces = 0
       }
-      if webView.url?.omnigentOrigin == pinnedOrigin, let pinnedURL {
-        parent.loadSucceeded(pinnedURL)
+      // Databricks workspace-hosted Omnigent renders inside the workspace's
+      // top-nav chrome (the SPA is a workspace page). Hide it by overlaying
+      // Omnigent's own root — see WorkspaceChromeScript, which also explains why
+      // this is keyed on the pinned origin and never on the URL's path.
+      // Re-applied on every full load (a server switch is a fresh document); the
+      // SPA's client-side routing keeps the same document, so the injected
+      // stylesheet persists across in-app navigation.
+      if pinnedOrigin != nil, webView.url?.omnigentOrigin == pinnedOrigin {
+        webView.evaluateJavaScript(WorkspaceChromeScript.source)
+        parent.loadSucceeded()
       }
     }
 
@@ -428,6 +503,16 @@ struct OmnigentWebView: UIViewRepresentable {
       if navigationAction.targetFrame == nil {
         openExternal(url)
         decisionHandler(.cancel)
+        return
+      }
+
+      // A main-frame landing on the bare workspace root belongs to Databricks
+      // rather than the app — cancel it and load the SPA mount instead.
+      if navigationAction.targetFrame?.isMainFrame == true, url.omnigentOrigin == pinnedOrigin,
+        let target = workspaceRootBounceTarget(for: url)
+      {
+        decisionHandler(.cancel)
+        bounce(webView, to: target)
         return
       }
 
@@ -555,26 +640,6 @@ struct OmnigentWebView: UIViewRepresentable {
       // redundant on the supported OS versions; callers already fall back to the
       // web view's own URL when the key is absent.
       error.userInfo[NSURLErrorFailingURLErrorKey] as? URL
-    }
-
-    private func injectWorkspaceChromeCSS(_ webView: WKWebView) {
-      let css = """
-        .omnigent-app {
-          position: fixed !important;
-          inset: 0 !important;
-          z-index: 2147483647 !important;
-        }
-        """
-      let script = """
-        (() => {
-          if (document.querySelector("style[data-omnigent-workspace-chrome]")) return;
-          const style = document.createElement("style");
-          style.dataset.omnigentWorkspaceChrome = "true";
-          style.textContent = \(WebViewModel.javascriptString(css));
-          document.documentElement.appendChild(style);
-        })();
-        """
-      webView.evaluateJavaScript(script)
     }
 
     private func topViewController() -> UIViewController? {

--- a/web/ios/Omnigent/ServerURL.swift
+++ b/web/ios/Omnigent/ServerURL.swift
@@ -29,7 +29,8 @@ enum ServerURL {
     if trimmed.contains("://") {
       withScheme = trimmed
     } else {
-      withScheme = "\(allowsInsecureHTTP ? "http" : "https")://\(trimmed)"
+      withScheme =
+        "\(defaultScheme(for: trimmed, allowsInsecureHTTP: allowsInsecureHTTP))://\(trimmed)"
     }
 
     guard let url = URL(string: withScheme), let scheme = url.scheme?.lowercased() else {
@@ -42,5 +43,24 @@ enum ServerURL {
       throw ServerURLError.insecureHTTPNotAllowed
     }
     return url
+  }
+
+  /// Loopback hosts where plain http is the norm (a local dev server). Mirrors the
+  /// desktop's `LOCAL_HOSTS` in `web/electron/src/url.js`.
+  private static let localHosts: Set<String> = ["localhost", "127.0.0.1", "[::1]", "::1"]
+
+  /// The scheme a schemeless input defaults to: http for a loopback host, https for
+  /// everything else.
+  ///
+  /// A remote host defaults to https even when `allowsInsecureHTTP` is set — that
+  /// flag exists so a debug build can reach a local dev server over http, not to
+  /// silently downgrade a pasted remote host. Pinning `http://` for a server that
+  /// redirects to https breaks every pinned-origin check in the web view (bridge
+  /// trust, the workspace-chrome overlay, load-success recording), because the
+  /// pinned and live origins then differ by scheme.
+  private static func defaultScheme(for trimmed: String, allowsInsecureHTTP: Bool) -> String {
+    guard allowsInsecureHTTP else { return "https" }
+    let host = URL(string: "https://\(trimmed)")?.host?.lowercased() ?? ""
+    return localHosts.contains(host) ? "http" : "https"
   }
 }

--- a/web/ios/Omnigent/WebShellView.swift
+++ b/web/ios/Omnigent/WebShellView.swift
@@ -5,7 +5,7 @@ struct WebShellView: View {
   let connectToNewServer: () -> Void
   let switchToServer: (URL) -> Void
   let loadFailed: (URL, String) -> Void
-  let loadSucceeded: (URL) -> Void
+  let loadSucceeded: () -> Void
 
   @Environment(\.colorScheme) private var colorScheme
   @EnvironmentObject private var settings: SettingsStore

--- a/web/ios/Omnigent/WebViewModel.swift
+++ b/web/ios/Omnigent/WebViewModel.swift
@@ -107,7 +107,9 @@ final class WebViewModel: ObservableObject {
     return String(format: "%g", Double(value))
   }
 
-  static func javascriptString(_ value: String) -> String {
+  /// `nonisolated` because it touches no main-actor state — a pure formatter, so
+  /// non-isolated callers (e.g. `WorkspaceChromeScript`) can share it.
+  nonisolated static func javascriptString(_ value: String) -> String {
     guard let data = try? JSONEncoder().encode(value),
       let encoded = String(data: data, encoding: .utf8)
     else {

--- a/web/ios/Omnigent/WorkspaceChromeScript.swift
+++ b/web/ios/Omnigent/WorkspaceChromeScript.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Hiding the Databricks workspace navigation chrome around a workspace-hosted
+/// Omnigent SPA. Kept in its own WebKit-free type so the script is unit-testable
+/// (`OmnigentTests/WorkspaceChromeScriptTests.swift`) without a `WKWebView`.
+///
+/// Ported from `web/electron/src/workspace-chrome.js`; the Android shell carries
+/// the same logic in `WorkspaceChromeScript.kt`. Keep the CSS identical in all
+/// three so a fix in one shell isn't silently missing from the others.
+enum WorkspaceChromeScript {
+  /// CSS that hides the Databricks workspace navigation chrome.
+  ///
+  /// On a workspace the SPA is mounted as a workspace *page*, so Databricks wraps
+  /// it in its top-nav shell (the dark bar with the workspace switcher). In a
+  /// dedicated app window that chrome is just noise. We promote Omnigent's own
+  /// root — `.omnigent-app`, which the embed entry sets (`web/src/embed.tsx`) —
+  /// to a full-viewport overlay so it paints over the workspace bar. Keying on
+  /// Omnigent's wrapper (defined in THIS repo) rather than the monolith-owned,
+  /// unstable workspace nav markup keeps this from silently breaking when
+  /// Databricks reshuffles its chrome; on a standalone (non-embed) build there is
+  /// no `.omnigent-app`, so the rule is a harmless no-op.
+  static let css = """
+    .omnigent-app {
+      position: fixed !important;
+      inset: 0 !important;
+      z-index: 2147483647 !important;
+    }
+    """
+
+  /// JS that installs ``css`` into the current document, at most once.
+  ///
+  /// The caller injects this on every finished main-frame load of the pinned
+  /// origin, and must NOT gate it on the URL's path. The workspace serves the SPA
+  /// on more than one mount (`/ml/omnigents` for the desktop shells, `/omnigent`
+  /// in `omnigent/conversation_browser.py`) and an auth redirect can land on
+  /// neither, so a path guard leaves the workspace switcher visible — from there a
+  /// user navigates into another workspace app with no way back. Do not
+  /// reintroduce a path guard.
+  static var source: String {
+    """
+    (() => {
+      if (document.querySelector("style[data-omnigent-workspace-chrome]")) return;
+      const style = document.createElement("style");
+      style.dataset.omnigentWorkspaceChrome = "true";
+      style.textContent = \(WebViewModel.javascriptString(css));
+      document.documentElement.appendChild(style);
+    })();
+    """
+  }
+}

--- a/web/ios/Omnigent/WorkspaceURLExpander.swift
+++ b/web/ios/Omnigent/WorkspaceURLExpander.swift
@@ -1,11 +1,20 @@
 import Foundation
 
 enum WorkspaceURLExpander {
-  static let workspaceUIPath = "/ml/omnigents"
+  /// Path the Omnigent SPA is mounted at inside a Databricks workspace. Matches
+  /// Android's `WORKSPACE_UI_PATH` (`Origins.kt`). The Electron shell still uses
+  /// `/ml/omnigents`; see the note in `web/electron/src/url.js`.
+  static let workspaceUIPath = "/omnigent"
+
+  /// Databricks domains that serve a workspace, and therefore mount the SPA at
+  /// ``workspaceUIPath``. `databricksapps.com` is deliberately absent: Apps share
+  /// the workspace login story but serve their own app at the root, with no
+  /// workspace mount to redirect to.
+  private static let workspaceDomains = ["databricks.com", "azuredatabricks.net"]
 
   /// Databricks Apps are served from `*.databricksapps.com` and answer with the
   /// same `server: databricks` header as a workspace, but they are NOT
-  /// workspaces and have no `/ml/omnigents` mount, so expansion is skipped for
+  /// workspaces and have no SPA mount, so expansion is skipped for
   /// these hosts.
   static let databricksAppsHostSuffix = "databricksapps.com"
 
@@ -41,13 +50,44 @@ enum WorkspaceURLExpander {
       guard (http.value(forHTTPHeaderField: "server") ?? "").lowercased() == "databricks" else {
         return url
       }
-      return URL(
-        string:
-          "\(origin.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/")))\(workspaceUIPath)"
-      ) ?? url
+      return mounted(url) ?? url
     } catch {
       return url
     }
+  }
+
+  /// The SPA-mount URL for a **bare** Databricks workspace root, or nil for
+  /// anything else — a non-workspace host, or a URL that already carries a path (a
+  /// deliberate deep link we must not override).
+  ///
+  /// A bare workspace root shows the Databricks landing page, not Omnigent, so the
+  /// shell rewrites it. Matched by domain with no probe, mirroring Android's
+  /// `databricksWorkspaceUiUrl`; query and fragment survive because `?o=<org>`
+  /// selects which workspace the request lands in.
+  static func workspaceUIURL(forBareRoot url: URL) -> URL? {
+    guard let scheme = url.scheme?.lowercased(), scheme == "https" || scheme == "http",
+      isWorkspaceHost(url.host), isBareRoot(url)
+    else {
+      return nil
+    }
+    return mounted(url)
+  }
+
+  /// `url` with its path replaced by ``workspaceUIPath``, preserving scheme, host,
+  /// port, query and fragment.
+  private static func mounted(_ url: URL) -> URL? {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return nil
+    }
+    components.path = workspaceUIPath
+    return components.url
+  }
+
+  /// Whether `host` is, or sits under, a Databricks workspace domain. Matched on a
+  /// dot boundary so a lookalike like `databricks.com.example.org` doesn't qualify.
+  private static func isWorkspaceHost(_ host: String?) -> Bool {
+    guard let host = host?.lowercased() else { return false }
+    return workspaceDomains.contains { host == $0 || host.hasSuffix(".\($0)") }
   }
 
   private static func isBareRoot(_ url: URL) -> Bool {

--- a/web/ios/OmnigentTests/ServerURLTests.swift
+++ b/web/ios/OmnigentTests/ServerURLTests.swift
@@ -13,6 +13,29 @@ final class ServerURLTests: XCTestCase {
     XCTAssertEqual(url.absoluteString, "http://localhost:6767")
   }
 
+  /// A remote host must not be downgraded to http just because the debug build
+  /// allows insecure http: an http pin that the server upgrades to https breaks
+  /// every pinned-origin check in the web view.
+  func testDebugPolicyStillDefaultsRemoteHostToHTTPS() throws {
+    let url = try ServerURL.normalize(
+      "dbc-b7cf3f6a-ac9f.cloud.databricks.com", allowsInsecureHTTP: true)
+    XCTAssertEqual(url.absoluteString, "https://dbc-b7cf3f6a-ac9f.cloud.databricks.com")
+  }
+
+  /// Loopback keeps defaulting to http so local dev still works.
+  func testDebugPolicyDefaultsLoopbackVariantsToHTTP() throws {
+    XCTAssertEqual(
+      try ServerURL.normalize("127.0.0.1:6767", allowsInsecureHTTP: true).absoluteString,
+      "http://127.0.0.1:6767")
+  }
+
+  /// An explicitly typed http:// URL is still honoured under the debug policy.
+  func testDebugPolicyHonoursExplicitHTTPForRemoteHost() throws {
+    XCTAssertEqual(
+      try ServerURL.normalize("http://example.com", allowsInsecureHTTP: true).absoluteString,
+      "http://example.com")
+  }
+
   func testReleasePolicyRejectsHTTP() {
     XCTAssertThrowsError(try ServerURL.normalize("http://example.com", allowsInsecureHTTP: false)) {
       error in

--- a/web/ios/OmnigentTests/WorkspaceChromeScriptTests.swift
+++ b/web/ios/OmnigentTests/WorkspaceChromeScriptTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import Omnigent
+
+final class WorkspaceChromeScriptTests: XCTestCase {
+  /// The rule must key on Omnigent's own embed root, not on the monolith-owned
+  /// workspace nav markup, and must win over it (fixed + full-inset + top layer).
+  func testCSSPromotesTheEmbedRootToAFullViewportOverlay() {
+    XCTAssertEqual(
+      WorkspaceChromeScript.css,
+      """
+      .omnigent-app {
+        position: fixed !important;
+        inset: 0 !important;
+        z-index: 2147483647 !important;
+      }
+      """,
+      "Keep this identical to WORKSPACE_CHROME_HIDE_CSS in "
+        + "web/electron/src/workspace-chrome.js and to WorkspaceChromeScript.kt."
+    )
+  }
+
+  /// The script is injected on every finished load, so re-running it on a document
+  /// that already has the stylesheet must not stack duplicate <style> nodes.
+  func testSourceInstallsTheStylesheetAtMostOncePerDocument() {
+    let source = WorkspaceChromeScript.source
+
+    XCTAssertTrue(
+      source.contains(
+        """
+        if (document.querySelector("style[data-omnigent-workspace-chrome]")) return;
+        """))
+    XCTAssertTrue(source.contains("document.documentElement.appendChild(style)"))
+  }
+
+  /// The CSS reaches the page as a JSON-encoded string literal, so a quote or
+  /// newline in it can't break out of the surrounding script.
+  func testSourceEmbedsTheCSSAsAnEscapedStringLiteral() {
+    XCTAssertTrue(
+      WorkspaceChromeScript.source.contains(
+        WebViewModel.javascriptString(WorkspaceChromeScript.css))
+    )
+  }
+}

--- a/web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
+++ b/web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
@@ -25,7 +25,7 @@ final class WorkspaceURLExpanderTests: XCTestCase {
       session: stubbedSession()
     )
 
-    XCTAssertEqual(expanded.absoluteString, "https://workspace.example.com/ml/omnigents")
+    XCTAssertEqual(expanded.absoluteString, "https://workspace.example.com/omnigent")
   }
 
   func testLeavesNonWorkspaceRootUnchanged() async {
@@ -46,7 +46,7 @@ final class WorkspaceURLExpanderTests: XCTestCase {
   }
 
   func testLeavesURLsWithPathsUnchangedWithoutProbe() async {
-    let original = URL(string: "https://workspace.example.com/ml/omnigents")!
+    let original = URL(string: "https://workspace.example.com/omnigent")!
     let expanded = await WorkspaceURLExpander.expandIfNeeded(original, session: stubbedSession())
 
     XCTAssertEqual(expanded, original)
@@ -121,4 +121,65 @@ private final class URLProtocolStub: URLProtocol {
   }
 
   override func stopLoading() {}
+}
+
+/// Domain-matched bare-root rewriting (no probe), mirroring Android's
+/// `OriginsWorkspaceUiUrlTest`.
+final class WorkspaceMountURLTests: XCTestCase {
+  private func mount(_ raw: String) -> String? {
+    guard let url = URL(string: raw) else { return nil }
+    return WorkspaceURLExpander.workspaceUIURL(forBareRoot: url)?.absoluteString
+  }
+
+  func testRewritesBareWorkspaceRoots() {
+    XCTAssertEqual(
+      mount("https://dbc-1234.cloud.databricks.com"),
+      "https://dbc-1234.cloud.databricks.com/omnigent")
+    XCTAssertEqual(
+      mount("https://dbc-1234.cloud.databricks.com/"),
+      "https://dbc-1234.cloud.databricks.com/omnigent")
+    XCTAssertEqual(
+      mount("https://adb-99.azuredatabricks.net/"), "https://adb-99.azuredatabricks.net/omnigent")
+    XCTAssertEqual(mount("https://databricks.com/"), "https://databricks.com/omnigent")
+  }
+
+  /// `?o=<org>` selects which workspace the request lands in, so it must survive.
+  func testPreservesQueryAndFragment() {
+    XCTAssertEqual(
+      mount("https://dbc-1234.cloud.databricks.com/?o=987654321"),
+      "https://dbc-1234.cloud.databricks.com/omnigent?o=987654321")
+    XCTAssertEqual(
+      mount("https://dbc-1234.cloud.databricks.com/?o=1#frag"),
+      "https://dbc-1234.cloud.databricks.com/omnigent?o=1#frag")
+  }
+
+  func testPreservesPortAndNormalizesHostCase() {
+    XCTAssertEqual(
+      mount("https://dbc-1234.cloud.databricks.com:8443/"),
+      "https://dbc-1234.cloud.databricks.com:8443/omnigent")
+    XCTAssertEqual(
+      mount("https://DBC-1234.Cloud.DataBricks.Com/"),
+      "https://DBC-1234.Cloud.DataBricks.Com/omnigent")
+  }
+
+  /// A URL that already carries a path is a deliberate deep link.
+  func testLeavesNonRootPathsAlone() {
+    XCTAssertNil(mount("https://dbc-1234.cloud.databricks.com/omnigent"))
+    XCTAssertNil(mount("https://dbc-1234.cloud.databricks.com/c/abc"))
+    XCTAssertNil(mount("https://dbc-1234.cloud.databricks.com/ml/omnigents"))
+  }
+
+  /// Apps serve their own app at the root and have no workspace mount.
+  func testLeavesDatabricksAppsAndOtherHostsAlone() {
+    XCTAssertNil(mount("https://my-app.databricksapps.com/"))
+    XCTAssertNil(mount("https://example.com/"))
+    XCTAssertNil(mount("https://localhost:8000/"))
+    // Lookalike host: must match on a dot boundary.
+    XCTAssertNil(mount("https://databricks.com.evil.example/"))
+  }
+
+  func testRejectsNonHTTPSchemes() {
+    XCTAssertNil(mount("omnigent://dbc-1234.cloud.databricks.com/"))
+    XCTAssertNil(mount("file:///tmp"))
+  }
 }


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; requested directly.

## Summary

- A workspace-hosted Omnigent on iOS was unusable in two ways: connecting with a
  bare workspace URL landed on the Databricks landing page instead of the app,
  and once on the app the workspace's top-nav bar was still painted over it —
  wasting vertical space and letting the user navigate into another workspace app
  with no way back.
- Ports the desktop's chrome hide (`web/electron/src/workspace-chrome.js`) into a
  testable `WorkspaceChromeScript`, replacing the previous injection that was
  gated on `path.starts(with: "/ml/omnigents")` — a path gate skips auth-redirect
  landings and the `/omnigent` mount entirely. Keyed on the pinned origin, never
  on the path.
- Mirrors the Android `/omnigent` bounce from #4543 on iOS: domain-matched with no
  probe, `?o=<org>` and fragment preserved, one bounce per app-page load, wired
  into the three iOS equivalents of Android's callbacks — `decidePolicyFor`
  (link/redirect navs), `didCommit` (every committed load, incl. the login
  chain's POST hand-back) and KVO on `webView.url` (in-page `pushState`, which
  fires no navigation callback at all).
- Root cause both of the above depended on: with `allowsInsecureHTTP` (debug
  only), a schemeless host was normalized to `http://`, so the app pinned
  `http://` while the server redirects to `https://`. Every pinned-origin
  comparison then failed silently — the chrome overlay, native bridge trust
  (`isTrustedBridgeMessage`, so the server switcher / Chat-Terminal bar / sidebar
  drag were dead), media-capture prompts, and load-success recording. A schemeless
  host now defaults to https unless it is loopback, mirroring the desktop's
  `LOCAL_HOSTS`, so the mismatch can't be created: release builds already reject
  `http://` outright and App Transport Security blocks it at the network layer.
- Derives the pinned origin from the pinned URL instead of caching it in a second
  field, so the two can't drift, and re-arms the bare-root bounce budget when a
  new server is pinned. Drops `loadSucceeded`'s URL argument: its only consumer
  discarded it.

ELI5: the app was told "the server is http://host", the server answered
"actually I'm https://host", and every later "is this page still my server?"
check compared the two strings, said no, and quietly skipped its work.

```
  connect "dbc-x.cloud.databricks.com"
        │
        ├─ before: http://dbc-x…            → pinned http://dbc-x
        │          server 301 → https://…   → page   https://dbc-x
        │          pinned != page  ─────────► chrome hide / bridge / recents SKIPPED
        │
        └─ after:  https://dbc-x…           → pinned https://dbc-x  (non-loopback ⇒ https)
                   bare root ⇒ /omnigent    → bounce once
                   pinned == page  ─────────► overlay covers the workspace bar
```

## Test Plan

- `cd web/ios && xcodebuild test -scheme Omnigent -destination 'platform=iOS
  Simulator,name=iPhone 17 Pro' -only-testing:OmnigentTests` → all tests pass.
- New/updated unit tests: `WorkspaceChromeScriptTests` (CSS byte-identical to the
  desktop's `WORKSPACE_CHROME_HIDE_CSS`, the install-once guard, CSS embedded as
  an escaped literal); `WorkspaceMountURLTests` (bare roots on both workspace
  domains, query + fragment preserved, port and host-case, non-root paths left
  alone, `databricksapps.com` and a `databricks.com.evil.example` lookalike
  rejected, non-http schemes rejected); `ServerURLTests` (schemeless host → https
  even under the debug policy, loopback → http, explicit `http://` honoured).
- Manual, iPhone 17 Pro simulator against a real Databricks workspace: a bare
  workspace URL lands on `/omnigent` and the workspace nav bar is gone. Confirmed
  during development with a temporary in-app probe (since removed) reporting
  `styleTag:true, position:"fixed", rect:{y:0,h:874}` — the embed root covers the
  viewport from y=0 — and independently by the maintainer on the same simulator.
- `pre-commit run --files <touched files>` clean.

## Demo

Before:
<img width="1206" height="2622" alt="ios-workspace-chrome-BEFORE" src="https://github.com/user-attachments/assets/823f02f7-d54d-4d84-9314-636076433d58" />


After:

<img width="1206" height="2622" alt="ios-workspace-chrome-AFTER" src="https://github.com/user-attachments/assets/155e9b7f-2215-4afa-ba77-350d1ec5c717" />




## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The mount-URL rewriting, scheme defaulting and the injected script are
unit-tested. The navigation wiring is not: `OmnigentWebView.Coordinator` needs a
live `WKWebView` plus a SwiftUI context to construct, so the callbacks and the
overlay were verified on the simulator against a real workspace instead.

## Changelog

Connecting the iOS app to a Databricks workspace now opens Omnigent directly and
hides the workspace navigation bar

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>


