### PR TITLE
feat(web): honor OSC 52 clipboard writes in the terminal

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: 3.23.4
         version: 3.23.4
+      '@xterm/addon-clipboard':
+        specifier: 0.2.0
+        version: 0.2.0
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -4109,6 +4112,9 @@ packages:
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
+  '@xterm/addon-clipboard@0.2.0':
+    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -5927,6 +5933,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-base64@3.9.2:
+    resolution: {integrity: sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==}
 
   js-cookie@3.0.8:
     resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
@@ -12984,6 +12993,10 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
+  '@xterm/addon-clipboard@0.2.0':
+    dependencies:
+      js-base64: 3.9.2
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -15097,6 +15110,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-base64@3.9.2: {}
 
   js-cookie@3.0.8: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "@tiptap/pm": "3.23.4",
     "@tiptap/react": "3.23.4",
     "@tiptap/starter-kit": "3.23.4",
+    "@xterm/addon-clipboard": "0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -9,6 +9,7 @@
 //   - Client → server: binary frames for keystrokes (`term.onData`);
 //     text frames for JSON control messages (currently only resize).
 
+import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -513,6 +514,12 @@ export class TerminalSession {
     // Turn bare URLs in terminal output into clickable links. Without
     // this addon xterm renders URLs as plain text.
     this.term.loadAddon(new WebLinksAddon(openTerminalLink));
+    // TUIs copy through the terminal with OSC 52 (opencode's "copy", vim's
+    // "+ register, tmux set-clipboard) — the app has no system clipboard
+    // access, so it asks the terminal to write it. Without this addon xterm
+    // silently drops the sequence and in-terminal copy never reaches the
+    // user's clipboard (reads surface as a browser permission prompt).
+    this.term.loadAddon(new ClipboardAddon());
     this.term.open(container);
     // Load the GPU renderer after open() (it needs the mounted canvas).
     // Falls back to the DOM renderer when WebGL is unavailable.


### PR DESCRIPTION
## Related issue

Closes #4605

## Summary

- In-session TUIs copy through the terminal with OSC 52 (opencode's copy action, vim's `"+` register, tmux `set-clipboard`) — the remote process has no system clipboard access, so it asks the terminal emulator to write it. xterm.js drops the sequence unless a clipboard handler is registered, so these copies were silent no-ops in the web terminal, while apps still showed "Copied to clipboard" (OSC 52 is fire-and-forget, with no acknowledgment).
- Load the official `@xterm/addon-clipboard` (0.2.0 — the release paired with xterm 6.x) alongside the existing fit/web-links/webgl addons in `TerminalSession`.
- Writes land on the system clipboard via the async Clipboard API. OSC 52 *reads* surface as the browser's clipboard-read permission prompt rather than being silently served.

**ELI5:** a program inside the terminal can't touch your clipboard, so it sends a special "please copy this for me" message to the terminal. Every desktop terminal honors it; the web terminal was throwing it away while the program believed it worked.

```
TUI (opencode / vim / tmux)
  └─ emits  ESC ] 52 ; c ; <base64> BEL
       └─ PTY → WebSocket → xterm.js
            ├─ before: no OSC 52 handler → dropped ✗
            └─ after:  ClipboardAddon → navigator.clipboard.writeText ✓
```

## Test Plan

- `cd web && pnpm run lint && pnpm run type-check && pnpm run build` — all green.
- In a session terminal in the web UI: `printf '\033]52;c;%s\007' "$(echo -n hello | base64)"`, then paste outside the browser → pastes `hello` (previously: clipboard unchanged).
- opencode's in-TUI copy action now lands on the system clipboard; toast and reality agree.
- Verified against a Kubernetes deployment (Chrome on macOS, focused tab).

## Demo

N/A — no visual change; the fix is protocol behavior (the terminal renders identically). The Test Plan's `printf` one-liner demonstrates it in any session terminal.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: the OSC 52 `printf` probe above plus opencode's copy action, end-to-end through a real deployment (PTY → WebSocket → xterm). The change itself is a one-line addon registration; the OSC 52 parsing/clipboard behavior is implemented and tested upstream in `@xterm/addon-clipboard`. Clipboard interaction inside the app's test harness isn't practical to automate (requires a focused browser with clipboard permissions).

## Changelog

Copying from TUIs in the web terminal (opencode, vim, tmux via OSC 52) now reaches your system clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
