### PR TITLE
chore(runner): raise the default idle timeout from 1h to 8h

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -41,7 +41,9 @@ _RUNNER_PREWARM_SPEC_PATH_ENV_VAR = "RUNNER_PREWARM_SPEC_PATH"
 # with the CLI/server/host) instead of a hard-coded placeholder.
 _RUNNER_VERSION = VERSION
 _RUNNER_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
-_DEFAULT_RUNNER_IDLE_TIMEOUT_S = 60 * 60
+# Default inactivity window before an idle runner gracefully shuts down.
+# 8 hours covers a workday of intermittent use; runner.idle_timeout_s overrides.
+_DEFAULT_RUNNER_IDLE_TIMEOUT_S = 8 * 60 * 60
 _RUNNER_IDLE_MONITOR_MAX_POLL_INTERVAL_S = 60.0
 # The runner offloads short native-CLI/IPC ops via asyncio.to_thread. Python's
 # default executor sizes to min(32, cpu+4) threads, which on a many-core host
@@ -116,12 +118,12 @@ def _load_runner_idle_timeout_s_from_config() -> float:
     """Load the runner inactivity timeout from config.
 
     Reads ``runner.idle_timeout_s`` from the global config file. Missing
-    config or missing key defaults to 1 hour. A value of ``0`` disables the
+    config or missing key defaults to 8 hours. A value of ``0`` disables the
     inactivity watchdog. Negative, boolean, or non-numeric values fail loud
     during runner startup so the user does not get silently different
     lifecycle behavior than requested.
 
-    :returns: Idle timeout in seconds, e.g. ``3600.0``. ``0.0`` disables
+    :returns: Idle timeout in seconds, e.g. ``28800.0``. ``0.0`` disables
         the watchdog.
     :raises RuntimeError: If ``runner.idle_timeout_s`` is invalid.
     """
@@ -216,7 +218,7 @@ async def _run_inactivity_monitor(
     while an agent turn is running, the monitor keeps waiting and exits soon
     after the active work clears unless new activity resets the timer.
 
-    :param idle_timeout_s: Idle window in seconds, e.g. ``3600.0``. ``0``
+    :param idle_timeout_s: Idle window in seconds, e.g. ``28800.0``. ``0``
         disables the monitor.
     :param get_last_activity: Callback returning the most recent real
         activity time from the event loop's monotonic clock.


### PR DESCRIPTION
## Related issue

N/A — chore (no issue required for this change type).

## Summary

An idle runner gracefully shuts down once its inactivity window expires (no non-keepalive tunnel frames, no active turns/tools/timers/approvals). The 1-hour default is short for interactive use — step away for a meeting or lunch and the runner is gone, forcing a reconnect.

- Bump `_DEFAULT_RUNNER_IDLE_TIMEOUT_S` from 3600s to 28800s (8h), covering a workday of intermittent use.
- `runner.idle_timeout_s` in `~/.omnigent/config.yaml` still overrides; `0` still disables the watchdog. Docstring examples updated to match.

## Test Plan

- `uv run --frozen pytest tests/runner/test_runner_entry.py tests/runner/test_runner_idle_active_work.py -q` — 103 passed (tests reference the constant symbolically, no hard-coded 3600).
- `pre-commit run --files omnigent/runner/_entry.py` — all checks passed.
- Manual check: with no `runner.idle_timeout_s` key in config, `_load_runner_idle_timeout_s_from_config()` now returns 28800.0; an explicit config value still wins.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing runner-entry and idle-watchdog tests assert against the constant (not a hard-coded value), so they validate the new default unchanged. Manually verified the config loader returns 28800.0 with no override present and that an explicit `runner.idle_timeout_s` still takes precedence.

## Changelog

Idle runners now stay connected for 8 hours (up from 1) before gracefully shutting down; tune with `runner.idle_timeout_s` in the omnigent config.

This pull request and its description were written by Isaac.