### PR TITLE
fix(codex): report truthful trace provenance

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias, cast
 
@@ -1841,6 +1841,15 @@ def build_codex_native_server(
 
 
 @dataclass(frozen=True)
+class CodexTraceLaunchProvenance:
+    """Immutable, resolver-proven launch routing metadata for telemetry."""
+
+    access_lane: str
+    provider: str
+    provider_fallback: bool
+
+
+@dataclass(frozen=True)
 class NativeCodexLaunch:
     """How a native Codex terminal should be launched, across all offerings.
 
@@ -1864,6 +1873,25 @@ class NativeCodexLaunch:
     model: str | None
     profile: str | None
     summary: str = ""
+    trace_provenance: CodexTraceLaunchProvenance | None = None
+
+
+def _with_trace_provenance(
+    launch: NativeCodexLaunch,
+    *,
+    access_lane: str,
+    provider: str,
+    provider_fallback: bool = False,
+) -> NativeCodexLaunch:
+    """Attach resolver-proven routing metadata to a launch."""
+    return replace(
+        launch,
+        trace_provenance=CodexTraceLaunchProvenance(
+            access_lane=access_lane,
+            provider=provider,
+            provider_fallback=provider_fallback,
+        ),
+    )
 
 
 def codex_session_meta_model_provider(launch: NativeCodexLaunch) -> str:
@@ -2170,7 +2198,12 @@ def _first_routable_codex_provider(
                 exclude,
                 name,
             )
-            return launch
+            return _with_trace_provenance(
+                launch,
+                access_lane="omniroute",
+                provider=candidate.name,
+                provider_fallback=True,
+            )
     return None
 
 
@@ -2216,6 +2249,11 @@ def _resolve_subscription_launch(
             model=model,
             profile=None,
             summary=f"Codex CLI login (subscription provider {entry.name!r}; Codex is logged in)",
+            trace_provenance=CodexTraceLaunchProvenance(
+                access_lane="codex-direct",
+                provider="openai-codex-subscription",
+                provider_fallback=False,
+            ),
         )
     fallback = _first_routable_codex_provider(explicit, exclude=entry.name, model=model)
     if fallback is not None:
@@ -2233,6 +2271,11 @@ def _resolve_subscription_launch(
             f"Codex CLI login (subscription provider {entry.name!r} has no usable Codex "
             "login and no alternative provider is configured) — the TUI likely renders "
             "the sign-in screen and never starts a thread"
+        ),
+        trace_provenance=CodexTraceLaunchProvenance(
+            access_lane="codex-direct",
+            provider="openai-codex-subscription",
+            provider_fallback=True,
         ),
     )
 
@@ -2357,7 +2400,11 @@ def resolve_native_codex_launch(
                         spec_entry.name,
                         launch.model,
                     )
-                return launch
+                return _with_trace_provenance(
+                    launch,
+                    access_lane="omniroute",
+                    provider=spec_entry.name,
+                )
             _logger.warning(
                 "native-codex: spec-level provider %r has no usable openai credential — "
                 "falling back to machine-level resolution.",
@@ -2410,7 +2457,11 @@ def resolve_native_codex_launch(
             _logger.info("native-codex routing: Databricks ucode profile %r", launch.profile)
         else:
             _logger.info("native-codex routing: provider %r (model=%s)", entry.name, launch.model)
-        return launch
+        return _with_trace_provenance(
+            launch,
+            access_lane="omniroute",
+            provider=entry.name,
+        )
     # Default provider can't route on its own (no openai surface / no usable
     # credential / unresolvable secret) → Codex's own login.
     _logger.warning(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -29,6 +29,7 @@ from omnigent.claude_native_bridge import url_component
 from omnigent.codex_native_app_server import (
     CodexAppServerClient,
     CodexMessage,
+    CodexTraceLaunchProvenance,
     client_for_transport,
 )
 from omnigent.codex_native_bridge import (
@@ -435,6 +436,11 @@ class _CodexForwarderState:
     # thread rotation), so a settled round stays settled and later items
     # can skip re-reading the bridge file for the life of the session.
     mcp_startup_settled: bool = False
+    telemetry_turn_span: object | None = None
+    telemetry_turn_id: str | None = None
+    trace_launch_provenance: CodexTraceLaunchProvenance | None = None
+    requested_model: str | None = None
+    requested_effort: str | None = None
 
     def note_resume_response(self, response: CodexMessage) -> None:
         """
@@ -1774,6 +1780,9 @@ async def supervise_forwarder(
     client: CodexAppServerClient | None = None,
     auth: httpx.Auth | None = None,
     ap_transport: httpx.AsyncBaseTransport | None = None,
+    trace_launch_provenance: CodexTraceLaunchProvenance | None = None,
+    requested_model: str | None = None,
+    requested_effort: str | None = None,
 ) -> None:
     """
     Mirror Codex app-server notifications into an Omnigent session.
@@ -1834,6 +1843,9 @@ async def supervise_forwarder(
         forwarder_state = _CodexForwarderState(
             parent_session_id=session_id,
             codex_client=client,
+            trace_launch_provenance=trace_launch_provenance,
+            requested_model=requested_model,
+            requested_effort=requested_effort,
         )
         # Released when the live event stream shows the thread became
         # active (its first turn materializes the rollout). Lets the
@@ -1907,19 +1919,30 @@ async def supervise_forwarder(
                         forwarder_state=forwarder_state,
                     )
                 except Exception:  # noqa: BLE001 - keep the long-lived mirror alive.
+                    # Do not leak a turn span when terminal-event processing fails.
+                    with contextlib.suppress(Exception):
+                        _end_codex_turn_span("turn/failed", {}, forwarder_state)
                     _logger.warning("Codex forwarder event handling failed", exc_info=True)
         finally:
+            # A disconnect or shutdown may arrive without a terminal event.
+            with contextlib.suppress(Exception):
+                _end_codex_turn_span("turn/failed", {}, forwarder_state)
             if mcp_settle_timer is not None:
                 mcp_settle_timer.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await mcp_settle_timer
-            await target.delta_coalescer.close()
-            await target.usage_coalescer.close()
-            await target.elicitation_tracker.close()
+            for resource in (
+                target.delta_coalescer,
+                target.usage_coalescer,
+                target.elicitation_tracker,
+            ):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await resource.close()
             subscribe_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await subscribe_task
-            await client.close()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await client.close()
 
 
 async def _maybe_rotate_session_on_thread_started(
@@ -3251,6 +3274,71 @@ async def _handle_terminal_turn_boundary(
         )
     if handled:
         await usage_coalescer.flush()
+    _end_codex_turn_span(method, params, forwarder_state)
+
+
+def _start_codex_turn_span(
+    session_id: str,
+    params: _JsonObject,
+    state: _CodexForwarderState,
+) -> None:
+    """Start one metadata-only span for a native Codex turn."""
+    if state.telemetry_turn_span is not None:
+        _end_codex_turn_span("turn/failed", {}, state)
+    from opentelemetry import trace
+
+    turn_id = _turn_id_from_payload(params.get("turn")) or _turn_id_from_payload(params)
+    attributes: dict[str, str | bool] = {
+        "session.id": session_id,
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": _AGENT_NAME,
+        "omnigent.harness": "codex-native",
+    }
+    provenance = state.trace_launch_provenance
+    if provenance is not None:
+        attributes["omnigent.access_lane"] = provenance.access_lane
+        attributes["gen_ai.provider.name"] = provenance.provider
+        attributes["omnigent.provider.fallback"] = provenance.provider_fallback
+    if turn_id:
+        attributes["omnigent.codex.turn_id"] = turn_id
+    if state.requested_model:
+        attributes["omnigent.requested_model"] = state.requested_model
+    if state.model:
+        attributes["gen_ai.response.model"] = state.model
+    if state.requested_effort:
+        attributes["omnigent.requested_reasoning_effort"] = state.requested_effort
+    if state.effort:
+        attributes["omnigent.effective_reasoning_effort"] = state.effort
+    span = trace.get_tracer("omnigent").start_span(
+        "agent:codex-native-ui",
+        attributes=attributes,
+    )
+    state.telemetry_turn_span = span
+    state.telemetry_turn_id = turn_id
+
+
+def _end_codex_turn_span(
+    method: str,
+    params: _JsonObject,
+    state: _CodexForwarderState | None,
+) -> None:
+    """Finish the current native Codex turn span without recording payloads."""
+    if state is None or state.telemetry_turn_span is None:
+        return
+    from opentelemetry.trace import StatusCode
+
+    span = state.telemetry_turn_span
+    error = _terminal_error_from_turn(params)
+    try:
+        span.set_status(  # type: ignore[attr-defined]
+            StatusCode.OK if method == "turn/completed" and error is None else StatusCode.ERROR
+        )
+    finally:
+        try:
+            span.end()  # type: ignore[attr-defined]
+        finally:
+            state.telemetry_turn_span = None
+            state.telemetry_turn_id = None
 
 
 def _handle_usage_update(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
     # Type-only import: the runner keeps codex deps out of its runtime import
     # graph (they are imported lazily inside the codex-native helpers).
     from omnigent.claude_native import ClaudeNativeUcodeConfig
-    from omnigent.codex_native_app_server import CodexAppServerClient, CodexNativeAppServer
+    from omnigent.codex_native_app_server import (
+        CodexAppServerClient,
+        CodexNativeAppServer,
+        CodexTraceLaunchProvenance,
+    )
     from omnigent.inner.datamodel import OSEnvSpec
     from omnigent.opencode_native_app_server import OpenCodeNativeServer
     from omnigent.opencode_native_client import OpenCodeClient, OpenCodeSession
@@ -4186,6 +4190,9 @@ async def _auto_create_codex_terminal(
                 codex_home=codex_home,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
+                trace_launch_provenance=_codex_launch.trace_provenance,
+                requested_model=_codex_launch.model,
+                requested_effort=None,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4195,6 +4202,9 @@ async def _auto_create_codex_terminal(
                 bridge_dir=bridge_dir,
                 codex_ws_url=codex_ws_url,
                 thread_id=launch_config.external_session_id,
+                trace_launch_provenance=_codex_launch.trace_provenance,
+                requested_model=_codex_launch.model,
+                requested_effort=None,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4235,6 +4245,9 @@ async def _codex_discover_thread_and_forward(
     codex_home: Path,
     event_client: CodexAppServerClient,
     routing_summary: str,
+    trace_launch_provenance: CodexTraceLaunchProvenance | None = None,
+    requested_model: str | None = None,
+    requested_effort: str | None = None,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4369,6 +4382,9 @@ async def _codex_discover_thread_and_forward(
             thread_id=thread_id,
             client=event_client,
             auth=_RunnerDatabricksAuth(auth_factory),
+            trace_launch_provenance=trace_launch_provenance,
+            requested_model=requested_model,
+            requested_effort=requested_effort,
         )
     finally:
         # Tear down the listener and the per-session app-server whenever
@@ -4394,6 +4410,9 @@ async def _codex_forward_known_thread(
     bridge_dir: Path,
     codex_ws_url: str,
     thread_id: str,
+    trace_launch_provenance: CodexTraceLaunchProvenance | None = None,
+    requested_model: str | None = None,
+    requested_effort: str | None = None,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4433,6 +4452,9 @@ async def _codex_forward_known_thread(
             app_server_url=codex_ws_url,
             thread_id=thread_id,
             auth=_RunnerDatabricksAuth(auth_factory),
+            trace_launch_provenance=trace_launch_provenance,
+            requested_model=requested_model,
+            requested_effort=requested_effort,
         )
     finally:
         leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -619,12 +619,18 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     del forward_calls[0]["subagent_router"]
     assert "turn_router" in forward_calls[0]
     del forward_calls[0]["turn_router"]
+    provenance = forward_calls[0].pop("trace_launch_provenance")
+    assert provenance.access_lane == "codex-direct"
+    assert provenance.provider == "openai-codex-subscription"
+    assert provenance.provider_fallback is False
     assert forward_calls == [
         {
             "session_id": session_id,
             "bridge_dir": bridge_dir,
             "codex_ws_url": app_server.listen_url,
             "thread_id": thread_id,
+            "requested_model": "gpt-5.4-mini",
+            "requested_effort": None,
         }
     ]
     bridge_state = codex_native_bridge.read_bridge_state(bridge_dir)

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -21,8 +21,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from opentelemetry.trace import StatusCode
 
 from omnigent import codex_native_forwarder as fwd
+from omnigent.codex_native_app_server import CodexTraceLaunchProvenance
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     codex_home_for_bridge_dir,
@@ -2673,3 +2675,129 @@ async def test_delta_coalescer_survives_a_cancelled_flush_caller() -> None:
     )
     await asyncio.wait_for(coalescer.flush(), timeout=5.0)
     assert len(client.posts) > posts_before
+
+
+def test_codex_turn_span_records_metadata_without_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native Codex turn spans expose provenance but no user payload."""
+
+    class Span:
+        def __init__(self) -> None:
+            self.status = None
+            self.ended = False
+
+        def set_status(self, status: object) -> None:
+            self.status = status
+
+        def end(self) -> None:
+            self.ended = True
+
+    class Tracer:
+        def start_span(self, name: str, *, attributes: dict[str, object]) -> Span:
+            assert name == "agent:codex-native-ui"
+            assert attributes["session.id"] == "session-1"
+            assert attributes["omnigent.codex.turn_id"] == "turn-1"
+            assert "omnigent.response.id" not in attributes
+            assert attributes["omnigent.requested_model"] == "gpt-requested"
+            assert attributes["gen_ai.response.model"] == "gpt-observed"
+            assert attributes["omnigent.requested_reasoning_effort"] == "medium"
+            assert attributes["omnigent.effective_reasoning_effort"] == "high"
+            assert attributes["omnigent.access_lane"] == "omniroute"
+            assert attributes["gen_ai.provider.name"] == "cx"
+            assert attributes["omnigent.provider.fallback"] is False
+            assert not any("input" in key or "output" in key for key in attributes)
+            return span
+
+    span = Span()
+    monkeypatch.setattr("opentelemetry.trace.get_tracer", lambda _name: Tracer())
+    state = fwd._CodexForwarderState(
+        model="gpt-observed",
+        effort="high",
+        requested_model="gpt-requested",
+        requested_effort="medium",
+        trace_launch_provenance=CodexTraceLaunchProvenance(
+            access_lane="omniroute", provider="cx", provider_fallback=False
+        ),
+    )
+
+    fwd._start_codex_turn_span("session-1", {"turn": {"id": "turn-1"}}, state)
+    fwd._end_codex_turn_span("turn/completed", {"turn": {"id": "turn-1"}}, state)
+
+    assert span.ended is True
+    assert state.telemetry_turn_span is None
+
+
+@pytest.mark.parametrize(
+    ("method", "params", "expected_status"),
+    [
+        ("turn/completed", {"turn": {"id": "turn-1"}}, StatusCode.OK),
+        ("turn/failed", {"turn": {"id": "turn-1"}}, StatusCode.ERROR),
+        (
+            "turn/completed",
+            {"turn": {"id": "turn-1", "error": {"message": "failed"}}},
+            StatusCode.ERROR,
+        ),
+    ],
+)
+def test_codex_turn_span_terminal_status(
+    method: str, params: dict[str, object], expected_status: object
+) -> None:
+    """Normal completion is OK; failed and error-bearing completion are ERROR."""
+
+    class Span:
+        status: object | None = None
+        ended = False
+
+        def set_status(self, status: object) -> None:
+            self.status = status
+
+        def end(self) -> None:
+            self.ended = True
+
+    span = Span()
+    state = fwd._CodexForwarderState(telemetry_turn_span=span, telemetry_turn_id="turn-current")
+    fwd._end_codex_turn_span(method, params, state)
+    assert span.status == expected_status
+    assert span.ended is True
+    assert state.telemetry_turn_span is None
+    assert state.telemetry_turn_id is None
+
+
+def test_codex_turn_span_omits_unavailable_effective_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Requested values remain useful without inventing effective model or effort."""
+    captured: dict[str, object] = {}
+
+    class Tracer:
+        def start_span(self, _name: str, *, attributes: dict[str, object]) -> object:
+            captured.update(attributes)
+            return object()
+
+    monkeypatch.setattr("opentelemetry.trace.get_tracer", lambda _name: Tracer())
+    state = fwd._CodexForwarderState(requested_model="gpt-requested", requested_effort="medium")
+
+    fwd._start_codex_turn_span("session-1", {"turn": {"id": "turn-1"}}, state)
+
+    assert captured["omnigent.requested_model"] == "gpt-requested"
+    assert captured["omnigent.requested_reasoning_effort"] == "medium"
+    assert "gen_ai.response.model" not in captured
+    assert "omnigent.effective_reasoning_effort" not in captured
+
+
+def test_codex_turn_span_clears_state_when_span_end_raises() -> None:
+    """A broken exporter cannot leave a stale active span in forwarder state."""
+
+    class Span:
+        def set_status(self, _status: object) -> None:
+            pass
+
+        def end(self) -> None:
+            raise RuntimeError("exporter failed")
+
+    state = fwd._CodexForwarderState(telemetry_turn_span=Span(), telemetry_turn_id="turn-current")
+
+    with pytest.raises(RuntimeError, match="exporter failed"):
+        fwd._end_codex_turn_span("turn/completed", {"turn": {"id": "turn-current"}}, state)
+
+    assert state.telemetry_turn_span is None
+    assert state.telemetry_turn_id is None


### PR DESCRIPTION
## Related issue

Tracking note: the supplied rollout context refers to issue #95, but `omnigent-ai/omnigent#95` currently resolves to the merged deep-research PR rather than an open tracing issue. This PR intentionally does not auto-close it; rollout acceptance must complete first.

## Summary

- Carry immutable Codex launch provenance into native turn spans so OmniRoute and direct-subscription traffic are labeled truthfully.
- Separate requested model/reasoning from observed effective values, omit unknowns, and correlate Codex turns with `omnigent.codex.turn_id` rather than a fabricated response ID.
- Close active spans on terminal errors, event-processing failures, cancellation, disconnect, and shutdown without recording prompt, response, tool, or terminal content.

ELI5: the trace now reports which road Codex actually took instead of calling every road “direct OpenAI,” and it only reports facts the runtime knows.

```text
persisted launch config -> immutable provenance -> forwarder state -> bounded turn span
                                  + observed settings ----^ 
```

## Test Plan

- `uv run pytest -q tests/test_codex_native_forwarder.py tests/test_native_codex_provider.py tests/runner/test_app_sessions_native_terminals_runtime.py` (155 passed)
- `uv run ruff check omnigent/codex_native_app_server.py omnigent/codex_native_forwarder.py omnigent/runner/native/orchestration.py tests/test_codex_native_forwarder.py tests/test_native_codex_provider.py tests/runner/test_app_sessions_native_terminals_runtime.py`
- `uv run ruff format --check omnigent/codex_native_app_server.py omnigent/codex_native_forwarder.py omnigent/runner/native/orchestration.py tests/test_codex_native_forwarder.py tests/test_native_codex_provider.py tests/runner/test_app_sessions_native_terminals_runtime.py`
- `git diff --check`

## Demo

N/A — non-visual telemetry correction.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover both explicit lanes, provider/fallback provenance, requested/effective omission rules, privacy-safe attributes, terminal status, and span cleanup. Deployment canaries remain gated until merge.

## Changelog

Codex traces now report truthful lane, provider, model, and reasoning provenance without exposing conversation content.
