### PR TITLE
fix(web): keep grown-composer transcript tail scrollable

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -16,12 +16,16 @@ scrollbar (drawn from ``clientHeight``/``scrollHeight``) and the turn rail
 (centered on the same box) still jittered. The composer now floats its extra
 rows over the transcript instead, so that box never changes.
 
+The floated growth does extend ``scrollHeight`` via a post-content spacer driven
+by ``--composer-growth`` (so the covered tail stays reachable). ``clientHeight``
+and ``scrollTop`` must still hold still — only the reachable range grows.
+
 Layout regressions like these are invisible below the browser — jsdom has no
 layout, so ``scrollHeight``/``clientHeight`` are 0 there and neither the clamp
 nor the viewport arithmetic happens at all. The assertions pin what has to hold
-at once: the messages, the scroll geometry, and the rail ticks all stay exactly
-where they were, and the transcript stays stuck to the bottom so a streaming
-reply still follows.
+at once: the messages, the scroll offset, and the rail ticks all stay exactly
+where they were, and the transcript stays stuck to the pre-growth bottom so a
+streaming reply still follows (with growth-sized room below to scroll into).
 """
 
 from __future__ import annotations
@@ -39,21 +43,26 @@ _TEXT_SECTION = '[data-testid="assistant-text-section"]'
 #
 # ``distanceFromBottom`` is 0-or-1 while the transcript is stuck to the bottom
 # (use-stick-to-bottom parks it one pixel short of the maximum) and grows once
-# a clamp has knocked it loose. ``viewport`` is the scroll geometry the native
-# scrollbar is drawn from — any change there moves the thumb, which reads as
-# jitter next to a composer that's only supposed to be growing. ``railTicks``
-# is the left-edge turn minimap, centered on the same box.
+# a clamp has knocked it loose — or, after composer growth, by the spacer that
+# extends scrollHeight without moving scrollTop. ``viewport`` is the scroll
+# geometry the native scrollbar is drawn from — ``clientHeight`` and
+# ``scrollTop`` must not move when the composer grows; ``scrollHeight`` may.
+# ``railTicks`` is the left-edge turn minimap, centered on the same box.
 _PROBE = """() => {
     const ta = document.querySelector('textarea[aria-label="Message the agent"]');
     const scroller = ta.closest('form').parentElement.querySelector('[role="log"] > div');
     const rail = document.querySelector('.turn-rail-fade');
+    const extent = document.querySelector('[data-testid="composer-growth-scroll-extent"]');
     return {
         messageTops: [...document.querySelectorAll('[data-testid="assistant-text-section"]')]
             .map((section) => Math.round(section.getBoundingClientRect().top)),
         composerHeight: Math.round(ta.getBoundingClientRect().height),
         distanceFromBottom: Math.round(
             scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop),
-        viewport: [scroller.clientHeight, scroller.scrollHeight, Math.round(scroller.scrollTop)],
+        clientHeight: scroller.clientHeight,
+        scrollHeight: scroller.scrollHeight,
+        scrollTop: Math.round(scroller.scrollTop),
+        composerGrowthPx: extent ? Math.round(extent.getBoundingClientRect().height) : 0,
         railTicks: rail
             ? [...rail.querySelectorAll('button')]
                   .map((tick) => Math.round(tick.getBoundingClientRect().top))
@@ -116,18 +125,30 @@ def test_composer_growth_does_not_shift_transcript(
     baseline = _settled_geometry(page)
     assert baseline["distanceFromBottom"] <= 1, baseline
     assert baseline["railTicks"], baseline
+    assert baseline["composerGrowthPx"] == 0, baseline
 
     def assert_transcript_idle(state: dict, label: str) -> None:
-        """Everything but the composer itself is byte-identical to baseline."""
-        for key in ("messageTops", "viewport", "railTicks"):
-            assert state[key] == baseline[key], (label, key, baseline[key], state[key])
-        assert state["distanceFromBottom"] <= 1, (label, state)
+        """Messages, offset, and rail stay put; only scroll extent may grow."""
+        assert state["messageTops"] == baseline["messageTops"], (label, baseline, state)
+        assert state["railTicks"] == baseline["railTicks"], (label, baseline, state)
+        assert state["clientHeight"] == baseline["clientHeight"], (label, baseline, state)
+        assert state["scrollTop"] == baseline["scrollTop"], (label, baseline, state)
+        growth = state["composerGrowthPx"]
+        assert state["scrollHeight"] == baseline["scrollHeight"] + growth, (
+            label,
+            baseline,
+            state,
+        )
+        # Still parked on the pre-growth bottom (stick-to-bottom parks ~1px
+        # short), with the growth-sized spacer as newly reachable room below.
+        assert abs(state["distanceFromBottom"] - growth) <= 1, (label, baseline, state)
 
     # Grow: three Shift+Enter newlines, one line taller each.
     for _ in range(3):
         composer.press("Shift+Enter")
     grown = _settled_geometry(page)
     assert grown["composerHeight"] > baseline["composerHeight"], grown
+    assert grown["composerGrowthPx"] > 0, grown
     assert_transcript_idle(grown, "after newlines")
 
     # Type into the now-multi-line composer: the height doesn't change, but the

--- a/web/src/components/ai-elements/conversation.composerGrowth.test.tsx
+++ b/web/src/components/ai-elements/conversation.composerGrowth.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Conversation, ConversationContent } from "./conversation";
+
+/** Install mutable jsdom metrics for the composer-growth scroll contract. */
+function setScrollMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => metrics.scrollTop,
+    set: (value: number) => {
+      metrics.scrollTop = value;
+    },
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => metrics.scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => metrics.clientHeight,
+  });
+}
+
+describe("ConversationContent composer-growth scroll extent", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("extends max scroll via --composer-growth without moving scrollTop", () => {
+    const { container } = render(
+      <div>
+        <Conversation>
+          <ConversationContent>
+            <div data-testid="tail-message">last reply line</div>
+          </ConversationContent>
+        </Conversation>
+      </div>,
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    const scroller = wrapper.querySelector('[role="log"] > div') as HTMLElement;
+    const content = scroller.firstElementChild as HTMLElement;
+    const extent = screen.getByTestId("composer-growth-scroll-extent");
+
+    // Spacer is a scroll-container sibling of contentRef — not inside it — so
+    // StickToBottom's content ResizeObserver does not re-pin on growth.
+    expect(extent.parentElement).toBe(scroller);
+    expect(content.contains(extent)).toBe(false);
+    expect(extent).toHaveStyle({ height: "var(--composer-growth, 0px)" });
+
+    const restingHeight = 1000;
+    const viewport = 400;
+    const pinnedTop = restingHeight - viewport;
+    const metrics = {
+      scrollTop: pinnedTop,
+      scrollHeight: restingHeight,
+      clientHeight: viewport,
+    };
+    setScrollMetrics(scroller, metrics);
+
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+
+    const growth = 72;
+    wrapper.style.setProperty("--composer-growth", `${growth}px`);
+    // Layout engines fold the spacer into scrollHeight; jsdom needs the same.
+    metrics.scrollHeight = restingHeight + growth;
+
+    // Pinned-at-bottom typing: extent grows, offset stays — no transcript jump.
+    expect(metrics.scrollTop).toBe(pinnedTop);
+    expect(metrics.scrollHeight - metrics.clientHeight).toBe(pinnedTop + growth);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(growth);
+
+    // Manually scrolled: same contract — only the reachable range grows.
+    metrics.scrollTop = 120;
+    metrics.scrollHeight = restingHeight;
+    wrapper.style.setProperty("--composer-growth", "0px");
+    expect(metrics.scrollTop).toBe(120);
+
+    wrapper.style.setProperty("--composer-growth", `${growth}px`);
+    metrics.scrollHeight = restingHeight + growth;
+    expect(metrics.scrollTop).toBe(120);
+    expect(metrics.scrollHeight - metrics.clientHeight).toBe(restingHeight + growth - viewport);
+
+    // Scroll-to-bottom can now land past the covered endpoint.
+    scroller.scrollTop = metrics.scrollHeight - metrics.clientHeight;
+    expect(metrics.scrollTop).toBe(pinnedTop + growth);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+  });
+});

--- a/web/src/components/ai-elements/conversation.tsx
+++ b/web/src/components/ai-elements/conversation.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactNode, RefObject } from "react";
 import { createContext, useCallback, useMemo } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
@@ -55,9 +55,43 @@ export const Conversation = ({ className, children, ...props }: ConversationProp
 
 export type ConversationContentProps = ComponentProps<typeof StickToBottom.Content>;
 
-export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
-  <StickToBottom.Content className={cn("flex flex-col gap-8 px-6 py-4", className)} {...props} />
-);
+/** Extend transcript scroll range without resizing StickToBottom's content. */
+export const ConversationContent = ({
+  className,
+  children,
+  scrollClassName,
+  ...props
+}: ConversationContentProps) => {
+  // scrollRef/contentRef exist at runtime but aren't in the library's public types.
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef: RefObject<HTMLElement | null>;
+    contentRef: RefObject<HTMLElement | null>;
+  };
+  return (
+    <div
+      ref={ctx.scrollRef}
+      style={{
+        height: "100%",
+        width: "100%",
+        scrollbarGutter: "stable both-edges",
+      }}
+      className={scrollClassName}
+    >
+      <div
+        ref={ctx.contentRef}
+        className={cn("flex flex-col gap-8 px-6 py-4", className)}
+        {...props}
+      >
+        {typeof children === "function" ? children(ctx) : children}
+      </div>
+      <div
+        aria-hidden
+        data-testid="composer-growth-scroll-extent"
+        style={{ height: "var(--composer-growth, 0px)", flexShrink: 0 }}
+      />
+    </div>
+  );
+};
 
 export type ConversationEmptyStateProps = ComponentProps<"div"> & {
   title?: string;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1818,12 +1818,9 @@ function MainAgentSurface({
     conversationRef.current = el;
     setContainerEl(el);
   }, []);
-  // How far the composer has grown past its resting height. The composer keeps
-  // that growth out of the flex column, so the wrapper's box never moves —
-  // this only lifts the overlays pinned to its bottom edge (the scroll-to-
-  // bottom button, the Working… tab, the message nav) clear of the taller
-  // card. Written straight to the DOM: a re-render per line of typing would
-  // re-render the whole transcript for a purely visual offset.
+  // Kept out of the flex column so growth moves neither the wrapper nor thread.
+  // The CSS variable lifts overlays and extends the transcript's scroll range
+  // without re-rendering the transcript on every keystroke.
   const publishComposerGrowth = useCallback((px: number) => {
     conversationRef.current?.style.setProperty("--composer-growth", `${px}px`);
   }, []);


### PR DESCRIPTION
## Related issue

Closes #4433 — A grown composer covers the transcript tail and prevents scrolling to it

## Summary

A growing composer floats over the transcript to avoid reflow, but the transcript's scroll range previously stayed fixed, leaving its final lines permanently covered. A spacer outside StickToBottom's observed content now extends the reachable range by `--composer-growth` without moving the current scroll offset or repinning the thread.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/components/ai-elements/conversation.composerGrowth.test.tsx` — 1 passed
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/pages/ChatPage.composer.test.tsx src/pages/ChatPage.test.ts` — 313 passed
- `pnpm run type-check` — passed
- Focused oxlint over the changed web files — passed
- Ran the branch against an isolated server, host, Vite frontend, and live Claude Code session; grew the composer from its resting size to 186px and confirmed the transcript gained 145px of scroll extent without moving its existing offset
- Existing browser geometry test updated to require growth-sized reachable space without message, rail, viewport, or scroll-offset movement
- Commit hooks and secret scanning passed

## Demo

The eight-line composer initially covers the final transcript lines while preserving their prior on-screen position:

![Grown composer over the transcript before scrolling](https://github.com/user-attachments/assets/97df20dc-a532-4268-9fc4-23d116f461a7)

Scrolling through the new growth-sized extent makes line 60 and the full tail reachable above the same grown composer:

![Transcript tail remains reachable with the grown composer](https://github.com/user-attachments/assets/043c7971-f33c-4d77-806b-9b49e5a0bb0d)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The DOM contract test covers pinned and manually scrolled offsets. The browser test covers real scroll geometry, where jsdom cannot calculate layout. Manual verification measured a 145px growth spacer and reached the transcript bottom at a 0.5px rounding distance.

## Changelog

Grow the composer without losing access to the final lines of the conversation.