### PR TITLE
fix(runner): resolve the zygote build stamp from its own module path

### DIFF
--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -90,14 +90,18 @@ def _disk_build_stamp(package_dir: Path | None = None) -> tuple[float, str] | No
     what this process imported at boot.
 
     :param package_dir: Directory holding ``_build_info.py``; defaults to the
-        installed ``omnigent`` package directory.
+        ``omnigent`` package directory this module was loaded from.
     :returns: The stamp, or ``None`` when the file is missing or unreadable
         (e.g. an unbuilt source checkout, or a package mid-rewrite).
     """
     if package_dir is None:
-        import omnigent
-
-        package_dir = Path(omnigent.__file__).resolve().parent
+        # Derived from this module's own location rather than the top-level
+        # ``omnigent.__file__``: the zygote runs as ``python -m``, which puts
+        # its cwd on sys.path, so a daemon started from a directory that holds
+        # an ``omnigent`` checkout binds the top-level name to a namespace
+        # package (``__file__`` is None) while this module still loads from the
+        # real package.
+        package_dir = Path(__file__).resolve().parents[1]
     spec = importlib.util.spec_from_file_location(
         "_omnigent_zygote_build_probe", package_dir / "_build_info.py"
     )

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -9,15 +9,18 @@ daemon's Popen fallback are all covered.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import socket
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
+import omnigent
 from omnigent.host.runner_zygote import (
     _ZYGOTE_LOST_EXIT_CODE,
     ZygoteManager,
@@ -463,6 +466,28 @@ def test_disk_build_stamp_reads_the_on_disk_file(tmp_path, content, expected) ->
     if content is not None:
         (tmp_path / "_build_info.py").write_text(content)
     assert _disk_build_stamp(package_dir=tmp_path) == expected
+
+
+def test_disk_build_stamp_resolves_package_dir_without_top_level_file(monkeypatch) -> None:
+    """The probe finds ``_build_info.py`` even when ``omnigent.__file__`` is None.
+
+    The zygote is spawned as ``python -m``, which puts the daemon's cwd on
+    sys.path, so a daemon started from a directory that holds an ``omnigent``
+    checkout binds the top-level name to a namespace package with no
+    ``__file__``. Reading it raised ``TypeError`` and killed the zygote at boot
+    before it served a single fork, so the probe keys off its own module path.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    probed: list[Path] = []
+    monkeypatch.setattr(omnigent, "__file__", None)
+    monkeypatch.setattr(
+        importlib.util,
+        "spec_from_file_location",
+        lambda name, location: probed.append(Path(location)),
+    )
+    assert _disk_build_stamp() is None
+    assert probed == [Path(_zygote.__file__).resolve().parents[1] / "_build_info.py"]
 
 
 def _dispatch_fork(


### PR DESCRIPTION
## Related issue

Closes #4630

## Summary

`omni host` printed a traceback right after connecting, and every session then fell back to a direct `Popen` launch instead of the copy-on-write zygote fork:

```
  File "omnigent/runner/_zygote.py", line 100, in _disk_build_stamp
    package_dir = Path(omnigent.__file__).resolve().parent
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

- The zygote is spawned as `python -m omnigent.runner._zygote`, and `-m` puts the daemon's cwd on `sys.path`. Starting the host from a directory that holds an `omnigent` checkout (e.g. `cd ~ && omni host` with the repo at `~/omnigent`) makes `PathFinder` bind the **top-level** name to a namespace package whose `__file__` is `None`, while `omnigent.<submodule>` still resolves to the real code through setuptools' editable finder — which is appended *after* `PathFinder`. `_disk_build_stamp()` dereferenced that `None` and killed the zygote at boot, before it served a single fork.
- Derive the package directory from this module's own location (`Path(__file__).resolve().parents[1]`) instead. That is correct however the top-level name resolved, and it keeps the fork-time upgrade gate working — falling back to `omnigent.__path__` would have pointed at the checkout *root*, silently reporting "stamp unknown" and disabling that check.

A plain (non-editable) install was never affected: site-packages holds a regular `omnigent/` package, and a regular package beats a namespace portion.

## Test Plan

- `pytest tests/host/test_runner_zygote.py tests/runtime/harnesses/test_harness_zygote_client.py` → 43 passed.
- New regression test `test_disk_build_stamp_resolves_package_dir_without_top_level_file` asserts the probe reads `<package>/_build_info.py` with `omnigent.__file__` set to `None`. It fails on the pre-fix code with exactly the reported `TypeError`.
- End-to-end against a faithful reproduction of the failing import topology (a decoy `omnigent/` directory on the child's cwd, with the real package reachable only through a meta-path finder), driving the daemon's own `ZygoteManager`:
  - pre-fix: reproduces the reported traceback frame-for-frame and ends in `ZygoteUnavailable: runner zygote closed the control socket`;
  - post-fix: the zygote answers `ping`, forks a runner, returns its exit code, and leaves an empty log.
- Ran a real `omni host` from `~` (namespace shadow confirmed active — `omnigent.__file__ is None` in the spawned children) against a dedicated local server: `✓ Connected … Listening for sessions`, no traceback.

## Demo

N/A — no user-visible UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test pins the contract (resolve the package dir from the module's own path, never from the top-level `__file__`) and fails on the old code. The namespace-shadow topology itself depends on how the package is installed — a setuptools editable install shadows, a regular install does not — so it is not reproducible as a hermetic in-repo test; that half was verified manually with a real zygote subprocess, before and after, as described in the Test Plan.

## Changelog

`omni host` no longer prints a zygote traceback — and keeps copy-on-write runner forking — when started from a directory that contains an `omnigent` checkout
