### PR TITLE
fix(web): use project workspace for project-created sessions

### DIFF
--- a/tests/e2e_ui/start_session/test_project_config_prefill.py
+++ b/tests/e2e_ui/start_session/test_project_config_prefill.py
@@ -35,6 +35,7 @@ _HOST_ID = "host_e2e_cfg"
 _PROJECT_ID = "proj_e2e_cfg"
 _PROJECT_NAME = "ConfiguredProject"
 _CONFIG_WORKSPACE = "/work/configured-repo"
+_STALE_WORKSPACE = "/work/stale-general-draft"
 # Bare create endpoint (POST captured); NOT the /{id}/... sub-routes.
 _SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
 # One project config endpoint: /v1/projects/<id> (not the bare list).
@@ -132,7 +133,17 @@ def test_composer_prefills_from_project_config(seeded_session: tuple[str, str]) 
     _run_in_fresh_loop(_drive_prefill(base_url, session_id))
 
 
-async def _drive_prefill(base_url: str, session_id: str) -> None:
+def test_project_pencil_prefill_beats_general_landing_draft(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A project pencil visit replaces stale draft launch settings with its config."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_prefill(base_url, session_id, via_project_pencil=True))
+
+
+async def _drive_prefill(
+    base_url: str, session_id: str, *, via_project_pencil: bool = False
+) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
@@ -192,18 +203,43 @@ async def _drive_prefill(base_url: str, session_id: str) -> None:
             await page.route(_SESSIONS_RE, handle_sessions)
             await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
 
-            await page.goto(f"{base_url}/?project={_PROJECT_NAME}")
+            if via_project_pencil:
+                await page.add_init_script(
+                    f"""window.localStorage.setItem(
+                        "omnigent:recent-workspaces",
+                        JSON.stringify({{ {_HOST_ID}: ["{_STALE_WORKSPACE}"] }})
+                    );"""
+                )
+                await page.goto(base_url)
+                await expect(
+                    page.get_by_test_id("new-chat-landing-workspace-chip")
+                ).to_contain_text("stale-general-draft", timeout=15_000)
+                await page.get_by_test_id("new-chat-landing-input").fill("keep this draft")
+                await page.get_by_role("link", name=f"New session in {_PROJECT_NAME}").click()
+                await expect(page).to_have_url(
+                    re.compile(rf"/\?project={_PROJECT_NAME}$"), timeout=15_000
+                )
+            else:
+                await page.goto(f"{base_url}/?project={_PROJECT_NAME}")
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
             )
 
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "configured-repo", timeout=15_000
+            )
             # The agent picker trigger reflects the config-pinned agent (Polly),
             # not the default-ranked Claude Code — proof the config seed won.
             await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
                 "Polly", timeout=15_000
             )
 
-            await page.get_by_test_id("new-chat-landing-input").fill("start here")
+            if via_project_pencil:
+                await expect(page.get_by_test_id("new-chat-landing-input")).to_have_value(
+                    "keep this draft"
+                )
+            else:
+                await page.get_by_test_id("new-chat-landing-input").fill("start here")
             await page.get_by_test_id("new-chat-landing-submit").click()
 
             await _wait_until(lambda: len(create_bodies) == 1)

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -15,7 +15,7 @@ import { useProjectConfig, useProjects } from "@/hooks/useConversations";
 import type { ProjectConfig } from "@/lib/projectsApi";
 import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import type { HostWorktree } from "@/hooks/useHostWorktrees";
-import { NewChatLandingScreen } from "./NewChatDialog";
+import { NewChatLandingScreen, resetLandingDraft } from "./NewChatDialog";
 
 // A `?project=` visit prefills the composer from the project's STORED config
 // (host / working directory / agent / worktree). A field the config leaves
@@ -149,6 +149,7 @@ async function submitAndReadBody(): Promise<Record<string, unknown>> {
 beforeEach(() => {
   navigateMock.mockReset();
   vi.mocked(authenticatedFetch).mockReset();
+  resetLandingDraft();
   searchParams = new URLSearchParams("project=Alpha");
   localStorage.clear();
   // A recent on the host that the generic seeding would use when the config
@@ -268,6 +269,36 @@ describe("NewChatLandingScreen project prefill", () => {
     );
     const body = await submitAndReadBody();
     expect(body.workspace).toBe(BETA_REPO);
+    expect(body.agent_id).toBe("ag_other");
+  });
+
+  it("project pencil remount wins over a stale general landing draft", async () => {
+    // Real path: visit general New session (recent workspace seeds), navigate
+    // away (module draft saves host/workspace), then click a project's pencil
+    // (remount with ?project=). Project defaults must win; message can stay.
+    searchParams = new URLSearchParams("");
+    setProjectConfig({});
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("foo"),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "keep this draft" },
+    });
+    cleanup();
+
+    searchParams = new URLSearchParams("project=Alpha");
+    setProjectConfig({ host_id: "host_1", workspace: REPO, agent_id: "ag_other" });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("alpha"),
+    );
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "keep this draft",
+    );
+    const body = await submitAndReadBody();
+    expect(body.workspace).toBe(REPO);
     expect(body.agent_id).toBe("ag_other");
   });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2253,16 +2253,20 @@ export function NewChatLandingScreen() {
   // Project driving this visit, when the sidebar's per-project "new session"
   // pencil landed here with a `?project=` query param. Empty otherwise.
   const projectParam = searchParams.get("project") ?? "";
+  // Project pencil visits must not restore host/workspace/agent from a prior
+  // general New-session draft — those slots belong to the project's stored
+  // defaults (or the composer's generic fallbacks). Message/files still restore.
+  const restoreLocationDraft = projectParam === "";
   // Seeded from the persisted last pick so a returning user starts on the
   // agent they used last; validated against the live list in
   // effectiveAgentId below (a stale id falls back to the default). A
   // project-driven visit defers to the project-prefill effect instead
   // (which falls back to the same last pick).
-  const [pickedAgentId, setPickedAgentId] = useState<string | null>(
-    () => landingDraft?.pickedAgentId ?? (projectParam !== "" ? null : readLastAgentId()),
+  const [pickedAgentId, setPickedAgentId] = useState<string | null>(() =>
+    restoreLocationDraft ? (landingDraft?.pickedAgentId ?? readLastAgentId()) : null,
   );
-  const [selectedHostId, setSelectedHostId] = useState<string | null>(
-    () => landingDraft?.selectedHostId ?? null,
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(() =>
+    restoreLocationDraft ? (landingDraft?.selectedHostId ?? null) : null,
   );
   // Sessions on the selected host — fetched only when a host is selected,
   // to avoid registering hundreds of sessions into the health poll at idle.
@@ -2270,8 +2274,8 @@ export function NewChatLandingScreen() {
   // True when the user picked the sandbox option instead of a connected
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
-  const [sandboxSelected, setSandboxSelected] = useState(
-    () => landingDraft?.sandboxSelected ?? false,
+  const [sandboxSelected, setSandboxSelected] = useState(() =>
+    restoreLocationDraft ? (landingDraft?.sandboxSelected ?? false) : false,
   );
   // Provider the sandbox pick launches on. Seeded to the sticky last pick (or
   // the first offered row) once the picker rows load; null both before that
@@ -2340,14 +2344,18 @@ export function NewChatLandingScreen() {
   // Sandbox repository inputs — composed into the managed create's
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
-  const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
-    () => landingDraft?.sandboxRepoUrl ?? "",
+  const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(() =>
+    restoreLocationDraft ? (landingDraft?.sandboxRepoUrl ?? "") : "",
   );
-  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
-    () => landingDraft?.sandboxRepoBranch ?? "",
+  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(() =>
+    restoreLocationDraft ? (landingDraft?.sandboxRepoBranch ?? "") : "",
   );
-  const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
-  const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
+  const [workspace, setWorkspace] = useState<string>(() =>
+    restoreLocationDraft ? (landingDraft?.workspace ?? "") : "",
+  );
+  const [branchName, setBranchName] = useState<string>(() =>
+    restoreLocationDraft ? (landingDraft?.branchName ?? "") : "",
+  );
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
   // touches it — clearing the branch name re-arms the auto-fill (see the effect
@@ -2363,8 +2371,8 @@ export function NewChatLandingScreen() {
   // at. When `branchName` still equals this, the session starts directly in
   // that worktree (no git opts). Editing the field away from it means the user
   // wants a *new* worktree off that name.
-  const [prefilledBranch, setPrefilledBranch] = useState<string>(
-    () => landingDraft?.prefilledBranch ?? "",
+  const [prefilledBranch, setPrefilledBranch] = useState<string>(() =>
+    restoreLocationDraft ? (landingDraft?.prefilledBranch ?? "") : "",
   );
   // Project to file the new session under. Empty = unfiled. Stamped as the
   // `omni_project` label at create (so the row is filed from its first sidebar


### PR DESCRIPTION
## Related issue

Closes #4495

## Summary

- Project-created sessions now ignore stale host, workspace, agent, sandbox, and branch values from the general New session draft.
- Drafted message content and attachments still carry over, while the project configuration supplies launch settings on the first click.

**ELI5:** The project pencil now uses the project address instead of an address left over from the general session form.

```mermaid
flowchart LR
  A[General session draft] -->|message and files| C[Project session form]
  B[Project configuration] -->|launch settings| C
```

## Test Plan

- `pnpm exec vitest run src/shell/NewChatDialog.projectPrefill.test.tsx` — 14 passed
- `uv run --no-sync pytest tests/e2e_ui/start_session/test_project_config_prefill.py -q --tb=short` — 5 passed
- `pnpm run lint` — passed
- `pnpm run type-check` — passed
- `pnpm run build` — passed
- `.venv/bin/pre-commit run --all-files` — passed

## Demo

![Alpha project new-session uses its configured workspace](https://github.com/user-attachments/assets/ef08e748-b979-497b-a3c0-5118376b987f)

The Alpha project landing uses its configured `examples` workspace on the first visit.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The component test reproduces a stale general landing draft before mounting the project form. The browser test clicks the project pencil and verifies the configured workspace and agent replace stale launch settings while the drafted prompt remains.

## Changelog

Starting a session from a project now uses that project's configured workspace on the first attempt.
