### PR TITLE
fix(skills): resolve read_skill_file against the same registry as load_skill

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -7122,9 +7122,9 @@ def _execute_skill_tool(
     """
     Runner-local handler for ``load_skill`` and ``read_skill_file``.
 
-    Instantiates the tool with the agent spec's bundled skills
-    plus host-scope discovery from the runner workspace, then
-    invokes it.
+    Both tools are built from one registry — the agent spec's bundled
+    skills merged with host-scope discovery from the runner workspace —
+    so anything ``load_skill`` can load, ``read_skill_file`` can read.
 
     :param tool_name: ``"load_skill"`` or ``"read_skill_file"``.
     :param args: Parsed JSON arguments from the LLM.
@@ -7144,15 +7144,14 @@ def _execute_skill_tool(
     # agent's own bundle to ship a skills/ directory.
     bundled_skills = _inject_orchestrator_skills(bundled_skills, agent_spec)
 
-    tool: Tool
-    if tool_name == "load_skill":
-        tool = LoadSkillTool(
-            bundled_skills,
-            agent_root=runner_workspace,
-            skills_filter=skills_filter,
-        )
-    else:
-        tool = ReadSkillFileTool(bundled_skills)
+    # Both tools must resolve the same registry: a skill load_skill can load
+    # from host scope must have its files readable too.
+    load_tool = LoadSkillTool(
+        bundled_skills,
+        agent_root=runner_workspace,
+        skills_filter=skills_filter,
+    )
+    tool: Tool = load_tool if tool_name == "load_skill" else ReadSkillFileTool(load_tool.skills)
 
     arguments_json = json.dumps(args)
     from omnigent.tools.base import ToolContext

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -355,7 +355,7 @@ def any_skill_has_resources(
     :param skills: The agent's skill list, e.g.
         ``[SkillSpec(name="code-review", ...)]``.
     :returns: ``True`` if at least one skill has a
-        ``skill_dir`` with files in references/, scripts/,
-        or assets/.
+        ``skill_dir`` with files beside SKILL.md, or in
+        references/, scripts/, or assets/.
     """
     return any(list_skill_resources(s) for s in skills)

--- a/omnigent/tools/builtins/load_skill.py
+++ b/omnigent/tools/builtins/load_skill.py
@@ -145,18 +145,24 @@ def list_skill_resources(skill: SkillSpec) -> list[str]:
     """
     List resource files in a skill's directory.
 
-    Scans ``references/``, ``scripts/``, and ``assets/``
-    subdirectories. Returns relative paths suitable for
-    ``read_skill_file``.
+    Covers auxiliary files beside ``SKILL.md`` (a common layout for
+    skills that split long guidance across sibling documents) plus
+    everything under ``references/``, ``scripts/``, and ``assets/``.
+    Returns relative paths suitable for ``read_skill_file``.
 
     :param skill: The skill to scan.
-    :returns: Sorted list of relative path strings, e.g.
-        ``["references/style-guide.md"]``. Empty if the
-        skill has no ``skill_dir`` or no resource files.
+    :returns: List of relative path strings, e.g.
+        ``["DEEPENING.md", "references/style-guide.md"]``. Root-level
+        files come first, each group sorted. Empty if the skill has no
+        ``skill_dir`` or no resource files.
     """
-    if skill.skill_dir is None:
+    if skill.skill_dir is None or not skill.skill_dir.is_dir():
         return []
     files: list[str] = []
+    for fp in sorted(skill.skill_dir.iterdir()):
+        # Dotfiles are editor/OS cruft, and SKILL.md is the skill itself.
+        if fp.is_file() and fp.name != "SKILL.md" and not fp.name.startswith("."):
+            files.append(fp.name)
     for subdir_name in ("references", "scripts", "assets"):
         subdir = skill.skill_dir / subdir_name
         if not subdir.is_dir():

--- a/omnigent/tools/builtins/read_skill_file.py
+++ b/omnigent/tools/builtins/read_skill_file.py
@@ -43,8 +43,9 @@ class ReadSkillFileTool(Tool):
         :returns: Human-readable description of the tool.
         """
         return (
-            "Read a file from a skill's directory "
-            "(references/, scripts/, or assets/). "
+            "Read a file from a skill's directory, "
+            "including files beside SKILL.md and under "
+            "references/, scripts/, or assets/. "
             "Requires the skill name and a relative "
             "file path."
         )
@@ -60,8 +61,9 @@ class ReadSkillFileTool(Tool):
             "function": {
                 "name": "read_skill_file",
                 "description": (
-                    "Read a file from a skill's directory "
-                    "(references/, scripts/, or assets/). "
+                    "Read a file from a skill's directory, "
+                    "including files beside SKILL.md and under "
+                    "references/, scripts/, or assets/. "
                     "Requires the skill name and a relative "
                     "file path."
                 ),

--- a/tests/runner/test_skill_tool_dispatch.py
+++ b/tests/runner/test_skill_tool_dispatch.py
@@ -1,0 +1,121 @@
+"""Tests for the runner's load_skill / read_skill_file dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent.runner.tool_dispatch import _execute_skill_tool
+
+SKILL_MD = (
+    "---\n"
+    "name: example\n"
+    "description: An example skill.\n"
+    "---\n"
+    "\n"
+    "Body of the example skill.\n"
+)
+
+
+def _write_host_skill(workspace: Path) -> None:
+    """Install a host-scope skill with a root-level auxiliary file."""
+    skill_dir = workspace / ".claude" / "skills" / "example"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD)
+    (skill_dir / "EXTRA.md").write_text("Auxiliary content.\n")
+
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin HOME so host-skill discovery cannot read the developer's own skills."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def test_read_skill_file_resolves_host_scope_skill(
+    tmp_path: Path,
+    isolated_home: Path,
+) -> None:
+    """A skill load_skill can load, read_skill_file can read."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_host_skill(workspace)
+    spec = SimpleNamespace(skills=[], skills_filter="all")
+
+    loaded = _execute_skill_tool(
+        "load_skill",
+        {"name": "example"},
+        agent_spec=spec,
+        runner_workspace=workspace,
+    )
+    assert "Body of the example skill." in loaded
+
+    read = _execute_skill_tool(
+        "read_skill_file",
+        {"skill_name": "example", "path": "EXTRA.md"},
+        agent_spec=spec,
+        runner_workspace=workspace,
+    )
+    assert read == "Auxiliary content.\n"
+
+
+def test_read_skill_file_resolves_bundled_skill(
+    tmp_path: Path,
+    isolated_home: Path,
+) -> None:
+    """Bundled skills keep working — the fix must not regress them."""
+    from omnigent.spec.types import SkillSpec
+
+    skill_dir = tmp_path / "bundle" / "skills" / "bundled"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD)
+    (skill_dir / "NOTES.md").write_text("Bundled notes.\n")
+    spec = SimpleNamespace(
+        skills=[
+            SkillSpec(
+                name="bundled",
+                description="A bundled skill.",
+                content="Bundled body.",
+                skill_dir=skill_dir,
+            )
+        ],
+        skills_filter="all",
+    )
+
+    read = _execute_skill_tool(
+        "read_skill_file",
+        {"skill_name": "bundled", "path": "NOTES.md"},
+        agent_spec=spec,
+        runner_workspace=tmp_path / "bundle",
+    )
+    assert read == "Bundled notes.\n"
+
+
+def test_skill_tools_agree_when_filter_suppresses_host_skills(
+    tmp_path: Path,
+    isolated_home: Path,
+) -> None:
+    """skills_filter='none' hides the skill from BOTH tools, not just one."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_host_skill(workspace)
+    spec = SimpleNamespace(skills=[], skills_filter="none")
+
+    loaded = _execute_skill_tool(
+        "load_skill",
+        {"name": "example"},
+        agent_spec=spec,
+        runner_workspace=workspace,
+    )
+    read = _execute_skill_tool(
+        "read_skill_file",
+        {"skill_name": "example", "path": "EXTRA.md"},
+        agent_spec=spec,
+        runner_workspace=workspace,
+    )
+    assert "not found" in loaded
+    assert "not found" in read

--- a/tests/runner/test_skill_tool_dispatch.py
+++ b/tests/runner/test_skill_tool_dispatch.py
@@ -10,12 +10,7 @@ import pytest
 from omnigent.runner.tool_dispatch import _execute_skill_tool
 
 SKILL_MD = (
-    "---\n"
-    "name: example\n"
-    "description: An example skill.\n"
-    "---\n"
-    "\n"
-    "Body of the example skill.\n"
+    "---\nname: example\ndescription: An example skill.\n---\n\nBody of the example skill.\n"
 )
 
 

--- a/tests/runner/test_skill_tool_dispatch.py
+++ b/tests/runner/test_skill_tool_dispatch.py
@@ -114,3 +114,44 @@ def test_skill_tools_agree_when_filter_suppresses_host_skills(
     )
     assert "not found" in loaded
     assert "not found" in read
+
+
+def test_load_then_read_auxiliary_file_reported_sequence(
+    tmp_path: Path,
+    isolated_home: Path,
+) -> None:
+    """load_skill advertises the auxiliary file, and read_skill_file returns it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    skill_dir = workspace / ".claude" / "skills" / "codebase-design"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: codebase-design\ndescription: Designs codebases.\n---\n\nDesign body.\n"
+    )
+    (skill_dir / "DEEPENING.md").write_text("Deepening content.\n")
+    (skill_dir / "DESIGN-IT-TWICE.md").write_text("Design it twice content.\n")
+    spec = SimpleNamespace(skills=[], skills_filter="all")
+
+    loaded = _execute_skill_tool(
+        "load_skill",
+        {"name": "codebase-design"},
+        agent_spec=spec,
+        runner_workspace=workspace,
+    )
+    assert "## Available files" in loaded
+    assert "- DEEPENING.md" in loaded
+    assert "- DESIGN-IT-TWICE.md" in loaded
+
+    for path, expected in (
+        ("DEEPENING.md", "Deepening content.\n"),
+        ("DESIGN-IT-TWICE.md", "Design it twice content.\n"),
+    ):
+        assert (
+            _execute_skill_tool(
+                "read_skill_file",
+                {"skill_name": "codebase-design", "path": path},
+                agent_spec=spec,
+                runner_workspace=workspace,
+            )
+            == expected
+        )

--- a/tests/tools/builtins/test_load_skill.py
+++ b/tests/tools/builtins/test_load_skill.py
@@ -146,3 +146,62 @@ def test_load_skill_schema_lists_skill_names(
     desc = schema["function"]["description"]
     assert "summarize" in desc
     assert "code-review" in desc
+
+
+def test_list_skill_resources_includes_root_level_files(tmp_path: Path) -> None:
+    """Auxiliary docs beside SKILL.md are readable resources."""
+    from omnigent.tools.builtins.load_skill import list_skill_resources
+
+    skill_dir = tmp_path / "codebase-design"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("body")
+    (skill_dir / "DEEPENING.md").write_text("deepening")
+    (skill_dir / "DESIGN-IT-TWICE.md").write_text("twice")
+    skill = SkillSpec(
+        name="codebase-design",
+        description="Designs codebases.",
+        content="body",
+        skill_dir=skill_dir,
+    )
+
+    assert list_skill_resources(skill) == ["DEEPENING.md", "DESIGN-IT-TWICE.md"]
+
+
+def test_list_skill_resources_excludes_skill_md_and_dotfiles(tmp_path: Path) -> None:
+    """SKILL.md is the skill itself, and dotfiles are not content."""
+    from omnigent.tools.builtins.load_skill import list_skill_resources
+
+    skill_dir = tmp_path / "example"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("body")
+    (skill_dir / ".DS_Store").write_text("junk")
+    skill = SkillSpec(
+        name="example",
+        description="An example.",
+        content="body",
+        skill_dir=skill_dir,
+    )
+
+    assert list_skill_resources(skill) == []
+
+
+def test_list_skill_resources_lists_root_files_before_subdirs(tmp_path: Path) -> None:
+    """Root files come first; subdir entries keep their relative paths."""
+    from omnigent.tools.builtins.load_skill import list_skill_resources
+
+    skill_dir = tmp_path / "example"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("body")
+    (skill_dir / "EXTRA.md").write_text("extra")
+    (skill_dir / "references" / "style-guide.md").write_text("style")
+    skill = SkillSpec(
+        name="example",
+        description="An example.",
+        content="body",
+        skill_dir=skill_dir,
+    )
+
+    assert list_skill_resources(skill) == [
+        "EXTRA.md",
+        "references/style-guide.md",
+    ]

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -299,11 +299,17 @@ def test_schemas_include_read_skill_file_with_resources(
 
 def test_schemas_exclude_read_skill_file_without_resources(
     skill_no_resources: SkillSpec,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     get_tool_schemas does NOT include read_skill_file when
     no skill has bundled resources.
     """
+    # Host-scope skill discovery falls back to cwd; run from an empty
+    # directory so this repo's own .claude/skills/ doesn't contribute
+    # resources to the check.
+    monkeypatch.chdir(tmp_path)
     mgr = ToolManager(
         _make_spec([skill_no_resources]),
     )
@@ -312,12 +318,19 @@ def test_schemas_exclude_read_skill_file_without_resources(
     assert "read_skill_file" not in names
 
 
-def test_schemas_empty_when_no_skills() -> None:
+def test_schemas_empty_when_no_skills(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     get_tool_schemas returns empty when agent has no skills,
     excluding the always-registered lifecycle tool
     (``sys_cancel_task``).
     """
+    # Host-scope skill discovery falls back to cwd; run from an empty
+    # directory so this repo's own .claude/skills/ doesn't contribute
+    # skills/resources to the check.
+    monkeypatch.chdir(tmp_path)
     mgr = ToolManager(_make_spec([]))
     assert _non_lifecycle_schemas(mgr) == []
 
@@ -779,7 +792,10 @@ def _make_client_side_spec(name: str) -> ClientSideToolSpec:
     )
 
 
-def test_client_tools_registered_in_schemas() -> None:
+def test_client_tools_registered_in_schemas(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Client-specified tools appear in get_tool_schemas() alongside
     built-in tools without calling start().
@@ -787,6 +803,10 @@ def test_client_tools_registered_in_schemas() -> None:
     A failure here means the LLM never sees client tools — the
     client_tool_specs constructor arg is not being wired up.
     """
+    # Host-scope skill discovery falls back to cwd; run from an empty
+    # directory so this repo's own .claude/skills/ doesn't contribute
+    # extra tool schemas to the count below.
+    monkeypatch.chdir(tmp_path)
     spec = _make_spec()
     mgr = ToolManager(
         spec,
@@ -880,11 +900,18 @@ def test_client_tool_shadows_skill_tool(
     )
 
 
-def test_client_tools_none_equivalent_to_empty() -> None:
+def test_client_tools_none_equivalent_to_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Passing client_tool_specs=None and client_tool_specs=[] produce
     the same result: no client tools registered.
     """
+    # Host-scope skill discovery falls back to cwd; run from an empty
+    # directory so this repo's own .claude/skills/ doesn't contribute
+    # extra tool schemas to the empty-list check.
+    monkeypatch.chdir(tmp_path)
     spec = _make_spec()
     mgr_none = ToolManager(spec, client_tool_specs=None)
     mgr_empty = ToolManager(spec, client_tool_specs=[])
@@ -1188,11 +1215,18 @@ def test_local_tools_registered_and_callable(
     )
 
 
-def test_local_tools_skipped_without_workdir() -> None:
+def test_local_tools_skipped_without_workdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     ToolManager with workdir=None skips local tool registration
     without error, even if spec has local_tools.
     """
+    # Host-scope skill discovery falls back to cwd (independent of
+    # workdir); run from an empty directory so this repo's own
+    # .claude/skills/ doesn't contribute extra tool schemas.
+    monkeypatch.chdir(tmp_path)
     info = LocalToolInfo(
         name="some_tool",
         path="tools/python/some_tool.py",
@@ -1239,3 +1273,21 @@ def test_web_search_does_not_emit_web_search_preview_for_databricks_model() -> N
         f"databricks-gpt-5-4 — Databricks does not support this tool type "
         f"and rejects the request with HTTP 400. Got schema: {schema!r}"
     )
+
+
+def test_read_skill_file_registered_for_root_level_resources(tmp_path: Path) -> None:
+    """A skill whose only extra files sit beside SKILL.md still gets the tool."""
+    from omnigent.tools.builtins import any_skill_has_resources
+
+    skill_dir = tmp_path / "codebase-design"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("body")
+    (skill_dir / "DEEPENING.md").write_text("deepening")
+    skill = SkillSpec(
+        name="codebase-design",
+        description="Designs codebases.",
+        content="body",
+        skill_dir=skill_dir,
+    )
+
+    assert any_skill_has_resources([skill]) is True

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -310,6 +310,7 @@ def test_schemas_exclude_read_skill_file_without_resources(
     # directory so this repo's own .claude/skills/ doesn't contribute
     # resources to the check.
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     mgr = ToolManager(
         _make_spec([skill_no_resources]),
     )
@@ -331,6 +332,7 @@ def test_schemas_empty_when_no_skills(
     # directory so this repo's own .claude/skills/ doesn't contribute
     # skills/resources to the check.
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     mgr = ToolManager(_make_spec([]))
     assert _non_lifecycle_schemas(mgr) == []
 
@@ -807,6 +809,7 @@ def test_client_tools_registered_in_schemas(
     # directory so this repo's own .claude/skills/ doesn't contribute
     # extra tool schemas to the count below.
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     spec = _make_spec()
     mgr = ToolManager(
         spec,
@@ -912,6 +915,7 @@ def test_client_tools_none_equivalent_to_empty(
     # directory so this repo's own .claude/skills/ doesn't contribute
     # extra tool schemas to the empty-list check.
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     spec = _make_spec()
     mgr_none = ToolManager(spec, client_tool_specs=None)
     mgr_empty = ToolManager(spec, client_tool_specs=[])
@@ -1227,6 +1231,7 @@ def test_local_tools_skipped_without_workdir(
     # workdir); run from an empty directory so this repo's own
     # .claude/skills/ doesn't contribute extra tool schemas.
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     info = LocalToolInfo(
         name="some_tool",
         path="tools/python/some_tool.py",


### PR DESCRIPTION
## Related issue

Closes #4597

## Summary

An agent could load a skill and then be told that same skill does not exist:

```text
load_skill({"name": "codebase-design"})                      # succeeds
read_skill_file({"skill_name": "codebase-design", ...})      # Error: skill not found. Available skills: []
```

Two independent defects produced that, and both are fixed here.

- **The two tools resolved different registries.** In `_execute_skill_tool`, `LoadSkillTool` was built with `agent_root=runner_workspace`, so it merged bundled skills with host-scope discovery — while `ReadSkillFileTool` was built from `bundled_skills` alone. Any host-scope skill was therefore loadable but unreadable. The runner now builds one `LoadSkillTool` and passes its merged `.skills` to `ReadSkillFileTool`, matching what `ToolManager._register_skill_tools` already did server-side.
- **Auxiliary files beside `SKILL.md` were invisible.** `list_skill_resources` scanned only `references/`, `scripts/`, and `assets/`. The reporter's skill keeps its extra docs at the skill root (`DEEPENING.md`, `DESIGN-IT-TWICE.md`), so `load_skill` never emitted the `## Available files` listing and `any_skill_has_resources` returned `False` — meaning `ToolManager` did not register `read_skill_file` at all for such an agent. The listing now includes files sitting beside `SKILL.md`, excluding `SKILL.md` itself and dotfiles.

`read_skill_file`'s own description was updated to match, since `load_skill` now advertises files outside those three subdirectories.

**ELI5:** two doors into the same room had different guest lists. `load_skill`'s list included guests who walked in off the street (host-scope skills); `read_skill_file`'s did not, so it turned away people the other door had just admitted. Now both doors read one list. Separately, the room's "what's inside" sign only counted three shelves and ignored everything lying on the floor — so files were there, but nobody was told.

```mermaid
graph TD
    subgraph Before
        A1[agent spec bundled skills] --> B1[LoadSkillTool]
        H1[host-scope discovery] --> B1
        A1 --> C1[ReadSkillFileTool]
        B1 --> D1[load_skill ✅]
        C1 --> E1["read_skill_file ❌ not found"]
    end
    subgraph After
        A2[agent spec bundled skills] --> B2[LoadSkillTool]
        H2[host-scope discovery] --> B2
        B2 -- ".skills" --> C2[ReadSkillFileTool]
        B2 --> D2[load_skill ✅]
        C2 --> E2[read_skill_file ✅]
    end
```

Path containment is unchanged — `_read_file_safely` still resolves and rejects `..`, absolute paths, and symlinks escaping the skill directory. Only the *listing* widened, not the read guard.

## Test Plan

New regression coverage:

- `tests/runner/test_skill_tool_dispatch.py` (new, 4 tests) — a host-scope skill is readable after being loadable; bundled skills keep working; `skills_filter: none` hides the skill from *both* tools (locks the parity invariant in both directions); and the issue's exact reported sequence, asserting the `## Available files` listing plus the contents of both auxiliary files.
- `tests/tools/builtins/test_load_skill.py` (+3) — root-level files listed; `SKILL.md` and dotfiles excluded; root files ordered before `references/…` entries.
- `tests/tools/test_manager.py` (+1) — `read_skill_file` is registered for a skill whose only extra files sit beside `SKILL.md`.

The new end-to-end test was verified to be a real net, not a rubber stamp: reverting the `tool_dispatch.py` fix makes it fail with the original `not found` error, and reverting the `list_skill_resources` widening makes the `## Available files` assertion fail.

Suites run locally (macOS, `uv run pytest`):

| Scope | Result |
|---|---|
| `tests/tools`, `tests/runner`, `tests/e2e/test_journey_skill_loading.py` | 884 passed |
| `tests/benchmarks tests/cli tests/client_tools tests/codex_parity tests/db tests/deploy` | 1,499 passed, 27 skipped |
| `tests/dev tests/entities tests/environments tests/frontends tests/github tests/harness_bench tests/host` | 1,416 passed, 19 skipped |
| `tests/inner` | 2,291 passed, 11 failed |
| `tests/llms tests/loadtest tests/onboarding tests/policies tests/repl tests/runner tests/runtime` | 5,393 passed, 4 failed |
| `tests/spec tests/scripts tests/stores` | 1,208 passed, 1 skipped |

**All 15 failures reproduce byte-identically on `main`** and are unrelated to this change — 11 are Linux-only (`bwrap`, `seccomp`, real `tmux`, unix-socket egress proxy) and fail on any macOS checkout; 3 are environment-dependent (`test_harness_readiness`, `test_boxlite`, `test_session_resources`); 1 (`test_openai_adapter::test_streamed_400_overflow_classified_as_context_window_exceeded`) is order-dependent and passes in isolation on both branches. Each was confirmed by checking out `main` and re-running the same node ids. `tests/server`, `tests/terminals`, `tests/sandbox`, `tests/testing` and top-level `tests/*.py` were not run locally (slow, and none import the changed modules) — CI covers them.

Manual verification: reproduced the original bug on `main` at `8487fa0e` with a scratch agent whose skill lives in `<workspace>/.claude/skills/example/` (`load_skill` ✅, `read_skill_file` → `Error: skill 'example' not found`), then re-ran the same script on this branch — `load_skill` now emits `## Available files` with `- EXTRA.md`, and `read_skill_file` returns the file contents.

`ruff format --check` and `ruff check` are clean on all changed files.

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the exact sequence in the issue report, against the pre-fix and post-fix trees, as described in the Test Plan.

Five pre-existing tests in `tests/tools/test_manager.py` gained `monkeypatch.chdir(tmp_path)` and `monkeypatch.setenv("HOME", str(tmp_path))`. They build a `ToolManager` with `workdir=None`, which makes host-skill discovery fall back to `Path.cwd()`; with the widened listing, this repo's own `.claude/skills/{cli-setup-verify,polly-e2e-dev}/` root-level scripts now count as resources, so `read_skill_file` was registered where those tests asserted zero tools. The tests were ambiently coupled to the developer's cwd and `$HOME` — they were never guarding production behaviour about either — so they are now isolated. No assertion was weakened; the behaviour change they would otherwise have caught is covered deliberately by the new `test_read_skill_file_registered_for_root_level_resources`.

**Known follow-up, deliberately out of scope.** A residual variant of this bug remains on a *different* code path and deserves its own issue. The slash-command path resolves skills via `resolve_harness_skills` (`omnigent/spec/skill_sources.py`), which knows about `~/.codex/skills` and Claude plugin skills, whereas `_execute_skill_tool` resolves only `discover_host_skills`. So invoking a plugin or Codex skill as a slash command in a `claude_sdk`-family session can advertise files via `format_skill_meta_text` and then hit the same "not found" error. Switching `_execute_skill_tool` to `resolve_harness_skills` would *widen* what `load_skill` can load, which is a behaviour change well beyond this bug — so this PR keeps `load_skill`'s registry exactly as-is and only brings `read_skill_file` up to match it.

## Changelog

Agents can now read a skill's auxiliary files after loading it, including files stored alongside `SKILL.md`
