### PR TITLE
perf(terminals): keep fastapi off the ws_bridge import path

### DIFF
--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -41,7 +41,7 @@ import time
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 # fcntl/pty/termios are POSIX-only. This module drives tmux PTY ``attach``
 # sessions, a feature that is disabled on Windows (see the terminal
@@ -53,7 +53,11 @@ if sys.platform != "win32":
     import pty
     import termios
 
-from fastapi import WebSocket, WebSocketDisconnect
+# fastapi costs ~300ms to import and is only needed by the server side of this
+# bridge; the client CLI reaches this module for its tmux helpers. Keep the
+# import off the module path so the CLI does not pay for it.
+if TYPE_CHECKING:
+    from fastapi import WebSocket
 
 _logger = logging.getLogger(__name__)
 
@@ -435,6 +439,8 @@ async def _forward_pty_to_ws(
         interactive cap while normal output keeps the larger flood cap.
     :returns: None on EOF or websocket disconnect.
     """
+    from fastapi import WebSocketDisconnect
+
     pending = bytearray()
     eof_seen = False
     while True:
@@ -621,6 +627,8 @@ async def bridge_tmux_pty_to_websocket(
     loop.add_reader(master_fd, _on_pty_readable)
 
     async def _ws_to_pty() -> None:
+        from fastapi import WebSocketDisconnect
+
         nonlocal last_client_input_at, last_pane_check_at
         try:
             while True:

--- a/tests/terminals/test_ws_bridge_lazy_fastapi.py
+++ b/tests/terminals/test_ws_bridge_lazy_fastapi.py
@@ -1,0 +1,85 @@
+"""Guard that ``ws_bridge`` keeps fastapi off the client CLI import path.
+
+``omnigent/terminals/ws_bridge.py`` supplies tmux helpers that the client
+CLI reaches through ``omnigent.claude_native``, but only the server half of
+the bridge talks to fastapi. Importing fastapi at module scope therefore
+charged every ``omnigent claude`` launch for a dependency it never uses.
+
+The module-scope checks must run in a subprocess: pytest imports the server
+routes, so ``fastapi`` is already in this interpreter's ``sys.modules`` and an
+in-process assertion would be vacuous.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+
+import pytest
+
+from omnigent.terminals.ws_bridge import _forward_pty_to_ws
+
+_PROBE = """
+import sys
+import {module}
+print("LOADED" if "fastapi" in sys.modules else "ABSENT")
+"""
+
+
+def _fastapi_state_after_importing(module: str) -> str:
+    """Report whether importing *module* in a fresh interpreter loads fastapi."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(module=module)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, f"probe failed for {module}: {proc.stderr}"
+    return proc.stdout.strip()
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["omnigent.terminals.ws_bridge", "omnigent.claude_native"],
+)
+def test_import_does_not_pull_in_fastapi(module: str) -> None:
+    """Neither the bridge nor the CLI path that reaches it may load fastapi."""
+    assert _fastapi_state_after_importing(module) == "ABSENT", (
+        f"importing {module} loaded fastapi; the deferred import regressed and "
+        f"every 'omnigent claude' launch pays ~190ms for it again"
+    )
+
+
+class _DisconnectingWebSocket:
+    """WebSocket fake whose first ``send_bytes`` raises ``WebSocketDisconnect``."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def send_bytes(self, data: bytes) -> None:
+        """Fail the way a client that vanished mid-frame does."""
+        from fastapi import WebSocketDisconnect
+
+        self.calls += 1
+        raise WebSocketDisconnect(code=1006)
+
+
+@pytest.mark.asyncio
+async def test_forward_pty_to_ws_still_catches_websocket_disconnect() -> None:
+    """The deferred import must resolve at runtime, not just at type-check time.
+
+    ``WebSocketDisconnect`` moved from module scope into the function body, so
+    a name error there would surface only when a client actually drops — this
+    exercises that path.
+    """
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+    queue.put_nowait(b"payload")
+
+    ws = _DisconnectingWebSocket()
+    await asyncio.wait_for(
+        _forward_pty_to_ws(ws, queue),  # type: ignore[arg-type]  # structural WS fake
+        timeout=5.0,
+    )
+
+    assert ws.calls == 1, "the disconnect should end forwarding after one attempt"


### PR DESCRIPTION
## Related issue

Closes #4642

## Summary

`omnigent/terminals/ws_bridge.py` imported fastapi at module scope, but only the
**server** half of that module talks to fastapi. The **client** CLI reaches the
same module for its tmux helpers, via
`omnigent.claude_native:128 → omnigent.terminals.ws_bridge:56 → fastapi`, so
every `omnigent claude` launch imported fastapi and its transitive dependencies
for a surface it never touches.

- `WebSocket` is annotation-only (lines 409, 507) and the module already has
  `from __future__ import annotations`, so it moves under `TYPE_CHECKING` — no
  runtime behaviour change.
- `WebSocketDisconnect` is used in two `except` clauses (lines 465, 680), so it
  becomes a function-scope import in each.

`import omnigent.claude_native`, min of 7 runs, Python 3.12:

| | wall | `len(sys.modules)` | fastapi loaded |
|---|---|---|---|
| `main` | 1.108s | 822 | yes |
| this PR | **0.920s** | **753** | no |

This composes with #4592 (lazy top-level re-exports). The two defer disjoint
dependency sets and are super-additive, not overlapping: 69 modules come off from
this PR, 51 from #4592, and a further 34 (`anyio` and friends) drop only once both
land. With both applied the same import is **0.881s / 668 modules**.

### ELI5

The bridge file is used by two very different callers. The server side needs a
big web framework; the client side just wants a few tmux helpers in the same
file. Because the framework was imported at the top, the client paid for it too.
Now it is imported only where it is actually used.

```
before:  omnigent claude ──> claude_native ──> ws_bridge ──> fastapi (+69 modules)
after:   omnigent claude ──> claude_native ──> ws_bridge
                                                  └─ fastapi only when the
                                                     server actually bridges a
                                                     websocket
```

## Test Plan

New `tests/terminals/test_ws_bridge_lazy_fastapi.py`:

1. Asserts `fastapi` is absent from `sys.modules` in a **fresh interpreter**
   after importing `omnigent.terminals.ws_bridge` and after importing
   `omnigent.claude_native`. This has to be a subprocess — pytest imports the
   server routes, so fastapi is already loaded in-process and an in-process
   assertion would be vacuous.
2. Drives a `WebSocketDisconnect` through `_forward_pty_to_ws` so the deferred
   import is exercised at runtime, not only at type-check time.

I confirmed the guard actually fails on unpatched code: restoring the eager
`from fastapi import WebSocket, WebSocketDisconnect` turns both import cases red,
and the patch turns them green again.

```
uv run pytest tests/terminals/test_ws_bridge_lazy_fastapi.py -q     # 3 passed
uv run pytest tests/terminals tests/test_native_terminal.py \
              tests/runner/test_terminal_resource_attach_ws.py \
              tests/server/routes/test_terminal_attach.py -q        # 139 passed
uv run ruff check . && uv run ruff format --check .                 # clean
uv run pyrefly check                                                # 0 errors
uv run pre-commit run --files <changed files>                       # all passed
```

Also verified end-to-end against a real launch: with the patch applied to an
installed 0.9.0.dev0, `omnigent claude` to an interactive prompt measured
min 10.41s vs 10.97s baseline over 5 PTY runs each, back to back on the same
machine.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit tests cover both the import-path guard and the runtime
`WebSocketDisconnect` path. Manual verification was the end-to-end launch
benchmark above (PTY harness, marker-matched on the interactive prompt, min of
5 runs per arm) plus the existing 139 terminal/bridge tests, which exercise the
server side of the bridge that still uses fastapi at runtime.
