### PR TITLE
fix(electron): normalize legacy host_ prefix so "Run on this machine" auto-selects

### DIFF
--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -135,12 +135,18 @@ function stateDir() {
 let cachedHostId = null;
 
 /**
- * This machine's Omnigent host id (e.g. "host_ab12…"), read from the machine
- * identity in `config.yaml` (`host: host_id:`, written by
+ * This machine's Omnigent host id (bare 32-char hex, e.g. "ab12…"), read from
+ * the machine identity in `config.yaml` (`host: host_id:`, written by
  * omnigent/host/identity.py) — instant, no subprocess. Present once generated,
  * even before connecting to any server. Returns null when no id exists yet;
  * after the first connect it resolves. Lets the renderer match "this machine"
  * against the server's /v1/hosts list and select it after an auto-connect.
+ *
+ * Installs predating the drop of the `host_` prefix still hold the legacy
+ * spelling on disk, while /v1/hosts always reports the bare form (`hosts.host_id`
+ * is a Uuid16 column). The renderer compares these as plain strings — it is the
+ * one consumer the server's own prefix-tolerance can't rescue — so strip the
+ * prefix here, mirroring `_normalize_host_id` in omnigent/host/identity.py.
  *
  * @returns {string | null}
  */
@@ -149,7 +155,7 @@ function localHostId() {
   try {
     const parsed = yaml.load(fs.readFileSync(path.join(localConfigDir(), "config.yaml"), "utf8"));
     const id = parsed && typeof parsed === "object" ? parsed.host?.host_id : null;
-    if (typeof id === "string" && id) cachedHostId = id;
+    if (typeof id === "string" && id) cachedHostId = id.replace(/^host_/, "");
   } catch {
     // No config yet, or unparseable.
   }

--- a/web/electron/test/omnigent_cli.test.js
+++ b/web/electron/test/omnigent_cli.test.js
@@ -20,6 +20,7 @@ const {
   parseDaemonRecord,
   daemonServerUrl,
   getHostConnectionFast,
+  localHostId,
 } = require("../src/omnigent_cli");
 
 describe("normalizeServerUrl", () => {
@@ -310,5 +311,18 @@ describe("getHostConnectionFast — probe destination & token handling (S1)", ()
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].headers.Authorization, undefined);
+  });
+});
+
+describe("localHostId", () => {
+  // The id is memoized process-wide, so this is the ONLY case that may call
+  // localHostId — a second one would read the cache, not the mocked file.
+  it("strips the legacy host_ prefix so the id matches a /v1/hosts row", () => {
+    mock.method(fs, "readFileSync", () => "host:\n  host_id: host_abc123\n  name: laptop\n");
+
+    // The renderer compares this against host_id as a plain string, so the
+    // prefixed form would make "this machine" unmatchable in the host list.
+    assert.equal(localHostId(), "abc123");
+    assert.equal(localHostId(), "abc123");
   });
 });


### PR DESCRIPTION
## Related issue

No linked issue — reported directly (the desktop host picker did not auto-select
this machine after "Run on this machine" finished connecting).

## Summary

The desktop shell handed the web UI this machine's host id in the legacy
`host_<hex>` spelling, read verbatim from `config.yaml`, while the server always
reports the **bare** hex form (`hosts.host_id` is a `Uuid16` column — 16 raw
bytes on disk, so a `host_` prefix is physically un-storable). The host picker
compares the two as plain strings, so on any install created before the prefix
was dropped, "this machine" never matched a `/v1/hosts` row.

- `localHostId()` now strips the `host_` prefix, mirroring `_normalize_host_id`
  in `omnigent/host/identity.py` — the desktop shell was the only place in the
  stack that didn't already normalize every id spelling to bare hex.
- Result: after "Run on this machine" finishes connecting, the machine now
  auto-selects (chip reads "This Mac" with the online dot, the row is
  highlighted, and the choice sticks across visits). Previously the selection
  was silently dropped and a redundant "Run on this machine" item showed even
  when the machine was already online in the list.
- Safe for both id styles: a bare 32-char hex id can never begin with `host_`
  (none of `h, o, s, t, _` are hex digits), so the strip is a no-op on new ids
  and cannot corrupt them.

## Test Plan

- `cd web/electron && node --test test/omnigent_cli.test.js` → 32/32 pass. Added
  a `localHostId` case asserting the prefix is stripped; verified it fails (red)
  without the one-line fix and passes (green) with it.
- Manually verified end-to-end in the real Electron desktop app (driven over CDP
  against a live local server), A/B between the buggy and fixed builds:

| | buggy build | fixed build |
|---|---|---|
| shell reports | `host_<hex>` | `<hex>` (bare) |
| matches a `/v1/hosts` row | false | true |
| host chip | raw hostname | "This Mac" + online dot |
| picker | online row **plus** a redundant "Run on this machine" | machine deduped, row active |
| after clicking "Run on this machine" | chip → "Choose host" (selection lost) | already selected |

## Demo

Host chip after connecting, before → after:

- **Before:** chip shows the raw hostname, and clicking "Run on this machine"
  leaves it on "Choose host" (no selection).
- **After:** chip shows "This Mac" with the green online dot; the machine is
  deduped and pre-selected.

<!-- Screenshots captured during verification (buggy / fixed / connect-buggy /
connect-fixed) — attach here. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit test added for the prefix-strip in `localHostId` (red→green verified).
Manual verification: launched the real Electron desktop shell against a live
local server and drove the host picker over CDP, comparing the buggy and fixed
builds — confirmed the machine auto-selects after "Run on this machine" (chip
"This Mac", row highlighted, selection persists) with the fix, and the selection
is lost without it.

## Changelog

The desktop app now auto-selects this machine after "Run on this machine"
finishes connecting, including on installs with a legacy host id.

This pull request and its description were written by Isaac.
