### PR TITLE
feat(harness): add jcode as a first-class ACP harness

### DIFF
--- a/.github/actions/e2e-run/action.yml
+++ b/.github/actions/e2e-run/action.yml
@@ -104,6 +104,16 @@ runs:
         node node_modules/@anthropic-ai/claude-code/install.cjs
         echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
 
+    - name: Install jcode harness CLI
+      # The builtin jcode catalog row launches via `jcode acp`. Host-daemon
+      # e2e tests bind sessions to the FIRST registered agent row, so a host
+      # without the jcode binary refuses the launch ("harness 'jcode' is not
+      # configured") and the runner never appears. Pin the version so CI is
+      # deterministic; bump to match the image bake's default when it moves.
+      shell: bash
+      run: |
+        sudo bash "${GITHUB_WORKSPACE}/deploy/docker/install-harness-cli.sh" jcode@v0.84.0
+
     - name: Build pinned old server (backwards-compat only)
       # Only runs when server_version is set. Builds the released tag into an
       # isolated venv (all three packages editable so the old ==<old> SDK

--- a/deploy/docker/install-harness-cli.sh
+++ b/deploy/docker/install-harness-cli.sh
@@ -41,11 +41,10 @@
 #   qwen      → npm @qwen-code/qwen-code
 #   goose     → vendor installer (aaif-goose/goose download_cli.sh), default
 #               pin 1.38.0 (mirroring _GOOSE_MIN_VERSION)
-#   jcode     → vendor installer (1jehuang/jcode install.sh) — jcode runs as a
-#               user-configured ACP agent (acp.agents in config.yaml), not a
-#               builtin harness; a deployment that runs jcode that way still
-#               needs the binary on the managed host's PATH, since the sandbox
-#               cannot run the installer at session start
+#   jcode     → vendor installer (1jehuang/jcode install.sh) — jcode is a
+#               builtin harness (omnigent/acp_cli_harnesses.py); a managed
+#               deployment still needs the binary on the host's PATH, since
+#               the sandbox cannot run the installer at session start
 #   cursor    → vendor installer (cursor.com/install) — always fetches the
 #               latest agent build, so VERSION pins are rejected
 #   kimi      → vendor installer (code.kimi.com/kimi-code/install.sh)
@@ -60,8 +59,9 @@
 #
 # Supply-chain note: only agy here (and kiro-cli baked in the Dockerfile) is
 # pinned to an immutable asset + sha256. The vendor-installer rows (goose,
-# jcode, cursor, kimi) run the harness's own `curl | bash` off mutable refs and
-# are checked only with `--version`; cursor cannot be pinned at all.
+# jcode, cursor, kimi) run the harness's own curl-piped install script off
+# mutable refs and are checked only with `--version`; cursor cannot be
+# pinned at all.
 # Off-by-default bounds this, but a deployment needing kiro-cli-grade integrity
 # should pin + verify in its own image rather than rely on a name here.
 #

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -54,11 +54,16 @@ class AcpCliHarness:
     :param args: Argv appended after the binary to start the CLI's ACP stdio
         server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
     :param aliases: Accepted alternate spellings, canonicalized to the row key.
+    :param omnigent_mcp: Whether to offer Omnigent's MCP server in
+        ``session/new``. Some vendor CLIs reject ``mcpServers`` over ACP and
+        configure MCP out of band (e.g. jcode reads ``~/.jcode/mcp.json``);
+        set ``False`` for those so the server isn't advertised.
     """
 
     install: HarnessInstallSpec
     args: tuple[str, ...]
     aliases: tuple[str, ...] = ()
+    omnigent_mcp: bool = True
 
     @property
     def label(self) -> str:
@@ -114,5 +119,21 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
         ),
         args=("agent", "stdio"),
         aliases=("grok-build",),
+    ),
+    # jcode (https://jcode.sh) drives ``jcode acp``. Ships via a curl
+    # installer (not npm) and owns its provider/model config in
+    # ``~/.jcode/config.toml``; Omnigent stores no credential. Its ACP server
+    # rejects ``mcpServers`` in ``session/new`` (MCP is configured in
+    # ``~/.jcode/mcp.json``), so the Omnigent MCP server is not offered.
+    "jcode": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "Jcode",
+            "jcode",
+            None,
+            install_hint="curl -fsSL https://jcode.sh/install | bash",
+            auth_hint="configure a provider in ~/.jcode/config.toml",
+        ),
+        args=("acp",),
+        omnigent_mcp=False,
     ),
 }

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -55,9 +55,10 @@ class AcpCliHarness:
         server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
     :param aliases: Accepted alternate spellings, canonicalized to the row key.
     :param omnigent_mcp: Whether to offer Omnigent's MCP server in
-        ``session/new``. Some vendor CLIs reject ``mcpServers`` over ACP and
-        configure MCP out of band (e.g. jcode reads ``~/.jcode/mcp.json``);
-        set ``False`` for those so the server isn't advertised.
+        ``session/new``. Some vendor CLIs don't yet support session-scoped
+        MCP and ignore ``mcpServers``, configuring MCP out of band instead
+        (e.g. jcode reads ``~/.jcode/mcp.json``); set ``False`` for those so
+        the server isn't advertised.
     """
 
     install: HarnessInstallSpec
@@ -123,8 +124,9 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
     # jcode (https://jcode.sh) drives ``jcode acp``. Ships via a curl
     # installer (not npm) and owns its provider/model config in
     # ``~/.jcode/config.toml``; Omnigent stores no credential. Its ACP server
-    # rejects ``mcpServers`` in ``session/new`` (MCP is configured in
-    # ``~/.jcode/mcp.json``), so the Omnigent MCP server is not offered.
+    # ignores ``mcpServers`` in ``session/new`` (session-scoped MCP isn't
+    # supported; MCP is configured in ``~/.jcode/mcp.json``), so the Omnigent
+    # MCP server is not offered.
     "jcode": AcpCliHarness(
         install=HarnessInstallSpec(
             "Jcode",

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1563,6 +1563,9 @@ def _build_acp_cli_spawn_env(
     env = {
         "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
         "HARNESS_ACP_NAME": row.label,
+        # Rows whose CLI rejects session/new mcpServers (e.g. jcode) opt out
+        # of advertising the Omnigent MCP server.
+        "HARNESS_ACP_OMNIGENT_MCP": "1" if row.omnigent_mcp else "0",
     }
     # Session workspace (selected working folder). ``None`` lets the wrap fall
     # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1563,8 +1563,9 @@ def _build_acp_cli_spawn_env(
     env = {
         "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
         "HARNESS_ACP_NAME": row.label,
-        # Rows whose CLI rejects session/new mcpServers (e.g. jcode) opt out
-        # of advertising the Omnigent MCP server.
+        # Rows whose CLI doesn't yet support session-scoped MCP and ignores
+        # session/new mcpServers (e.g. jcode) opt out of advertising the
+        # Omnigent MCP server.
         "HARNESS_ACP_OMNIGENT_MCP": "1" if row.omnigent_mcp else "0",
     }
     # Session workspace (selected working folder). ``None`` lets the wrap fall

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1748,6 +1748,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         # ACP-family builtin, sorted by id, before the non-ACP harnesses.
         "Devin",
         "Grok Build",
+        "Jcode",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1911,7 +1912,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1933,7 +1934,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1950,7 +1951,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2141,14 +2142,16 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
+        # 10-12 are the builtin ACP CLI rows (Devin, Grok Build, Jcode;
+        # sorted by id) every row after them shifted down by three when the
+        # jcode row landed.
         ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -139,6 +139,24 @@ def test_fake_row_login_command() -> None:
     assert _FAKE_ROW.binary == "fakecli"
 
 
+def test_spawn_env_mirrors_row_omnigent_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rows that opt out of MCP injection must propagate that to the wrap.
+
+    A vendor CLI that rejects ``session/new`` mcpServers (jcode) fails every
+    session if the Omnigent MCP server is advertised, so the row flag has to
+    reach ``HARNESS_ACP_OMNIGENT_MCP`` rather than relying on the wrap's
+    default-on.
+    """
+    no_mcp_row = dataclasses.replace(_FAKE_ROW, omnigent_mcp=False)
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", no_mcp_row)
+    env = _build_acp_cli_spawn_env(_spec("fakecli"), harness="fakecli")
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
+
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", _FAKE_ROW)
+    env = _build_acp_cli_spawn_env(_spec("fakecli"), harness="fakecli")
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == "1"
+
+
 # ---------------------------------------------------------------------------
 # Per-row registration (parametrized over the real catalog)
 # ---------------------------------------------------------------------------
@@ -197,6 +215,7 @@ def test_catalog_row_spawn_env_builds(name: str) -> None:
     if row.args:
         assert argv[-len(row.args) :] == list(row.args)
     assert env["HARNESS_ACP_NAME"] == row.label
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == ("1" if row.omnigent_mcp else "0")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #4660

## Summary

- Adds jcode (https://jcode.sh) as a builtin ACP harness: one row in `omnigent/acp_cli_harnesses.py` (`jcode acp`, curl installer, owns auth/model via `~/.jcode/config.toml`), following the grok pattern (#3075).
- Adds `omnigent_mcp: bool = True` to `AcpCliHarness`, wired through `_build_acp_cli_spawn_env` → `HARNESS_ACP_OMNIGENT_MCP`, because jcode's ACP server ignores `session/new` `mcpServers` (session-scoped MCP isn't supported yet; MCP is configured out of band in `~/.jcode/mcp.json`), so offering the Omnigent MCP server would be a silent no-op. Reusable by any future ACP CLI without session-scoped MCP support.

Host images need no Dockerfile changes: `EXTRA_HARNESS_CLIS` (merged in #4148) already installs jcode into managed host images via `deploy/docker/install-harness-cli.sh` (vendor installer, version-pinnable). This PR only updates that script's comment to reflect that jcode is now a builtin harness.

ELI5: Omnigent already knows how to drive any CLI that speaks ACP through one shared executor. jcode speaks ACP, so this PR adds jcode to the catalog of known harnesses — plus one flag meaning "don't offer this CLI an MCP server it would ignore."

```
omnigent/acp_cli_harnesses.py          runtime/workflow.py              inner/acp_harness.py
┌────────────────────────────┐   row   ┌──────────────────────┐  env   ┌─────────────────────┐
│ "jcode": AcpCliHarness(    │ ─────▶ │ _build_acp_cli_      │ ────▶ │ HARNESS_ACP_COMMAND │
│   args=("acp",),           │         │   spawn_env(...)     │        │ HARNESS_ACP_OMNIGENT│
│   omnigent_mcp=False)      │         │                      │        │ _MCP = "0"          │
└────────────────────────────┘         └──────────────────────┘        └─────────────────────┘
```

## Test Plan

- `uv run pytest tests/cli/test_configure_models.py` — 127 passed (setup-overview menu expectations updated for the new Jcode row: priority-order list entry, numbered dispatch entries, and the OpenClaw import choice each shift down by one).
- `uv run pytest tests/test_acp_cli_harnesses.py` — 16 passed (parametrized per-row registration/spawn-env coverage, plus a mechanism test for the `omnigent_mcp` flag and the per-row `HARNESS_ACP_OMNIGENT_MCP` assertion).
- `uv run pytest tests/test_harness_plugins.py tests/test_harness_aliases.py tests/test_harness_capabilities.py tests/test_harness_readiness.py tests/test_harness_startup_config.py` — 140 passed; the 2 failures are local-environment artifacts that also fail on `main` (machine has `acp:` agents in `~/.omnigent/config.yaml`, and an older `pi` CLI).
- Live: `_build_acp_cli_spawn_env(spec, harness="jcode")` → `HARNESS_ACP_COMMAND=/home/marko/.local/bin/jcode acp`, `HARNESS_ACP_OMNIGENT_MCP=0`; an `AcpExecutor` turn with that exact command answers correctly.
- Raw ACP probe against `jcode acp` v0.75.3 (initialize → session/new → session/prompt) streams `agent_message_chunk`s and ends with `stopReason: end_turn`.
- Also validated daily in production use as a custom `acp:` agent (`omni run --harness acp:jcode`, incl. file writes) — the row promotes exactly that config.
- Preview deployment validation complete (k8s staging runs jcode sessions against a corporate gateway; see #4660 discussion).

## Demo

N/A — no frontend change. The server harness catalog gains a `jcode` row (label "Jcode"), which surfaces in the existing harness picker.

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Manual: live `AcpExecutor` turn and raw ACP probe against real `jcode acp` v0.75.3 (routed through an OpenAI-compatible gateway, kimi-k3). Host-daemon e2e tests bind sessions to the first registered catalog row, so CI provisions the jcode CLI (pinned v0.84.0) via `.github/actions/e2e-run` (the `install-harness-cli.sh` vendor installer) to keep the new builtin row launchable.

## Changelog

Jcode is available as a harness (`omni run --harness jcode`, harness picker row "Jcode")

