### PR TITLE
fix(electron): handle unsupported passkey conditional mediation

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -87,6 +87,9 @@ const ERR_ABORTED = -3;
  */
 const POPUP_PRELOAD = path.join(__dirname, "popup_preload.js");
 
+/** Preload registered for top-level documents in the default session. */
+const WEB_AUTHN_PRELOAD = path.join(__dirname, "webauthn.js");
+
 /** Absolute path to the app icon (PNG works for the macOS dock at runtime). */
 const ICON_PNG = path.join(__dirname, "..", "icons", "icon.png");
 
@@ -1061,6 +1064,7 @@ function createWindow(targetUrl, opts = {}) {
       // Security: the SPA is remote/untrusted relative to the shell, so we
       // keep Node out of the renderer and isolate the preload's context.
       preload: path.join(__dirname, "preload.js"),
+      sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
       // Electron passes HTML5 drag-drop through to the page by default (no
@@ -2913,6 +2917,14 @@ if (!gotLock) {
     registerPermissions();
     registerLocalhostAccess();
     registerSessionExpiryAccess();
+    // Shell-created renderers use defaultSession; no custom partitions are
+    // created here. Electron 42 does not apply registered preloads to iframe
+    // documents or their later navigations, so this shim covers top-level only.
+    session.defaultSession.registerPreloadScript({
+      id: "omnigent-webauthn",
+      type: "frame",
+      filePath: WEB_AUTHN_PRELOAD,
+    });
     registerIpc();
     buildMenu();
     // Patch PATH for GUI-launched Electron on macOS/Linux:

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -16,6 +16,7 @@
 
 const { contextBridge, ipcRenderer } = require("electron");
 
+if (window.top !== window) return;
 // Collapse the update states the in-page UpdateBanner renders on
 // (available / downloaded / error-security) to `idle` so the server page can
 // never show a banner — that UI is shell-owned (the corner overlay). Kept here

--- a/web/electron/src/webauthn.js
+++ b/web/electron/src/webauthn.js
@@ -1,0 +1,73 @@
+"use strict";
+
+function installConditionalMediationGuard() {
+  const pageGlobal = typeof window === "object" ? window : globalThis;
+  const publicKeyCredential = pageGlobal.PublicKeyCredential;
+  if (typeof publicKeyCredential !== "function") return;
+  const credentials = pageGlobal.navigator?.credentials;
+  const originalGet = credentials?.get;
+
+  const replaceProperty = (target, property, value) => {
+    try {
+      Object.defineProperty(target, property, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  replaceProperty(publicKeyCredential, "isConditionalMediationAvailable", () =>
+    Promise.resolve(false),
+  );
+
+  const originalCapabilities = publicKeyCredential.getClientCapabilities;
+  if (typeof originalCapabilities === "function") {
+    replaceProperty(publicKeyCredential, "getClientCapabilities", function (...args) {
+      return Promise.resolve(originalCapabilities.apply(this, args)).then((capabilities) => {
+        if (!capabilities || typeof capabilities !== "object") return capabilities;
+        const result = { ...capabilities, conditionalGet: false };
+        if (Object.hasOwn(capabilities, "conditionalCreate")) {
+          result.conditionalCreate = false;
+        }
+        return result;
+      });
+    });
+  }
+
+  if (!credentials || typeof originalGet !== "function") return;
+  const guardedGet = function (options) {
+    if (options?.mediation !== "conditional" || options.signal?.aborted) {
+      return Reflect.apply(originalGet, this, arguments);
+    }
+
+    const timeoutSignal = pageGlobal.AbortSignal.timeout(60_000);
+    const signal = options.signal
+      ? pageGlobal.AbortSignal.any([options.signal, timeoutSignal])
+      : timeoutSignal;
+    const nativeResult = Reflect.apply(originalGet, this, [{ ...options, signal }]);
+    return nativeResult.catch((error) => {
+      if (timeoutSignal.aborted) {
+        throw new pageGlobal.DOMException(
+          "The sign-in request did not finish within 60 seconds. Use another sign-in method on this page.",
+          "TimeoutError",
+        );
+      }
+      throw error;
+    });
+  };
+
+  replaceProperty(credentials, "get", guardedGet);
+}
+
+if (typeof process === "object" && process.type === "renderer") {
+  const { contextBridge } = require("electron");
+
+  contextBridge.executeInMainWorld({ func: installConditionalMediationGuard });
+} else if (typeof module === "object" && module.exports) {
+  module.exports = { installConditionalMediationGuard };
+}

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -19,12 +19,32 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 const preloadSource = readFileSync(path.join(__dirname, "../src/preload.js"), "utf8");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
 const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+function runPreload(windowObject) {
+  const exposed = [];
+  const contextBridge = {
+    exposeInMainWorld: (name, value) => exposed.push({ name, value }),
+  };
+  const ipcRenderer = {
+    invoke: () => Promise.resolve(),
+    on: () => {},
+    removeListener: () => {},
+    send: () => {},
+  };
+  const context = vm.createContext({
+    window: windowObject,
+    require: () => ({ contextBridge, ipcRenderer }),
+  });
+  new vm.Script(`(function () {\n${preloadSource}\n})()`).runInContext(context);
+  return exposed;
+}
 
 describe("setup clipboard IPC wiring", () => {
   it("exposes a narrow copy action through the setup bridge", () => {
@@ -39,6 +59,37 @@ describe("setup clipboard IPC wiring", () => {
       liveCode,
       /ipcMain\.handle\("omnigent:copy-setup-text",[\s\S]{0,200}!isSetupPageSender\(event\)[\s\S]{0,300}clipboard\.writeText\(text\)/,
     );
+  });
+});
+
+describe("WebAuthn preload wiring", () => {
+  it("registers the guard preload for top-level default-session documents", () => {
+    assert.match(liveCode, /const WEB_AUTHN_PRELOAD = path\.join\(__dirname, "webauthn\.js"\)/);
+    assert.match(
+      liveCode,
+      /session\.defaultSession\.registerPreloadScript\(\{[\s\S]{0,180}type: "frame"[\s\S]{0,120}filePath: WEB_AUTHN_PRELOAD/,
+    );
+  });
+
+  it("keeps the shell renderer sandboxed and the preload gate fail-closed", () => {
+    assert.match(
+      liveCode,
+      /preload: path\.join\(__dirname, "preload\.js"\)[\s\S]{0,140}sandbox: true[\s\S]{0,100}contextIsolation: true[\s\S]{0,100}nodeIntegration: false/,
+    );
+    assert.match(preloadSource, /if \(window\.top !== window\) return;/);
+    assert.doesNotMatch(liveCode, /nodeIntegrationInSubFrames/);
+  });
+
+  it("keeps the popup preload sandboxed and without Node subframes", () => {
+    assert.match(
+      liveCode,
+      /preload: POPUP_PRELOAD[\s\S]{0,180}sandbox: true[\s\S]{0,140}contextIsolation: true[\s\S]{0,100}nodeIntegration: false/,
+    );
+    assert.doesNotMatch(liveCode, /nodeIntegrationInSubFrames/);
+  });
+
+  it("does not expose shell bridges to a subframe when process metadata is absent", () => {
+    assert.deepEqual(runPreload({ top: {} }), []);
   });
 });
 
@@ -86,18 +137,6 @@ describe("window-open policy wiring (src/main.js)", () => {
         "src/main.js no longer passes window.open through decideWindowOpen. Either every",
         "popup is denied (OAuth sign-in breaks) or popups open without the",
         "pinned-opener/https/allowlist conditions. Restore the dispatch.",
-      ].join(" "),
-    );
-  });
-
-  it("attaches the no-op popup preload and sandbox to allowed popups", () => {
-    assert.match(
-      liveCode,
-      /preload:\s*POPUP_PRELOAD[\s\S]{0,120}sandbox:\s*true/,
-      [
-        "Allowed popups no longer force preload: POPUP_PRELOAD + sandbox: true, so a child",
-        "window can inherit the SHELL preload's IPC bridges while showing third-party",
-        "sign-in pages. Restore both overrides (see popup_preload.js).",
       ].join(" "),
     );
   });

--- a/web/electron/test/webauthn.test.js
+++ b/web/electron/test/webauthn.test.js
@@ -1,0 +1,241 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const preloadSource = readFileSync(path.join(__dirname, "../src/webauthn.js"), "utf8");
+
+function makePage(timerLimit) {
+  const calls = [];
+  let activeConditional = false;
+  let timerCalls = 0;
+  let consoleWarnCalls = 0;
+  const PublicKeyCredential = function PublicKeyCredential() {};
+  PublicKeyCredential.isConditionalMediationAvailable = () => Promise.resolve(true);
+  PublicKeyCredential.getClientCapabilities = () =>
+    Promise.resolve({ conditionalGet: true, conditionalCreate: true, hybrid: true });
+
+  const credentialsPrototype = {
+    get(options) {
+      calls.push({ receiver: this, options });
+      if (options?.mediation !== "conditional") {
+        if (activeConditional) return Promise.reject(new Error("modal request was poisoned"));
+        return Promise.resolve("modal");
+      }
+      activeConditional = true;
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            activeConditional = false;
+            reject(new DOMException("aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+    },
+  };
+  const credentials = Object.create(credentialsPrototype);
+  function makeSignal() {
+    let aborted = false;
+    let reason;
+    const listeners = new Set();
+    return {
+      get aborted() {
+        return aborted;
+      },
+      get reason() {
+        return reason;
+      },
+      addEventListener(type, listener, options) {
+        if (type !== "abort") return;
+        if (aborted) {
+          listener.call(this, { type: "abort" });
+          return;
+        }
+        listeners.add({ listener, once: options?.once === true });
+      },
+      removeEventListener(type, listener) {
+        if (type !== "abort") return;
+        for (const entry of listeners) {
+          if (entry.listener === listener) listeners.delete(entry);
+        }
+      },
+      abort(nextReason) {
+        if (aborted) return;
+        aborted = true;
+        reason = nextReason;
+        for (const entry of [...listeners]) {
+          entry.listener.call(this, { type: "abort" });
+          if (entry.once) listeners.delete(entry);
+        }
+      },
+    };
+  }
+
+  const page = {
+    Object,
+    PublicKeyCredential,
+    navigator: { credentials },
+    AbortSignal: {
+      timeout(milliseconds) {
+        const signal = makeSignal();
+        page.setTimeout(
+          () => signal.abort(new DOMException("timed out", "TimeoutError")),
+          milliseconds,
+        );
+        return signal;
+      },
+      any(signals) {
+        const combined = makeSignal();
+        for (const signal of signals) {
+          if (signal.aborted) {
+            combined.abort(signal.reason);
+            break;
+          }
+          signal.addEventListener("abort", () => combined.abort(signal.reason), { once: true });
+        }
+        return combined;
+      },
+    },
+    DOMException,
+    console: { warn: () => consoleWarnCalls++ },
+    setTimeout: (callback, milliseconds) => {
+      timerCalls += 1;
+      return setTimeout(callback, Math.min(milliseconds, timerLimit ?? milliseconds));
+    },
+    clearTimeout,
+  };
+  page.window = page;
+  return {
+    page,
+    credentials,
+    credentialsPrototype,
+    calls,
+    get consoleWarnCalls() {
+      return consoleWarnCalls;
+    },
+    get timerCalls() {
+      return timerCalls;
+    },
+  };
+}
+
+function executeSerialized(script, page) {
+  const context = vm.createContext({ ...page, window: page });
+  const serialized = new vm.Script(
+    `new Function("return (" + ${JSON.stringify(script.func.toString())} + ")")()`,
+  ).runInContext(context);
+  return serialized(...(script.args ?? []));
+}
+
+function loadPreload(page) {
+  const injections = [];
+  const contextBridge = {
+    executeInMainWorld(script) {
+      injections.push(script);
+      executeSerialized(script, page);
+    },
+  };
+  const preloadContext = vm.createContext({
+    process: { type: "renderer" },
+    require(request) {
+      assert.equal(request, "electron");
+      return { contextBridge };
+    },
+  });
+  new vm.Script(preloadSource, { filename: "webauthn.js" }).runInContext(preloadContext);
+  assert.equal(injections.length, 1);
+  return injections[0];
+}
+
+describe("conditional WebAuthn mediation guard", () => {
+  it("reports conditional mediation and creation as unavailable", async () => {
+    const { page } = makePage();
+    loadPreload(page);
+
+    assert.equal(await page.PublicKeyCredential.isConditionalMediationAvailable(), false);
+    const capabilities = await page.PublicKeyCredential.getClientCapabilities();
+    assert.equal(capabilities.conditionalGet, false);
+    assert.equal(capabilities.conditionalCreate, false);
+    assert.equal(capabilities.hybrid, true);
+  });
+
+  it("passes non-conditional requests through unchanged", async () => {
+    const { page, credentials, calls } = makePage();
+    const originalOptions = { mediation: "required" };
+    const originalPromise = Promise.resolve("modal");
+    Object.getPrototypeOf(credentials).get = function () {
+      calls.push({ receiver: this, args: arguments });
+      return originalPromise;
+    };
+    const nativeGet = credentials.get;
+    loadPreload(page);
+
+    assert.notEqual(page.navigator.credentials.get, nativeGet);
+    assert.equal(page.navigator.credentials.get.call(credentials), originalPromise);
+    assert.equal(calls.at(-1).receiver, credentials);
+    assert.equal(calls.at(-1).args.length, 0);
+    assert.equal(
+      page.navigator.credentials.get.call(credentials, originalOptions),
+      originalPromise,
+    );
+    assert.equal(calls.at(-1).args.length, 1);
+    assert.equal(calls.at(-1).args[0], originalOptions);
+  });
+
+  it("uses native-like descriptors and bounds a conditional request", async () => {
+    const fixture = makePage(10);
+    const { page, credentials } = fixture;
+    loadPreload(page);
+
+    const instanceDescriptor = Object.getOwnPropertyDescriptor(credentials, "get");
+    assert.equal(instanceDescriptor.configurable, true);
+    assert.equal(instanceDescriptor.writable, true);
+    assert.equal(instanceDescriptor.enumerable, false);
+
+    const error = await credentials
+      .get({ mediation: "conditional" })
+      .catch((requestError) => requestError);
+    assert.equal(error.name, "TimeoutError");
+    assert.match(error.message, /Use another sign-in method/);
+    assert.doesNotMatch(error.message, /Omnigent|desktop app/);
+    assert.equal(fixture.consoleWarnCalls, 0);
+    assert.equal(await credentials.get({ mediation: "required" }), "modal");
+  });
+
+  it("composes an RP abort signal and preserves synchronous native throws", async () => {
+    const { page, calls } = makePage(20);
+    loadPreload(page);
+    const controller = new AbortController();
+    const request = page.navigator.credentials.get({
+      mediation: "conditional",
+      signal: controller.signal,
+    });
+    assert.notEqual(calls.at(-1).options.signal, controller.signal);
+    controller.abort();
+    await assert.rejects(request, { name: "AbortError" });
+
+    const throwing = makePage(20);
+    throwing.credentialsPrototype.get = () => {
+      throw new TypeError("invalid request");
+    };
+    loadPreload(throwing.page);
+    assert.throws(() => throwing.page.navigator.credentials.get({ mediation: "conditional" }), {
+      name: "TypeError",
+    });
+  });
+
+  it("does not add page globals while installing the compatibility shim", () => {
+    const { page } = makePage();
+    const before = Reflect.ownKeys(page);
+    loadPreload(page);
+    const beforeSet = new Set(before);
+    const after = Reflect.ownKeys(page);
+    assert.deepEqual(
+      after.filter((key) => !beforeSet.has(key)),
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Related issue

Fixes #4624

## Summary

- Stop advertising unsupported passkey autofill in shell-created top-level renderer documents by overriding `isConditionalMediationAvailable()` and `getClientCapabilities()` in one self-contained registered preload. The shim uses native-like configurable/writable descriptors so password managers and WebAuthn wrappers can replace it normally; it is a compatibility shim, not a security boundary.
- Bound conditional WebAuthn requests locally with `AbortSignal.timeout()` and `AbortSignal.any()`. On timeout the underlying request is aborted and the page receives only a neutral `TimeoutError`; there is no page console logging, IPC, banner, setup navigation, token, or shell recovery UI.
- Replace the fail-open `process.isMainFrame` bridge check with `window.top !== window`, restore/retain sandboxing, and keep Node out of subframes.

ELI5: the shell no longer says “passkey autofill is available” when it has no autofill UI. Feature-detecting IdPs use their own password/alternate-method flow; an IdP that ignores the capability answer gets a bounded, actionable promise rejection instead of an infinite spinner.

```text
Top-level IdP capability check ── false ──> IdP's alternate sign-in flow
conditional get() ── 60s ──> AbortSignal timeout ──> TimeoutError
```

## Test Plan

- `cd web/electron && /opt/homebrew/bin/node --test` — 248 passed, 0 failed.
- `uv run --frozen pre-commit run --files web/electron/src/main.js web/electron/src/preload.js web/electron/src/webauthn.js web/electron/test/main.test.js web/electron/test/webauthn.test.js` — passed.
- `git diff --check` — passed.
- Electron 42.7 runtime probe — verified `AbortSignal.timeout` and `AbortSignal.any` exist.
- Electron 42.7 runtime smoke — verified `conditional: false`, `conditionalGet: false`, and `conditionalCreate: false` in the main window, OAuth popup, and sandboxed `WebContentsView` top-level documents. The same smoke measured iframe capability values as `true`, documented as the intentional F3(b) limit below.
- Manual tester flow: open a self-hosted IdP in the desktop app. A feature-detecting IdP should show its own alternate sign-in controls immediately. An IdP that still starts conditional mediation should reject after about 60 seconds with `TimeoutError`; non-conditional YubiKey/modal requests remain direct pass-throughs.

## Demo

N/A — this is a renderer capability/error-path fix with no new shell UI. The expected tester-visible result is the IdP's own alternate sign-in controls instead of an indefinite passkey-autofill spinner.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

F3 option (b) is intentional. Electron 42's session preload registration reaches the shell-created top-level main window, OAuth popup, and `WebContentsView` documents, but does not run per iframe document or on later iframe navigations. The prior `frame-created` hook was asynchronous, fired once per frame rather than per document, and empirically left immediate `about:blank`, `document.write`, and subsequent iframe navigation realms advertising conditional mediation. It is deleted rather than left as misleading partial coverage. No safe, small before-document subframe mechanism is available here without adding Node to hostile frames or weakening renderer sandboxing. The acceptance criterion is therefore limited to top-level/popup documents, which covers the reported authentik/Keycloak login surface.

Automated tests execute the same serialized `webauthn.js` source registered by the Electron session, including capability overrides, native-like descriptors, AbortSignal composition, timeout rejection, neutral error text, synchronous native throws, exact zero/one-argument pass-through, and no page-global additions. Main wiring tests cover the fail-closed shell bridge gate and both main-window and popup sandbox settings. I could not validate against a real authentik or Keycloak server or a physical passkey in this environment.

Mutation checks were run against the shipped source and wiring: re-hardening descriptors, restoring the process gate, restoring page console logging, removing signal composition, forwarding an explicit `undefined`, and disabling shell sandboxing each made its targeted test exit 1; all mutations were restored and the full suite returned green.

## Changelog

Prevent desktop passkey sign-in from hanging when the IdP's autofill UI is unavailable.
