### PR TITLE
feat(polly): pin cross-review reviewer as a leaf agent

### DIFF
--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -28,7 +28,12 @@ anyone needs to read through.
    `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"agy"|"pi", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
    Review ONLY against the contract. Report blocking / non-blocking /
-   suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
+   suggestions. Do not edit code. You are a leaf reviewer. You have no
+   sub-agents and no ability to delegate — do not attempt to dispatch, and do
+   not describe a delegation plan. Review the diff in this message yourself and
+   return the structured report. Check that changed docstrings/comments
+   describe the shipped diff, not an approach that was tried and
+   rejected."})`. Give it the diff as text — do NOT point
    it at the implementer's worktree. Fetch the diff and emit the
    `sys_session_send` call in the SAME turn you decide to review — never end a
    turn having only announced "I'll load cross-review and fetch the diff" with

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -253,6 +253,36 @@ def test_polly_test_count_ground_truth_guidance() -> None:
         assert "distinguish collected test cases from test functions" in worker_compact, name
 
 
+def test_cross_review_reviewer_input_pins_leaf_role() -> None:
+    """
+    The cross-review dispatch template pins the reviewer as a leaf agent.
+
+    Reviewers that are not told otherwise narrate a delegation plan or try to
+    spawn their own sub-agents, so the review turn burns a worker and returns
+    no findings. The shipped ``args.input`` must carry the leaf / no-delegation
+    guardrail (and the stale docstring/comment check) so every reviewer
+    dispatch inherits it.
+    """
+    cross_review = (_POLLY_BUNDLE / "skills" / "cross-review" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    # Bound assertions to the shipped reviewer input template, not Notes prose.
+    marker = 'args={purpose: "review", input:'
+    assert marker in cross_review
+    input_template = cross_review.split(marker, 1)[1].split("})", 1)[0]
+    compact = " ".join(input_template.split())
+
+    assert "You are a leaf reviewer" in compact
+    assert "no ability to delegate" in compact
+    assert "do not attempt to dispatch" in compact
+    assert "do not describe a delegation plan" in compact
+    assert "Review the diff in this message yourself" in compact
+    assert "changed docstrings/comments" in compact
+    assert "shipped diff" in compact
+    assert "tried and rejected" in compact
+    assert "Do not edit code" in compact
+
+
 def test_orchestrator_forbids_premature_idle_after_announcing_intent() -> None:
     """
     The base prompt forbids ending a turn after only announcing intent.


### PR DESCRIPTION
## Related issue

Closes #4449

## Summary

Polly's shipped cross-review prompt did not constrain reviewers to act as leaves, so a reviewer could try to delegate instead of returning findings. This pins the reviewer to inspect the supplied diff itself and adds the requested stale-comment/docstring check, with a structural contract test over the dispatched `args.input`.

## Test Plan

- `uv run --no-sync python -m pytest -o addopts= tests/e2e/omnigent/test_example_polly.py -q` -- 15 passed
- `uv run --no-sync pre-commit run --files examples/polly/skills/cross-review/SKILL.md tests/e2e/omnigent/test_example_polly.py` -- all applicable hooks passed
- Confirmed the focused contract test fails against the pre-change skill text and passes with this change

## Demo

![Before and after Polly cross-review leaf-agent prompt behavior](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-4608-review-evidence.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The test scopes its assertions to the reviewer dispatch's shipped `args.input`, rather than accepting matching guidance elsewhere in the skill.

## Changelog

Polly cross-review agents now review their assigned diff directly instead of attempting to delegate the review.

