### PR TITLE
fix(spec): keep the acp:<slug> agent id through spec translation

### DIFF
--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -1697,7 +1697,16 @@ def _translate_executor_from_def(
     harness = oa_executor.harness if oa_executor is not None else None
     if harness is None:
         harness = ""
-    harness = canonicalize_harness(harness) or ""
+    # A namespaced generic-ACP id (``acp:<slug>``) canonicalizes to the base
+    # ``acp`` harness, but the slug is what selects which user-configured ACP
+    # agent to spawn — ``_build_acp_spawn_env`` reads it back off
+    # ``config["harness"]`` at spawn time (see the dispatch note in
+    # ``runner/app.py``). Canonicalizing it away here silently spawned the first
+    # configured agent instead of the requested one, so keep the full id for
+    # ``acp:`` and canonicalize everything else (so aliases still resolve).
+    # Mirrors ``_materialize_harness_launcher_file`` in ``omnigent/cli.py``.
+    _canonical_harness = canonicalize_harness(harness) or ""
+    harness = harness if _canonical_harness == "acp" and ":" in harness else _canonical_harness
     profile = oa_executor.profile if oa_executor is not None else None
     if profile is None:
         profile = ""

--- a/tests/spec/test_omnigent_translator.py
+++ b/tests/spec/test_omnigent_translator.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import pytest
 
 from omnigent.errors import OmnigentError
-from omnigent.inner.datamodel import OSEnvSpec
+from omnigent.inner.datamodel import AgentDef, OSEnvSpec
+from omnigent.inner.datamodel import ExecutorSpec as OmniExecutorSpec
 from omnigent.inner.tools import AgentTool, FunctionTool
 from omnigent.spec import (
     AgentSpec,
@@ -610,3 +611,42 @@ def test_client_runtime_tool_round_trips_through_reverse_translation(
     # Parameters preserved — without these the validator rejects
     # the round-tripped spec ("client tool has no parameters").
     assert tool_info.parameters == parameters
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected"),
+    [
+        # A generic-ACP id must keep its slug: it canonicalizes to the base
+        # ``acp`` harness for dispatch, but the slug is the only thing that says
+        # WHICH configured ACP agent to spawn.
+        ("acp:devin", "acp:devin"),
+        ("acp:kilocode", "acp:kilocode"),
+        # Bare ``acp`` has no slug to preserve.
+        ("acp", "acp"),
+        # Every other harness still canonicalizes, so aliases keep resolving.
+        ("claude", "claude-sdk"),
+    ],
+)
+def test_acp_slug_survives_reverse_translation(harness: str, expected: str) -> None:
+    """
+    ``acp:<slug>`` survives ``agent_def_to_agent_spec`` intact.
+
+    This is the path a harness launch actually takes: the omnigent loader parses
+    the YAML into an :class:`AgentDef`, the reverse translator turns it into an
+    ``AgentSpec``, and ``_build_acp_spawn_env`` then resolves which configured ACP
+    agent to launch by reading the slug back off ``executor.config["harness"]``.
+    The reverse translator used to canonicalize ``acp:<slug>`` down to ``acp``,
+    making the slug unrecoverable — so every ``acp:<slug>`` launch silently
+    spawned the *first* configured ACP agent instead of the requested one.
+
+    **What breaks if this fails**: ``omnigent run --harness acp:devin`` runs
+    somebody else's agent (whichever is first in the ``acp:`` config block)
+    while the UI still reports the one that was asked for.
+    """
+    agent_def = AgentDef(
+        name="hello-agent",
+        prompt="You are a helpful assistant.",
+        executor=OmniExecutorSpec(model="databricks-claude-sonnet-4-6", harness=harness),
+    )
+    spec = agent_def_to_agent_spec(agent_def)
+    assert spec.executor.config["harness"] == expected


### PR DESCRIPTION
## Related issue

No filed issue — found while wiring a new ACP-speaking vendor CLI (Devin) through
the generic ACP harness, and fixed in place. Happy to file one retroactively if
the review queue wants the priority signal.

## Summary

`omnigent run --harness acp:devin` silently ran a **different** agent.

`_translate_executor_from_def` canonicalized the namespaced generic-ACP id
`acp:<slug>` down to the base `acp` harness. The slug is the only thing that
says *which* configured ACP agent to spawn, so by spawn time it was gone and
`_build_acp_spawn_env` fell through to its `acp_agents()[0]` fallback —
launching the first agent in the `acp:` config block while the UI still
reported the requested one.

- Keep the full `acp:<slug>` id for ACP; canonicalize everything else so
  harness aliases (`claude` → `claude-sdk`) still resolve. This mirrors the
  logic `_materialize_harness_launcher_file` already applies in `omnigent/cli.py`.
- Add a regression test on the real translation path.

```
                       before                        after
--harness acp:devin ─┐                            ─┐
  cli.py             │ executor.harness=acp:devin   │ executor.harness=acp:devin
  spec translation   │ config["harness"]=acp  ✗     │ config["harness"]=acp:devin ✓
  _build_acp_spawn_env│ slug="" → agents[0]         │ slug="devin" → Devin
  spawned            ┘ kilo acp        ✗           ┘ devin acp   ✓
```

**ELI5**: the harness id is `acp:devin` — "the generic ACP driver, pointed at
Devin". We were throwing away the `:devin` half and then guessing, so you got
whichever ACP agent happened to be listed first.

## Test Plan

- New regression test, `tests/spec/test_omnigent_translator.py::test_acp_slug_survives_reverse_translation`
  — parametrized over `acp:devin`, `acp:kilocode`, bare `acp`, and `claude`.
  Fails on both `acp:<slug>` cases without the fix, passes with it.
- `pytest tests/spec tests/runtime/test_acp_spawn_env.py tests/test_acp_cli_harnesses.py tests/onboarding/test_acp_auth.py` → **609 passed**.
- `pre-commit run --files <changed>` → clean (ruff format, ruff check, pyrefly).
- Manual, end-to-end against a real vendor CLI: added `devin acp --model swe-1-6-slow`
  to the `acp:` config block and ran a turn through `omni run --harness acp:devin`.
  Before the fix the runner log showed `acp[kilocode]`; after it, Devin's own CLI
  log is created at the runner start timestamp, the reply is tagged
  `agent: acp-devin`, and a tool call routes through Omnigent's dispatch.

Reproduced directly, before the fix:

```python
spec = load(_materialize_harness_launcher_file(harness="acp:devin", model=None, system_prompt=None))
_build_acp_spawn_env(spec, cwd=None, workdir=None)
# HARNESS_ACP_NAME    = 'kilocode'
# HARNESS_ACP_COMMAND = 'kilo acp'   ← wrong agent
```

## Demo

N/A — non-visual fix (no UI change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The pre-existing `tests/runtime/test_acp_spawn_env.py` suite covers the
fallback behaviour (`test_bare_acp_falls_back_to_first_agent`,
`test_unknown_slug_falls_back_to_first_agent`) but constructs `AgentSpec`
**directly**, bypassing the YAML→spec translation where the slug was actually
lost — which is exactly how this escaped. The new test goes through
`agent_def_to_agent_spec`, the path a real YAML/`--harness` launch takes, so
the regression is caught at the layer that broke.

Manual verification covered the end-to-end launch (config → picker → spawn →
turn) against a real ACP vendor CLI, since no automated test spawns a live
third-party ACP subprocess.

## Changelog

`omnigent run --harness acp:<agent>` now launches the ACP agent you asked for instead of the first one configured
