### PR TITLE
fix(claude-native): supersede stranded in-flight text on later commits

### DIFF
--- a/omnigent/runtime/inflight_text.py
+++ b/omnigent/runtime/inflight_text.py
@@ -237,6 +237,39 @@ def _consume_recent_native_text(conversation_id: str, text: str) -> None:
         _native_recent_committed.pop(conversation_id, None)
 
 
+def _supersede_older_native(conversation_id: str, committed_id: str | None) -> None:
+    """
+    Evict native aggregates superseded by a just-committed message.
+
+    Native providers stream and commit assistant text one message at a
+    time, in order, so once a message commits every earlier un-``claimed``
+    aggregate is stale: its own commit either already dropped it, or failed
+    to reconcile (a lost/reordered/mismatched delta left ``text`` neither
+    equal to nor a prefix of the committed item) and it would otherwise
+    linger in :data:`_native_inflight` and replay on every reconnect via
+    :func:`snapshot_for`. Only ``_native_inflight`` is pruned; the committed
+    transcript is unaffected, so over-eviction can at worst drop a live
+    preview the committed item then supplies. Caller holds :data:`_lock`.
+
+    Only entries BEFORE the committed one are evicted, so the entry that
+    may still be streaming (always the most recent) is never touched.
+
+    :param conversation_id: Conversation whose native buffer to prune.
+    :param committed_id: The ``message_id`` the commit reconciled against,
+        or ``None`` when it matched none. With ``None`` the commit's own
+        aggregate is untracked, so every entry except the tail (which may
+        still be streaming) is treated as superseded.
+    """
+    messages = _native_inflight.get(conversation_id)
+    if not messages:
+        return
+    ids = list(messages)
+    cut = ids.index(committed_id) if committed_id in messages else len(ids) - 1
+    for message_id in ids[:cut]:
+        if not messages[message_id].claimed:
+            _drop_native_message(conversation_id, message_id)
+
+
 def record_publish(conversation_id: str, event: dict[str, Any]) -> dict[str, Any] | None:
     """
     Update the index from an SSE event on the publish path.
@@ -401,19 +434,32 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> dict[str, Any
                         None,
                     )
                     if exact_id is not None:
+                        # Native text commits in stream order, so every
+                        # earlier un-committed aggregate is superseded by
+                        # this one — evict them before dropping the match so
+                        # a mis-reconciled entry can't linger and replay.
+                        _supersede_older_native(conversation_id, exact_id)
                         _drop_native_message(conversation_id, exact_id)
                     else:
-                        claimed = next(
+                        claimed_id = next(
                             (
-                                message
-                                for message in messages.values()
+                                message_id
+                                for message_id, message in messages.items()
                                 if message.text and text.startswith(message.text)
                             ),
                             None,
                         )
-                        if claimed is not None:
+                        if claimed_id is not None:
+                            _supersede_older_native(conversation_id, claimed_id)
+                            claimed = messages[claimed_id]
                             claimed.claimed = True
                             claimed.forwarded = False
+                        else:
+                            # The commit matched no tracked aggregate (its
+                            # own deltas were lost or mismatched). Everything
+                            # but the tail — which may still be streaming —
+                            # is superseded and safe to evict.
+                            _supersede_older_native(conversation_id, None)
                     recent = _native_recent_committed.setdefault(
                         conversation_id, deque(maxlen=_RECENT_NATIVE_MESSAGES)
                     )

--- a/tests/runtime/test_inflight_text.py
+++ b/tests/runtime/test_inflight_text.py
@@ -461,16 +461,59 @@ def test_native_messages_replay_in_order_not_blobbed() -> None:
     ]
 
 
-def test_native_done_drops_equal_aggregate_by_content() -> None:
-    """A done item removes the equal aggregate rather than guessing by position."""
+def test_native_done_drops_matched_aggregate_and_supersedes_older() -> None:
+    """A commit drops its own aggregate by content and evicts older ones.
+
+    Committing the MIDDLE message proves the match is by content, not
+    position (a position drop would take the oldest ``m1``), while ``m1``
+    is evicted as superseded and the still-streamable tail ``m3`` survives.
+    """
     cid = "conv_native_content_match"
-    inflight_text.record_publish(cid, _native_delta("m1", 0, "first answer", final=True))
-    inflight_text.record_publish(cid, _native_delta("m2", 0, "second answer", final=True))
-    done = _message_done("ci_2", text="second answer")
+    inflight_text.record_publish(cid, _native_delta("m1", 0, "alpha", final=True))
+    inflight_text.record_publish(cid, _native_delta("m2", 0, "beta", final=True))
+    inflight_text.record_publish(cid, _native_delta("m3", 0, "gamma"))
+    done = _message_done("ci_2", text="beta")
 
     assert inflight_text.record_publish(cid, done) is done
     snap = inflight_text.snapshot_for(cid)
-    assert [(event["message_id"], event["delta"]) for event in snap] == [("m1", "first answer")]
+    assert [(event["message_id"], event["delta"]) for event in snap] == [("m3", "gamma")]
+
+
+def test_native_done_supersedes_stranded_older_message() -> None:
+    """A later commit evicts an earlier aggregate that never reconciled.
+
+    Reproduces the reconnect double-message bug: ``m1`` streamed but its
+    own commit never reconciled (a lost/mismatched delta), so it lingered
+    in the map and replayed on every reconnect. ``m2`` committing
+    supersedes it, so neither replays.
+    """
+    cid = "conv_native_stranded"
+    inflight_text.record_publish(cid, _native_delta("m1", 0, "I'll do the rebase.", final=True))
+    inflight_text.record_publish(cid, _native_delta("m2", 0, "Back to a clean state.", final=True))
+
+    done = _message_done("ci_2", text="Back to a clean state.")
+    assert inflight_text.record_publish(cid, done) is done
+
+    assert inflight_text.snapshot_for(cid) == []
+
+
+def test_stranded_commit_supersedes_older_but_keeps_tail() -> None:
+    """A commit matching no aggregate evicts older ones, sparing the tail.
+
+    When the committed text matches no tracked aggregate (its own deltas
+    were lost/mismatched), earlier messages are still superseded, but the
+    most-recent entry is spared in case it is still streaming.
+    """
+    cid = "conv_native_stranded_commit"
+    inflight_text.record_publish(cid, _native_delta("m1", 0, "alpha", final=True))
+    inflight_text.record_publish(cid, _native_delta("m2", 0, "beta"))
+
+    done = _message_done("ci_x", text="mismatched bytes")
+    assert inflight_text.record_publish(cid, done) is done
+
+    assert [(e["message_id"], e["delta"]) for e in inflight_text.snapshot_for(cid)] == [
+        ("m2", "beta")
+    ]
 
 
 def test_pi_empty_final_marker_is_inert() -> None:


### PR DESCRIPTION
## Related issue

N/A — surfaced from a user report of a duplicate assistant message on reconnect; no GitHub issue was filed.

## Summary

- A native (Claude Code) assistant message whose commit **failed to reconcile** against its streamed deltas got stranded in the server's `_native_inflight` map forever. A lost / reordered / mismatched delta leaves the accumulated aggregate *neither equal to nor a prefix of* the committed text, so the `output_item.done` handler neither dropped nor claimed it.
- Nothing evicted the stale entry afterwards: the map has no TTL/LRU, and native turns end via `session.status: idle` (which deliberately spares native buffers, for permission-parks) rather than a terminal `response.*`. So `snapshot_for` replayed the stranded aggregate as a phantom live preview on **every reconnect**, and the client's "remove the oldest live preview" heuristic then retired the *wrong* bubble on the next commit — surfacing as a **duplicate assistant message**.
- Fix: native text commits in stream order, so when a message commits, every earlier un-`claimed` aggregate is superseded. New `_supersede_older_native` helper evicts them in the `output_item.done` handler — older-than-the-match on an exact/prefix hit, and all-but-the-tail when the commit reconciles nothing. Only `_native_inflight` (the streaming-preview plane) is pruned; committed items pass through untouched.

**ELI5:** the server keeps a scratchpad of "text still being typed" so a reconnecting client can see it. Normally each line is erased once it's saved for real. One line got saved in a slightly different form than it was typed, so the eraser never matched it — and it kept re-appearing on every reconnect as a ghost copy. Now, saving a *later* line also wipes any earlier scratch lines, since those must already be saved.

```
stream order:   msg A (deltas) ──▶ A commits ──▶ msg B (deltas) ──▶ B commits
_native_inflight: {A}              {A}✗           {A, B}             {A, B}
                                    │                                  │
              A's commit mismatched─┘ (stranded, un-claimed)           │
              B's commit ───────────────────────────────────────▶ evict all older than B
                                                                    ⇒ A gone, then drop B ⇒ {}
              (before this fix, A lingered and snapshot_for replayed it every reconnect)
```

## Test Plan

- `python -m pytest tests/runtime/test_inflight_text.py -q` → **36 passed**, including `test_native_previews_survive_terminal_session_status[idle]` (confirms the deliberate "idle spares native buffers" path is untouched).
- New/updated unit tests:
  - `test_native_done_supersedes_stranded_older_message` — the reconnect repro: `m1` streams but never reconciles, `m2` commits, neither replays.
  - `test_native_done_drops_matched_aggregate_and_supersedes_older` — commit the *middle* of 3 messages: proves the match is by content (not position), older is superseded, tail survives.
  - `test_stranded_commit_supersedes_older_but_keeps_tail` — a commit matching nothing still evicts older, spares the possibly-streaming tail.
- `ruff check` and `ruff format --check` clean on both files (run via the main checkout's venv — the worktree `.venv` lacks ruff/pyrefly, so those pre-commit hooks report "No module named ruff" rather than a real failure).

## Demo

N/A — non-visual (server-side reconciliation change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior change to note when reviewing: the old `test_native_done_drops_equal_aggregate_by_content` asserted that an *older un-committed* message survived a newer message's commit. Supersede-eviction deliberately reverses that, so the test was replaced with the three tests above.

Not covered here (deliberately, as follow-ups): (1) a *tolerant* reconcile so an entry never strands in the first place — supersede only clears a stranded entry on the *next* commit, so a turn's final stranded message lingers until the following commit; (2) a client-side content/prefix-matched preview retirement in `chatStore.ts` as defense-in-depth.

## Changelog

Fixed a duplicate assistant message that could appear after reconnecting to a Claude Code (native) session


---

This pull request and its description were written by Isaac.
