### PR TITLE
fix(claude-native): pin bridge identity to SessionStart announcements

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1831,15 +1831,35 @@ def record_hook_event(bridge_dir: Path, payload: _JsonObject) -> None:
     event_name = payload.get("hook_event_name")
     if isinstance(event_name, str) and event_name:
         state["last_hook_event_name"] = event_name
-    transcript_path = payload.get("transcript_path")
-    if isinstance(transcript_path, str) and transcript_path:
-        state["transcript_path"] = transcript_path
     claude_session_id = payload.get("session_id")
-    if isinstance(claude_session_id, str) and claude_session_id:
-        state["claude_session_id"] = claude_session_id
-        seen = read_seen_claude_session_ids(bridge_dir)
-        seen.add(claude_session_id)
-        state["seen_claude_session_ids"] = sorted(seen)
+    pinned = state.get("claude_session_id")
+    # Identity pin: the transcript path and session identity may change only
+    # via a SessionStart announcement (startup / clear / resume / compact all
+    # fire one) or an event from the already-pinned session. A side-channel
+    # event carrying another session's identity (e.g. a background Task
+    # agent's edge) must not re-aim the forwarder at a foreign transcript.
+    identity_allowed = event_name == "SessionStart" or (
+        isinstance(claude_session_id, str)
+        and claude_session_id != ""
+        and (not isinstance(pinned, str) or not pinned or claude_session_id == pinned)
+    )
+    if identity_allowed:
+        transcript_path = payload.get("transcript_path")
+        if isinstance(transcript_path, str) and transcript_path:
+            state["transcript_path"] = transcript_path
+        if isinstance(claude_session_id, str) and claude_session_id:
+            state["claude_session_id"] = claude_session_id
+            seen = read_seen_claude_session_ids(bridge_dir)
+            seen.add(claude_session_id)
+            state["seen_claude_session_ids"] = sorted(seen)
+    else:
+        _logger.debug(
+            "Ignoring identity fields from side-channel hook event; "
+            "event=%s session_id=%s pinned=%s",
+            event_name,
+            claude_session_id,
+            pinned,
+        )
     state["updated_at"] = time.time()
     _write_json_file(bridge_dir / _STATE_FILE, state)
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -38,10 +38,12 @@ from omnigent.claude_native_bridge import (
     post_tools_changed,
     prepare_bridge_dir,
     read_assistant_text_since,
+    read_claude_session_id,
     read_hook_events_from_offset,
     read_launch_model,
     read_message_deltas_from_offset,
     read_permission_hook_config,
+    read_seen_claude_session_ids,
     read_transcript_items_from_offset,
     read_transcript_items_since,
     read_transcript_path,
@@ -614,6 +616,103 @@ def test_record_hook_event_updates_transcript_state(tmp_path: Path) -> None:
 
     assert read_transcript_path(bridge_dir) == transcript_path
     assert count_hook_events(bridge_dir) == 1
+
+
+def test_record_hook_event_ignores_foreign_identity(tmp_path: Path) -> None:
+    """
+    A side-channel event cannot re-aim the bridge at a foreign transcript.
+
+    Ordinary mid-session events (tool edges, stops) carry whatever
+    session_id/transcript_path their context reports; one from another
+    session — e.g. a background Task agent's edge — used to silently
+    repoint ``transcript_path``, starving the forwarder on a file that
+    never grows. The event is still recorded; only identity is ignored.
+    """
+    bridge_dir = tmp_path / "bridge"
+    pinned_transcript = tmp_path / "pinned.jsonl"
+    foreign_transcript = tmp_path / "agent-foreign.jsonl"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "pinned-session",
+            "transcript_path": str(pinned_transcript),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": "foreign-session",
+            "transcript_path": str(foreign_transcript),
+        },
+    )
+
+    assert read_transcript_path(bridge_dir) == pinned_transcript
+    assert read_claude_session_id(bridge_dir) == "pinned-session"
+    assert read_seen_claude_session_ids(bridge_dir) == {"pinned-session"}
+    # The event itself is still recorded — only its identity is ignored.
+    assert count_hook_events(bridge_dir) == 2
+
+
+def test_record_hook_event_session_start_rotates_identity(tmp_path: Path) -> None:
+    """
+    A SessionStart announcement legitimately moves the bridge's identity.
+
+    /clear, /fork and resume all become a new Claude session announced by
+    a SessionStart hook; the pin must follow the front door so rotation
+    keeps working, and the prior id stays in the seen set for the
+    fork-vs-resume classifier.
+    """
+    bridge_dir = tmp_path / "bridge"
+    old_transcript = tmp_path / "old.jsonl"
+    new_transcript = tmp_path / "new.jsonl"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "old-session",
+            "transcript_path": str(old_transcript),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "new-session",
+            "transcript_path": str(new_transcript),
+        },
+    )
+
+    assert read_transcript_path(bridge_dir) == new_transcript
+    assert read_claude_session_id(bridge_dir) == "new-session"
+    assert read_seen_claude_session_ids(bridge_dir) == {"old-session", "new-session"}
+
+
+def test_record_hook_event_first_event_bootstraps_identity(tmp_path: Path) -> None:
+    """
+    With no pin yet, the first identity-bearing event is trusted.
+
+    A fresh bridge may see an ordinary event before SessionStart lands
+    (hook ordering is not guaranteed); refusing it would leave the
+    forwarder with no transcript at all.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+
+    assert read_transcript_path(bridge_dir) == transcript_path
+    assert read_claude_session_id(bridge_dir) == "claude-session"
 
 
 def test_read_assistant_text_since_parses_claude_jsonl(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A — final PR of the batch with #4577/#4578/#4579, closing a door found during the 2026-08-10 incident forensics: `record_hook_event` wrote `transcript_path` and `session_id` into the bridge's `state.json` from **any** hook payload, unconditionally. Since `read_transcript_path` is the forwarder's steering wheel, any side-channel event carrying another session's identity (a background Task agent's edge, a mis-wired hook) silently re-aims mirroring at a foreign transcript — one that may never grow again, which presents as the same silent blackout signature.

## Summary

- **Identity may change only through the front door.** `record_hook_event` now applies identity fields (`transcript_path`, `claude_session_id`, the seen-ids set) only when the event is a `SessionStart` announcement (startup, `/clear`, resume, fork and compact all fire one), the payload's `session_id` matches the currently-pinned session, or no session is pinned yet (bootstrap — hook ordering is not guaranteed, so a fresh bridge trusts its first identity-bearing event).
- A rejected side-channel event is still appended to `hooks.jsonl` in full (the record stream is untouched — rotation/fork detection reads records, not `state.json`) and still updates `last_hook_event_name`; only its identity fields are ignored, with a DEBUG line naming the event and both ids.
- Resume and fork are unaffected by construction: they announce themselves via `SessionStart`, which updates the pin and grows the seen set exactly as before — the fork-vs-resume classifier (`seen_claude_session_ids`) keeps its semantics, now fed only by announcements. A trailing event from a *previous* session id (e.g. a late `Stop` after `/clear`) can no longer flap the transcript pointer back to the dead file — a small strictness improvement over last-writer-wins.

ELI5: announcements may change who you are; side effects may not. The bridge's "which transcript am I mirroring" pointer used to obey whoever spoke last; now it obeys only proper introductions (`SessionStart`) and the session it already knows.

```
before:  any event's transcript_path → state.json → forwarder re-aimed (last writer wins)
after:   SessionStart, or same-session, or first-ever event → applied
         anything else → recorded in hooks.jsonl, identity ignored (DEBUG-logged)
```

## Test Plan

```
python -m pytest tests/test_claude_native_bridge.py tests/test_claude_native_hook.py -q
python -m pytest tests/test_claude_native_forwarder.py -q -k "rotate or fork or clear or session_id"
```

- New `test_record_hook_event_ignores_foreign_identity` — a foreign `Stop` cannot repoint the transcript, change the pinned id, or grow the seen set; the event itself is still recorded.
- New `test_record_hook_event_session_start_rotates_identity` — the `/clear`-shaped front door still rotates the pin and accumulates the seen set.
- New `test_record_hook_event_first_event_bootstraps_identity` — a fresh bridge trusts its first identity-bearing event even when it isn't `SessionStart`.
- Suites: bridge **212 passed** + hook **55 passed** (fork/resume classification unchanged) + forwarder rotation subset **16 passed**. One pre-existing failure on current main (`test_relay_close_keeps_advertisement_owned_by_newer_relay`) fails identically with this change stashed — unrelated (tool-relay advertisement lifecycle).

## Demo

N/A — non-visual (bridge-internal state hygiene).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The three new tests pin the gate's three regimes (reject foreign, accept announcements, bootstrap); the existing hook-suite fork/resume classifier tests prove the seen-set semantics survive.

## Changelog

A stray hook event from another Claude session can no longer silently redirect a claude-native session's transcript mirroring; session identity now changes only via SessionStart announcements.
