### PR TITLE
fix(ios): keep viewport-fit=cover when the workspace host rewrites the viewport

### DIFF
--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -117,10 +117,38 @@ struct OmnigentWebView: UIViewRepresentable {
           ].join(", ")
         );
       };
-      if (document.head) {
+      // A workspace-hosted page reassigns the whole `content` attribute after it
+      // mounts, dropping `viewport-fit=cover` — and with it every
+      // `env(safe-area-inset-*)` the web layer pads with, so content lands under the
+      // status bar. One-shot injection isn't enough: the host rewrites again on its
+      // own re-renders, so re-assert whenever the token goes missing.
+      const hasViewportFitCover = () => {
+        const meta = document.querySelector('meta[name="viewport"]');
+        if (!meta) return false;
+        const content = (meta.getAttribute("content") || "").toLowerCase();
+        return content.split(" ").join("").includes("viewport-fit=cover");
+      };
+      const watchViewportFit = () => {
+        if (!document.head || typeof MutationObserver === "undefined") return;
+        // `ensureViewportFit` writes the attribute we're observing; the guard turns
+        // that re-entry into a no-op rather than a loop.
+        new MutationObserver(() => {
+          if (!hasViewportFitCover()) ensureViewportFit();
+        }).observe(document.head, {
+          childList: true, // the host may replace the tag instead of editing it
+          subtree: true,
+          attributes: true,
+          attributeFilter: ["content"],
+        });
+      };
+      const applyViewportFit = () => {
         ensureViewportFit();
+        watchViewportFit();
+      };
+      if (document.head) {
+        applyViewportFit();
       } else {
-        document.addEventListener("DOMContentLoaded", ensureViewportFit, { once: true });
+        document.addEventListener("DOMContentLoaded", applyViewportFit, { once: true });
       }
       const callbacks = new Set();
       const openPathCallbacks = new Set();


### PR DESCRIPTION
fix(ios): keep viewport-fit=cover when the workspace host rewrites the viewport

## Related issue

N/A — reported directly after #4559.

## Summary

- On a Databricks workspace-hosted server, the iOS app renders its top controls
  under the status bar / Dynamic Island: the sidebar toggle sits level with the
  clock and the chat header is flush at y=0. Self-hosted (OSS) servers are fine,
  and Android is fine.
- All of the shell's iOS insets derive from `env(safe-area-inset-*)`, which is
  non-zero only when the document's meta viewport carries `viewport-fit=cover`.
  No document ships it, so the bridge script installs it at `.atDocumentStart`.
- The workspace host then reassigns the whole `content` attribute once its app
  mounts (`useMobileViewport`, called for the Omnigent route), writing
  `width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no` —
  no `viewport-fit`. `env()` collapses to 0, so `--omnigent-safe-top` and
  `--omnigent-inset-top` become 0 and every rule padding for the notch pads by
  nothing.
- Re-asserts the token with a `MutationObserver` on `document.head` instead of
  trusting the one-shot injection: the host rewrites again on its own re-renders,
  and it may replace the tag rather than edit it. The observer only writes when
  `viewport-fit=cover` is absent, so the shell's own write settles instead of
  looping.
- Latent until now — the workspace nav bar used to occupy the top of the screen
  and pushed the app below the unsafe area. #4559 promotes the app to a
  full-viewport overlay to hide that bar, which is what exposes the missing inset.
- Android is unaffected and untouched: it injects measured insets as
  `--omnigent-android-safe-area-*` (`MainActivity.kt`) and never depends on
  `env()`. Only iOS trusts the page's viewport metadata.

```
  documentStart : … user-scalable=no, viewport-fit=cover   ← shell installs it
  host mounts   : … user-scalable=no                       ← token dropped
                  env(safe-area-inset-top) = 0px  →  header y = 0   (under the island)
  observer      : … user-scalable=no, viewport-fit=cover   ← re-asserted
                  env(safe-area-inset-top) = 62px →  header y = 54  (clear)
```

## Test Plan

- `cd web/ios && xcodebuild test -scheme Omnigent -destination 'platform=iOS
  Simulator,name=iPhone 17 Pro' -only-testing:OmnigentTests` → all tests pass.
- Manual, iPhone 17 Pro simulator against a real Databricks workspace, measuring
  from inside the page (temporary probe, since removed) at three points — page
  load, after the host's app mounts, and after further re-renders:
  - before this change, once the host mounted: `viewport-fit` gone,
    `env(safe-area-inset-top)` `0px`, `--omnigent-inset-top` `max(0px, 0px)`,
    `.chat-header` at `y=0`.
  - after: `viewport-fit=cover` present at all three points,
    `env(safe-area-inset-top)` `62px`, `--omnigent-inset-top` `max(62px, 0px)`,
    `.chat-header` at `y=54`, stable across re-renders.
  - to confirm the diagnosis before fixing, re-adding the token by hand at
    runtime moved the header from `y=0` to `y=54` on its own.
- `pre-commit run --files web/ios/Omnigent/OmnigentWebView.swift` clean.

## Demo

Before:
<img width="1206" height="2622" alt="ios-viewport-fit-BEFORE" src="https://github.com/user-attachments/assets/c40355af-5102-45f6-bbd4-7f8cfe51df62" />

After:
<img width="1206" height="2622" alt="ios-viewport-fit-AFTER" src="https://github.com/user-attachments/assets/78f0c9b2-ce04-4c13-869b-479fb4c8d742" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Not unit-tested: the fix is JavaScript embedded in a Swift string literal and
injected into a live `WKWebView`, and the behaviour it guards against only happens
when a third-party host page mutates the DOM after mount — there's no harness that
reproduces that. Verified by measuring the computed inset and header position in
the page against a real workspace, before and after, including after subsequent
host re-renders. A follow-up worth doing: push measured safe-area insets from
native as Android does, so iOS stops depending on page viewport metadata at all.

## Changelog

Fixed iOS controls rendering under the status bar on Databricks workspace-hosted
servers
