### PR TITLE
fix(runner): rebind the comment relay when a session's agent changes

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -617,6 +617,31 @@ class _SessionSnapshot:
 
 
 @dataclasses.dataclass(frozen=True)
+class _CommentRelayBinding:
+    """A running comment relay plus the agent and bridge it was built for.
+
+    A relay advertises the tool surface of one agent spec and writes it into
+    one bridge directory. Recording both lets
+    ``_ensure_comment_relay_started`` notice that the session moved to a
+    different agent and replace the relay, instead of leaving the previous
+    agent's surface advertised to the new harness.
+
+    :param relay: The relay currently serving the session.
+    :param spec_entry: Resolved spec the advertised surface was built from,
+        compared by identity: the session spec cache hands back the same
+        object until an agent switch or an agent update evicts it, so a
+        changed object means the surface has to be rebuilt. ``None`` when
+        the spec could not be resolved and the fallback surface was used.
+    :param bridge_dir: Directory the relay wrote ``tool_relay.json`` into,
+        e.g. ``Path("/tmp/omnigent-bridge/conv_abc123")``.
+    """
+
+    relay: ClaudeNativeToolRelay
+    spec_entry: _SpecEntry | None
+    bridge_dir: Path
+
+
+@dataclasses.dataclass(frozen=True)
 class _SessionInitContext:
     """Metadata source selected before shared session initialization runs."""
 
@@ -1938,7 +1963,7 @@ def create_runner_app(
     _session_sub_agent_names: dict[str, str] = {}
     _session_tool_schemas: dict[str, list[_JsonObject]] = {}  # session_id → cached tool schemas
     _session_mcp_spec_hash: dict[str, str] = {}  # session_id → last MCP spec hash
-    _session_comment_relays: dict[str, ClaudeNativeToolRelay] = {}
+    _session_comment_relays: dict[str, _CommentRelayBinding] = {}
     _codex_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _pi_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _opencode_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
@@ -3339,8 +3364,8 @@ def create_runner_app(
         _session_fs_registries.pop(session_id, None)
         _session_agent_ids.pop(session_id, None)
         _session_tool_schemas.pop(session_id, None)
-        if _relay := _session_comment_relays.pop(session_id, None):
-            _relay.close()
+        if _binding := _session_comment_relays.pop(session_id, None):
+            _binding.relay.close()
         _session_histories.pop(session_id, None)
         _last_server_item_id.pop(session_id, None)
         _session_event_queues.pop(session_id, None)
@@ -5053,6 +5078,24 @@ def create_runner_app(
         logger=_logger,
     )
 
+    def _discard_comment_relay(session_id: str, relay: ClaudeNativeToolRelay) -> None:
+        """Unbind and close *relay*, unless another path already replaced it.
+
+        Removal is by relay instance rather than by session id: a
+        replacement installed while the caller was working owns the entry
+        and has already closed *relay*, so popping the key would tear down
+        the newer relay instead of the intended one.
+
+        :param session_id: Session/conversation id the relay was bound to.
+        :param relay: The relay instance the caller installed.
+        :returns: None.
+        """
+        binding = _session_comment_relays.get(session_id)
+        if binding is None or binding.relay is not relay:
+            return
+        del _session_comment_relays[session_id]
+        relay.close()
+
     async def _ensure_comment_relay_started(
         session_id: str,
         *,
@@ -5061,41 +5104,64 @@ def create_runner_app(
         await_notify: bool = False,
         session_labels: Mapping[str, str] | None = None,
     ) -> None:
-        if session_id in _session_comment_relays:
-            return
-
         import json as _json
 
         from omnigent.claude_native_bridge import (
+            BRIDGE_ID_LABEL_KEY,
             bridge_dir_for_bridge_id,
             post_tools_changed,
             start_tool_relay,
         )
 
+        try:
+            spec_entry = await _resolve_session_spec_entry(session_id)
+        except OmnigentError:
+            spec_entry = None
+
+        # The bridge dir, when the caller pinned it down or handed over the
+        # labels it comes from. Deriving it any other way costs a server
+        # round trip, which a session whose agent has not changed must not
+        # pay on every turn.
+        known_bridge_dir: Path | None = None
         if explicit_bridge_dir is not None:
-            bridge_dir = explicit_bridge_dir
-        else:
-            if bridge_id is None:
-                bridge_id = await _claude_native_bridge_id_with_optional_labels(
+            known_bridge_dir = explicit_bridge_dir
+        elif bridge_id is not None:
+            known_bridge_dir = bridge_dir_for_bridge_id(bridge_id or session_id)
+        elif session_labels is not None:
+            known_bridge_dir = bridge_dir_for_bridge_id(
+                session_labels.get(BRIDGE_ID_LABEL_KEY) or session_id
+            )
+
+        current = _session_comment_relays.get(session_id)
+        if current is not None and current.spec_entry is spec_entry and known_bridge_dir is None:
+            return
+
+        bridge_dir = known_bridge_dir
+        if bridge_dir is None:
+            bridge_dir = bridge_dir_for_bridge_id(
+                await _claude_native_bridge_id_with_optional_labels(
                     server_client=server_client,
                     session_id=session_id,
                     session_labels=session_labels,
                 )
+                or session_id
+            )
 
-            if session_id in _session_comment_relays:
-                return
-
-            bridge_dir = bridge_dir_for_bridge_id(bridge_id or session_id)
-
-        try:
-            relay_spec = await _resolve_session_agent_spec(session_id)
-        except OmnigentError:
-            relay_spec = None
-        if session_id in _session_comment_relays:
+        # Re-read after the awaits above: a concurrent caller may have
+        # installed a relay that already matches the current agent.
+        current = _session_comment_relays.get(session_id)
+        if (
+            current is not None
+            and current.spec_entry is spec_entry
+            and current.bridge_dir == bridge_dir
+        ):
             return
+
         from omnigent.runner.tool_dispatch import build_native_relay_tool_schemas
 
-        relay_schemas: list[_JsonObject] = build_native_relay_tool_schemas(relay_spec)
+        relay_schemas: list[_JsonObject] = build_native_relay_tool_schemas(
+            _unwrap_spec_entry(spec_entry)
+        )
 
         _captured_session_id = session_id
 
@@ -5127,7 +5193,18 @@ def create_runner_app(
                 exc_info=True,
             )
             return
-        _session_comment_relays[session_id] = relay
+        superseded = _session_comment_relays.get(session_id)
+        _session_comment_relays[session_id] = _CommentRelayBinding(
+            relay=relay,
+            spec_entry=spec_entry,
+            bridge_dir=bridge_dir,
+        )
+        # Close last: the new advertisement is already written, and
+        # ClaudeNativeToolRelay.close only unlinks a tool_relay.json that
+        # still points at the relay being closed, so a shared bridge dir
+        # keeps the new file.
+        if superseded is not None:
+            superseded.relay.close()
 
         async def _notify_tools_changed() -> None:
             try:
@@ -6893,14 +6970,22 @@ def create_runner_app(
             )
         bridge_inject = bool(body.get("bridge_inject_dir"))
         bridge_id = session_id
-        relay_existed = False
+        # Set only when this launch installed the relay, so a failure rolls
+        # back what it started and leaves a relay that was already serving
+        # the session (or that another path installed meanwhile) alone.
+        launched_relay: ClaudeNativeToolRelay | None = None
         if bridge_inject:
             bridge_id = await _claude_native_bridge_id_for_session(
                 server_client=server_client,
                 session_id=session_id,
             )
-            relay_existed = session_id in _session_comment_relays
+            relay_before = _session_comment_relays.get(session_id)
             await _ensure_comment_relay_started(session_id, bridge_id=bridge_id)
+            relay_after = _session_comment_relays.get(session_id)
+            if relay_after is not None and (
+                relay_before is None or relay_before.relay is not relay_after.relay
+            ):
+                launched_relay = relay_after.relay
 
         try:
             launch_method = (
@@ -6919,10 +7004,8 @@ def create_runner_app(
                 resource_role=(CLAUDE_NATIVE_TERMINAL_ROLE if bridge_inject else None),
             )
         except RuntimeError as exc:
-            if bridge_inject and not relay_existed:
-                relay = _session_comment_relays.pop(session_id, None)
-                if relay is not None:
-                    relay.close()
+            if launched_relay is not None:
+                _discard_comment_relay(session_id, launched_relay)
             return JSONResponse(
                 status_code=500,
                 content={

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5116,6 +5116,14 @@ def create_runner_app(
         try:
             spec_entry = await _resolve_session_spec_entry(session_id)
         except OmnigentError:
+            # Resolution failed; this is not the same as a session that
+            # resolves to no spec. A relay already serving the session was
+            # built from a real spec, so replacing it with the fallback
+            # surface would withdraw spec-gated tools the agent does grant.
+            # Keep it: once resolution recovers, the resolved spec differs
+            # from the stored one and the relay rebuilds then.
+            if session_id in _session_comment_relays:
+                return
             spec_entry = None
 
         # The bridge dir, when the caller pinned it down or handed over the
@@ -5132,6 +5140,12 @@ def create_runner_app(
                 session_labels.get(BRIDGE_ID_LABEL_KEY) or session_id
             )
 
+        # Same agent and no bridge hint to check against: skip the lookup that
+        # would cost a server round trip. This rests on a bridge id only ever
+        # being reassigned alongside the agent (a native-harness-family
+        # switch), which the spec comparison already caught. The callers that
+        # can reassign it independently — the terminal-launch and per-harness
+        # startup paths — all pass a bridge hint and take the branch below.
         current = _session_comment_relays.get(session_id)
         if current is not None and current.spec_entry is spec_entry and known_bridge_dir is None:
             return

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -27,10 +27,15 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
-from omnigent.claude_native_bridge import bridge_dir_for_bridge_id, prepare_bridge_dir
+from omnigent.claude_native_bridge import (
+    BRIDGE_ID_LABEL_KEY,
+    bridge_dir_for_bridge_id,
+    prepare_bridge_dir,
+)
 from omnigent.entities.session_resources import SessionResourceView, terminal_resource_view
 from omnigent.inner.datamodel import TerminalEnvSpec
 from omnigent.runner import create_runner_app
+from omnigent.spec.types import AgentSpec, ToolsConfig
 from omnigent.terminals import TerminalListEntry
 from tests.runner.helpers import NullServerClient, make_test_terminal_instance
 
@@ -843,3 +848,451 @@ async def test_relay_policy_evaluate_truncates_long_upstream_error(
         assert len(body) < 500
     finally:
         relay.close()
+
+
+# ---------------------------------------------------------------------------
+# Agent switch: the relay must follow the session's current agent.
+#
+# The relay advertises a spec-derived tool surface. When the session moves to
+# a different agent, the surface the native harness sees has to move with it —
+# otherwise the harness keeps calling tools the new agent never granted, and
+# same-named tools keep the previous agent's schema.
+# ---------------------------------------------------------------------------
+
+
+class _SwitchableServerClient:
+    """Server client stub whose bound agent and bridge id can be reassigned.
+
+    Mutating :attr:`agent_id` / :attr:`bridge_id` between requests simulates
+    a server-side agent switch without restarting the runner: the runner
+    re-reads both after ``POST /v1/sessions/{id}/reset-state`` drops its
+    per-session caches.
+    """
+
+    def __init__(self, agent_id: str, bridge_id: str | None = None) -> None:
+        """
+        Initialize the stub.
+
+        :param agent_id: Agent id reported by ``GET /v1/sessions/{id}``.
+        :param bridge_id: Bridge id reported via the session labels
+            endpoint. ``None`` omits the label so the runner falls back to
+            the session id.
+        :returns: None.
+        """
+        self.agent_id = agent_id
+        self.bridge_id = bridge_id
+
+    class _Response:
+        """Stub 200 response carrying a caller-supplied JSON body."""
+
+        status_code = 200
+
+        def __init__(self, body: dict[str, Any]) -> None:
+            """
+            Initialize the response.
+
+            :param body: JSON body to return from :meth:`json`.
+            :returns: None.
+            """
+            self._body = body
+
+        def json(self) -> dict[str, Any]:
+            """Return the stub JSON body."""
+            return self._body
+
+        def raise_for_status(self) -> None:
+            """No-op: stub always succeeds."""
+
+    async def get(self, url: str, **kwargs: Any) -> _Response:
+        """Serve the session snapshot and label reads the runner performs.
+
+        :param url: Request URL, e.g. ``"/v1/sessions/conv_x/labels"``.
+        :param kwargs: Extra keyword arguments (ignored).
+        :returns: Stub 200 response.
+        """
+        del kwargs
+        if url.endswith("/labels"):
+            labels = {BRIDGE_ID_LABEL_KEY: self.bridge_id} if self.bridge_id else {}
+            return self._Response({"labels": labels})
+        return self._Response({"agent_id": self.agent_id})
+
+    async def post(self, url: str, **kwargs: Any) -> _Response:
+        """Return an empty 200 for any POST request."""
+        del url, kwargs
+        return self._Response({})
+
+    async def patch(self, url: str, **kwargs: Any) -> _Response:
+        """Return an empty 200 for any PATCH request."""
+        del url, kwargs
+        return self._Response({})
+
+
+class _FailingResourceRegistry(_StubResourceRegistry):
+    """Resource registry stub whose terminal launch can be made to fail.
+
+    Setting :attr:`fail_launch` makes the next launch raise ``RuntimeError``,
+    driving the runner's bridge-injected launch-failure rollback.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        """
+        Initialize the stub.
+
+        :param tmp_path: Temporary directory returned as the default env root.
+        :returns: None.
+        """
+        super().__init__(tmp_path)
+        self.fail_launch = False
+
+    async def _launch(self, **kwargs: Any) -> SessionResourceView:
+        """Raise when armed, otherwise defer to the non-spawning stub."""
+        if self.fail_launch:
+            raise RuntimeError("simulated terminal launch failure")
+        return await super()._launch(**kwargs)
+
+
+@pytest.fixture
+def terminal_registry_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Install a fresh ``TerminalRegistry`` as the runtime singleton.
+
+    ``ToolManager`` registers ``sys_terminal_*`` for a spec that declares
+    ``terminals:``, and looks the registry up via
+    :func:`omnigent.runtime.get_terminal_registry`, which raises unless the
+    runtime was initialized. These tests never run a real runtime, so they
+    install the singleton directly — the same approach
+    ``tests/runner/test_runner_dispatch.py`` uses for the relay schema
+    builder.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.runtime import _globals as rt_globals
+    from omnigent.terminals.registry import TerminalRegistry
+
+    monkeypatch.setattr(rt_globals, "_terminal_registry", TerminalRegistry())
+
+
+def _spec_with_terminals() -> AgentSpec:
+    """Return a spec that grants the ``sys_terminal_*`` family."""
+    return AgentSpec(
+        spec_version=1,
+        name="agent-with-terminals",
+        terminals={"bash": TerminalEnvSpec(command="bash")},
+    )
+
+
+def _spec_without_terminals() -> AgentSpec:
+    """Return a spec that grants no terminal tools."""
+    return AgentSpec(spec_version=1, name="agent-without-terminals")
+
+
+def _spec_with_sub_agent(sub_agent_name: str) -> AgentSpec:
+    """
+    Return a spec granting exactly one named sub-agent.
+
+    ``sys_session_send`` derives its ``agent`` enum from this list, so two
+    such specs advertise the same tool name with different schemas.
+
+    :param sub_agent_name: Sub-agent name to grant, e.g. ``"alpha"``.
+    :returns: Parent spec declaring that single sub-agent.
+    """
+    return AgentSpec(
+        spec_version=1,
+        name=f"parent-of-{sub_agent_name}",
+        tools=ToolsConfig(agents=[sub_agent_name]),
+        sub_agents=[AgentSpec(spec_version=1, name=sub_agent_name)],
+    )
+
+
+def _relay_tool_names(relay_file: Path) -> set[str]:
+    """
+    Return the tool names advertised in a ``tool_relay.json``.
+
+    :param relay_file: Path to the relay advertisement.
+    :returns: Advertised tool names.
+    """
+    return {t["name"] for t in json.loads(relay_file.read_text())["tools"]}
+
+
+def _sub_agent_enum(relay_file: Path) -> set[str]:
+    """
+    Return the ``sys_session_send`` sub-agent enum from a relay file.
+
+    :param relay_file: Path to the relay advertisement.
+    :returns: Allowed ``agent`` values, empty when the tool is absent.
+    """
+    for tool in json.loads(relay_file.read_text())["tools"]:
+        if tool["name"] == "sys_session_send":
+            agent_prop = tool.get("parameters", {}).get("properties", {}).get("agent", {})
+            if enum := agent_prop.get("enum"):
+                return set(enum)
+            for variant in agent_prop.get("anyOf", []):
+                if "enum" in variant:
+                    return set(variant["enum"])
+    return set()
+
+
+def _switch_app(
+    tmp_path: Path,
+    server_client: _SwitchableServerClient,
+    specs: dict[str, AgentSpec],
+    resource_registry: _StubResourceRegistry | None = None,
+) -> FastAPI:
+    """
+    Build a runner app that resolves each agent id to a distinct spec.
+
+    :param tmp_path: Pytest temp directory used for the stub env root.
+    :param server_client: Stub server client reporting the bound agent.
+    :param specs: Agent id → spec the resolver hands back.
+    :param resource_registry: Registry stub. ``None`` builds the default
+        non-spawning one.
+    :returns: The runner FastAPI app.
+    """
+
+    async def spec_resolver(agent_id: str, session_id: str | None) -> AgentSpec | None:
+        del session_id
+        return specs.get(agent_id)
+
+    return create_runner_app(
+        resource_registry=resource_registry or _StubResourceRegistry(tmp_path),
+        server_client=server_client,  # type: ignore[arg-type]  # duck-typed for test
+        spec_resolver=spec_resolver,
+    )
+
+
+async def _launch_bridged(client: httpx.AsyncClient, session_id: str) -> None:
+    """
+    Launch the bridge-injected claude terminal, requiring success.
+
+    :param client: HTTP client bound to the runner app.
+    :param session_id: Session/conversation identifier.
+    :returns: None.
+    """
+    resp = await _launch_terminal(client, session_id, bridge_inject_dir=True)
+    assert resp.status_code == 200, f"terminal launch failed: {resp.text}"
+
+
+async def _reset_state(client: httpx.AsyncClient, session_id: str) -> None:
+    """
+    Drop the runner's per-session caches, as an agent switch does.
+
+    :param client: HTTP client bound to the runner app.
+    :param session_id: Session/conversation identifier.
+    :returns: None.
+    """
+    resp = await client.post(f"/v1/sessions/{session_id}/reset-state")
+    assert resp.status_code == 200, f"reset-state failed: {resp.text}"
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_replaces_relay_in_same_bridge_dir(
+    tmp_path: Path,
+    terminal_registry_singleton: None,
+) -> None:
+    """A switch to an agent without terminals drops the ``sys_terminal_*`` grant.
+
+    Agent A declares ``terminals:``, so the relay advertises the terminal
+    family. Agent B declares none. Once the session is switched and its
+    caches are reset, the next relay lookup must rebuild the advertisement
+    from agent B's spec — keeping agent A's terminal tools would let the
+    harness call a family the current agent never granted.
+    """
+    agent_a, agent_b = "ag_terminals", "ag_plain"
+    server_client = _SwitchableServerClient(agent_a)
+    app = _switch_app(
+        tmp_path,
+        server_client,
+        {agent_a: _spec_with_terminals(), agent_b: _spec_without_terminals()},
+    )
+
+    session_id = f"conv_{uuid.uuid4().hex[:12]}"
+    bridge_dir = bridge_dir_for_bridge_id(session_id)
+    prepare_bridge_dir(session_id, workspace=tmp_path)
+    relay_file = bridge_dir / _TOOL_RELAY_FILE
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as c:
+            await _launch_bridged(c, session_id)
+            before = _relay_tool_names(relay_file)
+            # Precondition: agent A's spec gate really did grant the family.
+            assert {n for n in before if n.startswith("sys_terminal_")}, (
+                f"agent A declares terminals but advertised no sys_terminal_*: {before}"
+            )
+
+            server_client.agent_id = agent_b
+            await _reset_state(c, session_id)
+            await _launch_bridged(c, session_id)
+
+            after = _relay_tool_names(relay_file)
+            # The whole point of the fix: a stale relay would still be
+            # advertising agent A's terminal family here.
+            assert not {n for n in after if n.startswith("sys_terminal_")}, (
+                f"terminal tools survived a switch to an agent without terminals: {after}"
+            )
+            # The rest of the always-on surface must still be advertised —
+            # the relay was rebuilt, not torn down.
+            assert "list_comments" in after
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://runner"
+            ) as c:
+                await c.delete(f"/v1/sessions/{session_id}")
+        shutil.rmtree(bridge_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_moves_relay_to_new_bridge_dir(tmp_path: Path) -> None:
+    """A switch that changes the bridge id relays into the new directory.
+
+    Switching between native harness families reassigns the session's
+    bridge id. The relay has to follow: the new bridge directory needs an
+    advertisement (otherwise the new harness sees no relay tools at all),
+    and the old directory's advertisement must be withdrawn.
+    """
+    agent_a, agent_b = "ag_bridge_a", "ag_bridge_b"
+    bridge_a = f"bridge_{uuid.uuid4().hex[:10]}"
+    bridge_b = f"bridge_{uuid.uuid4().hex[:10]}"
+    server_client = _SwitchableServerClient(agent_a, bridge_id=bridge_a)
+    app = _switch_app(
+        tmp_path,
+        server_client,
+        {agent_a: _spec_without_terminals(), agent_b: _spec_without_terminals()},
+    )
+
+    session_id = f"conv_{uuid.uuid4().hex[:12]}"
+    dir_a = bridge_dir_for_bridge_id(bridge_a)
+    dir_b = bridge_dir_for_bridge_id(bridge_b)
+    prepare_bridge_dir(bridge_a, workspace=tmp_path)
+    prepare_bridge_dir(bridge_b, workspace=tmp_path)
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as c:
+            await _launch_bridged(c, session_id)
+            assert (dir_a / _TOOL_RELAY_FILE).exists(), "no relay written for the first bridge"
+
+            server_client.agent_id = agent_b
+            server_client.bridge_id = bridge_b
+            await _reset_state(c, session_id)
+            await _launch_bridged(c, session_id)
+
+            # Without the fix the cached relay short-circuits before the new
+            # bridge dir is computed, so the new harness gets nothing.
+            assert (dir_b / _TOOL_RELAY_FILE).exists(), (
+                "the new bridge directory received no relay after the switch"
+            )
+            # The superseded relay is closed, which unlinks its own file.
+            assert not (dir_a / _TOOL_RELAY_FILE).exists(), (
+                "the previous bridge directory kept a stale relay advertisement"
+            )
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://runner"
+            ) as c:
+                await c.delete(f"/v1/sessions/{session_id}")
+        for bdir in (dir_a, dir_b):
+            shutil.rmtree(bdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_rebuilds_same_named_tool_schema(tmp_path: Path) -> None:
+    """Two agents advertising the same tool names get their own schemas.
+
+    Both agents grant ``sys_session_send``, so the advertised name set is
+    identical and a name-level comparison would see no change. The schemas
+    differ: each enumerates only its own sub-agent. After a switch the
+    harness must be handed agent B's contract.
+    """
+    agent_a, agent_b = "ag_alpha", "ag_beta"
+    server_client = _SwitchableServerClient(agent_a)
+    app = _switch_app(
+        tmp_path,
+        server_client,
+        {agent_a: _spec_with_sub_agent("alpha"), agent_b: _spec_with_sub_agent("beta")},
+    )
+
+    session_id = f"conv_{uuid.uuid4().hex[:12]}"
+    bridge_dir = bridge_dir_for_bridge_id(session_id)
+    prepare_bridge_dir(session_id, workspace=tmp_path)
+    relay_file = bridge_dir / _TOOL_RELAY_FILE
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as c:
+            await _launch_bridged(c, session_id)
+            names_before = _relay_tool_names(relay_file)
+            # Precondition: the spec gate produced the sub-agent enum this
+            # test discriminates on.
+            assert _sub_agent_enum(relay_file) == {"alpha"}
+
+            server_client.agent_id = agent_b
+            await _reset_state(c, session_id)
+            await _launch_bridged(c, session_id)
+
+            # Same tool names on both sides — only the schema moved, which is
+            # exactly the case a name-only refresh check would miss.
+            assert _relay_tool_names(relay_file) == names_before
+            assert _sub_agent_enum(relay_file) == {"beta"}, (
+                "sys_session_send still advertises the previous agent's sub-agents"
+            )
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://runner"
+            ) as c:
+                await c.delete(f"/v1/sessions/{session_id}")
+        shutil.rmtree(bridge_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_failed_launch_rolls_back_the_relay_it_started(tmp_path: Path) -> None:
+    """A failed bridge-injected launch withdraws the relay that launch installed.
+
+    The rollback used to be gated on "was a relay already present", which a
+    relay left over from the previous agent makes true — so the relay this
+    launch built for the new agent stayed bound and advertised even though
+    the terminal never came up. Rollback is keyed on the relay instance
+    instead, so what this launch installed is what it removes.
+    """
+    agent_a, agent_b = "ag_first", "ag_second"
+    server_client = _SwitchableServerClient(agent_a)
+    registry = _FailingResourceRegistry(tmp_path)
+    app = _switch_app(
+        tmp_path,
+        server_client,
+        {agent_a: _spec_without_terminals(), agent_b: _spec_with_sub_agent("beta")},
+        resource_registry=registry,
+    )
+
+    session_id = f"conv_{uuid.uuid4().hex[:12]}"
+    bridge_dir = bridge_dir_for_bridge_id(session_id)
+    prepare_bridge_dir(session_id, workspace=tmp_path)
+    relay_file = bridge_dir / _TOOL_RELAY_FILE
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://runner") as c:
+            await _launch_bridged(c, session_id)
+            assert relay_file.exists()  # precondition: agent A's relay is up
+
+            server_client.agent_id = agent_b
+            await _reset_state(c, session_id)
+
+            registry.fail_launch = True
+            failed = await _launch_terminal(c, session_id, bridge_inject_dir=True)
+            assert failed.status_code == 500
+
+            assert not relay_file.exists(), (
+                "the relay this failed launch installed stayed bound and advertised"
+            )
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://runner"
+            ) as c:
+                await c.delete(f"/v1/sessions/{session_id}")
+        shutil.rmtree(bridge_dir, ignore_errors=True)


### PR DESCRIPTION
## Related issue

Closes #3950

## Summary

The claude-native comment relay advertises a tool surface built from the session's agent spec, but it outlived the agent it was built for. `_session_comment_relays` was keyed by session id alone, and `_ensure_comment_relay_started` returned early on that key *before* resolving the current agent or computing the bridge directory. No cache-clearing path (`_clear_session_agent_caches`, `reset-state`, `agent-cache/reset`, or the turn-level switch detection) removed the entry, so after an agent switch the native harness kept talking to the previous agent's relay:

- **Wrong tool set** — spec-gated families the new agent never granted stayed advertised (an agent with no `terminals:` block still saw `sys_terminal_*`), and families it *did* grant could be missing.
- **Wrong contract for the same tool name** — `sys_session_send` derives its sub-agent enum from the spec, so two agents can advertise identical tool names with different schemas. A name-level check sees no change; the harness gets agent A's contract.
- **No relay at all** — when the switch reassigned the bridge id (a switch between native harness families), the early return fired before the new bridge directory was computed, so nothing was ever written there.

**The fix.** Bind each relay to the spec entry and bridge directory it was built for (`_CommentRelayBinding`). A lookup now resolves the current spec *first* and reuses the relay only when both still match; otherwise it starts a replacement, installs it, and closes the superseded one. The new advertisement is written before the old relay is closed, and `ClaudeNativeToolRelay.close` only unlinks a `tool_relay.json` that still points at the relay being closed — so a shared bridge directory keeps the new file.

Identity comparison on the spec entry is sufficient because the session spec cache hands back the same object until an agent switch or agent update evicts it. A session whose agent has not changed still short-circuits without paying a bridge-id round trip: the bridge dir is derived only from what the caller already supplied (explicit dir, bridge id, or labels).

**Related rollback bug, also fixed.** The bridge-injected terminal-launch failure path rolled back the relay only when a boolean said none was present beforehand — which a stale relay makes true, so the relay this launch built for the *new* agent stayed bound and advertised after the terminal failed to come up. It also removed by session id, which could drop a relay a different path installed while the launch was in flight. Rollback is now keyed on the relay instance, satisfying the issue's second correction requirement ("a procedure that removes a relay does not remove a relay that a different path installed").

### ELI5

The relay is a menu the harness reads to know which tools it can call. The menu was filed under the session's name, not the agent's — so when the session swapped to a different agent, everyone kept reading the old agent's menu. Now the menu is filed under *which agent and which bridge folder* it was printed for, so a swap prints a fresh one and throws the old one away.

```
before:  _session_comment_relays[session_id] -> relay
         lookup: "session already has a relay?" -> yes -> return   # never asks which agent

after:   _session_comment_relays[session_id] -> (relay, spec_entry, bridge_dir)
         lookup: resolve current spec
                 same spec AND same bridge dir? -> reuse
                 otherwise -> start replacement, install, close superseded
```

## Test Plan

Four tests added to the existing `tests/runner/test_comment_relay.py` suite, covering the three cases the issue requires plus the rollback correction. They drive the real runner HTTP surface (`POST /v1/sessions/{id}/resources/terminals` with `bridge_inject_dir`, then `POST /v1/sessions/{id}/reset-state`) against a stub server client whose bound agent and bridge id can be reassigned mid-test.

| Test | Case |
| --- | --- |
| `test_agent_switch_replaces_relay_in_same_bridge_dir` | Replacement in the same bridge directory — agent A grants `terminals:`, agent B does not; `sys_terminal_*` must be gone after the switch, and the always-on surface must survive (relay rebuilt, not torn down) |
| `test_agent_switch_moves_relay_to_new_bridge_dir` | Switch that changes the bridge directory — new dir gets a relay, old dir's advertisement is withdrawn |
| `test_agent_switch_rebuilds_same_named_tool_schema` | Two agents advertising the *same tool names* with different schemas — asserts the name set is unchanged while `sys_session_send`'s sub-agent enum moves `{"alpha"}` → `{"beta"}` |
| `test_failed_launch_rolls_back_the_relay_it_started` | A failed bridge-injected launch withdraws the relay that launch installed, even though a previous agent's relay was present |

**Verification performed:**

```bash
# All green with the fix (14 = 10 pre-existing + 4 new)
pytest tests/runner/test_comment_relay.py -q
# -> 14 passed

# Reverting only omnigent/runner/app.py to origin/main: exactly the 4 new tests fail,
# each with the issue's symptom
# -> terminal tools survived a switch to an agent without terminals: {...'sys_terminal_launch'...}
# -> the new bridge directory received no relay after the switch
# -> sys_session_send still advertises the previous agent's sub-agents: {'alpha'} == {'beta'}
# -> the relay this failed launch installed stayed bound and advertised
```

The 10 pre-existing tests in the suite pass unchanged, including `test_repeated_terminal_launch_keeps_single_relay`, which pins the idempotency guard the fix had to preserve (an unchanged agent must not rebind the relay).

Adjacent suites run clean: `test_delete_session_bridge_cleanup.py`, `test_app_sessions_native_terminal_routing.py`, `test_launch_failure.py` — 48 passed.

Broader `tests/runner` slice (245 tests across the first 14 files) shows 9 failures, all in `test_app_sessions_native_events_lifecycle.py` and all codex-native. **These are pre-existing** — verified by running the same 9 against an unmodified `origin/main` checkout of `app.py`, where they fail identically (`9 failed`). They are local-environment failures (`no compatible model resolved from provider 'databricks'`, `Terminal registry not configured`), untouched by this change.

`pre-commit run --files` passes ruff-format, ruff-check, and every other hook. `pyrefly` reports 98 pre-existing `missing-import` errors for `omnigent_client` caused by the symlinked worktree venv; the same errors fire in `omnigent/chat.py` and `omnigent/repl/_repl.py`, which this PR does not touch, and none fall inside any hunk of this diff.

## Demo

N/A — runner-internal behavior with no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The four new tests are fail→pass guards: each was confirmed to fail against unmodified `origin/main` with the exact symptom from the issue, and to pass with the fix. The pre-existing `test_repeated_terminal_launch_keeps_single_relay` covers the inverse property the fix must not break — a session whose agent has not changed still reuses its relay rather than rebinding a new socket.

## Changelog

Switching a session's agent now updates the tools its native harness can call, instead of leaving the previous agent's tools in place
