### PR TITLE
fix(release): stop bump-main inheriting the benchmark chain's skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -666,6 +666,10 @@ jobs:
   # never re-freezes and doc-sync keeps deriving the right X.Y-docs branch.
   bump-main:
     needs: [authorize, plan, cut]
+    # The benchmark chain is skipped on most cuts, and a default `success()`
+    # gate inherits that skip through `cut`, so this job silently vanished on
+    # every cut but one. Depend on `cut` succeeding, not on the whole closure.
+    if: ${{ !cancelled() && needs.cut.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Related issue

No issue filed (`Test / CI` type, exempt per the template). Found while auditing
the v0.9.0 cut, [run 31526457974](https://github.com/omnigent-ai/omnigent/actions/runs/31526457974).

## Summary

- `bump-main` had no job-level `if:`, so it defaulted to `success()` and
  inherited the skipped benchmark jobs **transitively through `cut`**. Its own
  direct needs (`authorize`, `plan`, `cut`) were all green, so the skip is
  invisible in the run graph: the job reports 0 steps and
  `started == completed`.
- Across the last twelve release runs it fired **exactly once**,
  [29791811141](https://github.com/omnigent-ai/omnigent/actions/runs/29791811141)
  (2026-07-21), the only run where `benchmark-approve` itself succeeded. Every
  other cut left `main` frozen on the version that had just shipped.
- Gate on `cut` succeeding instead, reusing the `!cancelled()` opt-out that
  `cut` already uses three jobs up. The in-job shell gates (`dry_run`,
  `branch_exists`, version ordering) are untouched; they just get a chance to
  run now.

The v0.9.0 cut is the live case: `main` still reads `0.9.0.dev0`, a version that
has now shipped, and all three shell gates would have passed (real run,
`branch_exists=false`, `0.9.0 > 0.9.0.dev0`). #4634 unblocks `main` by hand;
this PR stops it recurring at the next cut.

```
plan ──┬─> benchmark-seed ─> benchmark ─> benchmark-approve ──┐
       │        (skipped)     (skipped)        (skipped)      │
       └────────────────────────────────────> cut  <──────────┘
                                    !cancelled() -> SUCCESS
                                              │
                                              v
                                          bump-main
                          before: success()            -> skipped (inherited)
                          after:  !cancelled() && cut  -> runs
```

## Test Plan

Both halves of the gate are already demonstrated by existing runs, so no new
release dispatch was needed to establish the mechanism:

1. **The taint is real, and `needs.cut.result` would have been `'success'`.**
   [Run 31139732759](https://github.com/omnigent-ai/omnigent/actions/runs/31139732759)
   is the controlled case: every benchmark job **succeeded**, only
   `benchmark-approve` skipped (no regression to approve), `cut` **succeeded**,
   and `bump-main` skipped anyway. Nothing but the 2-hop-upstream skip explains
   it, and it confirms the new condition evaluates true exactly there.
2. **`!cancelled()` defeats the taint in this workflow.** On the v0.9.0 run,
   `cut` ran to success with the entire benchmark chain skipped upstream of it,
   using the same opt-out this PR copies.
3. Job-history sweep over 12 release runs: `bump-main`'s conclusion tracks
   `benchmark-approve`'s in every single run, never `cut`'s.
4. `pre-commit run --files .github/workflows/release.yml` passes; YAML parses
   and the job graph resolves with the new gate.

Not verified end to end: a `dry_run` dispatch cannot exercise this, because
`cut` is skipped on a dry run and the new gate correctly skips `bump-main` with
it. First real proof is the next cut, where `bump-main` should appear with steps
and log its dispatch decision.

## Demo

N/A (CI-only change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by auditing job conclusions and timings across the last 12 `release.yml`
runs via the Actions API (see Test Plan), plus a local lint/parse of the changed
workflow. Release workflows have no automated harness in this repo, and the
change is a single job-level condition, so the next real cut is the remaining
verification step.
