### PR TITLE
fix(runner): refuse zygote runner forks after an in-place upgrade too

### DIFF
--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -300,10 +300,10 @@ class _ZygoteServer:
     :param control_sock: The daemon control socket (role ``"daemon"``).
     :param graph_stamp: The on-disk build stamp captured when the zygote
         imported its graph, or ``None`` when unknown (unbuilt checkout).
-        Harness forks are refused once the on-disk stamp no longer matches:
-        the child would import the lazily-loaded harness modules from the
-        *new* files against the *old* pre-imported graph, breaking on any
-        cross-version import (e.g. a name added to a preloaded module).
+        Both runner and harness forks are refused once the on-disk stamp no
+        longer matches: the child would resolve its lazily-imported modules
+        from the *new* files against the *old* pre-imported graph, breaking
+        on any cross-version import.
     """
 
     def __init__(
@@ -489,12 +489,42 @@ class _ZygoteServer:
             with contextlib.suppress(OSError):
                 sock.close()
 
+    def _refuse_if_upgraded(self, conn: socket.socket, kind: str) -> bool:
+        """Answer with an error when the package changed under this zygote.
+
+        A forked child inherits the graph imported at boot but resolves every
+        lazily-imported module from disk. Once an in-place upgrade rewrites the
+        package, those two disagree — the child either misses a name its old
+        in-memory modules gained, or fails to import a module the swapped-out
+        directory no longer offers. Both callers' fallbacks re-launch through a
+        fresh interpreter, which reads everything from disk coherently.
+
+        :param conn: The socket to answer on.
+        :param kind: Child being forked (``"runner"`` / ``"harness"``), named
+            in the error so operator logs say which launch fell back.
+        :returns: ``True`` when the request was refused (caller must return).
+        """
+        if self._graph_stamp is None or _disk_build_stamp() == self._graph_stamp:
+            return False
+        _send(
+            conn,
+            {
+                "error": (
+                    "omnigent was upgraded on disk after the zygote imported its "
+                    f"graph; refusing to fork a mixed-version {kind}"
+                )
+            },
+        )
+        return True
+
     def _handle_fork(self, conn: socket.socket, request: dict[str, Any]) -> None:
         """Fork a runner, giving it its own control socket back to the zygote.
 
         :param conn: The daemon socket to answer on.
         :param request: The ``fork`` request (``env`` + optional ``log_path``).
         """
+        if self._refuse_if_upgraded(conn, "runner"):
+            return
         try:
             z_end, r_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
         except OSError as exc:
@@ -530,22 +560,7 @@ class _ZygoteServer:
         :param conn: The runner socket to answer on.
         :param request: The ``fork_harness`` request (``argv`` + ``env``).
         """
-        if self._graph_stamp is not None and _disk_build_stamp() != self._graph_stamp:
-            # An in-place upgrade rewrote the package after this zygote
-            # imported its graph. A forked child would import the harness
-            # module from the new files against the old in-memory graph —
-            # a mixed-version process that fails on any new cross-module
-            # import. Refuse; the runner falls back to a direct exec, which
-            # runs the new code coherently.
-            _send(
-                conn,
-                {
-                    "error": (
-                        "omnigent was upgraded on disk after the zygote imported "
-                        "its graph; refusing to fork a mixed-version harness"
-                    )
-                },
-            )
+        if self._refuse_if_upgraded(conn, "harness"):
             return
         try:
             pid = os.fork()

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -465,40 +465,47 @@ def test_disk_build_stamp_reads_the_on_disk_file(tmp_path, content, expected) ->
     assert _disk_build_stamp(package_dir=tmp_path) == expected
 
 
-def _dispatch_fork_harness(
-    server: _ZygoteServer, conn: socket.socket, peer: socket.socket
+def _dispatch_fork(
+    server: _ZygoteServer, conn: socket.socket, peer: socket.socket, cmd: str
 ) -> dict:
-    """Dispatch one in-process ``fork_harness`` request and return the reply.
+    """Dispatch one in-process fork request and return the reply.
 
     :param server: The server under test.
     :param conn: The socket end handed to the dispatcher.
     :param peer: The other end, read for the reply.
+    :param cmd: ``"fork"`` (runner) or ``"fork_harness"``.
     :returns: The decoded reply.
     """
-    request = {"cmd": "fork_harness", "argv": [], "env": {}}
+    request = {"cmd": cmd, "argv": [], "env": {}}
     server._dispatch(conn, json.dumps(request).encode("utf-8"))
     return json.loads(peer.recv(65536).decode("utf-8"))
 
 
-def test_fork_harness_refused_after_in_place_upgrade(monkeypatch) -> None:
-    """A disk stamp differing from the boot stamp refuses the harness fork.
+@pytest.mark.parametrize(("cmd", "kind"), [("fork", "runner"), ("fork_harness", "harness")])
+def test_fork_refused_after_in_place_upgrade(monkeypatch, cmd, kind) -> None:
+    """A disk stamp differing from the boot stamp refuses the fork.
 
-    A forked child would import the harness module from the NEW on-disk files
-    against the OLD pre-imported graph — e.g. ``from omnigent.inner.executor
-    import describe_exception`` failing because the in-memory module predates
-    the symbol. The refusal makes the runner fall back to a direct exec, which
-    runs the new code coherently.
+    The child resolves its lazily-imported modules from the NEW on-disk files
+    against the OLD pre-imported graph. Both observed failures are this: a
+    harness missing ``describe_exception`` from an in-memory
+    ``omnigent.inner.executor`` that predates it, and a runner whose
+    ``create_app`` cannot import ``omnigent.cli_auth`` from the swapped-out
+    package directory. Refusing makes the caller fall back to a fresh
+    interpreter, which runs the new code coherently.
 
     :param monkeypatch: Pytest monkeypatch fixture.
+    :param cmd: The fork command under test.
+    :param kind: Child kind the error message must name.
     """
     daemon, daemon_peer = socket.socketpair()
     conn, peer = socket.socketpair()
     server = _ZygoteServer(daemon, graph_stamp=(1000.0, "oldsha"))
     monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (2000.0, "newsha"))
-    monkeypatch.setattr(os, "fork", lambda: pytest.fail("must not fork a mixed-version harness"))
+    monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
     try:
-        reply = _dispatch_fork_harness(server, conn, peer)
+        reply = _dispatch_fork(server, conn, peer, cmd)
         assert "upgraded on disk" in reply["error"]
+        assert kind in reply["error"]
         assert server._live == set()
     finally:
         server._sel.close()
@@ -506,13 +513,15 @@ def test_fork_harness_refused_after_in_place_upgrade(monkeypatch) -> None:
             sock.close()
 
 
-def test_fork_harness_proceeds_while_disk_stamp_matches(monkeypatch) -> None:
+@pytest.mark.parametrize("cmd", ["fork", "fork_harness"])
+def test_fork_proceeds_while_disk_stamp_matches(monkeypatch, cmd) -> None:
     """An unchanged disk stamp forks exactly as before the gate existed.
 
     ``os.fork`` is faked to a pid so the assertion is purely about the gate
     letting the request through to the fork path.
 
     :param monkeypatch: Pytest monkeypatch fixture.
+    :param cmd: The fork command under test.
     """
     daemon, daemon_peer = socket.socketpair()
     conn, peer = socket.socketpair()
@@ -520,7 +529,7 @@ def test_fork_harness_proceeds_while_disk_stamp_matches(monkeypatch) -> None:
     monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (1000.0, "sha"))
     monkeypatch.setattr(os, "fork", lambda: 4242)
     try:
-        reply = _dispatch_fork_harness(server, conn, peer)
+        reply = _dispatch_fork(server, conn, peer, cmd)
         assert reply == {"pid": 4242}
         assert 4242 in server._live
     finally:


### PR DESCRIPTION
## Related issue

No GitHub issue — reported on Slack. Follow-up to #4539, which fixed the *harness* fork; the same user then hit the identical failure on the *runner* fork.

## Summary

#4539 stopped the zygote from forking a harness after an in-place upgrade. The zygote also forks whole **runners**, and that path had the same bug — the next report was a different traceback with the same root cause:

```
  File ".../omnigent/runner/_zygote.py", line 474, in <lambda>
  File ".../omnigent/runner/_zygote.py", line 188, in _run_child
  File ".../omnigent/runner/_entry.py", line 1695, in main
  File ".../omnigent/runner/_entry.py", line 1142, in create_app
ModuleNotFoundError: No module named 'omnigent.cli_auth'
```

A forked child inherits the graph imported at zygote boot but resolves every *lazily*-imported module from disk. `create_app` imports `omnigent.cli_auth` lazily, so once `uv tool install` rewrites site-packages under a still-running host, the child looks for it in the swapped-out package directory and dies at boot. Same shape as the harness fork's missing `describe_exception`, just the other fork path and the other direction (a module that vanished rather than a name that appeared).

**ELI5:** the zygote memorized the library at startup; an upgrade swaps the books on the shelf. #4539 stopped the *harness* twins from being born into that mismatch — but the *runner* twins were still being born into it.

```
zygote boot ── stamp A captured ── graph imported
                    │
uv tool install (rewrites site-packages, stamp now B)
                    │
       ┌────────────┴────────────┐
   fork (runner)          fork_harness
       │                        │
   stamp B ≠ A ──► refuse ──► caller falls back to a fresh interpreter
   (was: unguarded)   (#4539)     (direct Popen / direct exec)
```

- Lift the stamp check out of `_handle_fork_harness` into `_refuse_if_upgraded()` and apply it to `fork` as well, naming the child kind (`runner` / `harness`) in the error so operator logs say which launch fell back.
- No new plumbing: `ZygoteManager.fork_runner` already raises `ZygoteUnavailable` on an error reply, and `host/connect.py` already catches it, logs, latches the zygote off for future launches, and falls back to a direct `Popen` — which reads the new code coherently.

## Test Plan

- **Unit** — the existing gate tests are parametrized over both fork paths (`fork`, `fork_harness`): refusal after the disk stamp changes (asserting the error names the child kind, with `os.fork` booby-trapped to fail the test if it is ever reached), and forking proceeding while the stamp matches. Full `tests/host/test_runner_zygote.py` suite: **37 passed** (drives real zygote subprocesses).
- **Live zygote** — booted a real zygote via `ZygoteManager` at stamp A, forked both a runner and a harness successfully, rewrote `_build_info.py` to stamp B under the running process, and confirmed both subsequent forks were refused with the kind-specific error.
- **End-to-end through the web UI** — ran a real server + `omnigent host` daemon, created a session in the UI (runner forked from the zygote: `Forked runner via zygote (zygote pid=50595, runner pid=50839)`), rewrote `_build_info.py` under the live host, then created a second session. The host logged `Runner zygote unavailable (zygote fork failed: omnigent was upgraded on disk after the zygote imported its graph; refusing to fork a mixed-version runner); falling back to direct spawn`, a fresh runner spawned, and the new session completed its turn in the UI instead of dying at boot.

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the two legs unit tests can't reach: a real zygote process refusing both fork kinds after its package was rewritten on disk, and the full host → runner → session path falling back to a direct spawn and still serving a turn (described under Test Plan). The gate itself and both refusal messages are unit-tested against `_ZygoteServer`; the refusal→fallback leg reuses the `ZygoteUnavailable` path already covered by the host/daemon suites.

## Changelog

Upgrading omnigent in place no longer breaks runner launches on already-running hosts
