### PR TITLE
fix(android): use the Omnigent creature mark for the notification icon

### DIFF
--- a/web/android/app/src/main/res/drawable/ic_notification.xml
+++ b/web/android/app/src/main/res/drawable/ic_notification.xml
@@ -4,7 +4,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:tint="#FFFFFF">
+    <!-- Android notification icons are monochrome alpha masks; only silhouette and cutouts survive tinting. -->
     <path
         android:fillColor="#000000"
-        android:pathData="M12,2L2,7v10l10,5 10,-5V7L12,2zM12,4.2l6.9,3.45L12,11.1 5.1,7.65 12,4.2zM4,9.3l7,3.5v6.9l-7,-3.5V9.3zM13,19.7v-6.9l7,-3.5v6.9l-7,3.5z" />
+        android:fillType="evenOdd"
+        android:pathData="M12.5 1.5C14.3 1.5 14.9 3.5 15.4 5.8C15.8 7.4 16.3 8.4 17.5 8.7C18.7 9 20.1 8.4 21.4 7.9C22.3 7.6 22.5 8.4 22.4 9.5C22.3 11.4 20.9 12.8 19.2 14.2C18 15.2 18.1 16.1 18.6 17.5C19.2 19.2 19.8 21.3 18.5 22C17.2 22.6 15.1 20.9 13.8 20C13.1 19.5 12.5 19.2 11.9 19.3C10.9 19.4 9.7 20.6 8.4 21.4C7 22.3 5.3 22.4 4.7 21.3C4.1 20.2 4.6 18.4 5.2 16.8C5.8 15.2 5.4 14.4 4.3 13.4C2.8 12.2 1.5 10.7 1.5 9.1C1.5 8.1 2 7.3 3.1 7.5C5.1 7.8 6.8 9 8.1 8.5C9.3 8 9.7 6.1 10 4.7C10.4 2.7 10.9 1.5 12.5 1.5ZM7.9 11.4a1.7 1.7 0 1 0 3.4 0a1.7 1.7 0 1 0-3.4 0ZM12.7 11.4a1.7 1.7 0 1 0 3.4 0a1.7 1.7 0 1 0-3.4 0Z" />
 </vector>


### PR DESCRIPTION
## Related issue

Fixes #4622

## Summary

Android status-bar small icons are system-tinted monochrome alpha masks: color and fine interior detail are discarded. The previously shipped icon was a generic isometric cube, while reusing the full launcher creature mark was also rejected because its pupils and nested sub-creature disappear entirely at 24dp.

This ships a purpose-built five-lobed creature silhouette with bold eye cutouts that survive at status-bar size. The drawable is now one 586-character path instead of the reused 4,332-character path, which also clears Android lint's `VectorPath` “very long vector path” warning.

**ELI5:** Android treats the small icon like a stencil, so this uses one simple creature-shaped stencil with two large eye holes instead of shrinking detailed artwork until it disappears.

```text
detailed launcher art -> simplify for alpha mask -> silhouette + bold eye holes -> Android tint
```

## Test Plan

- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --files web/android/app/src/main/res/drawable/ic_notification.xml` — passed all applicable hooks.
- From `web/android`: `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:lintDebug` — **BUILD SUCCESSFUL** in 14 seconds; 29 tasks completed or were up to date.
- Converted the final VectorDrawable to SVG while preserving `evenOdd`, rasterized it at 96px, 48px, 24px, and 16px, and compared each render against approved candidate B with ImageMagick. `magick compare -metric AE` returned `0` at every size.
- Inspected alpha-only white-on-dark composites at 24px and 16px; the five-lobed silhouette remains distinct and both eye cutouts remain separate.

## Demo

**24px system-tinted alpha-mask view** (shown enlarged):

<img src="https://raw.githubusercontent.com/btli/omnigent/942543b30a80f33d9d6077347907becc71117b99/pr-4623/notification-icon-24px-dark.png" width="144" alt="Approved Omnigent notification glyph rendered white on a dark status-bar background at 24 pixels">

**96px detail view:**

<img src="https://raw.githubusercontent.com/btli/omnigent/942543b30a80f33d9d6077347907becc71117b99/pr-4623/notification-icon-96px-detail.png" width="192" alt="Approved simplified Omnigent notification glyph at 96 pixels">

**Previous cube vs. purpose-built creature glyph:**

<img src="https://raw.githubusercontent.com/btli/omnigent/942543b30a80f33d9d6077347907becc71117b99/pr-4623/old-cube-vs-new-glyph.png" width="560" alt="Side-by-side comparison of the previous cube and new Omnigent creature notification glyph">

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is a static VectorDrawable asset, so automated unit, integration, and E2E coverage is not applicable. Manual verification covered Android resource linting, exact raster comparison against the approved design at four sizes, alpha-mask behavior, viewport containment, and visual legibility of the silhouette and eye cutouts at 24px and 16px.

## Changelog

Android notifications now use a legible Omnigent creature icon in the status bar.
