### PR TITLE
fix(sandbox): keep the previous host log across a relaunch

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -657,6 +657,35 @@ def supervise_host_command(command: str) -> str:
     )
 
 
+def rotate_host_log_command(log_path: str) -> str:
+    """
+    Keep the outgoing host log by moving it aside before a launch truncates it.
+
+    Every launch redirects with ``>``, which truncates. When the server
+    relaunches a host that is already unhealthy, that truncation lands *before*
+    the new attempt writes anything — so the previous host's log, including
+    whatever it said as it failed, is destroyed by the very attempt sent to
+    recover it. The launch that overwrote the evidence then reports only its own
+    error, and the original cause is unrecoverable.
+
+    Rotating to a single ``.prev`` generation keeps that last log while bounding
+    growth at two files, which matters because the log usually lives on a
+    RAM-backed ``/tmp``: an append-only log would charge unbounded memory
+    against the sandbox instead.
+
+    Always succeeds, so a caller may chain it with ``;`` ahead of the launch —
+    a missing log (first launch) is the normal case, not an error.
+
+    :param log_path: Log the launch is about to truncate, e.g.
+        ``"/tmp/omnigent-host.log"``.
+    :returns: A POSIX ``sh`` fragment ending in ``;``, safe to prefix to a
+        launch command.
+    """
+    quoted = shlex.quote(log_path)
+    prev = shlex.quote(f"{log_path}.prev")
+    return f"{{ [ -f {quoted} ] && mv -f {quoted} {prev}; }} 2>/dev/null || :;"
+
+
 class SandboxExecTransport(SandboxLifecycle):
     """
     Exec-transport primitives for providers that exec into a running sandbox.
@@ -701,6 +730,10 @@ class SandboxExecTransport(SandboxLifecycle):
         return (e.g. OpenShell) override this to hold the exec stream open
         instead — they supervise too, just without the detach.
 
+        The outgoing log is rotated to ``.prev`` first
+        (:func:`rotate_host_log_command`) so relaunching an unhealthy host does
+        not destroy the log explaining why it was unhealthy.
+
         :param sandbox_id: Target sandbox.
         :param command: Shell command to background, e.g.
             ``"ENV=val omnigent host --server https://…"``.
@@ -711,6 +744,7 @@ class SandboxExecTransport(SandboxLifecycle):
         """
         return self.run(
             sandbox_id,
+            f"{rotate_host_log_command(log_path)} "
             f"setsid nohup sh -c {shlex.quote(supervise_host_command(command))} "
             f"> {log_path} 2>&1 < /dev/null & echo launched",
         )

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -54,6 +54,7 @@ from omnigent.onboarding.sandboxes.base import (
     foreground_pidfile,
     foreground_record_prefix,
     host_image_wheel_install_command,
+    rotate_host_log_command,
     supervise_host_command,
 )
 from omnigent.onboarding.sandboxes.types import SandboxCapabilities
@@ -429,7 +430,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         supervisor along with the host, which no in-sandbox loop can survive.
         """
         script = supervise_host_command(command)
-        bg_command = f"{script} > {log_path} 2>&1 < /dev/null"
+        bg_command = f"{rotate_host_log_command(log_path)} {script} > {log_path} 2>&1 < /dev/null"
         self._openshell().exec_background(
             sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
         )

--- a/tests/onboarding/sandboxes/test_base.py
+++ b/tests/onboarding/sandboxes/test_base.py
@@ -24,6 +24,7 @@ from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
     SandboxLauncher,
     render_host_config_write_command,
+    rotate_host_log_command,
     supervise_host_command,
 )
 
@@ -77,12 +78,74 @@ def test_run_background_wraps_command_in_sh_c() -> None:
 
     [cmd] = launcher.commands
     assert cmd == (
+        f"{rotate_host_log_command('/tmp/omnigent-host.log')} "
         f"setsid nohup sh -c {shlex.quote(supervise_host_command(_HOST_LAUNCH))} "
         "> /tmp/omnigent-host.log 2>&1 < /dev/null & echo launched"
     )
     # The env prefix stays attached to the launch inside the quoted script, so
     # the inner shell re-applies it on every supervised restart attempt.
     assert _HOST_LAUNCH in cmd
+
+
+def test_rotate_host_log_command_keeps_the_previous_log(tmp_path: Path) -> None:
+    """
+    A relaunch must not destroy the log explaining why the last host died.
+
+    The launch redirects with ``>``, which truncates before the new attempt
+    writes anything. Relaunching an unhealthy host therefore erased the previous
+    host's log — including its failure — and the relaunch then reported only its
+    own error, leaving the original cause unrecoverable.
+
+    Regression: a managed host dropped its tunnel, the server relaunched it, and
+    the relaunch truncated the only record of the disconnect. The incident could
+    not be root-caused because the recovery attempt destroyed the evidence.
+    """
+    log = tmp_path / "omnigent-host.log"
+    log.write_text("the previous host's dying words\n")
+
+    # Rotate, then truncate exactly as run_background does.
+    subprocess.run(
+        f"{rotate_host_log_command(str(log))} printf 'new host\\n' > {shlex.quote(str(log))}",
+        shell=True,
+        check=True,
+    )
+
+    assert log.read_text() == "new host\n"
+    assert (tmp_path / "omnigent-host.log.prev").read_text() == (
+        "the previous host's dying words\n"
+    )
+
+
+def test_rotate_host_log_command_succeeds_on_the_first_launch(tmp_path: Path) -> None:
+    """
+    No log yet is the normal first-launch case, not an error.
+
+    The fragment is chained ahead of the launch, so a non-zero exit here would
+    be a spurious failure on every fresh sandbox.
+    """
+    missing = tmp_path / "absent.log"
+
+    result = subprocess.run(rotate_host_log_command(str(missing)) + " :", shell=True, check=False)
+
+    assert result.returncode == 0
+    assert not (tmp_path / "absent.log.prev").exists()
+
+
+def test_rotate_host_log_command_bounds_growth_at_one_generation(tmp_path: Path) -> None:
+    """
+    Rotation keeps one generation, never an unbounded chain.
+
+    The log usually lives on a RAM-backed ``/tmp``, so an append-only log (or a
+    growing ``.prev.prev…`` chain) would charge unbounded memory against the
+    sandbox it is meant to help debug.
+    """
+    log = tmp_path / "omnigent-host.log"
+    for generation in ("first", "second", "third"):
+        log.write_text(f"{generation}\n")
+        subprocess.run(rotate_host_log_command(str(log)) + " :", shell=True, check=True)
+
+    assert (tmp_path / "omnigent-host.log.prev").read_text() == "third\n"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["omnigent-host.log.prev"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

Closes #4561

## Summary

- Every host launch redirects with `>`, which truncates. When the server relaunches a host that is *already* unhealthy, that truncation lands **before** the new attempt writes anything — so the previous host's log, including whatever it said as it died, is destroyed by the very attempt sent to recover it. The relaunch then reports only its own error and the original cause is unrecoverable.
- This rotates the log to a single `.prev` generation before the redirect, so the outgoing log survives while growth stays bounded at two files.
- Applied to both launchers that redirect: the detached `setsid nohup` path in `base.py` and OpenShell's held-open exec stream.

ELI5: the launcher wipes the whiteboard before writing on it. If the last host wrote *why it died* on that whiteboard, the recovery attempt erases the answer before anyone reads it. Now we photograph the whiteboard first.

```
before:  [ host dies, logs cause ] -> relaunch truncates -> cause GONE
after:   [ host dies, logs cause ] -> rotate to .prev     -> cause KEPT
                                   -> relaunch truncates log
```

Why not the obvious alternatives:

- **`>>` (append)** — the log usually lives on a RAM-backed `/tmp`, so an append-only log charges unbounded memory against the sandbox it is meant to help debug. A crash-looping host would grow it fastest.
- **Numbered rotation** — same unbounded growth, in file count, for a log where one prior generation is what you actually read.

The fragment always exits 0, so it chains ahead of the launch with `;` — a missing log is the normal first-launch case, not an error.

## Test Plan

`uv run --extra dev pytest tests/onboarding/sandboxes/` → **357 passed**.
`ruff check` and `ruff format --check` → clean.

Three new tests in `tests/onboarding/sandboxes/test_base.py`, each running the generated fragment through a real shell rather than asserting on a string:

- `test_rotate_host_log_command_keeps_the_previous_log` — previous log survives a relaunch that truncates
- `test_rotate_host_log_command_succeeds_on_the_first_launch` — no existing log exits 0 and creates no `.prev`
- `test_rotate_host_log_command_bounds_growth_at_one_generation` — repeated rotation keeps exactly one generation, never a `.prev.prev…` chain

The existing `test_run_background_wraps_command_in_sh_c` assertion is updated, so removing the rotation from the launch path fails the suite.

## Demo

Non-visual (server-side launch path), so here is the behaviour as a runnable transcript rather than a screenshot. This is real output, not illustrative — the "before" line is exactly what `run_background` emits on `main` today, the "after" line is what this PR emits.

```console
$ ### BEFORE (main): relaunch truncates the log
--- log after the host failed ---
Connecting to https://server as host-abc
✗ tunnel lost: connection reset by peer
--- log after the relaunch ---
Error: A host daemon is already running (pid=77).
>>> the tunnel-lost cause is GONE

$ ### AFTER (this PR): rotate, then truncate
--- log after the host failed ---
Connecting to https://server as host-abc
✗ tunnel lost: connection reset by peer
--- log after the relaunch ---
Error: A host daemon is already running (pid=77).
--- omnigent-host.log.prev ---
Connecting to https://server as host-abc
✗ tunnel lost: connection reset by peer
>>> the tunnel-lost cause SURVIVED
```

The user-visible effect: after a failed relaunch, `cat /tmp/omnigent-host.log.prev` now answers "why did the host actually die?" — a question that had no answer before, because the recovery attempt had already erased it.

Reproduce it directly:

```sh
LOG=./omnigent-host.log
printf 'tunnel lost
' > "$LOG"
# main today:
sh -c "printf 'relaunch error
' > $LOG"; cat "$LOG"          # -> only "relaunch error"
# this PR:
printf 'tunnel lost
' > "$LOG"
sh -c "{ [ -f $LOG ] && mv -f $LOG $LOG.prev; } 2>/dev/null || :; printf 'relaunch error
' > $LOG"
cat "$LOG" "$LOG".prev                                          # -> both survive
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

A host relaunch no longer erases the previous host's log, so the reason a host failed survives the attempt to recover it.
