### PR TITLE
chore(deps): move OpenTelemetry packages to tracing extra

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -212,7 +212,7 @@ class _ClassifiedWheels:
     """Result of sorting built wheels by size for upload routing.
 
     :param main: The top-level ``omnigent`` wheel — always uploaded
-        with the ``[databricks]`` extra.
+        with the ``[databricks,tracing]`` extras.
     :param small: Wheels ≤ 10 MB. Uploaded into the bundle's
         ``source_code_path`` and referenced by relative path.
     :param oversize: Wheels > 10 MB. These cannot be used by the
@@ -369,7 +369,7 @@ def build_uv_pyproject(
     """
     source_lines = _uv_source_lines(main_wheel, small_wheels, oversize_wheels)
     dependencies = [
-        f'"omnigent[databricks]=={deploy_version}"',
+        f'"omnigent[databricks,tracing]=={deploy_version}"',
         f'"omnigent-client=={deploy_version}"',
         f'"omnigent-ui-sdk=={deploy_version}"',
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,11 +87,8 @@ dependencies = [
     # PostgreSQL, and MySQL rather than depending on each backend's storage engine.
     "zstandard>=0.22,<1",
     "tiktoken>=0.7,<1",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.20,<2",
-    "opentelemetry-exporter-otlp-proto-http>=1.20,<2",
-    "opentelemetry-instrumentation-fastapi>=0,<1",
-    "opentelemetry-instrumentation-httpx>=0,<1",
-    "opentelemetry-instrumentation-sqlalchemy>=0,<1",
+    # Server performance metrics use the no-op API even when tracing is off.
+    "opentelemetry-api>=1.20,<2",
     # The Claude Code and OpenAI Agents harnesses are part of the
     # baseline install — every CUJ command in the README depends on at
     # least one of them, so making them optional just forces every user
@@ -126,11 +123,17 @@ dependencies = [
 # working; the underlying packages are now default deps above.
 claude-sdk = []
 openai-agents = []
-# `all` additionally carries databricks-sdk: the SDK moved out of the
-# default install (it now lives in the `databricks` extra), but internal
-# CI / dev installs use `--extra all` and the test suite, deploy tooling,
-# and databricks_mcps servers import it.
-all = ["databricks-sdk>=0.56.0,<1"]
+# `all` carries dependencies moved out of the default install that internal
+# CI / dev workflows still exercise.
+all = [
+    "databricks-sdk>=0.56.0,<1",
+    "opentelemetry-sdk>=1.20,<2",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.20,<2",
+    "opentelemetry-instrumentation-fastapi>=0,<1",
+    "opentelemetry-instrumentation-httpx>=0,<1",
+    "opentelemetry-instrumentation-sqlalchemy>=0,<1",
+]
 # From omnigent.
 bedrock = ["boto3>=1.30,<2", "botocore>=1.30,<2"]
 # S3-compatible artifact store (AWS S3, Cloudflare R2, MinIO, …). Selected
@@ -176,11 +179,16 @@ openshell = ["openshell>=0.0.88,<1"]
 # package and imports the official client lazily, so only users of the
 # provider need this extra.
 kubernetes = ["kubernetes>=36,<37"]
-# The tracing extra is now a no-op shim kept for backwards compatibility.
-# Tracing is built on OpenTelemetry directly (opentelemetry-exporter-otlp-*
-# are in the default install). `omnigent[tracing]` still works — it just
-# no longer pulls in the heavy mlflow dependency.
-tracing = []
+# OpenTelemetry tracing is opt-in so the exporters and automatic
+# instrumentors do not inflate the default install.
+tracing = [
+    "opentelemetry-sdk>=1.20,<2",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.20,<2",
+    "opentelemetry-instrumentation-fastapi>=0,<1",
+    "opentelemetry-instrumentation-httpx>=0,<1",
+    "opentelemetry-instrumentation-sqlalchemy>=0,<1",
+]
 agents-sdk = [
     "openai-agents>=0.1,<1",
     "opentelemetry-instrumentation-openai-agents-v2>=0.1",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -45,6 +45,12 @@ ignore-missing-imports = [
     "numpy",
     "numpy.*",
     "omnigent.onboarding.internal_beta",
+    "opentelemetry.exporter",
+    "opentelemetry.exporter.*",
+    "opentelemetry.instrumentation",
+    "opentelemetry.instrumentation.*",
+    "opentelemetry.sdk",
+    "opentelemetry.sdk.*",
     "openshell",
     "openshell.*",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3238,11 +3238,7 @@ dependencies = [
     { name = "omnigent-ui-sdk" },
     { name = "openai" },
     { name = "openai-agents" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-fastapi" },
-    { name = "opentelemetry-instrumentation-httpx" },
-    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-api" },
     { name = "packaging" },
     { name = "pexpect", marker = "sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
@@ -3270,6 +3266,12 @@ agents-sdk = [
 ]
 all = [
     { name = "databricks-sdk" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-sdk" },
 ]
 antigravity = [
     { name = "google-antigravity" },
@@ -3368,6 +3370,14 @@ s3 = [
 slack = [
     { name = "omnigent-slack" },
 ]
+tracing = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-sdk" },
+]
 vertex = [
     { name = "google-auth" },
 ]
@@ -3427,13 +3437,21 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.0.17" },
     { name = "openai-agents", marker = "extra == 'agents-sdk'", specifier = ">=0.1,<1" },
     { name = "openshell", marker = "extra == 'openshell'", specifier = ">=0.0.88,<1" },
+    { name = "opentelemetry-api", specifier = ">=1.20,<2" },
     { name = "opentelemetry-distro", marker = "extra == 'databricks'", specifier = ">=0,<1" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20,<2" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20,<2" },
-    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0,<1" },
-    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0,<1" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'all'", specifier = ">=1.20,<2" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'tracing'", specifier = ">=1.20,<2" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'all'", specifier = ">=1.20,<2" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'tracing'", specifier = ">=1.20,<2" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'all'", specifier = ">=0,<1" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'tracing'", specifier = ">=0,<1" },
+    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'all'", specifier = ">=0,<1" },
+    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'tracing'", specifier = ">=0,<1" },
     { name = "opentelemetry-instrumentation-openai-agents-v2", marker = "extra == 'agents-sdk'", specifier = ">=0.1" },
-    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0,<1" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", marker = "extra == 'all'", specifier = ">=0,<1" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", marker = "extra == 'tracing'", specifier = ">=0,<1" },
+    { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.20,<2" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20,<2" },
     { name = "packaging", specifier = ">=23,<26" },
     { name = "pathspec", marker = "extra == 'dev'", specifier = ">=0.12" },
     { name = "pexpect", marker = "sys_platform != 'win32'", specifier = ">=4.9,<5" },


### PR DESCRIPTION
## Related issue

[OMNI-2505](https://linear.app/omnigent/issue/OMNI-2505/move-otel-dependencies-into-extra)

## Summary

- Keep the default installation lean by moving OTLP exporters and automatic instrumentors into `omnigent[tracing]`.
- Retain the lightweight OpenTelemetry API in the base package for server performance metrics and declare the SDK directly in tracing-enabled installs.
- Preserve tracing dependencies in internal `all` installs and Databricks deployments.

## Test Plan

- `uv run pytest tests/runtime/test_telemetry.py`
- Verified a bare isolated installation imports `omnigent.server.app`.
- Verified an isolated `--extra tracing` installation imports the SDK, exporters, and FastAPI, HTTPX, and SQLAlchemy instrumentors.
- `uv run --frozen pre-commit run --files pyproject.toml uv.lock deploy/databricks/deploy.py`

## Demo

N/A — dependency metadata only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Validated both dependency modes in isolated environments: the base install can import the server, while the tracing extra provides every exporter and instrumentor used by telemetry initialization. The existing telemetry unit suite covers runtime behavior.

## Changelog

OpenTelemetry exporters and automatic instrumentors are now installed through `omnigent[tracing]` instead of the default package.
