### PR TITLE
docs(debby): fix stale ambient-Databricks rationale and overstated provider prereq

### DIFF
--- a/examples/debby/agents/gpt/config.yaml
+++ b/examples/debby/agents/gpt/config.yaml
@@ -9,13 +9,13 @@ description: >-
 # (see the ``os_env`` block below) so it can read reference files while
 # reasoning.
 #
-# Why codex rather than openai-agents: the openai-agents harness treats an
-# unpinned model as a Databricks model (see
-# omnigent/inner/openai_agents_sdk_executor.py — `is_databricks_model =
-# model is None`) and, with no OPENAI_API_KEY/OPENAI_BASE_URL in the
-# environment, silently falls back to ambient Databricks credentials — routing
-# Debby's "GPT" head through the Databricks gateway instead of OpenAI. The
-# codex harness has no such unpinned-model Databricks fallback.
+# Why codex rather than openai-agents: codex is the GPT-native harness. It
+# speaks OpenAI's Responses API and uses OpenAI's own auth, so an unpinned
+# model resolves to the configured provider's default GPT model.
+#
+# Note: codex needs an endpoint implementing OpenAI's *Responses* API. OpenAI
+# itself works, as does any gateway that exposes it — a Databricks workspace
+# does. A Chat-Completions-only endpoint will not.
 executor:
   type: omnigent
   config:

--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -12,9 +12,15 @@
 # Usage:
 #   omnigent run examples/debby
 #
-# Debby's two heads run on the claude-sdk and codex harnesses, so
-# configure both a Claude and an OpenAI provider first (e.g. `omnigent setup`,
-# or export ANTHROPIC_API_KEY and OPENAI_API_KEY).
+# Debby's two heads run on the claude-sdk and codex harnesses, so configure a
+# provider for each first (`omnigent setup`). That does not require two vendor
+# accounts — a single Databricks workspace serves both heads. What each harness
+# actually needs:
+#   - claude-sdk — any Claude provider: an Anthropic API key, a Claude
+#     subscription, an OpenAI-compatible gateway, or a Databricks workspace.
+#   - codex — an endpoint implementing OpenAI's *Responses* API: OpenAI itself,
+#     or a gateway that exposes it (a Databricks workspace does). A
+#     Chat-Completions-only endpoint will not work.
 
 spec_version: 1
 name: debby

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5541,9 +5541,10 @@ def debby(run_args: tuple[str, ...]) -> None:
     """Launch debby, the bundled two-headed brainstorming agent.
 
     Shorthand for ``omnigent run`` on the packaged debby agent. Debby fans
-    every question out to both a Claude and a GPT sub-agent, so a Claude
-    and an OpenAI provider must both be configured. All ``run`` options are
-    accepted and forwarded.
+    every question out to both a Claude and a GPT sub-agent, running on the
+    claude-sdk and codex harnesses, so a provider for each must be configured
+    (``omnigent setup``) — a single Databricks workspace serves both. All
+    ``run`` options are accepted and forwarded.
 
     \b
     Examples:

--- a/tests/spec/test_debby_example.py
+++ b/tests/spec/test_debby_example.py
@@ -1,13 +1,14 @@
 """Regression guard for the Debby example's GPT head.
 
 Debby's "GPT" sub-agent must run on the ``codex`` harness, not
-``openai-agents``. The openai-agents harness treats an unpinned model as a
-Databricks model (``is_databricks_model = model is None`` in
-``omnigent/inner/openai_agents_sdk_executor.py``) and, with no
-``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` in the environment, silently falls
-back to ambient Databricks credentials — routing the "GPT" head through the
-Databricks gateway instead of OpenAI. The ``codex`` harness is GPT-only, uses
-OpenAI's native auth, and has no such unpinned-model Databricks fallback.
+``openai-agents``. ``codex`` is the GPT-native harness: it speaks OpenAI's
+Responses API and uses OpenAI's own auth, so an unpinned model resolves to the
+configured provider's default GPT model. This head was originally pinned to
+``codex`` to dodge an ``openai-agents`` bug where an unpinned model opted into
+ambient Databricks credentials; that bug is fixed (see
+``allow_ambient_databricks`` in ``omnigent/inner/openai_agents_sdk_executor.py``,
+which opts in only for explicit ``databricks-`` model names), but ``codex``
+remains the right harness for a GPT head on its own merits.
 
 This is a non-live parse-only check so it runs in the default suite (the
 dir-shaped example's own e2e coverage lives under ``tests/e2e``, which is
@@ -27,11 +28,11 @@ _PACKAGED_DEBBY_DIR = _REPO_ROOT / "omnigent" / "resources" / "examples" / "debb
 
 
 def test_debby_gpt_head_uses_codex_not_openai_agents() -> None:
-    """The GPT head runs on ``codex`` and never silently routes to Databricks.
+    """The GPT head runs on ``codex``, the GPT-native harness.
 
-    If this flips back to ``openai-agents`` with no pinned model, Debby's GPT
-    head falls back to ambient Databricks credentials for any user with a
-    Databricks profile configured — the exact bug this example was fixed for.
+    ``codex`` speaks OpenAI's Responses API and uses OpenAI's own auth. If this
+    flips to ``openai-agents``, Debby's "GPT" head is no longer guaranteed to
+    resolve a GPT model from an OpenAI-compatible provider.
     """
     spec = parse(_DEBBY_DIR)
     by_name = {sub.name: sub for sub in spec.sub_agents}
@@ -41,8 +42,8 @@ def test_debby_gpt_head_uses_codex_not_openai_agents() -> None:
 
     assert gpt.executor.harness_kind == "codex", (
         f"Debby's GPT head must run on the 'codex' harness; got "
-        f"{gpt.executor.harness_kind!r}. 'openai-agents' with no pinned model "
-        f"silently falls back to ambient Databricks credentials."
+        f"{gpt.executor.harness_kind!r}. Only 'codex' guarantees this head "
+        f"resolves a GPT model from an OpenAI-Responses-API provider."
     )
 
     # Belt-and-suspenders: the GPT head must not pin a Databricks model or


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue
Fixes #4298

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
The debby example's gpt head cites `is_databricks_model = model is None` in openai_agents_sdk_executor.py to explain why it runs on codex. That symbol no longer exists, and the behaviour it described was deliberately removed: the current `allow_ambient_databricks` opts in only for explicit `databricks-` model names, precisely because treating an unpinned model as a Databricks signal sent credential-less OpenAI agents into ambient Databricks auth. The comment also claims codex has no unpinned-model Databricks fallback, but codex_executor.py resolves a catalog Databricks model on the gateway path.

Separately, the example and `omnigent debby --help` tell users to configure both a Claude and an OpenAI provider. A single Databricks workspace serves both heads; the real constraint is that the codex head needs an endpoint implementing OpenAI's Responses API.

Rewrites the rationale rather than renaming the symbol, and reframes the prerequisite around harness requirements. The same stale rationale in tests/spec/test_debby_example.py (docstrings and a failure message) is updated too. No behaviour change.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
