### PR TITLE
fix(kiro-native): wait out a slow kiro TUI boot before injecting

### DIFF
--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -42,6 +42,13 @@ _MCP_BRIDGE_CONFIG_FILE = "bridge.json"
 # (confirmed against kiro-cli 2.10.0). Mirrors cursor-native's ``.cursor/mcp.json``.
 _WORKSPACE_MCP_CONFIG_REL = Path(".kiro") / "settings" / "mcp.json"
 _TMUX_READY_TIMEOUT_S = 30.0
+# kiro's TUI shows "Initializing · type to queue a message" while it boots its
+# JS renderer; on a slow or degraded network that boot measured 35-38s, past the
+# 30s gate, so the first web turn failed on an otherwise healthy TUI. While that
+# banner is on the pane kiro is provably still coming up, so keep waiting up to
+# this longer ceiling instead of giving up at ``_TMUX_READY_TIMEOUT_S``.
+_KIRO_BOOT_READY_TIMEOUT_S = 120.0
+_KIRO_BOOT_MARKERS = ("Initializing",)
 _TMUX_SEND_TIMEOUT_S = 10.0
 _POLL_INTERVAL_S = 0.2
 _TYPE_SETTLE_S = 0.3
@@ -517,13 +524,45 @@ def _wait_for_kiro_input_ready(
     *,
     timeout_s: float,
 ) -> None:
-    """Wait until Kiro has rendered an input prompt before typing."""
+    """Wait until Kiro has rendered an input prompt before typing.
+
+    Extends the wait to :data:`_KIRO_BOOT_READY_TIMEOUT_S` while kiro's
+    "Initializing" banner is still on the pane, so a slow TUI boot delays the
+    first turn instead of failing it. A pane that is neither ready nor booting
+    still fails at *timeout_s*.
+    """
     deadline = time.monotonic() + timeout_s
+    boot_deadline = time.monotonic() + max(timeout_s, _KIRO_BOOT_READY_TIMEOUT_S)
+    pane = ""
     while time.monotonic() < deadline:
-        if _kiro_input_ready(_capture_pane(socket_path, tmux_target)):
+        pane = _capture_pane(socket_path, tmux_target)
+        if _kiro_input_ready(pane):
             return
+        if _kiro_still_booting(pane) and time.monotonic() < boot_deadline:
+            deadline = boot_deadline
         time.sleep(_POLL_INTERVAL_S)
-    raise RuntimeError("kiro-native TUI input prompt was not ready before injection")
+    # A kiro-cli that refused its own argv (e.g. an unsupported flag) leaves the
+    # error on the pane and never renders a prompt; quote it so the surfaced
+    # failure names the real cause instead of just the readiness timeout.
+    raise RuntimeError(
+        "kiro-native TUI input prompt was not ready before injection"
+        + (f"; kiro terminal showed: {detail}" if (detail := _kiro_pane_error(pane)) else "")
+    )
+
+
+def _kiro_still_booting(pane: str) -> bool:
+    """Return whether Kiro's input region shows it is still initializing."""
+    region = _kiro_input_region(pane)
+    return any(marker in region for marker in _KIRO_BOOT_MARKERS)
+
+
+def _kiro_pane_error(pane: str) -> str:
+    """Return the last error-looking line from the pane, or an empty string."""
+    for raw_line in reversed(pane.splitlines()):
+        line = raw_line.strip()
+        if line.lower().startswith(("error:", "warning: ", "thread '")):
+            return line[:200]
+    return ""
 
 
 def _paste_payload_bytes(text: str) -> bytes:

--- a/tests/test_kiro_native_bridge.py
+++ b/tests/test_kiro_native_bridge.py
@@ -577,3 +577,63 @@ def test_inject_model_command_raises_when_switch_not_confirmed(
 
     with pytest.raises(RuntimeError, match="did not confirm the model switch"):
         bridge.inject_model_command(bridge_dir, model="bogus-model", timeout_s=0.1)
+
+
+_BOOTING_PANE = "old output\n────────────────\n\n Initializing · type to queue a message"
+
+
+def test_inject_user_message_waits_out_a_slow_kiro_tui_boot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TUI still showing "Initializing" past ``timeout_s`` is waited out, not failed."""
+    monkeypatch.setattr(bridge, "_TYPE_COMMIT_TIMEOUT_S", 0.0)
+    bridge_dir = tmp_path / "bridge"
+    # Still booting when the caller's short deadline expires, ready just after.
+    _install_fake_tmux(
+        monkeypatch,
+        pane_outputs=[_BOOTING_PANE, _BOOTING_PANE, _BOOTING_PANE, _READY_PANE],
+    )
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/tmux.sock"),
+        tmux_target="main",
+    )
+
+    inject_user_message(bridge_dir, content="hello", timeout_s=0.1)
+
+
+def test_inject_user_message_fails_fast_when_pane_is_not_booting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pane that is neither ready nor booting still fails at ``timeout_s``."""
+    monkeypatch.setattr(bridge, "_KIRO_BOOT_READY_TIMEOUT_S", 600.0)
+    bridge_dir = tmp_path / "bridge"
+    _install_fake_tmux(monkeypatch, pane_outputs=["idle pane, no kiro prompt\n$ \n"])
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/tmux.sock"),
+        tmux_target="main",
+    )
+
+    with pytest.raises(RuntimeError, match="was not ready before injection"):
+        inject_user_message(bridge_dir, content="hello", timeout_s=0.1)
+
+
+def test_inject_user_message_surfaces_kiro_cli_argv_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kiro-cli that refused its argv never renders a prompt; quote its error."""
+    error_pane = "error: Conflicting options: --tui cannot be used with --agent-engine=v1.\n$ \n"
+    bridge_dir = tmp_path / "bridge"
+    _install_fake_tmux(monkeypatch, pane_outputs=[error_pane])
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/tmux.sock"),
+        tmux_target="main",
+    )
+
+    with pytest.raises(RuntimeError, match="Conflicting options"):
+        inject_user_message(bridge_dir, content="hello", timeout_s=0.1)


### PR DESCRIPTION
## Related issue

Closes #3011

## Summary

kiro-cli's **interactive** TUI runs a separate ~97 MB `bun` runtime plus a ~12 MB `tui.js` bundle, extracted and initialized on first interactive launch. `--no-interactive` is pure Rust and never touches them. That asymmetry is exactly the reported signature: one-shot prompts worked, interactive sessions never responded.

While that renderer boots, the pane shows `Initializing · type to queue a message`. Measured against **kiro-cli 2.13.0** (the reported version) on a degraded network, the boot took **35s / 36s / 38s** across three runs, past the bridge's **30 s** readiness gate. The gate then raised `input prompt was not ready before injection`, which `proxy_stream` catches and reports to the UI as `connection_error` / "Harness stream connection error." on a TUI that was healthy and became ready seconds later.

- **Wait out the boot.** While kiro's own `Initializing` banner is in the input region, extend the readiness deadline (120 s ceiling) instead of giving up at 30 s. A pane that is neither ready nor booting still fails at the caller's `timeout_s`, so a genuinely dead TUI fails exactly as fast as before.
- **Name the real cause on timeout.** Quote the pane's error line, so a kiro-cli that rejected its own argv surfaces *that* rather than only a readiness timeout.

<details>
<summary>ELI5 + flow</summary>

Omnigent types your message into a real kiro terminal. Before typing it waits for kiro to show its "ask a question" prompt, and it only waited 30 seconds. The interactive kiro unpacks a large JS runtime on first launch, which can take longer than that, so Omnigent gave up on a kiro that was still starting and showed a confusing connection error. Now it notices kiro is still saying "Initializing" and keeps waiting.

```mermaid
flowchart TD
    A[web message] --> B[inject_user_message]
    B --> C{pane shows ready marker?}
    C -->|yes| D[paste + Enter, kiro answers]
    C -->|no| E{pane shows Initializing?}
    E -->|"yes, still booting"| F["extend deadline<br/>(was: fail at 30s)"] --> C
    E -->|no| G["fail at timeout_s<br/>+ quote pane error line"]
```
</details>

## Test Plan

**Live A/B on kiro-cli 2.13.0**, the reported version (obtained via the version-pinned download path, `stable/2.13.0/kirocli-x86_64-linux-musl.tar.gz`; the install script only ever fetches `latest`). Slow boot induced with `unshare -rn`, launched in a real tmux PTY exactly as the bridge does:

```
pane state: " Initializing · type to queue a message"
MAIN   : FAILED after 30s -> kiro-native TUI input prompt was not ready before injection
BRANCH : ready at 0s -> proceeding to inject
BRANCH : inject OK
```

Then a full round trip with the network up, driving the real `inject_user_message`: injected `Reply with one word: PONG` and kiro replied **PONG**.

**Back-compat, verified rather than assumed.** The `Initializing` boot marker and the input region are byte-identical on **2.10.0** (the version the bridge's markers were captured from) and **2.13.0**: `_kiro_still_booting` returns `True`, `_kiro_input_ready` returns `False`. 2.10.0's slow boot reached ready at 20 s under the extended wait. The change reads pane text only and touches no launch argv, so nothing about launch changes for any version.

**Unit tests**

```bash
python -m pytest tests/test_kiro_native_bridge.py tests/test_kiro_native.py \
  tests/runner/test_app_sessions_native_terminals_autocreate.py -q
# 129 passed, 1 pre-existing failure
```

`test_resolve_kiro_executable_errors_when_missing` asserts `kiro-cli` is *absent* from `PATH`; it fails identically on stashed `main` in this environment (kiro-cli is installed locally), so it is environmental and unrelated.

`test_inject_user_message_waits_out_a_slow_kiro_tui_boot` is a genuine fail-then-pass guard: reverting just the two-line boot branch makes it fail, restoring it makes it pass.

Also confirmed `pyrefly check` reports **0 errors** on both changed files.

## Demo

N/A, no visual change. The user-visible effect is the absence of a spurious "Harness stream connection error."; the terminal transcript above is the observable behaviour.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two unit tests cover both directions of the new branch: a pane that is still booting past `timeout_s` is waited out, and a pane that is neither ready nor booting still fails at `timeout_s` (so the fix cannot mask a dead TUI). A third asserts the quoted pane error reaches the raised message.

The timing behaviour itself cannot be unit-tested honestly, since it depends on a real kiro-cli boot, so it was verified manually against live kiro-cli 2.13.0 and 2.10.0 as described in the Test Plan.

Two things worth a reviewer's judgment:

- **120 s ceiling** was chosen from measured 35-38 s boots with headroom, and applies *only* while kiro is provably still initializing. Capping it lower (e.g. 60 s) is a one-constant change if preferred.
- **`Initializing` is an upstream string.** If kiro renames that banner the wait silently reverts to the old 30 s behaviour, a regression to today's bug rather than a new failure mode. It sits beside the existing `_KIRO_INPUT_READY_MARKERS`, which already carry the same coupling.

I could not reproduce the reporter's exact "exit 1, no output" variant on their auth path (they use AWS IAM Identity Center; this was verified with a GitHub login). A crashed kiro was simulated with a corrupted runtime: in that case tmux reaps the server and the bridge already reports `kiro terminal is no longer running (the TUI exited)` correctly, so no change was needed there.

## Changelog

kiro sessions no longer fail the first message with a connection error when the kiro TUI is slow to start
