### PR TITLE
fix(web): wrap long unbroken chat text/inline-code instead of overflowing

### DIFF
--- a/tests/e2e_ui/chat/test_chat_long_text_wrap.py
+++ b/tests/e2e_ui/chat/test_chat_long_text_wrap.py
@@ -1,11 +1,4 @@
-"""E2E: a long unbroken run of prose or inline code wraps instead of overflowing.
-
-A deterministic assistant message (seeded via the ``external_assistant_message``
-event — no LLM run) carries a long unbroken plain-text run and a long unbroken
-inline-code token at a narrow viewport. Asserts observable geometry: the
-transcript column and the message bubble itself never need a horizontal
-scrollbar to show either run.
-"""
+"""E2E: a long unbroken run of prose or inline code wraps instead of overflowing."""
 
 from __future__ import annotations
 
@@ -18,8 +11,7 @@ _MOBILE_VIEWPORT: ViewportSize = {"width": 390, "height": 844}
 _TRANSCRIPT_SCROLLER = ".transcript-hide-native-scrollbar"
 _ASSISTANT_BUBBLE = '[data-testid="message-bubble"][data-role="assistant"]'
 
-# Low-entropy repeated words (not real secrets/identifiers) long enough to
-# comfortably exceed the narrow chat column when rendered unbroken.
+# Low-entropy repeated word (not a secret), long enough to overflow the column unbroken.
 _LONG_PLAIN_RUN = "chatColumnOverflow" * 14
 _LONG_CODE_TOKEN = "inlineCodeOverflow" * 14
 
@@ -30,15 +22,7 @@ _MESSAGE_TEXT = (
 
 
 def _no_horizontal_overflow(selector: str) -> str:
-    """JS predicate: does *selector*'s first match fit without horizontal scroll?
-
-    ``scrollWidth``/``clientWidth`` catch overflow even under
-    ``overflow: visible``, unlike a bounding-rect read. 1px tolerance for
-    sub-pixel rounding.
-
-    :param selector: CSS selector for the element to measure.
-    :returns: JS arrow-function source for ``page.wait_for_function``.
-    """
+    """JS predicate: *selector*'s match has no horizontal overflow (1px tolerance)."""
     return (
         "() => { const el = document.querySelector('"
         + selector
@@ -69,13 +53,10 @@ def test_chat_long_unbroken_text_and_code_wrap_without_overflow(
     expect(bubble).to_be_visible(timeout=30_000)
     expect(bubble).to_contain_text("chatColumnOverflow")
 
-    # Confirms the token actually rendered as markdown inline code, not just
-    # as text somewhere in the bubble.
+    # Confirms the token rendered as markdown inline code, not just bubble text.
     code = bubble.locator('code[data-streamdown="inline-code"]')
     expect(code).to_be_visible(timeout=30_000)
     expect(code).to_contain_text("inlineCodeOverflow")
 
-    # The transcript column never needs a horizontal scrollbar to show either run.
     page.wait_for_function(_no_horizontal_overflow(_TRANSCRIPT_SCROLLER), timeout=30_000)
-    # Neither run pushes the bubble itself wider than the column.
     page.wait_for_function(_no_horizontal_overflow(_ASSISTANT_BUBBLE), timeout=10_000)

--- a/tests/e2e_ui/chat/test_chat_long_text_wrap.py
+++ b/tests/e2e_ui/chat/test_chat_long_text_wrap.py
@@ -1,14 +1,10 @@
 """E2E: a long unbroken run of prose or inline code wraps instead of overflowing.
 
-Chat text/inline-code had no ``overflow-wrap``, and the message bubble had no
-``min-w-0`` as a flex item of the transcript column, so an unbroken run (a
-hash, an id, a long inline-code span) forced the column wider than the
-viewport instead of wrapping inside it. A deterministic assistant message
-(seeded via the ``external_assistant_message`` event — no LLM run) carries
-both a long unbroken plain-text run and a long unbroken inline-code token at
-a narrow viewport; the test asserts the observable geometry — the transcript
-column and the message bubble itself must not need to scroll horizontally to
-show the content.
+A deterministic assistant message (seeded via the ``external_assistant_message``
+event — no LLM run) carries a long unbroken plain-text run and a long unbroken
+inline-code token at a narrow viewport. Asserts observable geometry: the
+transcript column and the message bubble itself never need a horizontal
+scrollbar to show either run.
 """
 
 from __future__ import annotations
@@ -36,15 +32,12 @@ _MESSAGE_TEXT = (
 def _no_horizontal_overflow(selector: str) -> str:
     """JS predicate: does *selector*'s first match fit without horizontal scroll?
 
-    ``scrollWidth``/``clientWidth`` reflect the element's actual rendered
-    content extent even under ``overflow: visible`` (unlike a bounding-rect
-    read, which only ever reports the constrained border box), so this
-    catches an unbroken run overflowing its container regardless of whether
-    that container happens to clip, scroll, or just let it paint past its
-    edge. 1px tolerance for sub-pixel layout rounding.
+    ``scrollWidth``/``clientWidth`` catch overflow even under
+    ``overflow: visible``, unlike a bounding-rect read. 1px tolerance for
+    sub-pixel rounding.
 
     :param selector: CSS selector for the element to measure.
-    :returns: A JS arrow-function source string for ``page.wait_for_function``.
+    :returns: JS arrow-function source for ``page.wait_for_function``.
     """
     return (
         "() => { const el = document.querySelector('"
@@ -75,7 +68,12 @@ def test_chat_long_unbroken_text_and_code_wrap_without_overflow(
     bubble = page.locator(_ASSISTANT_BUBBLE).last
     expect(bubble).to_be_visible(timeout=30_000)
     expect(bubble).to_contain_text("chatColumnOverflow")
-    expect(bubble).to_contain_text("inlineCodeOverflow")
+
+    # Confirms the token actually rendered as markdown inline code, not just
+    # as text somewhere in the bubble.
+    code = bubble.locator('code[data-streamdown="inline-code"]')
+    expect(code).to_be_visible(timeout=30_000)
+    expect(code).to_contain_text("inlineCodeOverflow")
 
     # The transcript column never needs a horizontal scrollbar to show either run.
     page.wait_for_function(_no_horizontal_overflow(_TRANSCRIPT_SCROLLER), timeout=30_000)

--- a/tests/e2e_ui/chat/test_chat_long_text_wrap.py
+++ b/tests/e2e_ui/chat/test_chat_long_text_wrap.py
@@ -1,0 +1,83 @@
+"""E2E: a long unbroken run of prose or inline code wraps instead of overflowing.
+
+Chat text/inline-code had no ``overflow-wrap``, and the message bubble had no
+``min-w-0`` as a flex item of the transcript column, so an unbroken run (a
+hash, an id, a long inline-code span) forced the column wider than the
+viewport instead of wrapping inside it. A deterministic assistant message
+(seeded via the ``external_assistant_message`` event — no LLM run) carries
+both a long unbroken plain-text run and a long unbroken inline-code token at
+a narrow viewport; the test asserts the observable geometry — the transcript
+column and the message bubble itself must not need to scroll horizontally to
+show the content.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, ViewportSize, expect
+
+_AGENT_NAME = "hello_world"
+_MOBILE_VIEWPORT: ViewportSize = {"width": 390, "height": 844}
+
+_TRANSCRIPT_SCROLLER = ".transcript-hide-native-scrollbar"
+_ASSISTANT_BUBBLE = '[data-testid="message-bubble"][data-role="assistant"]'
+
+# Low-entropy repeated words (not real secrets/identifiers) long enough to
+# comfortably exceed the narrow chat column when rendered unbroken.
+_LONG_PLAIN_RUN = "chatColumnOverflow" * 14
+_LONG_CODE_TOKEN = "inlineCodeOverflow" * 14
+
+_MESSAGE_TEXT = (
+    f"Plain unbroken run: {_LONG_PLAIN_RUN} end.\n\n"
+    f"Inline code unbroken run: `{_LONG_CODE_TOKEN}` end."
+)
+
+
+def _no_horizontal_overflow(selector: str) -> str:
+    """JS predicate: does *selector*'s first match fit without horizontal scroll?
+
+    ``scrollWidth``/``clientWidth`` reflect the element's actual rendered
+    content extent even under ``overflow: visible`` (unlike a bounding-rect
+    read, which only ever reports the constrained border box), so this
+    catches an unbroken run overflowing its container regardless of whether
+    that container happens to clip, scroll, or just let it paint past its
+    edge. 1px tolerance for sub-pixel layout rounding.
+
+    :param selector: CSS selector for the element to measure.
+    :returns: A JS arrow-function source string for ``page.wait_for_function``.
+    """
+    return (
+        "() => { const el = document.querySelector('"
+        + selector
+        + "'); return !!el && el.scrollWidth - el.clientWidth <= 1; }"
+    )
+
+
+def test_chat_long_unbroken_text_and_code_wrap_without_overflow(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A long unbroken plain-text run and inline-code token both wrap in place."""
+    base_url, session_id = seeded_session
+    event_resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": _MESSAGE_TEXT},
+        },
+        timeout=10.0,
+    )
+    event_resp.raise_for_status()
+
+    page.set_viewport_size(_MOBILE_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    bubble = page.locator(_ASSISTANT_BUBBLE).last
+    expect(bubble).to_be_visible(timeout=30_000)
+    expect(bubble).to_contain_text("chatColumnOverflow")
+    expect(bubble).to_contain_text("inlineCodeOverflow")
+
+    # The transcript column never needs a horizontal scrollbar to show either run.
+    page.wait_for_function(_no_horizontal_overflow(_TRANSCRIPT_SCROLLER), timeout=30_000)
+    # Neither run pushes the bubble itself wider than the column.
+    page.wait_for_function(_no_horizontal_overflow(_ASSISTANT_BUBBLE), timeout=10_000)

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -33,11 +33,7 @@ describe("MessageContent", () => {
 });
 
 describe("Message", () => {
-  it("stays shrinkable as a flex item of the conversation column", () => {
-    // OMNI-2900 regression: without min-w-0, a flex item in a column flex
-    // container refuses to shrink below its content's intrinsic width, so an
-    // unbroken run of text/code in the bubble forces the whole transcript
-    // column wider than the viewport instead of wrapping inside it.
+  it("keeps the message shrinkable", () => {
     render(<Message data-testid="message" from="assistant" />);
 
     expect(screen.getByTestId("message")).toHaveClass("min-w-0");

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -93,12 +93,6 @@ describe("MessageResponse", () => {
   });
 
   it("gives prose a break opportunity for an unbroken run (OMNI-2900)", () => {
-    // wrap-anywhere (overflow-wrap: anywhere) is inherited from this root, so
-    // a long unbroken token — a hash, an id, a long inline-code span — wraps
-    // inside the fixed-width chat column instead of overflowing it. Asserted
-    // as a class contract, not geometry: jsdom has no layout engine, so this
-    // is what actually pins the behavior (see index.css.test.ts + the live
-    // browser verification in the PR description for the geometry proof).
     const { container } = render(<MessageResponse>same text</MessageResponse>);
 
     expect(container.firstElementChild).toHaveClass("wrap-anywhere");

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MessageAction, MessageActions, MessageContent, MessageResponse } from "./message";
+import { Message, MessageAction, MessageActions, MessageContent, MessageResponse } from "./message";
 
 const clipboardDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, "clipboard");
 const execCommandDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "execCommand");
@@ -29,6 +29,25 @@ describe("MessageContent", () => {
     expect(content).toHaveClass("text-ui", "group-[.is-user]:px-3", "group-[.is-user]:py-2");
     expect(content).not.toHaveClass("text-[0.8125rem]", "leading-[1.125rem]");
     expect(content).not.toHaveClass("group-[.is-user]:px-4", "group-[.is-user]:py-3");
+  });
+});
+
+describe("Message", () => {
+  it("stays shrinkable as a flex item of the conversation column", () => {
+    // OMNI-2900 regression: without min-w-0, a flex item in a column flex
+    // container refuses to shrink below its content's intrinsic width, so an
+    // unbroken run of text/code in the bubble forces the whole transcript
+    // column wider than the viewport instead of wrapping inside it.
+    render(<Message data-testid="message" from="assistant" />);
+
+    expect(screen.getByTestId("message")).toHaveClass("min-w-0");
+  });
+
+  it("keeps a caller's width override alongside min-w-0", () => {
+    render(<Message className="max-w-3xl" data-testid="message" from="assistant" />);
+
+    const message = screen.getByTestId("message");
+    expect(message).toHaveClass("min-w-0", "max-w-3xl");
   });
 });
 
@@ -75,6 +94,26 @@ describe("MessageResponse", () => {
     await waitFor(() => {
       expect(container.firstElementChild).toHaveClass("math-config-b");
     });
+  });
+
+  it("gives prose a break opportunity for an unbroken run (OMNI-2900)", () => {
+    // wrap-anywhere (overflow-wrap: anywhere) is inherited from this root, so
+    // a long unbroken token — a hash, an id, a long inline-code span — wraps
+    // inside the fixed-width chat column instead of overflowing it. Asserted
+    // as a class contract, not geometry: jsdom has no layout engine, so this
+    // is what actually pins the behavior (see index.css.test.ts + the live
+    // browser verification in the PR description for the geometry proof).
+    const { container } = render(<MessageResponse>same text</MessageResponse>);
+
+    expect(container.firstElementChild).toHaveClass("wrap-anywhere");
+  });
+
+  it("keeps wrap-anywhere alongside a caller-supplied className", () => {
+    const { container } = render(
+      <MessageResponse className="math-config-a">same text</MessageResponse>,
+    );
+
+    expect(container.firstElementChild).toHaveClass("wrap-anywhere", "math-config-a");
   });
 });
 

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -35,11 +35,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      // min-w-0: this is a flex item of ConversationContent's column, so
-      // without it the browser refuses to shrink the bubble below its
-      // content's intrinsic width — an unbroken run of text/code then forces
-      // the whole transcript column wider than the viewport instead of
-      // wrapping inside it.
+      // min-w-0 lets this flex item shrink below its content's intrinsic width instead of widening the column.
       "group flex w-full min-w-0 max-w-[95%] flex-col gap-2",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className,
@@ -445,16 +441,7 @@ export const MessageResponse = memo(
 
     return (
       <Streamdown
-        // wrap-anywhere (overflow-wrap: anywhere) is inherited, so it reaches
-        // every prose descendant — paragraphs, list items, inline code — and
-        // gives a long unbroken run (a hash, an id, a path with no slashes)
-        // a break opportunity instead of blowing out the fixed-width chat
-        // column. Fenced code blocks are unaffected: they pin `white-space:
-        // pre` (or `pre-wrap` via the .chat-code-wrap toggle, which already
-        // sets its own overflow-wrap), so this never changes their
-        // scroll-vs-wrap behavior. Table cells opt back out in index.css —
-        // `anywhere` would otherwise shrink a cell's min-content and let one
-        // long word squeeze every other column.
+        // wrap-anywhere is inherited, giving every prose descendant (including inline code) a break opportunity.
         className={cn(
           "size-full wrap-anywhere [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
           className,

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -35,7 +35,12 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
+      // min-w-0: this is a flex item of ConversationContent's column, so
+      // without it the browser refuses to shrink the bubble below its
+      // content's intrinsic width — an unbroken run of text/code then forces
+      // the whole transcript column wider than the viewport instead of
+      // wrapping inside it.
+      "group flex w-full min-w-0 max-w-[95%] flex-col gap-2",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className,
     )}
@@ -440,7 +445,20 @@ export const MessageResponse = memo(
 
     return (
       <Streamdown
-        className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+        // wrap-anywhere (overflow-wrap: anywhere) is inherited, so it reaches
+        // every prose descendant — paragraphs, list items, inline code — and
+        // gives a long unbroken run (a hash, an id, a path with no slashes)
+        // a break opportunity instead of blowing out the fixed-width chat
+        // column. Fenced code blocks are unaffected: they pin `white-space:
+        // pre` (or `pre-wrap` via the .chat-code-wrap toggle, which already
+        // sets its own overflow-wrap), so this never changes their
+        // scroll-vs-wrap behavior. Table cells opt back out in index.css —
+        // `anywhere` would otherwise shrink a cell's min-content and let one
+        // long word squeeze every other column.
+        className={cn(
+          "size-full wrap-anywhere [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          className,
+        )}
         plugins={STREAMDOWN_PLUGINS}
         // Let links open on a plain click (and cmd/ctrl-click in a new tab)
         // instead of Streamdown's default "Open external link?" modal.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1129,6 +1129,19 @@ aside[aria-label="Workspace"][data-maximized] {
   overflow-wrap: break-word;
 }
 
+/* The chat prose root (MessageResponse in message.tsx) now sets `wrap-anywhere`
+ * so ordinary text/inline-code get a break opportunity instead of overflowing
+ * the fixed-width column. Inherited into a table cell, that has the exact
+ * column-collapsing effect described above for links, but for every cell:
+ * `anywhere` shrinks min-content to ~1 char, so one long-word cell can squeeze
+ * every other column down with it. Reset to `break-word` — still wraps an
+ * overlong run, but without collapsing the column below it. The table stays
+ * horizontally scrollable via its own wrapper for whatever still doesn't fit. */
+[data-streamdown="table-cell"],
+[data-streamdown="table-header-cell"] {
+  overflow-wrap: break-word;
+}
+
 /* KaTeX lays out radicals/fractions with positioned spans. Wide display math
  * gets its own horizontal scroll surface instead of relying on the surrounding
  * chat bubble to clip or wrap it. (No overflow-y override: with overflow-x

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1129,14 +1129,7 @@ aside[aria-label="Workspace"][data-maximized] {
   overflow-wrap: break-word;
 }
 
-/* The chat prose root (MessageResponse in message.tsx) now sets `wrap-anywhere`
- * so ordinary text/inline-code get a break opportunity instead of overflowing
- * the fixed-width column. Inherited into a table cell, that has the exact
- * column-collapsing effect described above for links, but for every cell:
- * `anywhere` shrinks min-content to ~1 char, so one long-word cell can squeeze
- * every other column down with it. Reset to `break-word` — still wraps an
- * overlong run, but without collapsing the column below it. The table stays
- * horizontally scrollable via its own wrapper for whatever still doesn't fit. */
+/* Resets table cells to `break-word` so the inherited `wrap-anywhere` from the chat prose root doesn't collapse a column's min-content. */
 [data-streamdown="table-cell"],
 [data-streamdown="table-header-cell"] {
   overflow-wrap: break-word;

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -185,6 +185,68 @@ describe("index.css table link wrapping rule", () => {
   });
 });
 
+/* Regression test for OMNI-2900: chat overflow at narrow viewports.
+ *
+ * message.tsx now sets `wrap-anywhere` on the chat prose root so ordinary
+ * text/inline-code get a break opportunity instead of overflowing the
+ * fixed-width column. Inherited into a table cell that has the same
+ * column-collapsing effect the link rule above exists to prevent, but for
+ * EVERY cell, not just linked ones: `anywhere` shrinks a cell's min-content
+ * to ~1 char, so one long-word cell can squeeze every other column. index.css
+ * resets table cells back to `break-word`; this pins the selector so the
+ * override applies to the cells themselves (and everything they inherit
+ * into), and never leaks into prose outside a table.
+ */
+describe("index.css table cell wrapping rule", () => {
+  const rule = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? []).find(
+    (block) =>
+      /\[data-streamdown="table-cell"\],?\s*\n?\s*\[data-streamdown="table-header-cell"\]\s*\{/.test(
+        block,
+      ) && /overflow-wrap\s*:/.test(block),
+  );
+
+  const selector = (rule ?? "")
+    .slice(0, rule ? rule.indexOf("{") : 0)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .trim();
+
+  it("has the rule this test exists to protect", () => {
+    expect(rule, "the table-cell wrapping rule is gone from index.css").toBeDefined();
+    expect(rule).toMatch(/overflow-wrap\s*:\s*break-word/);
+  });
+
+  function makeCell(cellAttr: string): HTMLElement {
+    const cell = document.createElement("div");
+    cell.setAttribute("data-streamdown", cellAttr);
+    document.body.appendChild(cell);
+    return cell;
+  }
+
+  it.each(["table-cell", "table-header-cell"])("targets the %s itself", (cellAttr) => {
+    const cell = makeCell(cellAttr);
+    expect(cell.matches(selector)).toBe(true);
+    cell.remove();
+  });
+
+  it("leaves ordinary prose (outside a table) on the inherited wrap-anywhere", () => {
+    const paragraph = document.createElement("p");
+    document.body.appendChild(paragraph);
+    expect(paragraph.matches(selector)).toBe(false);
+    paragraph.remove();
+  });
+
+  it("is declared after the link-in-cell rule, consistent with it rather than fighting it", () => {
+    // Same override, same reasoning, for the cell itself instead of just an
+    // inner link — keep them adjacent so a future edit sees both at once.
+    const linkRuleIndex = cssSource.indexOf(
+      '[data-streamdown="table-cell"], [data-streamdown="table-header-cell"])\n  [data-streamdown="link"]',
+    );
+    const cellRuleIndex = cssSource.indexOf(rule ?? " ");
+    expect(linkRuleIndex).toBeGreaterThan(-1);
+    expect(cellRuleIndex).toBeGreaterThan(linkRuleIndex);
+  });
+});
+
 describe("index.css sidebar canvas", () => {
   const omniLightRule = cssSource.match(
     /:root:not\(\.dark\):not\(\[data-theme\]\) \.conversations-sidebar \{[^}]*\}/,

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -185,18 +185,7 @@ describe("index.css table link wrapping rule", () => {
   });
 });
 
-/* Regression test for OMNI-2900: chat overflow at narrow viewports.
- *
- * message.tsx now sets `wrap-anywhere` on the chat prose root so ordinary
- * text/inline-code get a break opportunity instead of overflowing the
- * fixed-width column. Inherited into a table cell that has the same
- * column-collapsing effect the link rule above exists to prevent, but for
- * EVERY cell, not just linked ones: `anywhere` shrinks a cell's min-content
- * to ~1 char, so one long-word cell can squeeze every other column. index.css
- * resets table cells back to `break-word`; this pins the selector so the
- * override applies to the cells themselves (and everything they inherit
- * into), and never leaks into prose outside a table.
- */
+/* Pins the table-cell `overflow-wrap: break-word` override so it applies to the cells and never leaks into prose outside a table. */
 describe("index.css table cell wrapping rule", () => {
   const rule = (cssSource.match(/[^{}]+\{[^{}]*\}/g) ?? []).find(
     (block) =>
@@ -236,8 +225,6 @@ describe("index.css table cell wrapping rule", () => {
   });
 
   it("is declared after the link-in-cell rule, consistent with it rather than fighting it", () => {
-    // Same override, same reasoning, for the cell itself instead of just an
-    // inner link — keep them adjacent so a future edit sees both at once.
     const linkRuleIndex = cssSource.indexOf(
       '[data-streamdown="table-cell"], [data-streamdown="table-header-cell"])\n  [data-streamdown="link"]',
     );


### PR DESCRIPTION
## Related issue

Internal tracking: OMNI-2900 (not a GitHub issue in this repo).

## Summary

- Prevent long unbroken prose and inline-code tokens from widening or clipping narrow chat layouts by making `Message` shrinkable and adding safe inherited break opportunities.
- Preserve fenced-code wrap/scroll behavior and table readability with a scoped table-cell `overflow-wrap: break-word` override.

## Test Plan

- Reproduced before: transcript `scrollWidth: 1719` vs `clientWidth: 500`; inline code measured 1703px inside a 468px column.
- Verified after in light and dark: transcript `scrollWidth === clientWidth === 500`; inline code wraps inside the message column.
- Verified fenced code remains locally scrollable with wrapping disabled and long-token tables retain readable columns with local scrolling.
- `pnpm test`: 5542 passed. `pnpm run type-check`, `pnpm run lint`, and `pnpm run format:check`: passed.

## Demo

**Before — light**
![before-light](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni2900/tmp-screenshots/before-light.png?raw=true)

**Before — dark**
![before-dark](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni2900/tmp-screenshots/before-dark.png?raw=true)

**After — light**
![after-light](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni2900/tmp-screenshots/after-light.png?raw=true)

**After — dark**
![after-dark](https://github.com/zhengwin/omnigent/blob/tmp-screenshots-omni2900/tmp-screenshots/after-dark.png?raw=true)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added class/selector contract tests and verified real browser geometry in a running Omnigent stack at a 500px viewport in light and dark themes.

## Changelog

Fixed long unbroken text or inline code in chat messages overflowing or getting cut off at narrow window widths.
