### PR TITLE
fix(web): show hidden files by default and make the eye icon read as state

### DIFF
--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -2,20 +2,22 @@
 a browse control when the session has somewhere else to go.
 
 The desktop Workspace rail renders ``FilesPanel`` in its ``frameless``
-(inline) mode. Two behaviours are pinned here:
+(inline) mode. Three behaviours are pinned here:
 
 1. The header never collapses the panel. The file list is the whole point of
    the panel, so there is nothing to collapse to. This guards against
    reintroducing the collapse chevron: the header once doubled as a collapse
    toggle carrying ``aria-expanded``, which made no sense here. A session with
    nowhere else to browse (no bound host) keeps the plain, unclickable label.
-2. When the session IS host-bound and unconfined, the working-folder path
+2. The header's eye shows hidden files by default and reads as state: plain
+   while dot-prefixed entries are listed, slashed once they are filtered out.
+3. When the session IS host-bound and unconfined, the working-folder path
    becomes a button that opens the workspace directory browser, and picking a
    directory re-roots the file tree there — through the real server, runner,
    and filesystem, not a stub.
 
-Neither sends a message — the header is rail state, not a function of any
-turn — so both stay fast, LLM-free checks.
+None of them send a message — the header is rail state, not a function of any
+turn — so they all stay fast, LLM-free checks.
 """
 
 from __future__ import annotations
@@ -63,6 +65,52 @@ def test_files_rail_working_folder_header_is_a_static_label(
     # no toggle needed. Scope is the rail tab now (Files vs Changes), not an
     # in-panel switch.
     expect(rail.get_by_role("searchbox", name="Search all files")).to_be_visible()
+
+
+def test_files_rail_shows_hidden_files_until_the_eye_is_clicked(
+    page: Page,
+    seeded_session: tuple[str, str],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Dot-prefixed entries are listed without touching the eye, and the eye
+    reports the current state rather than the pending action: unslashed while
+    hidden files are visible, slashed once they are filtered out.
+
+    Agents write to ``.claude/``, ``.github/`` and friends constantly, so a
+    workspace whose dotfiles are invisible by default hides much of what a
+    turn actually changed.
+    """
+    base_url, session_id = seeded_session
+
+    env = page.request.get(f"{base_url}/v1/sessions/{session_id}/resources/environments/default")
+    assert env.status == 200, env.text()
+    root = Path(env.json()["metadata"]["root"])
+    hidden = root / ".hidden-demo"
+    hidden.mkdir(parents=True, exist_ok=True)
+    (hidden / "inside.txt").write_text("proof the dot-directory listed\n")
+    # The workspace is a real checkout shared with every other test in the
+    # shard, so this fixture directory must not outlive the test.
+    request.addfinalizer(lambda: shutil.rmtree(hidden, ignore_errors=True))
+
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+
+    row = rail.get_by_role("button", name=".hidden-demo/", exact=True)
+    expect(row).to_be_visible(timeout=30_000)
+
+    # Visible state → plain eye. The class regex is anchored on whitespace
+    # because "lucide-eye" is a prefix of "lucide-eye-off".
+    toggle = rail.get_by_role("button", name="Hide hidden files")
+    expect(toggle.locator("svg")).to_have_class(re.compile(r"(^|\s)lucide-eye(\s|$)"))
+
+    toggle.click()
+
+    expect(row).to_have_count(0)
+    expect(rail.get_by_role("button", name="Show hidden files").locator("svg")).to_have_class(
+        re.compile(r"(^|\s)lucide-eye-off(\s|$)")
+    )
 
 
 def test_files_panel_double_click_opens_a_folder_as_the_working_folder(

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -85,11 +85,17 @@ vi.mock("./FilesPanel", () => ({
   FilesPanel: ({
     onFileSelect,
     flatView,
+    showHidden,
   }: {
     onFileSelect: (path: string) => void;
     flatView: boolean;
+    showHidden: boolean;
   }) => (
-    <div data-testid="files-panel" data-flat-view={String(flatView)}>
+    <div
+      data-testid="files-panel"
+      data-flat-view={String(flatView)}
+      data-show-hidden={String(showHidden)}
+    >
       <button
         type="button"
         aria-label="files: select README.md"
@@ -2019,6 +2025,39 @@ describe("FilesPanel visibility", () => {
 
     expect(screen.queryByTestId("files-panel")).toBeNull();
     expect(screen.queryByTestId("files-panel-drawer")).toBeNull();
+  });
+
+  it("shows hidden files by default, on load and after a session switch", () => {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      { id: "conv_abc", permission_level: null },
+      { id: "conv_xyz", permission_level: null },
+    ]);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_abc"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route path="c/:conversationId" element={<SessionNavButton to="/c/conv_xyz" />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-show-hidden", "true");
+
+    // The conversation-switch reset must land on the same default, otherwise
+    // dotfiles would disappear the moment the user moves between sessions.
+    fireEvent.click(screen.getByTestId("nav-session"));
+    expect(screen.getByTestId("files-panel")).toHaveAttribute("data-show-hidden", "true");
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -289,7 +289,8 @@ export function AppShell() {
   // Skips the first persist run so mount can't write default state over the
   // values the restore effect is about to apply.
   const workspacePersistHydrated = useRef(false);
-  const [filesPanelShowHidden, setFilesPanelShowHidden] = useState(false);
+  // Hidden (dot-prefixed) files are shown by default; the eye toggle hides them.
+  const [filesPanelShowHidden, setFilesPanelShowHidden] = useState(true);
   // Lifted so the Changes list order and the FileViewer prev/next order
   // share one source of truth (otherwise the "X/N" index won't match the
   // list position). Default "recent" mirrors the prior FilesPanel default.
@@ -764,7 +765,7 @@ export function AppShell() {
     setSubagentsPanelOpen(false);
     setShellsPanelOpen(false);
     setTodosPanelOpen(false);
-    setFilesPanelShowHidden(false);
+    setFilesPanelShowHidden(true);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
       // effects stay quiet on non-session routes.

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -308,6 +308,23 @@ describe("FilesPanel working folder header role", () => {
   });
 });
 
+describe("FilesPanel hidden-files toggle icon", () => {
+  // The eye reflects the current state, not the pending action: a plain eye
+  // means hidden files are visible, a slashed eye means they are filtered out.
+  it("shows a plain eye while hidden files are visible", () => {
+    renderPanel({ conversationId: "conv_eye_on", files: [], showHidden: true });
+    const toggle = screen.getByRole("button", { name: "Hide hidden files" });
+    expect(toggle.querySelector(".lucide-eye")).not.toBeNull();
+    expect(toggle.querySelector(".lucide-eye-off")).toBeNull();
+  });
+
+  it("shows a slashed eye while hidden files are filtered out", () => {
+    renderPanel({ conversationId: "conv_eye_off", files: [], showHidden: false });
+    const toggle = screen.getByRole("button", { name: "Show hidden files" });
+    expect(toggle.querySelector(".lucide-eye-off")).not.toBeNull();
+  });
+});
+
 describe("FilesPanel scope (fixed by the caller's Files/Changes tab)", () => {
   it("does not enable the root filesystem listing while showing Changed files", () => {
     renderPanel({

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -114,7 +114,9 @@ function HiddenFilesToggle({
             )}
             onClick={onToggle}
           >
-            {showHidden ? <EyeOffIcon className={iconSize} /> : <EyeIcon className={iconSize} />}
+            {/* The icon shows the current state, not the action: a plain eye
+                means hidden files are visible, a slashed eye means they are not. */}
+            {showHidden ? <EyeIcon className={iconSize} /> : <EyeOffIcon className={iconSize} />}
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">{tooltipLabel}</TooltipContent>


### PR DESCRIPTION
## Related issue

N/A — reported directly. The Files rail hid every dot-prefixed path until you
found the eye, and the eye itself showed the *pending action* instead of the
current state.

## Summary

- **Hidden files are shown by default.** `filesPanelShowHidden` now starts
  `true`, both at mount and at the per-conversation reset in the workspace
  restore effect. Agents touch `.claude/`, `.github/`, `.env`, `.gitignore`
  constantly, so a panel that hides them by default hides a good chunk of what
  a turn actually changed.
- **The eye now reads as state, not as an action.** Previously a *slashed* eye
  was shown while hidden files were visible, which reads backwards next to
  every other visibility control. Now: plain eye = hidden files visible,
  slashed eye = hidden files filtered out.

Nothing else moves — the tooltip/aria-label copy ("Show hidden files" /
"Hide hidden files"), the warning-coloured "N files in hidden directories"
affordance, and the toggle's behaviour are unchanged.

```
        before                          after
  ┌────────────────────┐          ┌────────────────────┐
  │ dotfiles hidden 👁 │          │ dotfiles shown  👁 │
  │ dotfiles shown  👁̸ │          │ dotfiles hidden 👁̸ │
  └────────────────────┘          └────────────────────┘
   icon = what a click does        icon = what you see now
```

## Test Plan

- `pnpm vitest run src/shell/AppShell.test.tsx src/shell/FilesPanel.test.tsx`
  → 149 passed, including the two new cases below.
  - `FilesPanel`: the toggle renders `lucide-eye` when hidden files are visible
    and `lucide-eye-off` when they are not.
  - `AppShell`: the panel receives `showHidden=true` on load **and** after a
    session switch. A/B'd against the old value to confirm the test actually
    fails on the previous behaviour (it does).
- New e2e (`tests/e2e_ui/files/test_files_panel_header.py`): seeds a real
  `.hidden-demo/` directory in the session workspace, asserts the row is listed
  with no interaction and the eye is unslashed, then clicks it and asserts the
  row disappears and the eye is slashed.
- `pnpm tsc -b`, `oxlint`, `prettier --check`, and `pre-commit run --files …`
  all clean.
- Manual, against a live deployment: local Vite build proxied to a real
  Omnigent server, opened a session with a git workspace. The panel listed
  `.claude/`, `.github/`, `.ruff_cache/`, `.venv/`, `.gitignore`,
  `.pre-commit-config.yaml` with no interaction, header icon `lucide-eye`;
  clicking it dropped every dot-prefixed row and switched the icon to
  `lucide-eye-off`.

## Demo

The Workspace rail on this branch, against a real checkout. Left: the panel as
it opens now — plain eye, and `.ruff_cache/`, `.claude/`, `.github/`, `.venv/`,
`.gitignore`, `.pre-commit-config.yaml` all listed. Right: after one click on
the eye — slashed eye, every dot-prefixed row gone.

| default (new): hidden files shown | after one click: hidden files filtered |
| --- | --- |
| <img src="https://raw.githubusercontent.com/dbczumar/omnigent/demo-hidden-files-assets/rail-hidden-shown.png" alt="Files rail with hidden files visible and a plain eye icon" width="420" /> | <img src="https://raw.githubusercontent.com/dbczumar/omnigent/demo-hidden-files-assets/rail-hidden-filtered.png" alt="Files rail with hidden files filtered out and a slashed eye icon" width="420" /> |

(Images are hosted on a side branch of a fork, so this PR adds no binaries to
the repo.) The e2e test above pins this same transition against a real
workspace, so the behaviour is checked rather than only illustrated.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was run against a live Omnigent deployment (local UI build,
remote server) on a real git workspace, because the value of this change is
"the dotfiles you actually care about are there when the panel opens" — the
unit tests pin the default and the icon mapping, and the e2e test pins the
end-to-end listing, but neither proves it against a real repo's file tree.
Both states (default-on, and after toggling off) were checked there.

## Changelog

The workspace Files panel now shows hidden files by default, and its eye icon
shows whether they are visible rather than what clicking will do.
