### PR TITLE
Add session subtree promotion

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -592,9 +592,9 @@ class _SessionSnapshot:
         sub-agent's name, e.g. ``"claude_code"`` — used to swap the
         parent spec to the child's sub-spec so the child's harness
         (e.g. ``claude-native``) is resolved instead of the parent's.
-        ``None`` for top-level sessions. Projected from the server
-        snapshot so the identity survives a runner reconnect / spec-cache
-        eviction (the in-memory ``_session_sub_agent_names`` map does not).
+        Promoted sessions retain this value so their original sub-spec and
+        harness still resolve. Projected from the server snapshot so the
+        identity survives a runner reconnect / spec-cache eviction.
     :param parent_session_id: For sub-agent sessions, the parent
         conversation's id, e.g. ``"conv_parent987"``. ``None`` for
         top-level sessions. Lets ``_ensure_subagent_work_entry`` rebuild a lost
@@ -2420,6 +2420,10 @@ def create_runner_app(
         )
         _session_start_cache[session_id] = float(snapshot.created_at)
         _session_workspace_cache[session_id] = snapshot.workspace
+        if snapshot.parent_session_id is None:
+            unregister_child_session(session_id)
+            unregister_subagent_work(session_id)
+            _drained_delivered_subagent_children.discard(session_id)
         if envelope.sub_agent_name:
             _session_sub_agent_names[session_id] = envelope.sub_agent_name
         _session_init_envelopes[session_id] = (time.monotonic(), envelope)
@@ -6279,9 +6283,12 @@ def create_runner_app(
                     output=output or "Error: native sub-agent turn failed",
                 )
             if delivery_ack is not None:
-                is_known = (
-                    conversation_id in _session_sub_agent_names or recovered_entry is not None
-                )
+                snapshot = _session_snapshot_cache.get(conversation_id)
+                is_known = recovered_entry is not None or delivery_ack.entry is not None
+                if snapshot is not None:
+                    is_known = is_known or snapshot.parent_session_id is not None
+                else:
+                    is_known = is_known or conversation_id in _session_sub_agent_names
                 not_confirmed = _subagent_delivery_not_confirmed_response(
                     delivery_ack,
                     is_runner_known_subagent=is_known,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -94,6 +94,7 @@ from omnigent.server.routes._content_type import (
 from omnigent.server.routes._errors import session_not_found as _session_not_found
 from omnigent.server.routes._origin import require_trusted_origin
 from omnigent.server.routes._sessions.common import (
+    _CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY,
     _CLAUDE_NATIVE_UI_LABEL_KEY,
     _CLAUDE_NATIVE_UI_LABEL_VALUE,
     _CLAUDE_NATIVE_WRAPPER_LABEL_KEY,
@@ -225,14 +226,21 @@ def _promotion_tree_is_active(conversations: dict[str, Conversation]) -> bool:
 
 
 def _promoted_session_title(conversation: Conversation, latest_items: list[Any]) -> str | None:
-    """Build a useful top-level title for a promoted Codex child."""
-    if not _is_codex_native_subagent(conversation):
+    """Build a useful top-level title for a promoted native child."""
+    if _is_codex_native_subagent(conversation):
+        display_name = _codex_subagent_display_tool(conversation.labels)
+        summary = conversation.labels.get(_CODEX_NATIVE_SUBAGENT_PROMPT_LABEL_KEY)
+    elif _CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY in conversation.labels:
+        display_name = conversation.sub_agent_name
+        if not display_name and conversation.title:
+            display_name = conversation.title.partition(":")[0]
+        summary = conversation.labels.get(_CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY)
+    else:
         return None
-    summary = conversation.labels.get(_CODEX_NATIVE_SUBAGENT_PROMPT_LABEL_KEY)
     summary = " ".join(summary.split()) if summary else _latest_message_preview(latest_items)
-    if not summary:
+    if not display_name or not summary:
         return None
-    prefix = f"{_codex_subagent_display_tool(conversation.labels)}: "
+    prefix = f"{display_name}: "
     remaining = _PROMOTED_SESSION_TITLE_LIMIT - len(prefix)
     if remaining < 2:
         return None
@@ -2290,7 +2298,10 @@ def register_core_routes(
             )
 
         promoted_title: str | None = None
-        if _is_codex_native_subagent(conversation):
+        if (
+            _is_codex_native_subagent(conversation)
+            or _CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY in conversation.labels
+        ):
             latest_items = await asyncio.to_thread(
                 conversation_store.list_latest_message_items_for_conversations,
                 [session_id],

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -102,6 +102,7 @@ from omnigent.server.routes._sessions.common import (
     _CODEX_NATIVE_COLLABORATION_MODES,
     _CODEX_NATIVE_SUBAGENT_PROMPT_LABEL_KEY,
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE,
+    _UI_ADDED_AGENT_TITLE_PREFIX,
     _logger,
     _managed_launch_tasks,
     _session_active_response_cache,
@@ -235,6 +236,11 @@ def _promoted_session_title(conversation: Conversation, latest_items: list[Any])
         if not display_name and conversation.title:
             display_name = conversation.title.partition(":")[0]
         summary = conversation.labels.get(_CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY)
+    elif conversation.title and conversation.title.startswith(f"{_UI_ADDED_AGENT_TITLE_PREFIX}:"):
+        _, _, remainder = conversation.title.partition(":")
+        display_name, separator, summary = remainder.partition(":")
+        if not separator:
+            return None
     else:
         return None
     summary = " ".join(summary.split()) if summary else _latest_message_preview(latest_items)
@@ -2297,20 +2303,15 @@ def register_core_routes(
                 code=ErrorCode.CONFLICT,
             )
 
-        promoted_title: str | None = None
-        if (
-            _is_codex_native_subagent(conversation)
-            or _CLAUDE_NATIVE_DESCRIPTION_LABEL_KEY in conversation.labels
-        ):
-            latest_items = await asyncio.to_thread(
-                conversation_store.list_latest_message_items_for_conversations,
-                [session_id],
-                1,
-            )
-            promoted_title = _promoted_session_title(
-                conversation,
-                latest_items.get(session_id, []),
-            )
+        latest_items = await asyncio.to_thread(
+            conversation_store.list_latest_message_items_for_conversations,
+            [session_id],
+            1,
+        )
+        promoted_title = _promoted_session_title(
+            conversation,
+            latest_items.get(session_id, []),
+        )
 
         if permission_store is not None and user_id is not None:
             await asyncio.to_thread(permission_store.ensure_user, user_id)

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -102,6 +102,10 @@ from omnigent.server.routes._sessions.common import (
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE,
     _logger,
     _managed_launch_tasks,
+    _session_active_response_cache,
+    _session_background_task_count_cache,
+    _session_sandbox_status_cache,
+    _session_terminal_pending_cache,
     get_server_runner_router,
     set_server_runner_router,
 )
@@ -114,6 +118,7 @@ from omnigent.server.routes._sessions.helpers import (
     _apply_liveness_to_items,
     _authorize_bundled_parent_and_inherit_runner,
     _codex_plan_mode_enabled,
+    _collect_descendant_conversation_ids,
     _discovery_key,
     _forward_session_change_to_runner,
     _get_runner_client,
@@ -188,6 +193,30 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
+
+_ACTIVE_SANDBOX_STAGES = frozenset({"provisioning", "cloning", "starting", "connecting"})
+
+
+def _promotion_tree_is_active(conversations: dict[str, Conversation]) -> bool:
+    """Return whether any session in a proposed promoted tree is doing work."""
+    for conversation in conversations.values():
+        session_id = conversation.id
+        sandbox_status = _session_sandbox_status_cache.get(session_id)
+        if _session_status_from_cache(session_id, conversation.live_status) == "running":
+            return True
+        if (conversation.pending_elicitation_count or 0) > 0:
+            return True
+        if pending_elicitations.count_for(session_id) > 0:
+            return True
+        if session_id in _session_active_response_cache:
+            return True
+        if _session_background_task_count_cache.get(session_id, 0) > 0:
+            return True
+        if _session_terminal_pending_cache.get(session_id, False):
+            return True
+        if sandbox_status is not None and sandbox_status.stage in _ACTIVE_SANDBOX_STAGES:
+            return True
+    return False
 
 
 def register_core_routes(
@@ -2182,6 +2211,108 @@ def register_core_routes(
             permission_level=level,
             last_task_error=None,
             agent_name=base_agent.name,
+        )
+
+    # ── POST /sessions/{session_id}/promote ──────────────────────
+
+    @router.post(
+        "/sessions/{session_id}/promote",
+        response_model=None,
+        responses={200: {"model": SessionResponse}},
+    )
+    async def promote_session(request: Request, session_id: str) -> SessionResponse:
+        """Promote an inactive child session and its descendants to a new tree."""
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id,
+            session_id,
+            LEVEL_OWNER,
+            permission_store,
+            conversation_store,
+        )
+        conversation = access.conversation
+        if conversation is None:
+            conversation = await asyncio.to_thread(
+                conversation_store.get_conversation,
+                session_id,
+            )
+        if conversation is None:
+            raise OmnigentError(
+                f"Session not found: {session_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+        if conversation.parent_conversation_id is None:
+            raise OmnigentError(
+                "This agent is already a top-level session.",
+                code=ErrorCode.CONFLICT,
+            )
+
+        descendant_ids = await _collect_descendant_conversation_ids(
+            conversation_store,
+            session_id,
+        )
+        tree = await asyncio.to_thread(
+            conversation_store.get_conversations,
+            [session_id, *descendant_ids],
+        )
+        if len(tree) != len(descendant_ids) + 1:
+            raise OmnigentError(
+                "The session tree changed while promotion was being prepared. Try again.",
+                code=ErrorCode.CONFLICT,
+            )
+        if _promotion_tree_is_active(tree):
+            raise OmnigentError(
+                "This agent or one of its sub-agents is currently active. "
+                "Try again after it finishes.",
+                code=ErrorCode.CONFLICT,
+            )
+
+        if permission_store is not None and user_id is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+            await asyncio.to_thread(
+                permission_store.grant,
+                user_id,
+                session_id,
+                LEVEL_OWNER,
+            )
+
+        try:
+            updated = await asyncio.to_thread(
+                conversation_store.promote_subtree,
+                session_id,
+            )
+        except LookupError as exc:
+            raise OmnigentError(
+                f"Session not found: {session_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            ) from exc
+        except ValueError as exc:
+            raise OmnigentError(
+                "This agent is already a top-level session.",
+                code=ErrorCode.CONFLICT,
+            ) from exc
+
+        _announce_session_added(user_id, session_id)
+        items = await asyncio.to_thread(
+            conversation_store.list_items,
+            session_id,
+            limit=10000,
+        )
+        level = await _get_permission_level(user_id, session_id, permission_store)
+        agent_name: str | None = None
+        if updated.agent_id is not None:
+            bound_agent = await asyncio.to_thread(agent_store.get, updated.agent_id)
+            agent_name = bound_agent.name if bound_agent is not None else None
+        return _build_session_response(
+            updated,
+            items.data,
+            _session_status_from_cache(session_id, updated.live_status),
+            permission_level=level,
+            last_task_error=None,
+            agent_name=agent_name,
+            viewer_id=user_id,
+            agent_store=agent_store,
+            agent_cache=agent_cache,
         )
 
     # ── POST /sessions/{session_id}/switch-agent ─────────────────

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -99,6 +99,7 @@ from omnigent.server.routes._sessions.common import (
     _CLAUDE_NATIVE_WRAPPER_LABEL_KEY,
     _CODEX_NATIVE_COLLABORATION_MODE_LABEL_KEY,
     _CODEX_NATIVE_COLLABORATION_MODES,
+    _CODEX_NATIVE_SUBAGENT_PROMPT_LABEL_KEY,
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE,
     _logger,
     _managed_launch_tasks,
@@ -118,11 +119,14 @@ from omnigent.server.routes._sessions.helpers import (
     _apply_liveness_to_items,
     _authorize_bundled_parent_and_inherit_runner,
     _codex_plan_mode_enabled,
+    _codex_subagent_display_tool,
     _collect_descendant_conversation_ids,
     _discovery_key,
     _forward_session_change_to_runner,
     _get_runner_client,
     _invalidate_runner_backed_snapshot_state,
+    _is_codex_native_subagent,
+    _latest_message_preview,
     _multipart_missing_detail,
     _notify_runner_of_bundled_child,
     _parse_session_create_metadata,
@@ -195,6 +199,7 @@ from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
 
 _ACTIVE_SANDBOX_STAGES = frozenset({"provisioning", "cloning", "starting", "connecting"})
+_PROMOTED_SESSION_TITLE_LIMIT = 60
 
 
 def _promotion_tree_is_active(conversations: dict[str, Conversation]) -> bool:
@@ -217,6 +222,23 @@ def _promotion_tree_is_active(conversations: dict[str, Conversation]) -> bool:
         if sandbox_status is not None and sandbox_status.stage in _ACTIVE_SANDBOX_STAGES:
             return True
     return False
+
+
+def _promoted_session_title(conversation: Conversation, latest_items: list[Any]) -> str | None:
+    """Build a useful top-level title for a promoted Codex child."""
+    if not _is_codex_native_subagent(conversation):
+        return None
+    summary = conversation.labels.get(_CODEX_NATIVE_SUBAGENT_PROMPT_LABEL_KEY)
+    summary = " ".join(summary.split()) if summary else _latest_message_preview(latest_items)
+    if not summary:
+        return None
+    prefix = f"{_codex_subagent_display_tool(conversation.labels)}: "
+    remaining = _PROMOTED_SESSION_TITLE_LIMIT - len(prefix)
+    if remaining < 2:
+        return None
+    if len(summary) > remaining:
+        summary = summary[: remaining - 1].rstrip() + "…"
+    return prefix + summary
 
 
 def register_core_routes(
@@ -2267,6 +2289,18 @@ def register_core_routes(
                 code=ErrorCode.CONFLICT,
             )
 
+        promoted_title: str | None = None
+        if _is_codex_native_subagent(conversation):
+            latest_items = await asyncio.to_thread(
+                conversation_store.list_latest_message_items_for_conversations,
+                [session_id],
+                1,
+            )
+            promoted_title = _promoted_session_title(
+                conversation,
+                latest_items.get(session_id, []),
+            )
+
         if permission_store is not None and user_id is not None:
             await asyncio.to_thread(permission_store.ensure_user, user_id)
             await asyncio.to_thread(
@@ -2280,6 +2314,7 @@ def register_core_routes(
             updated = await asyncio.to_thread(
                 conversation_store.promote_subtree,
                 session_id,
+                title=promoted_title,
             )
         except LookupError as exc:
             raise OmnigentError(

--- a/omnigent/server/runner_session_init.py
+++ b/omnigent/server/runner_session_init.py
@@ -21,7 +21,7 @@ class RunnerSessionInitializer:
         self._registry = registry
         self._server_version = server_version
         self._tasks: dict[
-            tuple[str, int, str, str, str | None],
+            tuple[str, int, str, str, str | None, str | None],
             asyncio.Task[httpx.Response],
         ] = {}
 
@@ -49,6 +49,7 @@ class RunnerSessionInitializer:
             conversation.id,
             agent_id,
             conversation.sub_agent_name,
+            conversation.parent_conversation_id,
         )
         task = self._tasks.get(key)
         if task is None:

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1623,7 +1623,12 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
-    def promote_subtree(self, conversation_id: str) -> Conversation:
+    def promote_subtree(
+        self,
+        conversation_id: str,
+        *,
+        title: str | None = None,
+    ) -> Conversation:
         """Promote a child conversation and its descendants to a new tree.
 
         The target becomes top-level and every node in its subtree uses the
@@ -1631,6 +1636,7 @@ class ConversationStore(ABC):
         conversation content remain unchanged.
 
         :param conversation_id: Child conversation to promote.
+        :param title: Optional top-level title to assign during promotion.
         :returns: The updated target conversation.
         :raises LookupError: If the conversation does not exist.
         :raises ValueError: If the conversation is already top-level.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1623,6 +1623,21 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def promote_subtree(self, conversation_id: str) -> Conversation:
+        """Promote a child conversation and its descendants to a new tree.
+
+        The target becomes top-level and every node in its subtree uses the
+        target as ``root_conversation_id``. Descendant parent links and all
+        conversation content remain unchanged.
+
+        :param conversation_id: Child conversation to promote.
+        :returns: The updated target conversation.
+        :raises LookupError: If the conversation does not exist.
+        :raises ValueError: If the conversation is already top-level.
+        """
+        ...
+
+    @abstractmethod
     async def delete_conversation(self, conversation_id: str) -> bool:
         """
         Delete a conversation and all its items.

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3824,7 +3824,12 @@ class SqlAlchemyConversationStore(ConversationStore):
             raise LookupError(f"conversation not found: {conversation_id!r}")
         return conv
 
-    def promote_subtree(self, conversation_id: str) -> Conversation:
+    def promote_subtree(
+        self,
+        conversation_id: str,
+        *,
+        title: str | None = None,
+    ) -> Conversation:
         """Detach a child conversation and make its subtree a new tree.
 
         The parent detach and recursive root rewrite share one Agent Platform
@@ -3832,6 +3837,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         retry cannot silently re-promote an already top-level conversation.
 
         :param conversation_id: Child conversation to promote.
+        :param title: Optional top-level title to assign during promotion.
         :returns: The promoted target conversation.
         :raises LookupError: If the conversation does not exist.
         :raises ValueError: If the conversation is already top-level.
@@ -3872,6 +3878,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .values(root_conversation_id=conversation_id)
             )
             target.parent_conversation_id = None
+            if title is not None:
+                target.title = title
             target.updated_at = now_epoch()
 
         promoted = self.get_conversation(conversation_id)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3824,6 +3824,61 @@ class SqlAlchemyConversationStore(ConversationStore):
             raise LookupError(f"conversation not found: {conversation_id!r}")
         return conv
 
+    def promote_subtree(self, conversation_id: str) -> Conversation:
+        """Detach a child conversation and make its subtree a new tree.
+
+        The parent detach and recursive root rewrite share one Agent Platform
+        transaction. The target is re-checked while holding the write lock so a
+        retry cannot silently re-promote an already top-level conversation.
+
+        :param conversation_id: Child conversation to promote.
+        :returns: The promoted target conversation.
+        :raises LookupError: If the conversation does not exist.
+        :raises ValueError: If the conversation is already top-level.
+        """
+        with self._conv_session_immediate("promote_subtree") as session:
+            target_query = select(SqlConversation).where(
+                SqlConversation.workspace_id == current_workspace_id(),
+                SqlConversation.id == conversation_id,
+            )
+            if self._supports_for_update:
+                target_query = target_query.with_for_update()
+            target = session.execute(target_query).scalar_one_or_none()
+            if target is None:
+                raise LookupError(f"conversation not found: {conversation_id!r}")
+            if target.parent_conversation_id is None:
+                raise ValueError(f"conversation is already top-level: {conversation_id!r}")
+
+            subtree = (
+                select(SqlConversation.id)
+                .where(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.id == conversation_id,
+                )
+                .cte(name="promoted_subtree", recursive=True)
+            )
+            subtree = subtree.union_all(
+                select(SqlConversation.id).where(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.parent_conversation_id == subtree.c.id,
+                )
+            )
+            session.execute(
+                update(SqlConversation)
+                .where(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    SqlConversation.id.in_(select(subtree.c.id)),
+                )
+                .values(root_conversation_id=conversation_id)
+            )
+            target.parent_conversation_id = None
+            target.updated_at = now_epoch()
+
+        promoted = self.get_conversation(conversation_id)
+        if promoted is None:
+            raise LookupError(f"conversation not found: {conversation_id!r}")
+        return promoted
+
     async def delete_conversation(self, conversation_id: str) -> bool:
         """
         Delete a conversation and all of its descendants, cleaning up

--- a/openapi.json
+++ b/openapi.json
@@ -10713,6 +10713,49 @@
         ]
       }
     },
+    "/v1/sessions/{session_id}/promote": {
+      "post": {
+        "description": "Promote an inactive child session and its descendants to a new tree.",
+        "operationId": "promote_session_v1_sessions__session_id__promote_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Promote Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
     "/v1/sessions/{session_id}/read-state": {
       "put": {
         "description": "Set the calling user's read-state for one session.\n\nRequires `LEVEL_READ` on the session in multi-user mode \u2014 you can\nonly track read-state for sessions you can see. Stores the values\nverbatim (the client enforces the baseline's monotonicity and the\nunread semantics); the server does not interpret them against\nsession status. Returns `204` \u2014 the client already has the\noptimistic state and re-reads the authoritative value on the next\n`GET /v1/sessions` poll.\n\n**Parameters**\n\n- `body` \u2014 The validated `ReadStatePutRequest`.\n\n**Returns:** An empty `204 No Content` response.\n\n**Raises**\n\n- `OmnigentError` \u2014 403 if the caller lacks read access.",

--- a/tests/e2e_ui/agents/test_promote_subagent.py
+++ b/tests/e2e_ui/agents/test_promote_subagent.py
@@ -1,0 +1,87 @@
+"""UI journey: promote an idle sub-agent into a top-level session.
+
+The child is seeded through the public session API so this test stays fast and
+LLM-free. Playwright covers the user-facing contract: the owner opens the
+child's action menu, confirms promotion, and sees the child leave the Agents
+tree and appear in the top-level Sessions list.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+_SUBAGENT_ROW = '[data-testid="subagent-row"]'
+_PROMOTION_DIALOG = '[data-testid="promote-agent-dialog"]'
+
+
+def _create_child(base_url: str, parent_id: str, title: str) -> str:
+    """Create an idle child under ``parent_id`` and return its session id."""
+    agent = httpx.get(f"{base_url}/v1/sessions/{parent_id}/agent", timeout=10.0)
+    agent.raise_for_status()
+    response = httpx.post(
+        f"{base_url}/v1/sessions",
+        json={
+            "agent_id": agent.json()["id"],
+            "parent_session_id": parent_id,
+            "title": title,
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    return str(response.json()["id"])
+
+
+def test_promote_subagent_from_agents_panel(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Confirming promotion moves the child from the tree to the sidebar."""
+    base_url, parent_id = seeded_session
+    child_title = "ui:hello_world:promotion-e2e"
+    promoted_title = "hello_world: promotion-e2e"
+    child_id = _create_child(base_url, parent_id, child_title)
+
+    try:
+        page.goto(f"{base_url}/c/{parent_id}")
+        open_right_rail(page)
+        rail = page.get_by_role("complementary", name="Workspace")
+        rail.get_by_role("tab", name=re.compile("^Agents")).click()
+
+        child_row = rail.locator(f'{_SUBAGENT_ROW}[data-child-session-id="{child_id}"]')
+        expect(child_row).to_be_visible(timeout=30_000)
+
+        rail.get_by_role("button", name="Actions for promotion-e2e").click()
+        page.get_by_role("menuitem", name="Promote to session").click()
+
+        dialog = page.locator(_PROMOTION_DIALOG)
+        expect(dialog).to_be_visible()
+        expect(dialog).to_contain_text("Its sub-agents will move with it")
+
+        with page.expect_response(
+            lambda response: (
+                response.request.method == "POST"
+                and response.url.endswith(f"/v1/sessions/{child_id}/promote")
+            ),
+            timeout=30_000,
+        ) as promotion:
+            dialog.get_by_role("button", name="Promote", exact=True).click()
+        assert promotion.value.status == 200, promotion.value.text()
+
+        expect(child_row).to_have_count(0, timeout=30_000)
+        sidebar = page.get_by_role("complementary", name="Conversations")
+        expect(sidebar.get_by_role("link", name=promoted_title, exact=True)).to_be_visible(
+            timeout=30_000
+        )
+
+        promoted = httpx.get(f"{base_url}/v1/sessions/{child_id}", timeout=10.0)
+        promoted.raise_for_status()
+        assert promoted.json()["parent_session_id"] is None
+        assert promoted.json()["root_conversation_id"] == child_id
+        assert promoted.json()["title"] == promoted_title
+    finally:
+        httpx.delete(f"{base_url}/v1/sessions/{child_id}", timeout=10.0)

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -128,6 +128,7 @@ async def _post_native_idle(
     child_body: dict[str, Any],
     seed_parent_inbox: bool,
     register_work: bool,
+    initialize_sub_agent_name: bool = False,
     output: str = "review complete: LGTM",
 ) -> tuple[int, list[dict[str, Any]]]:
     """POST a native ``external_session_status: idle`` and return (http, inbox items).
@@ -136,7 +137,8 @@ async def _post_native_idle(
     ``register_work`` seeds the in-memory work entry (the healthy case); leaving
     it ``False`` models a reconnect-wiped map or a ``sys_session_create`` child
     the dispatch never registered. ``seed_parent_inbox`` controls whether the
-    parent's inbox queue is present on this runner.
+    parent's inbox queue is present on this runner. ``initialize_sub_agent_name``
+    registers the retained sub-spec identity before the status arrives.
     """
     if seed_parent_inbox:
         runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
@@ -165,6 +167,16 @@ async def _post_native_idle(
     )
 
     async with _runner_client(app) as client:
+        if initialize_sub_agent_name:
+            initialized = await client.post(
+                "/v1/sessions",
+                json={
+                    "session_id": CHILD_SESSION_ID,
+                    "agent_id": "ag_reviewer",
+                    "sub_agent_name": "reviewer",
+                },
+            )
+            assert initialized.status_code == 201, initialized.text
         resp = await client.post(
             f"/v1/sessions/{CHILD_SESSION_ID}/events",
             json={
@@ -345,6 +357,22 @@ async def test_top_level_session_idle_is_noop(
         child_body=_child_snapshot(sub_agent_name=None, parent_session_id=None),
         seed_parent_inbox=True,
         register_work=False,
+    )
+
+    assert http == 204
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_promoted_session_retains_sub_agent_name_without_parent_delivery(
+    _clean_subagent_registry: None,
+) -> None:
+    """A promoted session keeps its sub-spec identity but behaves as top-level."""
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=None),
+        seed_parent_inbox=True,
+        register_work=False,
+        initialize_sub_agent_name=True,
     )
 
     assert http == 204

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -89,6 +89,7 @@ def _seed_child(
     parent_id: str,
     title: str,
     agent_id: str | None = None,
+    sub_agent_name: str | None = None,
 ) -> Conversation:
     """
     Create a child sub-agent conversation.
@@ -105,6 +106,7 @@ def _seed_child(
         e.g. ``"researcher:auth"``.
     :param agent_id: Agent id to bind to this conversation (populates
         the ``agent_id`` field in the summary).
+    :param sub_agent_name: Optional sub-agent spec name retained by native children.
     :returns: The created child :class:`Conversation`.
     """
     return conv_store.create_conversation(
@@ -112,6 +114,7 @@ def _seed_child(
         title=title,
         parent_conversation_id=parent_id,
         agent_id=agent_id,
+        sub_agent_name=sub_agent_name,
     )
 
 
@@ -143,6 +146,7 @@ async def test_promote_session_detaches_subtree_and_updates_lists(
     assert body["kind"] == "default"
     assert body["parent_session_id"] is None
     assert body["root_conversation_id"] == promoted.id
+    assert body["title"] == "reviewer:B"
 
     old_children = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
     new_children = await client.get(f"/v1/sessions/{promoted.id}/child_sessions")
@@ -197,6 +201,37 @@ async def test_promote_codex_child_replaces_thread_id_with_name_and_summary(
     updated = conv_store.get_conversation(promoted.id)
     assert updated is not None
     assert updated.title == "Aquinas: Reviewed the promotion behavior"
+
+
+async def test_promote_claude_child_replaces_subagent_id_with_name_and_description(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A promoted Claude child uses its agent type and task description."""
+    parent = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    promoted = _seed_child(
+        conv_store=conv_store,
+        parent_id=parent["id"],
+        title="reviewer:agent-a1b2c3",
+        agent_id=parent["agent_id"],
+        sub_agent_name="reviewer",
+    )
+    conv_store.set_labels(
+        promoted.id,
+        {
+            "omnigent.wrapper": "claude-code-native-ui-subagent",
+            "omnigent.claude_native.description": "Review the promotion behavior",
+        },
+    )
+
+    response = await client.post(f"/v1/sessions/{promoted.id}/promote")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["title"] == "reviewer: Review the promotion behavior"
+    updated = conv_store.get_conversation(promoted.id)
+    assert updated is not None
+    assert updated.title == "reviewer: Review the promotion behavior"
 
 
 @pytest.mark.parametrize("active_node", ["target", "descendant"])

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -234,6 +234,29 @@ async def test_promote_claude_child_replaces_subagent_id_with_name_and_descripti
     assert updated.title == "reviewer: Review the promotion behavior"
 
 
+async def test_promote_ui_added_child_removes_internal_title_prefix(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A promoted user-added child gets a normal top-level title."""
+    parent = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    promoted = _seed_child(
+        conv_store=conv_store,
+        parent_id=parent["id"],
+        title="ui:hello_world:promotion-e2e",
+        agent_id=parent["agent_id"],
+    )
+
+    response = await client.post(f"/v1/sessions/{promoted.id}/promote")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["title"] == "hello_world: promotion-e2e"
+    updated = conv_store.get_conversation(promoted.id)
+    assert updated is not None
+    assert updated.title == "hello_world: promotion-e2e"
+
+
 @pytest.mark.parametrize("active_node", ["target", "descendant"])
 async def test_promote_session_rejects_active_tree(
     client: httpx.AsyncClient,

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -155,6 +155,50 @@ async def test_promote_session_detaches_subtree_and_updates_lists(
     assert promoted.id in top_level_ids
 
 
+async def test_promote_codex_child_replaces_thread_id_with_name_and_summary(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A promoted Codex child gets a useful sidebar title."""
+    parent = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    promoted = _seed_child(
+        conv_store=conv_store,
+        parent_id=parent["id"],
+        title="codex-native-ui-subagent:019fee4d-9e32-79b3-8709-f70bc75f455b",
+        agent_id=parent["agent_id"],
+    )
+    conv_store.set_labels(
+        promoted.id,
+        {
+            "omnigent.wrapper": "codex-native-ui-subagent",
+            "omnigent.codex_native.agent_nickname": "Aquinas",
+        },
+    )
+    conv_store.append(
+        promoted.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_codex_summary",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "Reviewed the promotion behavior"}],
+                    agent="codex-native-ui",
+                ),
+            )
+        ],
+    )
+
+    response = await client.post(f"/v1/sessions/{promoted.id}/promote")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["title"] == "Aquinas: Reviewed the promotion behavior"
+    updated = conv_store.get_conversation(promoted.id)
+    assert updated is not None
+    assert updated.title == "Aquinas: Reviewed the promotion behavior"
+
+
 @pytest.mark.parametrize("active_node", ["target", "descendant"])
 async def test_promote_session_rejects_active_tree(
     client: httpx.AsyncClient,

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -115,6 +115,81 @@ def _seed_child(
     )
 
 
+async def test_promote_session_detaches_subtree_and_updates_lists(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """The public endpoint promotes B while keeping C attached to it."""
+    parent = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    promoted = _seed_child(
+        conv_store=conv_store,
+        parent_id=parent["id"],
+        title="reviewer:B",
+        agent_id=parent["agent_id"],
+    )
+    child = _seed_child(
+        conv_store=conv_store,
+        parent_id=promoted.id,
+        title="researcher:C",
+        agent_id=parent["agent_id"],
+    )
+
+    response = await client.post(f"/v1/sessions/{promoted.id}/promote")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == promoted.id
+    assert body["kind"] == "default"
+    assert body["parent_session_id"] is None
+    assert body["root_conversation_id"] == promoted.id
+
+    old_children = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
+    new_children = await client.get(f"/v1/sessions/{promoted.id}/child_sessions")
+    assert [row["id"] for row in old_children.json()["data"]] == []
+    assert [row["id"] for row in new_children.json()["data"]] == [child.id]
+
+    top_level = await client.get("/v1/sessions?limit=100")
+    top_level_ids = {row["id"] for row in top_level.json()["data"]}
+    assert parent["id"] in top_level_ids
+    assert promoted.id in top_level_ids
+
+
+@pytest.mark.parametrize("active_node", ["target", "descendant"])
+async def test_promote_session_rejects_active_tree(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    active_node: str,
+) -> None:
+    """An active target or descendant keeps the complete tree attached."""
+    parent = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    promoted = _seed_child(
+        conv_store=conv_store,
+        parent_id=parent["id"],
+        title="reviewer:B",
+        agent_id=parent["agent_id"],
+    )
+    child = _seed_child(
+        conv_store=conv_store,
+        parent_id=promoted.id,
+        title="researcher:C",
+        agent_id=parent["agent_id"],
+    )
+    active_id = promoted.id if active_node == "target" else child.id
+    sessions_module._session_status_cache[active_id] = "running"
+    try:
+        response = await client.post(f"/v1/sessions/{promoted.id}/promote")
+    finally:
+        sessions_module._session_status_cache.pop(active_id, None)
+
+    assert response.status_code == 409
+    assert "currently active" in response.json()["error"]["message"]
+    unchanged = conv_store.get_conversation(promoted.id)
+    assert unchanged is not None
+    assert unchanged.parent_conversation_id == parent["id"]
+
+
 # ── 404 ──────────────────────────────────────────────────
 
 

--- a/tests/server/routes/test_sessions_promote.py
+++ b/tests/server/routes/test_sessions_promote.py
@@ -1,0 +1,95 @@
+"""Permission tests for ``POST /v1/sessions/{id}/promote``."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from omnigent.db.utils import generate_agent_id
+from omnigent.errors import OmnigentError
+from omnigent.server.auth import LEVEL_OWNER, LEVEL_READ, UnifiedAuthProvider
+from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+
+def _app(db_uri: str) -> tuple[FastAPI, SqlAlchemyConversationStore, SqlAlchemyPermissionStore]:
+    """Build an authenticated sessions router over the per-test database."""
+    conversations = SqlAlchemyConversationStore(db_uri)
+    agents = SqlAlchemyAgentStore(db_uri)
+    permissions = SqlAlchemyPermissionStore(db_uri)
+    router = create_sessions_router(
+        conversation_store=conversations,
+        agent_store=agents,
+        auth_provider=UnifiedAuthProvider(source="header"),
+        permission_store=permissions,
+    )
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle_error(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(router, prefix="/v1")
+    return app, conversations, permissions
+
+
+def _seed_tree(
+    db_uri: str,
+    conversations: SqlAlchemyConversationStore,
+) -> tuple[str, str]:
+    """Create a bound A -> B tree and return both conversation ids."""
+    agents = SqlAlchemyAgentStore(db_uri)
+    agent = agents.create(generate_agent_id(), "promote-agent", "bundle/promote")
+    parent = conversations.create_conversation(agent_id=agent.id)
+    child = conversations.create_conversation(
+        kind="sub_agent",
+        parent_conversation_id=parent.id,
+        agent_id=agent.id,
+        sub_agent_name="reviewer",
+    )
+    return parent.id, child.id
+
+
+def test_promote_requires_parent_owner_and_grants_direct_owner(db_uri: str) -> None:
+    """Inherited owner access becomes a direct grant before B is detached."""
+    app, conversations, permissions = _app(db_uri)
+    parent_id, child_id = _seed_tree(db_uri, conversations)
+    owner = "owner@promote.test"
+    permissions.ensure_user(owner)
+    permissions.grant(owner, parent_id, LEVEL_OWNER)
+
+    response = TestClient(app).post(
+        f"/v1/sessions/{child_id}/promote",
+        headers={"X-Forwarded-Email": owner},
+    )
+
+    assert response.status_code == 200, response.text
+    assert permissions.get_permission_level(owner, child_id) == LEVEL_OWNER
+    assert response.json()["permission_level"] == LEVEL_OWNER
+
+
+def test_promote_rejects_non_owner_without_mutation(db_uri: str) -> None:
+    """Read access to A is insufficient to detach B."""
+    app, conversations, permissions = _app(db_uri)
+    parent_id, child_id = _seed_tree(db_uri, conversations)
+    reader = "reader@promote.test"
+    permissions.ensure_user(reader)
+    permissions.grant(reader, parent_id, LEVEL_READ)
+
+    response = TestClient(app).post(
+        f"/v1/sessions/{child_id}/promote",
+        headers={"X-Forwarded-Email": reader},
+    )
+
+    assert response.status_code == 403
+    child = conversations.get_conversation(child_id)
+    assert child is not None
+    assert child.parent_conversation_id == parent_id
+    assert permissions.get_permission_level(reader, child_id) is None

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from typing import Any
 
 import httpx
@@ -106,6 +107,36 @@ async def test_initializer_evicts_rejected_result_for_retry() -> None:
 
     assert first.status_code == second.status_code == 503
     assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_initializer_reinitializes_when_parent_topology_changes() -> None:
+    """Promoting a child invalidates readiness for its prior parent link."""
+    registry = _Registry()
+    client = _Client()
+    client.release.set()
+    initializer = RunnerSessionInitializer(  # type: ignore[arg-type]
+        registry,
+        server_version="0.6.0.dev0",
+    )
+    child = dataclasses.replace(
+        _conversation(),
+        root_conversation_id="conv_parent",
+        parent_conversation_id="conv_parent",
+        sub_agent_name="reviewer",
+    )
+
+    await initializer.initialize(child, client, timeout=10)  # type: ignore[arg-type]
+    promoted = dataclasses.replace(
+        child,
+        root_conversation_id=child.id,
+        parent_conversation_id=None,
+    )
+    await initializer.initialize(promoted, client, timeout=10)  # type: ignore[arg-type]
+
+    assert len(client.calls) == 2
+    assert client.calls[0]["session_init"]["snapshot"]["parent_session_id"] == "conv_parent"
+    assert client.calls[1]["session_init"]["snapshot"]["parent_session_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1510,12 +1510,13 @@ def test_promote_subtree_detaches_target_and_preserves_descendants(
         ],
     )
 
-    result = conversation_store.promote_subtree(promoted.id)
+    result = conversation_store.promote_subtree(promoted.id, title="reviewer: keep this history")
 
     assert result.id == promoted.id
     assert result.kind == "default"
     assert result.parent_conversation_id is None
     assert result.root_conversation_id == promoted.id
+    assert result.title == "reviewer: keep this history"
     assert conversation_store.list_items(promoted.id).data[0].data == MessageData(
         role="user",
         content=[{"type": "input_text", "text": "keep this history"}],

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1471,6 +1471,82 @@ def test_list_conversations_archive_toggle_round_trips(
 # ── Delete ───────────────────────────────────────────
 
 
+def test_promote_subtree_detaches_target_and_preserves_descendants(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Promotion rewrites only the promoted subtree's structural fields."""
+    root = conversation_store.create_conversation(title="A")
+    promoted = conversation_store.create_conversation(
+        kind="sub_agent",
+        title="B",
+        parent_conversation_id=root.id,
+    )
+    child = conversation_store.create_conversation(
+        kind="sub_agent",
+        title="C",
+        parent_conversation_id=promoted.id,
+    )
+    grandchild = conversation_store.create_conversation(
+        kind="sub_agent",
+        title="D",
+        parent_conversation_id=child.id,
+    )
+    sibling = conversation_store.create_conversation(
+        kind="sub_agent",
+        title="sibling",
+        parent_conversation_id=root.id,
+    )
+    conversation_store.append(
+        promoted.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_promote",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "keep this history"}],
+                ),
+            )
+        ],
+    )
+
+    result = conversation_store.promote_subtree(promoted.id)
+
+    assert result.id == promoted.id
+    assert result.kind == "default"
+    assert result.parent_conversation_id is None
+    assert result.root_conversation_id == promoted.id
+    assert conversation_store.list_items(promoted.id).data[0].data == MessageData(
+        role="user",
+        content=[{"type": "input_text", "text": "keep this history"}],
+    )
+
+    fetched_child = conversation_store.get_conversation(child.id)
+    fetched_grandchild = conversation_store.get_conversation(grandchild.id)
+    fetched_sibling = conversation_store.get_conversation(sibling.id)
+    assert fetched_child is not None
+    assert fetched_child.parent_conversation_id == promoted.id
+    assert fetched_child.root_conversation_id == promoted.id
+    assert fetched_grandchild is not None
+    assert fetched_grandchild.parent_conversation_id == child.id
+    assert fetched_grandchild.root_conversation_id == promoted.id
+    assert fetched_sibling is not None
+    assert fetched_sibling.parent_conversation_id == root.id
+    assert fetched_sibling.root_conversation_id == root.id
+
+
+def test_promote_subtree_rejects_missing_and_top_level(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A retry or an unknown id cannot mutate an unrelated tree."""
+    root = conversation_store.create_conversation()
+
+    with pytest.raises(LookupError, match="conversation not found"):
+        conversation_store.promote_subtree("f" * 32)
+    with pytest.raises(ValueError, match="already top-level"):
+        conversation_store.promote_subtree(root.id)
+
+
 @pytest.mark.asyncio
 async def test_delete_conversation(
     conversation_store: SqlAlchemyConversationStore,

--- a/web/src/hooks/usePromoteSession.test.tsx
+++ b/web/src/hooks/usePromoteSession.test.tsx
@@ -1,0 +1,63 @@
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticatedFetch } from "@/lib/identity";
+import { childSessionsQueryKey } from "./useChildSessions";
+import { usePromoteSession } from "./usePromoteSession";
+
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+
+const authenticatedFetchMock = vi.mocked(authenticatedFetch);
+
+function wrapperWith(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe("usePromoteSession", () => {
+  beforeEach(() => authenticatedFetchMock.mockReset());
+
+  it("posts the promotion and invalidates only affected topology caches", async () => {
+    const promoted = { id: "conv_b", parentSessionId: null, rootConversationId: "conv_b" };
+    authenticatedFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(promoted), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => usePromoteSession(), { wrapper: wrapperWith(client) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ sessionId: "conv_b", previousParentId: "conv_a" });
+    });
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith("/v1/sessions/conv_b/promote", {
+      method: "POST",
+    });
+    expect(client.getQueryData(["session", "conv_b"])).toEqual(promoted);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: childSessionsQueryKey("conv_a") });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["session", "conv_b"] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["rootSessionId"] });
+    expect(invalidate).toHaveBeenCalledTimes(4);
+  });
+
+  it("turns a forbidden response into concise UI copy", async () => {
+    authenticatedFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "internal permission detail" } }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => usePromoteSession(), { wrapper: wrapperWith(client) });
+
+    await expect(
+      result.current.mutateAsync({ sessionId: "conv_b", previousParentId: "conv_a" }),
+    ).rejects.toThrow("You don't have permission to promote this agent.");
+  });
+});

--- a/web/src/hooks/usePromoteSession.ts
+++ b/web/src/hooks/usePromoteSession.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { childSessionsQueryKey } from "@/hooks/useChildSessions";
+import { authenticatedFetch } from "@/lib/identity";
+import type { Session } from "@/lib/types";
+
+export interface PromoteSessionInput {
+  sessionId: string;
+  previousParentId: string;
+}
+
+async function promoteSession(sessionId: string): Promise<Session> {
+  const response = await authenticatedFetch(
+    `/v1/sessions/${encodeURIComponent(sessionId)}/promote`,
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: { message?: string };
+    };
+    if (response.status === 403) {
+      throw new Error("You don't have permission to promote this agent.");
+    }
+    throw new Error(body.error?.message ?? "Unable to promote this agent.");
+  }
+  return (await response.json()) as Session;
+}
+
+/** Promote one child session and refresh the tree locations it changed. */
+export function usePromoteSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ sessionId }: PromoteSessionInput) => promoteSession(sessionId),
+    onSuccess: async (session, { sessionId, previousParentId }) => {
+      queryClient.setQueryData(["session", sessionId], session);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["conversations"] }),
+        queryClient.invalidateQueries({ queryKey: childSessionsQueryKey(previousParentId) }),
+        queryClient.invalidateQueries({ queryKey: ["session", sessionId] }),
+        queryClient.invalidateQueries({ queryKey: ["rootSessionId"] }),
+      ]);
+    },
+  });
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1576,7 +1576,11 @@ export function AppShell() {
                   onClose={() => setSubagentsPanelOpen(false)}
                   testId="subagents-panel-drawer"
                 >
-                  <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+                  <SubagentsPanel
+                    conversationId={conversationId}
+                    rootSessionId={rootSessionId}
+                    permissionLevel={permissionLevel}
+                  />
                 </MobilePanelDrawer>
               )}
               {conversationId && (

--- a/web/src/shell/SubagentsGraphView.test.tsx
+++ b/web/src/shell/SubagentsGraphView.test.tsx
@@ -41,6 +41,10 @@ vi.mock("@/hooks/useSession", () => ({
   useSession: vi.fn(),
 }));
 
+vi.mock("@/hooks/usePromoteSession", () => ({
+  usePromoteSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
 vi.mock("@/components/icons/ClaudeIcon", () => ({
   ClaudeIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="claude" />,
 }));
@@ -114,6 +118,7 @@ function renderPanel(opts: { conversationId?: string; rootSessionId?: string } =
       <SubagentsPanel
         conversationId={opts.conversationId ?? "conv_root"}
         rootSessionId={opts.rootSessionId ?? "conv_root"}
+        permissionLevel={4}
       />
     </MemoryRouter>,
   );

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -1,6 +1,7 @@
 import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+import type * as UsePromoteSessionModule from "@/hooks/usePromoteSession";
 
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   BookOpenIcon,
   Code2Icon,
@@ -15,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { type ChildSessionInfo, useChildSessions } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
+import { usePromoteSession } from "@/hooks/usePromoteSession";
 import { iconForAgentType, SubagentsPanel } from "./SubagentsPanel";
 
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
@@ -26,6 +28,11 @@ vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
 
 vi.mock("@/hooks/useSession", () => ({
   useSession: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePromoteSession", async (importOriginal) => ({
+  ...(await importOriginal<typeof UsePromoteSessionModule>()),
+  usePromoteSession: vi.fn(),
 }));
 
 // Stub the brand logos with plain SVGs so jsdom doesn't have to resolve
@@ -54,22 +61,31 @@ vi.mock("@/components/icons/OttoIcon", () => ({
 
 const useChildSessionsMock = vi.mocked(useChildSessions);
 const useSessionMock = vi.mocked(useSession);
+const usePromoteSessionMock = vi.mocked(usePromoteSession);
+const promoteMutateAsyncMock = vi.fn();
 
 interface RenderOptions {
   /** The conversation in main — used only for active-row highlighting. */
   conversationId?: string;
   /** The root id whose children populate the list. */
   rootSessionId?: string;
+  /** Effective root permission. */
+  permissionLevel?: number | null;
 }
 
 function renderPanel({
   conversationId = "conv_parent",
   rootSessionId = "conv_parent",
+  permissionLevel = 4,
   initialEntries,
 }: RenderOptions & { initialEntries?: string[] } = {}) {
   return render(
     <MemoryRouter initialEntries={initialEntries}>
-      <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+      <SubagentsPanel
+        conversationId={conversationId}
+        rootSessionId={rootSessionId}
+        permissionLevel={permissionLevel}
+      />
     </MemoryRouter>,
   );
 }
@@ -138,6 +154,13 @@ const ICON_CASES: [string | null, ReturnType<typeof iconForAgentType>][] = [
 beforeEach(() => {
   useChildSessionsMock.mockReset();
   useSessionMock.mockReset();
+  usePromoteSessionMock.mockReset();
+  promoteMutateAsyncMock.mockReset();
+  promoteMutateAsyncMock.mockResolvedValue({ id: "conv_promoted" });
+  usePromoteSessionMock.mockReturnValue({
+    mutateAsync: promoteMutateAsyncMock,
+    isPending: false,
+  } as unknown as ReturnType<typeof usePromoteSession>);
   // Default: parent's status is idle. Tests override per-case.
   useSessionMock.mockReturnValue({
     session: {
@@ -164,6 +187,42 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("SubagentsPanel", () => {
+  it("lets an owner confirm promotion for a child row", async () => {
+    mockChildTree({
+      conv_root: [childInfo({ id: "conv_child", session_name: "reviewer" })],
+    });
+    renderPanel({ rootSessionId: "conv_root" });
+
+    fireEvent.pointerDown(screen.getByTestId("subagent-actions"), { button: 0 });
+    fireEvent.click(await screen.findByText("Promote to session"));
+
+    expect(screen.getByTestId("promote-agent-dialog")).toHaveTextContent("Promote reviewer?");
+    fireEvent.click(screen.getByRole("button", { name: "Promote" }));
+    await waitFor(() =>
+      expect(promoteMutateAsyncMock).toHaveBeenCalledWith({
+        sessionId: "conv_child",
+        previousParentId: "conv_root",
+      }),
+    );
+  });
+
+  it("hides promotion actions from non-owners", () => {
+    mockChildTree({ conv_root: [childInfo({ id: "conv_child" })] });
+
+    renderPanel({ rootSessionId: "conv_root", permissionLevel: 2 });
+
+    expect(screen.queryByTestId("subagent-actions")).toBeNull();
+  });
+
+  it("disables promotion while the child is active", async () => {
+    mockChildTree({ conv_root: [childInfo({ id: "conv_child", busy: true })] });
+    renderPanel({ rootSessionId: "conv_root" });
+
+    fireEvent.pointerDown(screen.getByTestId("subagent-actions"), { button: 0 });
+
+    expect(await screen.findByText("Promote to session")).toHaveAttribute("data-disabled");
+  });
+
   it("always renders a 'main' row linking to the root session", () => {
     // No children at all — the panel still shows the main link so
     // the user always has a path back to the parent.

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -27,6 +27,7 @@ import {
   FileTextIcon,
   FlaskConicalIcon,
   ListIcon,
+  MoreHorizontalIcon,
   NetworkIcon,
   PlusIcon,
   ScanSearchIcon,
@@ -47,10 +48,27 @@ import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { PiIcon } from "@/components/icons/PiIcon";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { showToast } from "@/components/ui/toast";
 import { RunningDot } from "@/components/RunningDot";
 import { shortModelName } from "@/components/CostRoutingControl";
 import { MAX_TREE_DEPTH, useChildSessions, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
+import { usePromoteSession } from "@/hooks/usePromoteSession";
+import { isOwnerLevel } from "@/lib/permissionsApi";
 import type { SessionItem } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -105,18 +123,48 @@ interface SubagentsPanelProps {
    *  child it is the child's parent id. AppShell resolves this from
    *  ``activeSession.parentSessionId``. */
   rootSessionId: string;
+  /** Effective permission on the tree's root session. */
+  permissionLevel: number | null;
 }
 
 type ViewMode = "list" | "graph";
+interface PromotionTarget {
+  id: string;
+  label: string;
+  previousParentId: string;
+}
 
-export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
+export function SubagentsPanel({
+  conversationId,
+  rootSessionId,
+  permissionLevel,
+}: SubagentsPanelProps) {
   const { children, isLoading, error } = useChildSessions(rootSessionId);
+  const promoteSession = usePromoteSession();
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>({});
+  const [promotionTarget, setPromotionTarget] = useState<PromotionTarget | null>(null);
+  const canPromote = isOwnerLevel(permissionLevel);
   const toggleCollapsedRow = (id: string) => {
     setCollapsedRows((current) => ({ ...current, [id]: !current[id] }));
   };
+
+  async function confirmPromotion(): Promise<void> {
+    if (promotionTarget === null) return;
+    try {
+      await promoteSession.mutateAsync({
+        sessionId: promotionTarget.id,
+        previousParentId: promotionTarget.previousParentId,
+      });
+      setPromotionTarget(null);
+      showToast("Agent promoted to a top-level session.");
+    } catch (cause) {
+      showToast(cause instanceof Error ? cause.message : "Unable to promote this agent.", {
+        duration: 0,
+      });
+    }
+  }
 
   // Loading/error states only surface when there's no cached data to
   // show alongside the "main" row.
@@ -171,9 +219,12 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
             key={child.id}
             child={child}
             depth={1}
+            parentSessionId={rootSessionId}
             conversationId={conversationId}
             collapsedRows={collapsedRows}
             onToggleCollapsed={toggleCollapsedRow}
+            canPromote={canPromote}
+            onRequestPromotion={setPromotionTarget}
           />
         ))}
       </ul>
@@ -182,6 +233,34 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
       {addOpen && (
         <AddAgentDialog parentSessionId={rootSessionId} open={addOpen} onOpenChange={setAddOpen} />
       )}
+      <Dialog
+        open={promotionTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setPromotionTarget(null);
+        }}
+      >
+        <DialogContent data-testid="promote-agent-dialog">
+          <DialogHeader>
+            <DialogTitle>Promote {promotionTarget?.label ?? "this agent"}?</DialogTitle>
+            <DialogDescription>
+              Its sub-agents will move with it, and it will no longer belong to the current parent
+              session. People who only have access through the parent may lose access.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setPromotionTarget(null)}
+              disabled={promoteSession.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={() => void confirmPromotion()} disabled={promoteSession.isPending}>
+              {promoteSession.isPending ? "Promoting…" : "Promote"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -573,17 +652,24 @@ function rowPaddingLeft(depth: number): number {
 function SubagentRow({
   child,
   depth,
+  parentSessionId,
   conversationId,
   collapsedRows,
   onToggleCollapsed,
+  canPromote,
+  onRequestPromotion,
 }: {
   child: ChildSessionInfo;
   /** Levels below the root, 1 = direct child of "main". */
   depth: number;
+  /** Immediate parent used to invalidate the correct child list. */
+  parentSessionId: string;
   /** The conversation currently rendered in main, for row highlighting. */
   conversationId: string;
   collapsedRows: Record<string, boolean>;
   onToggleCollapsed: (id: string) => void;
+  canPromote: boolean;
+  onRequestPromotion: (target: PromotionTarget) => void;
 }) {
   const collapsed = collapsedRows[child.id] ?? false;
   const status = childStatus(child);
@@ -619,6 +705,36 @@ function SubagentRow({
             <ToggleIcon aria-hidden="true" className="size-3.5" />
           </button>
         )}
+        {canPromote && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`Actions for ${primary}`}
+                data-testid="subagent-actions"
+                className="absolute top-1.5 right-1.5 z-20"
+              >
+                <MoreHorizontalIcon className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                disabled={child.busy || child.pending_elicitations_count > 0}
+                onSelect={() =>
+                  onRequestPromotion({
+                    id: child.id,
+                    label: primary,
+                    previousParentId: parentSessionId,
+                  })
+                }
+              >
+                Promote to session
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         <Link
           // See MainRow: drop session-scoped params on rail navigation
           // (preserving global ones like ``?debug=1``) so a sticky
@@ -631,7 +747,8 @@ function SubagentRow({
           // under its parent, signaling where it sits in the tree.
           style={{ paddingLeft: rowPaddingLeft(depth) }}
           className={cn(
-            "flex w-full flex-col gap-0.5 py-2 pr-2.5 text-left hover:bg-accent/60",
+            "flex w-full flex-col gap-0.5 py-2 text-left hover:bg-accent/60",
+            canPromote ? "pr-10" : "pr-2.5",
             isActive && "bg-accent",
             dim && "opacity-60 hover:opacity-100",
           )}
@@ -680,9 +797,12 @@ function SubagentRow({
             key={grandchild.id}
             child={grandchild}
             depth={depth + 1}
+            parentSessionId={child.id}
             conversationId={conversationId}
             collapsedRows={collapsedRows}
             onToggleCollapsed={onToggleCollapsed}
+            canPromote={canPromote}
+            onRequestPromotion={onRequestPromotion}
           />
         ))}
     </>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -923,7 +923,11 @@ export function WorkspacePanel({
           // measures this rail slot to position the native view over it.
           <BrowserPane conversationId={conversationId} className="min-h-0 flex-1" />
         ) : rightRailTab === "subagents" && rootSessionId ? (
-          <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+          <SubagentsPanel
+            conversationId={conversationId}
+            rootSessionId={rootSessionId}
+            permissionLevel={permissionLevel}
+          />
         ) : rightRailTab === "todos" && todosSupported ? (
           <TodoPanel frameless />
         ) : rightRailTab === "terminals" && showShellsTab ? (


### PR DESCRIPTION
## Related issue

Closes #4429

## Summary

- Adds an owner-only action to promote an inactive sub-agent into a top-level session.
- Moves the sub-agent's full descendant tree with it while preserving its history and runtime identity.
- Gives promoted sessions descriptive titles instead of internal IDs: Codex uses its nickname and prompt/output, Claude uses its agent type and task description, and user-added agents shed the internal `ui:` prefix.

**ELI5:** A useful sub-agent no longer has to remain buried under its original session. Promoting it makes it a normal top-level session, and its own sub-agents move with it.

```text
Before: Parent -> Sub-agent -> Descendants
                         |
                      Promote
                         v
After:  Parent     Sub-agent -> Descendants
                   (top-level)
```

Promotion is rejected if the target or any descendant is active, and the tree update is performed in one database transaction.

## Test Plan

- Added store coverage for detaching the target, recursively updating descendant roots, assigning the promoted title, and rejecting invalid promotions.
- Added route and integration coverage for successful promotion, permissions, already-top-level sessions, active targets or descendants, and descriptive Codex, Claude, and user-added titles.
- Added frontend hook and component coverage for the owner-only action, confirmation dialog, errors, and query refresh behavior.
- Added a Playwright E2E journey covering the action menu, confirmation, API mutation, Agents-tree removal, and top-level sidebar insertion.
- Regenerated `openapi.json` and ran its drift test.
- Manually promoted a Codex sub-agent through the running app and confirmed it appeared as a top-level session with the expected descriptive title.
- Ran `.venv/bin/pre-commit run --all-files`.

## Demo

Manual UI verification completed in the running app. A promoted Codex child moved from its parent tree into the top-level session list, retained its transcript, and changed from the internal thread identifier to `Aquinas: Bugs hide in silence Bright logs bloom beneath moo...`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the complete Codex promotion flow against the local API and web app. The promoted session moved out of its parent tree, retained its transcript, appeared in the top-level session list, and received a descriptive title. Claude and user-added title generation are covered through the promotion endpoint. The Playwright journey passed locally against a freshly built SPA and isolated server. Promotion of active session trees remains blocked.

## Changelog

Promote a finished sub-agent and its descendants into a top-level session.
