### PR TITLE
Adopt a slow /v1/info probe instead of pinning the offline fallback

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1442,6 +1442,106 @@ async def _drive_managed_multi_provider(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_managed_sandbox_appears_after_slow_info_probe(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A slow ``/v1/info`` still surfaces the managed-sandbox host option.
+
+    The boot probe paints a fail-closed fallback (managed sandboxes OFF) if
+    ``/v1/info`` hasn't answered within 1.5s, so the chat UI never hangs on a
+    slow or proxied probe. The regression this guards: the SPA then *pinned*
+    that fallback for the tab's lifetime, so on a slow-but-successful probe the
+    "Databricks Sandbox" host option never appeared until a full reload — the
+    managed complaint, where a proxied ``/v1/info`` behind a busy server
+    routinely exceeds 1.5s. With the fix the boot code adopts the real
+    ``/v1/info`` value when it finally lands.
+
+    Here ``/v1/info`` is delayed past the 1.5s budget; once it resolves, the
+    sandbox option must appear on its own (no reload). Pre-fix it never does.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_managed_sandbox_after_slow_info(base_url, session_id))
+
+
+async def _drive_managed_sandbox_after_slow_info(base_url: str, session_id: str) -> None:
+    host_id, host_name = _HOST_ALPHA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            # Managed capability probe, but SLOW: held past the 1.5s boot budget
+            # so the SPA first paints the fail-closed fallback (sandboxes off),
+            # then must adopt this real value when it finally lands.
+            async def handle_slow_info(route: Route) -> None:
+                await asyncio.sleep(2.5)
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_managed_info_body()
+                )
+
+            await page.route("**/v1/info", handle_slow_info)
+
+            # One connected online host alongside the managed sandbox option.
+            async def handle_one_host(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "hosts": [
+                                {
+                                    "host_id": host_id,
+                                    "name": host_name,
+                                    "owner": "e2e",
+                                    "status": "online",
+                                }
+                            ]
+                        }
+                    ),
+                )
+
+            await page.route("**/v1/hosts", handle_one_host)
+
+            # Neutralize agent discovery so a leaked native agent from another
+            # test can't switch the picker mid-flow (see _drive_permission_mode).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=json.dumps({"data": []})
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ "{host_id}": ["/work/repo"] }})
+                );"""
+            )
+
+            # Load and wait for the slow probe to actually answer (~2.5s). The
+            # landing composer paints earlier, at the 1.5s fallback; the real
+            # /v1/info lands after, and the fix re-renders with it.
+            async with page.expect_response(lambda r: "/v1/info" in r.url):
+                await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the host picker: the "Databricks Sandbox" option must be
+            # present, proving the SPA adopted the late /v1/info rather than
+            # staying pinned to the fail-closed fallback (where it never appears).
+            await page.get_by_test_id("new-chat-landing-host-chip").click()
+            sandbox_option = page.get_by_test_id("new-chat-landing-sandbox-option")
+            await expect(sandbox_option).to_be_visible(timeout=15_000)
+            await expect(sandbox_option).to_contain_text("Databricks Sandbox")
+        finally:
+            await browser.close()
+
+
 def test_start_session_select_model_and_effort(seeded_session: tuple[str, str]) -> None:
     """Picking a model + reasoning effort rides along to the create call.
 

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -136,18 +136,26 @@ function EmbedCapabilitiesProvider({ children }: { children: ReactNode }) {
   const [info, setInfo] = useState<ServerInfo | "loading">("loading");
   useEffect(() => {
     let alive = true;
-    // Fail open to "accounts off" on a slow/missing probe (same 1.5s budget as
-    // main.tsx) so the chat UI still paints instead of hanging on "loading".
-    void Promise.race([
-      resolveServerInfo(),
-      new Promise<ServerInfo>((resolve) => {
-        setTimeout(() => resolve(SERVER_INFO_OFFLINE_FALLBACK), 1500);
-      }),
-    ]).then((resolved) => {
-      if (alive) setInfo(resolved);
+    let resolved = false;
+    // First paint must not hang on "loading": if the probe is still in flight
+    // after 1.5s, paint the offline fallback so the chat UI appears. Unlike a
+    // Promise.race, we do NOT stop there — when the real /v1/info value lands
+    // (even later, on a slow-but-successful probe) we adopt it. Otherwise a
+    // probe that loses the 1.5s race pins the fallback for the whole mount,
+    // hiding capability-gated UI (e.g. the managed-sandbox host option) until a
+    // full re-navigation. resolveServerInfo never rejects (its failure path
+    // resolves to the OFF sentinel), so the real value always arrives.
+    const fallbackTimer = setTimeout(() => {
+      if (alive && !resolved) setInfo(SERVER_INFO_OFFLINE_FALLBACK);
+    }, 1500);
+    void resolveServerInfo().then((real) => {
+      resolved = true;
+      clearTimeout(fallbackTimer);
+      if (alive) setInfo(real);
     });
     return () => {
       alive = false;
+      clearTimeout(fallbackTimer);
     };
   }, []);
   return <CapabilitiesContext.Provider value={info}>{children}</CapabilitiesContext.Provider>;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -110,8 +110,9 @@ const bootProbe: Promise<ServerInfo> = Promise.race([
   }),
 ]);
 
-void bootProbe.then((info) => {
-  createRoot(document.getElementById("root")!).render(
+const root = createRoot(document.getElementById("root")!);
+const renderApp = (info: ServerInfo) => {
+  root.render(
     <StrictMode>
       <CapabilitiesProvider info={info}>
         <QueryClientProvider client={queryClient}>
@@ -134,4 +135,16 @@ void bootProbe.then((info) => {
       </CapabilitiesProvider>
     </StrictMode>,
   );
-});
+};
+
+// Paint as soon as the boot probe settles — the real value, or the 1.5s
+// fallback on a slow/missing probe.
+void bootProbe.then(renderApp);
+// Then settle on the real value once it lands. If the 1.5s fallback painted
+// first (slow-but-successful probe), this adopts the real /v1/info and
+// re-renders the same root — so capability-gated UI (e.g. the managed-sandbox
+// host option, accounts routes) isn't pinned off for the tab's lifetime.
+// resolveServerInfo caches, so this shares the boot probe's single fetch, and
+// the real value always resolves no earlier than the fallback, so it never
+// downgrades a real render back to the fallback.
+void resolveServerInfo().then(renderApp);


### PR DESCRIPTION
## Related issue

N/A — no separate tracking issue; surfaced during a production investigation of a managed deployment where the "Databricks Sandbox" host option intermittently went missing from the New Chat picker.

## Summary

- The boot-time `/v1/info` probe races a **1.5s timeout** so the app still paints when the probe is slow or missing. But both web entry points then kept that fallback **for the tab's lifetime**: `EmbedCapabilitiesProvider`'s effect ran once and never re-read the resolved value, and `main.tsx` rendered a single time inside `bootProbe.then()`.
- So on a **slow-but-successful** probe — e.g. a proxied `/v1/info` behind a busy server, which routinely exceeds 1.5s — the real capability set never reached the UI. Capability-gated affordances stayed hidden until a full reload, most visibly the managed **"&lt;provider&gt; Sandbox"** host option (`managed_sandboxes_enabled`).
- Fix: keep the 1.5s fallback for first paint, but **adopt the real `/v1/info` value when it lands**. `embed.tsx` sets it via state; `main.tsx` re-renders the same root. `resolveServerInfo()` caches and never rejects, so this shares the boot probe's single fetch and the real value can only render at or after the fallback — never a downgrade.

**ELI5:** the app used to give up waiting for the server's "what can I do" answer after 1.5s and never look again, so a slow answer meant the Sandbox option vanished until you reloaded. Now it still shows something at 1.5s, but updates as soon as the real answer arrives.

```
Before:  boot ──1.5s──▶ paint fallback ──▶ real /v1/info arrives  ✗ ignored → Sandbox hidden until reload
After:   boot ──1.5s──▶ paint fallback ──▶ real /v1/info arrives  ✓ adopted → Sandbox appears on its own
```

## Test Plan

- `tests/e2e_ui/start_session/test_start_session.py::test_start_session_managed_sandbox_appears_after_slow_info_probe` — a new Playwright test that stubs a **managed** `/v1/info` **delayed 2.5s** (past the 1.5s budget), loads the landing screen, and asserts the "Databricks Sandbox" option appears in the host picker once the probe resolves. Pre-fix it never appears (the fallback is pinned).
- `pnpm type-check`, `pnpm exec oxlint`, and `pnpm exec prettier --check` pass on `web/src/embed.tsx` and `web/src/main.tsx`.
- `ruff check` / `ruff format --check` pass on the test; it collects cleanly (`pytest --collect-only`).

## Demo

N/A — this is a failure-mode fix (slow `/v1/info`); the new e2e test reproduces it by delaying the probe. No manual recording captured (the full browser e2e needs a built SPA + server + runner + chromium, not available in my dev sandbox).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new e2e_ui test covers the fixed behavior for the standalone (`main.tsx`) entry point, which the e2e harness serves. `embed.tsx` shares the identical fix (adopt the resolved value after the 1.5s fallback) but isn't directly loadable in this harness. I validated the TS locally with type-check/lint/format but could not run the full browser e2e in my dev sandbox (needs a built SPA + server + runner + chromium).

## Changelog

The managed sandbox host option (and other capability-gated UI) now appears on its own after a slow `/v1/info` probe, instead of staying hidden until a page reload.
