### PR TITLE
fix(web): guard the consumed committed-item branch against marker head-drop

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -4295,6 +4295,55 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
+    it("holds the pending head back when the committed item is a mirrored interrupt marker", () => {
+      // Claude's own `[Request interrupted by user]` record owns no
+      // pending entry and arrives with clearedPendingId unset. A snapshot
+      // merge can commit it into `blocks` before its consumed event, so it
+      // lands on the committed-item branch. A genuine queued message sits
+      // at the pending head — dropping it here (the FIFO fallback without a
+      // marker guard) would make the user's in-flight bubble vanish. The
+      // marker must not steal that slot, matching the promote path below.
+      const committedMarker: AnyBlock = {
+        type: "user_message",
+        ctx: {
+          agent: null,
+          depth: 0,
+          turn: 0,
+          timestamp: 0,
+          responseId: "resp_1",
+          itemId: "msg_interrupt",
+        },
+        content: [{ type: "input_text", text: "[Request interrupted by user]" }],
+      } as unknown as AnyBlock;
+      useChatStore.setState({
+        blocks: [committedMarker],
+        pendingUserMessages: [
+          { tempId: "pend_real", content: [{ type: "input_text", text: "still sending" }] },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_interrupt",
+        itemType: "message",
+        // No clearedPendingId — the server never drains a pending entry for
+        // the CLI's synthetic interrupt record.
+        data: {
+          role: "user",
+          content: [{ type: "input_text", text: "[Request interrupted by user]" }],
+        },
+      });
+
+      const state = useChatStore.getState();
+      // The real message's optimistic bubble survives.
+      expect(state.pendingUserMessages).toEqual([
+        { tempId: "pend_real", content: [{ type: "input_text", text: "still sending" }] },
+      ]);
+      // No second copy appended — the committed marker stands alone.
+      expect(state.blocks).toHaveLength(1);
+      expect(state.blocks[0]).toBe(committedMarker);
+    });
+
     it("threads the event's createdBy onto the promoted committed block", () => {
       // Multi-user attribution: the consumed event carries the human
       // author; the promoted block's ctx.createdBy must reflect it so

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4832,14 +4832,24 @@ export function handleSessionEvent(event: StreamEvent): void {
           // as below (named entry, then FIFO head), minus the append.
           const cleared = event.clearedPendingId;
           const at = cleared ? s.pendingUserMessages.findIndex((p) => p.tempId === cleared) : -1;
-          const dropAt = at >= 0 ? at : s.pendingUserMessages.length > 0 ? 0 : -1;
-          if (dropAt < 0) return {};
-          return {
-            pendingUserMessages: [
-              ...s.pendingUserMessages.slice(0, dropAt),
-              ...s.pendingUserMessages.slice(dropAt + 1),
-            ],
-          };
+          if (at >= 0) {
+            return {
+              pendingUserMessages: [
+                ...s.pendingUserMessages.slice(0, at),
+                ...s.pendingUserMessages.slice(at + 1),
+              ],
+            };
+          }
+          // FIFO-head fallback — same marker guard as the promote path
+          // below. A mirrored system marker (the vendor CLI's own
+          // `[Request interrupted by user]` record) is synthesized by the
+          // CLI, owns no pending entry, and arrives with clearedPendingId
+          // unset; dropping the head would steal a real queued message's
+          // bubble. Hold the head back for a marker.
+          const eventContent = userContentFromEvent(event);
+          if (eventContent !== null && isSystemUserContent(eventContent)) return {};
+          if (s.pendingUserMessages.length === 0) return {};
+          return { pendingUserMessages: s.pendingUserMessages.slice(1) };
         }
 
         // 1. Drop by id when the server names the drained entry.


### PR DESCRIPTION
## Related issue

Follow-up to #3595 — closes the gap flagged by the Polly AI review on that PR. No separate issue was filed; the parent PR closed #3594.

## Summary

#3595 added a committed-item branch to the `session_input_consumed` handler: when the committed copy is already in `blocks` (a forwarder-mirrored item beat the event through the stream or a snapshot merge), it acks the optimistic bubble instead of stranding a duplicate. But when `clearedPendingId` is unset it drops `pendingUserMessages[0]` **unconditionally** — omitting the system-marker guard its sibling promote path applies just below.

Claude's own `[Request interrupted by user]` record owns no pending entry (`_is_native_interrupt_record` makes the server skip the drain), so it is published with `clearedPendingId` unset. When a snapshot merge commits that marker into `blocks` before its consumed event arrives, this branch pops a **real** queued message's optimistic bubble — the user's in-flight message disappears from the transcript tail until it round-trips and re-renders.

- Split the branch to mirror the promote path: drop the named entry when `clearedPendingId` matches; otherwise apply the `isSystemUserContent` guard before popping the FIFO head, so a mirrored marker never steals a real message's slot.
- Add the regression test that was missing: an interrupt marker snapshot-merged into `blocks`, `clearedPendingId` unset, a genuine message at the pending head → the real bubble must survive.

**ELI5:** When you send a message, the UI shows a temporary bubble until the server's copy arrives. The previous fix, on seeing the real copy already rendered, dropped the oldest temporary bubble — but Claude's "interrupted" marker looks like it arrived that way too, and it has no temporary bubble of its own. So the code would grab your *actual* in-flight message's bubble and delete it by mistake. Now it recognizes the marker and leaves your bubble alone.

```
[Request interrupted by user] snapshot-merged into blocks
                     │
   session.input.consumed (clearedPendingId = None) ──▶ hasCommittedItem? yes
                     │
   before: FIFO head popped unconditionally ─▶ real queued message's bubble dropped  ✗
   after:  isSystemUserContent(marker)? yes  ─▶ return {}   ✓ real bubble untouched
```

## Test Plan

- `cd web && pnpm vitest run src/store/chatStore.test.ts` — **315 pass**, including the new regression test.
- Verified the new test **fails on the pre-fix code** (reverted `chatStore.ts`, ran the test in isolation → 1 failed), confirming it actually guards the bug.
- `tsc --noEmit` — no errors; `oxlint --deny-warnings` and `prettier --check` clean on the two touched files.

## Demo

N/A — non-visual. The bug is a timing-dependent snapshot-merge race with no on-demand visual repro; it's pinned by the deterministic unit test instead.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The race is timing-dependent in the real app (snapshot merge must commit the marker before its consumed event, with a genuine message queued), so verification is a deterministic unit test: seed the committed marker + a real pending head, deliver the late consumed event, assert the real bubble survives. The test was confirmed red on the pre-fix code and green with the fix.

## Changelog

Native-harness sessions no longer briefly drop your in-flight message bubble when an interrupt marker is reconciled at the same time.


---
This pull request and its description were written by Isaac.
