### PR TITLE
fix(setup): install harness CLIs into a user-owned npm prefix

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -40,6 +40,7 @@ import os
 import shutil
 import subprocess
 import sys
+from functools import cache
 from pathlib import Path
 from typing import NamedTuple
 
@@ -556,8 +557,35 @@ def harness_cli_installed(key: str) -> bool:
     return resolve_cli_binary(spec.binary) is not None
 
 
+@cache
+def _npm_global_prefix_writable() -> bool:
+    """Whether ``npm install -g`` can write to npm's configured global prefix.
+
+    A system Node install points the global prefix at a root-owned dir
+    (``/usr/local``), where a bare ``npm install -g`` dies with ``EACCES``.
+    Cached because the readiness screens render install hints per family.
+    """
+    try:
+        proc = subprocess.run(
+            ["npm", "prefix", "-g"], check=False, capture_output=True, text=True, timeout=30
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True  # can't tell — keep the plain global install
+    prefix = Path(proc.stdout.strip() or "/")
+    # npm writes bin/ and lib/node_modules under the prefix; permission is
+    # decided by the deepest ancestor that already exists.
+    while not prefix.exists() and prefix != prefix.parent:
+        prefix = prefix.parent
+    return os.access(prefix, os.W_OK)
+
+
 def harness_install_command(key: str) -> list[str]:
     """Return the argv that installs the harness CLI.
+
+    When npm's global prefix is root-owned, the argv targets a user-owned
+    prefix (``~/.local``, already probed by
+    :func:`omnigent._platform.resolve_cli_binary`) instead of failing with
+    ``EACCES`` — ``sudo npm install -g`` is what the vendor docs warn against.
 
     :param key: A harness family or :data:`PI_KEY`.
     :returns: The install command, e.g. ``["npm", "install", "-g",
@@ -576,6 +604,8 @@ def harness_install_command(key: str) -> list[str]:
     package = spec.package
     if package is None:
         raise ValueError(f"{key!r} has no npm package; show its install_hint instead")
+    if not _npm_global_prefix_writable():
+        return ["npm", "install", "-g", "--prefix", str(Path.home() / ".local"), package]
     return ["npm", "install", "-g", package]
 
 

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -13,6 +13,10 @@ import omnigent._platform as _platform
 from omnigent.onboarding import harness_install as hi
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 
+# Bound before the autouse fixture can stub it, so the probe's own test runs
+# the real implementation.
+_REAL_PREFIX_PROBE = hi._npm_global_prefix_writable
+
 
 @pytest.fixture(autouse=True)
 def _stub_cli_fallback_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -26,6 +30,56 @@ def _stub_cli_fallback_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
     assertion.
     """
     monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: ())
+
+
+@pytest.fixture(autouse=True)
+def _writable_npm_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the npm-global-prefix probe writable, and drop its cache.
+
+    ``harness_install_command`` appends ``--prefix ~/.local`` when npm's global
+    prefix is root-owned, so the plain-``-g`` assertions here would flip on a
+    machine with a system Node. The cache is cleared so the tests that *do*
+    exercise the root-owned branch can't leak a verdict into the others.
+    """
+    hi._npm_global_prefix_writable.cache_clear()
+    monkeypatch.setattr(hi, "_npm_global_prefix_writable", lambda: True)
+
+
+def test_install_command_uses_user_prefix_when_global_is_root_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A root-owned npm prefix installs into ``~/.local`` rather than EACCES-ing.
+
+    ``sudo npm install -g`` is what the vendor docs warn against, and
+    ``~/.local/bin`` is already on ``resolve_cli_binary``'s ladder, so the
+    freshly-installed CLI still resolves.
+    """
+    monkeypatch.setattr(hi, "_npm_global_prefix_writable", lambda: False)
+    assert hi.harness_install_command(ANTHROPIC_FAMILY) == [
+        "npm",
+        "install",
+        "-g",
+        "--prefix",
+        str(Path.home() / ".local"),
+        "@anthropic-ai/claude-code",
+    ]
+
+
+def test_npm_global_prefix_writable_detects_root_owned(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The probe reads ``npm prefix -g`` and reports the dir's writability."""
+    prefix = tmp_path / "usr" / "local"
+    prefix.mkdir(parents=True)
+
+    def _run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        assert argv == ["npm", "prefix", "-g"]
+        return subprocess.CompletedProcess(argv, 0, stdout=f"{prefix}\n", stderr="")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    monkeypatch.setattr(hi.os, "access", lambda p, _mode: Path(p) != prefix)
+    assert _REAL_PREFIX_PROBE() is False
+    _REAL_PREFIX_PROBE.cache_clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

Closes #890

## Summary

On a machine where npm's global prefix is root-owned — the default for a system
Node install (`/usr/local`) — choosing "Yes, install" for a harness CLI during
`omnigent setup` ran `npm install -g <pkg>`, which dies with `EACCES` and left
setup reporting a generic "install failed". The reflex fix, `sudo npm install -g`,
is exactly what Anthropic's docs warn against.

- Probe npm's configured global prefix for writability (`npm prefix -g`, then
  `os.access` on the deepest ancestor that exists) and, when it isn't writable,
  install into `--prefix ~/.local` instead. `~/.local/bin` was **already** on
  `omnigent._platform.resolve_cli_binary`'s fallback ladder, so the
  freshly-installed CLI resolves with no other plumbing.
- The change lives in `harness_install_command`, which is the single source for
  both the argv we exec *and* every "run it manually" hint
  (`cli_config.py:1354, 1973, 3068, 3309, 3381, 3464`). So the fallback message
  now prints a command that works instead of the one that just failed, and the
  fix covers every npm-installed harness (Claude, Codex, Pi, Qwen, OpenCode),
  not just the Claude path in the report.
- The probe is `@cache`d because the readiness screens render an install hint
  per family.

Machines with a writable prefix (nvm, Homebrew Node) keep the plain `-g`
install — the argv only changes on the path that was already broken.

## Test Plan

Unit (86 passed):

```
pytest tests/onboarding/test_harness_install.py
```

Two new cases: a root-owned prefix yields the `--prefix ~/.local` argv, and the
probe itself reports a non-writable prefix as `False`. An autouse fixture pins
the probe writable for the existing plain-`-g` assertions so they can't flip on
a contributor's system-Node machine.

Manual, on a real root-owned prefix (forced via `npm_config_prefix=/usr`):

```
$ python -c "from omnigent.onboarding.harness_install import *; print(*harness_install_command('anthropic'))"
npm prefix writable: False
claude: npm install -g --prefix /home/<user>/.local @anthropic-ai/claude-code
codex : npm install -g --prefix /home/<user>/.local @openai/codex
```

Reproduced the bug and confirmed the fix installs, before/after:

```
$ npm_config_prefix=/usr npm install -g @anthropic-ai/claude-code
npm error ... try running the command again as root/Administrator.   # EACCES

$ npm_config_prefix=/usr npm install -g --prefix /tmp/pfxtest @anthropic-ai/claude-code
added 1 package in 818ms
$ ls /tmp/pfxtest/bin
claude -> ../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe
```

`pre-commit run --files omnigent/onboarding/harness_install.py tests/onboarding/test_harness_install.py` clean.

## Demo

N/A — terminal-only change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests cover the argv selection and the writability probe with the
subprocess and `os.access` stubbed. The manual verification above covers what a
stub cannot: that a real `npm install -g --prefix <dir>` actually lands the
binary in `<dir>/bin` (where `resolve_cli_binary` looks), and that the bare
command genuinely fails with `EACCES` on the same machine.

One known limit, deliberately not addressed: if a user's shell `PATH` lacks
`~/.local/bin`, typing `claude` directly still won't find it. Omnigent itself
always resolves it via the fallback ladder, so setup and every harness launch
work; only a hand-typed invocation is affected.

## Changelog

`omnigent setup` now installs harness CLIs into `~/.local` when npm's global prefix is root-owned, instead of failing with a permissions error
