### PR TITLE
feat(web): add default Agents panel view setting

### DIFF
--- a/tests/e2e_ui/sessions/test_agents_view_default.py
+++ b/tests/e2e_ui/sessions/test_agents_view_default.py
@@ -1,0 +1,53 @@
+"""E2E: Settings -> Appearance controls the initial Agents panel view.
+
+The preference is browser-local and seeds each Agents panel mount. Switching
+views inside the panel is intentionally temporary and must not overwrite the
+Appearance default. No LLM turn is needed.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+STORAGE_KEY = "omnigent:default-agents-view"
+
+
+def _open_agents_panel(page: Page, base_url: str, session_id: str) -> None:
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Agents")).click()
+    expect(rail.get_by_role("button", name="Graph view")).to_be_visible(timeout=30_000)
+
+
+def test_agents_view_default_persists_and_seeds_panel_mounts(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Graph persists through reloads while an in-panel List switch does not."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/settings/appearance")
+
+    group = page.get_by_role("radiogroup", name="Default Agents view")
+    expect(group).to_be_visible(timeout=30_000)
+    graph_default = group.get_by_role("radio", name="Graph")
+    graph_default.click()
+    expect(graph_default).to_have_attribute("aria-checked", "true")
+    assert page.evaluate(f"() => localStorage.getItem('{STORAGE_KEY}')") == "graph"
+
+    _open_agents_panel(page, base_url, session_id)
+    rail = page.get_by_role("complementary", name="Workspace")
+    expect(rail.get_by_role("button", name="Zoom in")).to_be_visible(timeout=30_000)
+
+    rail.get_by_role("button", name="List view").click()
+    expect(rail.get_by_test_id("subagent-main-row")).to_be_visible()
+    assert page.evaluate(f"() => localStorage.getItem('{STORAGE_KEY}')") == "graph"
+
+    page.reload()
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Agents")).click()
+    expect(rail.get_by_role("button", name="Zoom in")).to_be_visible(timeout=30_000)

--- a/web/src/lib/agentsViewPreferences.test.ts
+++ b/web/src/lib/agentsViewPreferences.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AGENTS_VIEW_DEFAULT,
+  normalizeAgentsViewMode,
+  readAgentsViewDefault,
+  writeAgentsViewDefault,
+} from "./agentsViewPreferences";
+
+const STORAGE_KEY = "omnigent:default-agents-view";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("agentsViewPreferences — read/write", () => {
+  it("returns list when nothing is stored", () => {
+    expect(readAgentsViewDefault()).toBe(AGENTS_VIEW_DEFAULT);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("stores graph and clears the key for list", () => {
+    writeAgentsViewDefault("graph");
+    expect(readAgentsViewDefault()).toBe("graph");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("graph");
+
+    writeAgentsViewDefault("list");
+    expect(readAgentsViewDefault()).toBe("list");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("falls back to list when the stored value is unknown", () => {
+    localStorage.setItem(STORAGE_KEY, "tree");
+    expect(readAgentsViewDefault()).toBe("list");
+  });
+});
+
+describe("normalizeAgentsViewMode", () => {
+  it("passes through valid values", () => {
+    expect(normalizeAgentsViewMode("list")).toBe("list");
+    expect(normalizeAgentsViewMode("graph")).toBe("graph");
+  });
+
+  it("maps unknown, null, and garbage to list", () => {
+    expect(normalizeAgentsViewMode("tree")).toBe("list");
+    expect(normalizeAgentsViewMode("bogus")).toBe("list");
+    expect(normalizeAgentsViewMode(null)).toBe("list");
+    expect(normalizeAgentsViewMode(undefined)).toBe("list");
+  });
+});

--- a/web/src/lib/agentsViewPreferences.ts
+++ b/web/src/lib/agentsViewPreferences.ts
@@ -1,0 +1,47 @@
+// Browser-local default for each new Agents panel mount. In-panel toggles stay
+// ephemeral and do not update this preference.
+
+const STORAGE_KEY = "omnigent:default-agents-view";
+
+export const agentsViewModes = ["list", "graph"] as const;
+export type AgentsViewMode = (typeof agentsViewModes)[number];
+
+/** Match today's product default: the Agents panel opens in list view. */
+export const AGENTS_VIEW_DEFAULT: AgentsViewMode = "list";
+
+/** Return whether a string is one of the selectable Agents panel view modes. */
+export function isAgentsViewMode(value: string | null | undefined): value is AgentsViewMode {
+  return value === "list" || value === "graph";
+}
+
+/** Normalize persisted or manually edited values to the product default. */
+export function normalizeAgentsViewMode(value: string | null | undefined): AgentsViewMode {
+  return isAgentsViewMode(value) ? value : AGENTS_VIEW_DEFAULT;
+}
+
+/** Read the persisted view, falling back safely for unavailable storage. */
+export function readAgentsViewDefault(): AgentsViewMode {
+  if (typeof window === "undefined") return AGENTS_VIEW_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return AGENTS_VIEW_DEFAULT;
+    return normalizeAgentsViewMode(raw);
+  } catch {
+    return AGENTS_VIEW_DEFAULT;
+  }
+}
+
+/** Persist the view; the product default clears the storage key. */
+export function writeAgentsViewDefault(value: AgentsViewMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    const normalized = normalizeAgentsViewMode(value);
+    if (normalized === AGENTS_VIEW_DEFAULT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, normalized);
+    }
+  } catch {
+    // localStorage quota or access errors shouldn't break settings.
+  }
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -337,7 +337,10 @@ describe("SettingsPage", () => {
     renderPage("/settings/appearance");
     expect(screen.getByRole("radiogroup", { name: "Default Agents view" })).toBeInTheDocument();
     expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByTestId("agents-view-default-graph")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("agents-view-default-graph")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
     expect(localStorage.getItem("omnigent:default-agents-view")).toBeNull();
   });
 

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -333,6 +333,34 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "false");
   });
 
+  it("renders the Default Agents view radiogroup with list selected by default", () => {
+    renderPage("/settings/appearance");
+    expect(screen.getByRole("radiogroup", { name: "Default Agents view" })).toBeInTheDocument();
+    expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("agents-view-default-graph")).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBeNull();
+  });
+
+  it("persists the Default Agents view graph choice on card click", () => {
+    renderPage("/settings/appearance");
+
+    fireEvent.click(screen.getByTestId("agents-view-default-graph"));
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBe("graph");
+    expect(screen.getByTestId("agents-view-default-graph")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByTestId("agents-view-default-list"));
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBeNull();
+    expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("seeds Default Agents view from a stored graph preference", () => {
+    localStorage.setItem("omnigent:default-agents-view", "graph");
+    renderPage("/settings/appearance");
+    expect(screen.getByTestId("agents-view-default-graph")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "false");
+  });
+
   it("reflects a stored light terminal theme on mount", () => {
     localStorage.setItem("omnigent:terminal-theme", "light");
     renderPage("/settings/appearance");
@@ -556,6 +584,7 @@ describe("SettingsPage", () => {
     });
     fireEvent.click(screen.getByTestId("transcript-view-default-terminal"));
     fireEvent.click(screen.getByTestId("workspace-panel-default-collapsed"));
+    fireEvent.click(screen.getByTestId("agents-view-default-graph"));
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
@@ -573,6 +602,7 @@ describe("SettingsPage", () => {
     expect(localStorage.getItem("omnigent:terminal-theme")).toBe("dark");
     expect(localStorage.getItem("omnigent:default-transcript-view")).toBe("terminal");
     expect(localStorage.getItem("omnigent:ui-theme-palette")).toBe(JSON.stringify("github"));
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBe("graph");
     expect(localStorage.getItem("omnigent:ui-font-size")).toBe("15");
     expect(localStorage.getItem("omnigent:code-font-size")).toBe("15");
     expect(localStorage.getItem("omnigent:code-font-weight")).toBe("500");
@@ -599,7 +629,7 @@ describe("SettingsPage", () => {
     expect((screen.getByTestId("color-theme-select") as HTMLSelectElement).value).toBe("omni");
     expect(document.documentElement.getAttribute("data-theme")).toBeNull();
 
-    // Terminal theme, transcript view, workspace panel, and harness visibility are restored.
+    // Terminal theme, transcript view, workspace panel, agents view, and harness visibility reset.
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "true");
     expect(screen.getByTestId("transcript-view-default-chat")).toHaveAttribute(
       "aria-checked",
@@ -609,6 +639,8 @@ describe("SettingsPage", () => {
       "aria-checked",
       "true",
     );
+    expect(screen.getByTestId("agents-view-default-list")).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBeNull();
     expect(screen.getByTestId("hide-unconfigured-harnesses-toggle")).toHaveAttribute(
       "aria-checked",
       "false",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -11,7 +11,8 @@
  *
  * - **General** — app-wide behavior preferences.
  * - **Appearance** — theme mode (System / Light / Dark), terminal theme,
- *   default transcript view, Workspace panel default, and UI/code font controls.
+ *   default transcript view, Workspace panel default for new chats, default
+ *   Agents panel view, and UI/code font controls.
  * - **Git** — Git behavior: the global "always use a random worktree" default
  *   and the default base branch pre-filled when naming a new worktree branch.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
@@ -47,11 +48,13 @@ import {
   KeyRoundIcon,
   Loader2Icon,
   LaptopMinimalIcon,
+  ListIcon,
   LogOutIcon,
   MessagesSquareIcon,
   MinusIcon,
   MonitorIcon,
   MoonIcon,
+  NetworkIcon,
   PanelRightCloseIcon,
   PanelRightIcon,
   PlusIcon,
@@ -165,6 +168,12 @@ import {
   writeTranscriptViewDefault,
   type TranscriptViewDefault,
 } from "@/lib/transcriptViewPreferences";
+import {
+  AGENTS_VIEW_DEFAULT,
+  readAgentsViewDefault,
+  writeAgentsViewDefault,
+  type AgentsViewMode,
+} from "@/lib/agentsViewPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysSteer, writeAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import {
@@ -369,6 +378,15 @@ const workspacePanelCards: {
   { value: "collapsed", label: "Collapsed", icon: PanelRightCloseIcon },
 ];
 
+const agentsViewCards: {
+  value: AgentsViewMode;
+  label: string;
+  icon: typeof ListIcon;
+}[] = [
+  { value: "list", label: "List", icon: ListIcon },
+  { value: "graph", label: "Graph", icon: NetworkIcon },
+];
+
 /** Centered icon + label body shared by the Mode and Terminal theme cards. */
 function iconCardBody(Icon: typeof SunIcon, label: string) {
   return (
@@ -527,6 +545,36 @@ function WorkspacePanelDefaultControl() {
         items={workspacePanelCards.map((card) => ({
           value: card.value,
           testId: `workspace-panel-default-${card.value}`,
+          body: iconCardBody(card.icon, card.label),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
+/** Default List vs Graph view for each new Agents panel mount. */
+function AgentsViewDefaultControl() {
+  const [value, setValue] = useState(() => readAgentsViewDefault());
+  const labelId = useId();
+  const choose = useCallback((next: AgentsViewMode) => {
+    setValue(next);
+    writeAgentsViewDefault(next);
+  }, []);
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Default Agents view"
+      helper="Whether the Agents panel opens in list or graph view. Switching inside the panel only lasts until it remounts."
+    >
+      <CardRadioGroup<AgentsViewMode>
+        labelledBy={labelId}
+        value={value}
+        onSelect={choose}
+        className="grid grid-cols-2 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={agentsViewCards.map((card) => ({
+          value: card.value,
+          testId: `agents-view-default-${card.value}`,
           body: iconCardBody(card.icon, card.label),
         }))}
       />
@@ -775,6 +823,8 @@ function AppearanceSection() {
 
     writeWorkspacePanelDefault(WORKSPACE_PANEL_DEFAULT);
 
+    writeAgentsViewDefault(AGENTS_VIEW_DEFAULT);
+
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
 
     applyDesktopUiFontSize(UI_FONT_SIZE_DEFAULT);
@@ -801,6 +851,7 @@ function AppearanceSection() {
           "omnigent:custom-theme",
           "omnigent:default-transcript-view",
           "omnigent:default-workspace-panel",
+          "omnigent:default-agents-view",
           "omnigent:hide-unconfigured-harnesses",
         ]) {
           window.localStorage.removeItem(key);
@@ -884,6 +935,8 @@ function AppearanceSection() {
         <TranscriptViewDefaultControl />
 
         <WorkspacePanelDefaultControl />
+
+        <AgentsViewDefaultControl />
 
         <HideUnconfiguredHarnessesControl />
 

--- a/web/src/shell/SubagentsGraphView.test.tsx
+++ b/web/src/shell/SubagentsGraphView.test.tsx
@@ -140,9 +140,13 @@ beforeEach(() => {
   useChildSessionsMock.mockReset();
   useSessionMock.mockReset();
   useSessionMock.mockReturnValue(defaultSession());
+  localStorage.clear();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
 // ===========================================================================
 // Unit tests: childActivity
@@ -579,7 +583,7 @@ describe("buildTree", () => {
 // ===========================================================================
 
 describe("SubagentsPanel view-mode toggle", () => {
-  it("defaults to list view", () => {
+  it("defaults to list view when no preference is stored", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
 
     renderPanel();
@@ -588,6 +592,34 @@ describe("SubagentsPanel view-mode toggle", () => {
     expect(screen.getByTestId("view-mode-graph")).toBeInTheDocument();
     expect(screen.getByTestId("subagent-main-row")).toBeInTheDocument();
     expect(screen.queryByTestId("subagents-graph-view")).toBeNull();
+  });
+
+  it("starts in graph view when the Appearance preference is graph", async () => {
+    localStorage.setItem("omnigent:default-agents-view", "graph");
+    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+
+    renderPanel();
+
+    expect(await screen.findByTestId("subagents-graph-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("subagent-main-row")).toBeNull();
+  });
+
+  it("keeps an in-panel list switch ephemeral without writing the preference", async () => {
+    localStorage.setItem("omnigent:default-agents-view", "graph");
+    mockChildTree({
+      conv_root: [childInfo({ id: "c1", tool: "researcher" })],
+    });
+
+    const { unmount } = renderPanel();
+
+    expect(await screen.findByTestId("subagents-graph-view")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("view-mode-list"));
+    expect(screen.getByTestId("subagent-main-row")).toBeInTheDocument();
+    expect(localStorage.getItem("omnigent:default-agents-view")).toBe("graph");
+
+    unmount();
+    renderPanel();
+    expect(await screen.findByTestId("subagents-graph-view")).toBeInTheDocument();
   });
 
   it("switches to graph view when the graph button is clicked", async () => {

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -32,6 +32,7 @@ import {
   ScanSearchIcon,
   SearchIcon,
 } from "lucide-react";
+import { type AgentsViewMode, readAgentsViewDefault } from "@/lib/agentsViewPreferences";
 import { Link, useLocation } from "@/lib/routing";
 import { Badge } from "@/components/ui/badge";
 import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
@@ -108,12 +109,12 @@ interface SubagentsPanelProps {
   rootSessionId: string;
 }
 
-type ViewMode = "list" | "graph";
-
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
   const { children, isLoading, error } = useChildSessions(rootSessionId);
   const [addOpen, setAddOpen] = useState(false);
-  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  // Appearance "Default Agents view" seeds this mount; the toggle below only
+  // changes the current panel instance and does not write the preference.
+  const [viewMode, setViewMode] = useState<AgentsViewMode>(() => readAgentsViewDefault());
   const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>({});
   const toggleCollapsedRow = (id: string) => {
     setCollapsedRows((current) => ({ ...current, [id]: !current[id] }));
@@ -191,8 +192,8 @@ function ViewModeToggle({
   viewMode,
   onViewModeChange,
 }: {
-  viewMode: ViewMode;
-  onViewModeChange: (mode: ViewMode) => void;
+  viewMode: AgentsViewMode;
+  onViewModeChange: (mode: AgentsViewMode) => void;
 }) {
   return (
     <div className="flex shrink-0 items-center justify-end gap-0.5 border-b px-2 py-1">


### PR DESCRIPTION
## Related issue

Closes #4422 — Add a setting for the default Agents panel view (List vs Graph)

## Summary

Appearance settings now include a browser-local List versus Graph default for newly mounted Agents panels. In-panel switches remain temporary for the current mount, and Reset to defaults restores List while safely handling missing or invalid stored values.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/lib/agentsViewPreferences.test.ts src/shell/SubagentsGraphView.test.tsx src/pages/SettingsPage.test.tsx` — 102 passed
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_agents_view_default.py -v` — 1 passed in Chromium
- `pnpm run type-check` — passed
- Focused oxlint and Ruff checks — passed
- `pnpm run build` — passed
- Commit hooks and secret scanning passed

## Demo

![Appearance setting with Graph selected as the default Agents view](https://github.com/user-attachments/assets/62533421-a2b0-4681-8cad-8164128ee4d4)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover storage parsing and fallback, Appearance selection and reset, panel initialization, persisted Graph defaults across mounts, and ephemeral in-panel switching. Manual browser verification confirmed the Graph selection persisted.

## Changelog

Choose whether newly opened Agents panels start in List or Graph view.