### PR TITLE
fix(host): silent-endpoint backoff, slow-boot adoption, zygote respawn

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -330,6 +330,13 @@ _RECONNECT_JITTER = 0.5
 # process listens on the port — the local server is gone, not unreachable.
 _LOOPBACK_REFUSED_FATAL_ATTEMPTS = 30
 
+# Consecutive accepted-then-silent connections (upgrade completed, then the
+# socket died without one inbound frame) before the reconnect loop treats the
+# endpoint as unhealthy: it stops using the prompt "recycle" cadence and
+# escalates once, loudly. A healthy tunnel sends a frame within seconds; an
+# endpoint that accepts and never speaks is functionally down.
+_SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
+
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
 # user, so its environment holds the user's personal secrets (API keys,
@@ -794,6 +801,13 @@ class HostProcess:
         # upgrade or any non-refused error. Fatal past a bounded streak only
         # when the server URL is loopback (the local server is gone).
         self._refused_streak = 0
+        # Consecutive connections that were accepted but died without a single
+        # inbound frame; reset by any received frame or a rejected upgrade.
+        # Past a bound the reconnect loop escalates instead of fast-recycling.
+        self._silent_connect_streak = 0
+        # Per-connection markers feeding the silent-connect streak.
+        self._conn_upgrade_accepted = False
+        self._conn_frame_received = False
         # Live tunnel connection, set by _serve_frames for the watcher
         # tasks (which outlive any single connection) to report on.
         self._ws: websockets.asyncio.client.ClientConnection | None = None
@@ -1363,8 +1377,10 @@ class HostProcess:
         When the zygote is enabled it forks the runner there — sharing the import
         graph copy-on-write — and rewrites ``RUNNER_PARENT_PID`` to the zygote's
         pid so the runner's orphan watchdog (which compares ``os.getppid()``)
-        stays correct across the extra process hop. Any zygote failure disables
-        it for the rest of the daemon's life and falls back to a direct Popen.
+        stays correct across the extra process hop. A zygote start failure, or a
+        channel failure while the zygote is still alive, disables it for the
+        daemon's life; a zygote that died is reaped so the next launch respawns
+        a fresh one. Either way this launch falls back to a direct Popen.
 
         :param env: Runner environment from :func:`_build_runner_env` (its
             ``RUNNER_PARENT_PID`` is the daemon pid; overridden on the zygote path).
@@ -1381,29 +1397,58 @@ class HostProcess:
             if zygote is not None and not self._zygote_disabled:
                 try:
                     zygote.start()
-                    # The runner's OS parent will be the zygote, so its
-                    # getppid()-based orphan check must watch the zygote pid.
-                    zygote_env = dict(env)
-                    zygote_env[RUNNER_PARENT_PID_ENV_VAR] = str(zygote.pid)
-                    proc = zygote.fork_runner(zygote_env, str(log_path), str(workspace))
-                    _logger.info(
-                        "Forked runner via zygote (zygote pid=%s, runner pid=%s)",
-                        zygote.pid,
-                        proc.pid,
-                    )
-                    return proc, log_path
                 except ZygoteUnavailable as exc:
-                    # Disable the zygote for FUTURE launches, but do NOT stop it
-                    # here: healthy runners already forked from it would see
-                    # their parent die and self-terminate via the orphan
-                    # watchdog, so one failed fork must not tear down unrelated
-                    # live sessions. The still-running zygote is retained and
-                    # reaped on daemon shutdown (see run()'s finally); this
-                    # launch falls back to a direct Popen below.
+                    # Spawning the zygote itself is broken; retrying on every
+                    # launch would only add a doomed spawn to each, so disable
+                    # it for the daemon's life and fall back.
                     _logger.warning(
-                        "Runner zygote unavailable (%s); falling back to direct spawn", exc
+                        "Runner zygote failed to start (%s); disabling it and "
+                        "falling back to direct spawn",
+                        exc,
                     )
                     self._zygote_disabled = True
+                else:
+                    try:
+                        # The runner's OS parent will be the zygote, so its
+                        # getppid()-based orphan check must watch the zygote pid.
+                        zygote_env = dict(env)
+                        zygote_env[RUNNER_PARENT_PID_ENV_VAR] = str(zygote.pid)
+                        proc = zygote.fork_runner(zygote_env, str(log_path), str(workspace))
+                        _logger.info(
+                            "Forked runner via zygote (zygote pid=%s, runner pid=%s)",
+                            zygote.pid,
+                            proc.pid,
+                        )
+                        return proc, log_path
+                    except ZygoteUnavailable as exc:
+                        if zygote.is_running():
+                            # Alive but its control channel failed. Do NOT stop
+                            # it: healthy runners already forked from it would
+                            # see their parent die and self-terminate via the
+                            # orphan watchdog. Disable for future launches; the
+                            # still-running zygote is reaped on daemon shutdown
+                            # (see run()'s finally).
+                            _logger.warning(
+                                "Runner zygote unavailable (%s); disabling it "
+                                "and falling back to direct spawn",
+                                exc,
+                            )
+                            self._zygote_disabled = True
+                        else:
+                            # The zygote process died — its forked runners are
+                            # already self-terminating via their own orphan
+                            # watchdogs, so nothing depends on this instance.
+                            # Reap it and let the next launch's start() respawn
+                            # a fresh one instead of losing copy-on-write
+                            # forking for the rest of the daemon's life.
+                            _logger.warning(
+                                "Runner zygote died (%s); falling back to "
+                                "direct spawn and respawning the zygote on "
+                                "the next launch",
+                                exc,
+                            )
+                            with contextlib.suppress(Exception):
+                                zygote.stop()
 
             with child_logging_popen_kwargs(env) as logging_kwargs:
                 proc = subprocess.Popen(
@@ -2476,6 +2521,34 @@ class HostProcess:
                             ) from exc
                     else:
                         self._refused_streak = 0
+                    # An accepted upgrade that died without one inbound frame
+                    # is an endpoint that answers the door but never speaks —
+                    # functionally down even though every connect "succeeds",
+                    # so the recycle classification below would spin at the
+                    # prompt cadence forever, silently. Escalate once past a
+                    # streak; any received frame resets it.
+                    if self._conn_upgrade_accepted and not self._conn_frame_received:
+                        self._silent_connect_streak += 1
+                        if self._silent_connect_streak == _SILENT_CONNECT_ESCALATE_ATTEMPTS:
+                            cause = (
+                                f"The server at {self._server_url} accepted "
+                                f"{self._silent_connect_streak} consecutive "
+                                "connections but never responded on any of them."
+                            )
+                            _logger.error(
+                                "%s Treating the endpoint as unhealthy; "
+                                "reconnecting on slow backoff until it responds.",
+                                cause,
+                            )
+                            print(
+                                f"⚠ {cause} The server may be unhealthy. "
+                                "Retrying on a slower cadence — this recovers "
+                                "automatically once the server responds.",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                    else:
+                        self._silent_connect_streak = 0
                     # Classify the disconnect to choose a reconnect cadence.
                     #
                     # 1012 "service restart" / 1001 "going away" are explicit
@@ -2502,9 +2575,13 @@ class HostProcess:
                         t in reason for t in ("1012", "service restart", "1001", "going away")
                     )
                     ingress_recycle = any(t in reason for t in ("no close frame", "502"))
-                    recycle = explicit_recycle or (
-                        ingress_recycle and not _url_is_loopback(self._server_url)
-                    )
+                    # A silent-connect streak overrides the recycle fast path:
+                    # prompt reconnects are for endpoints that answer.
+                    silent_churn = self._silent_connect_streak >= _SILENT_CONNECT_ESCALATE_ATTEMPTS
+                    recycle = (
+                        explicit_recycle
+                        or (ingress_recycle and not _url_is_loopback(self._server_url))
+                    ) and not silent_churn
                     wait_s = _RECONNECT_BASE_S if recycle else backoff
                     _logger.warning(
                         "Host tunnel disconnected: %s. Reconnecting in %.1fs%s",
@@ -2525,9 +2602,18 @@ class HostProcess:
         except (KeyboardInterrupt, asyncio.CancelledError):
             pass
         finally:
+            # Await the cancellations: a bare cancel() leaves the tasks
+            # pending at loop close ("Task was destroyed but it is pending!").
             if self._reaper_task is not None:
                 self._reaper_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._reaper_task
                 self._reaper_task = None
+            for watcher in list(self._watcher_tasks):
+                watcher.cancel()
+            for watcher in list(self._watcher_tasks):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await watcher
             self._cleanup_runners()
             # Final drain: _cleanup_runners has just reaped the tracked
             # runners via Popen, so any of their still-orphaned tool
@@ -2562,6 +2648,9 @@ class HostProcess:
         :returns: None.
         :raises Exception: On WebSocket disconnect or error.
         """
+        # Fresh per-connection markers for the silent-connect streak.
+        self._conn_upgrade_accepted = False
+        self._conn_frame_received = False
         url = self._tunnel_url()
         headers = self._build_connect_headers()
 
@@ -2599,6 +2688,7 @@ class HostProcess:
         self._login_redirect_streak = 0
         self._auth_retry_streak = 0
         self._refused_streak = 0
+        self._conn_upgrade_accepted = True
         try:
             await self._serve_frames(ws)
         finally:
@@ -2761,6 +2851,9 @@ class HostProcess:
         try:
             while True:
                 raw = await ws.recv()
+                # Any inbound frame proves the server end is alive — the
+                # reconnect loop's silent-connect streak keys off this.
+                self._conn_frame_received = True
                 if isinstance(raw, str):
                     await self._handle_raw_message(ws, raw)
         finally:

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -17,6 +17,7 @@ importing ``cli.py`` to keep that dependency direction clean.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import subprocess
 import sys
@@ -36,7 +37,15 @@ from omnigent.process_logging import (
     open_process_log_file,
 )
 
+_logger = logging.getLogger(__name__)
+
 _LOCAL_SERVER_READY_TIMEOUT_SECONDS = 45.0
+
+# Hard cap on waiting for a server that outlived the ready timeout with its
+# process still alive. A first boot (cold imports + DB migrations) has taken
+# ~40s in the wild; adopting a slow boot beats failing a server that is
+# seconds from healthy — and then leaking it.
+_LOCAL_SERVER_BOOT_CEILING_SECONDS = 120.0
 
 # Max seconds to wait for a bind-race-doomed server child's natural
 # EADDRINUSE exit before the terminate backstop. Matches the readiness
@@ -848,8 +857,16 @@ def _wait_for_local_omnigent_server(
     proc: subprocess.Popen[bytes],
     log_path: Path,
     timeout: float = _LOCAL_SERVER_READY_TIMEOUT_SECONDS,
+    boot_ceiling: float = _LOCAL_SERVER_BOOT_CEILING_SECONDS,
 ) -> None:
     """Poll the background local server's ``/health`` until ready.
+
+    A server that outlives *timeout* with its process still alive is treated
+    as a slow boot and adopted by waiting up to *boot_ceiling* total, instead
+    of failing a server that is seconds from healthy. On final failure the
+    spawned child is stopped before raising — a raise here must never leave a
+    running server behind that nothing tracks anymore (the failure path
+    clears the pidfile record).
 
     :param base_url: Loopback server URL, e.g. ``"http://127.0.0.1:8123"``.
     :param proc: The server subprocess; early exit is detected via
@@ -857,7 +874,8 @@ def _wait_for_local_omnigent_server(
     :param log_path: Captured stdout/stderr log surfaced on failure so the
         underlying traceback (spec parse error, port clash, import failure)
         is visible.
-    :param timeout: Max seconds to wait for readiness.
+    :param timeout: Seconds to wait before considering the boot slow.
+    :param boot_ceiling: Cap on the total wait for a slow-but-alive boot.
     :raises click.ClickException: If the server exits or never answers.
     """
     import time
@@ -865,9 +883,20 @@ def _wait_for_local_omnigent_server(
     import httpx
 
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    ceiling = time.monotonic() + max(timeout, boot_ceiling)
+    slow_boot_logged = False
+    while time.monotonic() < ceiling:
         if proc.poll() is not None:
             _raise_local_server_failed(base_url, log_path)
+        if not slow_boot_logged and time.monotonic() >= deadline:
+            slow_boot_logged = True
+            _logger.info(
+                "Local server (pid %d) not ready after %.0fs but still "
+                "running — likely a slow boot; waiting up to %.0fs total",
+                proc.pid,
+                timeout,
+                max(timeout, boot_ceiling),
+            )
         try:
             resp = httpx.get(f"{base_url}/health", timeout=2.0, trust_env=False)
             if resp.status_code == 200:
@@ -880,6 +909,17 @@ def _wait_for_local_omnigent_server(
             # rather than crash on.
             pass
         time.sleep(0.2)
+    # The child never became healthy: stop it before reporting failure so the
+    # raise does not strand a running, untracked server. Popen-reap it too —
+    # this process spawned it, so an unreaped kill would leave a zombie.
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_STOP_GRACE_S)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5.0)
     _raise_local_server_failed(base_url, log_path)
 
 

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import logging
 import os
@@ -333,6 +334,16 @@ def terminal_log_formatter() -> logging.Formatter:
     return TerminalLogFormatter(use_colors=terminal_supports_color())
 
 
+def _unlink_if_empty(path: Path) -> None:
+    """Remove *path* if it is still an empty file.
+
+    :param path: Log file to sweep, e.g. a self-allocated host log.
+    """
+    with contextlib.suppress(OSError):
+        if path.stat().st_size == 0:
+            path.unlink()
+
+
 def configure_process_logging(
     destination: str,
     *,
@@ -354,6 +365,11 @@ def configure_process_logging(
     path = Path(log_path).expanduser() if log_path is not None else _process_log_file_from_env()
     if path is None:
         path = create_process_log_path(destination)
+        # A process that dies before its first record would leave this
+        # freshly created file empty forever (crash-at-birth hosts littered
+        # dozens a day); sweep it on exit. Self-allocated paths only — a
+        # parent-published or explicit path is the caller's to manage.
+        atexit.register(_unlink_if_empty, path)
     path.parent.mkdir(parents=True, exist_ok=True)
     _current_process_log_path = path
 

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -54,6 +54,7 @@ from omnigent.host.frames import (
     decode_host_frame,
 )
 from omnigent.host.identity import HostIdentity
+from omnigent.host.runner_zygote import ZygoteUnavailable
 from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
@@ -3133,12 +3134,24 @@ class _HandshakeFailingConnect:
 
 
 class _DroppedTunnel:
-    """Fake accepted tunnel whose receive loop drops immediately.
+    """Fake accepted tunnel that drops after *frames_before_drop* frames.
 
     Lets ``_serve_frames`` send the ``host.hello`` frame (proving the
-    upgrade was accepted), then fails the first ``recv()`` like an
-    abruptly closed connection, returning control to the reconnect loop.
+    upgrade was accepted), serves the scripted number of inbound frames
+    (undecodable junk the dispatcher ignores), then fails ``recv()`` like
+    an abruptly closed connection, returning control to the reconnect
+    loop.
+
+    :param frames_before_drop: Inbound frames to deliver before dropping;
+        ``0`` (the default) models an accepted-but-silent connection.
     """
+
+    def __init__(self, frames_before_drop: int = 0) -> None:
+        """Store the inbound-frame script.
+
+        :param frames_before_drop: Frames to serve before dropping.
+        """
+        self._frames_left = frames_before_drop
 
     async def send(self, data: str | bytes) -> None:
         """Accept any outbound frame (the ``host.hello``) silently.
@@ -3148,11 +3161,14 @@ class _DroppedTunnel:
         """
 
     async def recv(self) -> str:
-        """Fail like a connection that closed without a close frame.
+        """Serve scripted frames, then fail like an abrupt close.
 
-        :returns: Never returns — always raises.
-        :raises ConnectionClosedError: Always, with no close frames.
+        :returns: An undecodable frame while any are scripted.
+        :raises ConnectionClosedError: Once the script is exhausted.
         """
+        if self._frames_left > 0:
+            self._frames_left -= 1
+            return "not-a-decodable-frame"
         raise ConnectionClosedError(None, None)
 
 
@@ -3160,16 +3176,26 @@ class _AcceptingConnect:
     """Async-CM stand-in for a *successful* WS upgrade.
 
     ``__aenter__`` hands back a :class:`_DroppedTunnel`, so the host
-    marks the connection authenticated and then immediately loses it —
-    the minimal scripted "connected once" event.
+    marks the connection authenticated and then loses it after the
+    scripted number of inbound frames — the minimal "connected once"
+    event, silent by default.
+
+    :param frames_before_drop: Passed through to :class:`_DroppedTunnel`.
     """
 
+    def __init__(self, frames_before_drop: int = 0) -> None:
+        """Store the tunnel's inbound-frame script.
+
+        :param frames_before_drop: Frames the tunnel serves before dropping.
+        """
+        self._frames_before_drop = frames_before_drop
+
     async def __aenter__(self) -> _DroppedTunnel:
-        """Complete the handshake with a tunnel that drops on first recv.
+        """Complete the handshake with a tunnel that later drops.
 
         :returns: A :class:`_DroppedTunnel`.
         """
-        return _DroppedTunnel()
+        return _DroppedTunnel(self._frames_before_drop)
 
     async def __aexit__(self, *exc_info: object) -> bool:
         """No-op async-CM exit.
@@ -3186,20 +3212,22 @@ class _ConnectSpy:
 
     An exception entry fails that handshake; a ``None`` entry accepts it
     with a tunnel that drops on first ``recv()`` (so the reconnect loop
-    regains control). The last queued entry repeats for any further
-    calls, so a single fatal exception covers the "fails on first
-    attempt" case and a ``[transient, CancelledError]`` pair covers
-    "retried once, then stop".
+    regains control); an int entry accepts it with a tunnel that serves
+    that many inbound frames before dropping. The last queued entry
+    repeats for any further calls, so a single fatal exception covers
+    the "fails on first attempt" case and a ``[transient,
+    CancelledError]`` pair covers "retried once, then stop".
 
     :param exceptions: Per-call handshake script, e.g.
         ``[None, InvalidStatus(resp_503), asyncio.CancelledError()]``.
     """
 
-    def __init__(self, exceptions: list[BaseException | None]) -> None:
+    def __init__(self, exceptions: list[BaseException | int | None]) -> None:
         """Initialize the spy with a handshake script.
 
-        :param exceptions: Exception to raise (or ``None`` to accept) on
-            each successive call; the final entry repeats.
+        :param exceptions: Exception to raise (``None`` or an int frame
+            count to accept) on each successive call; the final entry
+            repeats.
         """
         self._exceptions = exceptions
         self.call_count = 0
@@ -3215,8 +3243,8 @@ class _ConnectSpy:
         """
         exc = self._exceptions[min(self.call_count, len(self._exceptions) - 1)]
         self.call_count += 1
-        if exc is None:
-            return _AcceptingConnect()
+        if exc is None or isinstance(exc, int):
+            return _AcceptingConnect(exc or 0)
         return _HandshakeFailingConnect(exc)
 
 
@@ -3909,3 +3937,213 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     while time.monotonic() < deadline and spawned[0].poll() is None:
         await asyncio.sleep(0.05)
     assert spawned[0].poll() is not None, "abandoned runner was leaked, still alive"
+
+
+async def test_silent_connect_streak_escalates_and_slows_reconnects(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Accepted-but-silent connections escalate past a bounded streak.
+
+    An endpoint that accepts the upgrade and never sends a frame used to
+    classify every drop as a benign ingress recycle and hammer it at the
+    prompt cadence forever (observed: ~6s cycles for 7 hours, silently).
+    Past the streak the host must log ONE error, warn the terminal once,
+    and drop to normal backoff.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
+    # Five accepted-silent connections (threshold 3), then stop.
+    spy = _ConnectSpy([None, None, None, None, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, "must escalate exactly once per episode"
+    assert "3 consecutive connections but never responded" in errors[0].message
+    # The terminal notice reached stderr exactly once.
+    assert capsys.readouterr().err.count("never responded") == 1
+    # Cadence flip: below the threshold the drops ride the recycle fast
+    # path; at/after it they must not.
+    reconnects = [r.message for r in caplog.records if "Reconnecting in" in r.message]
+    assert len(reconnects) == 5
+    assert "(recycle — prompt reconnect)" in reconnects[1]
+    assert "(recycle — prompt reconnect)" not in reconnects[-1]
+
+
+async def test_inbound_frame_resets_silent_connect_streak(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One received frame proves the endpoint alive and resets the streak.
+
+    Only CONSECUTIVE silent connections may escalate — a healthy
+    connection in between (any inbound frame, even one the dispatcher
+    ignores) restarts the count, so ordinary recycles never trip it.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
+    # 2 silent, one frame-serving (resets), 2 silent: never 3 in a row.
+    spy = _ConnectSpy([None, None, 1, None, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    assert host._silent_connect_streak == 2
+    assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+
+class _FakeZygote:
+    """Scripted ZygoteManager stand-in for the spawn-fallback tests.
+
+    :param fail_at: ``"start"`` or ``"fork"`` — which call raises
+        :class:`ZygoteUnavailable`.
+    :param running: What ``is_running()`` reports after the failure.
+    """
+
+    def __init__(self, *, fail_at: str, running: bool) -> None:
+        """Store the failure script.
+
+        :param fail_at: Which call raises.
+        :param running: Post-failure ``is_running()`` answer.
+        """
+        self._fail_at = fail_at
+        self._running = running
+        self.stop_calls = 0
+
+    @property
+    def pid(self) -> int:
+        """A fixed fake zygote pid."""
+        return 4242
+
+    def is_running(self) -> bool:
+        """Report the scripted liveness."""
+        return self._running
+
+    def start(self) -> None:
+        """Raise when scripted to fail at start."""
+        if self._fail_at == "start":
+            raise ZygoteUnavailable("scripted start failure")
+
+    def fork_runner(self, env: dict[str, str], log_path: str, workspace: str) -> object:
+        """Always raise — the fork channel is scripted broken."""
+        del env, log_path, workspace
+        raise ZygoteUnavailable("scripted fork failure")
+
+    def stop(self) -> None:
+        """Record the reap."""
+        self.stop_calls += 1
+
+
+class _FakeSpawnedProc:
+    """Minimal Popen stand-in for the direct-spawn fallback."""
+
+    pid = 31337
+
+    def poll(self) -> int | None:
+        """Report the fake runner still running."""
+        return None
+
+
+def _spawn_with_fake_zygote(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    zygote: _FakeZygote,
+) -> tuple[HostProcess, list[list[str]]]:
+    """Drive ``_spawn_runner_proc`` with *zygote* and a stubbed direct Popen.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :param tmp_path: Holds the fake runner log file.
+    :param zygote: The scripted zygote installed on the host.
+    :returns: The host and the argv of every direct ``Popen`` call.
+    """
+    host = _make_host_process()
+    host._zygote = zygote  # type: ignore[assignment]
+    host._zygote_disabled = False
+    popen_argvs: list[list[str]] = []
+    log_path = tmp_path / "runner.log"
+
+    def _fake_open_log(
+        destination: str,
+        *,
+        root: object = None,
+        prefix: str | None = None,
+    ) -> tuple[Path, object]:
+        del destination, root, prefix
+        return log_path, open(log_path, "ab", buffering=0)
+
+    def _fake_popen(argv: list[str], **kwargs: object) -> _FakeSpawnedProc:
+        del kwargs
+        popen_argvs.append(list(argv))
+        return _FakeSpawnedProc()
+
+    monkeypatch.setattr("omnigent.host.connect.open_process_log_file", _fake_open_log)
+    monkeypatch.setattr("omnigent.host.connect.subprocess.Popen", _fake_popen)
+    host._spawn_runner_proc({}, "slug", tmp_path)
+    return host, popen_argvs
+
+
+def test_dead_zygote_is_reaped_and_respawnable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A zygote that died mid-life must not disable forking forever.
+
+    Its forked runners self-terminate via their orphan watchdogs the
+    moment it dies, so nothing depends on the dead instance — reap it
+    and leave the zygote enabled so the next launch's ``start()``
+    respawns a fresh one, instead of losing copy-on-write forking for
+    the rest of the daemon's life.
+    """
+    zygote = _FakeZygote(fail_at="fork", running=False)
+
+    host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
+
+    assert host._zygote_disabled is False
+    assert zygote.stop_calls == 1
+    # This launch still succeeded, via the direct-spawn fallback.
+    assert len(popen_argvs) == 1
+
+
+def test_alive_zygote_with_broken_channel_is_disabled_not_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An alive zygote with a broken channel is disabled but never stopped.
+
+    Stopping it would orphan the healthy runners already forked from it
+    (their parent-death watchdogs would self-terminate live sessions).
+    """
+    zygote = _FakeZygote(fail_at="fork", running=True)
+
+    host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
+
+    assert host._zygote_disabled is True
+    assert zygote.stop_calls == 0
+    assert len(popen_argvs) == 1
+
+
+def test_zygote_start_failure_disables_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A zygote that cannot start is disabled — retrying every launch is waste."""
+    zygote = _FakeZygote(fail_at="start", running=False)
+
+    host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
+
+    assert host._zygote_disabled is True
+    assert zygote.stop_calls == 0
+    assert len(popen_argvs) == 1

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import click
+import httpx
 import pytest
 
 from omnigent.host import local_server
@@ -1124,3 +1125,135 @@ def test_ensure_does_not_advertise_pidfile_before_ownership_confirmed(
     assert result.url == "http://127.0.0.1:6767"
     # Once confirmed, the record IS advertised for reuse/discovery.
     assert pid_file.read_text() == "9001\n6767\n"
+
+
+def test_wait_adopts_a_slow_boot_while_the_process_is_alive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A server that outlives the ready timeout but is still booting is adopted.
+
+    A first boot (cold imports + DB migrations) has taken ~40s in the
+    wild — past the ready timeout. While the child process is alive the
+    wait must extend to the boot ceiling instead of failing a server
+    that is seconds from healthy (and then leaking it).
+    """
+
+    class _Proc:
+        pid = 4321
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    class _Resp:
+        status_code = 200
+
+    calls = {"n": 0}
+
+    def _fake_get(url: str, *, timeout: float, trust_env: bool) -> _Resp:
+        del url, timeout, trust_env
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("not ready yet")
+        return _Resp()
+
+    monkeypatch.setattr("httpx.get", _fake_get)
+
+    local_server._wait_for_local_omnigent_server(
+        "http://127.0.0.1:8123",
+        _Proc(),
+        tmp_path / "server.log",
+        timeout=0.05,
+        boot_ceiling=30.0,
+    )
+
+    assert calls["n"] == 3
+
+
+def test_wait_stops_the_spawned_server_when_the_boot_ceiling_expires(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exhausting the wait stops our own child before raising.
+
+    Raising while the spawned server keeps running leaves a healthy but
+    untracked orphan (the failure path clears the pidfile record) — the
+    exact leak behind background servers accumulating on a dev box.
+    """
+
+    class _Proc:
+        pid = 4321
+
+        def __init__(self) -> None:
+            self.terminated = False
+            self.killed = False
+            self._exited = False
+
+        def poll(self) -> int | None:
+            return 0 if self._exited else None
+
+        def terminate(self) -> None:
+            self.terminated = True
+            self._exited = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            del timeout
+            return 0
+
+    def _fake_get(url: str, *, timeout: float, trust_env: bool) -> None:
+        del url, timeout, trust_env
+        raise httpx.ConnectError("never ready")
+
+    monkeypatch.setattr("httpx.get", _fake_get)
+    monkeypatch.setattr(local_server, "_LOCAL_SERVER_PID_PATH", tmp_path / "local_server.pid")
+    monkeypatch.setattr(local_server, "_LOCAL_SERVER_SIG_PATH", tmp_path / "local_server.sig")
+    proc = _Proc()
+
+    with pytest.raises(click.ClickException):
+        local_server._wait_for_local_omnigent_server(
+            "http://127.0.0.1:8123",
+            proc,
+            tmp_path / "server.log",
+            timeout=0.05,
+            boot_ceiling=0.3,
+        )
+
+    assert proc.terminated is True
+    assert proc.killed is False
+
+
+def test_wait_fails_fast_without_stopping_a_child_that_already_died(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A dead child fails immediately; there is nothing left to stop."""
+
+    class _Proc:
+        pid = 4321
+        terminated = False
+
+        @staticmethod
+        def poll() -> int:
+            return 1
+
+        def terminate(self) -> None:
+            type(self).terminated = True
+
+    monkeypatch.setattr(local_server, "_LOCAL_SERVER_PID_PATH", tmp_path / "local_server.pid")
+    monkeypatch.setattr(local_server, "_LOCAL_SERVER_SIG_PATH", tmp_path / "local_server.sig")
+    proc = _Proc()
+
+    with pytest.raises(click.ClickException):
+        local_server._wait_for_local_omnigent_server(
+            "http://127.0.0.1:8123",
+            proc,
+            tmp_path / "server.log",
+            timeout=5.0,
+            boot_ceiling=5.0,
+        )
+
+    assert proc.terminated is False

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -18,6 +18,7 @@ from omnigent.process_logging import (
     LOG_TTY_FD_ENV_VAR,
     PROCESS_LOG_FILE_ENV_VAR,
     TerminalLogFormatter,
+    _unlink_if_empty,
     child_logging_popen_kwargs,
     configure_process_logging,
     current_process_log_path,
@@ -239,6 +240,62 @@ def test_configure_process_logging_publishes_its_log_path(
     )
     try:
         assert current_process_log_path() == log_path
+    finally:
+        logger = logging.getLogger(logger_name)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+
+
+def test_unlink_if_empty_sweeps_only_empty_files(tmp_path: Path) -> None:
+    """The exit sweep removes an empty log, keeps a written one, tolerates absence."""
+    empty = tmp_path / "empty.log"
+    empty.touch()
+    written = tmp_path / "written.log"
+    written.write_text("one line\n")
+
+    _unlink_if_empty(empty)
+    _unlink_if_empty(written)
+    _unlink_if_empty(tmp_path / "missing.log")
+
+    assert not empty.exists()
+    assert written.exists()
+
+
+def test_configure_registers_the_empty_log_sweep_for_self_allocated_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only a self-allocated log path gets the exit sweep.
+
+    A crash before the first record used to leave a fresh empty log
+    behind on every start (dozens a day for crash-at-birth hosts). A
+    parent-published (env) or explicit ``log_path`` is the caller's to
+    manage, so no hook is registered for those.
+    """
+    registered: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        "omnigent.process_logging.atexit.register",
+        lambda fn, *args: registered.append((fn, *args)),
+    )
+    monkeypatch.setattr("omnigent.process_logging._current_process_log_path", None)
+    monkeypatch.delenv(PROCESS_LOG_FILE_ENV_VAR, raising=False)
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(tmp_path))
+    logger_name = "omnigent.test_empty_log_sweep"
+
+    path = configure_process_logging("host", logger_names=(logger_name,), root=False)
+    try:
+        assert registered == [(_unlink_if_empty, path)]
+
+        registered.clear()
+        explicit = configure_process_logging(
+            "host",
+            log_path=tmp_path / "explicit.log",
+            logger_names=(logger_name,),
+            root=False,
+        )
+        assert registered == []
+        assert explicit == tmp_path / "explicit.log"
     finally:
         logger = logging.getLogger(logger_name)
         for handler in list(logger.handlers):


### PR DESCRIPTION
## Related issue

N/A — follow-ups from a host-log forensics pass over `~/.omnigent/logs/host` (106 files, Jul 28 → Aug 10) that identified four host↔server / host↔runner failure modes. Fixed together, prioritized by observed impact.

## Summary

- **Bound the accept-then-silent churn loop** (`host/connect.py`). One host spent **7 hours reconnecting every ~6s** (3,550 rounds, a 128k-line log) to an endpoint that *accepted* every WebSocket upgrade and then never sent a single frame. Because each upgrade succeeded, every drop classified as a benign ingress recycle → prompt 0.5s reconnects forever, at WARN level, with no operator signal. Now the host tracks consecutive accepted-but-silent connections (no inbound frame before the drop); past `_SILENT_CONNECT_ESCALATE_ATTEMPTS = 10` it logs one ERROR, prints one terminal notice, and drops to normal backoff until a frame gets through. No exit — remote endpoints recover and the host may carry live runners; any received frame resets the streak. This is the remote-side sibling of #4544 (which bounded *refused-on-loopback*; nothing bounded *accepted-but-dead*).
- **Adopt slow local-server boots; never strand the child** (`host/local_server.py`). The readiness wait gave up at 45s and the failure path cleared the pidfile **without stopping the just-spawned server** — a boot observed at ~39s (first-start DB migrations) produced a misleading "failed to start" *and* a healthy, untracked orphan. Now: while the child is alive the wait extends to a 120s boot ceiling (the observed slow boot was seconds from healthy); if it still never answers, the child is terminated and reaped *before* raising. Scoped strictly to the process this call spawned — deliberately no scanning or killing by name, since dev boxes legitimately run many intentional `omnigent server` processes.
- **Respawn a dead runner zygote** (`host/connect.py`). Any zygote failure latched `_zygote_disabled` for the daemon's life, so one broken pipe silently cost copy-on-write runner forking forever. The three regimes are now distinguished: start failure ⇒ disable (retrying every launch is waste); alive-but-broken channel ⇒ disable **without stopping it** (stopping would orphan healthy runners forked from it); **zygote process died ⇒ reap it and stay enabled**, so the next launch's `start()` respawns a fresh one (a dead zygote's children were already self-terminating via their orphan watchdogs — nothing depends on the corpse).
- **Hygiene**: self-allocated process logs that never receive a record are swept at exit (crash-at-birth hosts littered 59 empty log files in one day); host shutdown now cancels *and awaits* the orphan-reaper and runner-watcher tasks (the "Task was destroyed but it is pending!" teardown noise).

Investigated and dropped: early-runner-stderr crosstalk into host logs — on current main both spawn paths already point the child's stdout/stderr at the runner's own log; the observed crosstalk came from older builds.

ELI5: one fix stops the host from redialing every half-second, forever, a server that picks up the phone but never says a word (now it complains once and slows down); one stops `omnigent host` from declaring a slow-booting helper server dead and walking away while it's still running (now it waits, and if it truly gives up, it turns the server off first); one repairs the runner "fast-start template" after it crashes instead of quietly making every later start slow; and the last one cleans up small messes at shutdown (empty log files, half-abandoned background chores).

```
accept-then-silent churn, before → after:

connect ✓ → hello → silence → drop ~6s → retry 0.5s → … (forever, silent)
connect ✓ → hello → silence → drop  ×10 → ERROR + one terminal notice
    → retry on 10s backoff → first inbound frame → back to normal
```

## Test Plan

```
python -m pytest tests/host/test_connect.py -q        # 117 passed (112 pre-existing + 5 new)
python -m pytest tests/host/test_local_server.py -q   # 32 passed (29 + 3 new)
python -m pytest tests/test_process_logging.py -q     # 11 passed (9 + 2 new)
```

- `test_silent_connect_streak_escalates_and_slows_reconnects` — five accepted-silent drops against a threshold of 3: exactly one ERROR, one stderr notice, and the reconnect cadence leaves the recycle fast path at the threshold.
- `test_inbound_frame_resets_silent_connect_streak` — a frame-serving connection between silent ones resets the count; no escalation.
- `test_wait_adopts_a_slow_boot_while_the_process_is_alive`, `test_wait_stops_the_spawned_server_when_the_boot_ceiling_expires`, `test_wait_fails_fast_without_stopping_a_child_that_already_died` — adoption past the ready timeout, terminate-before-raise at the ceiling, and dead-child fail-fast.
- `test_dead_zygote_is_reaped_and_respawnable`, `test_alive_zygote_with_broken_channel_is_disabled_not_stopped`, `test_zygote_start_failure_disables_it` — the three zygote-failure regimes.
- `test_unlink_if_empty_sweeps_only_empty_files`, `test_configure_registers_the_empty_log_sweep_for_self_allocated_paths` — the sweep fires only for logs this process allocated itself.

## Demo

N/A — non-visual (host process lifecycle and logging).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The shutdown-await change (cancel *and await* reaper/watcher tasks) has no dedicated test — it is exercised by every existing `run()`-driving reconnect test, and the tasks involved were already tracked; the change only awaits their cancellation.

## Changelog

`omnigent host` now warns once and backs off when a server accepts connections but never responds, waits out (up to 120s) a slow-booting local server instead of stranding it — stopping it if it truly fails — recovers fast runner starts after a zygote crash, and no longer leaves empty log files behind.
