### PR TITLE
fix(web): redirect to home when archiving the active session

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_archive.py
+++ b/tests/e2e_ui/sessions/test_sidebar_archive.py
@@ -132,6 +132,10 @@ def test_archive_session_removes_row_without_stop_event(
     # flight, then unmounts entirely once the list refetches without it.
     expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
+    # Archiving the *active* session redirects to home so the user isn't
+    # stranded on a stale URL with no sidebar row to navigate from.
+    page.wait_for_url(f"{base_url}/", timeout=10_000)
+
     # And the archive is durable: the store row carries the flag, not
     # just the client cache. Poll — the list refetch that unmounts the
     # row can land marginally before the snapshot reflects it.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3262,7 +3262,10 @@ function ConversationRow({
       {
         // Point the user at where the session went — it's no longer in
         // the sidebar list, so surface its new home in Settings.
-        onSuccess: showArchivedToast,
+        onSuccess: () => {
+          if (isActive) navigate("/", { replace: true });
+          showArchivedToast();
+        },
         onError: () => setIsArchiving(false),
       },
     );
@@ -4242,6 +4245,8 @@ function BulkActionBar({
       { ids: nonArchivedSelected.map((c) => c.id), archived: true },
       {
         onSuccess: () => {
+          if (activeId && nonArchivedSelected.some((c) => c.id === activeId))
+            navigate("/", { replace: true });
           onDeselectAll();
         },
       },


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Archiving a session the user is currently viewing left them stranded on the now-archived session's URL — the sidebar row disappeared but the chat surface stayed on the stale page.
- Added a redirect to `/` (home) on archive success when the archived session matches the active one, mirroring the existing delete-flow behavior.
- Applied to both the single-session archive path (`ConversationRow.runArchive`) and the bulk archive path (`BulkActionBar.handleArchive`).

## Test Plan

- Existing `Sidebar.archive.test.tsx` tests pass (4/4) — the `MemoryRouter` starts at `/` so the new guard is a no-op in tests, preserving all current assertions.
- Manual verification: open a session via `/c/:id`, archive it from the kebab menu, confirm redirect to home.
- Manual verification: select multiple sessions including the active one, bulk-archive, confirm redirect to home.

## Demo

N/A — behavior change (navigation), no new visual elements.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing `Sidebar.archive.test.tsx` tests cover the archive mutation contract (single PATCH, no client stop, toast on success, archiving row lifecycle). The redirect guard is a no-op in tests since the `MemoryRouter` starts at `/` with no active `conversationId` param. Manual verification confirmed the redirect fires when archiving the active session.

## Changelog

Archiving the current session now redirects to the home page instead of leaving you on the archived session