### PR TITLE
fix(claude-native): pre-accept the bypass-permissions consent dialog

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1284,6 +1284,7 @@ def build_hook_settings(
     api_key_helper: str | None = None,
     launch_model: str | None = None,
     launch_permission_mode: str | None = None,
+    launch_bypass_permissions: bool = False,
     launch_effort: str | None = None,
     subagent_router_dir: Path | None = None,
     turn_routing: bool = False,
@@ -1313,6 +1314,11 @@ def build_hook_settings(
     :param launch_permission_mode: Effective launch permission mode from
         ``--permission-mode``. Mirrored into ``permissions.defaultMode``
         for the same re-exec hardening.
+    :param launch_bypass_permissions: ``True`` when this launch requests
+        bypass mode (``--dangerously-skip-permissions`` or
+        ``--permission-mode bypassPermissions``), which sets
+        ``skipDangerousModePermissionPrompt`` so the one-time acceptance
+        dialog never blocks a host-spawned terminal.
     :param launch_effort: Effective launch effort from ``--effort``.
         Mirrored into ``effortLevel`` for restart/re-exec parity.
     :param subagent_router_dir: Directory where the runner advertises its
@@ -1546,6 +1552,14 @@ def build_hook_settings(
         settings["model"] = launch_model
     if launch_permission_mode:
         settings["permissions"] = {"defaultMode": launch_permission_mode}
+    if launch_bypass_permissions:
+        # Bypass mode shows a one-time "Bypass Permissions mode" acceptance
+        # dialog. Like the trust/onboarding gates it fires no
+        # PermissionRequest hook, so a host-spawned terminal has nobody to
+        # answer it and the session hangs with a blank web UI. Claude checks
+        # the org policy (``disableBypassPermissionsMode``) BEFORE this
+        # consent gate, so a managed host still strips bypass regardless.
+        settings["skipDangerousModePermissionPrompt"] = True
     if launch_effort and launch_effort in CLAUDE_EFFORTS:
         settings["effortLevel"] = launch_effort
     if api_key_helper:
@@ -1704,6 +1718,7 @@ def augment_claude_args(
         api_key_helper=api_key_helper,
         launch_model=_arg_value(claude_args, "--model"),
         launch_permission_mode=_arg_value(claude_args, "--permission-mode"),
+        launch_bypass_permissions=_args_request_bypass_permissions(claude_args),
         launch_effort=_arg_value(claude_args, "--effort"),
         subagent_router_dir=subagent_router_dir,
         turn_routing=turn_routing,
@@ -1756,6 +1771,21 @@ def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
             if candidate and not candidate.startswith("--"):
                 value = candidate
     return value
+
+
+def _args_request_bypass_permissions(args: tuple[str, ...]) -> bool:
+    """Return whether ``args`` launch Claude Code in bypass-permissions mode.
+
+    Both spellings count: the standalone ``--dangerously-skip-permissions``
+    flag, and ``--permission-mode bypassPermissions`` (the form
+    ``permission_mode: bypassPermissions`` in a worker bundle becomes).
+
+    :param args: Claude CLI args, e.g. ``("--dangerously-skip-permissions",)``.
+    :returns: ``True`` when this launch requests bypass mode.
+    """
+    return "--dangerously-skip-permissions" in args or (
+        _arg_value(args, "--permission-mode") == "bypassPermissions"
+    )
 
 
 def _merge_allowed_tools(args: list[str], extra: tuple[str, ...]) -> list[str]:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2716,6 +2716,76 @@ def test_augment_claude_args_mirrors_launch_overrides_into_settings(
     assert settings["effortLevel"] == "xhigh"
 
 
+@pytest.mark.parametrize(
+    "bypass_args",
+    [
+        ("--dangerously-skip-permissions",),
+        ("--permission-mode", "bypassPermissions"),
+        ("--permission-mode=bypassPermissions",),
+    ],
+    ids=["skip-flag", "mode-spaced", "mode-joined"],
+)
+def test_augment_claude_args_preaccepts_bypass_dialog(
+    bypass_args: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    """
+    A bypass launch pre-accepts Claude's one-time bypass consent dialog.
+
+    Claude shows a blocking "Bypass Permissions mode / 1. No, exit /
+    2. Yes, I accept" dialog before the first bypass launch. It fires no
+    PermissionRequest hook, so a host-spawned worker has nobody to answer it
+    and hangs forever producing no output. Setting
+    ``skipDangerousModePermissionPrompt`` in the invocation-local settings
+    sidecar clears the gate without touching the user's own config. Both
+    spellings that reach the CLI must be recognised.
+    """
+    args = augment_claude_args(
+        bypass_args,
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    settings = _load_invocation_settings(args)
+    assert settings.get("skipDangerousModePermissionPrompt") is True, (
+        "bypass launches must set skipDangerousModePermissionPrompt; without it a "
+        f"headless worker hangs on the acceptance dialog. args={bypass_args!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "non_bypass_args",
+    [
+        (),
+        ("--permission-mode", "auto"),
+        ("--permission-mode", "acceptEdits"),
+        ("--permission-mode", "plan"),
+    ],
+    ids=["none", "auto", "acceptEdits", "plan"],
+)
+def test_augment_claude_args_leaves_bypass_consent_alone_otherwise(
+    non_bypass_args: tuple[str, ...],
+    tmp_path: Path,
+) -> None:
+    """
+    Non-bypass launches must NOT pre-accept bypass mode.
+
+    Writing the key unconditionally would silently record bypass consent for
+    every native session, including ones that never asked for it, so the gate
+    stays scoped to launches that actually request bypass.
+    """
+    args = augment_claude_args(
+        non_bypass_args,
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    settings = _load_invocation_settings(args)
+    assert "skipDangerousModePermissionPrompt" not in settings, (
+        f"non-bypass launch must not record bypass consent; args={non_bypass_args!r}"
+    )
+
+
 def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #151

## Summary

A native `claude_code` worker launched in bypass mode hangs forever on Claude Code's one-time acceptance dialog, producing no output: no worktree changes, no commit, no PR, and no error in the logs.

```
WARNING: Claude Code running in Bypass Permissions mode
  1. No, exit
  2. Yes, I accept
Enter to confirm
```

Like the trust and onboarding gates we already pre-accept, this one fires no `PermissionRequest` hook, so a host-spawned terminal has nobody to answer it.

- Set `skipDangerousModePermissionPrompt` in the invocation-local `--settings` sidecar omnigent already writes, gated on the launch actually requesting bypass.
- Both spellings that reach the CLI count: `--dangerously-skip-permissions`, and `--permission-mode bypassPermissions` (what `permission_mode: bypassPermissions` in a worker bundle becomes).
- One funnel: `augment_claude_args` is the single place every claude-native launch passes through, so the CLI and host-spawned paths are both covered.

**ELI5.** Claude asks "are you sure?" once before it will run with the safety catch off. A human at a keyboard hits `2`. A headless worker just stares at the question forever. We answer it in advance, in omnigent's own settings file, and only when this launch actually asked for the safety catch off.

Two properties worth a reviewer's attention:

- **Nothing is written to the user's config.** The alternative, `bypassPermissionsModeAccepted` in `~/.claude.json` (what the issue suggests), works but Claude migrates it into `~/.claude/settings.json` and deletes the original on the next launch, so we would rewrite the user's home config on every bypass launch. The sidecar is ours and is per-invocation.
- **This cannot defeat MDM.** Claude checks the org policy before the consent gate:

```
if (!isBypass(opts))                              return;   // 1. not bypass
if (policyDisablesBypass())                       return;   // 2. org policy  <-- wins
if (skipDangerousModePermissionPrompt() ||
    globalConfig.bypassPermissionsModeAccepted)   return;   // 3. our fix
render(BypassPermissionsModeDialog)                         // 4. the hang
```

A managed host still strips bypass and drops to manual mode, with or without this change. Verified live, below.

### Why this was never seen in-house

Two independent shields, neither of which is a fix. Managed hosts ship `permissions.disableBypassPermissionsMode: "disable"` in `/etc/claude-code/managed-settings.json`, so gate 2 fires. And polly's `claude_code` worker pins `permission_mode: auto`, so the default path never requests bypass. The reporter's environment (self-hosted Docker, Claude Max, no MDM) has neither shield. `IS_SANDBOX=1` does not help: it only clears Claude's refusal to run bypass as root, not this consent gate, exactly as the reporter said.

## Test Plan

**Unit** — `tests/test_claude_native_bridge.py`, 7 new cases, full file green:

```
pytest tests/test_claude_native_bridge.py -q     # 220 passed
```

- `test_augment_claude_args_preaccepts_bypass_dialog` — all three spellings (`--dangerously-skip-permissions`, `--permission-mode bypassPermissions`, `--permission-mode=bypassPermissions`) set the key.
- `test_augment_claude_args_leaves_bypass_consent_alone_otherwise` — no args, `auto`, `acceptEdits`, `plan` must NOT set it. Writing it unconditionally would silently record bypass consent for sessions that never asked.

**Live, real `claude` 2.1.227 in a headless tmux pane**, isolated `$HOME`, launched with the exact `--settings` payload this branch generates. `/etc/claude-code` masked with bwrap to simulate an unmanaged host:

| | host | settings payload | result |
|---|---|---|---|
| Before | unmanaged | pre-fix (key absent) | dialog renders, waits forever |
| After | unmanaged | this branch | no dialog, `⏵⏵ bypass permissions on` |
| Policy control | real MDM | this branch | no dialog, `Bypass permissions mode was disabled by settings`, drops to manual mode |

Also confirmed after the passing run: `bypassPermissionsModeAccepted` absent from `~/.claude.json` and no `~/.claude/settings.json` created, so the user's own config is untouched.

**Adjacent suites** — `tests/runner/test_app_claude_native_launch_args.py`, `tests/test_claude_native.py`, `tests/test_claude_native_hook.py` green (2 failures in `test_claude_native.py` are ambient `ANTHROPIC_BASE_URL` leakage from my shell, pass with it cleared, unrelated to this change).

**Lint** — `ruff format` / `ruff check` and all other pre-commit hooks pass. `pyrefly` reports 105 `missing-import` errors in files this PR does not touch; that is an artifact of running it against a borrowed venv from another checkout, and zero errors name either changed file. CI's pyrefly is authoritative here.

## Demo

Before (unmanaged host, pre-fix payload) — the worker sits here forever:

```
  WARNING: Claude Code running in Bypass Permissions mode
  In Bypass Permissions mode, Claude Code will not ask for your approval before running potentially dangerous commands.
  This mode should only be used in a sandboxed container/VM that has restricted internet access and can easily be restored if damaged.
  By proceeding, you accept all responsibility for actions taken while running in Bypass Permissions mode.
  https://code.claude.com/docs/en/security
  ❯ 1. No, exit
    2. Yes, I accept
  Enter to confirm · Esc to cancel
```

After (same host, this branch) — straight to the prompt, bypass active:

```
❯
  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests pin the contract (which launches set the key, which must not). They cannot prove the dialog is actually gone, since that depends on the `claude` binary's own gate, so the before/after/policy-control table above was produced by launching the real CLI in a headless pane with the payload this branch generates. The policy-control leg is the security-relevant one: it shows org policy still wins.

## Changelog

Native Claude Code workers no longer hang on the one-time bypass-permissions acceptance dialog on self-hosted runners.
