### PR TITLE
fix(bench): don't require gateway creds to --live an own_auth native harness

### DIFF
--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -223,7 +223,12 @@ class NativeTuiDriver:
         vendor = native_vendor(profile.harness)
         if vendor is None:
             return f"{profile.harness!r} is not a native-tui harness"
-        creds_skip = bench_creds_skip_reason(databricks_profile)
+        # An own_auth vendor logs its own model in, so it needs no gateway creds
+        # to run — only the vendor CLI. Requiring them would wrongly skip every
+        # own_auth native for a contributor with no Databricks/OpenAI gateway.
+        creds_skip = bench_creds_skip_reason(
+            databricks_profile, require_gateway=not vendor.own_auth
+        )
         if creds_skip is not None:
             return creds_skip
         binary = profile.cli_binary
@@ -275,7 +280,9 @@ class NativeTuiDriver:
         self._base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
 
-        self._resolved_env = resolve_bench_env(self._db_profile)
+        self._resolved_env = resolve_bench_env(
+            self._db_profile, require_gateway=not self._vendor.own_auth
+        )
         base_env = {
             **self._resolved_env.base_env,
             "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token,

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -99,7 +99,7 @@ def resolve_bench_env(
 
     :param explicit_profile: The ``--profile`` value, or ``None`` to derive.
     :param require_gateway: When ``False`` — an ``own_auth`` native harness that
-        authenticates its own model (agy, codex, …) — unresolvable creds are
+        authenticates its own model (agy, cursor, …) — unresolvable creds are
         tolerated: the server boots with no ``OPENAI_*`` rather than raising,
         since a native-tui turn never routes through the gateway. Ambient
         ``OPENAI_*`` or a resolvable profile is still used when present.

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -77,7 +77,9 @@ def _profile_from_config() -> str | None:
     return None
 
 
-def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:
+def resolve_bench_env(
+    explicit_profile: str | None, *, require_gateway: bool = True
+) -> BenchRuntimeEnv:
     """Build the bench runtime env, mirroring ``omni run``'s credential layering.
 
     Precedence:
@@ -96,9 +98,15 @@ def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:
        a typo'd named profile — filling in only the vars not already ambient.
 
     :param explicit_profile: The ``--profile`` value, or ``None`` to derive.
+    :param require_gateway: When ``False`` — an ``own_auth`` native harness that
+        authenticates its own model (agy, codex, …) — unresolvable creds are
+        tolerated: the server boots with no ``OPENAI_*`` rather than raising,
+        since a native-tui turn never routes through the gateway. Ambient
+        ``OPENAI_*`` or a resolvable profile is still used when present.
     :returns: A :class:`BenchRuntimeEnv`.
-    :raises OSError: When credentials cannot be resolved and no ambient
-        ``OPENAI_*`` covers auth (surfaced by the caller as a clean skip).
+    :raises OSError: When ``require_gateway`` and credentials cannot be resolved
+        and no ambient ``OPENAI_*`` covers auth (surfaced by the caller as a
+        clean skip).
     """
     base = dict(os.environ)
     have_ambient = bool(base.get("OPENAI_BASE_URL")) and bool(base.get("OPENAI_API_KEY"))
@@ -113,7 +121,16 @@ def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:
 
     from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
-    creds = resolve_databricks_workspace(profile)
+    try:
+        creds = resolve_databricks_workspace(profile)
+    except OSError:
+        if require_gateway:
+            raise
+        # own_auth native: the vendor logs its own model in, so the server
+        # needs no gateway. Boot without OPENAI_* rather than skip the harness.
+        if profile:
+            base["DATABRICKS_CONFIG_PROFILE"] = profile
+        return BenchRuntimeEnv(base_env=base, db_profile=profile)
     base["OPENAI_BASE_URL"] = f"{creds.host}/serving-endpoints"
     base["OPENAI_API_KEY"] = creds.token
     if profile:
@@ -121,7 +138,9 @@ def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:
     return BenchRuntimeEnv(base_env=base, db_profile=profile)
 
 
-def bench_creds_skip_reason(explicit_profile: str | None) -> str | None:
+def bench_creds_skip_reason(
+    explicit_profile: str | None, *, require_gateway: bool = True
+) -> str | None:
     """Cheap gate: why the bench cannot get gateway creds, or ``None`` if it can.
 
     Mirrors :func:`resolve_bench_env`'s precedence without minting a token, so a
@@ -131,8 +150,15 @@ def bench_creds_skip_reason(explicit_profile: str | None) -> str | None:
     ``omni run``.
 
     :param explicit_profile: The ``--profile`` value, or ``None`` to derive.
-    :returns: A skip reason, or ``None`` when creds are resolvable.
+    :param require_gateway: When ``False`` — an ``own_auth`` native harness that
+        authenticates its own model — the gateway is optional, so a missing
+        credential is never a skip: the harness's own turns don't route through
+        it. Mirrors :func:`resolve_bench_env`'s ``require_gateway``.
+    :returns: A skip reason, or ``None`` when creds are resolvable (or not
+        required).
     """
+    if not require_gateway:
+        return None
     if os.environ.get("OPENAI_BASE_URL") and os.environ.get("OPENAI_API_KEY"):
         return None
     profile = explicit_profile or _profile_from_config()

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -911,7 +911,21 @@ def test_native_tui_registered_and_gates(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.setattr("tests.harness_bench.runtime_env._profile_from_config", lambda: None)
+    # An omnigent-credential native (claude-native routes its model through the
+    # gateway) still skips when no creds resolve.
     assert NativeTuiDriver.unavailable(claude_native, databricks_profile=None) is not None
+
+    # An own_auth native (agy logs its own model in) is NOT skipped for missing
+    # gateway creds — the creds gate is bypassed; only a missing vendor CLI can.
+    agy_native = BenchProfile(
+        harness="antigravity-native",
+        model="m",
+        env_prefix="HARNESS_ANTIGRAVITY_NATIVE_",
+        marker="X",
+    )
+    assert native_vendor("antigravity-native").own_auth is True
+    agy_reason = NativeTuiDriver.unavailable(agy_native, databricks_profile=None)
+    assert agy_reason is None or "gateway creds" not in agy_reason
 
 
 def test_transport_resolution_family_default_and_fast() -> None:

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -189,3 +189,55 @@ def test_skip_reason_when_profile_hostless(monkeypatch: pytest.MonkeyPatch) -> N
     reason = bench_creds_skip_reason("typo-profile")
     assert reason is not None
     assert "typo-profile" in reason
+
+
+def test_skip_reason_none_when_gateway_not_required() -> None:
+    """An own_auth native never skips for missing gateway creds — its model
+    auth is self-contained, so no Databricks/OpenAI credential is needed."""
+    assert bench_creds_skip_reason(None, require_gateway=False) is None
+
+
+def test_resolve_env_tolerates_missing_creds_when_gateway_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``require_gateway=False`` and no resolvable creds, the env is built
+    without ``OPENAI_*`` instead of raising — the server boots and an own_auth
+    native drives its own model."""
+
+    def _no_creds(profile: str | None) -> _Creds:
+        raise OSError("no databricks credentials")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", _no_creds
+    )
+    env = resolve_bench_env(None, require_gateway=False)
+    assert isinstance(env, BenchRuntimeEnv)
+    assert "OPENAI_API_KEY" not in env.base_env
+    assert "OPENAI_BASE_URL" not in env.base_env
+
+
+def test_resolve_env_still_raises_when_gateway_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default (``require_gateway=True``) still fails loud on no creds, so
+    omnigent-credential harnesses skip cleanly rather than boot keyless."""
+
+    def _no_creds(profile: str | None) -> _Creds:
+        raise OSError("no databricks credentials")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", _no_creds
+    )
+    with pytest.raises(OSError):
+        resolve_bench_env(None)
+
+
+def test_resolve_env_uses_creds_when_present_even_if_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``require_gateway=False`` still uses a resolvable gateway when one exists,
+    so a configured contributor gets the server's incidental model too."""
+    _stub_resolver(monkeypatch, "https://ws.example.com", "tok-xyz")
+    env = resolve_bench_env("oss", require_gateway=False)
+    assert env.base_env["OPENAI_API_KEY"] == "tok-xyz"
+    assert env.base_env["OPENAI_BASE_URL"] == "https://ws.example.com/serving-endpoints"


### PR DESCRIPTION
## Related issue

N/A — `Test / CI` change to the harness bench (no issue required per template).

## Summary

The harness bench's `--live` mode required an OpenAI-compatible **gateway**
(Databricks by default) before it would run **any** native harness — including
the `own_auth` ones (agy, cursor, goose, kiro, qwen) that authenticate their
own model. But those resolved creds are only consumed to route the vendor's
model **when `not vendor.own_auth`** (`native_tui_driver.py:284`), so an
own_auth native never used them. `unavailable()` and `_provision()` demanded
them unconditionally anyway.

Consequence: an external contributor with no Databricks account can't
bench-verify an own_auth native they added. This is exactly what happened on
#3890 — the author had to patch the sources locally just to produce a matrix.

Fix: thread `require_gateway=not vendor.own_auth` through
`bench_creds_skip_reason` and `resolve_bench_env`.

- An own_auth native no longer **skips** for missing creds, and boots the
  server with **no** `OPENAI_*`. The gateway is resolved lazily with a
  placeholder key (`inner/databricks_executor.py`), so a native-tui turn that
  never routes through it is unaffected.
- A resolvable gateway is still **used** when present (ambient `OPENAI_*` or a
  configured profile), so a set-up contributor also gets the server's
  incidental model.
- omnigent-credential natives (`claude-native`, `codex-native`) are unchanged:
  they still fail loud / skip cleanly on no creds.

### ELI5

agy brings its own house key (its own model login). The bench was refusing to
let agy in unless it *also* handed over a spare key to a different building
(the Databricks gateway) it was never going to enter. Now the bench only asks
for the gateway key from harnesses that actually need it.

```
                       ┌ own_auth? ─ yes (agy, cursor, goose, kiro, qwen)
  --live <native>  ────┤             → gateway OPTIONAL: use if present,
                       │                else boot with no OPENAI_*  ✅ runs
                       │
                       └ no  (claude-native, codex-native)
                                     → gateway REQUIRED: skip cleanly if absent
```

## Test Plan

```
uv run pytest tests/harness_bench/test_runtime_env.py \
              tests/harness_bench/test_bench.py -q
# 90 passed, 15 skipped
```

New / updated unit tests (network-free, monkeypatched resolver):

- `resolve_bench_env(require_gateway=False)` tolerates an `OSError` from the
  resolver and returns an env with **no** `OPENAI_*` (server boots keyless).
- the default (`require_gateway=True`) still **raises** on no creds.
- `require_gateway=False` still **uses** a resolvable gateway when present.
- `bench_creds_skip_reason(require_gateway=False)` never skips.
- driver-level: `NativeTuiDriver.unavailable(antigravity-native, ...)` no longer
  returns the gateway-creds skip with no creds, while `claude-native` still does.

## Demo

N/A — non-visual (test tooling).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified via the unit suite above. I did **not** run a full `--live` bench end
to end here (no `agy` CLI in this environment): the one assumption the fix
rests on is that the omnigent server boots without `OPENAI_*` and only resolves
the gateway lazily per gateway-backed turn — supported by
`inner/databricks_executor.py` reading `OPENAI_API_KEY` with a placeholder
default, and by `spawn_omnigent_server` asserting no creds at boot. A live
own_auth run (e.g. `python -m tests.harness_bench --harness antigravity-native
--live` with only the vendor CLI logged in) is the real end-to-end
confirmation and is worth a spot-check before relying on it.
