### PR TITLE
fix(web): reject inexact markdown comment anchors

### DIFF
--- a/tests/e2e_ui/comments/test_markdown_editor_comments.py
+++ b/tests/e2e_ui/comments/test_markdown_editor_comments.py
@@ -355,6 +355,16 @@ def test_inexact_rendered_selection_cannot_create_comment(
     editor_content = file_viewer.locator("[contenteditable='true']")
     expect(editor_content).to_be_visible(timeout=10_000)
 
+    add_comment_btn = page.get_by_role(
+        "button",
+        name=re.compile("Add comment", re.IGNORECASE),
+    )
+
+    plain_paragraph = editor_content.get_by_text(_SELECTABLE_TEXT, exact=True)
+    expect(plain_paragraph).to_be_visible()
+    plain_paragraph.select_text()
+    expect(add_comment_btn).to_be_visible()
+
     formatted_paragraph = editor_content.get_by_text(
         _FORMATTED_PARAGRAPH_TEXT,
         exact=True,
@@ -362,8 +372,4 @@ def test_inexact_rendered_selection_cannot_create_comment(
     expect(formatted_paragraph).to_be_visible()
     formatted_paragraph.select_text()
 
-    add_comment_btn = page.get_by_role(
-        "button",
-        name=re.compile("Add comment", re.IGNORECASE),
-    )
     expect(add_comment_btn).not_to_be_visible()

--- a/tests/e2e_ui/comments/test_markdown_editor_comments.py
+++ b/tests/e2e_ui/comments/test_markdown_editor_comments.py
@@ -42,6 +42,10 @@ _SELECTABLE_TEXT = "Welcome to the editor."
 # include the ``## `` prefix when selecting text from a heading node.
 _HEADING_TEXT = "Editor Section Heading"
 
+# Selecting this whole rendered paragraph produces text that does not exist
+# verbatim in the raw Markdown because the emphasis markers sit in the middle.
+_FORMATTED_PARAGRAPH_TEXT = "This paragraph has formatted words inside."
+
 # Full markdown body — a heading followed by the selectable paragraph.
 _MARKDOWN_CONTENT = f"""\
 # Editor Comment Test
@@ -49,6 +53,8 @@ _MARKDOWN_CONTENT = f"""\
 ## {_HEADING_TEXT}
 
 {_SELECTABLE_TEXT}
+
+This paragraph has **formatted words** inside.
 
 This is another paragraph with some text.
 """
@@ -323,3 +329,41 @@ def test_heading_text_anchor_content_excludes_prefix(
         f"stored start_index={stored_idx} is more than 200 chars from "
         f"raw markdown position {raw_idx} for anchor {anchor!r}"
     )
+
+
+def test_inexact_rendered_selection_cannot_create_comment(
+    page: Page,
+    seeded_markdown_session: tuple[str, str, str],
+) -> None:
+    """Do not offer comment creation when rendered text has no exact raw range.
+
+    The paragraph renders without the Markdown emphasis markers, so its full
+    rendered text does not occur verbatim in the raw source. Persisting an
+    approximate range would silently anchor the comment to different text.
+    """
+    base_url, session_id, _ = seeded_markdown_session
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+
+    file_button = page.get_by_role(
+        "button", name=re.compile(re.escape(_MARKDOWN_FILE_PATH))
+    ).filter(has_text=_MARKDOWN_FILE_PATH)
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    editor_content = file_viewer.locator("[contenteditable='true']")
+    expect(editor_content).to_be_visible(timeout=10_000)
+
+    formatted_paragraph = editor_content.get_by_text(
+        _FORMATTED_PARAGRAPH_TEXT,
+        exact=True,
+    )
+    expect(formatted_paragraph).to_be_visible()
+    formatted_paragraph.select_text()
+
+    add_comment_btn = page.get_by_role(
+        "button",
+        name=re.compile("Add comment", re.IGNORECASE),
+    )
+    expect(add_comment_btn).not_to_be_visible()

--- a/web/src/shell/MarkdownCommentPlugin.tsx
+++ b/web/src/shell/MarkdownCommentPlugin.tsx
@@ -184,6 +184,14 @@ export function MarkdownCommentPlugin({
         setButtonPos(null);
         return;
       }
+      // A rendered Markdown selection is commentable only when it maps to an
+      // exact raw-source range. Approximate offsets can target different text.
+      if (
+        !computeSelectionData(selection.from, selection.to, editor.state.doc, contentRef.current)
+      ) {
+        setButtonPos(null);
+        return;
+      }
 
       const nativeSel = window.getSelection();
       if (!nativeSel || nativeSel.rangeCount === 0) return;

--- a/web/src/shell/TipTapEditorHelpers.test.ts
+++ b/web/src/shell/TipTapEditorHelpers.test.ts
@@ -187,31 +187,23 @@ describe("computeSelectionData", () => {
     expect(result).toEqual({ start_index: 0, end_index: 3, anchor_content: "foo" });
   });
 
-  it("falls back to proportional indices when anchor_content is not in rawContent verbatim", () => {
+  it("rejects a rendered selection that cannot be anchored verbatim in rawContent", () => {
     // Simulate a multi-line selection where the doc joins with "\n" but
     // rawContent uses a different representation.
     const docText = "first\nsecond"; // doc has "\n" as separator
     const rawContent = "first\r\nsecond"; // raw file has "\r\n" (different)
     const doc = makeDoc(docText);
-    // Select "first\nsecond" — the "\n" form won't be found in rawContent.
+    // Select "first\nsecond": persisting proportional raw offsets would mix
+    // rendered anchor text with a different raw source span.
     const result = computeSelectionData(0, 12, doc, rawContent);
-    expect(result).not.toBeNull();
-    // Should use proportional fallback (hint-based) rather than returning null.
-    expect(result!.anchor_content).toBe("first\nsecond");
-    // start_index is proportional: hint = round(0 * 13 / 12) = 0
-    expect(result!.start_index).toBe(0);
-    // end_index is start_index + anchor_content.length = 0 + 12 = 12
-    expect(result!.end_index).toBe(12);
+    expect(result).toBeNull();
   });
 
-  it("falls back to proportional indices when rawContent is empty", () => {
+  it("rejects a rendered selection when rawContent is empty", () => {
     const text = "Hello";
     const doc = makeDoc(text);
     const result = computeSelectionData(0, 5, doc, "");
-    expect(result).not.toBeNull();
-    expect(result!.anchor_content).toBe("Hello");
-    expect(result!.start_index).toBe(0);
-    expect(result!.end_index).toBe(5);
+    expect(result).toBeNull();
   });
 
   it("handles selection of the full document", () => {

--- a/web/src/shell/TipTapEditorHelpers.ts
+++ b/web/src/shell/TipTapEditorHelpers.ts
@@ -86,11 +86,10 @@ export function findPmRangeForComment(
  *
  * When the text cannot be found verbatim in the raw file (e.g. multi-line
  * selections, table cells, or code blocks whose markdown syntax the parser
- * strips), falls back to proportionally scaled indices so the button is never
- * blocked.  The anchor_content from the PM doc is still used for re-locating
- * the highlight later via findPmRangeForComment.
+ * strips), returns null. Persisting proportionally scaled indices would mix
+ * rendered anchor text with an unrelated raw-source range.
  *
- * Returns null only when the selection contains no text.
+ * Returns null when the selection contains no text or has no exact raw match.
  */
 export function computeSelectionData(
   from: number,
@@ -114,15 +113,7 @@ export function computeSelectionData(
     idx = rawContent.indexOf(anchor_content);
   }
 
-  // Fall back to proportional indices when the anchor text isn't found
-  // verbatim (multi-line, table, code block selections).
-  if (idx === -1) {
-    return {
-      start_index: hint,
-      end_index: hint + anchor_content.length,
-      anchor_content,
-    };
-  }
+  if (idx === -1) return null;
 
   return {
     start_index: idx,


### PR DESCRIPTION
## Related issue

Closes #4598

## Summary

`computeSelectionData()` fabricated raw-source offsets when a rendered Markdown selection had no verbatim match in the source: it returned a length-ratio estimate instead of a located position, and the plugin still offered Add comment, so a comment could display against one passage while its stored offsets addressed different text.

This removes the fallback: no exact raw match returns null, and the plugin hides the Add comment button on null. Exact-match behavior is unchanged.

The trade, stated openly: selections with no verbatim source match (multi-line, tables, code blocks, paragraphs spanning inline formatting) lose the comment button rather than storing a wrong anchor. An approximate anchor is not a weaker anchor but a wrong one, and nothing downstream can detect it, while a missing button is visible. Restoring the capability needs a real rendered-to-source position map, which is a follow-up, not a tweak to this diff.

ELI5: the editor saved your selected words with a guessed location in the source file. Now it only offers a comment when the words map to a real source range.

```text
exact raw match? -- yes --> persist the exact range
                -- no  --> hide Add comment
```

## Test Plan

Failing first, on the tests-only commit: `2 failed | 19 passed`, both failures showing the fabricated offsets. With the fix: web suite `5544 passed | 3 expected fail | 1 skipped`; type-check, lint, Prettier, and `git diff --check` green.

The new Playwright regression ran in the E2E UI workflow on this head: all three shards and the E2E UI Required gate passed.

## Demo

Browser captures from the Playwright module in this PR. Frames are script-captured; the block-type indicator in the toolbar reflects the programmatic selection.

Before, with the fallback in place: the formatted paragraph offers Add comment, and the stored anchor's offsets point at different text.

![Before: button offered on the formatted paragraph](https://raw.githubusercontent.com/dosenr/omnigent/assets/rt168-demo/before-01-formatted-button-visible.png)
![Before: stored anchor with mismatched offsets](https://raw.githubusercontent.com/dosenr/omnigent/assets/rt168-demo/before-02-stored-anchor-response.png)

After, with this fix: the same selection offers no comment button, and a plain paragraph still does.

![After: no button on the formatted paragraph](https://raw.githubusercontent.com/dosenr/omnigent/assets/rt168-demo/after-01-formatted-button-absent.png)
![After: plain paragraph still offers the button](https://raw.githubusercontent.com/dosenr/omnigent/assets/rt168-demo/after-02-plain-button-visible.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests lock the boundary both ways (exact match still returns its range; no exact match returns null). The Playwright test asserts the button appears on a plain paragraph and is not offered on a formatted one. The button guard re-runs the helper per selection change; same order of work the file already budgets, under its documented sub-200 KB assumption.

## Changelog

Markdown comments are no longer offered for selections whose position in the source file cannot be determined exactly.


