### PR TITLE
fix(claude-native): bound each forwarder iteration with a stall deadline

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -226,6 +226,12 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 # ``agent-<id>.jsonl`` transcript.
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
 _DEFAULT_POLL_INTERVAL_S = 0.25
+# Hard ceiling on one poll iteration of the forward loop. A silently stalled
+# await anywhere in the pipeline used to stop mirroring, status and the busy
+# signal forever; the deadline cancels the stall (the traceback names it) and
+# the loop resumes. Generous vs the 0.25s poll so a legitimately slow batch
+# (large backlog, slow posts) never trips it.
+_FORWARD_LOOP_STALL_DEADLINE_S = 300.0
 _POST_TIMEOUT_S = 10.0
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
@@ -945,214 +951,228 @@ async def forward_claude_transcript_to_session(
     ) as client:
         while True:
             try:
-                current_session_id = read_active_session_id(bridge_dir) or session_id
-                if hook_state is None:
-                    hook_state = await _ensure_hook_state(
-                        bridge_dir,
-                        start_at_end=start_at_end,
-                        session_id=current_session_id,
-                    )
-                rotation = await _maybe_rotate_session_on_clear(
-                    client=client,
-                    session_id=current_session_id,
-                    bridge_dir=bridge_dir,
-                    state=hook_state,
-                )
-                if rotation is not None:
-                    # Tell the superseded (old) conversation it was cleared:
-                    # persist a notice linking to the rotated-to session and
-                    # emit a live redirect event. Use the loop's ``session_id``
-                    # (the session being forwarded BEFORE this poll), NOT
-                    # ``current_session_id``: when the hook rotated the bridge's
-                    # active session synchronously, ``current_session_id`` already
-                    # reads the NEW id, whereas ``session_id`` is not reassigned
-                    # to ``rotation`` until below. The call is fully best-effort
-                    # (swallows its own errors) so the state reset below always
-                    # runs.
-                    await _post_clear_supersession(
-                        client,
-                        old_session_id=session_id,
-                        new_session_id=rotation,
-                        agent_name=agent_name,
-                    )
-                    session_id = rotation
-                    state = None
-                    hook_state = None
-                    # After a /clear or /fork the parent now resolves
-                    # to a new ``<session_uuid>/subagents/`` directory
-                    # on disk, so old sub-agent entries are dead. Drop
-                    # them; the watcher will rediscover any new ones
-                    # under the rotated session's dir.
-                    subagent_state = SubagentForwardState(subagents={})
-                    await _write_subagent_forward_state_async(bridge_dir, subagent_state)
-                    item_retries = _PostRetryTracker()
-                    status_retries = _PostRetryTracker()
-                    subagent_start_retries = _PostRetryTracker()
-                    subagent_item_retries = _PostRetryTracker()
-                    subagent_status_retries = _PostRetryTracker()
-                    external_session_id_mirrored = False
-                    task_subjects = {}
-                    task_statuses = {}
-                    task_order = []
-                    # A rotated session is a fresh dedupe context — reseed
-                    # so the new session's first model observation doesn't
-                    # post against the prior session's baseline.
-                    dedupe = _ForwardDedupeState()
-                    # The rotated session resolves to a new transcript +
-                    # subagents/ dir, so prior cost entries are dead; drop
-                    # them so cost is recomputed fresh for the new session.
-                    cost_cache = {}
-                    await asyncio.sleep(poll_interval_s)
-                    continue
-                rotation = await _maybe_rotate_session_on_fork(
-                    client=client,
-                    session_id=current_session_id,
-                    bridge_dir=bridge_dir,
-                    state=hook_state,
-                )
-                if rotation is not None:
-                    session_id = rotation
-                    state = None
-                    hook_state = None
-                    # After a /clear or /fork the parent now resolves
-                    # to a new ``<session_uuid>/subagents/`` directory
-                    # on disk, so old sub-agent entries are dead. Drop
-                    # them; the watcher will rediscover any new ones
-                    # under the rotated session's dir.
-                    subagent_state = SubagentForwardState(subagents={})
-                    await _write_subagent_forward_state_async(bridge_dir, subagent_state)
-                    item_retries = _PostRetryTracker()
-                    status_retries = _PostRetryTracker()
-                    subagent_start_retries = _PostRetryTracker()
-                    subagent_item_retries = _PostRetryTracker()
-                    subagent_status_retries = _PostRetryTracker()
-                    external_session_id_mirrored = False
-                    task_subjects = {}
-                    task_statuses = {}
-                    task_order = []
-                    # A rotated session is a fresh dedupe context — reseed
-                    # so the new session's first model observation doesn't
-                    # post against the prior session's baseline.
-                    dedupe = _ForwardDedupeState()
-                    # The rotated session resolves to a new transcript +
-                    # subagents/ dir, so prior cost entries are dead; drop
-                    # them so cost is recomputed fresh for the new session.
-                    cost_cache = {}
-                    await asyncio.sleep(poll_interval_s)
-                    continue
-                if not external_session_id_mirrored:
-                    external_session_id_mirrored = await _maybe_mirror_external_session_id(
-                        client=client,
-                        session_id=current_session_id,
-                        bridge_dir=bridge_dir,
-                    )
-                transcript_path = read_transcript_path(bridge_dir)
-                if transcript_path is not None:
-                    state = await _ensure_state_for_transcript(
-                        bridge_dir=bridge_dir,
-                        state=state,
-                        transcript_path=transcript_path,
-                        start_at_end=start_at_end,
-                        session_id=current_session_id,
-                        start_at_offset=start_at_offset,
-                    )
-                    # Forward streamed deltas BEFORE the transcript items so a
-                    # message's live chunks (incl. its ``final`` chunk) always
-                    # precede its own authoritative ``output_item.done``. If
-                    # items led, a message's final chunk — written to the
-                    # deltas file moments before the transcript record flushed
-                    # — would land just AFTER its done event and re-create the
-                    # already-finalized preview on the client (duplicate bubble
-                    # + a stale trailing preview). See the web reconciler.
-                    # Within-poll order can't cover the cross-poll race
-                    # (transcript flushed, hook delta write not yet);
-                    # ``delta_ordering`` closes it by holding the assistant
-                    # item until its deltas byte-match or a timeout expires.
-                    delta_state = await _forward_available_deltas(
-                        client=client,
-                        session_id=current_session_id,
-                        bridge_dir=bridge_dir,
-                        state=delta_state,
-                        seen_keys=seen_delta_keys,
-                        ordering=delta_ordering,
-                    )
-                    # Mint a pending token for any PreCompact that first
-                    # became visible THIS poll, before the transcript items
-                    # phase (which consumes the isCompactSummary completion
-                    # record) runs — else a PreCompact + summary landing in
-                    # the same poll would lose the boundary. Cursor-keyed, so
-                    # the main hook phase below does not re-mint.
-                    await _prescan_precompact_edges(bridge_dir, hook_state)
-                    state = await _forward_available_items(
-                        client=client,
-                        session_id=current_session_id,
-                        bridge_dir=bridge_dir,
-                        agent_name=agent_name,
-                        state=state,
-                        retry_tracker=item_retries,
-                        skip_user_messages=skip_user_messages,
-                        dedupe=dedupe,
-                        ordering=delta_ordering,
-                    )
-                    hook_state = await _forward_available_status_events(
+                async with asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S):
+                    current_session_id = read_active_session_id(bridge_dir) or session_id
+                    if hook_state is None:
+                        hook_state = await _ensure_hook_state(
+                            bridge_dir,
+                            start_at_end=start_at_end,
+                            session_id=current_session_id,
+                        )
+                    rotation = await _maybe_rotate_session_on_clear(
                         client=client,
                         session_id=current_session_id,
                         bridge_dir=bridge_dir,
                         state=hook_state,
-                        retry_tracker=status_retries,
-                        dedupe=dedupe,
-                        task_subjects=task_subjects,
-                        task_statuses=task_statuses,
-                        task_order=task_order,
-                        # The turn-end edges (Stop→idle / StopFailure→failed)
-                        # carry the turn's response id so ap-web can CLOSE the
-                        # streaming ``activeResponse`` opened by the turn-start
-                        # ``running`` edge (_forward_available_items). The
-                        # transcript forwarder ran just above, so
-                        # ``state.current_response_id`` is the active turn's id
-                        # (the user-message reset only fires on the next turn).
-                        response_id=state.current_response_id,
                     )
-                    subagent_state = await _forward_available_subagents(
-                        client=client,
-                        parent_session_id=current_session_id,
-                        bridge_dir=bridge_dir,
-                        transcript_path=transcript_path,
-                        state=subagent_state,
-                        agent_name=agent_name,
-                        start_retry_tracker=subagent_start_retries,
-                        item_retry_tracker=subagent_item_retries,
-                        status_retry_tracker=subagent_status_retries,
-                    )
-                    # Reconcile + POST cumulative cost AFTER sub-agents are
-                    # forwarded so the estimate sees this poll's sub-agent
-                    # transcript growth. This is what lets the parent's
-                    # cost-budget policy block a sub-agent's tool calls
-                    # mid-turn (the statusLine total alone lags until the
-                    # sub-agent finishes).
-                    await _forward_session_cost(
+                    if rotation is not None:
+                        # Tell the superseded (old) conversation it was cleared:
+                        # persist a notice linking to the rotated-to session and
+                        # emit a live redirect event. Use the loop's ``session_id``
+                        # (the session being forwarded BEFORE this poll), NOT
+                        # ``current_session_id``: when the hook rotated the bridge's
+                        # active session synchronously, ``current_session_id`` already
+                        # reads the NEW id, whereas ``session_id`` is not reassigned
+                        # to ``rotation`` until below. The call is fully best-effort
+                        # (swallows its own errors) so the state reset below always
+                        # runs.
+                        await _post_clear_supersession(
+                            client,
+                            old_session_id=session_id,
+                            new_session_id=rotation,
+                            agent_name=agent_name,
+                        )
+                        session_id = rotation
+                        state = None
+                        hook_state = None
+                        # After a /clear or /fork the parent now resolves
+                        # to a new ``<session_uuid>/subagents/`` directory
+                        # on disk, so old sub-agent entries are dead. Drop
+                        # them; the watcher will rediscover any new ones
+                        # under the rotated session's dir.
+                        subagent_state = SubagentForwardState(subagents={})
+                        await _write_subagent_forward_state_async(bridge_dir, subagent_state)
+                        item_retries = _PostRetryTracker()
+                        status_retries = _PostRetryTracker()
+                        subagent_start_retries = _PostRetryTracker()
+                        subagent_item_retries = _PostRetryTracker()
+                        subagent_status_retries = _PostRetryTracker()
+                        external_session_id_mirrored = False
+                        task_subjects = {}
+                        task_statuses = {}
+                        task_order = []
+                        # A rotated session is a fresh dedupe context — reseed
+                        # so the new session's first model observation doesn't
+                        # post against the prior session's baseline.
+                        dedupe = _ForwardDedupeState()
+                        # The rotated session resolves to a new transcript +
+                        # subagents/ dir, so prior cost entries are dead; drop
+                        # them so cost is recomputed fresh for the new session.
+                        cost_cache = {}
+                        await asyncio.sleep(poll_interval_s)
+                        continue
+                    rotation = await _maybe_rotate_session_on_fork(
                         client=client,
                         session_id=current_session_id,
                         bridge_dir=bridge_dir,
-                        parent_transcript_path=transcript_path,
-                        subagent_state=subagent_state,
-                        dedupe=dedupe,
-                        cost_cache=cost_cache,
+                        state=hook_state,
                     )
-                    # Mirror the live statusLine model EVERY poll (not just
-                    # when a turn produced new transcript items, which
-                    # _forward_available_items early-returns without). This
-                    # propagates an in-pane /model switch to model_override
-                    # before the user's next message, so model-gated policies
-                    # (cost-budget hard cap) no longer lag a switch by one turn.
-                    await _forward_model_from_status(
-                        client=client,
-                        session_id=current_session_id,
-                        bridge_dir=bridge_dir,
-                        dedupe=dedupe,
-                    )
+                    if rotation is not None:
+                        session_id = rotation
+                        state = None
+                        hook_state = None
+                        # After a /clear or /fork the parent now resolves
+                        # to a new ``<session_uuid>/subagents/`` directory
+                        # on disk, so old sub-agent entries are dead. Drop
+                        # them; the watcher will rediscover any new ones
+                        # under the rotated session's dir.
+                        subagent_state = SubagentForwardState(subagents={})
+                        await _write_subagent_forward_state_async(bridge_dir, subagent_state)
+                        item_retries = _PostRetryTracker()
+                        status_retries = _PostRetryTracker()
+                        subagent_start_retries = _PostRetryTracker()
+                        subagent_item_retries = _PostRetryTracker()
+                        subagent_status_retries = _PostRetryTracker()
+                        external_session_id_mirrored = False
+                        task_subjects = {}
+                        task_statuses = {}
+                        task_order = []
+                        # A rotated session is a fresh dedupe context — reseed
+                        # so the new session's first model observation doesn't
+                        # post against the prior session's baseline.
+                        dedupe = _ForwardDedupeState()
+                        # The rotated session resolves to a new transcript +
+                        # subagents/ dir, so prior cost entries are dead; drop
+                        # them so cost is recomputed fresh for the new session.
+                        cost_cache = {}
+                        await asyncio.sleep(poll_interval_s)
+                        continue
+                    if not external_session_id_mirrored:
+                        external_session_id_mirrored = await _maybe_mirror_external_session_id(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                        )
+                    transcript_path = read_transcript_path(bridge_dir)
+                    if transcript_path is not None:
+                        state = await _ensure_state_for_transcript(
+                            bridge_dir=bridge_dir,
+                            state=state,
+                            transcript_path=transcript_path,
+                            start_at_end=start_at_end,
+                            session_id=current_session_id,
+                            start_at_offset=start_at_offset,
+                        )
+                        # Forward streamed deltas BEFORE the transcript items so a
+                        # message's live chunks (incl. its ``final`` chunk) always
+                        # precede its own authoritative ``output_item.done``. If
+                        # items led, a message's final chunk — written to the
+                        # deltas file moments before the transcript record flushed
+                        # — would land just AFTER its done event and re-create the
+                        # already-finalized preview on the client (duplicate bubble
+                        # + a stale trailing preview). See the web reconciler.
+                        # Within-poll order can't cover the cross-poll race
+                        # (transcript flushed, hook delta write not yet);
+                        # ``delta_ordering`` closes it by holding the assistant
+                        # item until its deltas byte-match or a timeout expires.
+                        delta_state = await _forward_available_deltas(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            state=delta_state,
+                            seen_keys=seen_delta_keys,
+                            ordering=delta_ordering,
+                        )
+                        # Mint a pending token for any PreCompact that first
+                        # became visible THIS poll, before the transcript items
+                        # phase (which consumes the isCompactSummary completion
+                        # record) runs — else a PreCompact + summary landing in
+                        # the same poll would lose the boundary. Cursor-keyed, so
+                        # the main hook phase below does not re-mint.
+                        await _prescan_precompact_edges(bridge_dir, hook_state)
+                        state = await _forward_available_items(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            agent_name=agent_name,
+                            state=state,
+                            retry_tracker=item_retries,
+                            skip_user_messages=skip_user_messages,
+                            dedupe=dedupe,
+                            ordering=delta_ordering,
+                        )
+                        hook_state = await _forward_available_status_events(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            state=hook_state,
+                            retry_tracker=status_retries,
+                            dedupe=dedupe,
+                            task_subjects=task_subjects,
+                            task_statuses=task_statuses,
+                            task_order=task_order,
+                            # The turn-end edges (Stop→idle / StopFailure→failed)
+                            # carry the turn's response id so ap-web can CLOSE the
+                            # streaming ``activeResponse`` opened by the turn-start
+                            # ``running`` edge (_forward_available_items). The
+                            # transcript forwarder ran just above, so
+                            # ``state.current_response_id`` is the active turn's id
+                            # (the user-message reset only fires on the next turn).
+                            response_id=state.current_response_id,
+                        )
+                        subagent_state = await _forward_available_subagents(
+                            client=client,
+                            parent_session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            transcript_path=transcript_path,
+                            state=subagent_state,
+                            agent_name=agent_name,
+                            start_retry_tracker=subagent_start_retries,
+                            item_retry_tracker=subagent_item_retries,
+                            status_retry_tracker=subagent_status_retries,
+                        )
+                        # Reconcile + POST cumulative cost AFTER sub-agents are
+                        # forwarded so the estimate sees this poll's sub-agent
+                        # transcript growth. This is what lets the parent's
+                        # cost-budget policy block a sub-agent's tool calls
+                        # mid-turn (the statusLine total alone lags until the
+                        # sub-agent finishes).
+                        await _forward_session_cost(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            parent_transcript_path=transcript_path,
+                            subagent_state=subagent_state,
+                            dedupe=dedupe,
+                            cost_cache=cost_cache,
+                        )
+                        # Mirror the live statusLine model EVERY poll (not just
+                        # when a turn produced new transcript items, which
+                        # _forward_available_items early-returns without). This
+                        # propagates an in-pane /model switch to model_override
+                        # before the user's next message, so model-gated policies
+                        # (cost-budget hard cap) no longer lag a switch by one turn.
+                        await _forward_model_from_status(
+                            client=client,
+                            session_id=current_session_id,
+                            bridge_dir=bridge_dir,
+                            dedupe=dedupe,
+                        )
             except asyncio.CancelledError:
                 raise
+            except TimeoutError:
+                # The deadline cancelled a stalled await mid-iteration; the
+                # traceback names it. Cursor state advances only after
+                # successful posts, so resuming retries the interrupted step.
+                _logger.warning(
+                    "Claude transcript forwarder iteration exceeded %.0fs; "
+                    "cancelled the stalled await and resuming; session=%s "
+                    "bridge_dir=%s",
+                    _FORWARD_LOOP_STALL_DEADLINE_S,
+                    session_id,
+                    bridge_dir,
+                    exc_info=True,
+                )
             except Exception:
                 _logger.exception(
                     "Claude transcript forwarder loop failed; session=%s bridge_dir=%s",

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -8364,3 +8364,63 @@ def test_is_subagent_delivery_not_confirmed_classifier() -> None:
     assert forwarder._is_subagent_delivery_not_confirmed(no_status) is False
     assert forwarder._is_subagent_delivery_not_confirmed(no_body) is False
     assert forwarder._is_subagent_delivery_not_confirmed(httpx.ConnectError("boom")) is False
+
+
+@pytest.mark.asyncio
+async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A stalled await inside one poll iteration is cancelled and the loop resumes.
+
+    A silent stall in any forwarding stage used to stop mirroring, status
+    events and the pane busy signal forever — with zero log output — and
+    the pane reaper then killed the live session an hour later. The
+    iteration deadline converts such a stall into a logged, bounded
+    hiccup: the stuck await is cancelled (the warning's traceback names
+    it) and the next iteration proceeds.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    monkeypatch.setattr(forwarder, "_FORWARD_LOOP_STALL_DEADLINE_S", 0.2)
+    ensure_calls: list[int] = []
+    real_ensure = forwarder._ensure_hook_state
+
+    async def _stalls_on_first_call(*args: Any, **kwargs: Any) -> Any:
+        ensure_calls.append(len(ensure_calls) + 1)
+        if len(ensure_calls) == 1:
+            await asyncio.Event().wait()
+        return await real_ensure(*args, **kwargs)
+
+    monkeypatch.setattr(forwarder, "_ensure_hook_state", _stalls_on_first_call)
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.claude_native_forwarder"):
+        task = asyncio.create_task(
+            forward_claude_transcript_to_session(
+                base_url="http://127.0.0.1:9",
+                headers={},
+                session_id="conv_stall",
+                bridge_dir=bridge_dir,
+                agent_name="claude-native-ui",
+                start_at_end=False,
+                poll_interval_s=0.01,
+            )
+        )
+        try:
+
+            async def _second_iteration_ran() -> None:
+                while len(ensure_calls) < 2:
+                    await asyncio.sleep(0.01)
+
+            await asyncio.wait_for(_second_iteration_ran(), timeout=5.0)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    stall_warnings = [r for r in caplog.records if "iteration exceeded" in r.getMessage()]
+    assert stall_warnings, "the deadline trip must be loudly logged, never silent"
+    # The warning's traceback names the stalled await for next-time forensics.
+    assert stall_warnings[0].exc_info is not None


### PR DESCRIPTION
## Related issue

N/A — companion to #4577, from the same 2026-08-10 incident: the claude-native transcript forwarder silently stalled three times in one day (13:33, 15:06, 18:08), each time immediately after mirroring a turn-final assistant message. Mirroring, status events and the pane busy signal all went dark together for 34–60+ minutes with **zero log output** — the loop logs every exception, so the stall was a silently frozen await, which left no trace anywhere (the suspended coroutine has no stack in any log or sampler).

## Summary

- The forward loop's iteration body is a chain of awaits (hook state, rotation checks, deltas, items, status, sub-agents, cost, model). Each *known* wait is individually bounded (10s POST timeout, 2s delta hold, 30s-capped retry backoff) — but one unbounded or wedged await anywhere freezes the entire in-order pipeline forever, invisibly.
- Wrap each iteration in `asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S)` (300s). A stall now gets its await cancelled, a WARN logged **with the traceback naming the exact stalled await**, and the next iteration proceeds. External cancellation still propagates untouched (`asyncio.timeout` distinguishes its own deadline from outside cancels).
- Resuming after a trip is safe by the loop's existing crash-tolerance contract: cursor state advances only after successful posts, so a cancelled step is simply retried — the same exposure as a process crash mid-step, which the design already tolerates.
- 300s vs the 0.25s poll: a legitimately slow iteration (large backlog flush, slow posts) stays far under it, and server outages don't approach it either (failed posts return within their 10s timeouts and back off). Only a genuine stall trips.

The whitespace-ignoring diff is 20 inserted lines (constant + `async with` + the `except TimeoutError` branch); the rest is the mechanical re-indent of the wrapped body.

ELI5: the mirror-copier is allowed to say "not yet" while it waits for things — but it used to be able to say it forever, silently, which froze a live session's mirroring for an hour and got its terminal killed by the idle reaper (#4577 fixes the killing; this fixes the freezing). Now every wait has a time limit, and hitting the limit prints exactly where it got stuck.

```
before:  stalled await → mirroring/status/busy dark forever, zero logs → reaped at +1h
after:   stalled await → cancelled at 300s → WARN with the stalling line's traceback → loop resumes
```

## Test Plan

```
python -m pytest tests/test_claude_native_forwarder.py -q
```

- New `test_forward_loop_deadline_unsticks_a_stalled_iteration` — stalls the first iteration's `_ensure_hook_state` on an event that never fires (deadline patched to 0.2s), then asserts the loop reaches a second iteration, the trip is logged as a WARN, and the warning carries `exc_info` (the forensic traceback).
- Full suite: **156 passed** — every existing forwarder behavior runs through the wrapped body, so the suite is the regression net for the re-indent.

## Demo

N/A — non-visual (runner-internal forwarding loop).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The 155 pre-existing forwarder tests all execute inside the new `asyncio.timeout` scope, covering the no-trip path; the new test covers the trip-and-resume path and the loudness guarantee.

## Changelog

A silently stalled claude-native transcript forwarder now self-recovers within five minutes and logs exactly where it stalled, instead of freezing mirroring and session status indefinitely.
