### PR TITLE
fix(host,runner): pin child interpreters' omnigent resolution against cwd shadowing

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3441,14 +3441,15 @@ def _start_local_server(
         _spec = load_spec(agent_path)
         if _spec.executor.profile:
             child_env["DATABRICKS_CONFIG_PROFILE"] = _spec.executor.profile
+    # Paired with the -P argv below: the dev server must import this
+    # process's omnigent even when launched from a foreign checkout cwd.
+    _proc.pin_import_root_env(child_env)
 
     try:
         with child_logging_popen_kwargs(child_env) as logging_kwargs:
             server_proc: subprocess.Popen[bytes] = subprocess.Popen(
                 [
-                    sys.executable,
-                    "-m",
-                    "omnigent.cli",
+                    *_proc.pinned_module_argv("omnigent.cli"),
                     "server",
                     "--host",
                     "127.0.0.1",

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3005,10 +3005,10 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
 
     _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
-    args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
-    spawned = _spawn_host_daemon_process(
-        args=args, env=_build_host_daemon_env(server_url=server_url)
-    )
+    args = [*_proc.pinned_module_argv("omnigent.host._daemon_entry"), *mode_args]
+    env = _build_host_daemon_env(server_url=server_url)
+    _proc.pin_import_root_env(env)
+    spawned = _spawn_host_daemon_process(args=args, env=env)
     if spawned is None:
         return False
     _persist_spawned_daemon(
@@ -3418,6 +3418,8 @@ def _start_cli_runner_process(
     # an explicit operator export in the parent env still wins.
     for _k, _v in _proc.malloc_tuning_env().items():
         env.setdefault(_k, _v)
+    # Paired with the -P argv below: keep the runner immune to cwd shadowing.
+    _proc.pin_import_root_env(env)
 
     log_path: Path | None = None
     log_fh: BinaryIO | None = None
@@ -3427,7 +3429,7 @@ def _start_cli_runner_process(
     try:
         with child_logging_popen_kwargs(env) as logging_kwargs:
             runner_proc: subprocess.Popen[bytes] = subprocess.Popen(
-                [sys.executable, "-m", "omnigent.runner._entry"],
+                _proc.pinned_module_argv("omnigent.runner._entry"),
                 env=env,
                 stdout=log_fh,
                 stderr=log_fh,

--- a/omnigent/host/_daemon_entry.py
+++ b/omnigent/host/_daemon_entry.py
@@ -43,9 +43,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    from omnigent.inner import _proc
     from omnigent.process_logging import configure_process_logging
 
     configure_process_logging("host", force=True)
+    # Scrub the spawn-time import pin (already in sys.path); spawn sites
+    # re-pin their own children explicitly.
+    _proc.scrub_import_root_env()
 
     if args.local == bool(args.server):
         # Both or neither — the CLI always passes exactly one; fail loud.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -683,6 +683,10 @@ def _build_runner_env(
     # MALLOC_ARENA_MAX. setdefault so an operator override still wins.
     for key, value in _proc.malloc_tuning_env().items():
         env.setdefault(key, value)
+    # Runners exec with cwd=workspace and ``-m`` puts cwd on sys.path, so a
+    # workspace that is an omnigent checkout would shadow the install
+    # wholesale; pin resolution to this process's own package instead.
+    _proc.pin_import_root_env(env)
     return env
 
 
@@ -1457,7 +1461,7 @@ class HostProcess:
 
             with child_logging_popen_kwargs(env) as logging_kwargs:
                 proc = subprocess.Popen(
-                    [sys.executable, "-m", "omnigent.runner._entry"],
+                    _proc.pinned_module_argv("omnigent.runner._entry"),
                     env=env,
                     # A daemon may outlive the checkout it started from.
                     cwd=str(workspace),

--- a/omnigent/host/runner_zygote.py
+++ b/omnigent/host/runner_zygote.py
@@ -213,6 +213,10 @@ class ZygoteManager:
         # reach every child. setdefault keeps an operator override winning.
         for key, value in _proc.malloc_tuning_env().items():
             env.setdefault(key, value)
+        # The zygote imports the whole runner graph at boot; pin it (with the
+        # -P argv below) so the daemon's cwd can never decide which omnigent
+        # every forked runner inherits.
+        _proc.pin_import_root_env(env)
         with contextlib.ExitStack() as stack:
             # The zygote's own stdout/stderr go to its log file when configured,
             # else inherit the daemon's; stdin is always /dev/null.
@@ -227,7 +231,7 @@ class ZygoteManager:
             tty_kwargs = stack.enter_context(child_logging_popen_kwargs(env))
             pass_fds = (child_fd, *tty_kwargs.get("pass_fds", ()))
             return subprocess.Popen(
-                [self._python, "-m", "omnigent.runner._zygote"],
+                _proc.pinned_module_argv("omnigent.runner._zygote", python=self._python),
                 env=env,
                 pass_fds=pass_fds,
                 stdin=subprocess.DEVNULL,

--- a/omnigent/inner/_proc.py
+++ b/omnigent/inner/_proc.py
@@ -24,7 +24,10 @@ import logging
 import os
 import signal
 import subprocess
+import sys
+from collections.abc import MutableMapping
 from contextlib import suppress
+from pathlib import Path
 from typing import Protocol, TypedDict
 
 import psutil  # type: ignore[import-untyped]
@@ -107,6 +110,72 @@ class _ProcessLike(Protocol):
 
     def kill(self) -> None:
         pass
+
+
+def omnigent_import_root() -> str:
+    """Directory containing the ``omnigent`` package this process runs.
+
+    Derived from this module's own location, never ``omnigent.__file__``
+    (which is ``None`` under a cwd namespace shadow), so it names the tree
+    the running process actually imported — a checkout root for editable /
+    source runs, site-packages otherwise.
+
+    :returns: Absolute directory path, e.g. ``"/Users/me/omnigent"``.
+    """
+    return str(Path(__file__).resolve().parents[2])
+
+
+def pinned_module_argv(module: str, *, python: str | None = None) -> list[str]:
+    """argv prefix for a ``python -m omnigent.*`` child immune to cwd shadowing.
+
+    ``-m`` puts the child's cwd first on ``sys.path``: a cwd that IS an
+    omnigent checkout replaces the installed package wholesale (version
+    skew), and one merely containing a checkout binds a namespace decoy.
+    ``-P`` drops that entry; pair it with :func:`pin_import_root_env` so
+    the child resolves the parent's own package instead — including from
+    an uninstalled source checkout.
+
+    :param module: Dotted module to run, e.g. ``"omnigent.runner._entry"``.
+    :param python: Interpreter to spawn; ``None`` uses ``sys.executable``.
+    :returns: argv prefix, e.g. ``["/opt/py", "-P", "-m", "omnigent.runner._entry"]``.
+    """
+    return [python or sys.executable, "-P", "-m", module]
+
+
+def pin_import_root_env(env: MutableMapping[str, str]) -> None:
+    """Prepend this process's package root to ``env["PYTHONPATH"]``.
+
+    Counterpart of :func:`pinned_module_argv`: with cwd off the child's
+    ``sys.path``, this pin is what makes the child import the same
+    ``omnigent`` its parent runs. Existing entries are kept after it.
+
+    :param env: Child environment to mutate before spawn.
+    :returns: None.
+    """
+    root = omnigent_import_root()
+    rest = [p for p in env.get("PYTHONPATH", "").split(os.pathsep) if p and p != root]
+    env["PYTHONPATH"] = os.pathsep.join([root, *rest])
+
+
+def scrub_import_root_env() -> None:
+    """Drop this process's package root from ``os.environ["PYTHONPATH"]``.
+
+    Entry-point counterpart of :func:`pin_import_root_env`: the interpreter
+    consumed the pin into ``sys.path`` at startup, and leaving it in the
+    inheritable environment would leak into user-facing children (tmux
+    panes, agent CLIs, user shells). Spawn sites re-pin explicitly.
+
+    :returns: None.
+    """
+    rest = [
+        p
+        for p in os.environ.get("PYTHONPATH", "").split(os.pathsep)
+        if p and p != omnigent_import_root()
+    ]
+    if rest:
+        os.environ["PYTHONPATH"] = os.pathsep.join(rest)
+    else:
+        os.environ.pop("PYTHONPATH", None)
 
 
 def spawn_kwargs() -> SpawnKwargs:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1740,9 +1740,13 @@ def main() -> None:
 
     :returns: None.
     """
+    from omnigent.inner import _proc
     from omnigent.process_logging import configure_process_logging
 
     configure_process_logging("runner", force=True)
+    # The spawn-time import pin already landed in sys.path; scrub it so tmux
+    # panes and harness CLIs do not inherit our package root on PYTHONPATH.
+    _proc.scrub_import_root_env()
     _install_crash_logging()
     try:
         asyncio.run(_run_tunnel_from_env())

--- a/omnigent/runtime/harnesses/_runner.py
+++ b/omnigent/runtime/harnesses/_runner.py
@@ -434,6 +434,12 @@ def main(argv: list[str] | None = None) -> None:
     """
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
+    from omnigent.inner import _proc
+
+    # Scrub the spawn-time import pin (already in sys.path) so agent CLIs
+    # spawned below do not inherit our package root on PYTHONPATH.
+    _proc.scrub_import_root_env()
+
     # Attach a log handler before anything harness-specific runs. Without this
     # the child has no handler at all, so logging falls back to lastResort:
     # WARNING+ goes to the inherited stderr and every logger.debug/info/

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -27,7 +27,6 @@ import secrets
 import shutil
 import signal
 import socket
-import sys
 import tempfile
 import time
 import uuid
@@ -1229,6 +1228,9 @@ class HarnessProcessManager:
         :param effective_env: The harness subprocess environment.
         :returns: The process handle (real ``Process`` or ``ZygoteHarnessProc``).
         """
+        # Pin the child's omnigent resolution (paired with -P below): harness
+        # workers run in the workspace, which may itself be an omnigent checkout.
+        _proc.pin_import_root_env(effective_env)
         zygote = self._harness_zygote
         if zygote is not None and not self._harness_zygote_disabled:
             try:
@@ -1239,9 +1241,7 @@ class HarnessProcessManager:
                 )
                 self._harness_zygote_disabled = True
         return await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "omnigent.runtime.harnesses._runner",
+            *_proc.pinned_module_argv("omnigent.runtime.harnesses._runner"),
             *runner_argv,
             stdout=None,
             stderr=None,

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -490,7 +490,9 @@ def test_start_local_server_spawns_runner_as_sibling(
 
     # Server subprocess was spawned.
     assert len(server_popen_calls) == 1
-    assert server_popen_calls[0].args[2:6] == [
+    assert server_popen_calls[0].args[1:7] == [
+        "-P",
+        "-m",
         "omnigent.cli",
         "server",
         "--host",

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -890,6 +890,7 @@ def test_start_hosts_on_explicit_server(
     assert spawned_args == [
         [
             sys.executable,
+            "-P",
             "-m",
             "omnigent.host._daemon_entry",
             "--server",

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import errno
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -55,6 +56,7 @@ from omnigent.host.frames import (
 )
 from omnigent.host.identity import HostIdentity
 from omnigent.host.runner_zygote import ZygoteUnavailable
+from omnigent.inner import _proc
 from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
@@ -4147,3 +4149,66 @@ def test_zygote_start_failure_disables_it(
     assert host._zygote_disabled is True
     assert zygote.stop_calls == 0
     assert len(popen_argvs) == 1
+
+
+def test_build_runner_env_pins_the_import_root_first() -> None:
+    """The runner env pins this process's package root ahead of PYTHONPATH.
+
+    Paired with the ``-P`` spawn argv: without the pin, a workspace that is
+    an omnigent checkout is imported wholesale in place of the install (the
+    version-skew incident class); without preserving the tail, an
+    operator's own PYTHONPATH entries would be dropped.
+    """
+    root = _proc.omnigent_import_root()
+    # Sanity: the root really is the dir holding the running package.
+    assert (Path(root) / "omnigent" / "__init__.py").is_file()
+
+    env = _build_runner_env(
+        {"PATH": "/usr/bin", "PYTHONPATH": "/operator/extra"},
+        server_url="http://server",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/ws",
+        parent_pid=42,
+        initial_auth_token=None,
+    )
+
+    assert env["PYTHONPATH"].split(os.pathsep) == [root, "/operator/extra"]
+
+
+def test_direct_runner_spawn_argv_is_cwd_shadow_immune(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The direct runner spawn runs ``python -P -m`` so cwd cannot shadow.
+
+    Runners exec with cwd=workspace; without ``-P`` an omnigent-checkout
+    workspace shadows the installed package for the whole process tree.
+    """
+    zygote = _FakeZygote(fail_at="start", running=False)
+
+    _host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
+
+    assert len(popen_argvs) == 1
+    assert popen_argvs[0][1:4] == ["-P", "-m", "omnigent.runner._entry"]
+
+
+def test_pin_and_scrub_import_root_env_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin prepends exactly one root entry; scrub removes exactly that entry.
+
+    Scrub is what keeps the pin out of user-facing children (tmux panes,
+    agent CLIs); it must not touch an operator's own PYTHONPATH entries.
+    """
+    root = _proc.omnigent_import_root()
+    env = {"PYTHONPATH": os.pathsep.join(["/operator/extra", root])}
+    _proc.pin_import_root_env(env)
+    assert env["PYTHONPATH"].split(os.pathsep) == [root, "/operator/extra"]
+
+    monkeypatch.setenv("PYTHONPATH", env["PYTHONPATH"])
+    _proc.scrub_import_root_env()
+    assert os.environ["PYTHONPATH"] == "/operator/extra"
+    monkeypatch.setenv("PYTHONPATH", root)
+    _proc.scrub_import_root_env()
+    assert "PYTHONPATH" not in os.environ

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -756,3 +756,27 @@ def test_polled_harness_pid_is_released_from_its_owner(manager: ZygoteManager, t
     # Re-polling is None (code popped) and the zygote is still healthy.
     assert _control_exchange(manager, {"cmd": "poll", "pid": pid})["returncode"] is None
     assert _control_exchange(manager, {"cmd": "ping"}).get("pong") is True
+
+
+def test_zygote_survives_workspace_checkout_shadow_cwd(tmp_path, monkeypatch) -> None:
+    """A cwd that IS an omnigent checkout must not be imported by the zygote.
+
+    ``python -m`` puts the spawn cwd first on ``sys.path``, so a full decoy
+    package there used to replace the installed tree wholesale — every
+    forked runner then ran whatever branch that checkout had (the
+    version-skew incident). ``-P`` plus the PYTHONPATH pin resolve the
+    spawning process's own package instead.
+    """
+    decoy = tmp_path / "omnigent"
+    decoy.mkdir()
+    (decoy / "__init__.py").write_text("raise ImportError('decoy checkout imported')\n")
+    monkeypatch.chdir(tmp_path)
+
+    mgr = ZygoteManager(log_path=tmp_path / "zygote.log")
+    try:
+        mgr.start()
+        assert mgr.is_running()
+        proc = mgr.fork_runner(_fork_env(0), str(tmp_path / "runner.log"), str(tmp_path))
+        assert _wait_exit(proc) == 0
+    finally:
+        mgr.stop()


### PR DESCRIPTION
## Related issue

N/A — class fix for the cwd-shadowing incidents: the zygote namespace crash (#4630 / #4631 fixed the fatal *symptom*) and yesterday's version-skew duplicate-message incident (runner silently executing a stale worktree branch beneath a server deployed from main).

## Summary

Every `python -m omnigent.*` child puts its **cwd first on `sys.path`**. That has two failure variants, both observed in production this week:

- **Full-package shadow** — the child's cwd *is* an omnigent checkout. Runners exec with `cwd=workspace`, so a session whose workspace is an omnigent worktree imports **that worktree's currently-checked-out branch wholesale**, silently ignoring the installed build. This produced yesterday's incident: a runner 21 commits behind feeding a server+SPA deployed from main → streamed-text reconciliation skew → duplicate messages. Restarting doesn't help — it faithfully reloads the same wrong source.
- **Namespace shadow** — the cwd merely *contains* a checkout (`cd ~ && omni host`): the top-level name binds as a namespace package (`__file__ = None`). #4631 made one deadly dereference robust to this; the shadow itself remained, along with its latent mis-resolution hazards.

**The fix — pin the child's resolution to the parent's own package:**

- Spawn omnigent module children with **`-P`** (drops the cwd `sys.path` entry; we require Python ≥3.12) **paired with a `PYTHONPATH` pin** of the spawning process's package root — derived from a module's own `__file__`, never `omnigent.__file__` (the #4631 rule). The pairing is what makes `-P` safe for **uninstalled source-checkout runs** (the reason `-P` alone was previously ruled out): the child always imports exactly the tree its parent runs.
- **Entry points scrub the pin** from `os.environ` after startup (the interpreter already consumed it into `sys.path`), so tmux panes, agent CLIs, and user shells never inherit our package root; every spawn site re-pins its own children explicitly.

Covered sites: host→runner (direct Popen argv + `_build_runner_env`, which also feeds zygote fork requests), host→zygote, runner→harness worker, CLI→daemon, CLI→runner, chat→dev server. Scrubs: runner entry, daemon entry, harness-worker entry. Deliberately untouched: hook/popup spawns (already immune via `-I`), the codex `serve-mcp` bridge argv (executed by the codex CLI under its own contract — noted as a known residual site), and `omnigent_slack` (separate top-level package).

The invariant this establishes is **coherence**: a child imports the same code as its parent — so deliberately running a worktree's host still tests that worktree end-to-end; what can no longer happen is a *mixed* tree, where one process in the chain silently runs a different branch than the rest.

```
python -m omnigent.runner._entry           (cwd = session workspace)
before:  sys.path = [workspace, …site]      workspace IS a checkout → wrong tree wins
after :  python -P -m …, PYTHONPATH=<parent's package root>
         sys.path = [<parent's root>, …site]   parent's own tree wins, always
```

ELI5: programs omnigent launches used to load their code from whatever folder they woke up in, if that folder happened to be an omnigent checkout — so your runner quietly ran an old branch while your server ran main. Now every child is handed the exact address of its code, and it shreds that note before passing the environment on to your terminal.

## Test Plan

```
python -m pytest tests/host/test_connect.py tests/host/test_runner_zygote.py \
  tests/host/test_cli_host.py tests/host/test_daemon_launch.py \
  tests/runtime/harnesses/test_harness_zygote_client.py \
  tests/runtime/harnesses/test_process_manager.py tests/runner/test_runner_entry.py -q
```

- **`test_zygote_survives_workspace_checkout_shadow_cwd`** — the class regression test: a **real** zygote spawned from a cwd containing a decoy full `omnigent/` package (whose `__init__` raises) must boot, answer the control socket, fork a runner, and report its exit code. Verified in both directions locally: fails with `ZygoteUnavailable` on pre-fix code (decoy imported at boot), passes post-fix.
- `test_build_runner_env_pins_the_import_root_first` — pin is first, operator `PYTHONPATH` entries preserved after it, and the root demonstrably contains the running package.
- `test_direct_runner_spawn_argv_is_cwd_shadow_immune` — the direct spawn argv carries `-P -m omnigent.runner._entry`.
- `test_pin_and_scrub_import_root_env_round_trip` — scrub removes exactly the pin, leaves operator entries, and drops the var entirely when nothing remains.
- One existing daemon-argv assertion updated to the pinned shape. Full affected-suite runs, all green: test_connect **120**, the zygote/process-manager/daemon/entry group **187**, test_cli_host **23**, qwen bridge unaffected.

## Demo

N/A — non-visual (process spawn semantics).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The decoy zygote test is a real-subprocess integration test (actual `Popen`, actual control-socket handshake, actual fork), not a mock of the spawn path; the pre-fix failure mode was reproduced locally before landing the fix.

## Changelog

Runners, daemons, and harness workers spawned by omnigent now always import the same omnigent code as the process that launched them — a session workspace that happens to be an omnigent checkout can no longer silently substitute its own branch.
