### PR TITLE
fix(slack): fix flaky test_exhausted_reconnect_shows_non_alarming_text

### DIFF
--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -938,7 +938,7 @@ async def test_exhausted_reconnect_shows_non_alarming_text(tmp_path: Path) -> No
         client=slack,
         context={"bot_user_id": "B1"},
     )
-    await _wait_for_posts(slack, 1)
+    await _wait_for_ack_deleted(slack)
     await service.shutdown()
 
     # The notice is a public post (not ephemeral): the non-alarming stream-drop
@@ -1717,6 +1717,16 @@ async def _wait_for_posts(client: FakeSlackClient, count: int) -> None:
             return
         await asyncio.sleep(0.02)
     raise AssertionError(f"Timed out waiting for {count} posts")
+
+
+async def _wait_for_ack_deleted(client: FakeSlackClient) -> None:
+    # Wait until the "Working on it…" ack has been deleted and a follow-up post
+    # has landed — i.e. stop_with() fully completed (delete then postMessage).
+    for _ in range(50):
+        if client.deleted_ts and client.posts:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("Timed out waiting for ack deletion and follow-up post")
 
 
 async def test_unreachable_server_prompts_config_command(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

`test_exhausted_reconnect_shows_non_alarming_text` was intermittently asserting against `_Working on it…_` instead of the `StreamInterruptedError` notice. The race: `_wait_for_posts(slack, 1)` returns as soon as any post reaches `slack.posts`, which is satisfied by the "Working on it…" ack *before* `stop_with()` deletes it and posts the error. The turn runs as a background task, so `service.shutdown()` (which cancels tasks) could fire before `stop_with()` completed — leaving the ack as the last post.

Fix: add `_wait_for_ack_deleted`, which polls until `slack.deleted_ts` is non-empty *and* `slack.posts` is non-empty. That guarantees `stop_with()` has fully run (delete → postMessage) before the assertions execute.

## Test Plan

- [x] Re-ran `test_exhausted_reconnect_shows_non_alarming_text` — passes consistently
- [x] Ran full `integrations/slack/tests/test_service.py` suite to check for regressions

## Verification Commands

```bash
uv pip install -e integrations/slack
python -m pytest integrations/slack/tests/test_service.py -k exhausted -v
```

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change

## Coverage notes

Test-only change; the fix is in the test helper, not production code.