### PR TITLE
feat(web): steer queued messages with empty Enter

### DIFF
--- a/tests/e2e_ui/chat/test_queue_steer.py
+++ b/tests/e2e_ui/chat/test_queue_steer.py
@@ -7,8 +7,8 @@ Guards the steer affordance of the client-side queue:
     (busy). A follow-up typed into the composer is then held in the
     client-side queue — shown in the docked strip, NOT POSTed (the idle
     auto-flush never fires because idle never comes). Clicking the row's
-    "Steer" button POSTs it immediately — the only thing that could send
-    it here, since the session never went idle.
+    "Steer" button or pressing Enter on the empty composer POSTs it
+    immediately — the only actions that can send it while the session is busy.
 
 Why async Playwright (not the sync ``page`` fixture): the route handler
 inspects and fulfills every ``/events`` POST to record which messages the
@@ -32,6 +32,7 @@ import threading
 from collections.abc import Coroutine
 from typing import Any
 
+import pytest
 from playwright.async_api import Route, async_playwright, expect
 
 _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
@@ -84,20 +85,22 @@ async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
     raise AssertionError(f"condition not met within {timeout_s:.0f}s")
 
 
+@pytest.mark.parametrize("steer_action", ["button", "empty-enter"])
 def test_steer_sends_queued_message_while_busy(
     seeded_session: tuple[str, str],
+    steer_action: str,
 ) -> None:
-    """Steering a queued message POSTs it immediately, mid-turn.
+    """Button or empty-composer Enter POSTs the queued head mid-turn.
 
     Failure mode this catches: steer does nothing (message stays queued),
     or the message is only sent after the turn ends (indistinguishable
     from auto-flush) — either means the steer path is broken.
     """
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_steer(base_url, session_id))
+    _run_in_fresh_loop(_drive_steer(base_url, session_id, steer_action))
 
 
-async def _drive_steer(base_url: str, session_id: str) -> None:
+async def _drive_steer(base_url: str, session_id: str, steer_action: str) -> None:
     """Async body of the steer test. See the test docstring.
 
     :param base_url: Spawned server base URL.
@@ -154,22 +157,27 @@ async def _drive_steer(base_url: str, session_id: str) -> None:
                 f"msg2 was POSTed before steer (should be held client-side): {event_posts}"
             )
 
-            # The icon-only action explains itself on hover, with the tooltip
-            # placed above the control rather than covering the queued row.
-            steer_button = page.get_by_role("button", name="Send queued message now")
-            await steer_button.hover()
-            tooltip = page.locator("[data-slot=tooltip-content]", has_text="Send now")
-            await expect(tooltip).to_be_visible(timeout=5_000)
-            button_box = await steer_button.bounding_box()
-            tooltip_box = await tooltip.bounding_box()
-            assert button_box is not None
-            assert tooltip_box is not None
-            assert tooltip_box["y"] + tooltip_box["height"] <= button_box["y"]
+            if steer_action == "button":
+                # The icon-only action explains itself on hover, with the tooltip
+                # placed above the control rather than covering the queued row.
+                steer_button = page.get_by_role("button", name="Send queued message now")
+                await steer_button.hover()
+                tooltip = page.locator("[data-slot=tooltip-content]", has_text="Send now")
+                await expect(tooltip).to_be_visible(timeout=5_000)
+                button_box = await steer_button.bounding_box()
+                tooltip_box = await tooltip.bounding_box()
+                assert button_box is not None
+                assert tooltip_box is not None
+                assert tooltip_box["y"] + tooltip_box["height"] <= button_box["y"]
+                await steer_button.click()
+            else:
+                # With no draft in the composer, bare Enter steers the FIFO head
+                # through the same action as the per-row button.
+                assert await composer.input_value() == ""
+                await composer.press("Enter")
 
-            # Steer msg2 → it must POST now, even though the session never went
-            # idle. This is what distinguishes steer from the idle auto-flush:
-            # the only reason msg2 could POST here is the explicit steer.
-            await steer_button.click()
+            # msg2 must POST now, even though the session never went idle. This
+            # distinguishes both explicit steer actions from idle auto-flush.
             await _wait_until(lambda: any(text == _MSG2 for _, text in event_posts))
 
             # The steered message left the queue (strip empties).

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1804,9 +1804,7 @@ describe("Composer — Enter steers queued head", () => {
       sendSpy,
     );
     const onSend = vi.fn();
-    render(
-      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
-    );
+    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
 
     fireEvent.keyDown(textarea(), { key: "Enter" });
 
@@ -1843,9 +1841,7 @@ describe("Composer — Enter steers queued head", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
     const onSend = vi.fn();
-    render(
-      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
-    );
+    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
     const ta = textarea();
     fireEvent.change(ta, { target: { value: "new follow-up" } });
     fireEvent.keyDown(ta, { key: "Enter" });
@@ -1857,14 +1853,9 @@ describe("Composer — Enter steers queued head", () => {
 
   it("does not steer when empty and nothing is queued for this conversation", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
-    busyQueuedState(
-      [{ queueId: "other_1", text: "other", conversationId: "conv_other" }],
-      sendSpy,
-    );
+    busyQueuedState([{ queueId: "other_1", text: "other", conversationId: "conv_other" }], sendSpy);
     const onSend = vi.fn();
-    render(
-      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
-    );
+    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
 
     fireEvent.keyDown(textarea(), { key: "Enter" });
 

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1761,6 +1761,179 @@ describe("Composer — queued-message flush gating", () => {
   });
 });
 
+// Empty-composer Enter steers this conversation's FIFO head. Keep the agent
+// busy to prevent idle draining, and isolate drafts with a dedicated id.
+describe("Composer — Enter steers queued head", () => {
+  const CONV = "conv_enter_steer";
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    useChatStore.setState({
+      queuedMessages: [],
+      blocks: [],
+      status: "idle",
+      sessionStatus: "idle",
+    });
+  });
+
+  function busyQueuedState(
+    queuedMessages: QueuedMessage[],
+    send: (text: string, agentId: string, files?: File[]) => Promise<void>,
+  ) {
+    useChatStore.setState({
+      conversationId: CONV,
+      boundAgentId: "agent_xyz",
+      status: "streaming",
+      sessionStatus: "running",
+      send,
+      queuedMessages,
+      blocks: [],
+      skills: [],
+    });
+  }
+
+  it("Enter on an empty composer steers this conversation's queue head", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState(
+      [
+        { queueId: "other_1", text: "other conv", conversationId: "conv_other" },
+        { queueId: "q_1", text: "first", conversationId: CONV },
+        { queueId: "q_2", text: "second", conversationId: CONV },
+      ],
+      sendSpy,
+    );
+    const onSend = vi.fn();
+    render(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["first", "agent_xyz"]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual([
+      "other_1",
+      "q_2",
+    ]);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("repeated Enter drains successive heads (FIFO within the conversation)", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState(
+      [
+        { queueId: "q_1", text: "first", conversationId: CONV },
+        { queueId: "q_2", text: "second", conversationId: CONV },
+      ],
+      sendSpy,
+    );
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    const ta = textarea();
+
+    fireEvent.keyDown(ta, { key: "Enter" });
+    fireEvent.keyDown(ta, { key: "Enter" });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(sendSpy.mock.calls.map((c) => c[0])).toEqual(["first", "second"]);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+  });
+
+  it("does not steer when the composer has a draft", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
+    const onSend = vi.fn();
+    render(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "new follow-up" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith("new follow-up", undefined);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["q_1"]);
+  });
+
+  it("does not steer when empty and nothing is queued for this conversation", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState(
+      [{ queueId: "other_1", text: "other", conversationId: "conv_other" }],
+      sendSpy,
+    );
+    const onSend = vi.fn();
+    render(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["other_1"]);
+  });
+
+  it("does not steer while a pending elicitation locks the composer", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
+    useChatStore.setState({
+      blocks: [
+        {
+          type: "elicitation",
+          ctx: {
+            agent: null,
+            depth: 0,
+            turn: 0,
+            timestamp: 0,
+            responseId: "resp_1",
+            itemId: null,
+          },
+          elicitationId: "elic_1",
+          targetSessionId: null,
+          message: "Allow shell command?",
+          phase: "tool_call",
+          policyName: "ask-before-shell",
+          contentPreview: "{}",
+          requestedSchema: {},
+          url: null,
+          status: "pending",
+          response: null,
+        },
+      ],
+    });
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["q_1"]);
+  });
+
+  it("does not steer when Enter confirms active IME composition on an empty composer", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    const ta = textarea();
+    fireEvent.compositionStart(ta);
+
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["q_1"]);
+  });
+
+  it("Shift+Enter on an empty composer does not steer", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+
+    fireEvent.keyDown(textarea(), { key: "Enter", shiftKey: true });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["q_1"]);
+  });
+});
+
 describe("Composer config gear", () => {
   beforeEach(() => {
     useChatStore.setState({

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1804,7 +1804,9 @@ describe("Composer — Enter steers queued head", () => {
       sendSpy,
     );
     const onSend = vi.fn();
-    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
+    renderWithTooltips(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
 
     fireEvent.keyDown(textarea(), { key: "Enter" });
 
@@ -1826,7 +1828,7 @@ describe("Composer — Enter steers queued head", () => {
       ],
       sendSpy,
     );
-    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    renderWithTooltips(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
     const ta = textarea();
 
     fireEvent.keyDown(ta, { key: "Enter" });
@@ -1841,7 +1843,9 @@ describe("Composer — Enter steers queued head", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
     const onSend = vi.fn();
-    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
+    renderWithTooltips(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
     const ta = textarea();
     fireEvent.change(ta, { target: { value: "new follow-up" } });
     fireEvent.keyDown(ta, { key: "Enter" });
@@ -1855,7 +1859,9 @@ describe("Composer — Enter steers queued head", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     busyQueuedState([{ queueId: "other_1", text: "other", conversationId: "conv_other" }], sendSpy);
     const onSend = vi.fn();
-    render(<Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />);
+    renderWithTooltips(
+      <Composer {...composerProps({ onSend, status: "streaming", isWorking: true })} />,
+    );
 
     fireEvent.keyDown(textarea(), { key: "Enter" });
 
@@ -1892,7 +1898,7 @@ describe("Composer — Enter steers queued head", () => {
         },
       ],
     });
-    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    renderWithTooltips(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
 
     fireEvent.keyDown(textarea(), { key: "Enter" });
 
@@ -1903,7 +1909,7 @@ describe("Composer — Enter steers queued head", () => {
   it("does not steer when Enter confirms active IME composition on an empty composer", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
-    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    renderWithTooltips(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
     const ta = textarea();
     fireEvent.compositionStart(ta);
 
@@ -1916,7 +1922,7 @@ describe("Composer — Enter steers queued head", () => {
   it("Shift+Enter on an empty composer does not steer", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     busyQueuedState([{ queueId: "q_1", text: "queued", conversationId: CONV }], sendSpy);
-    render(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
+    renderWithTooltips(<Composer {...composerProps({ status: "streaming", isWorking: true })} />);
 
     fireEvent.keyDown(textarea(), { key: "Enter", shiftKey: true });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5477,6 +5477,15 @@ export function Composer({
       // ``mentionListingPending``); swallow Enter so the in-progress "@dir/"
       // token isn't sent as a chat message. The menu reopens when entries land.
       if (mentionListingPending) return;
+      // Empty composer + a queued head for this conversation: steer that head
+      // (same store path as the strip's Steer button). Repeated Enter drains
+      // successive heads FIFO; once empty, further presses stay no-ops.
+      if (!hasDraft) {
+        if (disabled || hasPendingElicitation) return;
+        const head = queuedMessages.find((m) => m.conversationId === conversationId);
+        if (head !== undefined) steerMessage(head.queueId);
+        return;
+      }
       submit();
       return;
     }

--- a/web/src/pages/QueuedMessagesStrip.tsx
+++ b/web/src/pages/QueuedMessagesStrip.tsx
@@ -23,9 +23,8 @@ interface QueuedMessagesStripProps {
   /** Pull a queued message back into the composer for editing. */
   onEdit: (queueId: string) => void;
   /**
-   * Send a queued message now (steer), instead of waiting for the idle flush.
-   * Omitted when the session can't steer mid-turn (e.g. native terminals),
-   * in which case no steer button is shown.
+   * Steer a queued message instead of waiting for the idle flush. Delivery is
+   * harness-dependent; omit this callback to hide the action.
    */
   onSteer?: (queueId: string) => void;
   /**

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -656,10 +656,9 @@ export interface ChatActions {
    */
   reorderQueuedMessage: (queueId: string, beforeQueueId: string | null) => void;
   /**
-   * Send a queued message NOW instead of waiting for the idle flush (the
-   * strip's per-row steer). Removes it from the queue and POSTs it: on an
-   * SDK harness the server live-injects it into the running turn; the
-   * optimistic bubble promotes on POST. No-op if the id isn't queued.
+   * Send a queued message now instead of waiting for idle. Native harnesses
+   * may inject it live; SDK harnesses typically deliver it as the next turn.
+   * Removes before POST to avoid double sends; unknown ids are no-ops.
    */
   steerMessage: (queueId: string) => void;
   /**


### PR DESCRIPTION
## Related issue

Closes #4426 — Bind queued-message steering to Enter on an empty composer

## Summary

When an agent is busy, Enter on a truly empty desktop composer now steers the current conversation's first queued message through the existing harness-agnostic action. Repeated presses drain that conversation's queue in FIFO order, while draft submission, IME composition, menus, Shift+Enter, mobile input, and pending-elicitation behavior remain unchanged. The stale harness-delivery comments discovered in the issue are corrected as part of the same change.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/pages/ChatPage.composer.test.tsx src/pages/QueuedMessagesStrip.test.tsx` — 167 passed
- `uv run --frozen pytest tests/e2e_ui/chat/test_queue_steer.py -q` — 2 passed; verified the Steer button and empty-composer Enter against the real SPA/server path
- `pnpm run lint && pnpm run format:check` — passed
- `pnpm run type-check` — passed
- `pnpm run build` — passed
- Focused pre-commit hooks, DCO signoffs, and secret scanning passed

## Demo

Before pressing Enter, both follow-ups are queued:

![Two follow-ups queued while the agent is working](https://github.com/user-attachments/assets/aa575f01-cca8-4991-8f5a-9c6a38b1c6b3)

After pressing Enter on the empty composer, the first follow-up is delivered and the second remains queued:

![Empty-composer Enter steers the FIFO queue head](https://github.com/user-attachments/assets/92145793-49c1-495b-84df-ae965c86e737)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component tests cover FIFO targeting, repeated Enter, draft submission, other-conversation queues, IME composition, Shift+Enter, and pending elicitation. The gated Playwright test drives the real SPA/server path and confirms both steering actions POST the queued head while the session remains busy.

## Changelog

Press Enter on an empty composer to steer the next queued message without leaving the keyboard.
