### PR TITLE
fix(host): keep the session workspace off the runner's sys.path (OMNI-2963)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3441,7 +3441,11 @@ def _start_cli_runner_process(
     try:
         with child_logging_popen_kwargs(env) as logging_kwargs:
             runner_proc: subprocess.Popen[bytes] = subprocess.Popen(
-                [sys.executable, "-m", "omnigent.runner._entry"],
+                # This runner inherits the CLI's cwd, so -P is what stops a
+                # checkout you launched from shadowing the installed omnigent
+                # (the daemon and zygote spawns do the same). _entry re-adds the
+                # cwd afterwards, keeping spec-declared local tools importable.
+                [sys.executable, "-P", "-m", "omnigent.runner._entry"],
                 env=env,
                 stdout=log_fh,
                 stderr=log_fh,

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -188,8 +188,11 @@ def codex_mcp_config_overrides(
         ``['mcp_servers.omnigent.command="python"', ...]``.
     """
     python = python_executable or sys.executable
+    # -I: codex launches this MCP server in the workspace, so cwd must stay off
+    # sys.path or a workspace that is an omnigent checkout shadows the installed
+    # package. Matches every other bridge's serve-mcp invocation.
     args_toml = json.dumps(
-        ["-m", "omnigent.claude_native_bridge", "serve-mcp", "--bridge-dir", str(bridge_dir)]
+        ["-I", "-m", "omnigent.claude_native_bridge", "serve-mcp", "--bridge-dir", str(bridge_dir)]
     )
     return [
         f'mcp_servers.omnigent.command="{python}"',

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -380,6 +380,10 @@ def write_policy_hook_config(
         "omnigent": {
             "command": sys.executable,
             "args": [
+                # hermes launches MCP servers in the workspace; -I keeps that
+                # cwd off sys.path so a workspace that is an omnigent checkout
+                # can't shadow the installed package (as every other bridge does).
+                "-I",
                 "-m",
                 "omnigent.claude_native_bridge",
                 "serve-mcp",

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1457,7 +1457,10 @@ class HostProcess:
 
             with child_logging_popen_kwargs(env) as logging_kwargs:
                 proc = subprocess.Popen(
-                    [sys.executable, "-m", "omnigent.runner._entry"],
+                    # -P keeps cwd off sys.path: a workspace that is itself an
+                    # omnigent checkout would otherwise shadow the installed
+                    # package. _entry re-adds it for spec-declared local tools.
+                    [sys.executable, "-P", "-m", "omnigent.runner._entry"],
                     env=env,
                     # A daemon may outlive the checkout it started from.
                     cwd=str(workspace),

--- a/omnigent/host/runner_zygote.py
+++ b/omnigent/host/runner_zygote.py
@@ -227,7 +227,10 @@ class ZygoteManager:
             tty_kwargs = stack.enter_context(child_logging_popen_kwargs(env))
             pass_fds = (child_fd, *tty_kwargs.get("pass_fds", ()))
             return subprocess.Popen(
-                [self._python, "-m", "omnigent.runner._zygote"],
+                # -P keeps the daemon's cwd off sys.path, so a daemon started
+                # inside an omnigent checkout can't hand forked runners a
+                # different omnigent than the installed one.
+                [self._python, "-P", "-m", "omnigent.runner._zygote"],
                 env=env,
                 pass_fds=pass_fds,
                 stdin=subprocess.DEVNULL,

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1742,6 +1742,13 @@ def main() -> None:
     """
     from omnigent.process_logging import configure_process_logging
 
+    # Spawned with -P, so the workspace is not on sys.path. Re-add it now that
+    # the real omnigent is imported (it can no longer be shadowed) so
+    # spec-declared local tools living in the workspace still import.
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
     configure_process_logging("runner", force=True)
     _install_crash_logging()
     try:

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1240,6 +1240,9 @@ class HarnessProcessManager:
                 self._harness_zygote_disabled = True
         return await asyncio.create_subprocess_exec(
             sys.executable,
+            # -P keeps the inherited workspace cwd off sys.path so it can't
+            # shadow the installed omnigent the harness module comes from.
+            "-P",
             "-m",
             "omnigent.runtime.harnesses._runner",
             *runner_argv,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1641,6 +1641,9 @@ def test_start_cli_runner_process_uses_token_bound_runner_id(
     assert env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] == "bind-token"
     assert env[RUNNER_PARENT_PID_ENV_VAR] == str(os.getpid())
     assert env[RUNNER_WORKSPACE_ENV_VAR] == str(workspace.resolve())
+    # -P: this runner inherits the CLI's cwd, so launching from inside an
+    # omnigent checkout must not shadow the installed package.
+    assert captured["args"] == [sys.executable, "-P", "-m", "omnigent.runner._entry"]
 
 
 def test_start_cli_runner_process_binds_stable_local_runner_to_generated_token(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4147,3 +4147,21 @@ def test_zygote_start_failure_disables_it(
     assert host._zygote_disabled is True
     assert zygote.stop_calls == 0
     assert len(popen_argvs) == 1
+
+
+def test_direct_spawn_keeps_the_workspace_off_sys_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The runner is spawned with ``-P`` so its workspace cannot shadow omnigent.
+
+    The runner's cwd is the session workspace, and ``python -m`` would otherwise
+    prepend it to ``sys.path`` — so a session opened *in an omnigent checkout*
+    imports that checkout instead of the installed package, and a long-lived
+    daemon plus a mid-flight ``git pull`` then skews the two.
+    """
+    zygote = _FakeZygote(fail_at="start", running=False)
+
+    _host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
+
+    assert popen_argvs[0][1:] == ["-P", "-m", "omnigent.runner._entry"]

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4156,7 +4156,7 @@ def test_direct_spawn_keeps_the_workspace_off_sys_path(
     """The runner is spawned with ``-P`` so its workspace cannot shadow omnigent.
 
     The runner's cwd is the session workspace, and ``python -m`` would otherwise
-    prepend it to ``sys.path`` — so a session opened *in an omnigent checkout*
+    prepend it to ``sys.path``, so a session opened *in an omnigent checkout*
     imports that checkout instead of the installed package, and a long-lived
     daemon plus a mid-flight ``git pull`` then skews the two.
     """

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -345,7 +345,7 @@ def test_zygote_boots_from_inside_an_omnigent_checkout(monkeypatch, tmp_path) ->
     """A daemon whose cwd holds an ``omnigent/`` package still starts a zygote.
 
     The zygote inherits the daemon's cwd, which ``python -m`` would prepend to
-    ``sys.path`` — so a daemon started inside an omnigent checkout would import
+    ``sys.path``, so a daemon started inside an omnigent checkout would import
     that checkout instead of the installed package. Booting against a poisoned
     package proves the spawn keeps cwd off ``sys.path``.
 

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -341,6 +341,30 @@ def test_operator_malloc_override_wins_at_the_zygote_exec(monkeypatch, tmp_path)
     assert captured["MALLOC_ARENA_MAX"] == "16"
 
 
+def test_zygote_boots_from_inside_an_omnigent_checkout(monkeypatch, tmp_path) -> None:
+    """A daemon whose cwd holds an ``omnigent/`` package still starts a zygote.
+
+    The zygote inherits the daemon's cwd, which ``python -m`` would prepend to
+    ``sys.path`` — so a daemon started inside an omnigent checkout would import
+    that checkout instead of the installed package. Booting against a poisoned
+    package proves the spawn keeps cwd off ``sys.path``.
+
+    :param monkeypatch: Fixture used to run from the poisoned directory.
+    :param tmp_path: Temp dir holding the poisoned package and the zygote log.
+    """
+    package = tmp_path / "omnigent"
+    package.mkdir()
+    (package / "__init__.py").write_text('raise ImportError("poisoned omnigent")\n')
+    monkeypatch.chdir(tmp_path)
+
+    mgr = ZygoteManager(log_path=tmp_path / "zygote.log")
+    mgr.start()
+    try:
+        assert mgr.is_running()
+    finally:
+        mgr.stop()
+
+
 # ── Harness-fork path (fork_harness) ──────────────────────────────
 #
 # The zygote also forks HARNESS children on request, sharing the harness import

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -184,7 +184,12 @@ class TestSetupHermesHome:
         key: a headless Hermes agent had zero Omnigent tools."""
         home, bridge_dir = setup
         omnigent_mcp = json.loads((home / "config.yaml").read_text())["mcp_servers"]["omnigent"]
-        assert omnigent_mcp["args"][:2] == ["-m", "omnigent.claude_native_bridge"]
+        assert omnigent_mcp["args"][:4] == [
+            "-I",
+            "-m",
+            "omnigent.claude_native_bridge",
+            "serve-mcp",
+        ]
         assert "serve-mcp" in omnigent_mcp["args"]
         assert str(bridge_dir) in omnigent_mcp["args"]  # serve-mcp --bridge-dir <bridge_dir>
 

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,27 @@ from omnigent.runner import create_runner_app
 from omnigent.runner.mcp_manager import McpSchemasResult
 from omnigent.spec.types import AgentSpec, ExecutorSpec, MCPServerConfig
 from tests.runner.helpers import NullServerClient
+
+# Project root: two parents up from this conftest (tests/runner/ → repo root).
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _ensure_subprocess_pythonpath(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put the project root on ``PYTHONPATH`` for spawned harness children.
+
+    Harnesses are spawned with ``-P``, so the child's cwd is deliberately kept
+    off ``sys.path`` (a workspace that is an omnigent checkout must not shadow
+    the installed package). Tests that register a fixture harness module such as
+    ``tests._fixtures.runner_test_harness`` therefore have to hand the child that
+    path through the environment, exactly as ``tests/runtime/harnesses/conftest``
+    already does. Prepend rather than overwrite so a developer-set value stays.
+
+    :param monkeypatch: Pytest monkeypatch fixture, scoping this to one test.
+    """
+    existing = os.environ.get("PYTHONPATH", "")
+    new_path = f"{_PROJECT_ROOT}{os.pathsep}{existing}" if existing else str(_PROJECT_ROOT)
+    monkeypatch.setenv("PYTHONPATH", new_path)
 
 
 def _drain_session_event_queue(queue: asyncio.Queue[Any] | None) -> list[dict[str, Any]]:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -2167,6 +2167,39 @@ def test_main_configures_runner_process_logging(
     assert captured == {"destination": "runner", "force": True}
 
 
+def test_main_makes_the_workspace_importable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``main`` puts the workspace back on ``sys.path`` for local tools.
+
+    The runner is spawned with ``-P`` so its workspace cannot shadow the
+    installed omnigent. Spec-declared local tools are still imported by dotted
+    path, so the workspace has to be restored once omnigent itself is imported.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Stands in for the session workspace.
+    :returns: None.
+    """
+
+    async def _stop_immediately() -> None:
+        """Let ``main`` return once the path is set up.
+
+        :returns: None.
+        """
+
+    monkeypatch.setattr(
+        "omnigent.runner._entry._run_tunnel_from_env",
+        _stop_immediately,
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if p != str(tmp_path)])
+
+    main()
+
+    assert str(tmp_path) in sys.path
+
+
 def test_main_preserves_unexpected_runtime_errors(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from omnigent.codex_native_bridge import (
     clear_active_turn_id_if_matches,
     clear_bridge_state,
     codex_home_for_bridge_dir,
+    codex_mcp_config_overrides,
     mcp_startup_waiting_detail,
     pending_mcp_servers,
     prepare_bridge_dir,
@@ -27,6 +29,22 @@ from omnigent.codex_native_bridge import (
     write_codex_config_model,
     write_policy_hook_config,
 )
+
+
+def test_codex_mcp_config_overrides_isolate_the_bridge_interpreter(tmp_path: Path) -> None:
+    """codex launches serve-mcp with ``-I`` so the workspace can't shadow omnigent.
+
+    The MCP server starts in the session workspace, and without ``-I`` python puts
+    that cwd on ``sys.path``, so a workspace that is an omnigent checkout supplies
+    the bridge's own package. Every other native bridge passes ``-I`` here.
+
+    :param tmp_path: Stands in for the per-session bridge dir.
+    """
+    overrides = codex_mcp_config_overrides(tmp_path)
+
+    prefix = "mcp_servers.omnigent.args="
+    raw = next(o[len(prefix) :] for o in overrides if o.startswith(prefix))
+    assert json.loads(raw)[:4] == ["-I", "-m", "omnigent.claude_native_bridge", "serve-mcp"]
 
 
 def _seed_active_turn(bridge_dir: Path, active_turn_id: str | None) -> None:


### PR DESCRIPTION
## Related issue

Tracked internally as **OMNI-2963** (no public issue). Reported live while preparing a customer demo: after upgrading to 0.9.0, every runner (OSS and managed) stopped working, with empty runner logs and `ValueError: runner fork request requires a cwd`.

## Summary

Opening a session **inside an omnigent checkout** made the runner import that checkout instead of the installed package.

Runners are spawned as `python -m omnigent.runner._entry`, and `-m` prepends the process cwd to `sys.path`. Since 3419de8d ("run session runners in the workspace, not the daemon's cwd", #3974) the runner's cwd is the *session workspace*, so a workspace that is itself a checkout wins over site-packages. That commit was a correct fix for a dead-cwd `FileNotFoundError`; the import-path side effect was the unintended part.

**ELI5:** the runner used to start in whatever directory the daemon was launched from. Now it starts in your project folder. If your project folder happens to be a copy of omnigent, Python finds *that* omnigent first, and you silently run a different version than the one you installed.

```
                  spawn: python -m omnigent.runner._entry
                  cwd = <session workspace>
                                │
        ┌───────────────────────┴───────────────────────┐
        │ before this PR                                │ after this PR (-P)
        │ sys.path[0] = <workspace>   ← wins            │ sys.path[0] dropped
        │ sys.path[1] = .../site-packages               │ sys.path[0] = .../site-packages
        └───────────────────────────────────────────────┘
   workspace == an omnigent checkout                 installed omnigent always wins
        → runner runs the checkout                   → workspace re-added afterwards,
        → long-lived host holds OLD code                so local_tools still import
        → `git pull` skews host vs zygote
        → "runner fork request requires a cwd"
```

That last line is itself proof of the skew: the error can only fire with a strict (new) child and a lenient (old) manager, and 3419de8d introduced both halves. A long-lived host keeps old code in memory while each freshly spawned zygote/runner re-reads the mutable checkout, so a `git pull` in between splits them.

**This is the same root cause as #4631.** That fix (one day earlier) handled a different symptom of it: with cwd on `sys.path`, a daemon started from a directory *holding* a checkout binds `omnigent` to a namespace package whose `__file__` is `None`, so `_disk_build_stamp()` raised `TypeError` and killed the zygote at boot. Deriving the stamp from the module's own path worked around that one call site; `-P` removes the condition itself. That workaround stays as defense in depth.

It also explains why the usual advice stopped working. Before 3419de8d the runner inherited the *daemon's* cwd, so "start the host from outside the repo" genuinely fixed it. After it, the workspace decides, and where you started the host no longer matters.

Changes:

- `-P` on all four spawns of runner-side code (the daemon's runner, the zygote, the harness runner, and the CLI's own local runner), so cwd never lands on `sys.path`. `-P` rather than `-I` because the runner must keep honoring `PYTHONPATH`.
- Re-add the workspace to `sys.path` in `_entry.main()`, after the real omnigent is imported. Spec-declared `local_tools` are imported by dotted path and would otherwise stop resolving. Once the real `omnigent` is in `sys.modules` its submodules resolve via `__path__`, so it can no longer be shadowed.
- `-I` on the two `serve-mcp` bridges that were missing it, hermes and codex, so every bridge now launches that server isolated. (Review caught codex: `codex_mcp_config_overrides` builds its own args list, and an earlier draft of this description wrongly claimed it was already covered. `codex_native_app_server` does pass `-I`; the bridge did not.)

## Test Plan

Three dedicated regression tests, each verified to **fail on the reverted code and pass with the fix** (plus argv assertions for the CLI and hermes spawns):

```bash
pytest tests/host/test_runner_zygote.py::test_zygote_boots_from_inside_an_omnigent_checkout \
       tests/host/test_connect.py::test_direct_spawn_keeps_the_workspace_off_sys_path \
       tests/runner/test_runner_entry.py::test_main_makes_the_workspace_importable
```

The zygote one is behavioural rather than an argv assertion: it boots a real zygote whose cwd holds a poisoned `omnigent/__init__.py` that raises on import, so the zygote cannot start at all unless cwd is kept off `sys.path`.

Suites run green on the rebased branch: `tests/host/test_runner_zygote.py` + `tests/runner/test_runner_entry.py` + the hermes and harness-fallback tests (174 passed), `tests/runtime/harnesses/` (145 passed). `ruff format`, `ruff check` clean; pyrefly reports the same 29 pre-existing errors on these files before and after, at identical locations.

Mechanism confirmed directly:

```
$ cd /tmp/ws && python -m omnigent.runner._entry        # /tmp/ws contains an omnigent/
SHADOWED: imported fake omnigent from /tmp/ws/omnigent/__init__.py
$ cd /tmp/ws && python -P -m omnigent.runner._entry
real: /.../site-packages/omnigent/__init__.py
```

## Demo

N/A (non-visual).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually reproduced the shadowing and its fix with a planted `omnigent/` package in the spawn cwd (transcript above), which is what the automated tests then pin. The CLI's local-runner spawn is pinned by a one-line argv assertion in the existing `_start_cli_runner_process` test. The hermes bridge change updates the existing `test_config_registers_omnigent_mcp_server` assertion, matching the form the qwen bridge test already uses; codex gets a new `test_codex_mcp_config_overrides_isolate_the_bridge_interpreter` (verified to fail without the `-I`).

**Why `-P` for runners but `-I` for the `serve-mcp` bridges.** The runner must keep honoring `PYTHONPATH` (spec-declared `local_tools`, and the test fixtures that ride on it), and `-I` implies `-E`, which would drop it. The MCP relay needs no such thing, so it takes the stricter flag that the other bridges already use. Please keep them different.

**Why `sys.path.insert(0, cwd)` and not `append`.** Before this change `-m` put cwd at `sys.path[0]`, so a workspace module already won over site-packages for any not-yet-imported top-level name. Re-inserting at 0 preserves exactly that precedence; appending would quietly flip resolution for anyone relying on a workspace-local module, which is a behavior change beyond this bug. `omnigent` itself is safe either way, since it is already in `sys.modules` by then. This is a load-order invariant: the re-add must stay after the `omnigent` imports at the top of `_entry.py`.

On the harness asymmetry (`_runner` gets `-P` but no cwd re-add): checked, and nothing is stranded. Callable local tools are resolved only in `runner/tool_dispatch.py`, i.e. the runner process, which is the one that restores cwd. No harness module imports the spec loader, and `_runner` never touches `agent_spec`, so no supported spec resolves a workspace-local callable inside a harness process.

Two same-class sites were deliberately left alone, since neither is a safe one-token change and neither is part of this regression: the sandbox helper spawn (`omnigent/inner/os_env.py:563`, whose argv gets wrapped by bwrap and which already does its own `PYTHONPATH` scrubbing) and the `omni chat` server spawn (`omnigent/chat.py:3450`, where `cli.main()` puts cwd on `sys.path` on purpose). Happy to file a follow-up to close that lane.

## Changelog

Sessions whose workspace is an omnigent checkout no longer run a different omnigent than the one you installed
