### PR TITLE
fix(onboarding): pin uv extra installs to the running interpreter

### DIFF
--- a/omnigent/onboarding/extra_install.py
+++ b/omnigent/onboarding/extra_install.py
@@ -9,8 +9,12 @@ install command depends on *how* omnigent itself was installed:
   git-source install (``uv tool install git+…``) instead reinstalls from that
   same source (``uv tool install --force "omnigent[extra] @ git+…"``) so the
   tool is not silently re-pulled from PyPI.
-* **``uv`` (non-tool)** — ``uv pip install "omnigent[extra]"`` targets the
-  active virtualenv.
+* **``uv`` (non-tool)** — ``uv pip install --python <sys.executable>
+  "omnigent[extra]"`` pins the install to the running interpreter.  The bare
+  form instead resolves the *active* virtualenv, which fails outright on a
+  Homebrew/pipx/system install that merely has ``uv`` on ``PATH`` ("No virtual
+  environment found") and can silently target an unrelated venv when one is
+  active.
 * **``pip`` / fallback** — ``<sys.executable> -m pip install "omnigent[extra]"``
   pins to the running interpreter.
 """
@@ -64,7 +68,8 @@ def extra_install_command(extra: str) -> list[str]:
        "omnigent[extra] @ git+…"`` (keeps the tool on its original source)
     2. ``uv tool`` install, registry → ``uv tool install --with ...
        omnigent --force``
-    3. ``uv`` on PATH (non-tool) → ``uv pip install "omnigent[extra]"``
+    3. ``uv`` on PATH (non-tool) → ``uv pip install --python <sys.executable>
+       "omnigent[extra]"``
     4. fallback → ``<sys.executable> -m pip install "omnigent[extra]"``
 
     :param extra: The pip extra name, e.g. ``"cursor"``.
@@ -81,7 +86,11 @@ def extra_install_command(extra: str) -> list[str]:
         return ["uv", "tool", "install", "--with", target, "omnigent", "--force"]
 
     if shutil.which("uv") is not None:
-        return ["uv", "pip", "install", target]
+        # ``--python`` pins the install to the interpreter that will import the
+        # extra.  Without it ``uv pip install`` requires an active virtualenv
+        # and errors out on Homebrew/pipx/system installs that merely have uv
+        # on PATH.
+        return ["uv", "pip", "install", "--python", sys.executable, target]
 
     return [sys.executable, "-m", "pip", "install", target]
 

--- a/tests/onboarding/test_antigravity_auth.py
+++ b/tests/onboarding/test_antigravity_auth.py
@@ -151,8 +151,16 @@ def test_antigravity_install_command_prefers_uv(monkeypatch: pytest.MonkeyPatch)
     """With ``uv`` on PATH, the install runs ``uv pip install`` — no index URL."""
     monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: False)
     monkeypatch.setattr(extra_install.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(extra_install.sys, "executable", "/opt/venv/bin/python")
     cmd = antigravity_install_command()
-    assert cmd == ["uv", "pip", "install", "omnigent[antigravity]"]
+    assert cmd == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "/opt/venv/bin/python",
+        "omnigent[antigravity]",
+    ]
     assert not any("index" in part or "://" in part for part in cmd)
 
 

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -279,8 +279,16 @@ def test_copilot_install_command_prefers_uv(monkeypatch: pytest.MonkeyPatch) -> 
     """With ``uv`` on PATH, the install runs ``uv pip install`` — no index URL."""
     monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: False)
     monkeypatch.setattr(extra_install.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(extra_install.sys, "executable", "/opt/venv/bin/python")
     cmd = copilot_install_command()
-    assert cmd == ["uv", "pip", "install", "omnigent[copilot]"]
+    assert cmd == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "/opt/venv/bin/python",
+        "omnigent[copilot]",
+    ]
     assert not any("index" in part or "://" in part for part in cmd)
 
 

--- a/tests/onboarding/test_cursor_auth.py
+++ b/tests/onboarding/test_cursor_auth.py
@@ -198,8 +198,16 @@ def test_cursor_install_command_prefers_uv(monkeypatch: pytest.MonkeyPatch) -> N
     """With ``uv`` on PATH, the install runs ``uv pip install`` — no index URL."""
     monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: False)
     monkeypatch.setattr(extra_install.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(extra_install.sys, "executable", "/opt/venv/bin/python")
     cmd = cursor_install_command()
-    assert cmd == ["uv", "pip", "install", "omnigent[cursor]"]
+    assert cmd == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "/opt/venv/bin/python",
+        "omnigent[cursor]",
+    ]
     assert not any("index" in part or "://" in part for part in cmd)
 
 

--- a/tests/onboarding/test_extra_install.py
+++ b/tests/onboarding/test_extra_install.py
@@ -96,11 +96,39 @@ def test_extra_install_command_uv_tool_git_source(monkeypatch: pytest.MonkeyPatc
 
 
 def test_extra_install_command_uv_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With uv on PATH (non-tool), produces ``uv pip install``."""
+    """With uv on PATH (non-tool), produces ``uv pip install`` for this interpreter."""
     monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: False)
     monkeypatch.setattr(extra_install.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(extra_install.sys, "executable", "/opt/venv/bin/python")
     cmd = extra_install_command("antigravity")
-    assert cmd == ["uv", "pip", "install", "omnigent[antigravity]"]
+    assert cmd == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "/opt/venv/bin/python",
+        "omnigent[antigravity]",
+    ]
+
+
+def test_extra_install_command_uv_on_path_targets_running_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``uv pip install`` is pinned to the running interpreter, not the active venv.
+
+    Regression test: a Homebrew/pipx/system install with ``uv`` merely on PATH
+    has no active virtualenv for ``uv pip install`` to discover, so the bare
+    form fails with "No virtual environment found" and the extra never lands.
+    ``--python sys.executable`` also keeps the install off an unrelated
+    virtualenv that happens to be active in the user's shell.
+    """
+    brew_python = "/opt/homebrew/Cellar/omnigent/0.8.2/libexec/bin/python"
+    monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: False)
+    monkeypatch.setattr(extra_install.shutil, "which", lambda name: "/opt/homebrew/bin/uv")
+    monkeypatch.setattr(extra_install.sys, "executable", brew_python)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    cmd = extra_install_command("copilot")
+    assert cmd == ["uv", "pip", "install", "--python", brew_python, "omnigent[copilot]"]
 
 
 def test_extra_install_command_pip_fallback(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Related issue

Closes #4831

## Summary

`extra_install_command()` returns a bare `uv pip install "omnigent[<extra>]"` whenever `uv` is found on `PATH` ([extra_install.py#L83-L84](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/onboarding/extra_install.py#L83-L84)). But `uv pip install` resolves the **active virtualenv**, not the interpreter that will import the extra — and this is the exact command `omnigent setup` offers when a user opts in to installing a harness extra.

- **It dead-ends the guided setup flow** on any install where omnigent doesn't live in an activated venv (Homebrew, pipx, system Python): `error: No virtual environment found; run uv venv ... or pass --system`. Having `uv` on `PATH` is common, not exotic.
- **When an unrelated venv *is* active, it's worse than an error** — the extra installs successfully into an environment omnigent never imports from, `find_spec()` still returns `None`, and harness readiness keeps reporting the harness as missing with no indication why.
- **Fix:** pass `--python sys.executable` so uv targets the interpreter that will actually import the extra. This matches the module's own documented contract — *"Return the argv that installs *extra* into the running environment"* — and makes the uv branch consistent with the pip fallback directly beneath it, which already pins to `sys.executable`.

The `uv tool` branches are deliberately untouched: those environments are managed by `uv tool` and are correctly reinstalled through it.

## Test Plan

Test-first: both new/updated assertions were confirmed RED against unpatched `main` before the one-line fix, then GREEN after.

```
tests/onboarding: 1110 passed, 2 failed
ruff check / ruff format --check: clean on all touched files
```

The 2 failures are pre-existing and unrelated — verified by stashing this change and re-running on a clean `main` checkout, where they fail identically (`test_databricks_sdk_installed_true_in_dev_env`, `test_claude_ready_via_configured_provider_without_cli_login`; both environment-dependent).

Manual verification of the underlying bug, on a Homebrew install of 0.8.2 (`/opt/homebrew/Cellar/omnigent/0.8.2/libexec`, `uv` at `/opt/homebrew/bin/uv`), installing the `copilot` extra:

```console
$ uv pip install "omnigent[copilot]"          # command as generated today
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

The workaround was to bypass the generated command entirely and target the interpreter directly (`<libexec>/bin/python -m pip install "github-copilot-sdk>=1,<2"`), which is what the patched command now produces. With the extra installed against the right interpreter, `harness_is_configured("copilot")` returns `True` and an end-to-end `omnigent run --harness copilot` succeeds.

## Demo

N/A — non-visual change to a generated argv.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed

## Coverage notes

Unit coverage is the right level here: the function's entire job is to return an argv, so the tests assert the produced argv directly.

- Added `test_extra_install_command_uv_on_path_targets_running_interpreter` — regression test for the Homebrew / no-active-venv case.
- Updated `test_extra_install_command_uv_on_path` for the new argv.
- Updated the three sibling `*_install_command_prefers_uv` tests (copilot / cursor / antigravity) that assert the same shared argv shape.

Manual verification is recorded in the Test Plan above: reproducing the failure requires a real Homebrew-style install layout with `uv` on `PATH`, which isn't something the unit tests can stand up.

## Changelog

`omnigent setup` now installs harness extras into the interpreter omnigent actually runs on, instead of failing with "No virtual environment found" or silently installing into an unrelated virtualenv.
