### PR TITLE
chore(ios): bump marketing version to 0.1.2

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -540,7 +540,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -571,7 +571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
chore(ios): bump marketing version to 0.1.2

## Related issue

N/A — release chore.

## Summary

- Bumps `MARKETING_VERSION` from 0.1.1 to 0.1.2 for the `ai.omnigent.ios` target
  (Debug and Release) ahead of a TestFlight build, so testers can tell the build
  carrying the workspace fixes apart from earlier 0.1.1 uploads.
- Covers two user-facing iOS fixes now on main: connecting to a Databricks
  workspace opens Omnigent directly and hides the workspace nav bar (#4559), and
  the top controls no longer render under the status bar on workspace-hosted
  servers (#4568).
- Only the app target moves. The `.tests` / `.uitests` bundles stay at 0.1.0 —
  they are never shipped, and `web/ios/RELEASE.md` scopes manual bumps to the
  Omnigent target.
- `CURRENT_PROJECT_VERSION` is deliberately untouched: the `beta` lane computes
  the build number as `latest_testflight_build_number + 1` and injects it via an
  xcodebuild override, so bumping it in git would only add churn.
- Not part of the repo-wide version lockstep: `scripts/update_versions.py` covers
  the Python packages and the Electron desktop app, not the iOS project.

## Test Plan

- `xcodebuild -project web/ios/Omnigent.xcodeproj -target Omnigent
  -showBuildSettings -configuration Release` reports `MARKETING_VERSION = 0.1.2`
  and `PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios`, confirming the resolved
  setting rather than just the edited text.
- `python scripts/update_versions.py check` is unaffected (iOS is not one of the
  locked locations).
- `pre-commit run --files web/ios/Omnigent.xcodeproj/project.pbxproj` clean.

## Demo

N/A — version metadata only, no UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Build-setting metadata with no runtime behaviour, so there is nothing to unit
test. Verified by reading back the resolved `MARKETING_VERSION` from
`xcodebuild -showBuildSettings` for the Release configuration of the shipping
target.

## Changelog

N/A
