### PR TITLE
fix(stores): resolve a session-scoped agent to its spawn-tree root (OMNI-1611)

### DIFF
--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -69,20 +69,34 @@ class SqlAlchemyAgentStore(AgentStore):
 
     def _session_id_for_agent(self, agent_id: str) -> str | None:
         """
-        Reverse-lookup the conversation bound to a session-scoped agent.
+        Resolve a session-scoped agent to a conversation in its spawn tree.
 
-        ``conversations.agent_id`` is the sole link (the agent row carries no
-        back-pointer), and the ``conversations`` table lives in the AP DB — so
-        this must run on the conversation engine, not the Omnigent engine that
-        owns the ``agents`` table.
+        The returned id backs the owning-session authorization in
+        ``validate_session_agent``: the caller must have READ on the agent's
+        session, so no one can run another user's private agent by guessing its
+        raw id. Access is resolved at the spawn-tree ROOT —
+        ``check_session_access`` walks ``parent_conversation_id`` up to the root
+        and grants on the root's ACL — so any conversation in the tree
+        authorizes identically.
+
+        That is what makes this a single bounded query. Named ``sys_session_send``
+        children are created bound to the *same* ``agent_id`` as their mint, so
+        several conversation rows can share it — but they all carry the SAME
+        ``root_conversation_id`` (children inherit their parent's root, and the
+        mint's own root when it is itself a child). So selecting the root from
+        *any one* of them (an unordered ``LIMIT 1``) is unambiguous and O(1):
+        there is no "wrong row" to return. It also sidesteps read-replica lag —
+        the root is the oldest node in the tree, never a just-written child that
+        a replica has not caught up to. ``conversations`` lives on the AP DB, so
+        this runs on the conversation engine.
 
         :param agent_id: Agent identifier, e.g. ``"ag_abc123"``.
-        :returns: Owning conversation id, or ``None`` when no
-            conversation points at this agent.
+        :returns: The agent's spawn-tree root conversation id, or ``None`` when
+            no conversation points at this agent.
         """
         with self._conv_session("select_session_id_for_agent") as conv_sess:
             return conv_sess.execute(
-                select(SqlConversation.id)
+                select(SqlConversation.root_conversation_id)
                 .where(
                     SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.agent_id == agent_id,

--- a/tests/server/integration/test_sessions_subagent_context.py
+++ b/tests/server/integration/test_sessions_subagent_context.py
@@ -22,16 +22,32 @@ no runner bound, no LLM):
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
+import pytest_asyncio
+from fastapi import FastAPI
 
-from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.entities.conversation import (
+    Conversation,
+    MessageData,
+    NewConversationItem,
+)
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
-from tests.server.helpers import create_test_agent
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+from tests.server.conftest import ControllableMockClient
+from tests.server.helpers import build_agent_bundle, create_test_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -283,3 +299,304 @@ async def test_child_sessions_lists_only_direct_children(
     # chain is intact rather than the grandchild being orphaned.
     assert grandchild["id"] in child_ids
     assert root["id"] not in child_ids
+
+
+# ── Named sub-agent sends from a bundled agent (OMNI-1611) ────
+#
+# End-user journey: someone uploads an agent bundle, which creates a
+# session-scoped agent plus the session it was minted for, and that agent
+# then delegates work with named ``sys_session_send`` calls. Each named send
+# is a ``POST /v1/sessions`` carrying the parent's ``agent_id``, its
+# ``parent_session_id``, and the declared ``sub_agent_name``.
+#
+# The reported failure: the first named send succeeded and every later one
+# returned ``404 {"code": "not_found", "message": "Conversation not found"}``.
+#
+# Two production conditions are required, so the tests below reproduce both
+# rather than asserting on internals:
+#
+# 1. **Auth is on.** ``validate_session_agent`` authorizes the caller against
+#    the agent's owning session. With no permission store that check returns
+#    immediately, which is why this never reproduced on a default local server.
+# 2. **The auth read lags.** Named children are bound to the *same* agent_id
+#    as their mint, so the reverse lookup can pick a just-written child row;
+#    on a deployment whose reads go to a replica, that row is not visible yet
+#    and the lookup's caller reads it as "conversation gone" -> 404.
+#
+# ``_ReplicaLagConversationStore`` models condition 2 by hiding specific
+# freshly-written rows from reads, the same way a replica that has not caught
+# up does. Nothing about the failure is simulated: the request, the auth path
+# and the 404 are all real.
+
+
+_OWNER = "alice@example.com"
+
+# A pinned, low-sorting id for the first named child. The pre-fix lookup was an
+# unordered ``LIMIT 1`` served by ``ix_conversations_agent_id``
+# (workspace_id, agent_id, id), so it effectively returned the lowest id among
+# the rows sharing the agent_id. Pinning one child below the mint's random uuid
+# makes the pre-fix path deterministically pick the child; left to chance it
+# picks the mint about half the time, which is exactly why the production
+# symptom looked intermittent.
+_LAGGING_CHILD_ID = "00000000000000000000000000000001"
+
+
+class _ReplicaLagConversationStore(SqlAlchemyConversationStore):
+    """Conversation store whose reads model a lagging read replica.
+
+    Ids added to :attr:`not_yet_replicated` read as missing, standing in for
+    rows the primary has written but the replica has not received yet.
+    """
+
+    def __init__(self, uri: str) -> None:
+        super().__init__(uri)
+        self.not_yet_replicated: set[str] = set()
+
+    def get_conversation(self, conversation_id: str) -> Conversation | None:
+        """Return the conversation unless it is still awaiting replication."""
+        if conversation_id in self.not_yet_replicated:
+            return None
+        return super().get_conversation(conversation_id)
+
+
+@pytest.fixture()
+def replica_lag_store(db_uri: str) -> _ReplicaLagConversationStore:
+    """:returns: A conversation store that can hide un-replicated rows."""
+    return _ReplicaLagConversationStore(db_uri)
+
+
+@pytest.fixture()
+def replica_lag_app(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    replica_lag_store: _ReplicaLagConversationStore,
+) -> FastAPI:
+    """App with auth enabled and reads served by the lagging store.
+
+    Auth must be on for the owning-session check in
+    ``validate_session_agent`` to run at all.
+    """
+    from omnigent.server.auth import UnifiedAuthProvider
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=replica_lag_store,
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+
+@pytest_asyncio.fixture()
+async def replica_lag_client(
+    replica_lag_app: FastAPI,
+    mock_llm: ControllableMockClient,
+    tmp_path: Path,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """:returns: HTTP client wired to the auth-enabled, lagging-read app."""
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+
+    transport = httpx.ASGITransport(app=replica_lag_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+async def _upload_bundled_agent_session(
+    client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    sub_agents: list[str],
+) -> tuple[str, str]:
+    """Upload a bundle, creating a session-scoped agent and its mint session.
+
+    :param client: The test HTTP client.
+    :param headers: Caller identity headers.
+    :param sub_agents: Names the bundle declares, e.g. ``["worker_a"]``.
+    :returns: ``(mint_session_id, agent_id)``.
+    """
+    bundle = build_agent_bundle(
+        name="orchestrator",
+        sub_agents=[{"name": name} for name in sub_agents],
+    )
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=headers,
+    )
+    assert resp.status_code == 201, f"bundle upload failed: {resp.text}"
+    mint_id = str(resp.json()["session_id"])
+    agent_resp = await client.get(f"/v1/sessions/{mint_id}/agent", headers=headers)
+    assert agent_resp.status_code == 200, agent_resp.text
+    return mint_id, str(agent_resp.json()["id"])
+
+
+async def _named_send(
+    client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    agent_id: str,
+    parent_session_id: str,
+    sub_agent_name: str,
+    title: str,
+) -> httpx.Response:
+    """Issue the create a named ``sys_session_send`` performs.
+
+    :returns: The raw response so the caller can assert on the status.
+    """
+    return await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent_id,
+            "parent_session_id": parent_session_id,
+            "sub_agent_name": sub_agent_name,
+            "title": title,
+        },
+        headers=headers,
+    )
+
+
+async def test_later_named_sends_survive_unreplicated_sibling_rows(
+    replica_lag_client: httpx.AsyncClient,
+    replica_lag_store: _ReplicaLagConversationStore,
+) -> None:
+    """A bundled agent can keep delegating after its first sub-agent session.
+
+    Reproduces OMNI-1611. Named children share the mint's ``agent_id``, so the
+    agent's owning-session lookup could return a just-written child instead of
+    the mint. While that child is still absent from the read replica, the
+    owning-session authorization reads it as missing and the user's second
+    delegation fails with ``404 Conversation not found`` -- even though they
+    own every session involved.
+    """
+    headers = {"X-Forwarded-Email": _OWNER}
+    mint_id, agent_id = await _upload_bundled_agent_session(
+        replica_lag_client,
+        headers=headers,
+        sub_agents=["worker_a", "worker_b"],
+    )
+
+    # First delegation: this always worked, and still must.
+    first = await _named_send(
+        replica_lag_client,
+        headers=headers,
+        agent_id=agent_id,
+        parent_session_id=mint_id,
+        sub_agent_name="worker_a",
+        title="worker_a:task-one",
+    )
+    assert first.status_code == 201, f"first named send failed: {first.text}"
+
+    # A sibling sub-agent row bound to the same agent, pinned low so the
+    # pre-fix lookup selects it over the mint (see _LAGGING_CHILD_ID).
+    sibling = replica_lag_store.create_conversation(
+        kind="sub_agent",
+        title="worker_a:task-zero",
+        parent_conversation_id=mint_id,
+        agent_id=agent_id,
+        sub_agent_name="worker_a",
+        conversation_id=_LAGGING_CHILD_ID,
+    )
+    # Every child of the mint belongs to the same spawn tree, which is what
+    # makes resolving the agent to that tree's root safe.
+    assert sibling.root_conversation_id == mint_id
+
+    # Those freshly-written child rows have not reached the replica yet. The
+    # mint is older and already replicated.
+    replica_lag_store.not_yet_replicated.update({sibling.id, str(first.json()["id"])})
+
+    # Second delegation: the user-visible regression.
+    second = await _named_send(
+        replica_lag_client,
+        headers=headers,
+        agent_id=agent_id,
+        parent_session_id=mint_id,
+        sub_agent_name="worker_b",
+        title="worker_b:task-two",
+    )
+    assert second.status_code == 201, (
+        f"second named send from a bundled agent returned {second.status_code}: {second.text}"
+    )
+    body = second.json()
+    assert body["parent_session_id"] == mint_id
+    assert body["sub_agent_name"] == "worker_b"
+
+
+async def test_bundled_agent_uploaded_as_child_stays_private(
+    replica_lag_client: httpx.AsyncClient,
+) -> None:
+    """Someone else cannot run a bundled agent they have no access to.
+
+    A bundle can be uploaded *into* an existing session, so the resulting
+    session-scoped agent is minted on a conversation that already has a
+    parent. ``validate_session_agent`` only enforces the owning-session check
+    when it can resolve which session owns the agent; if that resolution comes
+    back empty the check is skipped and anyone who learns the raw agent id can
+    bind a session to it. This asserts the outsider is turned away, which is
+    the user-facing shape of that gap.
+    """
+    owner_headers = {"X-Forwarded-Email": _OWNER}
+    outsider_headers = {"X-Forwarded-Email": "mallory@example.com"}
+
+    # The owner's existing session, then a bundle uploaded into it.
+    parent_id, _ = await _upload_bundled_agent_session(
+        replica_lag_client,
+        headers=owner_headers,
+        sub_agents=["worker_a"],
+    )
+    bundle = build_agent_bundle(
+        name="nested-orchestrator",
+        sub_agents=[{"name": "worker_a"}],
+    )
+    nested = await replica_lag_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"parent_session_id": parent_id})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=owner_headers,
+    )
+    assert nested.status_code == 201, f"nested bundle upload failed: {nested.text}"
+    nested_id = str(nested.json()["session_id"])
+    agent_resp = await replica_lag_client.get(
+        f"/v1/sessions/{nested_id}/agent", headers=owner_headers
+    )
+    assert agent_resp.status_code == 200, agent_resp.text
+    nested_agent_id = str(agent_resp.json()["id"])
+
+    # The owner can still delegate with it.
+    owner_send = await _named_send(
+        replica_lag_client,
+        headers=owner_headers,
+        agent_id=nested_agent_id,
+        parent_session_id=nested_id,
+        sub_agent_name="worker_a",
+        title="worker_a:owner-task",
+    )
+    assert owner_send.status_code == 201, f"owner named send failed: {owner_send.text}"
+
+    # Someone with no access to any of it must not be able to bind to the
+    # agent by id. 404 rather than 403 so the agent's existence stays hidden.
+    intruder = await replica_lag_client.post(
+        "/v1/sessions",
+        json={"agent_id": nested_agent_id},
+        headers=outsider_headers,
+    )
+    assert intruder.status_code == 404, (
+        "an outsider bound a session to a private bundled agent: "
+        f"{intruder.status_code} {intruder.text}"
+    )

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.utils import get_or_create_engine
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
 
 
 def test_create_and_get(agent_store: SqlAlchemyAgentStore) -> None:
@@ -317,3 +322,184 @@ def test_delete_nonexistent_returns_false(agent_store: SqlAlchemyAgentStore) -> 
     """delete returns False for an ID that was never created."""
     result = agent_store.delete("5996d55aa263c10a717e2ee631f46409")
     assert result is False
+
+
+# ── Session-scoped agent → spawn-tree root resolution ──────────────
+#
+# Regression for OMNI-1611. Named ``sys_session_send`` children are created
+# bound to the *same* agent_id as their mint, so several conversation rows share
+# it. ``get()`` resolves ``agent.session_id`` to the agent's spawn-tree ROOT,
+# which backs the owning-session auth check in ``validate_session_agent``
+# (``check_session_access`` grants on the root's ACL). Every row sharing the
+# agent_id carries the same ``root_conversation_id``, so the lookup is a single
+# bounded query and returns the same root regardless of which row it reads — no
+# "wrong row" to return, and never ``None`` for a session-scoped agent.
+
+
+def _add_named_child(
+    conversation_store: SqlAlchemyConversationStore,
+    *,
+    agent_id: str,
+    parent_conversation_id: str,
+    sub_agent_name: str,
+) -> str:
+    """Create a named sub-agent child bound to the parent's agent_id.
+
+    Mirrors the production named-``sys_session_send`` create, which passes
+    ``agent_id=<parent agent>`` and a non-null ``sub_agent_name``.
+
+    :returns: The new child conversation id.
+    """
+    child = conversation_store.create_conversation(
+        kind="sub_agent",
+        title=f"{sub_agent_name}:child",
+        parent_conversation_id=parent_conversation_id,
+        agent_id=agent_id,
+        sub_agent_name=sub_agent_name,
+    )
+    return child.id
+
+
+def test_session_scoped_agent_resolves_to_root_top_level(
+    agent_store: SqlAlchemyAgentStore,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A top-level-minted agent resolves to its own conversation, not a child.
+
+    Guards the original unordered ``LIMIT 1`` bug: after named children share
+    the agent_id, the reverse lookup must still return the owning session. For a
+    top-level mint the spawn-tree root IS the mint conversation.
+    """
+    created = conversation_store.create_session_with_agent(
+        agent_id="a0000000000000000000000000000001",
+        agent_name="orchestrator-top",
+        agent_bundle_location="ag_orchestrator_top/bundle",
+        agent_description=None,
+        title="orchestrator",
+    )
+    mint_id = created.conversation.id
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_a",
+    )
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_b",
+    )
+
+    fetched = agent_store.get(created.agent.id)
+    assert fetched is not None
+    assert fetched.session_id == mint_id  # top-level mint == its own root
+    # update() shares the same reverse lookup; it must resolve identically.
+    updated = agent_store.update(created.agent.id, "ag_orchestrator_top/bundle2")
+    assert updated is not None
+    assert updated.session_id == mint_id
+
+
+def test_session_scoped_agent_resolves_to_root_child_minted(
+    agent_store: SqlAlchemyAgentStore,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A child-minted agent resolves to its spawn-tree root, never ``None``.
+
+    This is the case the reverted ``parent_conversation_id IS NULL`` filter got
+    wrong: a bundle uploaded as a child has a mint whose own
+    ``parent_conversation_id`` is non-null, so that filter matched nothing and
+    returned ``None`` — which would skip the owning-session auth check. Resolving
+    the shared spawn-tree root returns a real, always-visible ancestor instead.
+    """
+    parent = conversation_store.create_conversation(
+        kind="default",
+        title="uploader-parent",
+    )
+    created = conversation_store.create_session_with_agent(
+        agent_id="a0000000000000000000000000000002",
+        agent_name="orchestrator-child",
+        agent_bundle_location="ag_orchestrator_child/bundle",
+        agent_description=None,
+        title="child-minted orchestrator",
+        parent_conversation_id=parent.id,
+    )
+    mint_id = created.conversation.id
+    # The mint itself is a child (non-null parent), so parent-nullness could not
+    # find it; its spawn-tree root is the uploader parent (top-level == own root).
+    mint_conv = conversation_store.get_conversation(mint_id)
+    assert mint_conv is not None
+    assert mint_conv.parent_conversation_id == parent.id
+    assert mint_conv.root_conversation_id == parent.id
+
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_a",
+    )
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_b",
+    )
+
+    fetched = agent_store.get(created.agent.id)
+    assert fetched is not None
+    assert fetched.session_id is not None  # the #4501 regression: must not be None
+    assert fetched.session_id == parent.id  # the shared spawn-tree root
+
+
+def test_session_scoped_agent_without_children_resolves_to_root(
+    agent_store: SqlAlchemyAgentStore,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The common case — no named children — resolves to the mint (its own root)."""
+    created = conversation_store.create_session_with_agent(
+        agent_id="a0000000000000000000000000000003",
+        agent_name="solo-agent",
+        agent_bundle_location="ag_solo/bundle",
+        agent_description=None,
+        title="solo",
+    )
+    fetched = agent_store.get(created.agent.id)
+    assert fetched is not None
+    assert fetched.session_id == created.conversation.id
+
+
+def test_session_scoped_agent_resolves_to_root_split_db(tmp_path: Path) -> None:
+    """Split-DB: the lookup resolves the root when conversations live in the AP DB.
+
+    ``conversations`` (agent_id + root_conversation_id) is on the AP DB while the
+    agent row is on the Omnigent DB; the reverse lookup must target the AP engine.
+    """
+    omnigent_uri = f"sqlite:///{tmp_path}/omnigent.db"
+    conv_uri = f"sqlite:///{tmp_path}/conversations.db"
+    conversation_store = SqlAlchemyConversationStore(omnigent_uri, conv_uri)
+
+    created = conversation_store.create_session_with_agent(
+        agent_id="a0000000000000000000000000000004",
+        agent_name="orchestrator-split",
+        agent_bundle_location="ag_orchestrator_split/bundle",
+        agent_description=None,
+        title="split orchestrator",
+    )
+    mint_id = created.conversation.id
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_a",
+    )
+    _add_named_child(
+        conversation_store,
+        agent_id=created.agent.id,
+        parent_conversation_id=mint_id,
+        sub_agent_name="worker_b",
+    )
+
+    agent_store = SqlAlchemyAgentStore(omnigent_uri, conv_uri)
+    fetched = agent_store.get(created.agent.id)
+    assert fetched is not None
+    assert fetched.session_id == mint_id


### PR DESCRIPTION
## Related issue

Closes #2539

(That issue was auto-closed by #4501, which was reverted in #4503 — so the bug is live on `main` again. This is the corrected fix.)

## Summary

The 2nd and later named `sys_session_send(agent, title)` from a **session-scoped (bundled)** agent returns `404 "Conversation not found"` in production.

- **Root cause:** `SqlAlchemyAgentStore._session_id_for_agent()` did an unordered `LIMIT 1` over `conversations WHERE agent_id=:id` and returned a conversation **id**. Named children are created bound to the *same* `agent_id` as their mint (`orchestration.py`, `create_conversation(agent_id=agent.id, …)`), so once child #1 exists the query can return a child's id. The one consumer, `validate_session_agent`, then runs `require_access(child_id, READ)` against a row not yet visible on the read replica → 404.
- **Fix (one line + docstring):** select **`root_conversation_id`** instead of `id`.

Every conversation sharing a session-scoped agent's `agent_id` — the mint **and** all its named children — carries the **same** `root_conversation_id` (children inherit their parent's root; a child-minted agent's mint inherits the uploader-parent's root). So an unordered `LIMIT 1` is now unambiguous and **O(1)**: there is no "wrong row" to return.

```
sys_session_send(agent="worker_a") → child #1 (agent_id A, root R)
sys_session_send(agent="worker_b") → _session_id_for_agent(A):
    SELECT root_conversation_id WHERE agent_id=A LIMIT 1  →  R   (any row → same R)
    require_access(R, READ)  →  resolves on R's ACL, always visible
```

**Why the root is the right thing to authorize on.** `check_session_access` already walks `parent_conversation_id` up to the spawn-tree root and grants on the **root's** ACL (permissions live only on top-level sessions; children inherit). So authorizing on the root is identical in effect to authorizing on the mint. The auth check itself is unchanged and still load-bearing — it is never replaced by the caller-supplied `parent_session_id`, which the caller controls independently of `agent_id`. For a top-level agent the root **is** the mint, so the common case is byte-identical to today.

**Also fixes the reverted attempt's regression.** #4501 filtered `parent_conversation_id IS NULL`, which returned `None` for a **child-minted** agent (a bundle uploaded as a child of another session, via multipart `POST /v1/sessions` with `parent_session_id`) — and a `None` `session_id` makes `validate_session_agent` skip the READ check entirely. Resolving the shared root is correct for child-minted agents too.

**Cost:** a single indexed seek on `ix_conversations_agent_id` (`workspace_id, agent_id, id`) returning one row — no unbounded scan, no cross-database metadata read, no migration.

## Test Plan

Added to the existing `tests/stores/test_agent_store.py`, using real store APIs:

1. **Top-level mint** — mint + 2 named children sharing the agent_id; resolves to the mint (== its own root). Also asserts `update()` resolves identically.
2. **Child-minted mint** — bundle minted under a parent session; resolves to the shared spawn-tree root and is **non-None** (the exact #4501 regression).
3. **No children** — resolves to the mint.
4. **Split-DB** — same, with `conversations` in a separate AP database.

Verified as genuine guards by patching the source back to each broken implementation:
- original unordered `LIMIT 1` on `.id` → child-minted + split-DB tests **fail**;
- #4501's `parent_conversation_id IS NULL` → child-minted test **fails** (returns `None`).

Local runs (all green):
- `tests/stores/test_agent_store.py` — **25 passed**
- `tests/stores/test_conversation_store.py` + `test_conversation_store_split_db.py` + `tests/server/integration/test_sessions_subagent_context.py` + `test_sessions_add_agent.py` — **217 passed, 1 xfailed**
- 4 targeted tests re-run after rebasing onto latest `main` — **4 passed**
- `ruff-format` + `ruff-check` clean on both changed files

## Demo

N/A — backend-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: each of the four tests was run against both prior broken implementations (the original unordered `LIMIT 1`, and the reverted `parent_conversation_id IS NULL` filter) to confirm it actually fails there, then against this change to confirm it passes — so they are real regression guards rather than tautologies. The store method feeds both `AgentStore.get()` and `AgentStore.update()`, so both call sites are covered by the single change.

## Changelog

Named `sys_session_send` no longer returns a spurious 404 on the second and later sub-agent sends from a bundled agent
