### PR TITLE
fix(web): show 'Changes' header on changes tab

### DIFF
--- a/tests/e2e_ui/files/test_changed_files_git_status_error.py
+++ b/tests/e2e_ui/files/test_changed_files_git_status_error.py
@@ -70,7 +70,10 @@ def test_git_status_failure_surfaces_in_files_panel(
     # The changed-files list — where the git-status error renders — is now the
     # Changes rail tab (a peer of Files). Select it explicitly so the assertion
     # does not depend on the remembered tab from a prior session.
-    rail.get_by_role("tab", name=re.compile("^Changes")).click()
+    changes_tab = rail.get_by_role("tab", name=re.compile("^Changes"))
+    changes_tab.click()
+    expect(changes_tab).to_have_attribute("aria-selected", "true")
+    expect(rail.get_by_role("heading", name="Changes", exact=True)).to_be_visible()
 
     # The panel surfaces the server's reason verbatim, in the destructive style —
     # not a bare status code and not the misleading empty state.

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -254,16 +254,22 @@ describe("FilesPanel working folder directory", () => {
 });
 
 describe("FilesPanel working folder header role", () => {
-  // The "Working folder" header is a static label in every mode — it is not a
-  // collapse toggle. Collapsing was removed: the panel's content is the whole
-  // point of the panel, so there is nothing to collapse to. The content is
-  // always visible and the header never carries aria-expanded.
+  // The scope heading is static in every mode — it is not a collapse toggle.
+  // Collapsing was removed: the panel's content is the whole point of the
+  // panel, so there is nothing to collapse to. The content is always visible.
   it("renders the header as a static label (no toggle button) in the standalone card", () => {
     renderPanel({ conversationId: "conv_header_card", files: [] });
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
-    expect(screen.getByText("Working folder")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Working folder" })).toBeInTheDocument();
     // Content is always shown — the tree search box is part of it.
     expect(screen.getByRole("searchbox", { name: "Search all files" })).toBeInTheDocument();
+  });
+
+  it("labels the changed-files scope with a Changes heading", () => {
+    renderPanel({ conversationId: "conv_header_changes", files: [], flatView: true });
+    expect(screen.getByRole("heading", { name: "Changes" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Working folder" })).toBeNull();
+    expect(screen.getByRole("searchbox", { name: "Search changed files" })).toBeInTheDocument();
   });
 
   it("renders the header as a static label (no toggle button) in frameless (inline rail) mode", () => {
@@ -295,7 +301,7 @@ describe("FilesPanel working folder header role", () => {
     );
 
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
-    expect(screen.getByText("Working folder")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Working folder" })).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: "Search all files" })).toBeInTheDocument();
   });
 
@@ -303,7 +309,7 @@ describe("FilesPanel working folder header role", () => {
     renderPanel({ conversationId: "conv_header_drawer", files: [], onClose: vi.fn() });
     // The drawer adds an X close button; the title is a plain label everywhere.
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
-    expect(screen.getByText("Working folder")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Working folder" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close files" })).toBeInTheDocument();
   });
 });

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -413,7 +413,9 @@ export function FilesPanel({
     >
       {/* Header — single row: [title · workingDir] [eye] [close?] */}
       <div className="flex shrink-0 items-center gap-2 px-3 py-2">
-        <span className="shrink-0 font-medium text-ui">Working folder</span>
+        <span className="shrink-0 font-medium text-ui">
+          {flatView ? "Changes" : "Working folder"}
+        </span>
         {workingDir && workspaceRoot && (
           <BrowseLocationBar
             current={workingDir}

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -413,9 +413,7 @@ export function FilesPanel({
     >
       {/* Header — single row: [title · workingDir] [eye] [close?] */}
       <div className="flex shrink-0 items-center gap-2 px-3 py-2">
-        <span className="shrink-0 font-medium text-ui">
-          {flatView ? "Changes" : "Working folder"}
-        </span>
+        <h2 className="shrink-0 font-medium text-ui">{flatView ? "Changes" : "Working folder"}</h2>
         {workingDir && workspaceRoot && (
           <BrowseLocationBar
             current={workingDir}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- On the Changes tab, the header label was identical to the Files tab ("Working folder"), making the two tabs visually indistinguishable at a glance.
- Now the Changes tab shows "Changes" as the label, while the Files tab keeps "Working folder".

## Test Plan

1. Open the web UI and navigate to the Changes tab — confirm the header reads "Changes".
2. Switch to the Files tab — confirm the header still reads "Working folder".

## Demo

<img width="308" height="111" alt="screenshot 2026-08-29-18-49-58-Arc" src="https://github.com/user-attachments/assets/2af063c6-9d7e-4c21-857f-3f37c8027505" />
<img width="363" height="123" alt="image" src="https://github.com/user-attachments/assets/1f70b84f-1102-40cf-9702-24acc4f294a9" />


## Type of change

- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

Single string conditional; no test coverage needed beyond manual verification.

## Changelog

The Changes tab now shows "Changes" in its header instead of "Working folder".