### PR TITLE
fix(sessions): let sys_session_get_history request longer items

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3619,7 +3619,7 @@ def _truncate_activity(
     max_chars: int = _ACTIVITY_MAX_CHARS,
 ) -> str | None:
     """
-    Truncate text to ``_ACTIVITY_MAX_CHARS`` to bound peek prompt size.
+    Truncate text to ``max_chars`` to bound peek prompt size.
 
     :param text: The text to truncate, or ``None``.
     :param max_chars: Maximum characters retained before the marker.

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -91,6 +91,8 @@ from omnigent.tools.builtins.spawn import (
     _ACTIVITY_MAX_CHARS,
     _CLOSED_TITLE_INFIX,
     _HISTORY_DEFAULT_TAIL,
+    _bound_history_content_chars,
+    _clamp_history_content_chars,
     _clamp_tail_items,
 )
 from omnigent.tools.builtins.sys_terminal import (
@@ -3611,19 +3613,24 @@ def _parse_session_title(raw_title: str | None) -> _ParsedTitle:
     return _ParsedTitle(agent=head, title=tail)
 
 
-def _truncate_activity(text: str | None) -> str | None:
+def _truncate_activity(
+    text: str | None,
+    *,
+    max_chars: int = _ACTIVITY_MAX_CHARS,
+) -> str | None:
     """
     Truncate text to ``_ACTIVITY_MAX_CHARS`` to bound peek prompt size.
 
     :param text: The text to truncate, or ``None``.
+    :param max_chars: Maximum characters retained before the marker.
     :returns: The (possibly truncated) text, or ``None`` when the input
         is ``None``.
     """
     if text is None:
         return None
-    if len(text) <= _ACTIVITY_MAX_CHARS:
+    if len(text) <= max_chars:
         return text
-    return text[:_ACTIVITY_MAX_CHARS] + " [truncated]"
+    return text[:max_chars] + " [truncated]"
 
 
 def _text_from_api_content(content: object) -> str:
@@ -3644,7 +3651,11 @@ def _text_from_api_content(content: object) -> str:
     return " ".join(parts)
 
 
-def _project_api_item(item: _JsonObject) -> _JsonObject:
+def _project_api_item(
+    item: _JsonObject,
+    *,
+    max_chars: int = _ACTIVITY_MAX_CHARS,
+) -> _JsonObject:
     """
     Project a REST API conversation item into the compact peek shape.
 
@@ -3655,6 +3666,7 @@ def _project_api_item(item: _JsonObject) -> _JsonObject:
     the same as the in-process tool's.
 
     :param item: One API item dict from the items endpoint.
+    :param max_chars: Maximum characters retained in each content field.
     :returns: A compact dict — ``{type, tool, args}`` for tool calls,
         ``{type, output}`` for tool results, ``{type, role, text}`` for
         messages.
@@ -3664,17 +3676,26 @@ def _project_api_item(item: _JsonObject) -> _JsonObject:
         return {
             "type": "function_call",
             "tool": _optional_string(item.get("name")),
-            "args": _truncate_activity(_optional_string(item.get("arguments"))),
+            "args": _truncate_activity(
+                _optional_string(item.get("arguments")),
+                max_chars=max_chars,
+            ),
         }
     if itype == "function_call_output":
         output = item.get("output")
         rendered = output if isinstance(output, str) else json.dumps(output)
-        return {"type": "function_call_output", "output": _truncate_activity(rendered)}
+        return {
+            "type": "function_call_output",
+            "output": _truncate_activity(rendered, max_chars=max_chars),
+        }
     if itype == "message":
         return {
             "type": "message",
             "role": _optional_string(item.get("role")),
-            "text": _truncate_activity(_text_from_api_content(item.get("content"))),
+            "text": _truncate_activity(
+                _text_from_api_content(item.get("content")),
+                max_chars=max_chars,
+            ),
         }
     return {"type": itype}
 
@@ -4787,7 +4808,7 @@ async def _session_get_history_via_rest(
     may read).
 
     :param args: Parsed tool arguments; requires ``conversation_id``,
-        optional ``tail_items``.
+        optional ``tail_items`` and ``content_max_chars``.
     :param server_client: HTTP client pointed at the Omnigent server.
     :returns: JSON peek result, or a JSON error object.
     """
@@ -4799,6 +4820,15 @@ async def _session_get_history_via_rest(
     tail_items = _clamp_tail_items(args.get("tail_items", _HISTORY_DEFAULT_TAIL))
     if isinstance(tail_items, str):
         return tail_items
+    content_max_chars = _clamp_history_content_chars(
+        args.get("content_max_chars", _ACTIVITY_MAX_CHARS),
+    )
+    if isinstance(content_max_chars, str):
+        return content_max_chars
+    content_max_chars = _bound_history_content_chars(
+        tail_items=tail_items,
+        content_max_chars=content_max_chars,
+    )
     try:
         resp = await server_client.get(
             f"/v1/sessions/{target_id}/items",
@@ -4816,7 +4846,9 @@ async def _session_get_history_via_rest(
     data: list[_JsonObject] = resp.json().get("data", [])
     # ``order="desc"`` returns newest-first; reverse to chronological so
     # the LLM reads top-to-bottom (matches the in-process peek).
-    items: list[_JsonObject] = [_project_api_item(it) for it in reversed(data)]
+    items: list[_JsonObject] = [
+        _project_api_item(it, max_chars=content_max_chars) for it in reversed(data)
+    ]
     meta = await _fetch_peek_meta(target_id, server_client)
     # A parked elicitation never lands in the conversation store (it
     # lives only in the Omnigent server's pending-elicitations index, replayed

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -49,7 +49,11 @@ _ACTIVITY_MAX_CHARS = 2000
 # response without sending another turn.
 _HISTORY_DEFAULT_TAIL = 10
 _HISTORY_MAX_TAIL = 50
+# Six activity previews in one field can hold a substantive review while
+# keeping an explicit read bounded.
 _HISTORY_MAX_CHARS_PER_ITEM = 12000
+# The total budget intentionally follows the default preview and tail cap;
+# changing either value above also changes this budget.
 _HISTORY_MAX_TOTAL_CHARS = _HISTORY_MAX_TAIL * _ACTIVITY_MAX_CHARS
 
 # sys_session_close still rewrites the stored title internally to free
@@ -962,14 +966,14 @@ def _project_activity_item(
 
     Handles three item types: messages (user/assistant text),
     function calls (tool name + args), and function call
-    outputs (tool name + result). All content fields are
-    truncated to ``_ACTIVITY_MAX_CHARS``.
+    outputs (tool name + result). Content fields are truncated
+    to ``max_chars``, which defaults to ``_ACTIVITY_MAX_CHARS``.
 
     :param item: A conversation item from the sub-agent's
         conversation.
+    :param max_chars: Maximum characters retained in each content field.
     :returns: A compact dict with ``role``, ``type``, and
         content fields.
-    :param max_chars: Maximum characters retained in each content field.
     """
     # Convert Pydantic model to dict so .get() works uniformly
     # across all data types (MessageData, FunctionCallData, etc.).
@@ -1013,7 +1017,7 @@ def _project_activity_item(
 
 def _truncate(text: str, *, max_chars: int = _ACTIVITY_MAX_CHARS) -> str:
     """
-    Truncate text to ``_ACTIVITY_MAX_CHARS``.
+    Truncate text to ``max_chars``.
 
     :param text: The input string.
     :param max_chars: Maximum characters retained before the marker.
@@ -1432,8 +1436,9 @@ class SysSessionGetHistoryTool(Tool):
                                 "or tool result. Defaults to the compact activity "
                                 f"preview limit ({_ACTIVITY_MAX_CHARS}); clamped to "
                                 f"{_HISTORY_MAX_CHARS_PER_ITEM} and scaled down when "
-                                "needed to keep the total requested history within "
-                                f"{_HISTORY_MAX_TOTAL_CHARS} characters."
+                                "needed to keep stored content near the existing "
+                                f"~{_HISTORY_MAX_TOTAL_CHARS}-character budget. "
+                                "Truncation markers and pending prompts are extra."
                             ),
                         },
                     },
@@ -1447,9 +1452,8 @@ class SysSessionGetHistoryTool(Tool):
         """
         Look up the target sub-agent and return its recent items.
 
-        :param arguments: JSON-encoded arguments string, e.g.
-            ``'{"conversation_id": "conv_abc123", "tail_items": 5,'
-            ' "content_max_chars": 12000}'``.
+        :param arguments: JSON-encoded arguments, such as
+            ``{"conversation_id": "conv_abc123", "content_max_chars": 12000}``.
         :param ctx: Server-side execution context.
         :returns: JSON ``{"conversation_id": ..., "agent": ...,
             "title": ..., "items": [...]}`` on success;

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -49,8 +49,8 @@ _ACTIVITY_MAX_CHARS = 2000
 # response without sending another turn.
 _HISTORY_DEFAULT_TAIL = 10
 _HISTORY_MAX_TAIL = 50
-# Six activity previews in one field can hold a substantive review while
-# keeping an explicit read bounded.
+# Enough for one substantive child result while staying below the ~100k
+# aggregate bound. Wide tails automatically reduce the per-item limit.
 _HISTORY_MAX_CHARS_PER_ITEM = 12000
 # The total budget intentionally follows the default preview and tail cap;
 # changing either value above also changes this budget.
@@ -1326,15 +1326,30 @@ def _clamp_history_content_chars(raw: Any) -> int | str:
     """
     Validate and clamp the per-item history content limit.
 
-    :param raw: Provider-supplied value, which may not have passed JSON
-        schema validation.
+    Accepts integers, integral floats, and other non-boolean values that
+    ``int()`` converts to whole numbers, including numeric integer strings.
+    Rejects booleans, fractional floats, values ``int()`` cannot convert, and
+    values below 1.
+
+    :param raw: Provider-supplied value that may not have passed JSON schema
+        validation.
     :returns: An integer in ``[1, _HISTORY_MAX_CHARS_PER_ITEM]`` or a
         JSON error string suitable for returning to the model.
     """
-    try:
+    error = json.dumps({"error": f"content_max_chars must be a whole number, got {raw!r}"})
+    if isinstance(raw, bool):
+        return error
+    if isinstance(raw, int):
+        max_chars = raw
+    elif isinstance(raw, float):
+        if not raw.is_integer():
+            return error
         max_chars = int(raw)
-    except (TypeError, ValueError):
-        return json.dumps({"error": f"content_max_chars must be an integer, got {raw!r}"})
+    else:
+        try:
+            max_chars = int(raw)
+        except (TypeError, ValueError):
+            return error
     if max_chars < 1:
         return json.dumps({"error": "content_max_chars must be >= 1"})
     return min(max_chars, _HISTORY_MAX_CHARS_PER_ITEM)

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -43,9 +43,14 @@ _ACTIVITY_MAX_CHARS = 2000
 # explicitly by the LLM rather than auto-injected on a poll).
 # The cap of 50 keeps the worst-case prompt addition bounded
 # (50 items × _ACTIVITY_MAX_CHARS ≈ 100k chars) while still
-# letting the LLM request a substantial slice for triage.
+# letting the LLM request a substantial slice for triage. Individual
+# content fields keep the compact activity limit by default, but an
+# explicit read may raise that limit to recover one substantive child
+# response without sending another turn.
 _HISTORY_DEFAULT_TAIL = 10
 _HISTORY_MAX_TAIL = 50
+_HISTORY_MAX_CHARS_PER_ITEM = 12000
+_HISTORY_MAX_TOTAL_CHARS = _HISTORY_MAX_TAIL * _ACTIVITY_MAX_CHARS
 
 # sys_session_close still rewrites the stored title internally to free
 # the DB's ``(parent_conversation_id, title)`` unique slot. API display
@@ -949,6 +954,8 @@ class SysSessionCreateTool(Tool):
 
 def _project_activity_item(
     item: ConversationItem,
+    *,
+    max_chars: int = _ACTIVITY_MAX_CHARS,
 ) -> dict[str, str | None]:
     """
     Project a conversation item into a compact dict.
@@ -962,6 +969,7 @@ def _project_activity_item(
         conversation.
     :returns: A compact dict with ``role``, ``type``, and
         content fields.
+    :param max_chars: Maximum characters retained in each content field.
     """
     # Convert Pydantic model to dict so .get() works uniformly
     # across all data types (MessageData, FunctionCallData, etc.).
@@ -973,6 +981,7 @@ def _project_activity_item(
             "name": data.get("name"),
             "args": _truncate(
                 data.get("arguments", ""),
+                max_chars=max_chars,
             ),
         }
     if item.type == "function_call_output":
@@ -982,6 +991,7 @@ def _project_activity_item(
             "name": data.get("name"),
             "content": _truncate(
                 data.get("output", ""),
+                max_chars=max_chars,
             ),
         }
     # Message item — extract role and text content.
@@ -997,21 +1007,22 @@ def _project_activity_item(
     return {
         "role": role,
         "type": "text",
-        "content": _truncate("\n".join(text_parts)),
+        "content": _truncate("\n".join(text_parts), max_chars=max_chars),
     }
 
 
-def _truncate(text: str) -> str:
+def _truncate(text: str, *, max_chars: int = _ACTIVITY_MAX_CHARS) -> str:
     """
     Truncate text to ``_ACTIVITY_MAX_CHARS``.
 
     :param text: The input string.
+    :param max_chars: Maximum characters retained before the marker.
     :returns: The original string if short enough, or a
         truncated version with ``" [truncated]"`` suffix.
     """
-    if len(text) <= _ACTIVITY_MAX_CHARS:
+    if len(text) <= max_chars:
         return text
-    return text[:_ACTIVITY_MAX_CHARS] + " [truncated]"
+    return text[:max_chars] + " [truncated]"
 
 
 # ── 13a: sys_session_get_history / sys_session_close ─────────
@@ -1307,6 +1318,29 @@ def _clamp_tail_items(raw: Any) -> int | str:
     return min(tail_items, _HISTORY_MAX_TAIL)
 
 
+def _clamp_history_content_chars(raw: Any) -> int | str:
+    """
+    Validate and clamp the per-item history content limit.
+
+    :param raw: Provider-supplied value, which may not have passed JSON
+        schema validation.
+    :returns: An integer in ``[1, _HISTORY_MAX_CHARS_PER_ITEM]`` or a
+        JSON error string suitable for returning to the model.
+    """
+    try:
+        max_chars = int(raw)
+    except (TypeError, ValueError):
+        return json.dumps({"error": f"content_max_chars must be an integer, got {raw!r}"})
+    if max_chars < 1:
+        return json.dumps({"error": "content_max_chars must be >= 1"})
+    return min(max_chars, _HISTORY_MAX_CHARS_PER_ITEM)
+
+
+def _bound_history_content_chars(*, tail_items: int, content_max_chars: int) -> int:
+    """Keep the requested per-item limit within the total history prompt budget."""
+    return min(content_max_chars, _HISTORY_MAX_TOTAL_CHARS // tail_items)
+
+
 class SysSessionGetHistoryTool(Tool):
     """
     Return the recent conversation items (history) of a session.
@@ -1323,10 +1357,10 @@ class SysSessionGetHistoryTool(Tool):
     in-process path is tree-scoped (it has no caller identity), reading
     only sessions sharing the caller's ``root_conversation_id``.
 
-    Item content is projected through the same compact activity
-    format used by ``check_task`` recent_activity: tool calls,
-    tool results, and message text, each truncated to
-    ``_ACTIVITY_MAX_CHARS``.
+    Item content uses the same compact activity format as
+    ``check_task``. It defaults to ``_ACTIVITY_MAX_CHARS`` per field;
+    callers may request a larger bounded field through
+    ``content_max_chars`` when they need a substantive response.
 
     Returns ``session_not_found`` when the conversation_id does
     not exist, ``session_out_of_tree`` when the server denies the read
@@ -1389,6 +1423,19 @@ class SysSessionGetHistoryTool(Tool):
                                 "prompt size bounded."
                             ),
                         },
+                        "content_max_chars": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": _HISTORY_MAX_CHARS_PER_ITEM,
+                            "description": (
+                                "Maximum characters returned per message, tool call, "
+                                "or tool result. Defaults to the compact activity "
+                                f"preview limit ({_ACTIVITY_MAX_CHARS}); clamped to "
+                                f"{_HISTORY_MAX_CHARS_PER_ITEM} and scaled down when "
+                                "needed to keep the total requested history within "
+                                f"{_HISTORY_MAX_TOTAL_CHARS} characters."
+                            ),
+                        },
                     },
                     "required": ["conversation_id"],
                     "additionalProperties": False,
@@ -1401,7 +1448,8 @@ class SysSessionGetHistoryTool(Tool):
         Look up the target sub-agent and return its recent items.
 
         :param arguments: JSON-encoded arguments string, e.g.
-            ``'{"conversation_id": "conv_abc123", "tail_items": 5}'``.
+            ``'{"conversation_id": "conv_abc123", "tail_items": 5,'
+            ' "content_max_chars": 12000}'``.
         :param ctx: Server-side execution context.
         :returns: JSON ``{"conversation_id": ..., "agent": ...,
             "title": ..., "items": [...]}`` on success;
@@ -1419,6 +1467,15 @@ class SysSessionGetHistoryTool(Tool):
         )
         if isinstance(tail_items, str):
             return tail_items
+        content_max_chars = _clamp_history_content_chars(
+            resolution.args.get("content_max_chars", _ACTIVITY_MAX_CHARS),
+        )
+        if isinstance(content_max_chars, str):
+            return content_max_chars
+        content_max_chars = _bound_history_content_chars(
+            tail_items=tail_items,
+            content_max_chars=content_max_chars,
+        )
         page = resolution.conv_store.list_items(
             resolution.child.id,
             limit=tail_items,
@@ -1427,7 +1484,8 @@ class SysSessionGetHistoryTool(Tool):
         # ``list_items(order="desc")`` returns newest-first; reverse
         # to chronological order so the LLM reads top-to-bottom.
         items: list[dict[str, Any]] = [
-            _project_activity_item(item) for item in reversed(page.data)
+            _project_activity_item(item, max_chars=content_max_chars)
+            for item in reversed(page.data)
         ]
         # A parked elicitation never lands in the conversation store
         # (it lives only in the pending-elicitations index), so without

--- a/tests/e2e/test_session_history_content_limit_e2e.py
+++ b/tests/e2e/test_session_history_content_limit_e2e.py
@@ -1,0 +1,258 @@
+"""End-to-end coverage for configurable child-session history reads.
+
+Uses the mock LLM with a live server and runner. Invoke with::
+
+    pytest tests/e2e/test_session_history_content_limit_e2e.py -v --timeout=180
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import POLL_INTERVAL_S
+
+pytestmark = [
+    pytest.mark.timeout(180, method="signal"),
+    pytest.mark.min_server_version("0.3.0"),
+    pytest.mark.min_runner_version("0.9.0"),
+]
+
+
+def _tool_call(
+    name: str,
+    arguments: dict[str, object],
+    call_id: str,
+) -> dict[str, str]:
+    """Build a mock LLM tool-call entry."""
+    return {"call_id": call_id, "name": name, "arguments": json.dumps(arguments)}
+
+
+def _session_items(http_client: httpx.Client, session_id: str) -> list[dict[str, Any]]:
+    """Return persisted session items in chronological order."""
+    response = http_client.get(
+        f"/v1/sessions/{session_id}/items",
+        params={"limit": 100, "order": "asc"},
+    )
+    response.raise_for_status()
+    items: list[dict[str, Any]] = response.json()["data"]
+    return items
+
+
+def _wait_for_session_text(
+    http_client: httpx.Client,
+    session_id: str,
+    text: str,
+    *,
+    timeout: float = 120,
+) -> list[dict[str, Any]]:
+    """Poll persisted items until *text* appears."""
+    deadline = time.monotonic() + timeout
+    items: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        items = _session_items(http_client, session_id)
+        if text in json.dumps(items):
+            return items
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"{text!r} did not appear in session {session_id} within {timeout}s; last items={items!r}"
+    )
+
+
+def _wait_for_child_session(
+    http_client: httpx.Client,
+    parent_id: str,
+    *,
+    timeout: float = 120,
+) -> str:
+    """Poll until the parent exposes its child session."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = http_client.get(f"/v1/sessions/{parent_id}/child_sessions")
+        response.raise_for_status()
+        children = response.json().get("data", [])
+        if children:
+            return str(children[0]["id"])
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"child session did not appear for parent {parent_id}")
+
+
+def _history_text(body: dict[str, Any], call_id: str) -> str:
+    """Extract the message text returned by one history tool call."""
+    output_item = next(
+        item
+        for item in body["output"]
+        if item.get("type") == "function_call_output" and item.get("call_id") == call_id
+    )
+    payload = json.loads(output_item["output"])
+    text: str = payload["items"][-1]["text"]
+    return text
+
+
+def _read_child_history(
+    http_client: httpx.Client,
+    *,
+    parent_id: str,
+    parent_model: str,
+    child_id: str,
+    mock_llm_server_url: str,
+    call_id: str,
+    content_max_chars: int | None,
+) -> str:
+    """Run one parent turn that reads the child session history."""
+    arguments: dict[str, object] = {
+        "conversation_id": child_id,
+        "tail_items": 1,
+    }
+    if content_max_chars is not None:
+        arguments["content_max_chars"] = content_max_chars
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    _tool_call("sys_session_get_history", arguments, call_id),
+                ]
+            },
+            {"text": f"{call_id}_COMPLETE"},
+        ],
+        key=parent_model,
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=parent_id,
+        content="Read the child session history.",
+    )
+    body = poll_session_until_terminal(
+        http_client,
+        session_id=parent_id,
+        response_id=response_id,
+        timeout=120,
+    )
+    assert body["status"] == "completed", body.get("error")
+    return _history_text(body, call_id)
+
+
+def test_session_history_raised_content_limit_recovers_full_child_response_e2e(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """A raised history limit recovers a child response truncated by default."""
+    uid = uuid.uuid4().hex[:6]
+    parent_model = f"mock-history-parent-{uid}"
+    child_model = f"mock-history-child-{uid}"
+    mock_base = f"{mock_llm_server_url}/v1"
+    long_child_text = "CHILD_BEGIN|" + ("0123456789" * 408)[:4074] + "|CHILD_END"
+    assert len(long_child_text) == 4096
+
+    parent_name = register_inline_agent(
+        http_client,
+        name=f"history-content-limit-{uid}",
+        harness="openai-agents",
+        model=parent_model,
+        profile="",
+        prompt="Follow the scripted mock tool calls exactly.",
+        mock_llm_base_url=mock_base,
+        extra_config={
+            "tools": {
+                "writer": {
+                    "type": "agent",
+                    "description": "Deterministic long-response writer.",
+                    "executor": {
+                        "harness": "openai-agents",
+                        "model": child_model,
+                        "auth": {
+                            "type": "api_key",
+                            "api_key": "mock-key",
+                            "base_url": mock_base,
+                        },
+                    },
+                    "prompt": "Return the scripted response.",
+                }
+            }
+        },
+    )
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "sys_session_send",
+                        {"agent": "writer", "title": "long", "args": "Emit long text"},
+                        "call_spawn",
+                    )
+                ]
+            },
+            {"text": "CHILD_DISPATCHED"},
+            {"text": "AUTO_WAKE_COMPLETE"},
+        ],
+        key=parent_model,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": long_child_text}],
+        key=child_model,
+    )
+
+    parent_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=parent_id,
+        content="Create the scripted writer child.",
+    )
+    body = poll_session_until_terminal(
+        http_client,
+        session_id=parent_id,
+        response_id=response_id,
+        timeout=120,
+    )
+    assert body["status"] == "completed", body.get("error")
+
+    child_id = _wait_for_child_session(http_client, parent_id)
+    _wait_for_session_text(http_client, child_id, "|CHILD_END")
+    _wait_for_session_text(http_client, parent_id, "AUTO_WAKE_COMPLETE")
+
+    default_text = _read_child_history(
+        http_client,
+        parent_id=parent_id,
+        parent_model=parent_model,
+        child_id=child_id,
+        mock_llm_server_url=mock_llm_server_url,
+        call_id="call_default_history",
+        content_max_chars=None,
+    )
+    assert default_text == long_child_text[:2000] + " [truncated]"
+
+    raised_text = _read_child_history(
+        http_client,
+        parent_id=parent_id,
+        parent_model=parent_model,
+        child_id=child_id,
+        mock_llm_server_url=mock_llm_server_url,
+        call_id="call_raised_history",
+        content_max_chars=5000,
+    )
+    assert raised_text == long_child_text

--- a/tests/e2e/test_session_history_content_limit_e2e.py
+++ b/tests/e2e/test_session_history_content_limit_e2e.py
@@ -2,7 +2,7 @@
 
 Uses the mock LLM with a live server and runner. Invoke with::
 
-    pytest tests/e2e/test_session_history_content_limit_e2e.py -v --timeout=180
+    pytest tests/e2e/test_session_history_content_limit_e2e.py -v --timeout=600
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from tests.e2e.conftest import (
 from tests.e2e.helpers import POLL_INTERVAL_S
 
 pytestmark = [
-    pytest.mark.timeout(180, method="signal"),
+    pytest.mark.timeout(600, method="signal"),
     pytest.mark.min_server_version("0.3.0"),
     pytest.mark.min_runner_version("0.9.0"),
 ]
@@ -153,7 +153,10 @@ def test_session_history_raised_content_limit_recovers_full_child_response_e2e(
     live_runner_id: str,
     mock_llm_server_url: str,
 ) -> None:
-    """A raised history limit recovers a child response truncated by default."""
+    """A raised history limit recovers a child response truncated by default.
+
+    This test exercises the runner REST dispatch path.
+    """
     uid = uuid.uuid4().hex[:6]
     parent_model = f"mock-history-parent-{uid}"
     child_model = f"mock-history-child-{uid}"

--- a/tests/e2e/test_session_history_content_limit_e2e.py
+++ b/tests/e2e/test_session_history_content_limit_e2e.py
@@ -23,7 +23,7 @@ from tests.e2e.conftest import (
     reset_mock_llm,
     send_user_message_to_session,
 )
-from tests.e2e.helpers import POLL_INTERVAL_S
+from tests.e2e.helpers import POLL_INTERVAL_S, get_output_items
 
 pytestmark = [
     pytest.mark.timeout(600, method="signal"),
@@ -41,17 +41,6 @@ def _tool_call(
     return {"call_id": call_id, "name": name, "arguments": json.dumps(arguments)}
 
 
-def _session_items(http_client: httpx.Client, session_id: str) -> list[dict[str, Any]]:
-    """Return persisted session items in chronological order."""
-    response = http_client.get(
-        f"/v1/sessions/{session_id}/items",
-        params={"limit": 100, "order": "asc"},
-    )
-    response.raise_for_status()
-    items: list[dict[str, Any]] = response.json()["data"]
-    return items
-
-
 def _wait_for_session_text(
     http_client: httpx.Client,
     session_id: str,
@@ -63,89 +52,18 @@ def _wait_for_session_text(
     deadline = time.monotonic() + timeout
     items: list[dict[str, Any]] = []
     while time.monotonic() < deadline:
-        items = _session_items(http_client, session_id)
+        response = http_client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"limit": 100, "order": "asc"},
+        )
+        response.raise_for_status()
+        items = response.json()["data"]
         if text in json.dumps(items):
             return items
         time.sleep(POLL_INTERVAL_S)
     raise AssertionError(
         f"{text!r} did not appear in session {session_id} within {timeout}s; last items={items!r}"
     )
-
-
-def _wait_for_child_session(
-    http_client: httpx.Client,
-    parent_id: str,
-    *,
-    timeout: float = 120,
-) -> str:
-    """Poll until the parent exposes its child session."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        response = http_client.get(f"/v1/sessions/{parent_id}/child_sessions")
-        response.raise_for_status()
-        children = response.json().get("data", [])
-        if children:
-            return str(children[0]["id"])
-        time.sleep(POLL_INTERVAL_S)
-    raise AssertionError(f"child session did not appear for parent {parent_id}")
-
-
-def _history_text(body: dict[str, Any], call_id: str) -> str:
-    """Extract the message text returned by one history tool call."""
-    output_item = next(
-        item
-        for item in body["output"]
-        if item.get("type") == "function_call_output" and item.get("call_id") == call_id
-    )
-    payload = json.loads(output_item["output"])
-    text: str = payload["items"][-1]["text"]
-    return text
-
-
-def _read_child_history(
-    http_client: httpx.Client,
-    *,
-    parent_id: str,
-    parent_model: str,
-    child_id: str,
-    mock_llm_server_url: str,
-    call_id: str,
-    content_max_chars: int | None,
-) -> str:
-    """Run one parent turn that reads the child session history."""
-    arguments: dict[str, object] = {
-        "conversation_id": child_id,
-        "tail_items": 1,
-    }
-    if content_max_chars is not None:
-        arguments["content_max_chars"] = content_max_chars
-
-    reset_mock_llm(mock_llm_server_url)
-    configure_mock_llm(
-        mock_llm_server_url,
-        [
-            {
-                "tool_calls": [
-                    _tool_call("sys_session_get_history", arguments, call_id),
-                ]
-            },
-            {"text": f"{call_id}_COMPLETE"},
-        ],
-        key=parent_model,
-    )
-    response_id = send_user_message_to_session(
-        http_client,
-        session_id=parent_id,
-        content="Read the child session history.",
-    )
-    body = poll_session_until_terminal(
-        http_client,
-        session_id=parent_id,
-        response_id=response_id,
-        timeout=120,
-    )
-    assert body["status"] == "completed", body.get("error")
-    return _history_text(body, call_id)
 
 
 def test_session_history_raised_content_limit_recovers_full_child_response_e2e(
@@ -234,28 +152,58 @@ def test_session_history_raised_content_limit_recovers_full_child_response_e2e(
     )
     assert body["status"] == "completed", body.get("error")
 
-    child_id = _wait_for_child_session(http_client, parent_id)
-    _wait_for_session_text(http_client, child_id, "|CHILD_END")
     _wait_for_session_text(http_client, parent_id, "AUTO_WAKE_COMPLETE")
+    response = http_client.get(f"/v1/sessions/{parent_id}/child_sessions")
+    response.raise_for_status()
+    child_sessions = response.json()["data"]
+    assert child_sessions, f"child session did not appear for parent {parent_id}"
+    child_id = child_sessions[0]["id"]
+    _wait_for_session_text(http_client, child_id, "|CHILD_END")
 
-    default_text = _read_child_history(
-        http_client,
-        parent_id=parent_id,
-        parent_model=parent_model,
-        child_id=child_id,
-        mock_llm_server_url=mock_llm_server_url,
-        call_id="call_default_history",
-        content_max_chars=None,
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "sys_session_get_history",
+                        {"conversation_id": child_id, "tail_items": 1},
+                        "call_default_history",
+                    ),
+                    _tool_call(
+                        "sys_session_get_history",
+                        {
+                            "conversation_id": child_id,
+                            "tail_items": 1,
+                            "content_max_chars": 5000,
+                        },
+                        "call_raised_history",
+                    ),
+                ]
+            },
+            {"text": "HISTORY_READ_COMPLETE"},
+        ],
+        key=parent_model,
     )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=parent_id,
+        content="Read the child session history with both limits.",
+    )
+    body = poll_session_until_terminal(
+        http_client,
+        session_id=parent_id,
+        response_id=response_id,
+        timeout=120,
+    )
+    assert body["status"] == "completed", body.get("error")
+
+    outputs = {
+        item["call_id"]: json.loads(item["output"])
+        for item in get_output_items(body, "function_call_output")
+    }
+    default_text = outputs["call_default_history"]["items"][-1]["text"]
+    raised_text = outputs["call_raised_history"]["items"][-1]["text"]
     assert default_text == long_child_text[:2000] + " [truncated]"
-
-    raised_text = _read_child_history(
-        http_client,
-        parent_id=parent_id,
-        parent_model=parent_model,
-        child_id=child_id,
-        mock_llm_server_url=mock_llm_server_url,
-        call_id="call_raised_history",
-        content_max_chars=5000,
-    )
     assert raised_text == long_child_text

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5307,6 +5307,75 @@ async def test_session_peek_returns_chronological_projected_items() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_peek_rest_can_request_larger_bounded_item() -> None:
+    """The runner REST path honors an explicit larger per-item history limit."""
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    long_review = "R" * 3000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target/items":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "i1",
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": long_review}],
+                        }
+                    ],
+                },
+            )
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(200, json={"id": "conv_target", "title": "researcher:auth"})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with _session_query_client(handler) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_get_history",
+                json.dumps(
+                    {
+                        "conversation_id": "conv_target",
+                        "tail_items": 1,
+                        "content_max_chars": 4000,
+                    }
+                ),
+                conversation_id="conv_caller",
+                server_client=client,
+            )
+        )
+
+    assert out["items"][0]["text"] == long_review
+
+
+@pytest.mark.asyncio
+async def test_session_peek_rest_rejects_non_positive_content_limit() -> None:
+    """The runner REST path rejects invalid provider-supplied limits."""
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    async with _session_query_client(lambda _: pytest.fail("REST call should not run")) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_get_history",
+                json.dumps(
+                    {
+                        "conversation_id": "conv_target",
+                        "content_max_chars": 0,
+                    }
+                ),
+                conversation_id="conv_caller",
+                server_client=client,
+            )
+        )
+
+    assert out["error"] == "content_max_chars must be >= 1"
+
+
+@pytest.mark.asyncio
 async def test_session_peek_appends_pending_elicitation_from_snapshot() -> None:
     """
     ``sys_session_get_history`` appends the target's parked elicitations (read

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5306,14 +5306,38 @@ async def test_session_peek_returns_chronological_projected_items() -> None:
     ]
 
 
+_REST_HISTORY_CONTENT_SCENARIOS = [
+    pytest.param(3000, 4000, "R" * 3000, id="raised-limit"),
+    pytest.param(3000, None, "R" * 2000 + " [truncated]", id="default-limit"),
+    pytest.param(13000, 50000, "R" * 12000 + " [truncated]", id="ceiling"),
+    # No REST request is expected because validation rejects before the GET.
+    pytest.param(None, 0, "content_max_chars must be >= 1", id="non-positive"),
+]
+
+
+@pytest.mark.parametrize(
+    ("content_length", "content_max_chars", "expected"),
+    _REST_HISTORY_CONTENT_SCENARIOS,
+)
 @pytest.mark.asyncio
-async def test_session_peek_rest_can_request_larger_bounded_item() -> None:
-    """The runner REST path honors an explicit larger per-item history limit."""
+async def test_session_peek_rest_content_limit_scenario(
+    content_length: int | None,
+    content_max_chars: int | None,
+    expected: str,
+) -> None:
+    """Apply one history content-limit scenario through runner REST dispatch."""
     from omnigent.runner.tool_dispatch import _execute_session_query_tool
 
-    long_review = "R" * 3000
+    content = "R" * content_length if content_length is not None else None
+    arguments: dict[str, object] = {"conversation_id": "conv_target"}
+    if content is not None:
+        arguments["tail_items"] = 1
+    if content_max_chars is not None:
+        arguments["content_max_chars"] = content_max_chars
 
     def handler(request: httpx.Request) -> httpx.Response:
+        if content is None:
+            pytest.fail("REST request should not run for rejected arguments")
         if request.url.path == "/v1/sessions/conv_target/items":
             return httpx.Response(
                 200,
@@ -5324,7 +5348,7 @@ async def test_session_peek_rest_can_request_larger_bounded_item() -> None:
                             "id": "i1",
                             "type": "message",
                             "role": "assistant",
-                            "content": [{"type": "output_text", "text": long_review}],
+                            "content": [{"type": "output_text", "text": content}],
                         }
                     ],
                 },
@@ -5334,136 +5358,21 @@ async def test_session_peek_rest_can_request_larger_bounded_item() -> None:
         raise AssertionError(f"unexpected path {request.url.path}")
 
     async with _session_query_client(handler) as client:
-        out = json.loads(
+        payload = json.loads(
             await _execute_session_query_tool(
                 "sys_session_get_history",
-                json.dumps(
-                    {
-                        "conversation_id": "conv_target",
-                        "tail_items": 1,
-                        "content_max_chars": 4000,
-                    }
-                ),
+                json.dumps(arguments),
                 conversation_id="conv_caller",
                 server_client=client,
             )
         )
 
-    assert out["items"][0]["text"] == long_review
-
-
-@pytest.mark.asyncio
-async def test_session_peek_rest_default_content_limit_matches_activity_preview() -> None:
-    """Omitting the content limit keeps the exact activity preview behavior."""
-    from omnigent.runner.tool_dispatch import _execute_session_query_tool
-
-    long_review = "R" * 3000
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/v1/sessions/conv_target/items":
-            return httpx.Response(
-                200,
-                json={
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "i1",
-                            "type": "message",
-                            "role": "assistant",
-                            "content": [{"type": "output_text", "text": long_review}],
-                        }
-                    ],
-                },
-            )
-        if request.url.path == "/v1/sessions/conv_target":
-            return httpx.Response(200, json={"id": "conv_target", "title": "researcher:auth"})
-        raise AssertionError(f"unexpected path {request.url.path}")
-
-    async with _session_query_client(handler) as client:
-        out = json.loads(
-            await _execute_session_query_tool(
-                "sys_session_get_history",
-                json.dumps(
-                    {
-                        "conversation_id": "conv_target",
-                        "tail_items": 1,
-                    }
-                ),
-                conversation_id="conv_caller",
-                server_client=client,
-            )
-        )
-
-    assert out["items"][0]["text"] == long_review[:2000] + " [truncated]"
-
-
-@pytest.mark.asyncio
-async def test_session_peek_rest_clamps_content_limit_above_maximum() -> None:
-    """Provider input above the advertised ceiling is clamped by the handler."""
-    from omnigent.runner.tool_dispatch import _execute_session_query_tool
-
-    long_review = "R" * 13000
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/v1/sessions/conv_target/items":
-            return httpx.Response(
-                200,
-                json={
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "i1",
-                            "type": "message",
-                            "role": "assistant",
-                            "content": [{"type": "output_text", "text": long_review}],
-                        }
-                    ],
-                },
-            )
-        if request.url.path == "/v1/sessions/conv_target":
-            return httpx.Response(200, json={"id": "conv_target", "title": "researcher:auth"})
-        raise AssertionError(f"unexpected path {request.url.path}")
-
-    async with _session_query_client(handler) as client:
-        out = json.loads(
-            await _execute_session_query_tool(
-                "sys_session_get_history",
-                json.dumps(
-                    {
-                        "conversation_id": "conv_target",
-                        "tail_items": 1,
-                        "content_max_chars": 50000,
-                    }
-                ),
-                conversation_id="conv_caller",
-                server_client=client,
-            )
-        )
-
-    assert out["items"][0]["text"] == long_review[:12000] + " [truncated]"
-
-
-@pytest.mark.asyncio
-async def test_session_peek_rest_rejects_non_positive_content_limit() -> None:
-    """The runner REST path rejects invalid provider-supplied limits."""
-    from omnigent.runner.tool_dispatch import _execute_session_query_tool
-
-    async with _session_query_client(lambda _: pytest.fail("REST call should not run")) as client:
-        out = json.loads(
-            await _execute_session_query_tool(
-                "sys_session_get_history",
-                json.dumps(
-                    {
-                        "conversation_id": "conv_target",
-                        "content_max_chars": 0,
-                    }
-                ),
-                conversation_id="conv_caller",
-                server_client=client,
-            )
-        )
-
-    assert out["error"] == "content_max_chars must be >= 1"
+    if "error" in payload:
+        actual = payload["error"]
+    else:
+        assert payload["title"] == "auth"
+        actual = payload["items"][0]["text"]
+    assert actual == expected
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5353,6 +5353,97 @@ async def test_session_peek_rest_can_request_larger_bounded_item() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_peek_rest_default_content_limit_matches_activity_preview() -> None:
+    """Omitting the content limit keeps the exact activity preview behavior."""
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    long_review = "R" * 3000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target/items":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "i1",
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": long_review}],
+                        }
+                    ],
+                },
+            )
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(200, json={"id": "conv_target", "title": "researcher:auth"})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with _session_query_client(handler) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_get_history",
+                json.dumps(
+                    {
+                        "conversation_id": "conv_target",
+                        "tail_items": 1,
+                    }
+                ),
+                conversation_id="conv_caller",
+                server_client=client,
+            )
+        )
+
+    assert out["items"][0]["text"] == long_review[:2000] + " [truncated]"
+
+
+@pytest.mark.asyncio
+async def test_session_peek_rest_clamps_content_limit_above_maximum() -> None:
+    """Provider input above the advertised ceiling is clamped by the handler."""
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    long_review = "R" * 13000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target/items":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "i1",
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": long_review}],
+                        }
+                    ],
+                },
+            )
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(200, json={"id": "conv_target", "title": "researcher:auth"})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with _session_query_client(handler) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_get_history",
+                json.dumps(
+                    {
+                        "conversation_id": "conv_target",
+                        "tail_items": 1,
+                        "content_max_chars": 50000,
+                    }
+                ),
+                conversation_id="conv_caller",
+                server_client=client,
+            )
+        )
+
+    assert out["items"][0]["text"] == long_review[:12000] + " [truncated]"
+
+
+@pytest.mark.asyncio
 async def test_session_peek_rest_rejects_non_positive_content_limit() -> None:
     """The runner REST path rejects invalid provider-supplied limits."""
     from omnigent.runner.tool_dispatch import _execute_session_query_tool

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -304,7 +304,11 @@ def test_peek_schema_required_fields_and_no_extra_props() -> None:
     params = schema["function"]["parameters"]
     assert params["required"] == ["conversation_id"]
     assert params["additionalProperties"] is False
-    assert set(params["properties"].keys()) == {"conversation_id", "tail_items"}
+    assert set(params["properties"].keys()) == {
+        "conversation_id",
+        "tail_items",
+        "content_max_chars",
+    }
 
 
 def test_peek_schema_tail_items_bounds() -> None:
@@ -322,6 +326,16 @@ def test_peek_schema_tail_items_bounds() -> None:
     assert tail_schema["type"] == "integer"
     assert tail_schema["minimum"] == 1
     assert tail_schema["maximum"] == _HISTORY_MAX_TAIL
+
+
+def test_peek_schema_content_limit_is_bounded() -> None:
+    """History can request a larger item without making the limit unbounded."""
+    content_schema = SysSessionGetHistoryTool().get_schema()["function"]["parameters"][
+        "properties"
+    ]["content_max_chars"]
+    assert content_schema["type"] == "integer"
+    assert content_schema["minimum"] == 1
+    assert content_schema["maximum"] == 12000
 
 
 def test_close_schema_required_fields_and_no_extra_props() -> None:
@@ -375,6 +389,84 @@ def test_peek_returns_items_chronological(session_fixture: _Fixture) -> None:
     assert items[0]["content"] == "find the auth bug"
     assert items[1]["role"] == "assistant"
     assert items[1]["content"] == "looking at handlers.py"
+
+
+def test_peek_can_request_more_than_activity_preview_limit(session_fixture: _Fixture) -> None:
+    """An explicit bounded limit returns a long child message in one read."""
+    long_review = "R" * 3000
+    session_fixture.conv_store.append(
+        session_fixture.child_conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_long_review",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": long_review}],
+                    agent="researcher",
+                ),
+            )
+        ],
+    )
+
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "tail_items": 1,
+                "content_max_chars": 4000,
+            }
+        ),
+        session_fixture.ctx,
+    )
+    payload = json.loads(raw)
+    assert payload["items"][0]["content"] == long_review
+
+
+def test_peek_rejects_non_positive_content_limit(session_fixture: _Fixture) -> None:
+    """Handler validation rejects a limit that providers let through."""
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "content_max_chars": 0,
+            }
+        ),
+        session_fixture.ctx,
+    )
+    assert json.loads(raw)["error"] == "content_max_chars must be >= 1"
+
+
+def test_peek_combined_limits_preserve_total_prompt_bound(session_fixture: _Fixture) -> None:
+    """The per-item override scales down when a large tail is requested."""
+    long_review = "R" * 3000
+    session_fixture.conv_store.append(
+        session_fixture.child_conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_bounded_review",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": long_review}],
+                    agent="researcher",
+                ),
+            )
+        ],
+    )
+
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "tail_items": _HISTORY_MAX_TAIL,
+                "content_max_chars": 12000,
+            }
+        ),
+        session_fixture.ctx,
+    )
+    content = json.loads(raw)["items"][-1]["content"]
+    assert content == long_review[:2000] + " [truncated]"
 
 
 def test_peek_surfaces_pending_elicitation_after_stored_items(

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -423,6 +423,73 @@ def test_peek_can_request_more_than_activity_preview_limit(session_fixture: _Fix
     assert payload["items"][0]["content"] == long_review
 
 
+def test_peek_default_content_limit_matches_activity_preview(
+    session_fixture: _Fixture,
+) -> None:
+    """Omitting the content limit keeps the exact activity preview behavior."""
+    long_review = "R" * 3000
+    session_fixture.conv_store.append(
+        session_fixture.child_conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_default_review",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": long_review}],
+                    agent="researcher",
+                ),
+            )
+        ],
+    )
+
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "tail_items": 1,
+            }
+        ),
+        session_fixture.ctx,
+    )
+
+    content = json.loads(raw)["items"][0]["content"]
+    assert content == long_review[:2000] + " [truncated]"
+
+
+def test_peek_clamps_content_limit_above_maximum(session_fixture: _Fixture) -> None:
+    """Provider input above the advertised ceiling is clamped by the handler."""
+    long_review = "R" * 13000
+    session_fixture.conv_store.append(
+        session_fixture.child_conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_clamped_review",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": long_review}],
+                    agent="researcher",
+                ),
+            )
+        ],
+    )
+
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "tail_items": 1,
+                "content_max_chars": 50000,
+            }
+        ),
+        session_fixture.ctx,
+    )
+
+    content = json.loads(raw)["items"][0]["content"]
+    assert content == long_review[:12000] + " [truncated]"
+
+
 def test_peek_rejects_non_positive_content_limit(session_fixture: _Fixture) -> None:
     """Handler validation rejects a limit that providers let through."""
     raw = SysSessionGetHistoryTool().invoke(

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -391,122 +391,58 @@ def test_peek_returns_items_chronological(session_fixture: _Fixture) -> None:
     assert items[1]["content"] == "looking at handlers.py"
 
 
-def test_peek_can_request_more_than_activity_preview_limit(session_fixture: _Fixture) -> None:
-    """An explicit bounded limit returns a long child message in one read."""
-    long_review = "R" * 3000
-    session_fixture.conv_store.append(
-        session_fixture.child_conv_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="resp_long_review",
-                data=MessageData(
-                    role="assistant",
-                    content=[{"type": "output_text", "text": long_review}],
-                    agent="researcher",
-                ),
-            )
-        ],
-    )
-
-    raw = SysSessionGetHistoryTool().invoke(
-        json.dumps(
-            {
-                "conversation_id": session_fixture.child_conv_id,
-                "tail_items": 1,
-                "content_max_chars": 4000,
-            }
-        ),
-        session_fixture.ctx,
-    )
-    payload = json.loads(raw)
-    assert payload["items"][0]["content"] == long_review
+_HISTORY_CONTENT_SCENARIOS = [
+    pytest.param(3000, 4000, "R" * 3000, id="raised-limit"),
+    pytest.param(3000, None, "R" * 2000 + " [truncated]", id="default-limit"),
+    pytest.param(13000, 50000, "R" * 12000 + " [truncated]", id="ceiling"),
+    # No stored item is needed because validation rejects before projection.
+    pytest.param(None, 0, "content_max_chars must be >= 1", id="non-positive"),
+]
 
 
-def test_peek_default_content_limit_matches_activity_preview(
+@pytest.mark.parametrize(
+    ("content_length", "content_max_chars", "expected"),
+    _HISTORY_CONTENT_SCENARIOS,
+)
+def test_peek_content_limit_scenario(
     session_fixture: _Fixture,
+    content_length: int | None,
+    content_max_chars: int | None,
+    expected: str,
 ) -> None:
-    """Omitting the content limit keeps the exact activity preview behavior."""
-    long_review = "R" * 3000
-    session_fixture.conv_store.append(
-        session_fixture.child_conv_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="resp_default_review",
-                data=MessageData(
-                    role="assistant",
-                    content=[{"type": "output_text", "text": long_review}],
-                    agent="researcher",
-                ),
-            )
-        ],
+    """Apply one history content-limit scenario through the in-process tool."""
+    content = "R" * content_length if content_length is not None else None
+    arguments: dict[str, object] = {"conversation_id": session_fixture.child_conv_id}
+    if content is not None:
+        arguments["tail_items"] = 1
+    if content_max_chars is not None:
+        arguments["content_max_chars"] = content_max_chars
+
+    if content is not None:
+        session_fixture.conv_store.append(
+            session_fixture.child_conv_id,
+            [
+                NewConversationItem(
+                    type="message",
+                    response_id="resp_content_limit",
+                    data=MessageData(
+                        role="assistant",
+                        content=[{"type": "output_text", "text": content}],
+                        agent="researcher",
+                    ),
+                )
+            ],
+        )
+
+    payload = json.loads(
+        SysSessionGetHistoryTool().invoke(json.dumps(arguments), session_fixture.ctx)
     )
-
-    raw = SysSessionGetHistoryTool().invoke(
-        json.dumps(
-            {
-                "conversation_id": session_fixture.child_conv_id,
-                "tail_items": 1,
-            }
-        ),
-        session_fixture.ctx,
-    )
-
-    content = json.loads(raw)["items"][0]["content"]
-    assert content == long_review[:2000] + " [truncated]"
+    actual = payload["error"] if "error" in payload else payload["items"][0]["content"]
+    assert actual == expected
 
 
-def test_peek_clamps_content_limit_above_maximum(session_fixture: _Fixture) -> None:
-    """Provider input above the advertised ceiling is clamped by the handler."""
-    long_review = "R" * 13000
-    session_fixture.conv_store.append(
-        session_fixture.child_conv_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="resp_clamped_review",
-                data=MessageData(
-                    role="assistant",
-                    content=[{"type": "output_text", "text": long_review}],
-                    agent="researcher",
-                ),
-            )
-        ],
-    )
-
-    raw = SysSessionGetHistoryTool().invoke(
-        json.dumps(
-            {
-                "conversation_id": session_fixture.child_conv_id,
-                "tail_items": 1,
-                "content_max_chars": 50000,
-            }
-        ),
-        session_fixture.ctx,
-    )
-
-    content = json.loads(raw)["items"][0]["content"]
-    assert content == long_review[:12000] + " [truncated]"
-
-
-def test_peek_rejects_non_positive_content_limit(session_fixture: _Fixture) -> None:
-    """Handler validation rejects a limit that providers let through."""
-    raw = SysSessionGetHistoryTool().invoke(
-        json.dumps(
-            {
-                "conversation_id": session_fixture.child_conv_id,
-                "content_max_chars": 0,
-            }
-        ),
-        session_fixture.ctx,
-    )
-    assert json.loads(raw)["error"] == "content_max_chars must be >= 1"
-
-
-# The following three cases cover the helper shared with the runner REST
-# dispatcher through its import in tool_dispatch.py, so the REST suite does not
-# duplicate them.
+# These coercion cases cover the helper imported by the runner REST dispatcher.
+# The runner suite repeats only the four path-level scenarios, not these cases.
 
 
 def test_peek_rejects_boolean_content_limit(session_fixture: _Fixture) -> None:

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -504,6 +504,73 @@ def test_peek_rejects_non_positive_content_limit(session_fixture: _Fixture) -> N
     assert json.loads(raw)["error"] == "content_max_chars must be >= 1"
 
 
+# The following three cases cover the helper shared with the runner REST
+# dispatcher through its import in tool_dispatch.py, so the REST suite does not
+# duplicate them.
+
+
+def test_peek_rejects_boolean_content_limit(session_fixture: _Fixture) -> None:
+    """Boolean content limits do not pass as integers."""
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "content_max_chars": True,
+            }
+        ),
+        session_fixture.ctx,
+    )
+
+    assert json.loads(raw)["error"] == "content_max_chars must be a whole number, got True"
+
+
+def test_peek_rejects_fractional_float_content_limit(session_fixture: _Fixture) -> None:
+    """Fractional float content limits are rejected instead of truncated."""
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "content_max_chars": 1.5,
+            }
+        ),
+        session_fixture.ctx,
+    )
+
+    assert json.loads(raw)["error"] == "content_max_chars must be a whole number, got 1.5"
+
+
+def test_peek_accepts_integral_float_content_limit(session_fixture: _Fixture) -> None:
+    """An integral float applies its exact effective content limit."""
+    content = "abcdefghij"
+    session_fixture.conv_store.append(
+        session_fixture.child_conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_integral_float_limit",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": content}],
+                    agent="researcher",
+                ),
+            )
+        ],
+    )
+
+    raw = SysSessionGetHistoryTool().invoke(
+        json.dumps(
+            {
+                "conversation_id": session_fixture.child_conv_id,
+                "tail_items": 1,
+                "content_max_chars": 5.0,
+            }
+        ),
+        session_fixture.ctx,
+    )
+
+    assert json.loads(raw)["items"][0]["content"] == "abcde [truncated]"
+
+
 def test_peek_combined_limits_preserve_total_prompt_bound(session_fixture: _Fixture) -> None:
     """The per-item override scales down when a large tail is requested."""
     long_review = "R" * 3000


### PR DESCRIPTION
## Related issue

Closes #4600

## Summary

ELI5: reading a child session's transcript used to cut every item at 2000 characters with no way to ask
for more, so now a caller can ask for up to 12000.

```
child item stored: 4096 chars
  default                 |  2000 chars + " [truncated]"
  content_max_chars=5000  |  4096 chars, no marker
```

- An orchestrating agent reading a child transcript with `sys_session_get_history` got only the first 2000
  characters of every item plus a bare ` [truncated]` marker, with no argument that could ask for more.
  Both dispatch paths projected history content through the compact activity preview constant
  `_ACTIVITY_MAX_CHARS = 2000` (`omnigent/tools/builtins/spawn.py:39`), which exists to bound auto-injected
  polling output, not explicit reads.
- This adds an opt-in `content_max_chars` on both paths: the in-process `SysSessionGetHistoryTool` in
  `omnigent/tools/builtins/spawn.py` and `_session_get_history_via_rest` in
  `omnigent/runner/tool_dispatch.py`. They share one validation helper and one ceiling.
- The default stays 2000, so no existing caller changes behaviour. An explicit request is bounded at 12000
  characters per content field, and that per-item bound scales down as `tail_items` grows so one request
  stays inside the pre-existing budget of approximately 100000 characters. At `tail_items=50` the effective
  limit is therefore still 2000. Activity polling is untouched: the shared helpers gained keyword-only
  limits defaulting to `_ACTIVITY_MAX_CHARS`, and only the two history callers pass an override.
- `content_max_chars` is validated, not coerced: booleans and non-integral values are rejected with an
  error naming what was sent; integral floats and numeric strings are accepted for client interop.

## Test Plan

| Gate | Rebased head `ec08a52c` | Pristine `901aa8d1` |
| --- | --- | --- |
| Touched modules, 225 collected | `224 passed, 1 skipped` | `211 passed, 1 skipped` |
| Tools shard, raw, `-n 8 --dist=loadfile` | `5 failed, 879 passed, 9 warnings` | `5 failed, 870 passed, 9 warnings` |
| Tools shard, the 5 pristine failures deselected | `879 passed, 9 warnings` | not applicable |
| Runner shard, raw, `-n 8 --dist=worksteal` | `4 failed, 1612 passed, 1 skipped, 4 xfailed` | `4 failed, 1608 passed, 1 skipped, 4 xfailed` |
| Runner shard, the 4 pristine failures deselected | `1612 passed, 1 skipped, 4 xfailed` | not applicable |
| E2E, local CI-shaped run | `1 passed in 7.61s` | not applicable |
| E2E, direct run | `1 passed in 10.68s` | not applicable |
| Changed-file `ruff check` and `ruff format --check` | passed | not applicable |
| `pre-commit run --all-files` | passed | not applicable |

The old eight-runner-failure exclusion is no longer needed. All 68
`tests/runner/test_environment_filesystem.py` nodes pass on the rebased head and pristine main. The four
current runner failures reproduce on pristine main: one macOS `linux_bwrap` availability case and three Pi
session-creation cases returning 400 instead of 201. The five current tools failures also reproduce on
pristine main and all assert the pre-existing `read_skill_file` registration behavior. The raw shards are
therefore baseline-red locally; both pass after only their reproduced baseline failures are excluded.

Repo-wide `ruff check .` and `ruff format --check .` reproduce the same notebook-fixture failures on
pristine main: two intentionally unformatted `.ipynb` fixtures and one intentionally invalid `.ipynb`
fixture. The five changed files pass both Ruff checks, and the repository's configured pre-commit suite
passes all files.

The e2e file is not covered by the main CI run: `.github/workflows/ci.yml:119` excludes `tests/e2e` from its
misc shard. `.github/workflows/e2e.yml` owns it, through its four `E2E Tests (shard N/4)` jobs and the
shared `.github/actions/e2e-run/action.yml`.

<details>
<summary>Failing-first and validation receipts</summary>

Failing first, stated precisely. It was established at the tests-only commit, against the tests as staged
then (`6 failed, 169 passed, 1 skipped`). Those functions are not the ones that exist today: a later
tests-only commit consolidated the four per-path scenarios into one parameterized table per owning suite.
Every node that exists now is instead proven red-capable individually by a mutation matrix, which is the
stronger claim. Ten cycles, each killing exactly one node under a targeted production mutation and passing
again after exact revert: the eight scenario nodes, `test_peek_accepts_integral_float_content_limit`, and
the e2e test.

The validation cases have their own receipt, `2 failed, 1 passed in 2.74s`. Only the two rejection cases can
be failing-first evidence, both `KeyError: 'error'` where the old code returned a payload instead of an
error. The integral-float case could not run red, because `int(5.0)` already produced 5 under the old
coercion; it is proven instead by a mutation cycle against the over-strict repair that rejects every float.

The rebase also repeated a whole-production revert check on current main. With only the two production
files restored to pristine `901aa8d1`, the touched suites report `11 failed, 213 passed, 1 skipped`; the
schema, raised-limit, ceiling, validation, and REST-path regressions all fail.

</details>

## Demo

Not a visual change, so this is a text capture. A live probe drove a real parent session, spawned a child
that emitted a 4096-character response, and read it back three ways. Session ids are elided; nothing else is
edited.

```
{"tail_items": 1}                                child 4096 -> returned 2012, marker " [truncated]"
{"tail_items": 1, "content_max_chars": 5000}     child 4096 -> returned 4096, no marker
{"tail_items": 50, "content_max_chars": 5000}    child 4096 -> returned 2012, marker " [truncated]"
```

The third row is the total-prompt budget scaling the requested limit back down. The argument is present on
the schema: `['content_max_chars', 'conversation_id', 'tail_items']`.

Captured at the reviewed tip `f29f5af95b24893a3ced34f97b4d5b977079e59d` on base
`fef6cbde85ba5ed79dd714cda47885d409c30709`, content-identical to the rebased head
`ec08a52c1192fd15e79e9a64dedb9f22389a6257` (`git range-diff` marks all seven commits unchanged).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the Demo capture above: a live parent and child session, the three reads shown, and
the returned lengths and marker state recorded for each. It drives the runner REST path only.

Eight new test functions, none removed. Four scenarios run against each dispatch path, as one parameterized
table per owning suite:

- `tests/tools/builtins/test_sys_session.py::test_peek_content_limit_scenario[raised-limit|default-limit|ceiling|non-positive]`
- `tests/runner/test_runner_dispatch.py::test_session_peek_rest_content_limit_scenario[raised-limit|default-limit|ceiling|non-positive]`

`raised-limit` recovers more than the preview limit, `default-limit` pins the unchanged 2000-character
prefix plus marker, `ceiling` requests 50000 and asserts exactly 12000 plus marker, and `non-positive`
asserts the shared rejection. Both dispatch paths are covered by these unit tests.

The in-process suite additionally holds `test_peek_combined_limits_preserve_total_prompt_bound`
(`tail_items=50` resolves to 2000), `test_peek_schema_content_limit_is_bounded`, and the three validation
cases for booleans, non-integral floats, and integral floats. Those three sit in one suite because the
validation is shared rather than duplicated: `_clamp_history_content_chars` is defined in
`omnigent/tools/builtins/spawn.py` and imported by `omnigent/runner/tool_dispatch.py:95`, so one
implementation validates both paths. The runner table asserts the shared rejection message, which pins that
import live rather than dormant.

The e2e test is `tests/e2e/test_session_history_content_limit_e2e.py`, one happy path against the mock LLM
with a live server and runner: a child emits a 4096-character response, the parent reads it at the default
and gets 2000 characters plus the marker, then reads the same item with `content_max_chars=5000` and gets
all 4096. It drives the runner REST path only, which its docstring states. The assertion reads
`payload["items"][-1]["text"]`, and only `_project_api_item` on that path emits `text`; the in-process
projection emits `content`, so the same test would raise `KeyError` against the in-process tool.

The ceiling, the `tail_items` budget scaling, and the argument validation are left to the unit tests rather
than repeated in a slow suite, per CONTRIBUTING.md's guidance to prefer the smallest test that covers the
change.

## Changelog

`sys_session_get_history` accepts `content_max_chars` to return up to 12000 characters per history item
instead of a fixed 2000. Non-integral values are rejected with a message naming the offending value rather
than silently coerced.
