### PR TITLE
fix(runner): return web_fetch findings from the call instead of a handle

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -349,6 +349,7 @@ _SUBAGENT_DELIVERY_ALREADY_DELIVERED = "already_delivered"
 _SUBAGENT_DELIVERY_UNTRACKED = "untracked"
 _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY = "missing_work_entry"
 _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX = "missing_parent_inbox"
+_SUBAGENT_DELIVERY_CONSUMED_INLINE = "consumed_inline"
 # Read budget for runner→server POSTs that can PARK behind a human-approval
 # ASK gate: policy evaluation (``_evaluate_policy_via_omnigent``) and sub-agent
 # wake-notice delivery (``_deliver_subagent_wake_post``). Both are gated at the
@@ -1017,6 +1018,11 @@ class _SubagentWorkEntry:
         terminal status, or ``None`` while running.
     :param delivered: Whether the terminal payload has been pushed to
         the parent's inbox.
+    :param deliver_to_inbox: Whether the terminal payload belongs in the
+        parent's inbox. ``False`` for a dispatch whose caller waits for
+        the result inline (``web_fetch``): the tool call returns the
+        findings itself, so an inbox item would wake the parent a second
+        time for work it already has.
     """
 
     parent_session_id: str
@@ -1031,6 +1037,7 @@ class _SubagentWorkEntry:
     created_at: float = dataclasses.field(default_factory=time.time)
     completed_at: float | None = None
     delivered: bool = False
+    deliver_to_inbox: bool = True
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1068,6 +1075,7 @@ def register_subagent_work(
     title: str,
     wrapper_label: str | None = None,
     created_by: str | None = None,
+    deliver_to_inbox: bool = True,
 ) -> _SubagentWorkEntry:
     """
     Register one running sub-agent dispatch.
@@ -1085,6 +1093,9 @@ def register_subagent_work(
         label, e.g. ``"claude-code-native-ui"``.
     :param created_by: Human actor that dispatched this child turn, if
         known from the parent turn context.
+    :param deliver_to_inbox: Whether the terminal payload should reach the
+        parent through its inbox. ``False`` when the dispatching tool call
+        waits for the result and returns it itself.
     :returns: The registered work entry.
     """
     prior = _subagent_work_by_child.get(child_session_id)
@@ -1103,6 +1114,7 @@ def register_subagent_work(
         title=title,
         wrapper_label=wrapper_label,
         created_by=created_by,
+        deliver_to_inbox=deliver_to_inbox,
     )
     _drained_delivered_subagent_children.discard(child_session_id)
     _subagent_work_by_child[child_session_id] = entry
@@ -1118,6 +1130,25 @@ def get_subagent_work(child_session_id: str) -> _SubagentWorkEntry | None:
     :returns: The work entry, or ``None`` if the child is not tracked.
     """
     return _subagent_work_by_child.get(child_session_id)
+
+
+def restore_subagent_inbox_delivery(child_session_id: str) -> _SubagentWorkEntry | None:
+    """
+    Send a child's result back to the parent inbox after an inline wait ends.
+
+    A tool that waits for its child inline suppresses inbox delivery, because
+    it returns the payload itself. When that wait gives up (the child outran
+    the tool's budget), the child is still running and its eventual result
+    would have nowhere to go — so the inbox route is re-armed here.
+
+    :param child_session_id: Child session id, e.g. ``"conv_child456"``.
+    :returns: The updated work entry, or ``None`` if the child is untracked.
+    """
+    entry = _subagent_work_by_child.get(child_session_id)
+    if entry is None:
+        return None
+    entry.deliver_to_inbox = True
+    return entry
 
 
 def mark_subagent_work_started(child_session_id: str) -> _SubagentWorkEntry | None:
@@ -1285,6 +1316,17 @@ def _deliver_subagent_completion(entry: _SubagentWorkEntry) -> _SubagentDelivery
             delivered=True,
             delivered_now=False,
             reason=_SUBAGENT_DELIVERY_ALREADY_DELIVERED,
+        )
+    if not entry.deliver_to_inbox:
+        # The dispatching tool call is waiting on this entry and returns the
+        # payload as its own result. Confirmed without an inbox item: a
+        # second copy there would wake the parent for finished work.
+        entry.delivered = True
+        return _SubagentDeliveryAck(
+            entry=entry,
+            delivered=True,
+            delivered_now=False,
+            reason=_SUBAGENT_DELIVERY_CONSUMED_INLINE,
         )
     inbox = _session_inboxes_ref.get(entry.parent_session_id)
     if inbox is None:

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -27,6 +27,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -315,6 +316,15 @@ _SHARE_PUBLIC_POLICY = "public"
 # ``__web_researcher`` sub-agent, then reuses
 # ``_execute_subagent_tool``.
 _WEB_FETCH_TOOLS = frozenset({"web_fetch"})
+
+# How long ``web_fetch`` waits for its researcher before giving up. The tool
+# promises page content in its own result, so it holds the parent's tool loop
+# until the child is terminal; the child's own ``max_iterations=5`` bounds a
+# healthy run well inside this. On expiry the call returns an error and the
+# late result falls back to the parent inbox.
+_WEB_FETCH_RESULT_TIMEOUT = 300.0
+# Gap between polls of the child's terminal status while waiting.
+_SUBAGENT_RESULT_POLL_INTERVAL = 0.05
 
 # Priority 5f.1b: web_search — the first-party search builtin. Runner-local
 # so a non-OpenAI model's web_search function call resolves to the spec's
@@ -1594,6 +1604,72 @@ async def _execute_list_models_tool(*, agent_spec: AgentSpec | None) -> str:
     return json.dumps(catalog)
 
 
+async def _await_subagent_result(
+    child_session_id: str,
+    *,
+    agent: str,
+    title: str,
+    timeout: float,
+) -> str:
+    """
+    Block until a dispatched child is terminal and return its result.
+
+    Used by tools that promise the child's work in their own result rather
+    than a handle the caller polls for. The child's terminal payload is
+    suppressed inbox-side for the duration (see ``deliver_to_inbox``), so
+    the text returned here is the only copy the parent gets.
+
+    On expiry the inbox route is re-armed and the caller gets an error: the
+    child is still running, and its late result must land somewhere.
+
+    :param child_session_id: Child session id, e.g. ``"conv_child456"``.
+    :param agent: Sub-agent name, used in the caller-visible messages.
+    :param title: Child instance title, used in the same messages.
+    :param timeout: Seconds to wait before giving up, e.g. ``300.0``.
+    :returns: The child's output on success, or an ``Error: ...`` string
+        describing a failed, cancelled, untracked, or too-slow child.
+    """
+    from omnigent.runner import app as _runner_app
+
+    deadline = time.monotonic() + timeout
+    while True:
+        entry = _runner_app.get_subagent_work(child_session_id)
+        if entry is None:
+            return (
+                f"Error: sub-agent {agent!r} title {title!r} stopped being "
+                "tracked before it returned a result; the work did not complete."
+            )
+        if entry.status in _runner_app._SUBAGENT_TERMINAL_STATUSES:
+            break
+        if time.monotonic() >= deadline:
+            _runner_app.restore_subagent_inbox_delivery(child_session_id)
+            return (
+                f"Error: sub-agent {agent!r} title {title!r} timed out after "
+                f"{timeout:.0f}s without returning a result. It is still "
+                "running; call sys_read_inbox later to collect the result. "
+                "Do not treat this as an answer."
+            )
+        try:
+            await asyncio.sleep(_SUBAGENT_RESULT_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            # The waiting turn is going away, so nothing will consume this
+            # result inline. Hand the child back to the inbox route before
+            # unwinding, or a child that outlives the cancellation reports
+            # into a queue that was told to drop it.
+            _runner_app.restore_subagent_inbox_delivery(child_session_id)
+            raise
+
+    if entry.status != "completed":
+        detail = entry.output or "no error detail reported"
+        return f"Error: sub-agent {agent!r} title {title!r} {entry.status}: {detail}"
+    output = entry.output
+    if output is None or not output.strip():
+        return (
+            f"Error: sub-agent {agent!r} title {title!r} completed without returning any content."
+        )
+    return output
+
+
 async def _execute_subagent_tool(
     args: _JsonObject,
     *,
@@ -1602,6 +1678,7 @@ async def _execute_subagent_tool(
     agent_spec: AgentSpec | None = None,
     publish_event: Callable[[str, _JsonObject], None] | None = None,
     session_inbox: asyncio.Queue[_JsonObject] | None = None,
+    await_result: float | None = None,
 ) -> str:
     """
     Dispatch a sub-agent tool call (``sys_session_send``).
@@ -1627,7 +1704,12 @@ async def _execute_subagent_tool(
         discovery events to the parent stream.
     :param session_inbox: Parent session's inbox queue for async
         completion delivery.
-    :returns: JSON child-session handle, or an error string.
+    :param await_result: Seconds to wait for the child's result before
+        returning, for callers that promise the work in their own tool
+        result (``web_fetch``). ``None`` keeps the async contract: the
+        handle returns immediately and the result arrives inbox-side.
+    :returns: The child's result when ``await_result`` is set, otherwise a
+        JSON child-session handle; an error string on failure.
     """
     # Lazy import to avoid circular dependency at module load.
     from omnigent.runner import app as _runner_app
@@ -2010,6 +2092,7 @@ async def _execute_subagent_tool(
         title=session_name,
         wrapper_label=child_wrapper_label,
         created_by=dispatch_created_by,
+        deliver_to_inbox=await_result is None,
     )
     _publish_child_launching_update(
         parent_session_id=conversation_id,
@@ -2076,6 +2159,14 @@ async def _execute_subagent_tool(
         if teardown_warning is not None:
             return f"{error}\n{teardown_warning}"
         return error
+
+    if await_result is not None:
+        return await _await_subagent_result(
+            child_session_id,
+            agent=str(sub_agent_name),
+            title=session_name,
+            timeout=await_result,
+        )
 
     # Return the structured handle mirrored from ``spawn.py``. The debug panel
     # parses this to discover child sessions in the sidebar.
@@ -2708,6 +2799,12 @@ async def _execute_web_fetch_tool(
     ``_execute_subagent_tool`` ultimately exercises via
     ``POST /v1/sessions``.
 
+    Waits for the researcher and returns its findings as the tool result.
+    ``web_fetch`` advertises page content to the model and reports itself
+    as synchronous, so a launching handle here let the turn answer from
+    training knowledge while the research was still pending — and hid a
+    failed researcher behind a handle that read like progress.
+
     :param args: Parsed LLM arguments — ``query`` (required) and
         optional ``url``.
     :param server_client: httpx client pointed at the Omnigent server.
@@ -2717,8 +2814,8 @@ async def _execute_web_fetch_tool(
         ``_execute_subagent_tool`` to resolve the sub-agent.
     :param task_id: Calling task id; used to discriminate parallel
         ``web_fetch`` invocations from the same parent.
-    :param session_inbox: Parent inbox queue for delayed sub-agent
-        completion delivery.
+    :param session_inbox: Parent inbox queue, used as the fallback route
+        when the researcher outruns the tool's wait budget.
     :returns: The researcher's findings, or an error string.
     """
     from omnigent.tools.builtins.web_fetch import (
@@ -2749,6 +2846,7 @@ async def _execute_web_fetch_tool(
         agent_spec=agent_spec,
         publish_event=publish_event,
         session_inbox=session_inbox,
+        await_result=_WEB_FETCH_RESULT_TIMEOUT,
     )
 
 

--- a/tests/runner/test_web_fetch_spawn_failure_surfacing.py
+++ b/tests/runner/test_web_fetch_spawn_failure_surfacing.py
@@ -1,0 +1,319 @@
+"""A failed ``web_fetch`` sub-agent spawn must reach the parent model.
+
+``web_fetch`` runs its research on a ``__web_researcher`` child session, so
+every way that child can fail to start is a way the parent can end up
+answering from training knowledge with no sign the tool never ran. Three
+seams carry that failure back:
+
+- the child-create call the runner makes on the parent's behalf,
+- the first-message forward that actually boots the child harness,
+- the terminal ``failed`` status a child reports after it was accepted.
+
+The first two must fail the tool call outright — a launching handle there
+would tell the model work is under way that never started. The third lands
+in the parent inbox, and the failure text must survive the trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner import app as runner_app
+from omnigent.runner import tool_dispatch
+from omnigent.runner.tool_dispatch import execute_tool
+from omnigent.spec.types import AgentSpec, ExecutorSpec, LLMConfig
+from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME, WebFetchTool
+
+_PARENT = "conv_parent"
+_CHILD = "conv_child"
+_TASK = "task_1"
+_SPAWN_DETAIL = "harness spawn failed (see runner log)"
+
+
+@pytest.fixture(autouse=True)
+def _clean_runner_state() -> Iterator[None]:
+    """Drop the runner-global session state each test touches."""
+    yield
+    runner_app.unregister_child_session(_CHILD)
+    runner_app.unregister_subagent_work(_CHILD)
+    runner_app._session_inboxes_ref.pop(_PARENT, None)
+
+
+@pytest.fixture(autouse=True)
+def _harness_cli_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the dispatch-time harness probe off the host's PATH.
+
+    ``_execute_subagent_tool`` refuses the dispatch when the child's harness
+    CLI is missing. That guard is not what these tests exercise, and whether
+    ``claude`` is installed must not decide the result.
+    """
+    from omnigent.onboarding import harness_install
+
+    monkeypatch.setattr(harness_install, "missing_harness_cli", lambda _harness: None)
+
+
+def _parent_spec() -> AgentSpec:
+    """Build a parent carrying the ``__web_researcher`` sub-agent."""
+    parent = AgentSpec(
+        spec_version=1,
+        name="test-parent",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+    )
+    WebFetchTool(parent)  # appends the researcher spec to parent.sub_agents
+    return parent
+
+
+def _handler(
+    *,
+    create_status: int = 200,
+    message_status: int = 202,
+) -> Any:  # type: ignore[explicit-any]
+    """Serve the server calls one ``web_fetch`` dispatch makes.
+
+    :param create_status: Status for ``POST /v1/sessions`` — 503 stands in
+        for a runner that could not spawn the child's harness.
+    :param message_status: Status for the child's first-message POST — 503
+        stands in for a harness that failed to boot on the turn path.
+    """
+
+    async def _serve(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == f"/v1/sessions/{_PARENT}":
+            return httpx.Response(200, json={"id": _PARENT, "agent_id": "ag_parent"})
+        if path == f"/v1/sessions/{_PARENT}/child_sessions":
+            return httpx.Response(200, json={"data": []})
+        if path == "/v1/sessions" and request.method == "POST":
+            if create_status >= 400:
+                return httpx.Response(
+                    create_status,
+                    json={"error": "harness_spawn_failed", "detail": _SPAWN_DETAIL},
+                )
+            return httpx.Response(200, json={"id": _CHILD, "session_id": _CHILD})
+        if path == f"/v1/sessions/{_CHILD}/events":
+            if message_status >= 400:
+                return httpx.Response(
+                    message_status,
+                    json={"error": "harness_spawn_failed", "detail": _SPAWN_DETAIL},
+                )
+            return httpx.Response(message_status, json={"status": "accepted"})
+        if path == f"/v1/sessions/{_CHILD}" and request.method == "DELETE":
+            return httpx.Response(204)
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    return _serve
+
+
+async def _dispatch_web_fetch(handler: Any) -> tuple[str, asyncio.Queue[Any]]:  # type: ignore[explicit-any]
+    """Run one ``web_fetch`` tool call against *handler*.
+
+    :returns: The tool output string and the parent's inbox queue.
+    """
+    inbox: asyncio.Queue[Any] = asyncio.Queue()  # type: ignore[explicit-any]
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="web_fetch",
+            arguments=json.dumps({"query": "what shipped in the latest release"}),
+            server_client=server_client,
+            conversation_id=_PARENT,
+            agent_spec=_parent_spec(),
+            task_id=_TASK,
+            session_inbox=inbox,
+        )
+    return output, inbox
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_fails_the_tool_call_when_the_child_cannot_be_created() -> None:
+    """A 503 on child-create must fail the call, not hand back a handle."""
+    output, _inbox = await _dispatch_web_fetch(_handler(create_status=503))
+
+    assert output.startswith("Error:"), output
+    assert "harness_spawn_failed" in output, output
+    assert "launching" not in output, output
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_fails_the_tool_call_when_the_child_harness_will_not_boot() -> None:
+    """A 503 on the child's first message must fail the call too.
+
+    The child row exists by then, so the dispatch has to tear it down and
+    report the spawn failure instead of returning a handle for work that
+    never started.
+    """
+    output, _inbox = await _dispatch_web_fetch(_handler(message_status=503))
+
+    assert output.startswith("Error:"), output
+    assert "harness_spawn_failed" in output, output
+    assert "launching" not in output, output
+    assert runner_app.get_subagent_work(_CHILD) is None
+
+
+async def _dispatch_and_settle(
+    handler: Any,  # type: ignore[explicit-any]
+    *,
+    status: str,
+    child_output: str,
+) -> tuple[str, asyncio.Queue[Any]]:  # type: ignore[explicit-any]
+    """Dispatch ``web_fetch`` and settle its child while the call is in flight.
+
+    The tool call blocks on the researcher, so the terminal status has to be
+    reported from outside it — the same shape as the runner reporting a
+    child's ``external_session_status``.
+
+    :param status: Terminal child status, e.g. ``"completed"``.
+    :param child_output: Text the child reports as its result.
+    :returns: The tool output string and the parent's inbox queue.
+    """
+    inbox: asyncio.Queue[Any] = asyncio.Queue()  # type: ignore[explicit-any]
+
+    async def _settle() -> None:
+        while runner_app.get_subagent_work(_CHILD) is None:
+            await asyncio.sleep(0)
+        runner_app.mark_subagent_work_terminal(_CHILD, status=status, output=child_output)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server",
+    ) as server_client:
+        settle = asyncio.create_task(_settle())
+        output = await execute_tool(
+            tool_name="web_fetch",
+            arguments=json.dumps({"query": "what shipped in the latest release"}),
+            server_client=server_client,
+            conversation_id=_PARENT,
+            agent_spec=_parent_spec(),
+            task_id=_TASK,
+            session_inbox=inbox,
+        )
+        await settle
+    return output, inbox
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_returns_the_researcher_findings_as_its_result() -> None:
+    """``web_fetch`` must answer with content, not a handle for later work.
+
+    Its description promises page content and ``is_async`` reports the call
+    as synchronous, so the parent has no reason to poll an inbox before
+    answering. Returning a launching handle is what lets a turn answer from
+    training knowledge while the research is still pending.
+    """
+    findings = "The 0.9.0 release notes list a new sandbox backend."
+    output, _inbox = await _dispatch_and_settle(
+        _handler(), status="completed", child_output=findings
+    )
+
+    assert findings in output, output
+    assert "launching" not in output, output
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_reports_a_failed_researcher_as_a_tool_error() -> None:
+    """A failed researcher must reach the model as a failed tool call.
+
+    This is the reported defect: the spawn failure has to arrive as a tool
+    error the model can disclose, not as a handle it can ignore.
+    """
+    output, _inbox = await _dispatch_and_settle(
+        _handler(),
+        status="failed",
+        child_output=f"harness_spawn_failed: {_SPAWN_DETAIL}",
+    )
+
+    assert output.startswith("Error:"), output
+    assert "harness_spawn_failed" in output, output
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_result_is_not_also_delivered_to_the_parent_inbox() -> None:
+    """A result returned inline must not wake the parent a second time.
+
+    The parent already has the findings in its tool result; a duplicate
+    inbox item would re-enter the turn loop for work that is done.
+    """
+    _output, inbox = await _dispatch_and_settle(
+        _handler(), status="completed", child_output="findings"
+    )
+
+    assert inbox.empty(), inbox.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_that_outruns_its_budget_falls_back_to_the_inbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A researcher slower than the budget must not strand its result.
+
+    The tool call gives up and says so — the model must not read a timeout
+    as findings — but the late completion still has to reach the parent
+    inbox rather than vanish.
+    """
+    monkeypatch.setattr(tool_dispatch, "_WEB_FETCH_RESULT_TIMEOUT", 0.05)
+
+    output, inbox = await _dispatch_web_fetch(_handler())
+
+    assert output.startswith("Error:"), output
+    assert "timed out" in output, output
+
+    ack = runner_app.mark_subagent_work_terminal(
+        _CHILD, status="completed", output="late findings"
+    )
+    assert ack.delivered, ack.reason
+    assert inbox.get_nowait()["output"] == "late findings"
+
+
+@pytest.mark.asyncio
+async def test_subagent_failure_after_accept_reaches_the_parent_inbox() -> None:
+    """A sub-agent that fails after accept must deliver its error inbox-side.
+
+    ``sys_session_send`` keeps its async contract — only ``web_fetch`` waits
+    — so the terminal payload still has to survive the trip to the parent.
+    """
+    inbox: asyncio.Queue[Any] = asyncio.Queue()  # type: ignore[explicit-any]
+    runner_app._session_inboxes_ref[_PARENT] = inbox
+    runner_app.register_subagent_work(
+        parent_session_id=_PARENT,
+        child_session_id=_CHILD,
+        agent=RESEARCHER_NAME,
+        title=f"web_fetch_{_TASK}",
+    )
+
+    ack = runner_app.mark_subagent_work_terminal(
+        _CHILD,
+        status="failed",
+        output=f"harness_spawn_failed: {_SPAWN_DETAIL}",
+    )
+    assert ack.delivered, ack.reason
+
+    item = inbox.get_nowait()
+    assert item["status"] == "failed", item
+    assert "harness_spawn_failed" in item["output"], item
+    assert item["conversation_id"] == _CHILD, item
+
+
+@pytest.mark.asyncio
+async def test_parent_wake_notice_names_the_failure() -> None:
+    """The notice that wakes the parent must say the child failed.
+
+    The parent is re-entered by this text alone; a notice that reads like a
+    normal completion invites the model to answer as if the fetch worked.
+    """
+    notice = runner_app._format_subagent_wake_notice(
+        agent=RESEARCHER_NAME,
+        title=f"web_fetch_{_TASK}",
+        status="failed",
+        pending=1,
+    )
+
+    assert "failed" in notice, notice
+    assert "sys_read_inbox" in notice, notice


### PR DESCRIPTION
## Related issue

Closes #2630

## Summary

`web_fetch` promises the model page content — "fetches live web pages and summarizes relevant content" — reports itself as synchronous (`is_async()` is `False`), and its docstring states "the parent agent sees this as a synchronous function tool call". It did not behave that way: the dispatch returned the launching handle from `_execute_subagent_tool`, so the tool result told the model the research was under way and the findings would arrive in its inbox later.

Nothing makes the parent wait for that. There is no turn-end gate on a pending inbox and no framework instruction to drain one before answering, so the turn could finish on training knowledge while the researcher was still running — or after it had already failed, since a spawn failure was equally invisible behind a handle that read like progress. That is the ungrounded-answer behavior reported in #2630.

- `web_fetch` now waits for its researcher and returns the findings as its own tool result.
- A failed or cancelled researcher comes back as an `Error: …` tool result carrying the child's own error text, so the model can say it could not ground the answer.
- `_execute_subagent_tool` takes an `await_result` budget and only `web_fetch` passes one; `sys_session_send` keeps its async handle contract unchanged.
- While a caller waits inline, the child's terminal payload is kept out of the parent inbox (`deliver_to_inbox` on the work entry) so a result already returned as the tool output cannot wake the parent a second time for finished work. That suppression is undone whenever the wait ends without a result — on the 300s timeout and on cancellation of the waiting turn — so a child that outlives its waiter still reports somewhere. The timeout result states explicitly that it is not an answer.

### ELI5

The tool used to hand back a receipt saying "your research is being done, check your mailbox." Nobody told the agent to go check the mailbox before answering, so it answered from memory and sounded just as confident as if it had read the page. Now the tool waits for the research and hands back the actual findings — or an error saying the research failed.

```mermaid
sequenceDiagram
    participant M as Model (parent turn)
    participant T as web_fetch dispatch
    participant C as __web_researcher child

    rect rgb(245, 235, 235)
    note over M,C: before — handle returns immediately
    M->>T: web_fetch(query)
    T->>C: spawn + first message
    T-->>M: {"status": "launching"}
    M-->>M: answers from training knowledge
    C--)T: completed / failed (inbox, after the answer)
    end

    rect rgb(235, 243, 235)
    note over M,C: after — the call waits for the result
    M->>T: web_fetch(query)
    T->>C: spawn + first message
    C--)T: completed / failed
    T-->>M: findings, or "Error: … failed: <child error>"
    end
```

### Note on the issue as filed

The report attributes this to a swallowed `harness_spawn_failed`. I could not reproduce that part on `main`: every dispatch seam already surfaces the error (child-create 503, child first-message rejection, and the post-accept terminal status through the parent inbox). Those paths are covered by tests in this PR and pass unmodified without the fix. The defect that produces the reported symptom is the sync/async contract mismatch above — a spawn failure just made it visible, since the answer would have been ungrounded even had the spawn succeeded. Full trace in [this comment](https://github.com/omnigent-ai/omnigent/issues/2630#issuecomment-5248546275).

## Test Plan

New file `tests/runner/test_web_fetch_spawn_failure_surfacing.py` drives the real dispatch path — `execute_tool(tool_name="web_fetch")` over an `httpx.MockTransport` server — with 8 cases:

- findings come back as the tool result, not a handle
- a failed researcher becomes an `Error:` tool result carrying `harness_spawn_failed`
- an inline result is not also delivered to the parent inbox
- a researcher that outruns the budget returns a timeout error *and* its late result still reaches the inbox
- child-create 503 fails the call, no handle
- child first-message 503 fails the call and tears the child down
- a sub-agent failing after accept still reaches the parent inbox (`sys_session_send` contract intact)
- the parent wake notice names the failure

```
pytest tests/runner/test_web_fetch_spawn_failure_surfacing.py    # 8 passed
pytest tests/runner/ tests/tools/                                # 2370 passed, 6 failed
pre-commit run --files <changed files>                           # clean
```

The 6 failures are pre-existing on a clean `main` on macOS (the `linux_bwrap`/platform-gating family tracked in #4279) and reproduce with this branch stashed: `tests/runner/test_session_resources.py::test_reset_state_rematerializes_env_from_new_agent_spec` and 5 in `tests/tools/test_manager.py`.

## Demo

No UI surface — the user-visible change is what the model receives as the tool result, so the capture below is that. Both panels are real output from the runner dispatch path (`execute_tool(tool_name="web_fetch")` against a mock Omnigent server), taken on `main` and on this branch with the same script.

![web_fetch tool result before and after](https://raw.githubusercontent.com/Vivek1106-04/omnigent/assets/pr-4581-web-fetch/web-fetch-demo.png)

The point is the top panel: on `main` the tool result is **byte-identical whether the fetch succeeded or the researcher failed to spawn**. The model cannot tell the two apart, and in both cases it is holding a `"status": "launching"` handle rather than any page content, with the real outcome arriving in the inbox after the turn is free to answer.

<details>
<summary>Same capture as text</summary>

Before (`main`):

```
1. researcher succeeded
   {"task_id": "conv_child", ..., "status": "launching", "message":
    "[System: sub-agent __web_researcher title 'web_fetch_task_1' launching
     as task conv_child. Result will appear in your inbox; ...]"}
   [parent inbox: ['completed: omnigent 0.9.0 (2026-08-10) ships a new sandbox backend.']]

2. researcher failed to spawn
   {"task_id": "conv_child", ..., "status": "launching", "message":
    "[System: sub-agent __web_researcher title 'web_fetch_task_1' launching
     as task conv_child. Result will appear in your inbox; ...]"}
   [parent inbox: ['failed: harness_spawn_failed: harness spawn failed (see runner log)']]
```

After (this PR):

```
1. researcher succeeded
   omnigent 0.9.0 (2026-08-10) ships a new sandbox backend.
   [parent inbox: empty]

2. researcher failed to spawn
   Error: sub-agent '__web_researcher' title 'web_fetch_task_1' failed:
   harness_spawn_failed: harness spawn failed (see runner log)
   [parent inbox: empty]
```

</details>

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new tests cover the dispatch path end to end against a mock server, including the timeout fallback and the inbox-suppression behavior. Not exercised automatically: a live researcher against a real harness, since that needs model credentials and network.

## Changelog

`web_fetch` now returns the page findings from the tool call itself, and reports a failed lookup as a tool error instead of answering without the content.
