### PR TITLE
fix(runner): log an obituary on every transcript-forwarder task exit

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -272,9 +272,32 @@ def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -
     _AUTO_FORWARDER_TASKS[session_id] = task
 
     def _evict(done_task: asyncio.Task[object]) -> None:
-        """Drop the registry entry unless a successor already replaced it."""
+        """Drop the registry entry unless a successor already replaced it; log the exit."""
         if _AUTO_FORWARDER_TASKS.get(session_id) is done_task:
             del _AUTO_FORWARDER_TASKS[session_id]
+        # Obituary: a stopped forwarder takes mirroring, status and the busy
+        # signal with it, so no exit path may be silent. ``exception()`` also
+        # retrieves the failure (no "Task exception was never retrieved").
+        if done_task.cancelled():
+            _logger.info(
+                "Transcript forwarder task %s cancelled; session=%s",
+                done_task.get_name(),
+                session_id,
+            )
+        elif (exc := done_task.exception()) is not None:
+            _logger.error(
+                "Transcript forwarder task %s died; session mirroring is down "
+                "until the terminal is recreated; session=%s",
+                done_task.get_name(),
+                session_id,
+                exc_info=exc,
+            )
+        else:
+            _logger.warning(
+                "Transcript forwarder task %s returned; session mirroring has stopped; session=%s",
+                done_task.get_name(),
+                session_id,
+            )
 
     task.add_done_callback(_evict)
 

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -966,3 +967,67 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
         runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
         runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
         await _drain_forwarder_runs(runs)
+
+
+async def test_forwarder_task_exit_paths_are_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Every forwarder-task exit path leaves an obituary log line.
+
+    A forwarder that stops takes mirroring, status events and the pane
+    busy signal with it, and a silent exit once presented as an hour-long
+    session blackout with nothing to grep for. Cancellation is routine
+    (INFO), an escaped exception is fatal to mirroring (ERROR, carrying
+    the traceback), and an unexpected clean return still warns.
+    """
+    cancelled_id = "0b17aa000000000000000000000000c1"
+    died_id = "0b17aa000000000000000000000000d2"
+    returned_id = "0b17aa000000000000000000000000e3"
+
+    async def _parked() -> None:
+        await asyncio.Event().wait()
+
+    async def _raises() -> None:
+        raise RuntimeError("client construction failed")
+
+    async def _returns() -> None:
+        return None
+
+    try:
+        with caplog.at_level(logging.INFO, logger="omnigent.runner.app"):
+            parked_task = asyncio.create_task(_parked(), name="claude-forwarder-cancelled")
+            runner_app_mod._register_auto_forwarder_task(cancelled_id, parked_task)
+            await asyncio.sleep(0)
+            parked_task.cancel()
+            await asyncio.wait([parked_task])
+
+            raising_task = asyncio.create_task(_raises(), name="claude-forwarder-died")
+            runner_app_mod._register_auto_forwarder_task(died_id, raising_task)
+            await asyncio.wait([raising_task])
+
+            returning_task = asyncio.create_task(_returns(), name="claude-forwarder-returned")
+            runner_app_mod._register_auto_forwarder_task(returned_id, returning_task)
+            await asyncio.wait([returning_task])
+            # Done callbacks run via call_soon after task completion.
+            await asyncio.sleep(0)
+
+        def _obits(level: int, needle: str) -> list[logging.LogRecord]:
+            return [
+                record
+                for record in caplog.records
+                if record.name == "omnigent.runner.app"
+                and record.levelno == level
+                and needle in record.getMessage()
+            ]
+
+        assert _obits(logging.INFO, "cancelled; session=" + cancelled_id)
+        died = _obits(logging.ERROR, "died; session mirroring is down")
+        assert died and died[0].exc_info is not None, (
+            "a forwarder killed by an escaped exception must log an ERROR "
+            "obituary carrying the traceback"
+        )
+        assert _obits(logging.WARNING, "returned; session mirroring has stopped")
+    finally:
+        for sid in (cancelled_id, died_id, returned_id):
+            runner_app_mod._AUTO_FORWARDER_TASKS.pop(sid, None)


### PR DESCRIPTION
## Related issue

N/A — companion to #4577 and #4578, from the same 2026-08-10 incident forensics: when a claude-native session's mirroring went dark for an hour, there was **nothing to grep for** — the transcript-forwarder task's exit paths (cancellation, an exception escaping the supervisor, a clean return) are all silent, so "the forwarder stopped" and "the forwarder is healthy but idle" produce identical logs: none.

## Summary

- The forwarder-task registry (`_register_auto_forwarder_task`) already attaches a done-callback to every registered task to evict the registry slot. Extend that same callback with an obituary: **no forwarder exit path can be silent anymore.**
  - cancelled → INFO (routine: terminal re-create/teardown paths cancel deliberately)
  - exception escaped → ERROR with the traceback ("session mirroring is down until the terminal is recreated")
  - unexpected clean return → WARNING ("session mirroring has stopped")
- Calling `task.exception()` in the callback also *retrieves* the failure, so a dead forwarder can no longer resurface minutes later as an unattributed asyncio "Task exception was never retrieved" — the error is attributed to the session at the moment it happens.
- One callback site covers all six registration call sites (fresh create, re-create, wake, resume, transfer, codex variants).

ELI5: when the mail-mirroring clerk leaves the building — fired, quit, or carried out — the building log now records it. Before, you only found out an hour later when the mail pile was noticed (or never).

## Test Plan

```
python -m pytest tests/runner/test_app_sessions_native_wake_forwarders.py -q
```

- New `test_forwarder_task_exit_paths_are_logged` — registers three tasks and drives each exit path: asserts the INFO obituary for cancellation, the ERROR obituary carrying `exc_info` for an escaped exception, and the WARNING obituary for a clean return, all attributed to the right session id.
- Full suite: **21 passed** (the existing register/cancel ordering tests exercise the extended callback on their teardown paths).

## Demo

N/A — non-visual (runner-internal logging).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is a pure logging extension of an existing done-callback; the new test pins all three exit paths and the exc_info guarantee.

## Changelog

A claude-native transcript forwarder that stops — cancelled, crashed, or returned — now always logs an attributed exit line instead of dying silently.
