### PR TITLE
fix(runner): ground the pane reaper's busy check in tmux's own activity clock

### DIFF
--- a/omnigent/native_cost_popup.py
+++ b/omnigent/native_cost_popup.py
@@ -121,6 +121,49 @@ def _list_tmux_clients(socket_path: str, tmux_target: str) -> list[str]:
     return [line for line in proc.stdout.splitlines() if line.strip()]
 
 
+def _tmux_window_activity_at(socket_path: str, tmux_target: str) -> float | None:
+    """
+    Epoch seconds of the last output activity in *tmux_target*'s window.
+
+    tmux stamps ``window_activity`` on every byte a pane emits, making it
+    direct evidence that the terminal's program is producing output —
+    independent of any Omnigent-side status pipeline. Harness-agnostic.
+
+    :param socket_path: Absolute path to the tmux socket, e.g.
+        ``"/tmp/.../tmux.sock"``.
+    :param tmux_target: tmux target whose window to inspect, e.g. ``"main"``.
+    :returns: Epoch seconds of the window's last activity, or ``None`` when
+        the tmux server/target is gone or the value is unparseable.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                socket_path,
+                "display-message",
+                "-p",
+                "-t",
+                tmux_target,
+                "#{window_activity}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_LIST_TIMEOUT_S,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        return float(proc.stdout.strip())
+    except ValueError:
+        return None
+
+
 def launch_cost_popup(
     socket_path: str,
     tmux_target: str,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8800,9 +8800,13 @@ def create_runner_app(
         and _pane_reaper_registry is not None
         and hasattr(_pane_reaper_registry, "native_panes")
     ):
-        from omnigent.native_cost_popup import _list_tmux_clients
+        from omnigent.native_cost_popup import _list_tmux_clients, _tmux_window_activity_at
         from omnigent.runner.tool_dispatch import _publish_terminal_deleted_event
-        from omnigent.terminals.pane_reaper import NativePaneReaper, PaneRef
+        from omnigent.terminals.pane_reaper import (
+            PANE_OUTPUT_BUSY_WINDOW_S,
+            NativePaneReaper,
+            PaneRef,
+        )
 
         def _native_panes_for_reaper() -> list[PaneRef]:
             panes: list[PaneRef] = []
@@ -8823,7 +8827,18 @@ def create_runner_app(
             if _native_pane_status.get(conv_id) == "running":
                 return True
             clients = await asyncio.to_thread(_list_tmux_clients, str(pane.socket_path), "main")
-            return bool(clients)
+            if clients:
+                return True
+            # Primary evidence: tmux stamps window_activity on every byte the
+            # pane emits, so a producing terminal stays busy even when the
+            # status pipeline above has silently stalled (a stalled forwarder
+            # once froze the busy signal and got a live session reaped).
+            activity_at = await asyncio.to_thread(
+                _tmux_window_activity_at, str(pane.socket_path), "main"
+            )
+            return (
+                activity_at is not None and time.time() - activity_at < PANE_OUTPUT_BUSY_WINDOW_S
+            )
 
         async def _reap_native_pane(pane: PaneRef) -> None:
             try:

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -42,6 +42,12 @@ from typing import NamedTuple
 
 _logger = logging.getLogger(__name__)
 
+# A pane whose window emitted output this recently counts as busy. tmux's own
+# activity clock is evidence independent of the harness status pipeline, whose
+# silent stall must not get a live, producing terminal reaped. Two reaper scan
+# intervals, so any output between scans re-arms the idle clock.
+PANE_OUTPUT_BUSY_WINDOW_S = 120.0
+
 # Native CLI panes are keyed (conversation_id, <harness short name>, "main") in
 # the terminal registry. These short names match the ``terminal_name`` the
 # per-harness ``_auto_create_<harness>_terminal`` paths launch with. This is the

--- a/tests/test_native_cost_popup.py
+++ b/tests/test_native_cost_popup.py
@@ -403,3 +403,63 @@ def test_launch_blocked_notice_skips_without_client(
 
     monkeypatch.setattr(subprocess, "Popen", _boom)
     native_cost_popup.launch_blocked_notice("/tmp/x.sock", "main", message="x")
+
+
+def test_tmux_window_activity_at_tracks_a_live_server() -> None:
+    """
+    A live tmux window reports recent activity; a killed server reports None.
+
+    The pane reaper uses this as primary evidence that a terminal is
+    producing output, so the live reading must be a fresh epoch timestamp
+    and a dead server must read as "no evidence", never as an error.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+    import time
+
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux not installed")
+    # A short socket dir: pytest's tmp_path exceeds the Unix sun_path limit.
+    tmp_dir = tempfile.mkdtemp(prefix="omni-wa-")
+    socket_path = str(Path(tmp_dir) / "t.sock")
+    try:
+        subprocess.run(
+            ["tmux", "-S", socket_path, "new-session", "-d", "-s", "main", "-x", "20", "-y", "5"],
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+        try:
+            activity_at = native_cost_popup._tmux_window_activity_at(socket_path, "main")
+            assert activity_at is not None
+            assert abs(time.time() - activity_at) < 120.0
+        finally:
+            subprocess.run(
+                ["tmux", "-S", socket_path, "kill-server"],
+                check=False,
+                capture_output=True,
+                timeout=10,
+            )
+        assert native_cost_popup._tmux_window_activity_at(socket_path, "main") is None
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def test_tmux_window_activity_at_none_on_unparseable_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Garbage from tmux is treated as "no evidence", not a crash.
+
+    An old tmux that doesn't know the format variable echoes it back
+    verbatim; the reaper must fall back to its other signals rather than
+    treat that as activity (or blow up mid-scan).
+    """
+    import subprocess
+
+    def _fake_run(*_a: Any, **_k: Any) -> Any:
+        return types.SimpleNamespace(returncode=0, stdout="#{window_activity}\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert native_cost_popup._tmux_window_activity_at("/tmp/x.sock", "main") is None


### PR DESCRIPTION
## Related issue

N/A — from a live incident root-caused on 2026-08-10: the native pane reaper killed an actively-working claude-native terminal twice in one day (`reaping idle native pane … idle > 3600s` at exactly stall+3600s), because every signal its busy check consults is derived from the harness status pipeline, which had silently stalled. The session's transcript kept being written and the pane kept emitting output the whole time.

## Summary

- `_native_pane_is_busy` had three signals — active Omnigent turns, the forwarder-fed `_native_pane_status`, and attached tmux clients — and all three can be false while the terminal is demonstrably working: harness-internal scheduled wakes never register as Omnigent turns, the status value freezes with a stalled forwarder, and headless panes have no attached client. One silent stall upstream turned the reaper destructive.
- Add **primary evidence** to the busy check: tmux's own `#{window_activity}` clock, which tmux stamps on every byte a pane emits — kernel-fed, harness-agnostic, and independent of any Omnigent pipeline. A pane whose window produced output within `PANE_OUTPUT_BUSY_WINDOW_S` (120s = two reaper scan intervals) counts as busy, so any output between scans re-arms the idle clock and a producing terminal can never be reaped, no matter what breaks upstream.
- New `_tmux_window_activity_at()` helper beside `_list_tmux_clients` (same subprocess shape, same timeout, fails toward "no evidence"). A genuinely silent pane — including a dead one held by `remain-on-exit` — still reaps on the normal schedule, so the reaper's cleanup job is unchanged.

ELI5: the reaper used to ask the bookkeeping department whether the terminal was busy; when bookkeeping fell asleep, it killed a terminal that was typing at that very moment. Now it also just looks at the terminal: if characters are appearing on screen, it's busy.

```
before:  turn? no · status says running? (frozen) no · client attached? no → REAP live pane
after:   … → pane emitted output in the last 120s? yes → busy, re-arm clock
```

## Test Plan

```
python -m pytest tests/test_native_cost_popup.py tests/terminals/test_pane_reaper.py \
                 tests/runner/test_app_sessions_native_terminals_autocreate.py -q
```

- `test_tmux_window_activity_at_tracks_a_live_server` — real tmux server on a short-path socket: live window reports a fresh epoch timestamp; after `kill-server` the helper reports `None` (no evidence), not an error.
- `test_tmux_window_activity_at_none_on_unparseable_output` — an old tmux echoing the format string back verbatim is treated as no evidence, so the reaper falls back to its other signals instead of treating garbage as activity.
- Full suites: 30 passed (cost popup + pane reaper), 58 passed (runner app terminal autocreate — exercises the changed `create_runner_app` wiring).

## Demo

N/A — non-visual (runner-internal reaping policy).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two-line busy-check addition lives in a closure inside `create_runner_app`, so it is covered indirectly (the autocreate suite constructs the app and its reaper wiring); the new helper carrying the actual logic is unit-tested directly against a real tmux server.

## Changelog

The native pane reaper no longer kills a terminal that is actively producing output when the harness status pipeline stalls; it now checks tmux's own activity clock before reaping.
