### PR TITLE
fix(encoding): read user-authored files as UTF-8, not the locale codepage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:
         files: \.(py|ya?ml|json|toml|sh)$
         exclude: (^|/)tests/|^openapi\.json$
 
+      - id: read-text-encoding
+        name: no `read_text()` without an explicit encoding
+        language: system
+        entry: .venv/bin/python dev/lint/lint_read_text_encoding.py
+        types: [python]
+        files: ^omnigent/
+
       - id: web-prettier
         name: web prettier
         language: system

--- a/dev/lint/lint_read_text_encoding.py
+++ b/dev/lint/lint_read_text_encoding.py
@@ -1,0 +1,220 @@
+"""Flag ``Path.read_text()`` calls in the shipped package that omit ``encoding``.
+
+What goes wrong
+---------------
+
+``Path.read_text()`` with no ``encoding`` argument decodes using the
+*locale* encoding. On POSIX that is effectively always UTF-8, so the
+omission is invisible in CI and on maintainer machines. On Windows it
+is the ANSI codepage — ``cp1252`` for a Western install — and the same
+call then reads a UTF-8 file as if it were single-byte Latin-1::
+
+    em dash  U+2014  ->  UTF-8 bytes E2 80 94  ->  cp1252 gives 'a EUR "'
+
+Only five byte values (``0x81 0x8D 0x8F 0x90 0x9D``) are undefined in
+cp1252, so roughly 98% of mis-decoded bytes produce *no error at all* —
+they silently become the wrong characters. A file crashes only if its
+non-ASCII content happens to include one of those five. That makes the
+loud failures the lucky minority and silent corruption the norm: the
+bundled ``examples/polly/config.yaml`` carries 189 non-ASCII bytes,
+none of which land on a hole, so its system prompt loaded corrupted on
+Windows without raising anything.
+
+Every file a *user* authors is exposed: agent ``config.yaml``,
+``SKILL.md``, ``AGENTS.md`` / ``CLAUDE.md``, ``tools/mcp/*.yaml``, and
+the third-party tool configs Omnigent inspects (``uv.toml``,
+``~/.qwen/settings.json``). Naming the encoding makes the behaviour
+identical on every platform.
+
+What this catches
+-----------------
+
+``<expr>.read_text()`` anywhere under ``omnigent/`` with no
+``encoding=`` keyword argument.
+
+What this does NOT catch
+------------------------
+
+- ``write_text()``. It has the identical defect on the write side and
+  there are ~36 bare call sites in the package; folding them in here
+  would widen a focused fix into a package-wide sweep. Deliberate
+  follow-up, not an oversight.
+- Bare ``open()`` / ``io.open()``, for the same reason.
+- Reads outside ``omnigent/`` (``tests/``, ``dev/``, ``scripts/``,
+  ``.github/``). Those never run on a user's machine, so they cannot
+  produce this bug in an install.
+
+Allowed exceptions
+------------------
+
+``ALLOWED`` lists reads of files Omnigent writes for itself — pid
+files, caches, ledgers, generated secrets, daemon records. Their
+content is digits, hashes, and ASCII identifiers, so the locale
+encoding cannot corrupt them. Each entry is keyed by enclosing
+function rather than line number so it survives unrelated edits. A new
+entry should be added only when the file being read is machine-written;
+if a human can type into it, add ``encoding="utf-8"`` instead.
+
+Exit code 1 if any hits are found.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# (repo-relative path, enclosing function) pairs whose read targets are
+# written by Omnigent itself and can never contain non-ASCII text.
+ALLOWED: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("omnigent/cli.py", "_migrate_legacy_state_dir"),
+        ("omnigent/cli.py", "_read_daemon_record"),
+        ("omnigent/cli.py", "_read_host_pid_file"),
+        ("omnigent/cli_auth.py", "_store_entry"),
+        ("omnigent/cli_auth.py", "_load_entry"),
+        ("omnigent/cli_auth.py", "clear_token"),
+        ("omnigent/host/local_server.py", "_read_local_server_pid_file"),
+        ("omnigent/host/local_server.py", "_read_local_server_log_path"),
+        ("omnigent/host/local_server.py", "_read_local_server_sig"),
+        ("omnigent/install_ledger.py", "load_ledger"),
+        ("omnigent/install_ledger.py", "read_installation_id"),
+        ("omnigent/install_ledger.py", "find_profile_block"),
+        ("omnigent/integration_daemon.py", "read_record"),
+        ("omnigent/llms/_usage_observer.py", "_current_test_from_sidecar"),
+        ("omnigent/onboarding/ucode_state.py", "read_ucode_state"),
+        ("omnigent/onboarding/ucode_state.py", "read_current_ucode_state"),
+        ("omnigent/runner/identity.py", "load_or_create_runner_id"),
+        ("omnigent/server/accounts_secret.py", "load_or_generate_cookie_secret"),
+        ("omnigent/update_check.py", "_read_cache"),
+        ("omnigent/update_check.py", "_read_uv_tool_extras"),
+        ("omnigent/update_check.py", "_read_pipx_extras"),
+    }
+)
+
+
+def _repo_relative(path: Path) -> str | None:
+    """
+    Return ``path`` as a repo-relative POSIX string under ``omnigent/``.
+
+    :param path: File path as handed over by pre-commit (relative) or a
+        developer (possibly absolute).
+    :returns: e.g. ``"omnigent/spec/parser.py"``, or ``None`` when the
+        path is not inside the shipped package.
+    """
+    parts = path.as_posix().split("/")
+    if "omnigent" not in parts:
+        return None
+    # Last occurrence handles an absolute path into a clone that is
+    # itself named "omnigent" (…/projects/omnigent/omnigent/spec/…).
+    idx = len(parts) - 1 - parts[::-1].index("omnigent")
+    return "/".join(parts[idx:])
+
+
+def _function_owners(tree: ast.Module) -> list[tuple[int, int, str]]:
+    """
+    Return ``[(start, end, name), ...]`` for every function in ``tree``.
+
+    :param tree: Parsed module.
+    :returns: One span per function; innermost wins when spans nest,
+        resolved by the caller taking the largest ``start``.
+    """
+    spans: list[tuple[int, int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            spans.append((node.lineno, node.end_lineno or node.lineno, node.name))
+    return spans
+
+
+def _enclosing(spans: list[tuple[int, int, str]], lineno: int) -> str:
+    """
+    Return the innermost function name containing ``lineno``.
+
+    :param spans: Output of :func:`_function_owners`.
+    :param lineno: Line to locate.
+    :returns: Function name, or ``"<module>"`` at module scope.
+    """
+    best = ("<module>", -1)
+    for start, end, name in spans:
+        if start <= lineno <= end and start > best[1]:
+            best = (name, start)
+    return best[0]
+
+
+def scan(path: Path) -> list[tuple[int, str]]:
+    """
+    Return ``[(lineno, message), ...]`` for each bare ``read_text()``.
+
+    :param path: File to scan. Ignored unless it sits under ``omnigent/``.
+    :returns: Hits with line numbers and descriptive messages.
+    """
+    rel = _repo_relative(path)
+    if rel is None:
+        return []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return []
+
+    spans = _function_owners(tree)
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "read_text":
+            continue
+        if node.args:
+            # ``Path.read_text`` takes no positional arguments, so a
+            # positional call is a different API that merely shares the
+            # name — notably ``importlib.metadata.Distribution.read_text``,
+            # which takes a filename and always decodes as UTF-8.
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        owner = _enclosing(spans, node.lineno)
+        if (rel, owner) in ALLOWED:
+            continue
+        hits.append(
+            (
+                node.lineno,
+                f"`read_text()` in `{owner}` has no `encoding=`: decodes with the "
+                "locale codepage, corrupting non-ASCII on Windows",
+            ),
+        )
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    """
+    Scan every file in ``argv[1:]`` and report bare ``read_text()`` calls.
+
+    :param argv: Command-line args (``argv[0]`` is the script name).
+    :returns: Exit code — 0 on clean scan, 1 if any hits.
+    """
+    failed = False
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.is_file():
+            continue
+        hits = scan(path)
+        if hits:
+            failed = True
+            for line, msg in hits:
+                sys.stdout.write(f"{path}:{line}: {msg}\n")
+    if failed:
+        sys.stdout.write(
+            '\nPass `encoding="utf-8"` explicitly. Without it Python decodes '
+            "using the locale encoding, which is UTF-8 on POSIX but the ANSI "
+            "codepage on Windows — so the same file reads correctly in CI and "
+            "corrupts on a user's machine, usually with no error raised. If "
+            "the file is written by Omnigent itself and can only ever contain "
+            "ASCII, add its (path, function) to ALLOWED in this script with a "
+            "note saying why.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2833,7 +2833,7 @@ def _materialize_override_bundle(source: Path, overrides: ChatOverrides) -> Path
                 raise click.ClickException(f"{source}: directory has no config.yaml to override.")
             target = config
 
-        raw = yaml.safe_load(target.read_text())
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise click.ClickException(
                 f"{source}: expected YAML mapping at top level, got {type(raw).__name__}"
@@ -2886,7 +2886,7 @@ def _load_yaml_for_override_peek(source: Path) -> _YamlMapping | None:
         config = source / "config.yaml"
         if not config.is_file():
             return None
-        parsed = yaml.safe_load(config.read_text())
+        parsed = yaml.safe_load(config.read_text(encoding="utf-8"))
         return parsed if isinstance(parsed, dict) else None
     return _load_yaml_if_single_file(source)
 
@@ -2906,7 +2906,7 @@ def _load_yaml_if_single_file(source: Path) -> _YamlMapping | None:
     """
     if not source.is_file():
         return None
-    parsed = yaml.safe_load(source.read_text())
+    parsed = yaml.safe_load(source.read_text(encoding="utf-8"))
     return parsed if isinstance(parsed, dict) else None
 
 
@@ -3590,7 +3590,7 @@ def _raise_server_failed(server: LocalServer) -> None:
     else:
         cmd_display = str(args)
     try:
-        lines = server.log_path.read_text(errors="replace").splitlines()
+        lines = server.log_path.read_text(encoding="utf-8", errors="replace").splitlines()
         tail = "\n".join(lines[-_SERVER_LOG_TAIL_LINES:]) if lines else "(empty log file)"
     except OSError as e:
         tail = f"(could not read log file: {e})"

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -834,7 +834,7 @@ def _peek_default_agent_harness(target: str) -> str | None:
     if not path.is_file():
         return None
     try:
-        raw = yaml.safe_load(path.read_text()) or {}
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
         return None
     if not isinstance(raw, dict):
@@ -2611,7 +2611,7 @@ def _load_existing_host_id() -> str | None:
         candidate_paths.append(CONFIG_PATH)
     for path in candidate_paths:
         try:
-            raw = yaml.safe_load(path.read_text()) if path.exists() else None
+            raw = yaml.safe_load(path.read_text(encoding="utf-8")) if path.exists() else None
         except (OSError, yaml.YAMLError):
             continue
         if not isinstance(raw, dict):
@@ -5290,7 +5290,7 @@ def _resolve_bundle_env_vars(source: Path) -> dict[str, str]:
     # ── config.yaml ──────────────────────────────────
     config_path = source / "config.yaml"
     if config_path.exists():
-        raw = yaml.safe_load(config_path.read_text())
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         if isinstance(raw, dict):
             changed = _expand_config_env_vars(raw, expand_env_vars)
             if changed:
@@ -5306,7 +5306,7 @@ def _resolve_bundle_env_vars(source: Path) -> dict[str, str]:
     mcp_dir = source / "tools" / "mcp"
     if mcp_dir.is_dir():
         for yaml_file in sorted(mcp_dir.glob("*.yaml")):
-            raw = yaml.safe_load(yaml_file.read_text())
+            raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
             if not isinstance(raw, dict):
                 continue
             changed = False
@@ -10167,7 +10167,7 @@ def debug_logs(
         # Show all files for the session, oldest first, with separators.
         for f in reversed(log_files):
             click.echo(f"# {f}", err=True)
-            content = f.read_text(errors="replace")
+            content = f.read_text(encoding="utf-8", errors="replace")
             if lines > 0:
                 content = "\n".join(content.splitlines()[-lines:])
             click.echo(content)
@@ -10175,7 +10175,7 @@ def debug_logs(
     else:
         latest = log_files[0]
         click.echo(f"# {latest}", err=True)
-        content = latest.read_text(errors="replace")
+        content = latest.read_text(encoding="utf-8", errors="replace")
         if lines > 0:
             content = "\n".join(content.splitlines()[-lines:])
         click.echo(content)
@@ -11324,7 +11324,7 @@ def _bundled_agent_brain_harness(name: str) -> str | None:
     if not config_path.is_file():
         return None
     try:
-        raw = yaml.safe_load(config_path.read_text()) or {}
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
         return None
     if not isinstance(raw, dict):

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1941,7 +1941,7 @@ def _qwen_auth_configured() -> bool:
     settings = Path.home() / ".qwen" / "settings.json"
     if settings.is_file():
         try:
-            data = json.loads(settings.read_text())
+            data = json.loads(settings.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return False
         if isinstance(data, dict):

--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -78,7 +78,7 @@ def Read(
             for large files.
     """
     try:
-        text = Path(file_path).read_text()
+        text = Path(file_path).read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return _truncate(f"Error reading {file_path}: {exc}")
     lines = text.splitlines()
@@ -132,7 +132,7 @@ def Edit(
     """
     target = Path(file_path)
     try:
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
     except OSError as exc:
         return _truncate(f"Error reading {target}: {exc}")
     count = text.count(old_string)

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -338,7 +338,7 @@ def read_codex_config_model(bridge_dir: Path) -> str | None:
     """
     config_path = codex_home_for_bridge_dir(bridge_dir) / "config.toml"
     try:
-        data = tomllib.loads(config_path.read_text())
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         return None
     model = data.get("model")

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -288,7 +288,7 @@ def _load_user_hermes_config() -> _ConfigObject:
     try:
         import yaml
 
-        full = yaml.safe_load(user_config.read_text()) or {}
+        full = yaml.safe_load(user_config.read_text(encoding="utf-8")) or {}
         return {k: v for k, v in full.items() if k in _USER_CONFIG_KEYS}
     except Exception:  # noqa: BLE001
         _logger.debug("Failed to load user Hermes config at %s", user_config, exc_info=True)

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -152,7 +152,7 @@ def _read_model_from_hermes_config(bridge_dir: Path) -> str | None:
         try:
             import yaml
 
-            data = yaml.safe_load(config_path.read_text()) or {}
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
             model = data.get("model")
             if isinstance(model, str) and model:
                 return model

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -931,7 +931,7 @@ def _raise_local_server_failed(base_url: str, log_path: Path) -> None:
     :raises click.ClickException: Always.
     """
     try:
-        lines = log_path.read_text(errors="replace").splitlines()
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
         tail = "\n".join(lines[-50:]) if lines else "(empty log file)"
     except OSError as exc:
         tail = f"(could not read log file: {exc})"

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -826,7 +826,7 @@ def _populate_codex_home_config(
             # The title worker needs custom-provider routing, but copying the
             # full user config also starts unrelated MCPs/plugins and can exceed
             # its timeout. auth.json alone cannot supply these provider tables.
-            source_config = tomlkit.parse(source_file.read_text())
+            source_config = tomlkit.parse(source_file.read_text(encoding="utf-8"))
             minimal_document = tomlkit.document()
             for key in ("model_provider", "model_providers", "profiles"):
                 if key in source_config:

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -176,7 +176,7 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     try:
         resolved = candidate.resolve()
         if resolved.is_relative_to(root.resolve()) and resolved.is_file():
-            return resolved.read_text()
+            return resolved.read_text(encoding="utf-8")
     except OSError:
         # Path too long or invalid characters — fall through to inline text.
         pass

--- a/omnigent/integration_daemon.py
+++ b/omnigent/integration_daemon.py
@@ -138,7 +138,9 @@ class IntegrationDaemon:
         if record is None:
             return ""
         try:
-            lines = Path(record.log_path).read_text(errors="replace").splitlines()
+            lines = (
+                Path(record.log_path).read_text(encoding="utf-8", errors="replace").splitlines()
+            )
         except OSError:
             return ""
         return "\n".join(lines[-max_lines:])

--- a/omnigent/runner/background_titles/codex_native.py
+++ b/omnigent/runner/background_titles/codex_native.py
@@ -123,4 +123,4 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
             return None
         if not output_path.is_file():
             return None
-        return output_path.read_text(errors="replace").strip()
+        return output_path.read_text(encoding="utf-8", errors="replace").strip()

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -512,7 +512,7 @@ def _preserve_keys(
 
 def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     """Read a YAML mapping from disk."""
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"YAML file must be a mapping: {path.name}",

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -229,7 +229,7 @@ def is_omnigent_yaml(path: Path) -> bool:
     if path.suffix.lower() not in {".yaml", ".yml"}:
         return False
     try:
-        raw = yaml.safe_load(path.read_text())
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError:
         return False
     if not isinstance(raw, dict):
@@ -269,7 +269,7 @@ def diagnose_yaml_rejection(path: Path) -> str:
     if path.suffix.lower() not in {".yaml", ".yml"}:
         return f"file extension is {path.suffix!r}, expected '.yaml' or '.yml'"
     try:
-        raw = yaml.safe_load(path.read_text())
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
         # Strip trailing whitespace so the message stays one line —
         # PyYAML embeds the source location in its error string,
@@ -377,7 +377,7 @@ def load_omnigent_yaml(
     # read resolves booleans the same way load_agent_def's YAML
     # parsing did — both loaders keep on/off as plain strings
     # instead of the YAML 1.1 bool aliases.
-    raw = _yaml.load(path.read_text(), Loader=_OmnigentYamlLoader) or {}
+    raw = _yaml.load(path.read_text(encoding="utf-8"), Loader=_OmnigentYamlLoader) or {}
     if not isinstance(raw, dict):
         raw = {}
     spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw)

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -184,7 +184,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     if not config_path.exists():
         raise FileNotFoundError(f"config.yaml not found in {root}")
 
-    raw = yaml.load(config_path.read_text(), Loader=_ConfigYamlLoader)
+    raw = yaml.load(config_path.read_text(encoding="utf-8"), Loader=_ConfigYamlLoader)
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"config.yaml must be a YAML mapping, got {type(raw).__name__}",
@@ -2050,7 +2050,7 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     try:
         resolved = candidate.resolve()
         if resolved.is_relative_to(root.resolve()) and resolved.is_file():
-            return resolved.read_text()
+            return resolved.read_text(encoding="utf-8")
     except OSError:
         # Path too long or invalid characters — treat as inline text.
         pass
@@ -2091,7 +2091,7 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
         candidate = root / filename
         try:
             if candidate.is_file():
-                return candidate.read_text()
+                return candidate.read_text(encoding="utf-8")
         except OSError:
             pass
     return None
@@ -2373,7 +2373,7 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         ``strict=False``) can catch them uniformly.
     """
     try:
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         # UnicodeDecodeError (a non-UTF-8 SKILL.md) is a ValueError, not an
         # OSError — funnel it through OmnigentError too so the lenient
@@ -2641,7 +2641,7 @@ def _discover_mcp_servers(
         return []
     servers: list[MCPServerConfig] = []
     for yaml_file in sorted(mcp_dir.glob("*.yaml")):
-        raw = yaml.safe_load(yaml_file.read_text())
+        raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise OmnigentError(
                 f"MCP config must be a YAML mapping: {yaml_file}",

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -133,7 +133,7 @@ def resolve_harness_skills(ctx: SkillSourceContext, harness: str | None) -> list
 def _read_json(path: Path) -> dict[str, object] | None:
     """Best-effort JSON read; ``None`` unless it is a string-keyed object."""
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     if not isinstance(data, dict) or not all(isinstance(key, str) for key in data):

--- a/omnigent/tools/builtins/read_skill_file.py
+++ b/omnigent/tools/builtins/read_skill_file.py
@@ -155,4 +155,4 @@ def _read_file_safely(
     if not resolved.is_file():
         return f"Error: file not found: {rel_path}"
 
-    return resolved.read_text()
+    return resolved.read_text(encoding="utf-8")

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -432,7 +432,7 @@ def _index_from_uv_config() -> str:
 
     for path in (_user_config_base() / "uv" / "uv.toml", Path("/etc/uv/uv.toml")):
         try:
-            data = tomllib.loads(path.read_text())
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
         legacy = data.get("index-url")


### PR DESCRIPTION
Fixes #4696.

## Problem

`Path.read_text()` with no `encoding` argument decodes using the **locale**
encoding. On POSIX that is effectively always UTF-8, so the omission is
invisible in CI and on maintainer machines. On Windows it is the ANSI
codepage — `cp1252` on a Western install — and the same call then reads a
UTF-8 file as if it were single-byte Latin-1:

```
em dash  U+2014  ->  UTF-8 bytes  E2 80 94  ->  cp1252 gives  â€"
```

Only five byte values (`0x81 0x8D 0x8F 0x90 0x9D`) are undefined in cp1252,
so the overwhelming majority of mis-decoded bytes raise **no error at all** —
they silently become the wrong characters. A file crashes only when its
non-ASCII content happens to include one of those five.

That makes the loud failures the lucky minority. The bundled
`resources/examples/polly/config.yaml` carries 189 non-ASCII bytes, none of
which land on a hole, so on Windows it loads **successfully and corrupted**:

```
correct: writes no code itself — it plans and splits up the work, delegates all
loaded : writes no code itself â€" it plans and splits up the work, delegates all
```

Polly's system prompt has been reaching the model with every em-dash mangled,
with nothing logged. The visible symptom is narrower — a `SKILL.md`
containing an emoji hits one of the five undefined bytes and raises:

```
SKILL.md could not be read: .../privacy-policy/SKILL.md:
'charmap' codec can't decode byte 0x8f in position 3274: character maps to <undefined>
```

Worth noting the existing comment at that call site reads *"UnicodeDecodeError
(a non-UTF-8 SKILL.md)"*. The file is valid UTF-8; it is the **read** that is
not. The handler defends against a bad file when the defect is a bad decode.

## Fix

Pass `encoding="utf-8"` at every site that reads a file a human may have
authored — 34 call sites across 18 modules.

The boundary, stated so it can be checked line by line:

> Every read of a file authored or edited by a human — Omnigent's own agent
> configs, skills and instruction files, plus the third-party tool configs it
> inspects — names its encoding. Files Omnigent writes for itself are
> untouched.

Covered: agent `config.yaml`, `SKILL.md`, `AGENTS.md` / `CLAUDE.md`,
`tools/mcp/*.yaml`, plugin manifests, Codex and Hermes configs, `uv.toml`,
`~/.qwen/settings.json`, and the log files surfaced in error messages
(subprocess output is UTF-8).

Untouched: pid files, install ledger, auth tokens, generated secrets, daemon
records, update cache and receipts — all written by Omnigent, all ASCII by
construction. These are enumerated in the lint rule's `ALLOWED` set rather
than left implicit.

One judgment call worth flagging: `~/.qwen/settings.json` is only inspected
for the presence of an API key, so its content looks machine-ish. It is
included because settings files embed **filesystem paths**, and a user whose
Windows account name is non-ASCII has that string in every path on the
machine — the same population whose locale is not UTF-8 in the first place.

## Lint guard

`dev/lint/lint_read_text_encoding.py` follows the existing
`dev/lint/lint_no_*.py` pattern and is wired into `.pre-commit-config.yaml`.
It AST-scans `omnigent/` and fails on any `read_text()` without `encoding=`,
with an `ALLOWED` set keyed by `(path, enclosing function)` so exceptions
survive unrelated edits and each one documents itself.

**It is not speculative — it found six sites this change would otherwise have
missed.** A `read_text()` text search only matches literal empty parens, so
six log readers spelled `read_text(errors="replace")` were invisible to it.
Those calls are themselves revealing: the authors anticipated a decode
failure and defended against the *crash*, but not against the wrong
*encoding*.

Deliberately out of scope, named rather than silently skipped:

- **`write_text()`** — the identical defect on the write side, ~36 bare call
  sites in the package (including `chat.py`, which writes an agent config).
  Folding it in would turn a focused fix into a package-wide sweep. Happy to
  follow up in a separate PR.
- **Bare `open()`** — same reasoning.
- **`tests/`, `dev/`, `scripts/`, `.github/`** — never run on a user's
  machine, so they cannot produce this bug in an install. (`dev/lint/`'s own
  scripts have it too.)

## Relationship to existing Windows work

This is the **decode** direction and does not overlap the open encode-side
work. Listed for reviewer context; deliberately not issue-linked, so nothing
here should be read as a duplicate.

- The open console-glyph work covers `UnicodeEncodeError` when *writing* to a
  cp1252 console. This change is `UnicodeDecodeError` when *reading* UTF-8
  files. Different call sites, opposite direction, no shared lines — the one
  file in common is `cli.py`, in an unrelated region.
- The open `os.getuid()` / workspace-path work shares no files with this
  change.
- Neither existing report covers reads. `Path.read_text()` without an
  `encoding` argument is untouched by any of them, which is why the silent
  corruption of `examples/polly/config.yaml` has gone unreported.

Also still unfixed and worth noting, because it limits the user-side
workaround: `WINDOWS_ENV_PASSTHROUGH` in `_platform.py` carries no
`PYTHONUTF8` / `PYTHONIOENCODING`, so setting UTF-8 mode in the shell does not
reach spawned runners and daemons. That is a separate defect from this one and
is not addressed here.

## Verification

Ran on Windows 11 / CPython 3.12 with `PYTHONUTF8` unset, so `read_text()`
uses the real `cp1252` locale — the condition that produces the bug.
`_parse_skill` run against the two files that were failing, first from the
installed package, then from this branch:

```
SHIPPED (no fix)     locale cp1252
  privacy-policy                 FAIL -> OmnigentError: 'charmap' codec can't decode...
  api-security-best-practices    FAIL -> OmnigentError: 'charmap' codec can't decode...

PATCHED (this branch)  locale cp1252
  privacy-policy                 OK   -> name='privacy-policy'
  api-security-best-practices    OK   -> name='api-security-best-practices'
```

Gates run locally with the pinned ruff 0.15.16:

```
ruff check                All checks passed!
ruff format --check       19 files already formatted
lint_read_text_encoding   exit 0 across all 705 package files
```

The lint rule was mutation-tested: reverting `spec/parser.py:2376` and
`chat.py:3531` each made it exit 1 with the correct file and line, and
restoring each returned it to 0. Without that check a rule that silently
matches nothing also passes.

## Note on test coverage

The suite was not run locally. `CONTRIBUTING.md` states native Windows is
unsupported for development, so `pytest` is not runnable here — the same
caveat as #4475. CI is the first real run of the suite against this change.
The diff is 34 single-line edits of identical shape plus one new lint script,
so the risk profile is low, but I would rather state the gap than imply
coverage I do not have.
