### PR TITLE
feat(agents): add admin shared-agent publishing

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2016,14 +2016,18 @@ def create_app(
         prefix="/v1",
         tags=["usage"],
     )
-    # Read-only built-in agent discovery (designs/BUILTIN_AGENTS.md).
-    # Successor to the removed GET /api/agents list; lists only
-    # built-in (session_id IS NULL) agents for the new-session picker.
+    # Template-agent discovery plus narrow admin publishing. GET still lists
+    # only session_id IS NULL agents for the new-session picker.
     app.include_router(
         create_builtin_agents_router(
             agent_store,
             agent_cache,
+            artifact_store=artifact_store,
+            conversation_store=conversation_store,
+            runner_router=runner_router,
             auth_provider=auth_provider,
+            permission_store=permission_store,
+            admin_list=admin_list,
         ),
         prefix="/v1",
         tags=["agents"],

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -1,4 +1,4 @@
-"""Read-only route for discovering built-in agents (``GET /v1/agents``).
+"""Routes for discovering and publishing instance-wide template agents.
 
 Built-in agents are the long-lived, shared agents the server provides
 out of the box — the seeded ``claude-native-ui`` agent plus anything
@@ -13,26 +13,38 @@ built-ins, then creates a session with
 ``POST /v1/sessions {agent_id, host_id, workspace}``. See
 ``designs/BUILTIN_AGENTS.md``.
 
-This is the read-only successor to the removed ``GET /api/agents`` list:
-there is intentionally no create/update/delete — agent writes happen
-through session creation.
+Admins may also create and update non-seeded template agents with multipart
+``POST /v1/agents`` and ``PUT /v1/agents/{agent_id}``. Seeded agents remain
+read-only, and session-scoped agents stay on their session routes.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Annotated
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Query, Request, UploadFile
+from sqlalchemy.exc import IntegrityError
 
-from omnigent.db.utils import builtin_agent_id
+from omnigent.db.utils import builtin_agent_id, generate_agent_id
 from omnigent.entities import Agent
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime.agent_cache import AgentCache
-from omnigent.server.auth import AuthProvider
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import AuthProvider, local_single_user_enabled
+from omnigent.server.bundles import bundle_location, validate_agent_bundle
+from omnigent.server.routes._auth_helpers import get_user_id
 from omnigent.server.routes._auth_helpers import require_user as _require_user
+from omnigent.server.routes._origin import require_trusted_origin
+from omnigent.server.routes.session_mcp_servers import reset_runner_session_agent_cache
 from omnigent.server.schemas import AgentObject, MCPServerSummary, PaginatedList, SkillSummary
-from omnigent.stores import AgentStore
+from omnigent.stores import AgentStore, ArtifactStore, ConversationStore
+from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
+_RUNNER_RESET_PAGE_SIZE = 25
 
 
 def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
@@ -122,9 +134,14 @@ def create_builtin_agents_router(
     agent_store: AgentStore,
     agent_cache: AgentCache,
     *,
+    artifact_store: ArtifactStore | None = None,
+    conversation_store: ConversationStore | None = None,
+    runner_router: RunnerRouter | None = None,
     auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+    admin_list: AdminList | None = None,
 ) -> APIRouter:
-    """Build the router for ``GET /v1/agents`` (built-in discovery).
+    """Build the router for template-agent discovery and admin publishing.
 
     Mounted with ``prefix="/v1"`` so the final path is ``/v1/agents``.
 
@@ -132,11 +149,188 @@ def create_builtin_agents_router(
         (``session_id IS NULL``) agents.
     :param agent_cache: Cache for loading specs (populates
         ``mcp_servers`` on each agent).
+    :param artifact_store: Store for uploaded bundles.
+    :param conversation_store: Store used to find sessions bound to an updated agent.
+    :param runner_router: Router used for best-effort runner cache resets.
     :param auth_provider: Optional auth provider; when set, the caller
         must be authenticated.
-    :returns: A FastAPI router exposing the read-only list.
+    :param permission_store: Optional permission store for admin checks.
+    :param admin_list: File/config-backed administrator roster.
+    :returns: A FastAPI router exposing discovery and admin publishing.
     """
     router = APIRouter()
+
+    async def _require_admin(request: Request) -> None:
+        if local_single_user_enabled():
+            return
+        user_id = get_user_id(request, auth_provider)
+        if user_id is None:
+            raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+        store_admin = permission_store is not None and await asyncio.to_thread(
+            permission_store.is_admin, user_id
+        )
+        if not store_admin and not (admin_list is not None and admin_list.is_admin(user_id)):
+            raise OmnigentError(
+                "Admin privileges required to publish agents",
+                code=ErrorCode.FORBIDDEN,
+            )
+
+    def _require_writable_stores() -> ArtifactStore:
+        if artifact_store is None:
+            raise OmnigentError(
+                "Artifact store not configured",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        return artifact_store
+
+    async def _reset_bound_runner_caches(agent_id: str) -> None:
+        if conversation_store is None:
+            return
+        after: str | None = None
+        while True:
+            try:
+                page = await asyncio.to_thread(
+                    conversation_store.list_conversations,
+                    limit=_RUNNER_RESET_PAGE_SIZE,
+                    after=after,
+                    kind=None,
+                    agent_id=agent_id,
+                    include_archived=False,
+                )
+            except Exception:  # noqa: BLE001 - reset is best-effort after durable update
+                _logger.warning(
+                    "runner agent-cache reset scan failed after agent update for agent=%s",
+                    agent_id,
+                    exc_info=True,
+                )
+                return
+            results = await asyncio.gather(
+                *(
+                    reset_runner_session_agent_cache(conversation.id, agent_id, runner_router)
+                    for conversation in page.data
+                ),
+                return_exceptions=True,
+            )
+            for conversation, result in zip(page.data, results, strict=True):
+                if isinstance(result, BaseException):
+                    _logger.warning(
+                        "runner agent-cache reset failed after agent update "
+                        "for session=%s agent=%s",
+                        conversation.id,
+                        agent_id,
+                        exc_info=(type(result), result, result.__traceback__),
+                    )
+            if not page.has_more or page.last_id is None:
+                return
+            after = page.last_id
+
+    @router.post(
+        "/agents",
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def create_agent(
+        request: Request,
+        bundle: Annotated[UploadFile, File(...)],
+    ) -> AgentObject:
+        """Create a non-seeded instance-wide template agent."""
+        await _require_admin(request)
+        store = _require_writable_stores()
+        bundle_bytes = await bundle.read()
+        spec = await asyncio.to_thread(
+            validate_agent_bundle,
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        assert spec.name is not None
+        if await asyncio.to_thread(agent_store.get_by_name, spec.name) is not None:
+            raise OmnigentError(
+                f"Agent with name '{spec.name}' already exists",
+                code=ErrorCode.CONFLICT,
+            )
+
+        agent_id = generate_agent_id()
+        location = bundle_location(agent_id, bundle_bytes)
+        await asyncio.to_thread(store.put, location, bundle_bytes)
+        try:
+            agent = await asyncio.to_thread(agent_store.create, agent_id, spec.name, location)
+        except IntegrityError as exc:
+            raise OmnigentError(
+                f"Agent with name '{spec.name}' already exists",
+                code=ErrorCode.CONFLICT,
+            ) from exc
+        await asyncio.to_thread(
+            agent_cache.replace,
+            agent.id,
+            location,
+            bundle_bytes,
+            expand_env=True,
+        )
+        return _to_agent_object(agent, agent_cache)
+
+    @router.put(
+        "/agents/{agent_id}",
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def update_agent(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        agent_id: str,
+        bundle: Annotated[UploadFile, File(...)],
+    ) -> AgentObject:
+        """Update a non-seeded instance-wide template agent."""
+        await _require_admin(request)
+        store = _require_writable_stores()
+        agent = await asyncio.to_thread(agent_store.get, agent_id)
+        if agent is None:
+            raise OmnigentError(
+                f"Agent not found: {agent_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+        if agent.session_id is not None:
+            raise OmnigentError(
+                "Session-scoped agents cannot be updated through this endpoint",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if agent.id == builtin_agent_id(agent.name):
+            raise OmnigentError(
+                "Seeded agents cannot be updated through this endpoint",
+                code=ErrorCode.FORBIDDEN,
+            )
+
+        bundle_bytes = await bundle.read()
+        spec = await asyncio.to_thread(
+            validate_agent_bundle,
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        assert spec.name is not None
+        if spec.name != agent.name:
+            raise OmnigentError(
+                f"spec name '{spec.name}' does not match agent "
+                f"name '{agent.name}'; name is immutable",
+                code=ErrorCode.INVALID_INPUT,
+            )
+
+        location = bundle_location(agent.id, bundle_bytes)
+        if location == agent.bundle_location:
+            return _to_agent_object(agent, agent_cache)
+
+        await asyncio.to_thread(store.put, location, bundle_bytes)
+        updated = await asyncio.to_thread(agent_store.update, agent.id, location)
+        if updated is None:
+            raise OmnigentError(
+                f"Agent not found: {agent.id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+        await asyncio.to_thread(
+            agent_cache.replace,
+            agent.id,
+            location,
+            bundle_bytes,
+            expand_env=True,
+        )
+        background_tasks.add_task(_reset_bound_runner_caches, agent.id)
+        return _to_agent_object(updated, agent_cache)
 
     @router.get("/agents")
     async def list_builtin_agents(

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -122,7 +122,7 @@ def create_session_mcp_servers_router(
             mode="create",
             target_name=None,
         )
-        await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
+        await reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
         return _summary_from_spec(spec, body.name)
 
@@ -142,7 +142,7 @@ def create_session_mcp_servers_router(
             mode="update",
             target_name=server_name,
         )
-        await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
+        await reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
         return _summary_from_spec(spec, body.name)
 
@@ -164,7 +164,7 @@ def create_session_mcp_servers_router(
             mode="delete",
             target_name=server_name,
         )
-        await _reset_runner_session_agent_cache(session_id, agent.id, runner_router)
+        await reset_runner_session_agent_cache(session_id, agent.id, runner_router)
         _publish_agent_changed(session_id, agent)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -264,7 +264,7 @@ def create_session_mcp_servers_router(
     return router
 
 
-async def _reset_runner_session_agent_cache(
+async def reset_runner_session_agent_cache(
     session_id: str,
     agent_id: str,
     runner_router: RunnerRouter | None,
@@ -288,7 +288,7 @@ async def _reset_runner_session_agent_cache(
         resp.raise_for_status()
     except (ConnectionError, RuntimeError, httpx.HTTPError):
         _logger.warning(
-            "runner agent-cache reset failed after MCP edit for session=%s agent=%s",
+            "runner agent-cache reset failed after agent update for session=%s agent=%s",
             session_id,
             agent_id,
             exc_info=True,

--- a/openapi.json
+++ b/openapi.json
@@ -223,6 +223,34 @@
         "title": "AutomaticSessionRenameResponse",
         "type": "object"
       },
+      "Body_create_agent_v1_agents_post": {
+        "properties": {
+          "bundle": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Bundle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundle"
+        ],
+        "title": "Body_create_agent_v1_agents_post",
+        "type": "object"
+      },
+      "Body_update_agent_v1_agents__agent_id__put": {
+        "properties": {
+          "bundle": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Bundle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundle"
+        ],
+        "title": "Body_update_agent_v1_agents__agent_id__put",
+        "type": "object"
+      },
       "Body_update_session_agent_v1_sessions__session_id__agent_put": {
         "properties": {
           "bundle": {
@@ -7217,6 +7245,99 @@
           }
         },
         "summary": "List Builtin Agents",
+        "tags": [
+          "agents"
+        ]
+      },
+      "post": {
+        "description": "Create a non-seeded instance-wide template agent.",
+        "operationId": "create_agent_v1_agents_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_agent_v1_agents_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Agent",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/v1/agents/{agent_id}": {
+      "put": {
+        "description": "Update a non-seeded instance-wide template agent.",
+        "operationId": "update_agent_v1_agents__agent_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_agent_v1_agents__agent_id__put"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Agent",
         "tags": [
           "agents"
         ]

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -1196,6 +1196,103 @@ async def test_runner_session_tool_schemas_use_resolved_bundle_workdir(tmp_path:
     )
 
 
+@pytest.mark.asyncio
+async def test_agent_cache_reset_refreshes_session_spec_and_tool_schemas(tmp_path: Path) -> None:
+    """The reset refreshes spec/tools, not persistent claude-sdk instructions (#3558)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    bundle_dirs = [tmp_path / "v1", tmp_path / "v2"]
+    specs: list[AgentSpec] = []
+    for version, bundle_dir in enumerate(bundle_dirs, start=1):
+        tool_dir = bundle_dir / "tools" / "python"
+        tool_dir.mkdir(parents=True)
+        tool_name = f"tool_v{version}"
+        (tool_dir / f"{tool_name}.py").write_text(
+            "from omnigent_client.tools import tool\n\n"
+            "@tool\n"
+            f"def {tool_name}(text: str) -> str:\n"
+            "    return text\n"
+        )
+        specs.append(
+            AgentSpec(
+                spec_version=1,
+                name="published-agent",
+                description=f"v{version}",
+                local_tools=[
+                    LocalToolInfo(
+                        name=tool_name,
+                        path=f"tools/python/{tool_name}.py",
+                        language="python",
+                    )
+                ],
+            )
+        )
+
+    current = 0
+    resolver_calls = 0
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> ResolvedSpec:
+        nonlocal resolver_calls
+        del agent_id, session_id
+        resolver_calls += 1
+        return ResolvedSpec(spec=specs[current], workdir=bundle_dirs[current])
+
+    harness_client = _ScriptedHarnessClient(
+        [_sse({"type": "response.completed", "response": {"id": "resp_done"}})]
+    )
+    process_manager = _FakeProcessManager(harness_client)
+    app = create_runner_app(
+        process_manager=process_manager,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        runner_workspace=workspace,
+    )
+    session_id = "c7f36aa769270cac30144784fad50acc"
+    event = {
+        "type": "message",
+        "role": "user",
+        "agent_id": "31ebfedf721b44dabd76f662cb70a400",
+        "model": "published-agent",
+        "content": [{"type": "input_text", "text": "hi"}],
+        "harness": "openai-agents",
+    }
+
+    async with _runner_client(app) as client:
+        first = await client.post(f"/v1/sessions/{session_id}/events", json=event)
+        assert first.status_code == 202
+        for _ in range(20):
+            if len(harness_client.posted_bodies) == 1:
+                break
+            await asyncio.sleep(0.05)
+
+        current = 1
+        reset = await client.post(
+            f"/v1/sessions/{session_id}/agent-cache/reset",
+            json={"agent_id": event["agent_id"]},
+        )
+        assert reset.status_code == 200
+
+        second = await client.post(f"/v1/sessions/{session_id}/events", json=event)
+        assert second.status_code == 202
+        for _ in range(20):
+            if len(harness_client.posted_bodies) == 2:
+                break
+            await asyncio.sleep(0.05)
+
+    assert resolver_calls == 2
+    assert process_manager.released == []
+    tool_names = [
+        {
+            schema.get("function", {}).get("name")
+            for schema in body.get("tools", [])
+            if isinstance(schema, dict)
+        }
+        for body in harness_client.posted_bodies
+    ]
+    assert "tool_v1" in tool_names[0] and "tool_v2" not in tool_names[0]
+    assert "tool_v2" in tool_names[1] and "tool_v1" not in tool_names[1]
+
+
 def test_resolved_workdir_for_spec_prefers_bundle_workdir(tmp_path: Path) -> None:
     """``_resolved_workdir_for_spec`` uses ``ResolvedSpec.workdir`` over fallback.
 

--- a/tests/server/integration/test_agent_publishing.py
+++ b/tests/server/integration/test_agent_publishing.py
@@ -1,0 +1,386 @@
+"""Focused tests for admin publishing of instance-wide template agents."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import BackgroundTasks, FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.requests import HTTPConnection
+
+from omnigent.db.utils import builtin_agent_id, generate_agent_id
+from omnigent.errors import OmnigentError
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes import builtin_agents as agent_routes
+from omnigent.server.routes.builtin_agents import create_builtin_agents_router
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from tests.server.helpers import build_agent_bundle
+
+pytestmark = pytest.mark.asyncio
+
+
+class _HeaderAuth(AuthProvider):
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        return request.headers.get("x-user")
+
+
+class _Permissions:
+    def is_admin(self, user_id: str) -> bool:
+        return user_id == "admin"
+
+
+@dataclass
+class _PublishingStores:
+    agents: SqlAlchemyAgentStore
+    artifacts: LocalArtifactStore
+    conversations: SqlAlchemyConversationStore
+    cache: AgentCache
+    artifact_root: Path
+
+
+@pytest.fixture()
+def publishing_stores(db_uri: str, tmp_path: Path) -> _PublishingStores:
+    artifact_root = tmp_path / "artifacts"
+    artifacts = LocalArtifactStore(str(artifact_root))
+    return _PublishingStores(
+        agents=SqlAlchemyAgentStore(db_uri),
+        artifacts=artifacts,
+        conversations=SqlAlchemyConversationStore(db_uri),
+        cache=AgentCache(artifact_store=artifacts, cache_dir=tmp_path / "cache"),
+        artifact_root=artifact_root,
+    )
+
+
+def _build_publishing_app(
+    stores: _PublishingStores,
+    *,
+    permission_store: object | None,
+    admin_list: AdminList,
+) -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle_error(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(
+        create_builtin_agents_router(
+            stores.agents,
+            stores.cache,
+            artifact_store=stores.artifacts,
+            conversation_store=stores.conversations,
+            auth_provider=_HeaderAuth(),
+            permission_store=permission_store,  # type: ignore[arg-type]
+            admin_list=admin_list,
+        ),
+        prefix="/v1",
+    )
+    return app
+
+
+@pytest.fixture()
+def publishing_app(
+    publishing_stores: _PublishingStores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> FastAPI:
+    monkeypatch.setattr(agent_routes, "local_single_user_enabled", lambda: False)
+    return _build_publishing_app(
+        publishing_stores,
+        permission_store=_Permissions(),
+        admin_list=AdminList(publishing_stores.artifact_root.parent / "admins"),
+    )
+
+
+@pytest_asyncio.fixture()
+async def publishing_client(publishing_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=publishing_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def _upload(bundle: bytes) -> dict[str, tuple[str, bytes, str]]:
+    return {"bundle": ("agent.tar.gz", bundle, "application/gzip")}
+
+
+async def test_remote_without_permission_store_requires_file_admin(
+    publishing_stores: _PublishingStores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(agent_routes, "local_single_user_enabled", lambda: False)
+    admins_path = publishing_stores.artifact_root.parent / "admins"
+    app = _build_publishing_app(
+        publishing_stores,
+        permission_store=None,
+        admin_list=AdminList(admins_path),
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        unauthenticated = await client.post(
+            "/v1/agents",
+            files=_upload(build_agent_bundle("unauthenticated-agent")),
+        )
+        assert unauthenticated.status_code == 401
+
+        denied = await client.post(
+            "/v1/agents",
+            files=_upload(build_agent_bundle("denied-agent")),
+            headers={"x-user": "member"},
+        )
+        assert denied.status_code == 403
+
+        admins_path.write_text("file-admin\n")
+        accepted = await client.post(
+            "/v1/agents",
+            files=_upload(build_agent_bundle("file-admin-agent")),
+            headers={"x-user": "file-admin"},
+        )
+        assert accepted.status_code == 200, accepted.text
+
+
+async def test_changed_put_schedules_runner_resets_in_background(
+    publishing_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = await publishing_client.post(
+        "/v1/agents",
+        files=_upload(build_agent_bundle("background-agent", description="v1")),
+        headers={"x-user": "admin"},
+    )
+    agent_id = created.json()["id"]
+    queued: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    def _record_task(
+        self: BackgroundTasks,
+        func: object,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        del self
+        queued.append((func, args, kwargs))
+
+    monkeypatch.setattr(BackgroundTasks, "add_task", _record_task)
+    updated = await publishing_client.put(
+        f"/v1/agents/{agent_id}",
+        files=_upload(build_agent_bundle("background-agent", description="v2")),
+        headers={"x-user": "admin"},
+    )
+
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["version"] == 2
+    assert len(queued) == 1
+    assert queued[0][1] == (agent_id,)
+
+
+async def test_create_requires_admin_and_is_create_only(
+    publishing_client: httpx.AsyncClient,
+    publishing_stores: _PublishingStores,
+) -> None:
+    bundle = build_agent_bundle("shared-reviewer", description="v1")
+
+    forbidden = await publishing_client.post(
+        "/v1/agents", files=_upload(bundle), headers={"x-user": "member"}
+    )
+    assert forbidden.status_code == 403
+    assert publishing_stores.agents.get_by_name("shared-reviewer") is None
+
+    created = await publishing_client.post(
+        "/v1/agents", files=_upload(bundle), headers={"x-user": "admin"}
+    )
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert body["name"] == "shared-reviewer"
+    assert body["version"] == 1
+    assert body["builtin"] is False
+    assert body["id"] != builtin_agent_id("shared-reviewer")
+    stored = publishing_stores.agents.get(body["id"])
+    assert stored is not None
+    assert publishing_stores.artifacts.exists(stored.bundle_location)
+    assert (
+        publishing_stores.cache.load(
+            stored.id, stored.bundle_location, expand_env=True
+        ).spec.description
+        == "v1"
+    )
+
+    forbidden_update = await publishing_client.put(
+        f"/v1/agents/{stored.id}",
+        files=_upload(build_agent_bundle("shared-reviewer", description="v2")),
+        headers={"x-user": "member"},
+    )
+    assert forbidden_update.status_code == 403
+    assert publishing_stores.agents.get(stored.id) == stored
+
+    duplicate = await publishing_client.post(
+        "/v1/agents", files=_upload(bundle), headers={"x-user": "admin"}
+    )
+    assert duplicate.status_code == 409
+    assert publishing_stores.agents.get_by_name("shared-reviewer") == stored
+
+
+async def test_invalid_create_and_update_leave_durable_state_unchanged(
+    publishing_client: httpx.AsyncClient,
+    publishing_stores: _PublishingStores,
+) -> None:
+    before = list(publishing_stores.artifact_root.rglob("*"))
+    invalid_create = await publishing_client.post(
+        "/v1/agents", files=_upload(b"not a tarball"), headers={"x-user": "admin"}
+    )
+    assert invalid_create.status_code == 400
+    assert publishing_stores.agents.list(limit=100).data == []
+    assert list(publishing_stores.artifact_root.rglob("*")) == before
+
+    bundle = build_agent_bundle("safe-agent", description="v1")
+    created = await publishing_client.post(
+        "/v1/agents", files=_upload(bundle), headers={"x-user": "admin"}
+    )
+    agent_id = created.json()["id"]
+    original = publishing_stores.agents.get(agent_id)
+    assert original is not None
+
+    invalid_update = await publishing_client.put(
+        f"/v1/agents/{agent_id}",
+        files=_upload(b"still not a tarball"),
+        headers={"x-user": "admin"},
+    )
+    assert invalid_update.status_code == 400
+    assert publishing_stores.agents.get(agent_id) == original
+    assert publishing_stores.artifacts.get(original.bundle_location) == bundle
+
+
+async def test_update_protects_seeded_session_scoped_and_name(
+    publishing_client: httpx.AsyncClient,
+    publishing_stores: _PublishingStores,
+) -> None:
+    seeded_name = "seeded-agent"
+    seeded_id = builtin_agent_id(seeded_name)
+    seeded_bundle = build_agent_bundle(seeded_name)
+    seeded_location = f"{seeded_id}/seeded"
+    publishing_stores.artifacts.put(seeded_location, seeded_bundle)
+    publishing_stores.agents.create(seeded_id, seeded_name, seeded_location)
+
+    seeded = await publishing_client.put(
+        f"/v1/agents/{seeded_id}",
+        files=_upload(build_agent_bundle(seeded_name, description="changed")),
+        headers={"x-user": "admin"},
+    )
+    assert seeded.status_code == 403
+    assert publishing_stores.agents.get(seeded_id).bundle_location == seeded_location  # type: ignore[union-attr]
+
+    session_agent_id = generate_agent_id()
+    session_bundle = build_agent_bundle("session-only")
+    session_location = f"{session_agent_id}/session"
+    publishing_stores.artifacts.put(session_location, session_bundle)
+    publishing_stores.conversations.create_session_with_agent(
+        agent_id=session_agent_id,
+        agent_name="session-only",
+        agent_bundle_location=session_location,
+        agent_description=None,
+    )
+    session_scoped = await publishing_client.put(
+        f"/v1/agents/{session_agent_id}",
+        files=_upload(session_bundle),
+        headers={"x-user": "admin"},
+    )
+    assert session_scoped.status_code == 400
+
+    created = await publishing_client.post(
+        "/v1/agents",
+        files=_upload(build_agent_bundle("immutable-name")),
+        headers={"x-user": "admin"},
+    )
+    agent_id = created.json()["id"]
+    renamed = await publishing_client.put(
+        f"/v1/agents/{agent_id}",
+        files=_upload(build_agent_bundle("new-name")),
+        headers={"x-user": "admin"},
+    )
+    assert renamed.status_code == 400
+    assert publishing_stores.agents.get(agent_id).version == 1  # type: ignore[union-attr]
+
+
+async def test_update_is_idempotent_refreshes_cache_and_resets_bound_sessions(
+    publishing_client: httpx.AsyncClient,
+    publishing_stores: _PublishingStores,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original_bundle = build_agent_bundle("live-agent", description="v1")
+    created = await publishing_client.post(
+        "/v1/agents", files=_upload(original_bundle), headers={"x-user": "admin"}
+    )
+    agent_id = created.json()["id"]
+    active_sessions = [
+        publishing_stores.conversations.create_conversation(agent_id=agent_id)
+        for _ in range(agent_routes._RUNNER_RESET_PAGE_SIZE + 2)
+    ]
+    archived = publishing_stores.conversations.create_conversation(agent_id=agent_id)
+    publishing_stores.conversations.update_conversation(archived.id, archived=True)
+    reset_calls: list[str] = []
+    failed_session = active_sessions[0].id
+
+    async def _record_reset(session_id: str, reset_agent_id: str, runner_router: object) -> None:
+        del reset_agent_id, runner_router
+        reset_calls.append(session_id)
+        if session_id == failed_session:
+            raise RuntimeError("unexpected runner failure")
+
+    list_calls: list[dict[str, object]] = []
+    original_list = SqlAlchemyConversationStore.list_conversations
+
+    def _record_list(
+        store: SqlAlchemyConversationStore,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        list_calls.append(dict(kwargs))
+        return original_list(store, *args, **kwargs)
+
+    monkeypatch.setattr(agent_routes, "reset_runner_session_agent_cache", _record_reset)
+    monkeypatch.setattr(SqlAlchemyConversationStore, "list_conversations", _record_list)
+
+    identical = await publishing_client.put(
+        f"/v1/agents/{agent_id}",
+        files=_upload(original_bundle),
+        headers={"x-user": "admin"},
+    )
+    assert identical.status_code == 200
+    assert identical.json()["version"] == 1
+    assert reset_calls == []
+
+    changed_bundle = build_agent_bundle("live-agent", description="v2")
+    changed = await publishing_client.put(
+        f"/v1/agents/{agent_id}",
+        files=_upload(changed_bundle),
+        headers={"x-user": "admin"},
+    )
+    assert changed.status_code == 200, changed.text
+    assert changed.json()["id"] == agent_id
+    assert changed.json()["version"] == 2
+    stored = publishing_stores.agents.get(agent_id)
+    assert stored is not None
+    assert publishing_stores.artifacts.get(stored.bundle_location) == changed_bundle
+    assert (
+        publishing_stores.cache.load(
+            agent_id, stored.bundle_location, expand_env=True
+        ).spec.description
+        == "v2"
+    )
+    assert set(reset_calls) == {session.id for session in active_sessions}
+    assert archived.id not in reset_calls
+    assert failed_session in caplog.text
+    assert len(list_calls) == 2
+    assert all(call["limit"] == agent_routes._RUNNER_RESET_PAGE_SIZE for call in list_calls)
+    assert all(call["include_archived"] is False for call in list_calls)

--- a/tests/server/integration/test_session_mcp_servers.py
+++ b/tests/server/integration/test_session_mcp_servers.py
@@ -70,7 +70,7 @@ async def test_mcp_server_mutations_reset_bound_runner_agent_cache(
     ) -> None:
         calls.append((session_id, agent_id, runner_router))
 
-    monkeypatch.setattr(mcp_routes, "_reset_runner_session_agent_cache", _fake_reset)
+    monkeypatch.setattr(mcp_routes, "reset_runner_session_agent_cache", _fake_reset)
     session = await create_test_session(client, name="mcp-reset-agent")
     session_id = session["id"]
 


### PR DESCRIPTION
## Related issue

Closes #4603

## Summary

- Adds administrator-only multipart `POST /v1/agents` and `PUT /v1/agents/{agent_id}` for restart-free publishing of instance-wide template agents.
- Preserves seeded-agent and session-scoped-agent protection, stable IDs, content-addressed bundles, idempotent updates, and existing picker behavior.
- Refreshes server and bound-runner spec/tool caches in the background without interrupting active turns. Persistent Claude SDK instruction replacement remains tracked separately in #3558.
- Admin-published templates follow the existing shared-template (`session_id IS NULL`) environment-expansion policy because administrators are operator-designated; the content-addressed bundle itself remains stored unexpanded.

Unlike closed PR #1402, which was declined as a user-facing agent-catalog product with ownership, migration, sidebar UI, and broad CRUD, this is only an operator publish path over existing shared template rows: no catalog, UI, delete API, ownership schema, or migration.

**ELI5:** an administrator can replace a shared agent's bundle while Omnigent is running; new and idle sessions see the new version, while a turn already in progress finishes on the version it started with.

```text
admin bundle -> validate -> content-addressed artifact -> template row/version
                                                        |
                                                        +-> server cache
                                                        +-> background runner cache reset
```

Diff note: 216 non-test lines; the `size/XL` label comes from 484 lines of focused tests.

## Test Plan

- Focused suite: `22 passed, 1` pre-existing `xfail`.
- `ruff check` and `ruff format --check`: passed.
- `uv run --no-sync pyrefly check`: `0 errors`.
- Isolated real-server test: non-admin create `403`; admin create `200`/v1; duplicate `409`; seeded update `403`; changed update `200`/v2 with stable ID; identical update stayed v2; an existing bound session returned the exact v2 bundle without a server restart; final health `200`.
- Cross-vendor review passed after hardening fail-closed admin authorization and moving bounded runner-reset fan-out off the PUT response path.

## Demo

https://github.com/user-attachments/assets/1cbbc128-f38b-4326-8135-2e79cc125282

Administrator-only create (member `403`, admin version 1), update with the same agent ID to version 2, and immediate list visibility while the same server PID remains healthy.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No `tests/e2e/` addition: that suite covers LLM-gateway-bound full-stack turns, while this administrator API does not execute an LLM turn. Its happy path is covered by `tests/server/integration/test_agent_publishing.py`, the runner cache-reset regression, and the disposable real-server acceptance run described above.

## Changelog

Administrators can publish and update instance-wide agents without restarting the server.


