### PR TITLE
fix(web): delete sessions optimistically so the row leaves the sidebar at once

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_delete.py
+++ b/tests/e2e_ui/sessions/test_sidebar_delete.py
@@ -2,17 +2,26 @@
 
 The row kebab's "Delete" item opens a confirmation dialog; confirming it
 fires the stop→``DELETE /v1/sessions/{id}`` chain
-(``useStopAndDeleteConversation``). Delete is fire-and-forget: the dialog
-closes immediately, the row shows a transient "Deleting…" status, then
-drops out of the list, and if the deleted session is the active one the
-SPA bounces back to ``/``.
+(``useStopAndDeleteConversation``), and if the deleted session is the
+active one the SPA bounces back to ``/``.
 
-This asserts both halves of a real delete:
+Delete is *optimistic*: the row is spliced out of every cached list in
+``onMutate``, so it leaves the sidebar on the next frame rather than
+after the stop + DELETE round trip (which carries runner teardown,
+worktree cleanup, and managed-sandbox teardown behind it). There is
+deliberately no in-flight placeholder — the row unmounts outright.
 
-  - The row is removed from the sidebar (client list converges).
+This asserts three things:
+
+  - The row is removed from the sidebar, with no "Deleting…" placeholder
+    standing in for it (the pre-optimistic behavior, which kept the row
+    on screen for the whole round trip).
   - The session is gone from the conversation store —
     ``GET /v1/sessions/{id}`` returns 404 — so the removal is durable,
     not just a cache splice the next refetch would resurrect.
+  - A *failed* delete puts the row back and reports via a toast. That
+    rollback is only reachable because the row left before the server
+    answered, so it is the load-bearing proof that delete is optimistic.
 
 The runner-kill half of "delete stops its runner" isn't asserted here:
 the e2e harness binds a tunneled, non-host runner, and the stop forwarded
@@ -23,16 +32,34 @@ store-removal contract above is the part observable in this harness.
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 
 import httpx
-from playwright.sync_api import Locator, Page, expect
+from playwright.sync_api import Locator, Page, Route, expect
 
 
 def _row(page: Page, session_id: str) -> Locator:
     """Locate the sidebar row (``<li>``) for *session_id* by its href."""
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _confirm_delete(page: Page, row: Locator) -> None:
+    """Open *row*'s kebab and confirm the delete dialog.
+
+    Hovers first so the desktop hover-revealed kebab trigger is
+    interactable.
+
+    :param page: Playwright page.
+    :param row: The sidebar ``<li>`` to delete.
+    """
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("delete-conversation").click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    dialog.get_by_role("button", name="Delete", exact=True).click()
 
 
 def test_delete_session_removes_row_and_from_store(
@@ -65,26 +92,22 @@ def test_delete_session_removes_row_and_from_store(
     row = _row(page, session_id)
     expect(row).to_be_visible()
 
-    # Open the kebab → Delete → confirm in the dialog. Hover first so the
-    # desktop hover-revealed kebab trigger is interactable.
-    row.hover()
-    row.get_by_test_id("conversation-actions").click()
-    page.get_by_test_id("delete-conversation").click()
-    dialog = page.get_by_role("dialog")
-    expect(dialog).to_be_visible()
-    dialog.get_by_role("button", name="Delete", exact=True).click()
+    _confirm_delete(page, row)
 
-    # The row drops out of the sidebar: it first swaps to a transient
-    # "Deleting…" status (no href) while the stop→DELETE chain is in
-    # flight, then unmounts entirely on success.
-    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    # The row unmounts outright — no placeholder stands in for it. Assert
+    # the whole <li> is gone, not just its href: the pre-optimistic code
+    # kept the <li> and swapped its contents for a "Deleting…" status,
+    # which would satisfy an href-only check while the row was still
+    # visibly occupying the sidebar.
+    expect(row).to_have_count(0)
+    expect(page.get_by_test_id("conversation-deleting")).to_have_count(0)
 
     # And the deletion is durable: the conversation is gone from the
-    # store, not just spliced from the client cache. The href vanishes
-    # the moment the mutation starts (the "Deleting…" state), and the
-    # mutation runs ``stopSession`` ahead of the DELETE, so the
-    # server-side row removal lands slightly after the UI does — poll
-    # until ``GET /v1/sessions/{id}`` reports 404.
+    # store, not just spliced from the client cache. The row leaves the
+    # sidebar the moment the mutation starts, and the mutation runs
+    # ``stopSession`` ahead of the DELETE, so the server-side row removal
+    # lands well after the UI does — poll until ``GET /v1/sessions/{id}``
+    # reports 404.
     deadline = time.monotonic() + 15.0
     last_status = None
     while time.monotonic() < deadline:
@@ -95,3 +118,67 @@ def test_delete_session_removes_row_and_from_store(
     assert last_status == 404, (
         f"deleted session should be gone from the store (404), got {last_status}"
     )
+
+
+def test_failed_delete_restores_row_and_warns(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A failed delete puts the row back and surfaces a toast.
+
+    This is the load-bearing test for delete being optimistic: the row
+    can only come *back* if it had already left before the server
+    answered. It also covers the failure path the removed inline
+    error/retry row used to own — once the row is spliced out it
+    unmounts, taking any in-row error state with it, so the toast is the
+    only signal the user gets.
+
+    Failure modes this catches:
+
+    - The optimistic splice is never rolled back, so a delete that
+      failed still looks like it succeeded and the session silently
+      reappears on the next reload.
+    - The rollback restores the list but drops the user's only notice
+      that anything went wrong.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-delete-fail-{uuid.uuid4().hex[:8]}"
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Fail the DELETE (and only the DELETE — the stop that precedes it,
+    # and every unrelated session request, must still reach the server).
+    def _fail_delete(route: Route) -> None:
+        if route.request.method == "DELETE":
+            route.fulfill(status=500, content_type="application/json", body='{"detail":"boom"}')
+        else:
+            route.continue_()
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _fail_delete)
+
+    _confirm_delete(page, row)
+
+    # Rolled back: the row is in the sidebar again...
+    expect(row).to_be_visible()
+    # ...and the user is told, naming the session so a failure is
+    # attributable when several deletes are in flight.
+    toast = page.get_by_test_id("toast")
+    expect(toast).to_be_visible()
+    expect(toast).to_contain_text("back in the sidebar")
+    expect(toast).to_contain_text(title)
+
+    # The session really is still there — the rollback reflects reality
+    # rather than just repainting a row the server had already dropped.
+    assert httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0).status_code == 200

--- a/tests/e2e_ui/sessions/test_sidebar_delete_pinned.py
+++ b/tests/e2e_ui/sessions/test_sidebar_delete_pinned.py
@@ -92,12 +92,11 @@ def test_delete_pinned_session_clears_it_from_pinned_section(
 
     # This was the only pinned session, so once the delete patches the pinned
     # cache the whole "Pinned" section unmounts. Assert on the SECTION, not the
-    # row's href: while the delete is in flight the row swaps to a "Deleting…"
-    # status row that has no href, so an href-count assertion flickers to 0
-    # during that transient and would pass even against the buggy build (the
-    # href reappears a beat later when the stale pinned cache re-renders the
-    # row). The section only disappears when the pinned cache is truly empty —
-    # the DeletingRow keeps it mounted — so it can't be fooled by the transient.
+    # row's href: the optimistic splice drops the row from the list caches
+    # immediately, so an href-count assertion goes to 0 even against a build
+    # that forgets the pinned cache (the href reappears a beat later when the
+    # stale pinned cache re-renders the row). The section only disappears when
+    # the pinned cache is truly empty, so it can't be fooled by that window.
     #
     # In place, no reload: a reload refetches ?pinned=true and converges the
     # section on its own, hiding the bug. A tight 3s timeout (vs the suite's

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -28,6 +28,7 @@ import {
   useStopSession,
   useTogglePinnedConversation,
   fetchPinnedConversations,
+  unmarkSessionsDeleting,
   PINNED_CONVERSATIONS_KEY,
   type Conversation,
   type PinnedConversationsResult,
@@ -56,6 +57,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  // Optimistic delete hides ids from every list fetch until the delete
+  // settles, in module-level state that would otherwise leak into the next
+  // test (which reuses the same ids against a fresh cache).
+  unmarkSessionsDeleting();
 });
 
 describe("renameConversation", () => {
@@ -468,10 +473,19 @@ function infinitePage(rows: Conversation[]): ConversationsInfiniteData {
 }
 
 describe("useStopAndDeleteConversation cache eviction", () => {
-  function seedAndDelete() {
-    // Call 1: stop_session → {queued:false}. Call 2: DELETE → {deleted:true}.
+  /**
+   * Seed the caches a delete touches and render the hook.
+   *
+   * @param deleteResult - What the DELETE resolves to. Pass a pending
+   *   promise to hold the mutation in flight, or a non-ok response to
+   *   exercise the rollback.
+   */
+  function seedAndDelete(
+    deleteResult: Response | Promise<Response> = mockResponse({ deleted: true }),
+  ) {
+    // Call 1: stop_session → {queued:false}. Call 2: the DELETE.
     fetchMock.mockResolvedValueOnce(mockResponse({ queued: false }));
-    fetchMock.mockResolvedValueOnce(mockResponse({ deleted: true }));
+    fetchMock.mockImplementationOnce(() => Promise.resolve(deleteResult));
     const queryClient = new QueryClient({
       defaultOptions: { mutations: { retry: false } },
     });
@@ -575,6 +589,106 @@ describe("useStopAndDeleteConversation cache eviction", () => {
     expect(pinned!.conversations.map((c) => c.id)).toEqual(["conv_pinned_other"]);
     // The patch preserves the query's filterHonored flag.
     expect(pinned!.filterHonored).toBe(true);
+  });
+
+  it("drops the row before the DELETE resolves (optimistic)", async () => {
+    // Hold the DELETE open so the assertions land while it's still in
+    // flight. This is the whole point of the optimistic path: the sidebar
+    // repaints now, not after seconds of server-side teardown (stop,
+    // runner resources, worktree, managed sandbox).
+    let settleDelete = (_res: Response) => {};
+    const pendingDelete = new Promise<Response>((resolve) => {
+      settleDelete = resolve;
+    });
+    const { queryClient, rendered } = seedAndDelete(pendingDelete);
+
+    rendered.result.current.mutate({ id: "conv_x" });
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+      ]);
+      expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_other"]);
+    });
+    // Still un-settled: the row left the list on the strength of the
+    // request alone.
+    expect(rendered.result.current.isPending).toBe(true);
+
+    settleDelete(mockResponse({ deleted: true }));
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+  });
+
+  it("keeps the row out of a list refetch that lands mid-delete", async () => {
+    let settleDelete = (_res: Response) => {};
+    const pendingDelete = new Promise<Response>((resolve) => {
+      settleDelete = resolve;
+    });
+    const { queryClient, rendered } = seedAndDelete(pendingDelete);
+
+    rendered.result.current.mutate({ id: "conv_x" });
+    await waitFor(() => expect(rendered.result.current.isPending).toBe(true));
+
+    // The server still lists the session — the DELETE hasn't landed, and
+    // the search-indexed deployment lags further still. Any list fetch in
+    // this window (the reconcile poll, a WS-triggered refetch, a search)
+    // must not repaint the row the user just deleted.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "list",
+        data: [
+          { id: "conv_x", object: "conversation", title: "Doomed", created_at: 0, updated_at: 5 },
+          { id: "conv_other", object: "conversation", title: "Kept", created_at: 0, updated_at: 4 },
+        ],
+        first_id: "conv_x",
+        last_id: "conv_other",
+        has_more: false,
+      }),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    // An unseeded query variant, so this really hits the network rather
+    // than reading the already-spliced cache.
+    const list = renderHook(() => useConversations("doomed"), { wrapper });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    expect(fetchMock.mock.calls.at(-1)![0]).toContain("search_query=doomed");
+    expect(list.result.current.data!.pages[0].data.map((c) => c.id)).toEqual(["conv_other"]);
+
+    settleDelete(mockResponse({ deleted: true }));
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+  });
+
+  it("puts the row back when the delete fails", async () => {
+    const { queryClient, rendered } = seedAndDelete(mockResponse({}, { ok: false, status: 500 }));
+    // The restored row carries no failure state of its own (it unmounted
+    // when it was spliced out), so the toast is the only signal the user
+    // gets that the delete didn't land.
+    const toasts: string[] = [];
+    window.addEventListener("omnigent:toast", (e) => {
+      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
+    });
+
+    rendered.result.current.mutate({ id: "conv_x" });
+    await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+    // Named, so a user who deleted several sessions knows which came back.
+    expect(toasts).toEqual(["Couldn't delete Old name — it's back in the sidebar."]);
+
+    // The session still exists, so every list it was optimistically
+    // removed from must show it again — including the project folder and
+    // the sibling Pinned cache.
+    const base = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(base!.pages[0].data.map((c) => c.id)).toEqual(["conv_x", "conv_other"]);
+    const folder = queryClient.getQueryData<ConversationsInfiniteData>([
+      "project-sessions",
+      "Sprint 42",
+    ]);
+    expect(folder!.pages[0].data.map((c) => c.id)).toEqual(["conv_x", "conv_sibling"]);
+    const pinned = queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
+    expect(pinned!.conversations.map((c) => c.id)).toEqual(["conv_x", "conv_pinned_other"]);
+    // The per-session caches survive a failed delete — the session is still
+    // there to open.
+    expect(queryClient.getQueryData(["session", "conv_x"])).toBeDefined();
   });
 
   it("does not refetch the conversations list, but does refresh the project list", async () => {

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1,7 +1,7 @@
 // TanStack Query wrapper around `GET /v1/sessions`, plus mutation
 // hooks for `PATCH /v1/sessions/{id}` (rename) and
-// `DELETE /v1/sessions/{id}`. Rename and delete patch the cached
-// lists in place (see `useRenameConversation` /
+// `DELETE /v1/sessions/{id}`. Rename and delete are optimistic and patch
+// the cached lists in place (see `useRenameConversation` /
 // `useStopAndDeleteConversation` — a refetch would race the server's
 // async search reindex); the remaining mutations invalidate the
 // conversations list on success so the sidebar reflects the change.
@@ -34,7 +34,8 @@ import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
 } from "@/lib/sessionListCache";
-import { setLegacyPinnedConversationId } from "@/shell/sidebarNav";
+import { showToast } from "@/components/ui/toast";
+import { conversationDisplayLabel, setLegacyPinnedConversationId } from "@/shell/sidebarNav";
 import { stopSession } from "@/lib/sessionsApi";
 import {
   createProject as apiCreateProject,
@@ -228,6 +229,68 @@ export interface ConversationsPage {
   has_more: boolean;
 }
 
+// ── Deleting-session tombstones ───────────────────────────────────────
+//
+// Delete paints optimistically: the row leaves the sidebar the moment the
+// user confirms, long before the server finishes tearing the session down
+// (stop, runner resources, worktree, managed sandbox — seconds). Until
+// that lands, `GET /v1/sessions` still returns the session, and on the
+// search-indexed deployment it keeps returning it for a while after. Any
+// list fetch in that window — the reconcile poll, the refetch a WS frame
+// schedules, expanding a project folder — would repaint the row the user
+// just deleted.
+//
+// Ids recorded here are filtered out of every list fetch until the delete
+// settles: dropped immediately when it fails (the row comes back), or
+// after a grace window once it succeeds (the server's async reindex).
+const deletingSessionIds = new Set<string>();
+
+/** Grace window for the server's async delete reindex. */
+const DELETED_TOMBSTONE_MS = 60_000;
+
+/** Hide these sessions from every list fetch (optimistic delete). */
+export function markSessionsDeleting(ids: Iterable<string>): void {
+  for (const id of ids) deletingSessionIds.add(id);
+}
+
+/**
+ * Stop hiding sessions — their delete failed, so the rows return.
+ * Omit `ids` to release every tombstone at once.
+ */
+export function unmarkSessionsDeleting(ids?: Iterable<string>): void {
+  if (ids === undefined) {
+    deletingSessionIds.clear();
+    return;
+  }
+  for (const id of ids) deletingSessionIds.delete(id);
+}
+
+/** Release confirmed-delete tombstones once the server has caught up. */
+function expireSessionsDeleting(ids: string[]): void {
+  setTimeout(() => unmarkSessionsDeleting(ids), DELETED_TOMBSTONE_MS);
+}
+
+/**
+ * Drop rows for sessions with a delete in flight from a freshly fetched
+ * page, recomputing the page cursors from the survivors so pagination
+ * never anchors on an id the server is about to forget (mirrors
+ * `removeIdsFromPages`).
+ *
+ * @param page - A page as returned by `GET /v1/sessions`.
+ * @returns The page, or a filtered copy when it held a deleting session.
+ */
+function withoutDeletingSessions(page: ConversationsPage): ConversationsPage {
+  if (deletingSessionIds.size === 0) return page;
+  const data = page.data.filter((conv) => !deletingSessionIds.has(conv.id));
+  if (data.length === page.data.length) return page;
+  return {
+    ...page,
+    data,
+    first_id: data[0]?.id ?? null,
+    last_id: data[data.length - 1]?.id ?? null,
+  };
+}
+
 /**
  * Fetch a single session as a sidebar-shaped ``Conversation`` object.
  *
@@ -300,7 +363,7 @@ async function fetchConversationsPage({
   const signal = searchQuery ? AbortSignal.timeout(SEARCH_FETCH_TIMEOUT_MS) : undefined;
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`, { signal });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return (await res.json()) as ConversationsPage;
+  return withoutDeletingSessions((await res.json()) as ConversationsPage);
 }
 
 /**
@@ -581,37 +644,152 @@ export function useArchiveConversation() {
 }
 
 /**
+ * Splice conversations out of every cached sidebar list at once.
+ *
+ * Covers the global `["conversations", ...]` variants, each project
+ * folder's own `["project-sessions", <name>]` list (same page shape), and
+ * the sibling Pinned cache the two sweeps above don't reach — a deleted
+ * pinned row would otherwise linger there until a reload.
+ *
+ * Patched in place rather than invalidated: `GET /v1/sessions` may be
+ * served from a search index that catches up to the delete asynchronously
+ * (the Databricks deployment lists via search-midtier over WHS), so a
+ * refetch races the reindex and can resurrect the row (the same race
+ * `useRenameConversation` documents for titles).
+ *
+ * @param queryClient - The app QueryClient.
+ * @param ids - Conversation ids to drop from the lists.
+ */
+function removeConversationsFromLists(queryClient: QueryClient, ids: Set<string>): void {
+  for (const queryKey of [["conversations"], ["project-sessions"]]) {
+    for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey,
+    })) {
+      const { data: next, removed } = removeIdsFromPages(data, ids);
+      if (removed) queryClient.setQueryData(key, next);
+    }
+  }
+  queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
+    old ? { ...old, conversations: old.conversations.filter((c) => !ids.has(c.id)) } : old,
+  );
+}
+
+/** Every cached list touched by an optimistic delete, as it was before. */
+interface DeletedListsSnapshot {
+  lists: [readonly unknown[], ConversationsInfiniteData | undefined][];
+  pinned: PinnedConversationsResult | undefined;
+}
+
+/**
+ * Paint a delete before the server confirms it: hide the sessions from
+ * every list fetch, then splice their rows out of the cached lists.
+ *
+ * In-flight list refetches are cancelled first so one can't resolve after
+ * the splice and repaint the rows the user just deleted.
+ *
+ * @param queryClient - The app QueryClient.
+ * @param ids - Conversation ids being deleted.
+ * @returns The pre-delete cache state, for `restoreDeletedConversations`.
+ */
+async function paintConversationsDeleted(
+  queryClient: QueryClient,
+  ids: readonly string[],
+): Promise<DeletedListsSnapshot> {
+  markSessionsDeleting(ids);
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: ["conversations"] }),
+    queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
+  ]);
+  const snapshot: DeletedListsSnapshot = {
+    lists: [
+      ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] }),
+      ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["project-sessions"] }),
+    ],
+    pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
+  };
+  removeConversationsFromLists(queryClient, new Set(ids));
+  return snapshot;
+}
+
+/**
+ * Put optimistically-removed rows back after a failed delete.
+ *
+ * Restores the snapshot wholesale (the same rollback shape
+ * `useMoveToProject` uses) rather than re-deriving positions, then
+ * re-splices whatever DID delete — a bulk delete can fail for only part
+ * of its selection. The lists are invalidated afterwards so the server
+ * reconciles the window the snapshot froze over.
+ *
+ * @param queryClient - The app QueryClient.
+ * @param snapshot - Cache state captured by `paintConversationsDeleted`.
+ * @param failedIds - Conversation ids whose delete failed (rows return).
+ * @param deletedIds - Conversation ids that did delete (rows stay gone).
+ */
+function restoreDeletedConversations(
+  queryClient: QueryClient,
+  snapshot: DeletedListsSnapshot | undefined,
+  failedIds: readonly string[],
+  deletedIds: readonly string[] = [],
+): void {
+  unmarkSessionsDeleting(failedIds);
+  if (snapshot) {
+    for (const [key, data] of snapshot.lists) queryClient.setQueryData(key, data);
+    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, snapshot.pinned);
+    if (deletedIds.length > 0) removeConversationsFromLists(queryClient, new Set(deletedIds));
+  }
+  void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+  void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+}
+
+/**
+ * Drop the caches that only a confirmed delete makes dead: the
+ * per-session snapshot and the pinned-row backfill entry (a pinned
+ * session would otherwise re-enter the sidebar from the still-fresh
+ * `["conversation-backfill", id]` entry the moment it leaves the
+ * paginated pages, and stay until a full reload).
+ *
+ * @param queryClient - The app QueryClient.
+ * @param ids - Conversation ids the server confirmed deleted.
+ */
+function finalizeDeletedConversations(queryClient: QueryClient, ids: readonly string[]): void {
+  for (const id of ids) {
+    queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
+    queryClient.removeQueries({ queryKey: ["session", id] });
+  }
+  expireSessionsDeleting([...ids]);
+  // Deleting the last member of a project empties it, so refresh the
+  // project list to drop the now-empty folder. Unlike the conversations
+  // list, /v1/sessions/projects reads the DB directly (no search-index
+  // lag), so this can't resurrect the deleted rows.
+  void queryClient.invalidateQueries({ queryKey: ["projects"] });
+  // Deleting an archived session may empty its project of archived members.
+  void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+}
+
+/**
  * Delete a conversation: stop the running session, then
  * `DELETE /v1/sessions/{id}`.
  *
- * The DELETE route only tears down resources (env, terminals) and
- * removes the conversation row — it does NOT kill the running agent,
- * so a claude-native tmux pane or a host-spawned runner would keep
- * executing orphaned after the chat disappears from the UI. We send
- * the same `stop_session` the Stop action uses first so the live
- * process is terminated as part of the delete.
+ * The DELETE route tears down resources (env, terminals) and removes the
+ * conversation row, but only the `stop_session` event tears down a
+ * host-spawned session's dedicated runner — without it that runner stays
+ * connected after the chat is gone. We send the same `stop_session` the
+ * Stop action uses first so the live process is terminated as part of the
+ * delete.
  *
  * The stop is best-effort: a failure (offline/wedged runner, an
  * already-stopped or never-running session) must not block the
  * delete, so it's swallowed and the DELETE proceeds regardless.
  *
- * Server-side, the DELETE also tears down associated tasks and tmux
- * terminals (see `routes/conversations.py:delete_conversation`).
- *
- * On success the deleted row is removed from every cached
- * `["conversations", ...]` page in place — NOT via invalidation.
- * `GET /v1/sessions` may be served from a search index that catches
- * up to the delete asynchronously (the Databricks deployment lists
- * via search-midtier over WHS), so an immediate refetch races the
- * reindex and can resurrect the just-deleted row (same race
- * `useRenameConversation` documents for titles). The per-session
- * caches are dropped too: a pinned session would otherwise re-enter
- * the sidebar from the still-fresh `["conversation-backfill", id]`
- * entry the moment it leaves the paginated pages, and stay until a
- * full reload. List pagination converges later via the
- * `WS /v1/sessions/updates` stream and the low-rate reconciliation
- * polls. Callers (the sidebar row) are responsible for navigating
- * away from `/c/{id}` if the deleted conversation is the active one.
+ * Optimistic: the row leaves every cached list in `onMutate`, so the
+ * sidebar repaints on the next frame instead of after the stop + DELETE
+ * round-trip — server-side teardown (runner resources, worktree, managed
+ * sandbox) can take seconds, which is what made delete feel slower than
+ * archive. The session is tombstoned for that window so a concurrent list
+ * fetch can't repaint the row (see `withoutDeletingSessions`); `onError`
+ * drops the tombstone and refetches, restoring the row. Callers (the
+ * sidebar row) are responsible for navigating away from `/c/{id}` if the
+ * deleted conversation is the active one.
  */
 export function useStopAndDeleteConversation() {
   const queryClient = useQueryClient();
@@ -624,37 +802,26 @@ export function useStopAndDeleteConversation() {
       }
       await deleteConversation(id, deleteBranch);
     },
-    onSuccess: (_data, { id }) => {
-      const ids = new Set([id]);
-      // Drop the row from the global list AND every project folder's own
-      // paginated list (["project-sessions", <name>]) — both share the same
-      // page shape. Patched in place rather than invalidated for the same
-      // reason as the global list: an immediate refetch races the server's
-      // async search reindex and can resurrect the just-deleted row.
-      for (const queryKey of [["conversations"], ["project-sessions"]]) {
-        for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
-          queryKey,
-        })) {
-          const { data: next, removed } = removeIdsFromPages(data, ids);
-          if (removed) queryClient.setQueryData(key, next);
-        }
-      }
-      queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
-      queryClient.removeQueries({ queryKey: ["session", id] });
-      // The Pinned section reads a separate, sibling cache that the
-      // ["conversations"] sweep above deliberately skips, so a deleted pinned
-      // row lingers there until a reload unless we drop it explicitly. Patched
-      // (not invalidated) for the same reindex-lag reason as the list.
-      queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
-        old ? { ...old, conversations: old.conversations.filter((c) => !ids.has(c.id)) } : old,
+    onMutate: async ({ id }) => {
+      // Snapshot the label before the row leaves the cache — a failure
+      // toast fired later can no longer look it up.
+      const row = findCachedConversationRow(queryClient, id);
+      const snapshot = await paintConversationsDeleted(queryClient, [id]);
+      return { label: row ? conversationDisplayLabel(row) : null, snapshot };
+    },
+    onError: (_err, { id }, context) => {
+      restoreDeletedConversations(queryClient, context?.snapshot, [id]);
+      // The row is back in the sidebar but nothing else marks it as failed
+      // (the row unmounted when it was spliced out, taking any in-row error
+      // state with it), so the toast is the only failure signal.
+      showToast(
+        context?.label
+          ? `Couldn't delete ${context.label} — it's back in the sidebar.`
+          : "Couldn't delete the session — it's back in the sidebar.",
       );
-      // Deleting the last member of a project empties it, so refresh the
-      // project list to drop the now-empty folder. Unlike the conversations
-      // list, /v1/sessions/projects reads the DB directly (no search-index
-      // lag), so this can't resurrect the deleted row.
-      void queryClient.invalidateQueries({ queryKey: ["projects"] });
-      // Deleting an archived session may empty its project of archived members.
-      void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+    },
+    onSuccess: (_data, { id }) => {
+      finalizeDeletedConversations(queryClient, [id]);
     },
   });
 }
@@ -726,8 +893,10 @@ export function useBulkArchiveConversations() {
  * Delete multiple conversations in parallel (stop + delete each).
  *
  * Each session is stopped (best-effort) then deleted independently.
- * The conversations list cache is patched to remove successful
- * deletions. Returns an array of session IDs that failed.
+ * Optimistic like the single-session delete: every selected row leaves
+ * the cached lists in `onMutate` so the sidebar repaints immediately,
+ * and only the ones whose delete failed are restored. Returns the
+ * succeeded / failed session IDs.
  */
 export function useBulkDeleteConversations() {
   const queryClient = useQueryClient();
@@ -758,54 +927,23 @@ export function useBulkDeleteConversations() {
       }
       return { succeeded, failed };
     },
+    onMutate: (ids) => paintConversationsDeleted(queryClient, ids),
     onSuccess: (_data, ids) => {
-      const idSet = new Set(ids);
-      // Splice deleted rows out of the global list AND every project folder's
-      // own paginated list (same page shape) so filed sessions leave their
-      // folder without a refresh.
-      for (const queryKey of [["conversations"], ["project-sessions"]]) {
-        for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
-          queryKey,
-        })) {
-          const { data: next, removed } = removeIdsFromPages(data, idSet);
-          if (removed) queryClient.setQueryData(key, next);
-        }
-      }
-      for (const id of ids) {
-        queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
-        queryClient.removeQueries({ queryKey: ["session", id] });
-      }
-      // Drop deleted rows from the sibling Pinned cache the sweep above skips.
-      queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
-        old ? { ...old, conversations: old.conversations.filter((c) => !idSet.has(c.id)) } : old,
-      );
-      // Refresh the project list so a project emptied by these deletes drops
-      // its now-empty folder (DB-direct read, no search-index lag).
-      void queryClient.invalidateQueries({ queryKey: ["projects"] });
-      void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+      finalizeDeletedConversations(queryClient, ids);
     },
-    onError: (error) => {
-      if (error instanceof BulkConversationMutationError && error.succeeded.length > 0) {
-        const idSet = new Set(error.succeeded);
-        for (const queryKey of [["conversations"], ["project-sessions"]]) {
-          for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
-            queryKey,
-          })) {
-            const { data: next, removed } = removeIdsFromPages(data, idSet);
-            if (removed) queryClient.setQueryData(key, next);
-          }
-        }
-        for (const id of error.succeeded) {
-          queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
-          queryClient.removeQueries({ queryKey: ["session", id] });
-        }
-        // Drop the successfully-deleted rows from the sibling Pinned cache too.
-        queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
-          old ? { ...old, conversations: old.conversations.filter((c) => !idSet.has(c.id)) } : old,
-        );
-        void queryClient.invalidateQueries({ queryKey: ["projects"] });
-        void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
-      }
+    onError: (error, ids, snapshot) => {
+      // Partial failure: the sessions that did delete stay gone; the rest
+      // come back. A non-bulk error (nothing reported) restores everything.
+      const bulk = error instanceof BulkConversationMutationError ? error : null;
+      const failed = bulk ? bulk.failed : [...ids];
+      const succeeded = bulk ? bulk.succeeded : [];
+      restoreDeletedConversations(queryClient, snapshot, failed, succeeded);
+      if (succeeded.length > 0) finalizeDeletedConversations(queryClient, succeeded);
+      showToast(
+        failed.length === 1
+          ? "Couldn't delete 1 session — it's back in the sidebar."
+          : `Couldn't delete ${failed.length} sessions — they're back in the sidebar.`,
+      );
     },
   });
 }
@@ -900,7 +1038,7 @@ export async function fetchPinnedConversations(): Promise<PinnedConversationsRes
   });
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const rows = ((await res.json()) as ConversationsPage).data;
+  const rows = withoutDeletingSessions((await res.json()) as ConversationsPage).data;
   const conversations = rows.filter((c) => c.labels?.[PINNED_LABEL_KEY] != null);
   // Honored iff the server returned nothing, or everything it returned is
   // actually pinned. An old server returns unfiltered rows (none pinned), so a
@@ -1496,7 +1634,7 @@ async function fetchProjectSessionsPage(
   if (after) params.set("after", after);
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return (await res.json()) as ConversationsPage;
+  return withoutDeletingSessions((await res.json()) as ConversationsPage);
 }
 
 /**

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -190,7 +190,7 @@ describe("archive flow", () => {
     const row = screen.getByTestId("conversation-archiving");
     expect(within(row).getByText("Archiving…")).toBeInTheDocument();
     // The interactive link is replaced by the status row, so the session
-    // can't be re-opened or re-archived mid-flight (mirrors Deleting…).
+    // can't be re-opened or re-archived mid-flight.
     expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
   });
 

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -1,9 +1,10 @@
-// Tests for the async (non-blocking) delete-session flow in the
-// sidebar. The contract: clicking "Delete" in the confirm dialog fires
-// the mutation and closes the dialog *immediately* (without awaiting the
-// server), and the row then shows its own "Deleting…" / error status so
-// the user is never blocked on the page. See ConversationRow.confirmDelete
-// and DeletingRow in Sidebar.tsx.
+// Tests for the optimistic delete-session flow in the sidebar. The
+// contract: clicking "Delete" in the confirm dialog fires the mutation,
+// closes the dialog, and leaves the row alone — the mutation itself
+// splices the row out of the cached lists on the next frame (see
+// `useStopAndDeleteConversation`), so the sidebar never shows an
+// in-flight status row for a delete the way it does for an archive.
+// See ConversationRow.confirmDelete in Sidebar.tsx.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
@@ -132,7 +133,7 @@ afterEach(() => {
   cleanup();
 });
 
-describe("async delete session flow", () => {
+describe("optimistic delete session flow", () => {
   it("closes the confirm dialog immediately on Delete without awaiting the mutation", () => {
     renderSidebar();
     openDeleteDialog();
@@ -143,65 +144,49 @@ describe("async delete session flow", () => {
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
 
-    // The mutation fired with the row's id and the (unchecked) branch flag,
-    // plus an onSuccess callback for the active-session redirect.
+    // The mutation fired with the row's id and the (unchecked) branch flag.
+    // No mutate-level callbacks: the row is spliced out of the cached lists
+    // optimistically, which unmounts this component — callbacks on an
+    // unmounted observer never fire, so everything lives in the hook or runs
+    // synchronously at click time.
     expect(mocks.del.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.del.mutate).toHaveBeenCalledWith(
-      { id: "conv_1", deleteBranch: false },
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
-    );
+    expect(mocks.del.mutate).toHaveBeenCalledWith({ id: "conv_1", deleteBranch: false });
 
-    // The dialog is gone even though the mutate stub never invoked
-    // onSuccess. If confirmDelete awaited the server before closing
-    // (the old blocking behavior), the dialog would still be open here.
+    // The dialog is gone even though the mutate stub never resolved. If
+    // confirmDelete awaited the server before closing (the old blocking
+    // behavior), the dialog would still be open here.
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("renders a Deleting… status row while the delete is in flight", () => {
+  it("shows no in-flight status row — the row is removed optimistically instead", () => {
+    // The real hook drops the row from the cached list in onMutate, so by
+    // the time a delete is pending the row is already gone from the sidebar.
+    // A "Deleting…" placeholder would therefore only ever appear when the
+    // splice hadn't happened — and would reintroduce the round-trip-long
+    // wait that made delete feel slower than archive.
     mocks.del.isPending = true;
     renderSidebar();
 
-    // The in-flight status row replaces the interactive row.
-    expect(screen.getByTestId("conversation-deleting")).toBeInTheDocument();
-    expect(screen.getByText("Deleting…")).toBeInTheDocument();
-    // The navigable row link is gone while deleting — the user can't
-    // re-open or re-delete a row that's mid-deletion.
-    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("conversation-deleting")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deleting…")).not.toBeInTheDocument();
+    // With this mocked hook the cache is never spliced, so the row stays —
+    // and it stays fully interactive rather than being swapped for a stub.
+    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
   });
 
-  it("shows a retryable error row when the delete fails; Retry replays the same args", () => {
+  it("keeps the row interactive when a delete fails (no error row)", () => {
+    // A failed delete restores the row and reports via a toast (fired by the
+    // hook). The row itself must come back as an ordinary, usable row — the
+    // old inline error/retry state can't survive a row that unmounted when
+    // it was spliced out.
     mocks.del.isError = true;
-    // Mirrors react-query exposing the last mutate() args; a user who
-    // opted into branch deletion must get the same on retry.
     mocks.del.variables = { id: "conv_1", deleteBranch: true };
     renderSidebar();
 
-    const failed = screen.getByTestId("conversation-delete-failed");
-    expect(within(failed).getByText(/Couldn't delete/)).toBeInTheDocument();
-    // The session label is in the *visible* text (not just a tooltip) so
-    // the user can tell which row failed when several deletes fail.
-    expect(within(failed).getByText("My Session")).toBeInTheDocument();
-
-    fireEvent.click(within(failed).getByRole("button", { name: "Retry" }));
-    // Retry replays the exact prior args (incl. deleteBranch: true), not
-    // a freshly-recomputed payload that could drop the branch flag.
-    expect(mocks.del.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.del.mutate).toHaveBeenCalledWith(
-      { id: "conv_1", deleteBranch: true },
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
-    );
-  });
-
-  it("clears the error row via Dismiss (resets the mutation back to idle)", () => {
-    mocks.del.isError = true;
-    mocks.del.variables = { id: "conv_1", deleteBranch: false };
-    renderSidebar();
-
-    const failed = screen.getByTestId("conversation-delete-failed");
-    fireEvent.click(within(failed).getByRole("button", { name: /dismiss delete error/i }));
-    // Dismiss calls reset() so the next render drops back to the normal
-    // interactive row (isError → false).
-    expect(mocks.del.reset).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("conversation-delete-failed")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
+    // No automatic replay: the restored row is the retry affordance.
+    expect(mocks.del.mutate).not.toHaveBeenCalled();
   });
 });
 
@@ -248,13 +233,14 @@ describe("branch-name wrapping in the delete dialog", () => {
   });
 });
 
-// --- Active-session redirect on successful delete ---------------------
+// --- Active-session redirect on delete --------------------------------
 //
-// Delete is fire-and-forget, so the onSuccess redirect must key off the
-// conversation the user is viewing *when it resolves*, not the one they
-// were viewing when they clicked Delete. These tests render with a real
-// router (so useParams resolves the active id) and a probe that reports
-// the current pathname.
+// The row leaves the sidebar the moment Delete is confirmed, so the
+// redirect runs then too: if the user is viewing the session being
+// deleted, the chat surface would otherwise sit on an id that's about to
+// 404. Deleting any other row must leave them where they are. These tests
+// render with a real router (so useParams resolves the active id) and a
+// probe that reports the current pathname.
 
 const CONV_OTHER: Conversation = { ...CONV, id: "conv_2", title: "Other Session" };
 
@@ -286,48 +272,39 @@ function renderSidebarRouted(path: string) {
   );
 }
 
-/** Drive a Delete through to the captured onSuccess callback for `row`. */
+/** Confirm a Delete from `row`'s kebab menu. */
 function fireDeleteFrom(row: HTMLElement) {
   fireEvent.pointerDown(within(row).getByTestId("conversation-actions"), { button: 0 });
   fireEvent.click(screen.getByTestId("delete-conversation"));
-  fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Delete" }));
-  // del.mutate is a stub; pull the onSuccess it was handed so the test
-  // can fire it at the moment of its choosing.
-  const call = mocks.del.mutate.mock.calls.at(-1);
-  return call?.[1]?.onSuccess as () => void;
+  act(() => {
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Delete" }));
+  });
 }
 
-describe("active-session redirect on successful delete", () => {
-  it("redirects to / when the deleted conversation is still the active one", () => {
+describe("active-session redirect on delete", () => {
+  it("redirects to / when the deleted conversation is the active one", () => {
     mockConversations([CONV, CONV_OTHER]);
     renderSidebarRouted("/c/conv_1");
     expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_1");
 
-    const row = screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement;
-    const onSuccess = fireDeleteFrom(row);
-    act(() => onSuccess());
+    fireDeleteFrom(screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement);
 
-    // Still viewing conv_1 when it was deleted → bounce to / so the chat
-    // surface doesn't 404 on the missing id.
+    // Viewing conv_1 when it was deleted → bounce to / immediately, so the
+    // chat surface never sits on an id the server is about to forget. The
+    // mutate stub never resolves, proving the redirect doesn't wait on it.
     expect(screen.getByTestId("loc")).toHaveTextContent("/");
   });
 
-  it("does NOT redirect when the user navigated away before the delete resolved", () => {
+  it("does NOT redirect when deleting a row the user isn't viewing", () => {
     mockConversations([CONV, CONV_OTHER]);
-    renderSidebarRouted("/c/conv_1");
-
-    const row = screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement;
-    // Initiate the delete while conv_1 is active...
-    const onSuccess = fireDeleteFrom(row);
-    // ...then navigate to conv_2 before the (still-pending) delete resolves.
-    fireEvent.click(screen.getByRole("link", { name: /Other Session/ }));
+    renderSidebarRouted("/c/conv_2");
     expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_2");
 
-    act(() => onSuccess());
+    // Delete the *other* session from the sidebar while viewing conv_2.
+    fireDeleteFrom(screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement);
 
-    // The redirect reads the *live* active id (conv_2 ≠ conv_1), so the
-    // user stays put. The old code captured isActive=true at click time
-    // and would have yanked them to /.
+    // conv_2 is untouched, so the user stays in the chat they're reading —
+    // a redirect here would yank them out of an unrelated session.
     expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_2");
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3091,8 +3091,8 @@ function ConversationRow({
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   // True while an archive is in flight. Drives the "Archiving…" status
-  // row, mirroring delete's "Deleting…" indicator — without it the row
-  // shows nothing while the archive completes.
+  // row — without it the row shows nothing while the archive completes.
+  // Delete needs no counterpart: it drops its row optimistically.
   const [isArchiving, setIsArchiving] = useState(false);
   const gitBranch = conversation.git_branch ?? null;
   // Every row action gates on ownership alone — the sidebar carries no

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -106,7 +106,6 @@ import {
 import {
   type Conversation,
   type PinnedConversationsResult,
-  BulkConversationMutationError,
   useArchiveConversation,
   useBulkArchiveConversations,
   useBulkDeleteConversations,
@@ -3052,14 +3051,6 @@ function ConversationRow({
   // project flyout's HoverCard and leave it lingering over the chat. Gate the
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
   const isMobile = useIsMobileViewport();
-  // Track the *live* active conversation id. Delete is fire-and-forget,
-  // so the user can navigate to another conversation before the mutation
-  // resolves — the onSuccess redirect must key off where they are now,
-  // not the `isActive` captured when delete was initiated.
-  const activeIdRef = useRef(activeId);
-  useEffect(() => {
-    activeIdRef.current = activeId;
-  }, [activeId]);
   // When this row becomes the active conversation (e.g. a freshly created
   // session navigated to via `/c/:id`), scroll it toward the center of the
   // sidebar so it's comfortably in view rather than pinned to an edge.
@@ -3270,26 +3261,6 @@ function ConversationRow({
     );
   }
 
-  // While a delete is in flight (or after it failed), swap the
-  // interactive row for a status row so the user sees progress without
-  // the dialog blocking. On success the row is spliced out of the
-  // cached list and this row unmounts; on error we keep it with
-  // retry/dismiss affordances.
-  if (del.isPending || del.isError) {
-    return (
-      <li>
-        <DeletingRow
-          label={label}
-          isError={del.isError}
-          // `del.variables` holds the args from the last mutate call,
-          // so retry replays the exact same delete (incl. deleteBranch).
-          onRetry={() => del.variables && runDelete(del.variables)}
-          onDismiss={() => del.reset()}
-        />
-      </li>
-    );
-  }
-
   // Archiving is a single PATCH (see runArchive); show a status row for the
   // span instead of leaving the row looking idle. The spinner stays up until
   // the row itself leaves the sidebar: on success the list refetches and this
@@ -3305,27 +3276,19 @@ function ConversationRow({
     );
   }
 
-  function runDelete(args: { id: string; deleteBranch?: boolean }) {
-    del.mutate(args, {
-      onSuccess: () => {
-        // If the user is *still* viewing the conversation we just
-        // deleted, bounce back to `/` so the chat surface doesn't
-        // 404-loop on the now-missing id. Read the live activeId (ref)
-        // — they may have navigated away while the delete was in flight.
-        if (activeIdRef.current === conversation.id) navigate("/", { replace: true });
-      },
-    });
-  }
-
   function confirmDelete() {
-    // Fire-and-forget: close the dialog immediately so the user isn't
-    // blocked on the (potentially slow) DELETE — worktree cleanup can
-    // take seconds. The row renders its own "Deleting…" indicator while
-    // `del.isPending`, and a retryable error state if it fails.
-    const args = { id: conversation.id, deleteBranch: gitBranch !== null && deleteBranch };
+    // Fire-and-forget: close the dialog and drop the row immediately so the
+    // user isn't blocked on the (potentially slow) DELETE — server-side
+    // teardown can take seconds. The mutation removes the row from the
+    // cached lists optimistically, which unmounts this component, so
+    // anything that must happen on delete either runs here or lives in the
+    // hook (a mutate-level callback would never fire).
     setDeleteOpen(false);
     setDeleteBranch(false);
-    runDelete(args);
+    // Viewing the session being deleted? Leave now, so the chat surface
+    // doesn't sit on an id that's about to 404.
+    if (isActive) navigate("/", { replace: true });
+    del.mutate({ id: conversation.id, deleteBranch: gitBranch !== null && deleteBranch });
   }
 
   function runArchive() {
@@ -3814,76 +3777,12 @@ function PinnedProjectFlyoutContent({
 }
 
 /**
- * Status row shown in place of a conversation while its delete is in
- * flight (`isError === false`) or after it failed (`isError === true`).
- * Keeps the user un-blocked: the delete dialog closes immediately and
- * this surfaces progress / failure inline in the sidebar.
- */
-function DeletingRow({
-  label,
-  isError,
-  onRetry,
-  onDismiss,
-}: {
-  label: string;
-  isError: boolean;
-  onRetry: () => void;
-  onDismiss: () => void;
-}) {
-  if (isError) {
-    return (
-      <div
-        className="flex w-full items-center gap-1.5 rounded-md px-2 py-2 text-ui"
-        data-testid="conversation-delete-failed"
-        role="alert"
-      >
-        <AlertTriangleIcon className="size-3.5 shrink-0 text-destructive" />
-        {/* Name the session in the visible text — with multiple failed
-            deletes the user must be able to tell the rows apart. */}
-        <span
-          className="min-w-0 flex-1 truncate text-destructive"
-          title={`Couldn't delete ${label}`}
-        >
-          Couldn't delete <span className="font-medium">{label}</span>
-        </span>
-        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5" onClick={onRetry}>
-          Retry
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Dismiss delete error"
-          onClick={onDismiss}
-        >
-          <XIcon className="size-3.5" />
-        </Button>
-      </div>
-    );
-  }
-  return (
-    // Match the interactive row's responsive metrics so the swap only changes
-    // color/opacity rather than shifting the list.
-    <div
-      className={cn(SIDEBAR_ROW, "flex w-full items-center text-muted-foreground opacity-70")}
-      data-testid="conversation-deleting"
-      aria-live="polite"
-    >
-      <Loader2Icon className="size-3.5 shrink-0 animate-spin" aria-hidden />
-      <span className="min-w-0 flex-1 truncate" title={label}>
-        {label}
-      </span>
-      <span className="shrink-0 text-sm">Deleting…</span>
-    </div>
-  );
-}
-
-/**
  * In-flight status row shown while a session is being archived (the
- * archive PATCH in ConversationRow.runArchive). Mirrors the
- * non-error arm of {@link DeletingRow}; archive failures fall back to
- * the interactive row rather than a persistent error state, so there's
- * no retry/dismiss affordance here.
+ * archive PATCH in ConversationRow.runArchive). Delete has no
+ * counterpart: it removes its row optimistically, so there is nothing
+ * left to show progress on. Archive failures fall back to the
+ * interactive row rather than a persistent error state, so there's no
+ * retry/dismiss affordance here.
  */
 function ArchivingRow({ label }: { label: string }) {
   return (
@@ -4420,21 +4319,14 @@ function BulkActionBar({
     const ids = ownedSelected.map((c) => c.id);
     if (ids.length === 0) return;
     setConfirmDeleteOpen(false);
-    bulkDelete.mutate(ids, {
-      onSuccess: () => {
-        if (activeId && ids.includes(activeId)) navigate("/", { replace: true });
-        onDeselectAll();
-      },
-      onError: (error) => {
-        if (
-          activeId &&
-          error instanceof BulkConversationMutationError &&
-          error.succeeded.includes(activeId)
-        ) {
-          navigate("/", { replace: true });
-        }
-      },
-    });
+    // The rows leave the sidebar optimistically, so the selection is already
+    // meaningless and the chat surface would be sitting on an id that's about
+    // to 404. Both are settled here rather than in a mutate-level callback:
+    // this bar unmounts with the selection, and callbacks on an unmounted
+    // observer never fire.
+    if (activeId && ids.includes(activeId)) navigate("/", { replace: true });
+    onDeselectAll();
+    bulkDelete.mutate(ids);
   }
 
   return (


### PR DESCRIPTION
## Related issue

Closes #4565

## Summary

Deleting a session from the sidebar felt slower than archiving it, and the
reason was structural rather than server-side: archive removes its row on a
single `PATCH`, while delete kept the row on screen — swapped for a `Deleting…`
placeholder — until the whole `stop_session` + `DELETE` round trip finished. The
cache splice only ran in `onSuccess`, so the row outlived runner teardown,
worktree cleanup, and managed-sandbox teardown.

Both delete mutations now paint optimistically in `onMutate`, the same shape
`useMoveToProject` already uses:

- **Splice on mutate.** The row leaves every cached list at once — the
  `["conversations", …]` variants, each project folder's own
  `["project-sessions", <name>]` list, and the sibling Pinned cache.
- **Tombstone the session.** Ids with a delete in flight are filtered out of
  *every* list fetch. Without this the reconcile poll, a WS-triggered refetch, or
  expanding a project folder would repaint the row you just deleted — and the
  search-indexed deployment keeps returning the session for a while even after
  the `DELETE` lands. Tombstones drop immediately on failure and after a grace
  window on success.
- **Roll back on failure.** `onError` restores the pre-delete snapshot and fires
  a toast. A bulk delete restores only the ids that actually failed; the ones
  that succeeded stay gone.

The `Deleting…` / retry / dismiss row is gone with it: the row unmounts the
moment it is spliced out, so there is nothing left to render progress or an
inline retry on. The restored row *is* the retry affordance, and the toast is
the failure signal. For the same reason the active-session redirect and the
bulk-selection reset moved to click time — a mutate-level callback on an
unmounted observer never fires.

```
before:  click ──[ stop_session ][ DELETE ][ teardown ]──> row leaves      ~2000 ms
after:   click ──> row leaves                                                ~100-300 ms
                   └─[ stop_session ][ DELETE ][ teardown ]──> reconcile (background)
```

## Test Plan

**Unit** — `web/src/hooks/useConversations.test.ts`, `web/src/shell/Sidebar.delete.test.tsx`:

- the row leaves the cached lists *before* the `DELETE` resolves (held open on a
  pending promise, asserted while `isPending`)
- a list fetch that lands mid-delete does not repaint the row (tombstone)
- a failed delete restores the row to the list, the project folder, and the
  Pinned cache, keeps the per-session caches, and fires a named toast
- the sidebar renders no in-flight placeholder and keeps the row interactive
- deleting the active session redirects to `/`; deleting any other row does not

```
vitest run src/hooks/useConversations.test.ts src/shell/Sidebar.delete.test.tsx
  → 81 passed
vitest run src/shell/ src/hooks/
  → 2576 passed (NewChatDialog.test.tsx fails 3/271 on a clean tree too — pre-existing)
tsc -b            → clean
oxlint / prettier → clean
pre-commit (changed files) → clean
```

**E2E** — `tests/e2e_ui/sessions/test_sidebar_delete.py`:

- `test_delete_session_removes_row_and_from_store` now asserts the whole `<li>`
  unmounts (not just its href) and that no in-flight placeholder stands in for
  it. The href-only check it used before would have passed against the old
  build, where the row stayed on screen showing `Deleting…`.
- `test_failed_delete_restores_row_and_warns` (new) stubs the `DELETE` to 500 and
  asserts the row returns to the sidebar, a toast names the session, and
  `GET /v1/sessions/{id}` still reports 200. The rollback is only reachable if
  the row left *before* the server answered, so this is the deterministic proof
  that delete is optimistic — and it covers the failure path the removed inline
  error/retry row used to own.

**Manual, end-to-end against a live deployment** — dev UI proxied to a real
server, timing the click on **Delete** until the row actually leaves the sidebar
(a `Deleting…` placeholder counts as the row still being there), driven with
Playwright so the numbers aren't eyeballed:

| | row actually gone | placeholder shown |
|---|---|---|
| before | **2007 ms** | yes |
| after | **97 / 213 / 312 ms** | no |

Six throwaway sessions were created for this and all six deleted afterwards;
nothing pre-existing was touched. Server-side deletion was confirmed by polling
`GET /v1/sessions` after each run — the row disappearing early does not mean the
`DELETE` was skipped.

Note the probe sessions had no runner attached, so those are the *best* case for
the old path. A session with a live runner, worktree, or managed sandbox takes
much longer server-side, and the new path stays flat because it no longer waits.

## Demo

Delete is a timing change rather than a visual one — there is no new chrome to
screenshot, and the old `Deleting…` placeholder is removed. The measured
before/after table above is the demo; the user-visible difference is that the
row now leaves the sidebar on the next frame instead of ~2 s later, exactly like
archive already does.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the optimistic splice, the tombstone-vs-concurrent-refetch
race, rollback across all three caches, the failure toast, and the sidebar's
redirect behaviour. E2E tests cover the same contract in a real browser against
a live server, including the failure rollback. Three tests that asserted on the removed `Deleting…` /
retry / dismiss row were replaced rather than dropped — the coverage moved to
the new contract (no placeholder, row stays interactive, no automatic replay).

Manual verification covers what a unit test cannot: real end-to-end latency
against a live server, and confirmation that the session is genuinely deleted
server-side even though the row leaves early. Numbers and method above.

## Changelog

Deleting a session removes it from the sidebar immediately instead of waiting for the server to finish tearing it down
