### PR TITLE
fix(web): destroy embedded browser view when leaving a server (Electron)

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -562,6 +562,18 @@ function pinWindow(win, origin) {
     // Leaving a server: this window's unread contribution goes with it.
     state.badgeCount = 0;
     updateBadge();
+    // Destroy the window's embedded-browser views. They belong to sessions on
+    // the origin we're leaving, and the navigation tears down the renderer
+    // (setup page / new server) WITHOUT running BrowserPane's unmount detach —
+    // so without this the native WebContentsView keeps painting over the new
+    // page. Skip the initial pin (no prior origin: cold connect, nothing open).
+    if (state.origin != null) {
+      try {
+        state.browserRegistry?.closeAll("server-changed");
+      } catch {
+        /* registry already torn down */
+      }
+    }
   }
   state.origin = origin;
 }

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -344,3 +344,36 @@ describe("deep-link ingestion wiring (src/main.js)", () => {
     );
   });
 });
+
+// pinWindow is the one chokepoint every "leave this server" path routes through
+// (Connect to new server, Change Server…, switch-server, did-fail-load fallback).
+// Those navigations tear down the renderer WITHOUT running BrowserPane's unmount
+// detach, so pinWindow must close the window's browser registry when the origin
+// changes — else the native WebContentsView dangles over the setup/welcome page.
+describe("browser-view teardown on server change (src/main.js)", () => {
+  it("closes the window's browserRegistry when pinWindow changes origin", () => {
+    assert.match(
+      liveCode,
+      /function pinWindow\(win,\s*origin\)\s*\{[\s\S]{0,600}browserRegistry\?\.closeAll\(/,
+      [
+        "pinWindow no longer closes the window's embedded-browser views when the",
+        "origin changes. Leaving a server (Connect to new server / Change Server / switch)",
+        "navigates the window away and tears down the renderer WITHOUT running",
+        "BrowserPane's unmount detach, so the native WebContentsView keeps painting over",
+        "the setup/welcome page. Restore the closeAll call in pinWindow.",
+      ].join(" "),
+    );
+  });
+
+  it("guards the teardown so the initial cold-connect pin doesn't fire it", () => {
+    assert.match(
+      liveCode,
+      /function pinWindow\(win,\s*origin\)\s*\{[\s\S]{0,600}state\.origin\s*!=\s*null[\s\S]{0,120}browserRegistry\?\.closeAll\(/,
+      [
+        "The closeAll in pinWindow is no longer guarded on a prior origin. Without the",
+        "state.origin != null guard the initial pin (setup→first connect) would try to",
+        "close a registry with nothing open. Keep the guard.",
+      ].join(" "),
+    );
+  });
+});


### PR DESCRIPTION
## Related issue

Closes #

## Summary

In the Electron shell, leaving a server (**Connect to new server…**, **Change
Server…**, the title-bar server switcher, or a failed load falling back to the
setup page) left the embedded Browser tab's native `WebContentsView` dangling —
still painted over the setup/welcome screen.

Root cause: those actions navigate the window away, which **tears down the React
renderer** — so `BrowserPane`'s unmount effect (its `browserSetActive(null)`
detach) never runs. Meanwhile the main-process handlers that trigger the
navigation never closed the window's browser-view registry; only
`win.on("closed")` did.

Fix: every "leave this server" path routes through `pinWindow(win, origin)`, so
close the window's browser views there when the origin actually changes. One
guarded block covers all entry points instead of patching each button.

```js
if (state.origin !== origin) {
  ...
  if (state.origin != null) {              // skip the initial cold-connect pin
    try { state.browserRegistry?.closeAll("server-changed"); } catch {}
  }
}
```

The `state.origin != null` guard skips the setup→first-connect pin (nothing is
open yet); windows that cold-open onto a server set `origin` at creation, not via
`pinWindow`, so they don't fire it either. `closeAll` is idempotent, so a path
that pins twice is harmless.

## Test Plan

- `cd web/electron && node --test` — 240 pass, incl. 2 new wiring guards in `main.test.js`.
- `web-prettier` + `web-oxlint` pre-commit hooks pass on the changed files.
- Manual (Electron desktop shell): connect to a server, open the Browser tab and
  load a page, then leave the server each way and confirm the pane disappears,
  leaving a clean setup/welcome screen:
  - title-bar picker → **Connect to new server…** (the reported case);
  - Server menu → **Change Server…** (native menu);
  - title-bar picker → switch to a recent server;
  - enter an unreachable URL so the load fails back to the setup page.

## Demo

### Before

https://github.com/user-attachments/assets/9b43ad3f-59bd-4c79-b725-8ad70648b864

### After

https://github.com/user-attachments/assets/1ecc8584-0cb6-4235-8d88-3c62290f3ef2

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`main.js` has no exports and is guarded by source-string regression tests (the
established pattern in `main.test.js`), so two guards were added: one asserts
`pinWindow` calls `browserRegistry.closeAll(...)` on an origin change, the other
asserts the `state.origin != null` guard stays (so the initial cold-connect pin
doesn't try to close an empty registry). The actual view teardown behavior is
already unit-tested in `browserViewRegistry.test.js` (`closeAll`). The
native-overlay disappearance itself can only be seen in a real Electron window,
so it's covered by the manual steps above.

## Changelog

The embedded browser pane no longer lingers over the welcome screen after switching or disconnecting from a server
