### PR TITLE
feat(sessions): add multi-directory core support

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -631,6 +631,9 @@ class SqlConversationMetadata(OmnigentBase):
     terminal_launch_args: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
     # Required when host_id is set; enforced by check constraint below.
     workspace: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    # JSON-encoded stable session directory records. NULL preserves the
+    # legacy single-workspace representation for existing rows.
+    directories: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
     git_branch: Mapped[str | None] = mapped_column(String(255), nullable=True)
     # Live-state columns, written by the replica holding the runner
     # tunnel so any replica can serve the sidebar's live fields.

--- a/omnigent/db/migrations/versions/aa0d1e2f3a4b_add_session_directories.py
+++ b/omnigent/db/migrations/versions/aa0d1e2f3a4b_add_session_directories.py
@@ -1,0 +1,30 @@
+"""Add stable multi-directory metadata to sessions.
+
+Revision ID: aa0d1e2f3a4b
+Revises: d5e9f1a2b3c4
+Create Date: 2026-07-28 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "aa0d1e2f3a4b"
+down_revision: str | None = "d5e9f1a2b3c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the compressed JSON directory-set column."""
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.add_column(sa.Column("directories", sa.LargeBinary(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove multi-directory metadata."""
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.drop_column("directories")

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnigent.inner.native_attachments import UNRESOLVED_ATTACHMENT_MARKER_PATTERN
 from omnigent.llms.adapters._content import redact_binary_payloads
+from omnigent.session_directories import SessionDirectory
 
 # Attachment markers the native executors prepend to prompt text
 # ("[Attached: /tmp/.../x.png]" from claude-native's _content_to_text,
@@ -183,6 +184,10 @@ class Conversation:
         creation — see designs/SESSION_WORKSPACE_SELECTION.md. When
         a git worktree was created for the session, this is the
         worktree directory path rather than the picked source repo.
+    :param directories: Stable project roots visible to the session.
+        The primary ``workspace`` root has id ``"default"``; additional
+        roots have opaque ``dir_<uuid>`` ids. Child sessions inherit this
+        set or an explicit subset at creation time.
     :param git_branch: Git branch checked out in the session's
         worktree, e.g. ``"feature/login"``. Set only when the
         session was created with a server-created git worktree (the
@@ -228,6 +233,7 @@ class Conversation:
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
     workspace: str | None = None
+    directories: tuple[SessionDirectory, ...] = ()
     git_branch: str | None = None
     archived: bool = False
     # Live-state fields written by the replica holding the runner tunnel

--- a/omnigent/harness_capabilities.py
+++ b/omnigent/harness_capabilities.py
@@ -101,6 +101,8 @@ class HarnessCapabilities:
     :param streaming: Whether the harness forwards token-level deltas (vs a
         single complete blob). Declared claim; verified by the bench's
         streaming probe.
+    :param additional_directories: Whether the harness receives all attached
+        session directories in addition to its primary cwd.
     :param steering: Whether input can be added to an active turn.
     :param live_queue: Whether follow-up input can be queued during an active
         turn.
@@ -137,6 +139,7 @@ class HarnessCapabilities:
     fork_history: ForkHistory = ForkHistory.NONE
     shell_tool_name: str | None = None
     shell_tool_prompt: str | None = None
+    additional_directories: bool = False
 
     def as_dict(self) -> dict[str, str | bool | None]:
         """Return a JSON-serializable view for the ``/v1/harnesses`` catalog."""
@@ -150,6 +153,7 @@ class HarnessCapabilities:
             "subagents": self.subagents,
             "interrupt": self.interrupt,
             "streaming": self.streaming,
+            "additional_directories": self.additional_directories,
             "steering": self.steering,
             "live_queue": self.live_queue,
             "images": self.images,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -152,6 +152,11 @@ from omnigent.server.schemas import (
     BackgroundSessionTitleRequest,
     BackgroundSessionTitleResponse,
 )
+from omnigent.session_directories import (
+    SessionDirectory,
+    build_session_directories,
+    validate_session_directories,
+)
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
@@ -610,10 +615,35 @@ class _SessionSnapshot:
     status_code: int | None
     created_at: float
     workspace: str | None
+    directories: tuple[SessionDirectory, ...]
     agent_id: str | None
     sub_agent_name: str | None = None
     parent_session_id: str | None = None
     agent_name: str | None = None
+
+
+def _session_directories_from_wire(
+    raw: object,
+    workspace: str | None,
+) -> tuple[SessionDirectory, ...]:
+    """Parse a session snapshot's stable roots with legacy fallback."""
+    if raw is None:
+        return build_session_directories(workspace)
+    if not isinstance(raw, list):
+        raise ValueError("session directories must be a list")
+    directories: list[SessionDirectory] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("session directory entries must be objects")
+        directory_id = item.get("id")
+        path = item.get("path")
+        nickname = item.get("nickname")
+        if not isinstance(directory_id, str) or not isinstance(path, str):
+            raise ValueError("session directory entries require string id and path")
+        if nickname is not None and not isinstance(nickname, str):
+            raise ValueError("session directory nickname must be a string or null")
+        directories.append(SessionDirectory(directory_id, path, nickname))
+    return validate_session_directories(directories)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1920,6 +1950,7 @@ def create_runner_app(
     _session_skills_cache: dict[str, tuple[float, list[SkillSpec]]] = {}
     _session_workspace_cache: dict[str, str | None] = {}  # session_id → workspace path
     _session_cursor_model_names: dict[str, dict[str, str]] = {}
+    _session_directories_cache: dict[str, tuple[SessionDirectory, ...]] = {}
     _session_claude_launch_configs: dict[str, ClaudeNativeUcodeConfig | None] = {}
     _session_claude_launch_config_tasks: dict[
         str, asyncio.Task[ClaudeNativeUcodeConfig | None]
@@ -2361,6 +2392,7 @@ def create_runner_app(
             status_code: int | None = None
             created_at: float | None = None
             workspace: str | None = None
+            directories: tuple[SessionDirectory, ...] = ()
             agent_id: str | None = None
             sub_agent_name: str | None = None
             parent_session_id: str | None = None
@@ -2374,6 +2406,9 @@ def create_runner_app(
                     if raw_created is not None:
                         created_at = float(raw_created)
                     workspace = body.get("workspace")
+                    directories = _session_directories_from_wire(
+                        body.get("directories"), workspace
+                    )
                     raw_agent_id = body.get("agent_id")
                     if isinstance(raw_agent_id, str) and raw_agent_id:
                         agent_id = raw_agent_id
@@ -2393,6 +2428,7 @@ def create_runner_app(
                 status_code=status_code,
                 created_at=created_at if created_at is not None else time.time(),
                 workspace=workspace,
+                directories=directories,
                 agent_id=agent_id,
                 sub_agent_name=sub_agent_name,
                 parent_session_id=parent_session_id,
@@ -2410,12 +2446,34 @@ def create_runner_app(
             if not snapshot.ok:
                 return None
             _session_workspace_cache[session_id] = snapshot.workspace
+            _session_directories_cache[session_id] = snapshot.directories
+            if snapshot.directories or snapshot.parent_session_id is not None:
+                resource_registry.configure_session_directories(session_id, snapshot.directories)
         return _session_workspace_cache.get(session_id)
+
+    async def _session_directory_values(
+        session_id: str,
+    ) -> tuple[SessionDirectory, ...]:
+        """Return and configure immutable roots for one session."""
+        if session_id not in _session_directories_cache:
+            snapshot = await _session_snapshot(session_id)
+            if not snapshot.ok:
+                return ()
+            _session_workspace_cache[session_id] = snapshot.workspace
+            _session_directories_cache[session_id] = snapshot.directories
+            if snapshot.directories or snapshot.parent_session_id is not None:
+                resource_registry.configure_session_directories(session_id, snapshot.directories)
+        return _session_directories_cache[session_id]
 
     async def _session_runtime_cwd(session_id: str) -> Path | None:
         workspace = await _session_workspace_value(session_id)
         if workspace and workspace.strip():
             return Path(workspace.strip()).expanduser().resolve()
+        directories = await _session_directory_values(session_id)
+        snapshot = await _session_snapshot(session_id)
+        if directories or snapshot.parent_session_id is not None:
+            root = resource_registry.compute_default_env_root(session_id, None)
+            return Path(root).resolve() if root is not None else None
         return runner_workspace.resolve() if runner_workspace is not None else None
 
     async def _load_legacy_session_init_context() -> _SessionInitContext:
@@ -2439,12 +2497,24 @@ def create_runner_app(
             status_code=200,
             created_at=float(snapshot.created_at),
             workspace=snapshot.workspace,
+            directories=tuple(
+                SessionDirectory(directory.id, directory.path, directory.nickname)
+                for directory in snapshot.directories
+            ),
             agent_id=agent_id,
             sub_agent_name=envelope.sub_agent_name,
             parent_session_id=snapshot.parent_session_id,
         )
         _session_start_cache[session_id] = float(snapshot.created_at)
         _session_workspace_cache[session_id] = snapshot.workspace
+        _session_directories_cache[session_id] = tuple(
+            SessionDirectory(directory.id, directory.path, directory.nickname)
+            for directory in snapshot.directories
+        )
+        if _session_directories_cache[session_id] or snapshot.parent_session_id is not None:
+            resource_registry.configure_session_directories(
+                session_id, _session_directories_cache[session_id]
+            )
         if envelope.sub_agent_name:
             _session_sub_agent_names[session_id] = envelope.sub_agent_name
         _session_init_envelopes[session_id] = (time.monotonic(), envelope)
@@ -3357,6 +3427,7 @@ def create_runner_app(
         _drop_session_claude_launch_config(session_id)
         _session_start_cache.pop(session_id, None)
         _session_workspace_cache.pop(session_id, None)
+        _session_directories_cache.pop(session_id, None)
         _session_snapshot_cache.pop(session_id, None)
         _session_snapshot_locks.pop(session_id, None)
         _session_init_envelopes.pop(session_id, None)
@@ -7802,6 +7873,9 @@ def create_runner_app(
         # fetch is re-resolved lazily by _session_workspace_value.
         if snapshot.ok:
             _session_workspace_cache[session_id] = snapshot.workspace
+            _session_directories_cache[session_id] = snapshot.directories
+            if snapshot.directories or snapshot.parent_session_id is not None:
+                resource_registry.configure_session_directories(session_id, snapshot.directories)
 
     async def _resolve_session_spec_entry(session_id: str) -> _SpecEntry | None:
         if session_id in _session_spec_cache:

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -12,6 +12,7 @@ See ``designs/SESSION_RESOURCES_API_DESIGN.md`` §Runner internal model.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import os
 import re
@@ -37,6 +38,11 @@ from omnigent.entities.session_resources import (
     terminal_resource_view,
 )
 from omnigent.inner.sandbox import contained_realpath, containment_prefix
+from omnigent.session_directories import (
+    DEFAULT_DIRECTORY_ID,
+    SessionDirectory,
+    validate_session_directories,
+)
 
 if TYPE_CHECKING:
     from omnigent.claude_native_status_file import SessionStatusPoller
@@ -340,6 +346,7 @@ class SessionResourceRegistry:
         self._runner_workspace = runner_workspace
         self._per_session_workspace = per_session_workspace
         self._primary_envs: dict[str, OSEnvironment] = {}
+        self._session_directories: dict[str, tuple[SessionDirectory, ...]] = {}
         self._terminal_roles: dict[tuple[str, str], str] = {}
         self._terminal_lifecycles: dict[tuple[str, str], TerminalLifecycle] = {}
         self._is_alive_cache: TTLCache[str, bool] = TTLCache(
@@ -387,6 +394,47 @@ class SessionResourceRegistry:
         # instead of polling. Entries self-remove on completion.
         self._terminal_exit_tasks: set[asyncio.Task[None]] = set()
         self._terminal_exit_scheduled: asyncio.Event = asyncio.Event()
+
+    def configure_session_directories(
+        self,
+        session_id: str,
+        directories: tuple[SessionDirectory, ...],
+    ) -> None:
+        """Register the immutable project roots for a session.
+
+        Configuration must happen before the primary environment is
+        materialized. A changed set therefore requires a session relaunch.
+        """
+        values = validate_session_directories(directories)
+        with self._lock:
+            existing = self._session_directories.get(session_id)
+            if existing is not None and existing != values:
+                raise ValueError("session directory changes require a relaunch")
+            primary = self._primary_envs.get(session_id)
+            if primary is not None and existing != values:
+                # Legacy callers may materialize the environment before the
+                # first session snapshot is fetched. Registering that same cwd
+                # as the sole default directory is metadata-only: it neither
+                # changes the environment cwd nor adds sandbox roots.
+                is_matching_legacy_default = (
+                    len(values) == 1
+                    and values[0].id == DEFAULT_DIRECTORY_ID
+                    and Path(values[0].path).resolve() == primary.cwd.resolve()
+                )
+                if not is_matching_legacy_default:
+                    raise ValueError("session directory changes require a relaunch")
+            self._session_directories[session_id] = values
+
+    def session_directories(self, session_id: str) -> tuple[SessionDirectory, ...]:
+        """Return configured roots in stable session order."""
+        with self._lock:
+            return self._session_directories.get(session_id, ())
+
+    def _configured_default_root(self, session_id: str) -> str | None:
+        for directory in self._session_directories.get(session_id, ()):
+            if directory.id == DEFAULT_DIRECTORY_ID:
+                return directory.path
+        return None
 
     def set_terminal_activity_publisher(
         self,
@@ -781,11 +829,23 @@ class SessionResourceRegistry:
         from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
         from omnigent.inner.os_env import create_os_environment
 
+        configured = self._session_directories.get(session_id)
+        configured_default = self._configured_default_root(session_id)
+
+        # Prefer the session's stable default directory. A scoped child with
+        # roots but no ``default`` starts in private scratch so it does not
+        # regain access to its parent's primary cwd through runner affinity.
+        if configured_default is not None:
+            default_cwd = configured_default
+        elif configured is not None:
+            default_cwd = _session_workspace(session_id)
+            os.makedirs(default_cwd, mode=0o700, exist_ok=True)
+            os.chmod(default_cwd, 0o700)
         # Prefer the CLI launch workspace so that the OS environment
         # cwd matches the filesystem-registry watch path.  Fall back
         # to the per-session temp dir for remote/cloud runners that
         # have no workspace affinity.
-        if self._runner_workspace is not None:
+        elif self._runner_workspace is not None:
             if self._per_session_workspace:
                 # Isolate sessions under the shared workspace.
                 default_cwd = _contained_session_dir(self._runner_workspace, session_id)
@@ -810,17 +870,32 @@ class SessionResourceRegistry:
             # Otherwise the spec's absolute cwd wins; otherwise we
             # fall back to the per-session tmpdir (default_cwd).
             if (
-                self._runner_workspace is not None
+                configured is not None
+                or self._runner_workspace is not None
                 or spec_os_env.cwd is None
                 or spec_os_env.cwd in (".", "./")
             ):
                 cwd = default_cwd
             else:
                 cwd = spec_os_env.cwd
+            additional_roots = [
+                directory.path for directory in configured or () if directory.path != cwd
+            ]
+            sandbox_spec = spec_os_env.sandbox
+            if sandbox_spec is not None and additional_roots:
+                sandbox_spec = dataclasses.replace(
+                    sandbox_spec,
+                    read_paths=list(
+                        dict.fromkeys([*(sandbox_spec.read_paths or []), *additional_roots])
+                    ),
+                    write_paths=list(
+                        dict.fromkeys([*(sandbox_spec.write_paths or []), *additional_roots])
+                    ),
+                )
             effective_spec = OSEnvSpec(
                 type=spec_os_env.type,
                 cwd=cwd,
-                sandbox=spec_os_env.sandbox,
+                sandbox=sandbox_spec,
                 fork=spec_os_env.fork,
                 start_in_scratch=spec_os_env.start_in_scratch,
             )
@@ -881,6 +956,13 @@ class SessionResourceRegistry:
             spec_os_env = getattr(agent_spec, "os_env", None)
             if spec_os_env is None:
                 return None
+
+        configured = self._session_directories.get(session_id)
+        configured_default = self._configured_default_root(session_id)
+        if configured_default is not None:
+            return str(Path(configured_default).resolve())
+        if configured is not None:
+            return str(Path(_session_workspace(session_id)).resolve())
 
         # Runner workspace wins when set. Per-session subdirectory
         # isolation is preserved so concurrent sessions
@@ -1591,6 +1673,7 @@ class SessionResourceRegistry:
         self._take_session_status_memo(session_id)
         with self._lock:
             primary = self._primary_envs.pop(session_id, None)
+            self._session_directories.pop(session_id, None)
             stale_role_keys = [key for key in self._terminal_roles if key[0] == session_id]
             for key in stale_role_keys:
                 self._terminal_roles.pop(key, None)

--- a/omnigent/runner/session_init_protocol.py
+++ b/omnigent/runner/session_init_protocol.py
@@ -8,9 +8,17 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from omnigent.entities import Conversation
 
-SessionInitProtocolVersion: TypeAlias = Literal[2]
-SESSION_INIT_PROTOCOL_VERSION: SessionInitProtocolVersion = 2
+SessionInitProtocolVersion: TypeAlias = Literal[3]
+SESSION_INIT_PROTOCOL_VERSION: SessionInitProtocolVersion = 3
 SESSION_INIT_PAYLOAD_KEY = "session_init"
+
+
+class RunnerSessionDirectory(BaseModel):
+    """One stable project directory in a runner initialization snapshot."""
+
+    id: str
+    path: str
+    nickname: str | None = None
 
 
 class RunnerSessionInitSnapshot(BaseModel):  # type: ignore[explicit-any]  # Pydantic uses Any
@@ -21,6 +29,7 @@ class RunnerSessionInitSnapshot(BaseModel):  # type: ignore[explicit-any]  # Pyd
     created_at: int
     updated_at: int
     workspace: str | None = None
+    directories: list[RunnerSessionDirectory] = Field(default_factory=list)
     labels: dict[str, str] = Field(default_factory=dict)
     reasoning_effort: str | None = None
     model_override: str | None = None
@@ -71,6 +80,14 @@ def build_runner_session_init_payload(
             created_at=conversation.created_at,
             updated_at=conversation.updated_at,
             workspace=conversation.workspace,
+            directories=[
+                RunnerSessionDirectory(
+                    id=directory.id,
+                    path=directory.path,
+                    nickname=directory.nickname,
+                )
+                for directory in conversation.directories
+            ],
             labels=conversation.labels,
             reasoning_effort=conversation.reasoning_effort,
             model_override=conversation.model_override,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -59,6 +59,10 @@ from omnigent.model_override import (
 )
 from omnigent.native_coding_agents import public_agent_name
 from omnigent.runtime import pending_elicitations
+from omnigent.session_directories import (
+    MAX_SESSION_DIRECTORIES,
+    validate_directory_id,
+)
 from omnigent.session_lifecycle import (
     CLOSED_LABEL_KEY,
     CLOSED_LABEL_VALUE,
@@ -1214,6 +1218,31 @@ def _subagent_file_ids_from_args(args: _JsonObject) -> list[str]:
     return list(raw_ids)
 
 
+def _validate_directory_ids(raw_ids: object) -> list[str] | None:
+    """Validate an optional child-session directory scope."""
+    if raw_ids is None:
+        return None
+    if not isinstance(raw_ids, list) or not all(
+        isinstance(directory_id, str) and directory_id for directory_id in raw_ids
+    ):
+        raise ValueError("'directory_ids' must be a list of non-empty strings")
+    if len(raw_ids) > MAX_SESSION_DIRECTORIES:
+        raise ValueError(f"'directory_ids' supports at most {MAX_SESSION_DIRECTORIES} entries")
+    if len(set(raw_ids)) != len(raw_ids):
+        raise ValueError("'directory_ids' must not contain duplicates")
+    for directory_id in raw_ids:
+        validate_directory_id(directory_id)
+    return list(raw_ids)
+
+
+def _subagent_directory_ids_from_args(args: _JsonObject) -> list[str] | None:
+    """Extract the create-time directory scope from object-form send args."""
+    raw_message = args.get("args")
+    if not isinstance(raw_message, dict):
+        return None
+    return _validate_directory_ids(raw_message.get("directory_ids"))
+
+
 async def _teardown_failed_child(
     server_client: httpx.AsyncClient,
     child_session_id: str,
@@ -1655,6 +1684,11 @@ async def _execute_subagent_tool(
         return f"Error: sys_session_send invalid 'file_ids': {exc}"
 
     try:
+        directory_ids = _subagent_directory_ids_from_args(args)
+    except ValueError as exc:
+        return f"Error: sys_session_send invalid 'directory_ids': {exc}"
+
+    try:
         harness_override = _subagent_harness_override_from_args(args)
     except ValueError as exc:
         return f"Error: sys_session_send invalid 'harness': {exc}"
@@ -1688,6 +1722,12 @@ async def _execute_subagent_tool(
                 "Error: sys_session_send 'file_ids' is supported only when "
                 "addressing a sub-agent by 'agent'/'title'; it cannot be "
                 f"forwarded to an existing session by id ({target_session_id!r})."
+            )
+        if directory_ids is not None:
+            return (
+                "Error: sys_session_send 'directory_ids' applies only when a "
+                "child session is first created; it cannot change an existing "
+                f"session ({target_session_id!r})."
             )
         if harness_override is not None:
             return (
@@ -1785,6 +1825,14 @@ async def _execute_subagent_tool(
                 f"{child_session_id}. Re-send without 'file_ids' to "
                 "continue it, or sys_session_close it first to spawn a "
                 "fresh session with the requested files."
+            )
+        if directory_ids is not None:
+            return (
+                f"Error: sys_session_send 'directory_ids' applies only when a "
+                f"sub-agent session is first created; {sub_agent_name!r} title "
+                f"{session_name!r} already exists as {child_session_id}. "
+                "Re-send without 'directory_ids' to continue it, or "
+                "sys_session_close it first to spawn a fresh scoped session."
             )
         if cost_budget is not None:
             return (
@@ -1890,6 +1938,8 @@ async def _execute_subagent_tool(
             "title": f"{sub_agent_name}:{session_name}",
             "sub_agent_name": sub_agent_name,
         }
+        if directory_ids is not None:
+            create_body["directory_ids"] = directory_ids
         if harness_override_canonical is not None:
             create_body["harness_override"] = harness_override_canonical
         if model is not None:
@@ -2241,6 +2291,7 @@ def _build_session_create_body(
     title: object,
     message: object,
     model: object = None,
+    directory_ids: list[str] | None = None,
 ) -> _JsonObject:
     """
     Build the JSON ``POST /v1/sessions`` body for ``sys_session_create``.
@@ -2259,6 +2310,8 @@ def _build_session_create_body(
         non-empty string.
     :param model: Optional model override, e.g. ``"databricks-glm-5-2"``;
         written as ``model_override`` on the session.
+    :param directory_ids: Optional inherited directory scope. ``None``
+        inherits all parent roots; an empty list selects private scratch.
     :returns: The JSON request body.
     """
     body: _JsonObject = {
@@ -2269,6 +2322,8 @@ def _build_session_create_body(
         body["title"] = title
     if isinstance(model, str) and model:
         body["model_override"] = model
+    if directory_ids is not None:
+        body["directory_ids"] = directory_ids
     if isinstance(message, str) and message:
         body["initial_items"] = [
             {
@@ -2407,6 +2462,10 @@ async def _execute_session_create(
                 )
             }
         )
+    try:
+        directory_ids = _validate_directory_ids(args.get("directory_ids"))
+    except ValueError as exc:
+        return json.dumps({"error": f"invalid directory_ids: {exc}"})
     if has_config_path:
         return await _session_create_from_config_path(
             str(config_path),
@@ -2423,6 +2482,7 @@ async def _execute_session_create(
         args.get("title"),
         args.get("message"),
         model=args.get("model"),
+        directory_ids=directory_ids,
     )
     try:
         resp = await server_client.post("/v1/sessions", json=body, timeout=30.0)
@@ -2586,6 +2646,9 @@ async def _upload_config_bundle(
         return json.dumps({"error": f"sys_session_create failed to bundle config: {exc}"})
 
     metadata: _JsonObject = {"parent_session_id": conversation_id}
+    directory_ids = _validate_directory_ids(args.get("directory_ids"))
+    if directory_ids is not None:
+        metadata["directory_ids"] = directory_ids
     title = args.get("title")
     if isinstance(title, str) and title:
         metadata["title"] = title

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -184,3 +184,49 @@ async def validate_existing_host_workspace(
             exc.message,
             code=ErrorCode.INVALID_INPUT,
         ) from exc
+
+
+async def validate_existing_host_directory(
+    *,
+    user_id: str | None,
+    host_id: str,
+    directory: str,
+    host_store: Any | None,
+    host_registry: Any | None,
+) -> str:
+    """Authorize, stat, and canonicalize an additional project root."""
+    from omnigent.server.routes._workspace_validation import (
+        WorkspaceValidationError,
+        validate_directory,
+    )
+
+    if host_registry is None:
+        raise OmnigentError(
+            "host registry is not configured on this server",
+            code=ErrorCode.INTERNAL_ERROR,
+        )
+
+    from omnigent.server.routes._host_launch import resolve_host_owner
+
+    host_name: str | None = None
+    if host_store is not None:
+        host = await asyncio.to_thread(
+            resolve_host_owner,
+            user_id=user_id,
+            host_id=host_id,
+            host_store=host_store,
+        )
+        host_name = host.name
+
+    try:
+        return await validate_directory(
+            host_registry=host_registry,
+            host_id=host_id,
+            directory=directory,
+            host_name_for_errors=host_name,
+        )
+    except WorkspaceValidationError as exc:
+        raise OmnigentError(
+            exc.message,
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -113,6 +113,7 @@ from omnigent.server.routes._auth_helpers import (
 )
 from omnigent.server.routes._host_worktree import CreatedWorktree
 from omnigent.server.routes._session_create_validation import (
+    validate_existing_host_directory,
     validate_existing_host_workspace,
 )
 
@@ -260,6 +261,11 @@ from omnigent.server.schemas import (
     SessionTodosEvent,
     SkillSummary,
     ToolOutputDeltaEvent,
+)
+from omnigent.session_directories import (
+    DEFAULT_DIRECTORY_ID,
+    build_session_directories,
+    select_session_directories,
 )
 from omnigent.session_lifecycle import (
     labels_with_closed_status,
@@ -4411,6 +4417,23 @@ async def _validate_session_workspace(
     )
 
 
+async def _validate_session_directory(
+    *,
+    user_id: str | None,
+    host_id: str,
+    directory: str,
+    request: Request,
+) -> str:
+    """Authorize and canonicalize one boundary-independent project root."""
+    return await validate_existing_host_directory(
+        user_id=user_id,
+        host_id=host_id,
+        directory=directory,
+        host_store=getattr(request.app.state, "host_store", None),
+        host_registry=getattr(request.app.state, "host_registry", None),
+    )
+
+
 @dataclass
 class _HostLaunchAttempt:
     """
@@ -8284,6 +8307,27 @@ def _persist_stored_session_bundle(
         any non-integrity reason.
     """
     try:
+        if metadata.parent_session_id is not None:
+            parent = conversation_store.get_conversation(metadata.parent_session_id)
+            if parent is None:
+                raise ConversationNotFoundError(
+                    f"parent conversation {metadata.parent_session_id!r} does not exist"
+                )
+            directories = select_session_directories(
+                parent.directories,
+                metadata.directory_ids,
+            )
+            default_directory = next(
+                (directory for directory in directories if directory.id == DEFAULT_DIRECTORY_ID),
+                None,
+            )
+            workspace = default_directory.path if default_directory is not None else None
+        else:
+            workspace = metadata.workspace
+            directories = build_session_directories(
+                workspace,
+                (directory.path for directory in metadata.directories),
+            )
         created = conversation_store.create_session_with_agent(
             agent_id=agent_id,
             agent_name=agent_name,
@@ -8292,7 +8336,8 @@ def _persist_stored_session_bundle(
             title=metadata.title,
             labels=metadata.labels,
             reasoning_effort=metadata.reasoning_effort,
-            workspace=metadata.workspace,
+            workspace=workspace,
+            directories=directories,
             terminal_launch_args=metadata.terminal_launch_args,
             parent_conversation_id=metadata.parent_session_id,
             runner_id=runner_id,
@@ -8308,6 +8353,12 @@ def _persist_stored_session_bundle(
             str(exc),
             code=ErrorCode.NOT_FOUND,
         ) from exc
+    except ValueError as exc:
+        _delete_stored_session_bundle_after_failure(
+            artifact_store,
+            agent_bundle_location,
+        )
+        raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
     except IntegrityError as exc:
         _delete_stored_session_bundle_after_failure(
             artifact_store,
@@ -9589,6 +9640,7 @@ __all__ = [
     "_usage_by_model_for_display",
     "_utc_day",
     "_validate_external_reasoning_effort",
+    "_validate_session_directory",
     "_validate_session_workspace",
     "_validate_terminal_launch_args",
     "_validated_cost_control_mode_override",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -63,7 +63,10 @@ from omnigent.policies.types import (
     PolicyResult,
 )
 from omnigent.runner.routing import RunnerRouter
-from omnigent.runner.session_init_protocol import build_runner_session_init_payload
+from omnigent.runner.session_init_protocol import (
+    SESSION_INIT_PROTOCOL_VERSION,
+    build_runner_session_init_payload,
+)
 from omnigent.runner.subagent_routing import (
     ROUTING_DECISION_LABEL_KEY,
     auto_harness_session,
@@ -292,6 +295,7 @@ from omnigent.server.routes._sessions.helpers import (
     _spec_harness,
     _stop_session_via_runner,
     _usage_by_model_for_display,
+    _validate_session_directory,
     _validate_session_workspace,
     _validate_terminal_launch_args,
     _validated_cost_control_mode_override,
@@ -320,6 +324,11 @@ from omnigent.server.schemas import (
     SessionStatusEvent,
     SessionUsageEvent,
     SkillSummary,
+)
+from omnigent.session_directories import (
+    DEFAULT_DIRECTORY_ID,
+    build_session_directories,
+    select_session_directories,
 )
 from omnigent.session_lifecycle import (
     labels_with_closed_status,
@@ -855,6 +864,7 @@ def _build_session_list_item(
             else pending_count
         ),
         workspace=conv.workspace,
+        directories=[directory.as_dict() for directory in conv.directories],
         git_branch=conv.git_branch,
         archived=conv.archived,
         comments_count=comments_fingerprint.count if comments_fingerprint else 0,
@@ -1110,6 +1120,7 @@ def _build_session_response(
         # (their message is already persisted into ``items``).
         pending_inputs=pending_inputs.snapshot_for(conv.id),
         workspace=conv.workspace,
+        directories=[directory.as_dict() for directory in conv.directories],
         git_branch=conv.git_branch,
         archived=conv.archived,
         # Replay the latest todo list for claude-native sessions.
@@ -3565,7 +3576,7 @@ async def _ensure_runner_session_initialized(
             return False
         return bool(
             isinstance(payload, dict)
-            and payload.get("session_init_protocol_version") == 2
+            and payload.get("session_init_protocol_version") == SESSION_INIT_PROTOCOL_VERSION
             and payload.get("terminal_ready") is True
         )
     except (httpx.HTTPError, ConnectionError):
@@ -7567,6 +7578,7 @@ async def _create_session_from_existing_agent(
     # otherwise a forged parent link lets them inherit runner
     # bindings and establish a parent-child relationship with a
     # session they don't control.
+    parent_conv: Conversation | None = None
     if body.parent_session_id is not None:
         await _require_access(
             user_id,
@@ -7575,6 +7587,11 @@ async def _create_session_from_existing_agent(
             permission_store,
             conversation_store,
         )
+        parent_conv = await asyncio.to_thread(
+            conversation_store.get_conversation, body.parent_session_id
+        )
+        if parent_conv is None:
+            raise _session_not_found()
 
     # Reject an undeclared sub-agent before persisting the row. Downstream
     # spec swaps are all guarded by ``if ... is not None`` with no
@@ -7722,20 +7739,13 @@ async def _create_session_from_existing_agent(
     # Inherit runner affinity from the parent session so the child
     # is assigned to the same runner (sub-agent co-location).
     inherited_runner_id: str | None = None
-    if body.parent_session_id is not None:
-        parent_conv = conversation_store.get_conversation(body.parent_session_id)
-        if parent_conv is not None:
-            inherited_runner_id = parent_conv.runner_id
-            # Defense-in-depth: don't inherit a runner the
-            # caller doesn't own.
-            if (
-                inherited_runner_id is not None
-                and user_id is not None
-                and runner_router is not None
-            ):
-                runner_owner = runner_router.runner_owner(inherited_runner_id)
-                if runner_owner is not None and runner_owner != user_id:
-                    inherited_runner_id = None
+    if parent_conv is not None:
+        inherited_runner_id = parent_conv.runner_id
+        # Defense-in-depth: don't inherit a runner the caller doesn't own.
+        if inherited_runner_id is not None and user_id is not None and runner_router is not None:
+            runner_owner = runner_router.runner_owner(inherited_runner_id)
+            if runner_owner is not None and runner_owner != user_id:
+                inherited_runner_id = None
 
     # Workspace validation: if the caller is binding to a host,
     # they must also pass a workspace, and the workspace must
@@ -7744,8 +7754,9 @@ async def _create_session_from_existing_agent(
     # create_conversation so a bad workspace never produces a row.
     # With git worktree creation, the validated path is the source
     # repo; the worktree it produces becomes the stored workspace.
-    canonical_workspace: str | None = body.workspace
-    if body.host_id is not None:
+    canonical_workspace: str | None = None if body.host_type == "managed" else body.workspace
+    canonical_additional_paths = [directory.path for directory in body.directories]
+    if body.host_id is not None and parent_conv is None:
         canonical_workspace = await _validate_session_workspace(
             user_id=user_id,
             host_id=body.host_id,
@@ -7753,6 +7764,19 @@ async def _create_session_from_existing_agent(
             agent=agent,
             agent_cache=agent_cache,
             request=request,
+        )
+        canonical_additional_paths = list(
+            await asyncio.gather(
+                *(
+                    _validate_session_directory(
+                        user_id=user_id,
+                        host_id=body.host_id,
+                        directory=directory.path,
+                        request=request,
+                    )
+                    for directory in body.directories
+                )
+            )
         )
 
     # Git worktree options (optional). Two modes on body.git:
@@ -7789,6 +7813,43 @@ async def _create_session_from_existing_agent(
             canonical_workspace = created_worktree.worktree_path
             git_branch = created_worktree.branch
             created_worktree_path = created_worktree.worktree_path
+
+    try:
+        if parent_conv is not None:
+            session_directories = select_session_directories(
+                parent_conv.directories,
+                body.directory_ids,
+            )
+            default_directory = next(
+                (
+                    directory
+                    for directory in session_directories
+                    if directory.id == DEFAULT_DIRECTORY_ID
+                ),
+                None,
+            )
+            canonical_workspace = default_directory.path if default_directory is not None else None
+        else:
+            session_directories = build_session_directories(
+                canonical_workspace,
+                canonical_additional_paths,
+                requested_additional_paths=(directory.path for directory in body.directories),
+            )
+    except ValueError as exc:
+        if (
+            created_worktree_path is not None
+            and body.host_id is not None
+            and git_branch is not None
+        ):
+            await _remove_session_worktree_best_effort(
+                host_id=body.host_id,
+                worktree_path=created_worktree_path,
+                branch=git_branch,
+                delete_branch=True,
+                request=request,
+                reason="create-rollback",
+            )
+        raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
 
     # Native-terminal pass-through args.
     #
@@ -7844,6 +7905,7 @@ async def _create_session_from_existing_agent(
             sub_agent_name=body.sub_agent_name,
             host_id=body.host_id,
             workspace=canonical_workspace,
+            directories=session_directories,
             git_branch=git_branch,
             terminal_launch_args=validated_launch_args,
         )

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -305,3 +305,52 @@ async def validate_workspace(
             )
 
     return canonical_workspace
+
+
+async def validate_directory(
+    *,
+    host_registry: HostRegistry,
+    host_id: str,
+    directory: str,
+    host_name_for_errors: str | None = None,
+) -> str:
+    """Validate and canonicalize an additional session directory.
+
+    Additional roots are independent projects, so they must exist on the
+    selected host but are not constrained by the primary agent cwd boundary.
+
+    :param host_registry: Registry used for the ``host.stat`` round trip.
+    :param host_id: Target host's stable id.
+    :param directory: Absolute directory path supplied by the caller.
+    :param host_name_for_errors: Optional human-readable host name.
+    :returns: The canonical path returned by the host.
+    :raises WorkspaceValidationError: If the host is offline or the path is
+        invalid, missing, not a directory, or cannot be canonicalized.
+    """
+    if not directory.startswith("/"):
+        raise WorkspaceValidationError("directory path must be absolute and start with /")
+
+    display_host = host_name_for_errors or host_id
+    host_conn = host_registry.get(host_id)
+    if host_conn is None:
+        raise WorkspaceValidationError(
+            f"host '{display_host}' is offline; reconnect the host and try again"
+        )
+
+    directory_stat = await _ask_host_stat(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        path=directory,
+    )
+    if not directory_stat.get("exists"):
+        raise WorkspaceValidationError(
+            f"directory path does not exist on host '{display_host}': {directory}"
+        )
+    if directory_stat.get("type") != "directory":
+        raise WorkspaceValidationError(
+            f"directory path is not a directory on host '{display_host}': {directory}"
+        )
+    canonical_directory = directory_stat.get("canonical_path")
+    if not isinstance(canonical_directory, str):
+        raise WorkspaceValidationError("host returned an empty canonical_path for the directory")
+    return canonical_directory

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -17,6 +17,7 @@ from typing import Annotated, Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, Strict, field_validator, model_validator
 
 from omnigent.entities import ConversationItem
+from omnigent.session_directories import validate_directory_id
 
 # ── Shared ──────────────────────────────────────────────────────
 
@@ -1196,6 +1197,30 @@ class SessionEventInput(BaseModel):
     created_by: str | None = None
 
 
+class SessionDirectoryInput(BaseModel):
+    """An additional absolute directory requested at session creation."""
+
+    path: str = Field(min_length=1, max_length=2048)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("path")
+    @classmethod
+    def _absolute_path(cls, value: str) -> str:
+        """Reject ambiguous relative and tilde-prefixed host paths."""
+        if not value.startswith("/"):
+            raise ValueError("directory path must be absolute and start with /")
+        return value
+
+
+class SessionDirectoryObject(BaseModel):
+    """Stable public identity for one directory visible to a session."""
+
+    id: str
+    path: str
+    name: str
+
+
 class SessionGitOptions(BaseModel):
     """
     Git worktree options for ``POST /v1/sessions``.
@@ -1384,6 +1409,8 @@ class SessionCreateRequest(BaseModel):
     host_type: Literal["external", "managed"] = "external"
     host_id: str | None = None
     workspace: str | None = None
+    directories: list[SessionDirectoryInput] = Field(default_factory=list, max_length=15)
+    directory_ids: list[str] | None = Field(default=None, max_length=16)
     git: SessionGitOptions | None = None
     terminal_launch_args: list[str] | None = None
     model_override: str | None = None
@@ -1392,6 +1419,35 @@ class SessionCreateRequest(BaseModel):
     subagent_routing_override: str | None = None
     harness_override: str | None = None
     smart_routing_message: str | None = None
+
+    @model_validator(mode="after")
+    def _check_directory_mode(self) -> SessionCreateRequest:
+        """Separate top-level path attachment from child scope selection."""
+        if self.parent_session_id is None and self.directory_ids is not None:
+            raise ValueError("directory_ids is only valid for child sessions")
+        if self.parent_session_id is not None and self.directories:
+            raise ValueError("child sessions select parent directory_ids; they cannot add paths")
+        if self.parent_session_id is not None and (
+            self.host_id is not None
+            or self.workspace is not None
+            or self.host_type != "external"
+            or self.git is not None
+        ):
+            raise ValueError(
+                "child sessions inherit their parent's host and directories; "
+                "host_type, host_id, workspace, and git cannot be overridden"
+            )
+        if self.host_type == "managed" and self.directories:
+            raise ValueError("managed hosts do not support additional directories")
+        paths = [directory.path for directory in self.directories]
+        if len(paths) != len(set(paths)):
+            raise ValueError("directory paths must not contain duplicates")
+        if self.directory_ids is not None:
+            if len(self.directory_ids) != len(set(self.directory_ids)):
+                raise ValueError("directory_ids must not contain duplicates")
+            for directory_id in self.directory_ids:
+                validate_directory_id(directory_id)
+        return self
 
     @model_validator(mode="after")
     def _check_git_requires_host(self) -> SessionCreateRequest:
@@ -1507,8 +1563,35 @@ class SessionCreateMetadata(BaseModel):
     reasoning_effort: str | None = None
     host_id: str | None = None
     workspace: str | None = None
+    directories: list[SessionDirectoryInput] = Field(default_factory=list, max_length=15)
+    directory_ids: list[str] | None = Field(default=None, max_length=16)
     terminal_launch_args: list[str] | None = None
     parent_session_id: str | None = None
+
+    @model_validator(mode="after")
+    def _check_directory_mode(self) -> SessionCreateMetadata:
+        """Apply the same top-level/child directory contract as JSON create."""
+        if self.parent_session_id is None and self.directory_ids is not None:
+            raise ValueError("directory_ids is only valid for child sessions")
+        if self.parent_session_id is not None and self.directories:
+            raise ValueError("child sessions select parent directory_ids; they cannot add paths")
+        if self.parent_session_id is not None and (
+            self.host_id is not None or self.workspace is not None
+        ):
+            raise ValueError(
+                "child sessions inherit their parent's host and directories; "
+                "host_id and workspace cannot be overridden"
+            )
+        paths = [directory.path for directory in self.directories]
+        if len(paths) != len(set(paths)):
+            raise ValueError("directory paths must not contain duplicates")
+        if self.directory_ids is not None and len(self.directory_ids) != len(
+            set(self.directory_ids)
+        ):
+            raise ValueError("directory_ids must not contain duplicates")
+        for directory_id in self.directory_ids or ():
+            validate_directory_id(directory_id)
+        return self
 
     model_config = ConfigDict(extra="forbid")
 
@@ -1910,6 +1993,7 @@ class SessionResponse(BaseModel):
     # Source: :mod:`omnigent.runtime.pending_inputs`.
     pending_inputs: list[dict[str, Any]] = Field(default_factory=list)
     workspace: str | None = None
+    directories: list[SessionDirectoryObject] = Field(default_factory=list)
     git_branch: str | None = None
     archived: bool = False
     todos: list[dict[str, Any]] = Field(default_factory=list)
@@ -2357,6 +2441,7 @@ class SessionListItem(BaseModel):
     external_session_id: str | None = None
     pending_elicitations_count: int = 0
     workspace: str | None = None
+    directories: list[SessionDirectoryObject] = Field(default_factory=list)
     git_branch: str | None = None
     archived: bool = False
     comments_count: int = 0

--- a/omnigent/session_directories.py
+++ b/omnigent/session_directories.py
@@ -1,0 +1,306 @@
+"""Stable directory identities for multi-directory sessions."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import PurePath
+
+DEFAULT_DIRECTORY_ID = "default"
+DIRECTORY_ID_PREFIX = "dir_"
+MAX_SESSION_DIRECTORIES = 16
+MAX_DIRECTORY_NICKNAME_LENGTH = 80
+
+
+@dataclass(frozen=True)
+class SessionDirectory:
+    """One project directory attached to a session.
+
+    ``default`` is the session's primary cwd (the legacy ``workspace``
+    field). Additional roots receive opaque ``dir_<uuid>`` identifiers that
+    remain stable when the directory set is inherited by child sessions.
+    """
+
+    id: str
+    path: str
+    nickname: str | None = None
+
+    @property
+    def basename(self) -> str:
+        """Return the physical directory basename."""
+        return PurePath(self.path).name or self.path
+
+    @property
+    def name(self) -> str:
+        """Return the persisted nickname or physical directory basename."""
+        return self.nickname or self.basename
+
+    @property
+    def environment_name(self) -> str:
+        """Return the environment label shown by filesystem clients."""
+        if self.nickname:
+            return self.nickname
+        if self.id == DEFAULT_DIRECTORY_ID:
+            return "Working folder"
+        return self.basename
+
+    def as_dict(self) -> dict[str, str]:
+        """Return the public JSON representation."""
+        return {"id": self.id, "path": self.path, "name": self.name}
+
+
+def generate_directory_id() -> str:
+    """Mint an opaque stable id for an additional directory."""
+    return f"{DIRECTORY_ID_PREFIX}{uuid.uuid4().hex}"
+
+
+def validate_directory_id(directory_id: str) -> str:
+    """Validate and return a public session-directory identifier."""
+    if directory_id == DEFAULT_DIRECTORY_ID:
+        return directory_id
+    suffix = directory_id.removeprefix(DIRECTORY_ID_PREFIX)
+    if (
+        not directory_id.startswith(DIRECTORY_ID_PREFIX)
+        or len(suffix) != 32
+        or any(ch not in "0123456789abcdef" for ch in suffix)
+    ):
+        raise ValueError(f"invalid session directory id: {directory_id!r}")
+    return directory_id
+
+
+def normalize_directory_nickname(nickname: str | None) -> str | None:
+    """Validate and normalize an optional user-facing directory nickname."""
+    if nickname is None:
+        return None
+    normalized = nickname.strip()
+    if not normalized:
+        raise ValueError("directory nickname must not be blank")
+    if "\n" in normalized or "\r" in normalized:
+        raise ValueError("directory nickname must be a single line")
+    if len(normalized) > MAX_DIRECTORY_NICKNAME_LENGTH:
+        raise ValueError(
+            f"directory nickname must be at most {MAX_DIRECTORY_NICKNAME_LENGTH} characters"
+        )
+    return normalized
+
+
+def build_session_directories(
+    workspace: str | None,
+    additional_paths: Iterable[str] = (),
+    *,
+    requested_additional_paths: Iterable[str] | None = None,
+) -> tuple[SessionDirectory, ...]:
+    """Build a new session directory set from canonical paths.
+
+    When a host resolves a picked symlink, ``additional_paths`` contains the
+    canonical target while ``requested_additional_paths`` retains the path the
+    user selected. If their basenames differ, preserve the selected basename as
+    the initial nickname so the UI does not replace the link name with its
+    target's name.
+    """
+    canonical_paths = tuple(additional_paths)
+    requested_paths = (
+        canonical_paths
+        if requested_additional_paths is None
+        else tuple(requested_additional_paths)
+    )
+    if len(requested_paths) != len(canonical_paths):
+        raise ValueError("requested and canonical additional directory counts must match")
+
+    directories: list[SessionDirectory] = []
+    if workspace is not None and workspace.strip():
+        directories.append(SessionDirectory(DEFAULT_DIRECTORY_ID, workspace))
+    directories.extend(
+        SessionDirectory(
+            generate_directory_id(),
+            canonical_path,
+            _requested_directory_nickname(requested_path, canonical_path),
+        )
+        for requested_path, canonical_path in zip(
+            requested_paths,
+            canonical_paths,
+            strict=True,
+        )
+    )
+    validate_session_directories(directories)
+    return tuple(directories)
+
+
+def _requested_directory_nickname(requested_path: str, canonical_path: str) -> str | None:
+    """Return a safe picked-path basename when canonicalization changes it."""
+    requested_name = PurePath(requested_path).name or requested_path
+    canonical_name = PurePath(canonical_path).name or canonical_path
+    if requested_name == canonical_name:
+        return None
+    try:
+        return normalize_directory_nickname(requested_name)
+    except ValueError:
+        # A filesystem basename can exceed the editable nickname limit. Keep
+        # creation working and fall back to the canonical basename in that case.
+        return None
+
+
+def validate_session_directories(
+    directories: Iterable[SessionDirectory],
+) -> tuple[SessionDirectory, ...]:
+    """Validate size, identifier, and canonical-path uniqueness invariants."""
+    values = tuple(directories)
+    if len(values) > MAX_SESSION_DIRECTORIES:
+        raise ValueError(f"a session supports at most {MAX_SESSION_DIRECTORIES} directories")
+    ids = [directory.id for directory in values]
+    if len(ids) != len(set(ids)):
+        raise ValueError("session directory ids must be unique")
+    paths = [directory.path for directory in values]
+    if len(paths) != len(set(paths)):
+        raise ValueError("session directory paths must be unique")
+    for directory in values:
+        if not directory.path:
+            raise ValueError("session directory paths must be non-empty")
+        validate_directory_id(directory.id)
+        if directory.nickname is not None:
+            normalized = normalize_directory_nickname(directory.nickname)
+            if normalized != directory.nickname:
+                raise ValueError("directory nickname must not have surrounding whitespace")
+    return values
+
+
+def validate_workspace_directory_consistency(
+    directories: Iterable[SessionDirectory],
+    workspace: str | None,
+) -> tuple[SessionDirectory, ...]:
+    """Ensure ``workspace`` and the stable ``default`` root agree.
+
+    An empty directory tuple is the legacy representation and remains valid
+    with a non-null workspace. A non-empty set must include exactly the same
+    default path when workspace is set; additional-only child scopes require
+    workspace to be null.
+    """
+    values = validate_session_directories(directories)
+    if not values:
+        return values
+    default = next(
+        (directory for directory in values if directory.id == DEFAULT_DIRECTORY_ID),
+        None,
+    )
+    if workspace is None and default is not None:
+        raise ValueError("a default session directory requires workspace")
+    if workspace is not None and (default is None or default.path != workspace):
+        raise ValueError("the default session directory must match workspace")
+    return values
+
+
+def select_session_directories(
+    parent_directories: Iterable[SessionDirectory],
+    directory_ids: Iterable[str] | None,
+) -> tuple[SessionDirectory, ...]:
+    """Return an inherited child scope, rejecting attempts to widen it.
+
+    ``None`` inherits all parent roots. An explicit empty list creates a
+    private scratch child with no project roots. Order always follows the
+    parent's order rather than caller input.
+    """
+    parent = validate_session_directories(parent_directories)
+    if directory_ids is None:
+        return parent
+    selected_ids = tuple(directory_ids)
+    if len(selected_ids) != len(set(selected_ids)):
+        raise ValueError("directory_ids must not contain duplicates")
+    parent_ids = {directory.id for directory in parent}
+    unknown = sorted(set(selected_ids) - parent_ids)
+    if unknown:
+        raise ValueError(f"directory_ids are outside the parent scope: {unknown}")
+    wanted = set(selected_ids)
+    return tuple(directory for directory in parent if directory.id in wanted)
+
+
+def encode_session_directories(directories: Iterable[SessionDirectory]) -> str | None:
+    """Encode a directory set for the session metadata table."""
+    values = validate_session_directories(directories)
+    if not values:
+        return None
+    return json.dumps(
+        [
+            {
+                "id": directory.id,
+                "path": directory.path,
+                **({"nickname": directory.nickname} if directory.nickname is not None else {}),
+            }
+            for directory in values
+        ],
+        separators=(",", ":"),
+    )
+
+
+def replace_directory_nickname(
+    directories: Iterable[SessionDirectory],
+    directory_id: str,
+    nickname: str | None,
+) -> tuple[SessionDirectory, ...]:
+    """Replace one attached directory's nickname while preserving its identity."""
+    values = validate_session_directories(directories)
+    normalized = normalize_directory_nickname(nickname)
+    found = False
+    updated: list[SessionDirectory] = []
+    for directory in values:
+        if directory.id != directory_id:
+            updated.append(directory)
+            continue
+        found = True
+        updated.append(SessionDirectory(directory.id, directory.path, normalized))
+    if not found:
+        raise ValueError(f"directory {directory_id!r} is not attached to the session")
+    return validate_session_directories(updated)
+
+
+def replace_default_directory(
+    directories: Iterable[SessionDirectory],
+    workspace: str,
+) -> tuple[SessionDirectory, ...]:
+    """Set the primary workspace while preserving additional stable roots."""
+    values = validate_session_directories(directories)
+    current_default = next(
+        (directory for directory in values if directory.id == DEFAULT_DIRECTORY_ID),
+        None,
+    )
+    additional = tuple(directory for directory in values if directory.id != DEFAULT_DIRECTORY_ID)
+    return validate_session_directories(
+        (
+            SessionDirectory(
+                DEFAULT_DIRECTORY_ID,
+                workspace,
+                current_default.nickname if current_default is not None else None,
+            ),
+            *additional,
+        )
+    )
+
+
+def decode_session_directories(
+    raw: str | bytes | None,
+    *,
+    workspace: str | None,
+) -> tuple[SessionDirectory, ...]:
+    """Decode stored roots, falling back to legacy ``workspace`` rows."""
+    if raw is None:
+        return build_session_directories(workspace)
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    payload: object = json.loads(raw)
+    if not isinstance(payload, list):
+        raise ValueError("stored session directories must be a list")
+    directories: list[SessionDirectory] = []
+    for value in payload:
+        if not isinstance(value, dict):
+            raise ValueError("stored session directory entries must be objects")
+        directory_id = value.get("id")
+        path = value.get("path")
+        nickname = value.get("nickname")
+        if not isinstance(directory_id, str) or not isinstance(path, str):
+            raise ValueError("stored session directories require string id and path")
+        if nickname is not None and not isinstance(nickname, str):
+            raise ValueError("stored session directory nickname must be a string or null")
+        directories.append(SessionDirectory(directory_id, path, nickname))
+    values = validate_session_directories(directories)
+    return validate_workspace_directory_consistency(values, workspace)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -13,6 +13,7 @@ from omnigent.entities import (
     NewConversationItem,
     PagedList,
 )
+from omnigent.session_directories import SessionDirectory
 from omnigent.session_import import IMPORT_PROVENANCE_LABEL_KEYS
 
 # Label set on a fork of a session that had a working directory. Its
@@ -336,6 +337,7 @@ class ConversationStore(ABC):
         sub_agent_name: str | None = None,
         host_id: str | None = None,
         workspace: str | None = None,
+        directories: tuple[SessionDirectory, ...] = (),
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
         conversation_id: str | None = None,
@@ -381,6 +383,8 @@ class ConversationStore(ABC):
             the canonicalized realpath returned by ``host.stat``;
             this method does no path expansion. When a git worktree
             was created, this is the worktree directory path.
+        :param directories: Stable project roots attached to this
+            session. Empty preserves the legacy workspace-only shape.
         :param git_branch: Git branch checked out in the session's
             worktree, e.g. ``"feature/login"``. Set only when the
             session was created with a server-created worktree;
@@ -1273,7 +1277,8 @@ class ConversationStore(ABC):
     def clear_host_binding(self, conversation_id: str) -> Conversation:
         """
         Revert a session to fully unbound: NULL ``host_id``,
-        ``workspace``, ``git_branch``, and ``runner_id`` together.
+        ``workspace``, ``directories``, ``git_branch``, and
+        ``runner_id`` together.
 
         Used to undo a failed per-session bind (``POST
         /v1/hosts/{id}/runners``) after the runner was atomically
@@ -1345,6 +1350,9 @@ class ConversationStore(ABC):
             existing row has ``workspace=NULL`` (DB constraint
             ``ck_conversations_workspace_required_for_host``).
             ``None`` leaves the workspace untouched.
+            When provided, the stored ``default`` directory is updated
+            atomically to the same path while additional roots retain
+            their stable ids.
         :param git_branch: Optional git branch checked out in a
             server-created worktree, e.g. ``"feature/login"``. Set
             when binding an existing session to a freshly created
@@ -1355,6 +1363,26 @@ class ConversationStore(ABC):
             with ``conversation_id`` exists.
         """
         ...
+
+    @abstractmethod
+    def set_directory_nickname(
+        self,
+        conversation_id: str,
+        directory_id: str,
+        nickname: str | None,
+    ) -> Conversation:
+        """Persist or clear one attached directory's display nickname.
+
+        :param conversation_id: Session/conversation identifier.
+        :param directory_id: Stable attached-directory id.
+        :param nickname: Normalized nickname, or ``None`` to restore the
+            default display name.
+        :returns: The updated :class:`Conversation`.
+        :raises ConversationNotFoundError: If the conversation does not exist.
+        :raises ValueError: If the directory is not attached or the nickname
+            is invalid.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def set_external_session_id(
@@ -1404,6 +1432,7 @@ class ConversationStore(ABC):
         labels: dict[str, str] | None = None,
         reasoning_effort: str | None = None,
         workspace: str | None = None,
+        directories: tuple[SessionDirectory, ...] = (),
         terminal_launch_args: list[str] | None = None,
         parent_conversation_id: str | None = None,
         runner_id: str | None = None,
@@ -1433,6 +1462,7 @@ class ConversationStore(ABC):
         :param workspace: Optional starting cwd to record on the
             session, e.g. ``"/Users/corey/projects/myapp"``.
             ``None`` leaves the column NULL.
+        :param directories: Stable project roots visible to the session.
         :param terminal_launch_args: Optional pass-through CLI args
             for a native terminal wrapper (claude / codex), e.g.
             ``["--dangerously-skip-permissions"]``. ``None`` leaves

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -73,6 +73,14 @@ from omnigent.entities import (
     PagedList,
     parse_item_data,
 )
+from omnigent.session_directories import (
+    SessionDirectory,
+    decode_session_directories,
+    encode_session_directories,
+    replace_default_directory,
+    replace_directory_nickname,
+    validate_workspace_directory_consistency,
+)
 from omnigent.session_import.models import (
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
@@ -224,6 +232,10 @@ def _to_conversation(
             else None
         ),
         workspace=meta.workspace if meta else None,
+        directories=decode_session_directories(
+            meta.directories if meta else None,
+            workspace=meta.workspace if meta else None,
+        ),
         git_branch=meta.git_branch if meta else None,
         archived=row.archived,
         live_status=(
@@ -292,6 +304,7 @@ def _new_session_metadata_row(
     parent_conversation_id: str | None = None,
     runner_id: str | None = None,
     workspace: str | None = None,
+    directories: tuple[SessionDirectory, ...] = (),
     terminal_launch_args: list[str] | None = None,
 ) -> SqlConversationMetadata:
     """
@@ -303,16 +316,23 @@ def _new_session_metadata_row(
     :param runner_id: Optional runner binding inherited from the
         parent session. ``None`` leaves the column NULL.
     :param workspace: Optional starting cwd. ``None`` leaves it NULL.
+    :param directories: Stable project roots visible to the session.
+        Empty preserves the legacy single-workspace representation.
     :param terminal_launch_args: Optional pass-through CLI args for a
         native terminal wrapper. ``None`` leaves it NULL; a list
         (including ``[]``) is JSON-encoded.
     :returns: Unsaved :class:`SqlConversationMetadata` row.
     """
+    validated_directories = validate_workspace_directory_consistency(
+        directories,
+        workspace,
+    )
     return SqlConversationMetadata(
         id=conversation_id,
         kind=encode_conversation_kind("sub_agent" if parent_conversation_id else "default"),
         runner_id=runner_id,
         workspace=workspace,
+        directories=encode_session_directories(validated_directories),
         terminal_launch_args=(
             json.dumps(terminal_launch_args) if terminal_launch_args is not None else None
         ),
@@ -864,6 +884,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         sub_agent_name: str | None = None,
         host_id: str | None = None,
         workspace: str | None = None,
+        directories: tuple[SessionDirectory, ...] = (),
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
         conversation_id: str | None = None,
@@ -903,6 +924,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             already-canonicalized realpath from
             ``host.stat`` — this method does no expansion. When a git
             worktree was created, this is the worktree directory path.
+        :param directories: Stable project roots visible to the session.
+            Empty preserves the legacy single-workspace representation.
         :param git_branch: Git branch checked out in the session's
             worktree, e.g. ``"feature/login"``. Set only when the
             session was created with a server-created worktree;
@@ -933,6 +956,10 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         now = now_epoch()
         new_id = conversation_id if conversation_id is not None else generate_conversation_id()
+        validated_directories = validate_workspace_directory_consistency(
+            directories,
+            workspace,
+        )
         try:
             # Get parent's root from AP, then write AP row and Omnigent meta separately.
             root_id = new_id
@@ -994,6 +1021,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 host_id=host_id,
                 sub_agent_name=sub_agent_name,
                 workspace=workspace,
+                directories=encode_session_directories(validated_directories),
                 git_branch=git_branch,
                 terminal_launch_args=(
                     json.dumps(terminal_launch_args) if terminal_launch_args is not None else None
@@ -3017,7 +3045,8 @@ class SqlAlchemyConversationStore(ConversationStore):
 
     def clear_host_binding(self, conversation_id: str) -> Conversation:
         """
-        NULL ``host_id``/``workspace``/``git_branch``/``runner_id`` together.
+        NULL ``host_id``/``workspace``/``directories``/``git_branch``/
+        ``runner_id`` together.
 
         Single-transaction full unbind — see
         :meth:`ConversationStore.clear_host_binding`. ``host_id`` and
@@ -3038,6 +3067,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
             meta.host_id = None
             meta.workspace = None
+            meta.directories = None
             meta.git_branch = None
             meta.runner_id = None
         with self._conv_session("clear_host_binding") as ap_sess:
@@ -3147,10 +3177,47 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
             meta.host_id = host_id
             if workspace is not None:
+                current_directories = decode_session_directories(
+                    meta.directories,
+                    workspace=meta.workspace,
+                )
                 meta.workspace = workspace
+                meta.directories = encode_session_directories(
+                    replace_default_directory(current_directories, workspace)
+                )
             if git_branch is not None:
                 meta.git_branch = git_branch
         with self._conv_session("set_host_id") as ap_sess:
+            ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
+            if ap_row is None:
+                raise ConversationNotFoundError(
+                    f"conversation {conversation_id!r} does not exist",
+                )
+            ap_row.updated_at = now_epoch()
+            labels = _fetch_labels(ap_sess, conversation_id)
+        return _to_conversation(ap_row, meta, labels)
+
+    def set_directory_nickname(
+        self,
+        conversation_id: str,
+        directory_id: str,
+        nickname: str | None,
+    ) -> Conversation:
+        """Persist or clear one attached directory's display nickname."""
+        with self._session("set_directory_nickname") as session:
+            meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
+            if meta is None:
+                raise ConversationNotFoundError(
+                    f"conversation {conversation_id!r} does not exist",
+                )
+            directories = decode_session_directories(
+                meta.directories,
+                workspace=meta.workspace,
+            )
+            meta.directories = encode_session_directories(
+                replace_directory_nickname(directories, directory_id, nickname)
+            )
+        with self._conv_session("set_directory_nickname") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -3221,6 +3288,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         labels: dict[str, str] | None = None,
         reasoning_effort: str | None = None,
         workspace: str | None = None,
+        directories: tuple[SessionDirectory, ...] = (),
         terminal_launch_args: list[str] | None = None,
         parent_conversation_id: str | None = None,
         runner_id: str | None = None,
@@ -3287,6 +3355,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             labels=labels,
             reasoning_effort=reasoning_effort,
             workspace=workspace,
+            directories=directories,
             terminal_launch_args=terminal_launch_args,
             parent_conversation_id=parent_conversation_id,
             runner_id=runner_id,
@@ -3304,6 +3373,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         labels: dict[str, str] | None = None,
         reasoning_effort: str | None = None,
         workspace: str | None = None,
+        directories: tuple[SessionDirectory, ...] = (),
         terminal_launch_args: list[str] | None = None,
         parent_conversation_id: str | None = None,
         runner_id: str | None = None,
@@ -3355,6 +3425,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             parent_conversation_id=parent_conversation_id,
             runner_id=runner_id,
             workspace=workspace,
+            directories=directories,
             terminal_launch_args=terminal_launch_args,
         )
         with self._session("create_session_with_agent") as session:

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -372,6 +372,19 @@ def _build_sys_session_send_schema(
                                             "named session."
                                         ),
                                     },
+                                    "directory_ids": {
+                                        "type": "array",
+                                        "items": {"type": "string", "minLength": 1},
+                                        "maxItems": 16,
+                                        "uniqueItems": True,
+                                        "description": (
+                                            "Optional directory scope for a newly-created "
+                                            "child. Omit to inherit every parent directory, "
+                                            "pass [] for private scratch, or pass stable ids "
+                                            "from the parent session's directories list. "
+                                            "Accepted only on the first named send."
+                                        ),
+                                    },
                                     **harness_property,
                                     "cost_budget": {
                                         "type": "object",
@@ -934,6 +947,18 @@ class SysSessionCreateTool(Tool):
                                 "or 'provider-local-model-id'. Sets the harness "
                                 "model at session creation; omit to use the "
                                 "agent's default."
+                            ),
+                        },
+                        "directory_ids": {
+                            "type": "array",
+                            "items": {"type": "string", "minLength": 1},
+                            "maxItems": 16,
+                            "uniqueItems": True,
+                            "description": (
+                                "Optional directory scope inherited by the new child. "
+                                "Omit to inherit all parent directories, pass [] for "
+                                "private scratch, or pass stable directory ids exposed "
+                                "by the parent session."
                             ),
                         },
                     },

--- a/openapi.json
+++ b/openapi.json
@@ -3872,6 +3872,30 @@
         "title": "SessionCreatedEvent",
         "type": "object"
       },
+      "SessionDirectoryObject": {
+        "description": "Stable public identity for one directory visible to a session.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path",
+          "name"
+        ],
+        "title": "SessionDirectoryObject",
+        "type": "object"
+      },
       "SessionForkRequest": {
         "additionalProperties": false,
         "description": "Request body for `POST /v1/sessions/{source_id}/fork`.\n\nCreates a deep copy of an existing session's items into a new\nsession. All fields are optional.",
@@ -4256,6 +4280,13 @@
             "description": "Unix epoch seconds of creation.",
             "title": "Created At",
             "type": "integer"
+          },
+          "directories": {
+            "items": {
+              "$ref": "#/components/schemas/SessionDirectoryObject"
+            },
+            "title": "Directories",
+            "type": "array"
           },
           "external_session_id": {
             "anyOf": [
@@ -4991,6 +5022,13 @@
             "description": "Unix epoch seconds of creation.",
             "title": "Created At",
             "type": "integer"
+          },
+          "directories": {
+            "items": {
+              "$ref": "#/components/schemas/SessionDirectoryObject"
+            },
+            "title": "Directories",
+            "type": "array"
           },
           "external_session_id": {
             "anyOf": [

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -327,6 +327,7 @@ def test_sanitize_real_sys_session_send_args_collapses_to_object() -> None:
         "purpose",
         "model",
         "file_ids",
+        "directory_ids",
         "cost_budget",
     }
     assert sanitized_args["required"] == ["input"]

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -723,7 +723,7 @@ async def test_auto_create_claude_terminal_passes_session_effort(
     session_init = (
         RunnerSessionInitEnvelope.model_validate(
             {
-                "protocol_version": 2,
+                "protocol_version": 3,
                 "server_version": "0.6.0.dev0",
                 "session_id": session_id,
                 "agent_id": "agent",
@@ -766,7 +766,7 @@ async def test_claude_launch_metadata_envelope_never_calls_server() -> None:
 
     envelope = RunnerSessionInitEnvelope.model_validate(
         {
-            "protocol_version": 2,
+            "protocol_version": 3,
             "server_version": "0.6.0.dev0",
             "session_id": "conv_resume",
             "agent_id": "agent_resume",
@@ -2304,7 +2304,7 @@ async def test_create_session_auto_create_guard_skips_rotation_targets(
     }
     if use_envelope:
         payload["session_init"] = {
-            "protocol_version": 2,
+            "protocol_version": 3,
             "server_version": "0.6.0.dev0",
             "session_id": payload["session_id"],
             "agent_id": payload["agent_id"],

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -2095,7 +2095,7 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
         "agent_id": agent_id,
         "sub_agent_name": None,
         "session_init": {
-            "protocol_version": 2,
+            "protocol_version": 3,
             "server_version": "0.6.0.dev0",
             "session_id": session_id,
             "agent_id": agent_id,
@@ -2119,7 +2119,7 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
 
     assert first_response.status_code == second_response.status_code == 201
     assert first_response.json()["created_at"] == 1234
-    assert first_response.json()["session_init_protocol_version"] == 2
+    assert first_response.json()["session_init_protocol_version"] == 3
     assert resolver_calls == 1
     assert len(pm.get_client_calls) == 1
     assert server_client.get_paths == [f"/v1/sessions/{session_id}/items"]

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -27,6 +27,7 @@ from omnigent.runner.resource_registry import (
     _terminal_exit_diagnostics,
     _trim_terminal_exit_output,
 )
+from omnigent.session_directories import SessionDirectory
 from omnigent.terminals import TerminalRegistry
 from tests.runner.helpers import make_test_terminal_instance
 
@@ -1287,6 +1288,98 @@ def test_compute_default_env_root_runner_workspace_overrides_relative_cwd(
     root = reg.compute_default_env_root("conv_rel", spec)
 
     assert root == str(workspace.resolve())
+
+
+def test_configured_directories_control_cwd_and_sandbox_reach(tmp_path: Path) -> None:
+    """The default root becomes cwd and every additional root is writable."""
+    primary = tmp_path / "primary"
+    shared = tmp_path / "shared"
+    primary.mkdir()
+    shared.mkdir()
+    registry = SessionResourceRegistry(runner_workspace=tmp_path / "wrong-runner-root")
+    registry.configure_session_directories(
+        "conv_multi",
+        (
+            SessionDirectory("default", str(primary)),
+            SessionDirectory(f"dir_{1:032x}", str(shared)),
+        ),
+    )
+    spec = SimpleNamespace(
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=".",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        )
+    )
+
+    env = registry.resolve_environment("conv_multi", DEFAULT_ENVIRONMENT_ID, spec)
+
+    assert env.cwd == primary.resolve()
+    assert env.sandbox.read_roots == [shared.resolve()]
+    assert env.sandbox.write_roots == [shared.resolve()]
+    # Core deliberately exposes only the legacy/default environment. The
+    # per-root Files/Git resource surface is layered in a child PR.
+    assert [resource.id for resource in registry.list_resources("conv_multi").data] == [
+        DEFAULT_ENVIRONMENT_ID
+    ]
+
+
+def test_child_without_default_directory_gets_private_scratch(tmp_path: Path) -> None:
+    """A narrowed child cannot regain the runner's primary cwd."""
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    runner_root = tmp_path / "runner"
+    runner_root.mkdir()
+    registry = SessionResourceRegistry(
+        runner_workspace=runner_root,
+        per_session_workspace=False,
+    )
+    registry.configure_session_directories(
+        "conv_scoped",
+        (SessionDirectory(f"dir_{1:032x}", str(shared)),),
+    )
+    spec = _agent_spec_with_sandbox_none(tmp_path / "spec-root")
+
+    env = registry.resolve_environment("conv_scoped", DEFAULT_ENVIRONMENT_ID, spec)
+
+    assert env.cwd != runner_root.resolve()
+    assert env.cwd != shared.resolve()
+    assert env.sandbox.write_roots == [shared.resolve()]
+
+
+def test_session_directory_configuration_is_immutable() -> None:
+    """Changing attached roots requires relaunching the session."""
+    registry = SessionResourceRegistry()
+    initial = (SessionDirectory("default", "/repo/one"),)
+    registry.configure_session_directories("conv_immutable", initial)
+    registry.configure_session_directories("conv_immutable", initial)
+
+    with pytest.raises(ValueError, match="require a relaunch"):
+        registry.configure_session_directories(
+            "conv_immutable",
+            (SessionDirectory("default", "/repo/two"),),
+        )
+
+
+def test_matching_legacy_default_can_be_registered_after_environment(
+    tmp_path: Path,
+) -> None:
+    """A lazy legacy snapshot may describe the already-materialized cwd."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = SessionResourceRegistry(runner_workspace=workspace)
+    spec = _agent_spec_with_sandbox_none(tmp_path / "spec-root")
+    environment = registry.resolve_environment("conv_legacy", DEFAULT_ENVIRONMENT_ID, spec)
+
+    registry.configure_session_directories(
+        "conv_legacy",
+        (SessionDirectory("default", str(workspace)),),
+    )
+
+    assert environment.cwd == workspace.resolve()
+    assert registry.session_directories("conv_legacy") == (
+        SessionDirectory("default", str(workspace)),
+    )
 
 
 def test_compute_default_env_root_runner_workspace_overrides_absolute_cwd(

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3105,6 +3105,7 @@ async def test_sys_session_send_model_lands_in_child_create_body(
                         "args": {
                             "input": "fix the auth bug",
                             "model": model,
+                            "directory_ids": [],
                         },
                     }
                 ),
@@ -3123,6 +3124,7 @@ async def test_sys_session_send_model_lands_in_child_create_body(
     # server persists and the harness launch consumes.
     assert len(create_bodies) == 1, "fresh named send must create exactly one child"
     assert create_bodies[0]["model_override"] == model
+    assert create_bodies[0]["directory_ids"] == []
     assert create_bodies[0]["sub_agent_name"] == "worker"
 
 
@@ -3203,18 +3205,28 @@ async def test_sys_session_send_blocks_fresh_dispatch_when_harness_cli_missing(
 
 
 @pytest.mark.asyncio
-async def test_sys_session_send_model_rejected_for_existing_child(
+@pytest.mark.parametrize(
+    ("create_only_args", "field"),
+    [
+        ({"model": "claude-opus-4-8"}, "model"),
+        ({"directory_ids": []}, "directory_ids"),
+    ],
+)
+async def test_sys_session_send_create_only_args_rejected_for_existing_child(
     monkeypatch: pytest.MonkeyPatch,
+    create_only_args: dict[str, Any],
+    field: str,
 ) -> None:
     """
-    Passing ``model`` on a continuation send fails loud, sends nothing.
+    Passing create-time metadata on a continuation fails loud, sends nothing.
 
-    A native child bakes ``--model`` in at terminal launch, so applying
-    a new model to an existing session would be silently ignored. The
-    tool must return an actionable error (continue without ``model`` or
-    close and respawn) instead of continuing on the wrong model.
+    Models and directory scopes are fixed at launch. The tool must return
+    an actionable error (continue without the field or close and respawn)
+    instead of silently ignoring a requested change.
 
     :param monkeypatch: Pytest monkeypatch fixture.
+    :param create_only_args: Metadata that cannot change after launch.
+    :param field: Field name expected in the actionable error.
     """
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import execute_tool
@@ -3265,7 +3277,7 @@ async def test_sys_session_send_model_rejected_for_existing_child(
                     {
                         "agent": "worker",
                         "title": "fix-auth",
-                        "args": {"input": "continue", "model": "claude-opus-4-8"},
+                        "args": {"input": "continue", **create_only_args},
                     }
                 ),
                 server_client=server_client,
@@ -3277,22 +3289,33 @@ async def test_sys_session_send_model_rejected_for_existing_child(
             runner_app._session_inboxes_ref.pop("conv_parent_model_cont", None)
 
     assert output.startswith("Error:"), output
+    assert field in output
     # The error must name the existing session and the recovery paths.
     assert "conv_existing_model" in output
     assert "sys_session_close" in output
-    # No write happened: the wrong-model continuation never started.
+    # No write happened: the invalid continuation never started.
     assert create_posts == 0
     assert event_posts == 0
 
 
 @pytest.mark.asyncio
-async def test_sys_session_send_model_rejected_in_by_id_mode() -> None:
+@pytest.mark.parametrize(
+    ("create_only_args", "field"),
+    [
+        ({"model": "claude-opus-4-8"}, "model"),
+        ({"directory_ids": []}, "directory_ids"),
+    ],
+)
+async def test_sys_session_send_create_only_args_rejected_in_by_id_mode(
+    create_only_args: dict[str, Any],
+    field: str,
+) -> None:
     """
-    ``model`` plus ``session_id`` fails loud before any server call.
+    Create-time metadata plus ``session_id`` fails before any server call.
 
-    By-id mode always targets an existing session, where a model
-    override cannot take effect — the tool must reject it instead of
-    silently dropping the field.
+    By-id mode always targets an existing session, where model and directory
+    scope overrides cannot take effect. The tool rejects them rather than
+    silently dropping either field.
     """
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import execute_tool
@@ -3316,7 +3339,7 @@ async def test_sys_session_send_model_rejected_in_by_id_mode() -> None:
                 arguments=json.dumps(
                     {
                         "session_id": "conv_some_child",
-                        "args": {"input": "continue", "model": "claude-opus-4-8"},
+                        "args": {"input": "continue", **create_only_args},
                     }
                 ),
                 server_client=server_client,
@@ -3327,7 +3350,7 @@ async def test_sys_session_send_model_rejected_in_by_id_mode() -> None:
             runner_app._session_inboxes_ref.pop("conv_parent_by_id_model", None)
 
     assert output.startswith("Error:"), output
-    assert "model" in output
+    assert field in output
     # Rejected before lookup: a misaddressed override must not even read
     # the target session.
     assert requests_seen == 0
@@ -6199,7 +6222,14 @@ async def test_sys_session_create_spawns_child_under_caller() -> None:
     ) as server_client:
         output = await execute_tool(
             tool_name="sys_session_create",
-            arguments=json.dumps({"agent_id": "ag_x", "title": "auth", "message": "start"}),
+            arguments=json.dumps(
+                {
+                    "agent_id": "ag_x",
+                    "title": "auth",
+                    "message": "start",
+                    "directory_ids": [],
+                }
+            ),
             server_client=server_client,
             conversation_id="conv_caller",
         )
@@ -6209,6 +6239,7 @@ async def test_sys_session_create_spawns_child_under_caller() -> None:
     assert captured["parent_session_id"] == "conv_caller"
     assert captured["agent_id"] == "ag_x"
     assert captured["title"] == "auth"
+    assert captured["directory_ids"] == []
     assert captured["initial_items"][0]["data"]["content"][0]["text"] == "start"
     handle = json.loads(output)
     assert handle["conversation_id"] == "conv_child"
@@ -6333,7 +6364,12 @@ async def test_sys_session_create_bundle_mode_uploads_child_under_caller(
         output = await execute_tool(
             tool_name="sys_session_create",
             arguments=json.dumps(
-                {"config_path": "helper.yaml", "title": "auth", "message": "start"}
+                {
+                    "config_path": "helper.yaml",
+                    "title": "auth",
+                    "message": "start",
+                    "directory_ids": [],
+                }
             ),
             server_client=server_client,
             conversation_id="conv_caller",
@@ -6346,7 +6382,11 @@ async def test_sys_session_create_bundle_mode_uploads_child_under_caller(
         f"expected exactly one create POST, got {len(create_requests)}"
     )
     parts = _parse_multipart_create(create_requests[0])
-    assert parts["metadata"] == {"parent_session_id": "conv_caller", "title": "auth"}
+    assert parts["metadata"] == {
+        "parent_session_id": "conv_caller",
+        "directory_ids": [],
+        "title": "auth",
+    }
 
     # The uploaded bundle is a gzipped tar holding the authored config
     # verbatim — proves the local file traversed materialize → tar.

--- a/tests/server/integration/test_session_directories.py
+++ b/tests/server/integration/test_session_directories.py
@@ -1,0 +1,140 @@
+"""Integration coverage for child-session directory inheritance."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.session_directories import SessionDirectory
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+_DEFAULT = SessionDirectory("default", "/repo/main")
+_SHARED = SessionDirectory(f"dir_{1:032x}", "/repo/shared")
+
+
+async def _seed_parent(client: httpx.AsyncClient, db_uri: str) -> tuple[str, str]:
+    """Create an agent and a parent session with two stable roots."""
+    agent = await create_test_agent(client, name="directory-test-agent")
+    parent = SqlAlchemyConversationStore(db_uri).create_conversation(
+        agent_id=agent["id"],
+        workspace=_DEFAULT.path,
+        directories=(_DEFAULT, _SHARED),
+    )
+    return parent.id, agent["id"]
+
+
+async def _create_child(
+    client: httpx.AsyncClient,
+    *,
+    parent_id: str,
+    agent_id: str,
+    title: str,
+    directory_ids: list[str] | None | object = ...,
+) -> httpx.Response:
+    """POST one child while preserving omitted-vs-empty scope semantics."""
+    body: dict[str, Any] = {
+        "agent_id": agent_id,
+        "parent_session_id": parent_id,
+        "title": title,
+    }
+    if directory_ids is not ...:
+        body["directory_ids"] = directory_ids
+    return await client.post("/v1/sessions", json=body)
+
+
+async def test_child_directory_scope_inherit_subset_and_empty(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Omitted inherits all, a subset narrows, and [] creates scratch."""
+    parent_id, agent_id = await _seed_parent(client, db_uri)
+
+    inherited = await _create_child(
+        client,
+        parent_id=parent_id,
+        agent_id=agent_id,
+        title="inherit",
+    )
+    assert inherited.status_code == 201, inherited.text
+    assert inherited.json()["directories"] == [
+        _DEFAULT.as_dict(),
+        _SHARED.as_dict(),
+    ]
+    assert inherited.json()["workspace"] == _DEFAULT.path
+
+    narrowed = await _create_child(
+        client,
+        parent_id=parent_id,
+        agent_id=agent_id,
+        title="narrowed",
+        directory_ids=[_SHARED.id],
+    )
+    assert narrowed.status_code == 201, narrowed.text
+    assert narrowed.json()["directories"] == [_SHARED.as_dict()]
+    assert narrowed.json().get("workspace") is None
+
+    scratch = await _create_child(
+        client,
+        parent_id=parent_id,
+        agent_id=agent_id,
+        title="scratch",
+        directory_ids=[],
+    )
+    assert scratch.status_code == 201, scratch.text
+    assert scratch.json()["directories"] == []
+    assert scratch.json().get("workspace") is None
+
+
+async def test_nested_child_cannot_widen_parent_directory_scope(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A grandchild may only select ids still visible to its direct parent."""
+    parent_id, agent_id = await _seed_parent(client, db_uri)
+    narrowed = await _create_child(
+        client,
+        parent_id=parent_id,
+        agent_id=agent_id,
+        title="narrowed",
+        directory_ids=[_SHARED.id],
+    )
+    assert narrowed.status_code == 201, narrowed.text
+
+    widened = await _create_child(
+        client,
+        parent_id=narrowed.json()["id"],
+        agent_id=agent_id,
+        title="widened",
+        directory_ids=[_DEFAULT.id, _SHARED.id],
+    )
+
+    assert widened.status_code == 400
+    assert "outside the parent scope" in widened.text
+
+
+async def test_child_rejects_independent_host_or_worktree_fields(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Child sessions inherit placement and cannot create an orphan worktree."""
+    parent_id, agent_id = await _seed_parent(client, db_uri)
+
+    response = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent_id,
+            "parent_session_id": parent_id,
+            "host_id": "host_untrusted",
+            "workspace": "/repo/other",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "inherit their parent's host and directories" in response.text

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -194,6 +194,7 @@ async def _serve_one_launch(
     launch_status: str,
     launch_error: str | None = None,
     launch_error_code: str | None = None,
+    canonical_paths: dict[str, str] | None = None,
 ) -> HostLaunchRunnerFrame:
     """Answer the host round-trips for a single inline session launch.
 
@@ -212,6 +213,8 @@ async def _serve_one_launch(
     :param launch_error_code: Structured failure category to attach,
         e.g. ``"harness_not_configured"``; ``None`` reports an
         uncategorized failure (legacy host behavior).
+    :param canonical_paths: Optional requested-path to canonical-path mapping
+        for simulating symlinks. Unmapped paths echo unchanged.
     :returns: The ``host.launch_runner`` frame the server sent, so
         callers can assert on its fields (e.g. ``harness``).
     """
@@ -232,7 +235,7 @@ async def _serve_one_launch(
                             status="ok",
                             exists=True,
                             type="directory",
-                            canonical_path=frame.path,
+                            canonical_path=(canonical_paths or {}).get(frame.path, frame.path),
                         )
                     ),
                 }
@@ -799,6 +802,43 @@ async def _inline_launch_session(
     await launch_responder
     assert create_resp.status_code == 201, create_resp.text
     return {"id": create_resp.json()["id"], "runner_id": create_resp.json()["runner_id"]}
+
+
+async def test_inline_launch_keeps_symlink_name_as_additional_directory_title(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+) -> None:
+    """Canonical storage keeps the basename the user selected as the title."""
+    comm = await _connect_host(app)
+    requested = "/work/linked-repo"
+    canonical = "/mnt/repos/actual-repo"
+    agent = await create_test_agent(client)
+    launch_responder = asyncio.create_task(
+        _serve_one_launch(
+            comm,
+            launch_status="launched",
+            canonical_paths={requested: canonical},
+        )
+    )
+
+    response = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "host_id": _HOST_ID,
+            "workspace": _WORKSPACE,
+            "directories": [{"path": requested}],
+        },
+    )
+    launch_frame = await launch_responder
+
+    assert response.status_code == 201, response.text
+    assert launch_frame.workspace == _WORKSPACE
+    additional = next(
+        directory for directory in response.json()["directories"] if directory["id"] != "default"
+    )
+    assert additional["path"] == canonical
+    assert additional["name"] == "linked-repo"
 
 
 async def _stop_host_session(

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -430,3 +430,31 @@ async def test_create_failure_rolls_back_omnigent_created_worktree(
     assert len(cap.remove) == 1, f"expected a create-rollback remove frame, got {cap.remove}"
     assert cap.remove[0].branch == "feature/orphan"
     assert cap.remove[0].delete_branch is True
+
+
+async def test_directory_set_failure_rolls_back_omnigent_created_worktree(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+) -> None:
+    """A post-worktree directory collision cannot leave an orphan worktree."""
+    cap = register_worktree_host()
+    agent = await create_test_agent(client, name="wt-directory-rollback-agent")
+    worktree_path = f"{_SOURCE_REPO}-worktrees/feature-collision"
+
+    response = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "host_id": _HOST_ID,
+            "workspace": _SOURCE_REPO,
+            "directories": [{"path": worktree_path}],
+            "git": {"branch_name": "feature/collision"},
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert "paths must be unique" in response.text
+    assert len(cap.create) == 1, cap.create
+    assert len(cap.remove) == 1, cap.remove
+    assert cap.remove[0].worktree_path == worktree_path
+    assert cap.remove[0].branch == "feature/collision"

--- a/tests/server/routes/test_workspace_validation.py
+++ b/tests/server/routes/test_workspace_validation.py
@@ -24,6 +24,7 @@ from omnigent.host.frames import (
 from omnigent.server.host_registry import HostRegistry
 from omnigent.server.routes._workspace_validation import (
     WorkspaceValidationError,
+    validate_directory,
     validate_workspace,
 )
 
@@ -194,6 +195,26 @@ async def test_offline_host_rejected() -> None:
             spec_cwd=".",
         )
     assert "is offline" in exc_info.value.message
+
+
+async def test_additional_directory_is_canonicalized_without_primary_boundary(
+    host_setup: tuple[HostRegistry, _FakeWebSocket, asyncio.Task[None]],
+) -> None:
+    """An independent project root only needs to exist on the same host."""
+    registry, _, _ = host_setup
+    _set_stat(
+        registry,
+        "/Users/corey/other-repo-link",
+        canonical="/Volumes/projects/other-repo",
+    )
+
+    canonical = await validate_directory(
+        host_registry=registry,
+        host_id=_HOST_ID,
+        directory="/Users/corey/other-repo-link",
+    )
+
+    assert canonical == "/Volumes/projects/other-repo"
 
 
 # ── Step 4: workspace stat ──────────────────────────────

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -15,6 +15,7 @@ from omnigent.runner.session_init_protocol import (
     parse_runner_session_init_envelope,
 )
 from omnigent.server.runner_session_init import RunnerSessionInitializer
+from omnigent.session_directories import SessionDirectory
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store import (
     FORK_CARRY_HISTORY_LABEL_KEY,
@@ -55,6 +56,10 @@ def _conversation() -> Conversation:
         agent_id="agent_init",
         runner_id="runner_init",
         workspace="/tmp/workspace",
+        directories=(
+            SessionDirectory("default", "/tmp/workspace"),
+            SessionDirectory(f"dir_{1:032x}", "/tmp/shared", nickname="Shared services"),
+        ),
         labels={"example": "value"},
     )
 
@@ -79,6 +84,14 @@ async def test_initializer_shares_result_for_one_tunnel_generation() -> None:
     assert first_response is second_response
     assert len(client.calls) == 1
     assert client.calls[0]["session_init"]["snapshot"]["workspace"] == "/tmp/workspace"
+    assert client.calls[0]["session_init"]["snapshot"]["directories"] == [
+        {"id": "default", "path": "/tmp/workspace", "nickname": None},
+        {
+            "id": f"dir_{1:032x}",
+            "path": "/tmp/shared",
+            "nickname": "Shared services",
+        },
+    ]
 
     cached = await initializer.initialize(conversation, client, timeout=10)  # type: ignore[arg-type]
     assert cached is first_response
@@ -112,7 +125,7 @@ async def test_initializer_evicts_rejected_result_for_retry() -> None:
 @pytest.mark.parametrize(
     ("payload", "expected_ready"),
     [
-        ({"session_init_protocol_version": 2, "terminal_ready": True}, True),
+        ({"session_init_protocol_version": 3, "terminal_ready": True}, True),
         ({}, False),
     ],
     ids=["current-runner", "legacy-runner"],

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -769,6 +769,94 @@ def test_session_create_external_rejects_repo_url_workspace() -> None:
         )
 
 
+def test_session_create_directory_contract_distinguishes_top_level_and_child() -> None:
+    """Top-level paths and child ids are mutually exclusive request modes."""
+    from omnigent.server.schemas import SessionCreateRequest, SessionDirectoryInput
+
+    top_level = SessionCreateRequest(
+        agent_id="ag_x",
+        workspace="/repo/main",
+        directories=[SessionDirectoryInput(path="/repo/shared")],
+    )
+    assert [directory.path for directory in top_level.directories] == ["/repo/shared"]
+
+    child = SessionCreateRequest(
+        agent_id="ag_x",
+        parent_session_id="conv_parent",
+        directory_ids=[],
+    )
+    assert child.directory_ids == []
+
+    with pytest.raises(ValidationError, match="cannot add paths"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            parent_session_id="conv_parent",
+            directories=[SessionDirectoryInput(path="/repo/shared")],
+        )
+    with pytest.raises(ValidationError, match="only valid for child sessions"):
+        SessionCreateRequest(agent_id="ag_x", directory_ids=[])
+    with pytest.raises(ValidationError, match="managed hosts do not support"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            host_type="managed",
+            workspace="https://github.com/org/repo",
+            directories=[SessionDirectoryInput(path="/repo/shared")],
+        )
+
+
+def test_session_create_rejects_invalid_or_duplicate_directory_ids() -> None:
+    """Stable ids are bounded, canonical, and unique before route dispatch."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    with pytest.raises(ValidationError, match="invalid session directory id"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            parent_session_id="conv_parent",
+            directory_ids=["dir_not-a-uuid"],
+        )
+    with pytest.raises(ValidationError, match="must not contain duplicates"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            parent_session_id="conv_parent",
+            directory_ids=["default", "default"],
+        )
+
+
+def test_session_create_child_rejects_host_workspace_and_git_overrides() -> None:
+    """A child inherits placement; worktree creation remains top-level-only."""
+    from omnigent.server.schemas import SessionCreateRequest, SessionGitOptions
+
+    with pytest.raises(ValidationError, match="cannot be overridden"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            parent_session_id="conv_parent",
+            host_id="host_abc",
+            workspace="/repo/main",
+            git=SessionGitOptions(branch_name="child-branch"),
+        )
+
+
+def test_multipart_child_directory_metadata_rejects_malformed_ids_and_paths() -> None:
+    """Bundle-mode child scope errors become clean metadata validation errors."""
+    from omnigent.server.schemas import SessionCreateMetadata, SessionDirectoryInput
+
+    with pytest.raises(ValidationError, match="invalid session directory id"):
+        SessionCreateMetadata(
+            parent_session_id="conv_parent",
+            directory_ids=["not-a-directory-id"],
+        )
+    with pytest.raises(ValidationError, match="cannot be overridden"):
+        SessionCreateMetadata(
+            parent_session_id="conv_parent",
+            workspace="/repo/other",
+        )
+    with pytest.raises(ValidationError, match="cannot add paths"):
+        SessionCreateMetadata(
+            parent_session_id="conv_parent",
+            directories=[SessionDirectoryInput(path="/repo/other")],
+        )
+
+
 @pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])
 def test_session_response_status_accepts_canonical_set(status: str) -> None:
     """

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -118,6 +118,7 @@ def test_optional_bench_capabilities_default_to_unknown() -> None:
     assert capability.fork_history is ForkHistory.NONE
     assert capability.shell_tool_name is None
     assert capability.shell_tool_prompt is None
+    assert capability.additional_directories is False
     assert capability.as_dict() == {
         "integration_mode": "sdk-in-process",
         "elicitation": "none",
@@ -128,6 +129,7 @@ def test_optional_bench_capabilities_default_to_unknown() -> None:
         "subagents": False,
         "interrupt": True,
         "streaming": True,
+        "additional_directories": False,
         "steering": None,
         "live_queue": None,
         "images": None,

--- a/tests/test_session_directories.py
+++ b/tests/test_session_directories.py
@@ -1,0 +1,159 @@
+"""Unit coverage for stable multi-directory session scopes."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.session_directories import (
+    DEFAULT_DIRECTORY_ID,
+    MAX_SESSION_DIRECTORIES,
+    SessionDirectory,
+    build_session_directories,
+    decode_session_directories,
+    encode_session_directories,
+    replace_default_directory,
+    replace_directory_nickname,
+    select_session_directories,
+    validate_session_directories,
+)
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+
+def _directory(index: int, path: str | None = None) -> SessionDirectory:
+    """Build one deterministic additional directory for a test."""
+    return SessionDirectory(f"dir_{index:032x}", path or f"/repo/{index}")
+
+
+def test_encode_decode_round_trip_and_legacy_workspace_fallback() -> None:
+    """Stored ids round-trip while old workspace-only rows gain ``default``."""
+    values = (
+        SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/main"),
+        SessionDirectory(f"dir_{1:032x}", "/repo/1", nickname="Shared API"),
+    )
+
+    encoded = encode_session_directories(values)
+
+    assert encoded is not None
+    assert decode_session_directories(encoded, workspace="/repo/main") == values
+    assert decode_session_directories(None, workspace="/repo/legacy") == (
+        SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/legacy"),
+    )
+    assert decode_session_directories(None, workspace="   ") == ()
+
+
+def test_directory_nicknames_override_display_names_and_can_be_cleared() -> None:
+    """Nicknames are optional metadata; clearing restores stable defaults."""
+    values = (
+        SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/main"),
+        _directory(1, "/repo/shared"),
+    )
+
+    assert values[0].environment_name == "Working folder"
+    assert values[1].environment_name == "shared"
+
+    renamed = replace_directory_nickname(values, values[1].id, "Shared services")
+    assert renamed[1].nickname == "Shared services"
+    assert renamed[1].name == "Shared services"
+    assert renamed[1].environment_name == "Shared services"
+
+    cleared = replace_directory_nickname(renamed, values[1].id, None)
+    assert cleared[1].nickname is None
+    assert cleared[1].environment_name == "shared"
+
+    with pytest.raises(ValueError, match="not attached"):
+        replace_directory_nickname(values, f"dir_{99:032x}", "Missing")
+
+    with pytest.raises(ValueError, match="must not be blank"):
+        replace_directory_nickname(values, values[1].id, "   ")
+
+
+def test_build_uses_requested_alias_basename_for_canonicalized_directory() -> None:
+    """A symlinked input keeps its picked basename as the default title."""
+    directories = build_session_directories(
+        "/repo/main",
+        ["/mnt/repos/shared-services"],
+        requested_additional_paths=["/repo/shared"],
+    )
+
+    assert directories[1].path == "/mnt/repos/shared-services"
+    assert directories[1].nickname == "shared"
+    assert directories[1].environment_name == "shared"
+
+
+def test_child_scope_inherits_all_or_an_explicit_subset_in_parent_order() -> None:
+    """Omitted, empty, and subset scopes have distinct stable semantics."""
+    values = (
+        SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/main"),
+        _directory(1),
+        _directory(2),
+    )
+
+    assert select_session_directories(values, None) == values
+    assert select_session_directories(values, []) == ()
+    assert select_session_directories(values, [values[2].id, values[0].id]) == (
+        values[0],
+        values[2],
+    )
+    with pytest.raises(ValueError, match="outside the parent scope"):
+        select_session_directories(values[1:], [DEFAULT_DIRECTORY_ID])
+
+
+def test_directory_set_rejects_duplicate_paths_and_more_than_sixteen_roots() -> None:
+    """Canonical path uniqueness and the root-count bound are enforced."""
+    with pytest.raises(ValueError, match="paths must be unique"):
+        validate_session_directories((_directory(1, "/same"), _directory(2, "/same")))
+
+    too_many = tuple(_directory(index) for index in range(MAX_SESSION_DIRECTORIES + 1))
+    with pytest.raises(ValueError, match="at most 16"):
+        validate_session_directories(too_many)
+
+
+def test_replacing_default_workspace_preserves_additional_ids() -> None:
+    """A managed/fork host bind changes only the primary root path."""
+    extra = _directory(1)
+    assert replace_default_directory((extra,), "/new/main") == (
+        SessionDirectory(DEFAULT_DIRECTORY_ID, "/new/main"),
+        extra,
+    )
+
+
+def test_store_round_trips_stable_directories_and_host_rebinds(db_uri: str) -> None:
+    """SQL metadata retains ids and keeps ``workspace`` consistent."""
+    store = SqlAlchemyConversationStore(db_uri)
+    directories = build_session_directories("/repo/main", ["/repo/shared"])
+    created = store.create_conversation(
+        workspace="/repo/main",
+        directories=directories,
+    )
+
+    fetched = store.get_conversation(created.id)
+    assert fetched is not None
+    assert fetched.directories == directories
+
+    renamed = store.set_directory_nickname(created.id, directories[1].id, "Shared services")
+    assert renamed.directories[1].nickname == "Shared services"
+    fetched_after_rename = store.get_conversation(created.id)
+    assert fetched_after_rename is not None
+    assert fetched_after_rename.directories[1].nickname == "Shared services"
+
+    rebound = store.set_host_id(created.id, "1" * 32, workspace="/repo/rebound")
+    assert rebound.workspace == "/repo/rebound"
+    assert rebound.directories[0] == SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/rebound")
+    assert rebound.directories[1].nickname == "Shared services"
+
+    cleared = store.clear_host_binding(created.id)
+    assert cleared.workspace is None
+    assert cleared.directories == ()
+
+
+def test_store_rejects_mismatched_default_directory_and_workspace(db_uri: str) -> None:
+    """Invalid metadata never lands as a row that fails during hydration."""
+    store = SqlAlchemyConversationStore(db_uri)
+
+    with pytest.raises(ValueError, match="must match workspace"):
+        store.create_conversation(
+            workspace="/repo/main",
+            directories=(SessionDirectory(DEFAULT_DIRECTORY_ID, "/repo/other"),),
+        )

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -32,6 +32,7 @@ from omnigent.tools.builtins.spawn import (
     _HISTORY_DEFAULT_TAIL,
     _HISTORY_MAX_TAIL,
     SysSessionCloseTool,
+    SysSessionCreateTool,
     SysSessionGetHistoryTool,
     SysSessionListTool,
     SysSessionSendTool,
@@ -193,6 +194,7 @@ def test_send_schema_advertises_plain_string_and_purpose_object_args() -> None:
         "purpose",
         "model",
         "file_ids",
+        "directory_ids",
         "cost_budget",
     }
     assert "dispatch metadata" in object_schema["properties"]["purpose"]["description"]
@@ -234,6 +236,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "purpose",
         "model",
         "file_ids",
+        "directory_ids",
         "cost_budget",
     }
 
@@ -258,6 +261,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "purpose",
         "model",
         "file_ids",
+        "directory_ids",
         "harness",
         "cost_budget",
     }
@@ -284,9 +288,19 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "purpose",
         "model",
         "file_ids",
+        "directory_ids",
         "harness",
         "cost_budget",
     }
+
+
+def test_session_create_schema_advertises_inherited_directory_scope() -> None:
+    """Durable child creation exposes omitted/all, empty, and subset scopes."""
+    properties = SysSessionCreateTool().get_schema()["function"]["parameters"]["properties"]
+
+    assert properties["directory_ids"]["type"] == "array"
+    assert properties["directory_ids"]["maxItems"] == 16
+    assert properties["directory_ids"]["uniqueItems"] is True
 
 
 def test_peek_schema_required_fields_and_no_extra_props() -> None:


### PR DESCRIPTION
<!-- stacker:begin -->
## 🥞 Stacked PR

- [**stack/multidir-core**](https://github.com/omnigent-ai/omnigent/pull/4636) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4636/files/97471b0ed0a0e5d35617ee70e00571ef312fa52a..51dd903d810692e1739580e414bd37ba9d86f9ef)]
  - [stack/multidir-claude](https://github.com/omnigent-ai/omnigent/pull/4637) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4637/files/51dd903d810692e1739580e414bd37ba9d86f9ef..8fc782f55457f548be22bb0b1b9f3c41ded8b62d)]
  - [stack/multidir-codex](https://github.com/omnigent-ai/omnigent/pull/4638) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4638/files/51dd903d810692e1739580e414bd37ba9d86f9ef..1577b41d5272801368f3a2e49770d3ad867ba4f5)]
  - [stack/multidir-file-git](https://github.com/omnigent-ai/omnigent/pull/4639) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4639/files/51dd903d810692e1739580e414bd37ba9d86f9ef..e87f6e3762b02e6ceeb65d42d162195398b906ab)]
    - [stack/multidir-projects](https://github.com/omnigent-ai/omnigent/pull/4640) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4640/files/e87f6e3762b02e6ceeb65d42d162195398b906ab..1fee2480252480e83930df4cac30059b89885666)]
      - [stack/multidir-web](https://github.com/omnigent-ai/omnigent/pull/4641) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/4641/files/1fee2480252480e83930df4cac30059b89885666..0b6f27a0359079a4c038f4d224a14f0412445150)]
        - stack/pm-integration-core
          - stack/pm-integration-web

---------
<!-- stacker:end -->

## Related issue

Part of #4620

## Summary

- Add stable, persisted directory identities to sessions and expose them through the session API.
- Validate top-level attachments and let child sessions inherit a selected subset without escaping the parent scope.

ELI5: a session now carries a named set of project folders instead of assuming it has only one.

```text
create request -> directory snapshot -> runtime roots -> child scope
```

## Test Plan

`make check`, including new unit and integration coverage for validation, persistence, inheritance, host launch, and runtime registration.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covers API validation, database round trips, child scoping, sandbox roots, and legacy single-workspace compatibility.

## Changelog

Sessions can attach multiple project folders and scope child sessions to selected folders.