### PR TITLE
fix(search): match content with ILIKE so the trigram index is not chosen

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -584,10 +584,14 @@ def _fetch_search_snippets(
     # workspace_id leads the (workspace_id, conversation_id, position) index.
     # Both the aggregate and the join-back below must include it or Postgres
     # can't use that index and falls back to a full table scan of every item.
+    # ILIKE on the raw column rather than ``lower(search_text) LIKE`` for the
+    # same reason as the content match in ``list_conversations``: the lower()
+    # form matches the pg_trgm index expression, and the planner then scans the
+    # whole workspace even though this is already scoped to one page of ids.
     match_pred = and_(
         SqlConversationItem.workspace_id == workspace_id,
         SqlConversationItem.conversation_id.in_(conversation_ids),
-        func.lower(SqlConversationItem.search_text).like(pattern),
+        SqlConversationItem.search_text.ilike(pattern),
     )
     # Earliest matching position per conversation — a small (conv_id, position)
     # aggregate, no bodies materialized.
@@ -2396,12 +2400,20 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # cannot see. Correlating on conversation_id keeps each probe on
                 # the (workspace_id, conversation_id) index and lets it stop at
                 # the first matching item per conversation.
+                # ``ILIKE`` on the raw column, NOT ``lower(search_text) LIKE``:
+                # the latter matches the ``lower(search_text)`` pg_trgm index
+                # expression, and the planner then prefers that index — scanning
+                # every item in the workspace out of a multi-GB index that does
+                # not fit in shared_buffers. ILIKE is the same case-insensitive
+                # match but cannot use that index, so the probe stays on the
+                # (workspace_id, conversation_id) btree above. Do not "simplify"
+                # this back to lower(...) LIKE; see the covering test.
                 content_match = (
                     select(SqlConversationItem.conversation_id)
                     .where(
                         SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.conversation_id == SqlConversation.id,
-                        func.lower(SqlConversationItem.search_text).like(pattern),
+                        SqlConversationItem.search_text.ilike(pattern),
                     )
                     .exists()
                 )

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1456,6 +1456,57 @@ def test_list_conversations_search_content_match_is_correlated(
     assert "distinct conversation_items.conversation_id" not in select_sql, select_sql
 
 
+def test_search_predicate_avoids_the_trigram_index_expression(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    Content search matches with ``ILIKE`` on the raw column, never
+    ``lower(search_text) LIKE``.
+
+    ``lower(search_text)`` is exactly the expression the pg_trgm index
+    (migration ``d5e9f1a2b3c4``) is built on. Writing the predicate that way
+    makes the planner prefer that index, which scans every item in the
+    workspace out of a multi-GB index rather than probing the handful of
+    conversations the query is scoped to. ILIKE is the same case-insensitive
+    substring match but cannot match the index expression, so the scoped btree
+    probe wins. Covers both the list predicate and the snippet lookup, since
+    both run on a search request.
+    """
+    conv = conversation_store.create_conversation()
+    conversation_store.append(
+        conv.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_ilike1",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "fix the DEPLOYMENT pipeline"}],
+                ),
+            ),
+        ],
+    )
+
+    # Case-insensitivity is the behavioural contract and holds on every dialect
+    # (row stored as "DEPLOYMENT", queried as "deployment").
+    page = conversation_store.list_conversations(search_query="deployment")
+    assert conv.id in {c.id for c in page.data}
+
+    # The SQL-shape guarantee is Postgres-specific: SQLAlchemy emits native
+    # ILIKE there, while SQLite (which has no trigram index to avoid) compiles
+    # ILIKE down to lower(...) LIKE lower(...).
+    if conversation_store._conv_engine.dialect.name != "postgresql":
+        return
+
+    statements = _captured_sql(
+        conversation_store,
+        lambda: conversation_store.list_conversations(search_query="deployment"),
+    )
+    item_sql = " ".join(s for s in statements if "conversation_items" in s).lower()
+    assert "ilike" in item_sql, item_sql
+    assert "lower(conversation_items.search_text)" not in item_sql, item_sql
+
+
 def test_list_conversations_search_snippet_uses_earliest_match(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; follow-up to #4502 / #4546, diagnosed against the deployed instance. -->

## Summary

Session search still timed out on the deployed app after #4546. Root-caused against production: the correlated `EXISTS` from #4546 is correct, but Postgres never got to use it — because the predicate was written as `lower(search_text) LIKE ?`, which is **exactly the expression the `pg_trgm` index is built on**. The planner therefore preferred that index and scanned every item in the workspace out of a 2.2 GB index that doesn't fit in 456 MB of `shared_buffers`.

This switches the content predicate to `ILIKE` on the raw column. Same case-insensitive substring match, but it cannot match the index expression, so the planner falls back to probing the `(workspace_id, conversation_id)` btree that the correlated `EXISTS` was written for.

**The `pg_trgm` index is deliberately kept.** Nothing is dropped and no migration is needed — this only stops *this one query* from being lured onto it. Other queries (and any future global-search feature) can still use it.

The same fix is applied to `_fetch_search_snippets`, which had the identical problem and would have become the next timeout as soon as the main query got fast — it never ran before because the main query died first.

### ELI5

The index is organised by "lowercased message text." Because our query asked for exactly "lowercased message text," Postgres thought the index was the perfect tool and used it — even though it means reading a 2.2 GB index that doesn't fit in memory to answer a question about 437 conversations. Asking the same question a slightly different way (`ILIKE`) means the index no longer looks applicable, so Postgres does the cheap thing instead: look inside just those 437 conversations.

## Test Plan

Measured against the **deployed database** (3.16 M `conversation_items` / 12 GB; trigram index 2.2 GB vs 456 MB `shared_buffers`), all planner settings at defaults:

| search term | `lower(...) LIKE` (today) | `ILIKE` (this PR) |
|---|---|---|
| `%claude%` (common) | 0.03 s | **0.02 s** |
| `%speed%` | **>30 s timeout** | **6.42 s** |
| `%zzqqxwv%` (no matches) | **>30 s timeout** | **10.84 s** |
| snippet query (30 ids) | **>25 s timeout** | **1.13 s** |

Plans confirm the intent: `trgm=False`, `seq_scan=False` — i.e. the trigram index is avoided *and* it doesn't degrade into a sequential scan; it uses the per-conversation btree.

Automated:

- `tests/stores/test_conversation_store.py` — **181 passed / 1 skipped** on SQLite; **14 passed** for the search subset against real Postgres 16.
- New `test_search_predicate_avoids_the_trigram_index_expression` asserts the emitted SQL uses `ILIKE` and never `lower(conversation_items.search_text)`, plus that matching stays case-insensitive end to end. The SQL-shape half is Postgres-scoped on purpose: SQLAlchemy emits native `ILIKE` there, while SQLite compiles `.ilike()` down to `lower(...) LIKE lower(...)` — and SQLite has no trigram index to avoid.

```bash
python3 -m pytest tests/stores/test_conversation_store.py -k search
docker run -d --name pg -e POSTGRES_PASSWORD=pg -p 55435:5432 postgres:16
export OMNIGENT_TEST_DB_URI="postgresql+psycopg://postgres:pg@localhost:55435/postgres"
python3 -m pytest tests/stores/test_conversation_store.py -k search
```

## Demo

N/A — no visual change. Search returns results instead of timing out.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the plan/timing comparison against the deployed database above; the regression only reproduces at production scale, which no fixture recreates. Automated coverage pins the SQL shape (the thing that regresses silently) and the case-insensitivity behaviour.

Two things worth flagging for follow-up rather than fixing here:

1. **Worst case is still ~11 s**, for a term with *no* matches — `EXISTS` cannot short-circuit, so it reads all ~239 items × ~314 kB per conversation. That exceeds the client's 10 s `SEARCH_FETCH_TIMEOUT_MS`, so a no-result search may still abort — showing "No results found", which is at least the correct answer. Narrowing the searched item types would fix it properly (below).
2. **77% of `search_text` is `function_call_output` and another 6% is `compaction`** (avg 49 kB each); actual messages are ~7%. Restricting content search to message-type items would cut the scanned volume ~6× and make the worst case ~2 s. That's a semantics change, so it belongs in its own PR.

Separately: `ANALYZE conversation_items` was run against production during this investigation (its stats predated the trigram index, so the planner had no statistics for `lower(search_text)`). That alone took the query from >45 s to ~12 s but did not change the chosen plan.

## Changelog

Session search no longer times out on large workspaces.
