### PR TITLE
feat(acp): gate agent shell through omnigent, warm model switch, cached-token usage, setup discovery

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2136,6 +2136,40 @@ def _launch_goose_configure() -> str | None:
     return "Provider not detected yet"
 
 
+def _show_acp_cli_harness(name: str) -> None:
+    """Show install + sign-in instructions for one builtin ACP CLI harness.
+
+    These harnesses own their credentials (``OWN_AUTH``) and install out-of-band,
+    so there is nothing for Omnigent to store or run on the user's behalf — the
+    drill-in reports what it can and names the two commands. Read-only: it
+    changes no config, which is why it's a display rather than a manage loop.
+
+    :param name: The :data:`ACP_CLI_HARNESSES` row key, e.g. ``"grok"``.
+    """
+    from omnigent._platform import resolve_cli_binary
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+    from omnigent.onboarding.interactive import console
+
+    row = ACP_CLI_HARNESSES.get(name)
+    if row is None:  # defensive: a stale key from a concurrent config change
+        return
+
+    installed = resolve_cli_binary(row.binary) is not None
+    console.print(f"\n  [bold]{row.label}[/bold] — ACP agent (owns its own auth)")
+    if installed:
+        console.print(f"    ✓ `{row.binary}` found on PATH")
+    else:
+        hint = row.install.install_hint or row.binary
+        console.print(
+            f"    ○ `{row.binary}` not found. Install with:\n        [bold]{hint}[/bold]"
+        )
+    if row.login_command:
+        console.print(f"    Sign in with:\n        [bold]{row.login_command}[/bold]")
+    if row.install.auth_hint:
+        console.print(f"    {row.install.auth_hint}")
+    console.print(f"    Launch with: [bold]omnigent run --harness {name}[/bold]\n")
+
+
 def _manage_goose_harness() -> None:
     """Run the level-2 loop for Goose: ensure the CLI, then guide ``goose configure``.
 
@@ -3475,6 +3509,7 @@ def _run_configure_harnesses_interactive() -> None:
     _ACP_IMPORT = "\x00acp-import-openclaw"
     _ACP_ADD = "\x00acp-add"
     _ACP_AGENT_PREFIX = "\x00acp-agent:"
+    _ACP_CLI_PREFIX = "\x00acp-cli:"
     families = [ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE]
 
     # Status glyph + Rich color per readiness kind: "ready" is a configured,
@@ -3752,6 +3787,39 @@ def _run_configure_harnesses_interactive() -> None:
                     (_GOOSE, "Goose", "Not configured", "warn", "Open to run `goose configure`."),
                 )
 
+        # Builtin ACP CLI harnesses (omnigent/acp_cli_harnesses.py) — vendor CLIs
+        # that speak ACP on stdio. Derived from the catalog so adding a row there
+        # surfaces it here too; without this they were addressable via
+        # `--harness <name>` but invisible in setup, making a shipped harness less
+        # discoverable than a user's own `acp:` entry.
+        from omnigent._platform import resolve_cli_binary
+        from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+        for _acp_cli_name, _acp_cli_row in sorted(ACP_CLI_HARNESSES.items()):
+            _acp_cli_key = _ACP_CLI_PREFIX + _acp_cli_name
+            if resolve_cli_binary(_acp_cli_row.binary) is None:
+                rows.append(
+                    (
+                        _acp_cli_key,
+                        _acp_cli_row.label,
+                        "Not installed",
+                        "missing",
+                        _install_hint(_acp_cli_row.install.install_hint or _acp_cli_row.binary),
+                    )
+                )
+            else:
+                # The vendor owns its auth, so we can report the binary is present
+                # but not whether it is signed in.
+                rows.append(
+                    (
+                        _acp_cli_key,
+                        _acp_cli_row.label,
+                        "ACP · own auth",
+                        "ready",
+                        "Select for install and sign-in instructions.",
+                    )
+                )
+
         # Copilot — GitHub token (github-copilot-sdk extra is soft).
         if copilot_github_token_configured(config) or any(
             os.environ.get(v) for v in COPILOT_TOKEN_ENV_VARS
@@ -3939,6 +4007,8 @@ def _run_configure_harnesses_interactive() -> None:
             _add_acp_agent()
         elif isinstance(selected_target, str) and selected_target.startswith(_ACP_AGENT_PREFIX):
             _manage_acp_agent(selected_target[len(_ACP_AGENT_PREFIX) :])
+        elif isinstance(selected_target, str) and selected_target.startswith(_ACP_CLI_PREFIX):
+            _show_acp_cli_harness(selected_target[len(_ACP_CLI_PREFIX) :])
         elif selected_target == _HERMES:
             _manage_hermes_harness()
         elif selected_target == _KIRO:

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -172,6 +172,12 @@ class AcpAgentConfig:
     :param omnigent_mcp: Expose Omnigent's builtin tools to the agent via
         ``session/new.mcpServers`` (the shared ``serve-mcp`` relay). On by
         default; the global ``OMNIGENT_ACP_MCP=0`` kill switch also disables it.
+    :param terminal_delegation: Advertise ``clientCapabilities.terminal`` so the
+        agent delegates shell execution to Omnigent (gated by TOOL_CALL policy,
+        run through the OSEnvironment) instead of executing it itself. **Off by
+        default**: honouring the capability changes how a compliant agent runs
+        every command, so each agent opts in once verified. Requires an os_env —
+        without one there is nothing to execute with.
     :param env_passthrough: Environment variable *names* this agent may read at
         spawn, e.g. ``("XAI_API_KEY",)``. The spawn env is deny-by-default and
         this executor drives an arbitrary agent, so it cannot infer the family
@@ -186,6 +192,7 @@ class AcpAgentConfig:
     session_id_mode: str = "server"
     send_model_in_session_new: bool = False
     omnigent_mcp: bool = True
+    terminal_delegation: bool = False
     env_passthrough: tuple[str, ...] = ()
 
 
@@ -289,7 +296,20 @@ class AcpExecutor(Executor):
         # an os_env is configured and it isn't a ``fork`` env — a forked env
         # operates on a *copied* tree whose path diverges from the agent's cwd.
         self._fs_delegation: bool = os_env is not None and not bool(getattr(os_env, "fork", False))
+        # Advertise ``clientCapabilities.terminal`` only when the agent opted in
+        # *and* an os_env can execute. Delegation puts every command through the
+        # TOOL_CALL policy + elicitation gate and the spec's sandbox rather than
+        # trusting the agent to ask — but it also changes how a compliant agent
+        # runs commands, so it stays opt-in per agent rather than flipping on for
+        # every already-working ACP agent at once.
+        self._terminal_delegation: bool = self._fs_delegation and bool(config.terminal_delegation)
         self._os_environment: OSEnvironment | None = None
+        # Completed delegated commands, keyed by the id we handed the agent.
+        # ``OSEnvironment.shell`` runs to completion, so a terminal is created
+        # already-exited; ``terminal/output`` and ``terminal/wait_for_exit`` then
+        # serve the stored record.
+        self._terminals: dict[str, _AcpJsonObject] = {}
+        self._terminal_seq: int = 0
 
         # Parsed argv; the first token is the binary we resolve / sandbox.
         self._argv: list[str] = shlex.split(config.command)
@@ -609,7 +629,7 @@ class AcpExecutor(Executor):
                             "readTextFile": self._fs_delegation,
                             "writeTextFile": self._fs_delegation,
                         },
-                        "terminal": False,
+                        "terminal": self._terminal_delegation,
                     },
                 },
                 timeout=_INIT_TIMEOUT_SECONDS,
@@ -687,6 +707,9 @@ class AcpExecutor(Executor):
         - ``fs/read_text_file`` / ``fs/write_text_file`` — when fs delegation is
           advertised, execute through the Omnigent OSEnvironment so the spec's
           sandbox read/write roots are enforced. Off → never arrive.
+        - ``terminal/*`` — when terminal delegation is advertised, run the command
+          ourselves after the same policy + elicitation gate. This is the one path
+          that governs an agent's shell use without relying on the agent to ask.
         - anything else — reply with JSON-RPC ``method not found`` so the agent
           fails loudly rather than acting on empty data.
         """
@@ -705,6 +728,14 @@ class AcpExecutor(Executor):
                 result = await self._handle_fs_read(params)
             elif method == "fs/write_text_file" and self._fs_delegation:
                 result = await self._handle_fs_write(params)
+            elif method == "terminal/create" and self._terminal_delegation:
+                result = await self._handle_terminal_create(params)
+            elif method == "terminal/output" and self._terminal_delegation:
+                result = await self._handle_terminal_output(params)
+            elif method == "terminal/wait_for_exit" and self._terminal_delegation:
+                result = await self._handle_terminal_wait(params)
+            elif method in ("terminal/release", "terminal/kill") and self._terminal_delegation:
+                result = await self._handle_terminal_release(params)
             else:
                 error = {
                     "code": -32601,
@@ -735,6 +766,106 @@ class AcpExecutor(Executor):
                 raise _AcpRequestError(-32603, "omnigent: no os_env for fs delegation")
             self._os_environment = env
         return self._os_environment
+
+    # ------------------------------------------------------------------
+    # Terminal delegation (agent → client, when terminal capability advertised)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _terminal_command(params: _AcpJsonObject) -> str:
+        """Join ACP ``{command, args?}`` into one shell command string.
+
+        :raises _AcpRequestError: When ``command`` is missing or not a string.
+        """
+        command = params.get("command")
+        if not isinstance(command, str) or not command.strip():
+            raise _AcpRequestError(-32602, "terminal/create requires a string 'command'")
+        args = params.get("args")
+        if isinstance(args, list) and args:
+            return shlex.join([command, *[str(a) for a in args]])
+        return command
+
+    async def _handle_terminal_create(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/create`` — the tool-mediation gate for shell.
+
+        The command runs through :meth:`_authorize` first, so a DENY verdict (or a
+        refused approval card) means it never executes. Execution then goes
+        through :meth:`OSEnvironment.shell`, inheriting the spec's sandbox.
+
+        A denial is reported as a *failed command* (exit 126 + explanation) rather
+        than a JSON-RPC error: the agent reads it as an ordinary tool failure and
+        can adapt, instead of treating the transport as broken and retrying.
+        """
+        command = self._terminal_command(params)
+        self._terminal_seq += 1
+        terminal_id = f"omnigent-term-{self._terminal_seq}"
+
+        if not await self._authorize("Run shell command", {"command": command}):
+            logger.info("acp[%s] terminal/create denied: %s", self._config.name, command)
+            self._terminals[terminal_id] = {
+                "output": "omnigent: command denied by policy",
+                "exitCode": 126,
+            }
+            return {"terminalId": terminal_id}
+
+        env = await self._ensure_os_environment()
+        result = await env.shell(command)
+        if "error" in result:
+            raise _AcpRequestError(-32603, str(result["error"]))
+        stdout = str(result.get("stdout", ""))
+        stderr = str(result.get("stderr", ""))
+        output = stdout + (("\n" if stdout and stderr else "") + stderr if stderr else "")
+        if result.get("timed_out"):
+            output = f"{output}\nomnigent: command timed out".lstrip("\n")
+        exit_code = result.get("exit_code")
+        self._terminals[terminal_id] = {
+            "output": output,
+            "exitCode": exit_code if isinstance(exit_code, int) else 0,
+        }
+        logger.info(
+            "acp[%s] terminal/create executed by omnigent (exit=%s): %s",
+            self._config.name,
+            exit_code,
+            command,
+        )
+        return {"terminalId": terminal_id}
+
+    def _terminal_record(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Look up a stored terminal by ``terminalId``.
+
+        :raises _AcpRequestError: When the id is unknown — better a loud error
+            than silently reporting empty output for a command that ran.
+        """
+        terminal_id = params.get("terminalId")
+        record = self._terminals.get(terminal_id) if isinstance(terminal_id, str) else None
+        if record is None:
+            raise _AcpRequestError(-32602, f"unknown terminalId {terminal_id!r}")
+        return record
+
+    async def _handle_terminal_output(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/output`` from the stored command result."""
+        record = self._terminal_record(params)
+        return {
+            "output": record["output"],
+            "truncated": False,
+            "exitStatus": {"exitCode": record["exitCode"]},
+        }
+
+    async def _handle_terminal_wait(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/wait_for_exit`` — already exited when created."""
+        return {"exitCode": self._terminal_record(params)["exitCode"]}
+
+    async def _handle_terminal_release(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/release`` / ``terminal/kill`` by dropping the record.
+
+        The command has already run to completion, so there is nothing to kill;
+        releasing just frees the stored output. Unknown ids are tolerated here so
+        a duplicate release can't fail a turn.
+        """
+        terminal_id = params.get("terminalId")
+        if isinstance(terminal_id, str):
+            self._terminals.pop(terminal_id, None)
+        return {}
 
     async def _handle_fs_read(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
@@ -815,6 +946,19 @@ class AcpExecutor(Executor):
         operation the adapter installs both, so destructive actions are gated.
         """
         tool_name, tool_input = self._extract_tool_call(params)
+        return await self._authorize(tool_name, tool_input)
+
+    async def _authorize(self, tool_name: str, tool_input: _AcpJsonObject) -> bool:
+        """Run one tool through TOOL_CALL policy, then human-consent elicitation.
+
+        Shared by the agent's own ``session/request_permission`` and by the
+        delegated ``terminal/*`` handlers, so a command the agent would have run
+        silently is gated identically to one it asked about.
+
+        :param tool_name: Display name for the policy verdict and approval card.
+        :param tool_input: Tool arguments the policy inspects.
+        :returns: ``True`` to proceed.
+        """
         handler = getattr(self, "_elicitation_handler", None)
         policy_eval = getattr(self, "_policy_evaluator", None)
 

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -1143,21 +1143,32 @@ class AcpExecutor(Executor):
     def _usage_from_result(result: _AcpJsonObject) -> dict[str, int] | None:
         """Map an agent's final ``result.usage`` to Omnigent's usage keys.
 
-        ACP does not standardize usage, but agents that report it (Goose) use
-        ``{totalTokens, inputTokens, outputTokens}``; Omnigent's
-        ``TurnComplete.usage`` uses ``{input_tokens, output_tokens, total_tokens}``.
+        ACP does not standardize usage, but agents that report it (Goose, Devin)
+        use ``{totalTokens, inputTokens, outputTokens}`` plus an optional
+        ``cachedReadTokens``; Omnigent's ``TurnComplete.usage`` uses
+        ``{input_tokens, output_tokens, total_tokens, cache_read_input_tokens}``.
         Absent → ``None`` (usage simply isn't shown for agents that don't report).
+
+        ``cachedReadTokens`` is kept as its own key rather than folded into
+        ``input_tokens``: cache reads are real consumption but billed at a
+        fraction of the rate, so collapsing them would overstate cost — in one
+        measured turn 10,944 of 15,637 input tokens were cache reads.
+        ``cache_read_input_tokens`` is the key the rest of the stack already
+        speaks, so it renders without any UI change.
         """
         usage = result.get("usage")
         if not isinstance(usage, dict):
             return None
         out: dict[str, int] = {}
-        if isinstance(usage.get("inputTokens"), int):
-            out["input_tokens"] = usage["inputTokens"]
-        if isinstance(usage.get("outputTokens"), int):
-            out["output_tokens"] = usage["outputTokens"]
-        if isinstance(usage.get("totalTokens"), int):
-            out["total_tokens"] = usage["totalTokens"]
+        for acp_key, omni_key in (
+            ("inputTokens", "input_tokens"),
+            ("outputTokens", "output_tokens"),
+            ("totalTokens", "total_tokens"),
+            ("cachedReadTokens", "cache_read_input_tokens"),
+        ):
+            value = usage.get(acp_key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                out[omni_key] = value
         return out or None
 
     def _handle_session_update(self, update: _AcpJsonObject) -> list[ExecutorEvent]:

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -119,6 +119,13 @@ _UPDATE_AGENT_THOUGHT_CHUNK = "agent_thought_chunk"
 _UPDATE_TOOL_CALL = "tool_call"
 _UPDATE_TOOL_CALL_UPDATE = "tool_call_update"
 _UPDATE_USAGE = "usage_update"
+_UPDATE_CONFIG_OPTION = "config_option_update"
+
+# ACP ``session/set_config_option`` — the standard warm-switch method. The
+# option id for the model, and the param name the agent expects (``configId``,
+# not ``optionId``).
+_AGENT_METHOD_SET_CONFIG_OPTION = "session/set_config_option"
+_CONFIG_OPTION_MODEL = "model"
 
 # ACP tool-call lifecycle statuses (the terminal ones close a tool card).
 _TOOL_STATUS_COMPLETED = "completed"
@@ -310,6 +317,14 @@ class AcpExecutor(Executor):
         # serve the stored record.
         self._terminals: dict[str, _AcpJsonObject] = {}
         self._terminal_seq: int = 0
+
+        # Session config options the agent advertises (``mode``, ``model``, …)
+        # and the live model value, both learned from ``config_option_update``.
+        self._config_option_ids: set[str] = set()
+        self._active_model: str | None = None
+        # Latches off once an agent proves it can't warm-switch, so we don't
+        # retry a failing request on every turn.
+        self._model_switch_supported: bool = True
 
         # Parsed argv; the first token is the binary we resolve / sandbox.
         self._argv: list[str] = shlex.split(config.command)
@@ -1226,14 +1241,92 @@ class AcpExecutor(Executor):
             if isinstance(size, int) and size > 0:
                 self._context_window = size
 
+        elif update_type == _UPDATE_CONFIG_OPTION:
+            self._note_config_options(update.get("configOptions"))
+
         return events
+
+    def _note_config_options(self, options: object) -> None:
+        """Record which session config options the agent exposes, and their values.
+
+        ACP agents advertise settable options (``mode``, ``model``, …) via
+        ``config_option_update``. Tracking the ids tells us whether a warm model
+        switch is possible at all; tracking ``model``'s ``currentValue`` is the
+        only trustworthy record of which model is live — an agent's own
+        self-report is unreliable.
+        """
+        if not isinstance(options, list):
+            return
+        for opt in options:
+            if not isinstance(opt, dict):
+                continue
+            opt_id = opt.get("id")
+            if not isinstance(opt_id, str):
+                continue
+            self._config_option_ids.add(opt_id)
+            if opt_id == _CONFIG_OPTION_MODEL:
+                current = opt.get("currentValue")
+                if isinstance(current, str) and current:
+                    self._active_model = current
+
+    async def _apply_model_override(self, session_id: str, model: str | None) -> None:
+        """Warm-switch the agent's model via ACP ``session/set_config_option``.
+
+        Standard ACP (not a vendor extension), so this works for any agent that
+        exposes a ``model`` session config option. The transcript is preserved —
+        the session is not recreated — so a ``/model`` pick mid-conversation keeps
+        the history the agent has already built up.
+
+        No-ops when the model is unset, already active, or the agent never
+        advertised a ``model`` option. A failed attempt latches the feature off
+        for this process rather than re-requesting on every turn, and never fails
+        the turn: an agent that can't switch should still answer on the model it
+        has.
+
+        :param session_id: The live ACP session to reconfigure.
+        :param model: Requested model id, or ``None`` to leave it alone.
+        """
+        if not model or model == self._active_model or not self._model_switch_supported:
+            return
+        # Before the first ``config_option_update`` we don't know what's settable;
+        # attempting is harmless because a rejection just latches the feature off.
+        if self._config_option_ids and _CONFIG_OPTION_MODEL not in self._config_option_ids:
+            self._model_switch_supported = False
+            logger.info(
+                "acp[%s] agent exposes no %r config option; leaving model as-is",
+                self._config.name,
+                _CONFIG_OPTION_MODEL,
+            )
+            return
+
+        response = await self._rpc(
+            _AGENT_METHOD_SET_CONFIG_OPTION,
+            {"sessionId": session_id, "configId": _CONFIG_OPTION_MODEL, "value": model},
+        )
+        if "error" in response:
+            self._model_switch_supported = False
+            logger.warning(
+                "acp[%s] model switch to %s rejected (%s); continuing on the current model",
+                self._config.name,
+                model,
+                response["error"].get("message", response["error"]),
+            )
+            return
+        # The agent echoes its options back; trust that over our request so
+        # ``_active_model`` reflects what the agent actually holds.
+        result = response.get("result")
+        if isinstance(result, dict):
+            self._note_config_options(result.get("configOptions"))
+        if self._active_model != model:
+            self._active_model = model
+        logger.info("acp[%s] model switched to %s (transcript kept)", self._config.name, model)
 
     async def run_turn(
         self,
         messages: list[Message],
         tools: list[ToolSpec],
         system_prompt: str,
-        config: ExecutorConfig | None = None,  # noqa: ARG002 — unused; required by the interface
+        config: ExecutorConfig | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         """Run one turn of the agent loop via ACP.
 
@@ -1255,6 +1348,16 @@ class AcpExecutor(Executor):
         except Exception as exc:  # noqa: BLE001
             yield ExecutorError(message=self._startup_error_message(exc), retryable=False)
             return
+
+        # Apply a ``/model`` pick to the live session before prompting, so the
+        # switch takes effect on this turn with the transcript intact. Never fatal
+        # — an agent that can't switch answers on the model it already has.
+        requested_model = config.model if config is not None else None
+        try:
+            await self._apply_model_override(session_id, requested_model)
+        except Exception as exc:  # noqa: BLE001
+            self._model_switch_supported = False
+            logger.warning("acp[%s] model switch failed: %s", self._config.name, exc)
 
         # A fresh ACP session holds no prior context. Captured before the latch
         # flips so we know whether to replay history into this turn.

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -26,6 +26,10 @@ Env vars read at startup:
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
 - ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to disable Omnigent's MCP relay;
   ``session/new`` still receives an empty ``mcpServers`` array.
+- ``HARNESS_ACP_TERMINAL``: ``"1"`` to advertise the ACP ``terminal``
+  capability, so the agent delegates shell execution to Omnigent (policy-gated,
+  run through the os_env) instead of running commands itself. Off by default —
+  it changes how a compliant agent executes every command, so agents opt in.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_ENV_PASSTHROUGH``: comma-separated environment variable *names*
@@ -57,6 +61,7 @@ _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
+_ENV_TERMINAL = "HARNESS_ACP_TERMINAL"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -126,6 +131,7 @@ def _build_acp_executor() -> Executor:
     session_id_mode = os.environ.get(_ENV_SESSION_ID_MODE, "").strip() or "server"
     send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
     omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
+    terminal_delegation = _env_enabled(_ENV_TERMINAL, default=False)
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
 
     config = AcpAgentConfig(
@@ -135,6 +141,7 @@ def _build_acp_executor() -> Executor:
         session_id_mode=session_id_mode,
         send_model_in_session_new=send_model,
         omnigent_mcp=omnigent_mcp,
+        terminal_delegation=terminal_delegation,
         env_passthrough=_env_passthrough_names(),
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -52,6 +52,11 @@ class AcpAgentEntry:
     :param session_id_mode: ``"server"`` (default) or ``"client"``.
     :param send_model: Send the model in ``session/new`` (Qwen-shaped agents).
     :param omnigent_mcp: Lend Omnigent's builtin MCP relay in ``session/new``.
+    :param terminal_delegation: Advertise the ACP ``terminal`` capability so the
+        agent delegates shell execution to Omnigent — policy-gated and run through
+        the session's os_env — instead of executing commands itself. Off by
+        default: it changes how a compliant agent runs every command, so it is
+        enabled per agent once verified.
     :param env_passthrough: Environment variable *names* the agent may read at
         spawn, e.g. ``("XAI_API_KEY",)``. The spawn env is deny-by-default and
         the executor cannot know which variable an arbitrary agent
@@ -67,6 +72,7 @@ class AcpAgentEntry:
     session_id_mode: str = "server"
     send_model: bool = False
     omnigent_mcp: bool = True
+    terminal_delegation: bool = False
     env_passthrough: tuple[str, ...] = ()
 
 
@@ -157,6 +163,9 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
         omnigent_mcp = raw.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("acp agent omnigent_mcp must be a boolean")
+        terminal_delegation = raw.get("terminal_delegation", False)
+        if not isinstance(terminal_delegation, bool):
+            raise ValueError("acp agent terminal_delegation must be a boolean")
         entries.append(
             AcpAgentEntry(
                 slug=slug,
@@ -166,6 +175,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 session_id_mode=mode if mode in ("server", "client") else "server",
                 send_model=bool(raw.get("send_model", False)),
                 omnigent_mcp=omnigent_mcp,
+                terminal_delegation=terminal_delegation,
                 env_passthrough=parse_env_passthrough(raw.get("env_passthrough")),
             )
         )
@@ -206,6 +216,8 @@ def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:
             item["send_model"] = True
         if not e.omnigent_mcp:
             item["omnigent_mcp"] = False
+        if e.terminal_delegation:
+            item["terminal_delegation"] = True
         if e.env_passthrough:
             item["env_passthrough"] = list(e.env_passthrough)
         agents.append(item)

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1614,11 +1614,15 @@ def _build_acp_spawn_env(
         omnigent_mcp = embedded.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("executor acp_agent omnigent_mcp must be a boolean")
+        terminal_delegation = embedded.get("terminal_delegation", False)
+        if not isinstance(terminal_delegation, bool):
+            raise ValueError("executor acp_agent terminal_delegation must be a boolean")
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
             command=command.strip(),
             omnigent_mcp=omnigent_mcp,
+            terminal_delegation=terminal_delegation,
             env_passthrough=parse_env_passthrough(embedded.get("env_passthrough")),
         )
     else:
@@ -1634,6 +1638,10 @@ def _build_acp_spawn_env(
         if agent.send_model:
             env["HARNESS_ACP_SEND_MODEL"] = "1"
         env["HARNESS_ACP_OMNIGENT_MCP"] = "1" if agent.omnigent_mcp else "0"
+        if agent.terminal_delegation:
+            # Only set when opted in, so an agent that never declared it keeps
+            # running its own shell exactly as before.
+            env["HARNESS_ACP_TERMINAL"] = "1"
         if agent.env_passthrough:
             # Names only; the harness reads each value from its own environment.
             env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(agent.env_passthrough)

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1698,6 +1698,9 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "Antigravity",
         "Qwen Code",
         "Goose",
+        # Builtin ACP CLI rows (ACP_CLI_HARNESSES) render after Goose, the other
+        # ACP-family builtin, and before the non-ACP harnesses.
+        "Grok Build",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1825,7 +1828,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["13", "", "", "q"]) + "\n"
+    stdin = "\n".join(["14", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1847,7 +1850,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["13", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["14", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1864,7 +1867,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["13", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["14", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2055,10 +2058,13 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        ("10", "_manage_copilot_harness"),
-        ("11", "_manage_kiro_harness"),
-        ("12", "_manage_kimi_harness"),
-        ("14", "_add_acp_agent"),
+        # 10 is the builtin ACP CLI row (Grok Build); every row after it shifted
+        # down by one when that block landed.
+        ("10", "_show_acp_cli_harness"),
+        ("11", "_manage_copilot_harness"),
+        ("12", "_manage_kiro_harness"),
+        ("13", "_manage_kimi_harness"),
+        ("15", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -227,6 +227,46 @@ def test_usage_update_sets_context_window() -> None:
     assert ex.max_context_tokens() == 200000
 
 
+def test_usage_maps_cached_reads_to_the_canonical_key() -> None:
+    """
+    ``cachedReadTokens`` surfaces as its own ``cache_read_input_tokens``.
+
+    Cache reads are real consumption billed at a fraction of the input rate, so
+    folding them into ``input_tokens`` (or dropping them, as before) misreports
+    cost — in a measured Devin turn 10,944 of 15,637 input tokens were cache
+    reads. ``cache_read_input_tokens`` is the key the SSE layer and AgentInfo
+    already render, so no UI change is needed.
+
+    **What breaks if this fails**: a future token budget computes ~3x the real
+    consumption and fires almost immediately.
+    """
+    usage = AcpExecutor._usage_from_result(
+        {
+            "usage": {
+                "totalTokens": 15675,
+                "inputTokens": 15637,
+                "outputTokens": 38,
+                "cachedReadTokens": 10944,
+            }
+        }
+    )
+    assert usage == {
+        "total_tokens": 15675,
+        "input_tokens": 15637,
+        "output_tokens": 38,
+        "cache_read_input_tokens": 10944,
+    }
+
+
+def test_usage_omits_absent_and_non_integer_fields() -> None:
+    """Agents that report a subset (or garbage) still yield usable usage."""
+    assert AcpExecutor._usage_from_result({"usage": {"totalTokens": 10}}) == {"total_tokens": 10}
+    # ``True`` is an int subclass — it must not be mistaken for a token count.
+    assert AcpExecutor._usage_from_result({"usage": {"inputTokens": True}}) is None
+    assert AcpExecutor._usage_from_result({"usage": {"totalTokens": "nope"}}) is None
+    assert AcpExecutor._usage_from_result({}) is None
+
+
 def test_in_progress_tool_update_emits_nothing() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x"))
     ex._handle_session_update({"sessionUpdate": "tool_call", "toolCallId": "c3", "title": "t"})

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -285,6 +285,133 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
 
 
 # ---------------------------------------------------------------------------
+# terminal delegation (agent → client shell mediation)
+# ---------------------------------------------------------------------------
+
+
+def _os_env() -> OSEnvSpec:
+    """A minimal non-fork os_env, which is what enables delegation."""
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+class _Deny:
+    action = "POLICY_ACTION_DENY"
+
+
+def test_terminal_capability_tracks_os_env() -> None:
+    """
+    ``terminal`` needs both the per-agent opt-in and an os_env to execute with.
+
+    Opt-in matters for compatibility: honouring the capability changes how a
+    compliant agent runs *every* command, so it must not switch on for the ACP
+    agents that already work (goose, kilocode, qwen, grok) just because the
+    harness always supplies a default os_env.
+
+    **What breaks if this fails**: advertising without an OSEnvironment makes the
+    agent delegate shell to a client that cannot run it, so every command fails;
+    advertising without the opt-in silently changes execution for every existing
+    ACP agent.
+    """
+    opted_in = AcpAgentConfig(command="x", terminal_delegation=True)
+    default = AcpAgentConfig(command="x")
+    # Needs BOTH the opt-in and an os_env to execute with.
+    assert AcpExecutor(opted_in)._terminal_delegation is False
+    assert AcpExecutor(default, os_env=_os_env())._terminal_delegation is False
+    assert AcpExecutor(opted_in, os_env=_os_env())._terminal_delegation is True
+
+
+@pytest.mark.asyncio
+async def test_terminal_create_denied_by_policy_never_executes() -> None:
+    """
+    A DENY verdict stops the command running and reports a failed exit.
+
+    This is the whole point of mediation: the agent asked us to run something, so
+    policy decides — not the agent's own permission mode.
+
+    **What breaks if this fails**: a DENY-ed shell command executes anyway,
+    meaning omnigent's policy engine is advisory for delegated shell.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    ex._policy_evaluator = AsyncMock(return_value=_Deny())
+    shell = AsyncMock()
+    ex._os_environment = type("E", (), {"shell": shell})()  # type: ignore[assignment]
+
+    result = await ex._handle_terminal_create({"command": "rm", "args": ["-rf", "/"]})
+
+    shell.assert_not_awaited()
+    out = await ex._handle_terminal_output(result)
+    assert out["exitStatus"]["exitCode"] == 126
+    assert "denied by policy" in out["output"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_create_allowed_runs_through_os_environment() -> None:
+    """
+    An allowed command executes via the OSEnvironment (so the sandbox applies).
+
+    **What breaks if this fails**: delegated commands bypass the spec's sandbox
+    read/write roots, or don't run at all and the agent sees empty output.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    shell = AsyncMock(return_value={"stdout": "hi", "stderr": "", "exit_code": 0})
+    ex._os_environment = type("E", (), {"shell": shell})()  # type: ignore[assignment]
+
+    created = await ex._handle_terminal_create({"command": "echo", "args": ["hi"]})
+    shell.assert_awaited_once_with("echo hi")
+
+    assert (await ex._handle_terminal_wait(created))["exitCode"] == 0
+    assert (await ex._handle_terminal_output(created))["output"] == "hi"
+    # Release drops the record; a second release must not raise.
+    await ex._handle_terminal_release(created)
+    await ex._handle_terminal_release(created)
+
+
+@pytest.mark.asyncio
+async def test_terminal_stderr_is_folded_into_output() -> None:
+    """Both streams reach the agent — stderr alone would otherwise be invisible."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    ex._os_environment = type(  # type: ignore[assignment]
+        "E", (), {"shell": AsyncMock(return_value={"stdout": "o", "stderr": "e", "exit_code": 2})}
+    )()
+    created = await ex._handle_terminal_create({"command": "x"})
+    out = await ex._handle_terminal_output(created)
+    assert out["output"] == "o\ne"
+    assert out["exitStatus"]["exitCode"] == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_methods_unsupported_without_delegation() -> None:
+    """
+    With no os_env, ``terminal/*`` is answered ``method not found`` — unchanged.
+
+    **What breaks if this fails**: agents that would have used their own shell
+    start delegating to a client that can't execute, regressing every existing
+    ACP agent that runs without an os_env.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    sent: list[dict] = []
+    ex._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await ex._respond_to_agent_request(
+        {"id": 7, "method": "terminal/create", "params": {"command": "echo hi"}}
+    )
+    assert sent[0]["error"]["code"] == -32601
+
+
+@pytest.mark.asyncio
+async def test_terminal_unknown_id_is_an_error() -> None:
+    """An unknown terminalId must fail loudly, not report empty output."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    with pytest.raises(acp_executor_module._AcpRequestError):
+        await ex._handle_terminal_output({"terminalId": "nope"})
+
+
+# ---------------------------------------------------------------------------
 # interrupt → session/cancel
 # ---------------------------------------------------------------------------
 

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -325,6 +325,124 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
 
 
 # ---------------------------------------------------------------------------
+# warm model switch (session/set_config_option)
+# ---------------------------------------------------------------------------
+
+
+def _model_option(current: str, *values: str) -> dict:
+    """A ``config_option_update`` payload advertising a settable model."""
+    return {
+        "sessionUpdate": "config_option_update",
+        "configOptions": [
+            {
+                "id": "model",
+                "currentValue": current,
+                "options": [{"value": v} for v in values],
+            }
+        ],
+    }
+
+
+def test_config_option_update_records_options_and_active_model() -> None:
+    """
+    The agent's ``currentValue`` is the only trustworthy record of the live model.
+
+    **What breaks if this fails**: we'd re-request a switch already in effect, or
+    trust the model's own self-report — which lies (Devin reported ``FAMILY=SWE``
+    after a confirmed switch to Gemini).
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium", "swe-1-7-medium", "gemini-3-1-pro"))
+    assert ex._active_model == "swe-1-7-medium"
+    assert "model" in ex._config_option_ids
+
+
+@pytest.mark.asyncio
+async def test_model_override_switches_warm_via_set_config_option() -> None:
+    """
+    A new model is applied with ``session/set_config_option`` using ``configId``.
+
+    ``configId`` is the parameter name the agent expects; ``optionId`` fails with
+    ``missing field 'configId'``. The session is NOT recreated, so the transcript
+    survives the switch.
+
+    **What breaks if this fails**: ``/model`` silently does nothing mid-session,
+    or the switch drops the conversation by respawning.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_rpc(method, params, timeout=30.0):
+        calls.append((method, params))
+        return {"result": {"configOptions": [{"id": "model", "currentValue": params["value"]}]}}
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "gemini-3-1-pro-low")
+
+    assert calls == [
+        (
+            "session/set_config_option",
+            {"sessionId": "s1", "configId": "model", "value": "gemini-3-1-pro-low"},
+        )
+    ]
+    assert ex._active_model == "gemini-3-1-pro-low"
+
+
+@pytest.mark.asyncio
+async def test_model_override_noops_when_already_active_or_unset() -> None:
+    """No redundant round-trip when the model is unchanged or unspecified."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+    ex._rpc = AsyncMock()  # type: ignore[assignment]
+
+    await ex._apply_model_override("s1", None)
+    await ex._apply_model_override("s1", "swe-1-7-medium")
+    ex._rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_override_skipped_when_agent_has_no_model_option() -> None:
+    """
+    An agent advertising options but no ``model`` one is left alone.
+
+    **What breaks if this fails**: every turn sends a doomed request to agents
+    that simply don't support switching (goose, kilocode, …).
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(
+        {"sessionUpdate": "config_option_update", "configOptions": [{"id": "mode"}]}
+    )
+    ex._rpc = AsyncMock()  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "some-model")
+    ex._rpc.assert_not_awaited()
+    assert ex._model_switch_supported is False
+
+
+@pytest.mark.asyncio
+async def test_model_override_rejection_latches_off_and_does_not_raise() -> None:
+    """
+    A rejected switch is logged and disabled, never fatal.
+
+    **What breaks if this fails**: an agent that doesn't implement
+    ``session/set_config_option`` fails the whole turn instead of answering on
+    the model it already has.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("m1"))
+    ex._rpc = AsyncMock(return_value={"error": {"code": -32601, "message": "unsupported"}})  # type: ignore[assignment]
+
+    await ex._apply_model_override("s1", "m2")
+    assert ex._model_switch_supported is False
+    assert ex._active_model == "m1"  # unchanged
+
+    # Latched off: a later turn must not retry.
+    ex._rpc.reset_mock()
+    await ex._apply_model_override("s1", "m3")
+    ex._rpc.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # terminal delegation (agent → client shell mediation)
 # ---------------------------------------------------------------------------
 

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -126,6 +126,41 @@ def test_send_model_flag_forwarded(_isolate_config: Path) -> None:
     assert env["HARNESS_ACP_SEND_MODEL"] == "1"
 
 
+def test_terminal_delegation_absent_unless_opted_in(_isolate_config: Path) -> None:
+    """
+    ``HARNESS_ACP_TERMINAL`` is set only for agents that declared it.
+
+    **What breaks if this fails**: every existing ACP agent starts delegating
+    shell execution to Omnigent the moment this ships, changing how they run
+    commands without anyone opting in.
+    """
+    _write_acp_config(
+        _isolate_config,
+        [
+            {"name": "Plain", "command": "plain acp"},
+            {"name": "Mediated", "command": "mediated acp", "terminal_delegation": True},
+        ],
+    )
+    plain = _build_acp_spawn_env(_make_spec(harness="acp:plain"), cwd=None, workdir=None)
+    assert "HARNESS_ACP_TERMINAL" not in plain
+
+    mediated = _build_acp_spawn_env(_make_spec(harness="acp:mediated"), cwd=None, workdir=None)
+    assert mediated["HARNESS_ACP_TERMINAL"] == "1"
+
+
+def test_embedded_agent_forwards_terminal_delegation() -> None:
+    """An embedded one-shot agent carries the opt-in too (remote-server path)."""
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:embedded",
+            acp_agent={"name": "E", "command": "e acp", "terminal_delegation": True},
+        ),
+        cwd=None,
+        workdir=None,
+    )
+    assert env["HARNESS_ACP_TERMINAL"] == "1"
+
+
 def test_omnigent_mcp_flag_forwarded(_isolate_config: Path) -> None:
     _write_acp_config(_isolate_config)
     env = _build_acp_spawn_env(_make_spec(harness="acp:openclaw"))

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -156,6 +156,10 @@ def test_catalog_row_is_fully_registered(name: str) -> None:
     assert steps
     if row.login_command is not None and row.install.package is not None:
         assert any(step.command == row.login_command for step in steps)
+    # `omni setup` renders a row per catalog entry and needs somewhere to point a
+    # user who hasn't installed the CLI. Without one the row would say "Not
+    # installed" with no way to fix it.
+    assert row.install.install_hint or row.install.package
 
 
 @pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
@@ -168,3 +172,49 @@ def test_catalog_row_spawn_env_builds(name: str) -> None:
     if row.args:
         assert argv[-len(row.args) :] == list(row.args)
     assert env["HARNESS_ACP_NAME"] == row.label
+
+
+# ---------------------------------------------------------------------------
+# `omni setup` drill-in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
+def test_setup_drill_in_names_install_and_login(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    Selecting a builtin ACP row in ``omni setup`` names how to install and sign in.
+
+    These rows own their auth and install out-of-band, so the drill-in is the only
+    place a user learns the two commands. Without it the row is a dead end — which
+    is what shipped before: ``grok`` was addressable via ``--harness grok`` but
+    absent from setup entirely, making a builtin *less* discoverable than a
+    user-configured ``acp:`` entry.
+
+    **What breaks if this fails**: a user picks the harness in setup and is told
+    nothing about how to make it work.
+    """
+    from omnigent import cli_config
+
+    row = ACP_CLI_HARNESSES[name]
+    # Force the "not installed" branch so the install hint has to be shown.
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _binary: None)
+    cli_config._show_acp_cli_harness(name)
+
+    out = capsys.readouterr().out
+    assert row.label in out
+    assert (row.install.install_hint or row.binary) in out
+    if row.login_command:
+        assert row.login_command in out
+    # Tells the user how to actually launch it.
+    assert f"--harness {name}" in out
+
+
+def test_setup_drill_in_ignores_unknown_row() -> None:
+    """A stale key (concurrent config change) must not raise."""
+    from omnigent import cli_config
+
+    cli_config._show_acp_cli_harness("definitely-not-a-row")


### PR DESCRIPTION
## Related issue

No filed issue — this came out of wiring a new ACP-speaking vendor CLI (Devin's
`devin acp`) through the existing generic ACP harness, which surfaced four
concrete gaps. Happy to file issues retroactively if the review queue wants the
priority signal.

## Summary

Four independent improvements to the **generic** ACP harness. Everything here is
standard ACP (`session/set_config_option`, `terminal/*`, client capabilities) — not
vendor-specific — so each one lifts every ACP agent (Goose, kilocode, Qwen, Grok,
BYO `acp:<slug>`), not just Devin.

**1. Omnigent can now gate an ACP agent's shell** (`terminal/*` delegation)

An ACP agent running its own shell decides for itself whether to ask permission,
so the TOOL_CALL policy only saw what the agent chose to surface. ACP already has
the answer: the client advertises a `terminal` capability and the agent delegates
execution back to us. We were hardcoding it to `false`.

```
              before                          after (opt-in)
agent wants   agent runs it itself            terminal/create -> omnigent
to run `rm`   omnigent sees a card, after     policy: ALLOW/ASK/DENY -> we run it
              the fact                        DENY  -> never runs (exit 126)
```

**Opt-in per agent** (`terminal_delegation`, default off): honouring the capability
changes how a compliant agent executes *every* command, so agents that already
work must not change behaviour without opting in.

**2. `/model` now applies to a live ACP session** — previously it reached the
executor as `ExecutorConfig.model` and was ignored, so the pick silently did
nothing until a respawn (which costs the conversation). Now driven through
`session/set_config_option`, transcript intact.

**3. Cached-read tokens are no longer dropped** — `_usage_from_result` mapped only
input/output/total. In one measured turn **10,944 of 15,637 input tokens were cache
reads**; discarding them overstates a turn ~3x, which would make any future token
budget useless.

**4. Builtin ACP CLI harnesses appear in `omni setup`** — `grok` was in
`harness_labels`, `valid_harnesses` and the `/v1/harnesses` catalog, and
`harness_install.py` even generated it a "Sign in to Grok Build" step, but the setup
overview builds rows by hand and never read the catalog. A *shipped* harness was
less discoverable than a user's own `acp:` entry.

<details>
<summary>ELI5</summary>

Omnigent can drive any coding agent that speaks ACP. Four things were missing:
we never offered to run the agent's shell commands for it (so we couldn't block a
dangerous one), switching models mid-chat didn't work, we threw away part of the
token count, and one of our own built-in agents didn't show up in the setup menu.
</details>

## Test Plan

- **New unit tests**: 16 across `tests/inner/test_acp_executor.py` (terminal
  delegation incl. the DENY path and the no-opt-in no-regression case, warm model
  switch incl. rejection latching, usage mapping),
  `tests/runtime/test_acp_spawn_env.py` (opt-in plumbing, embedded-agent path), and
  `tests/test_acp_cli_harnesses.py` (setup drill-in, parametrized over the real
  catalog so a new row is covered for free).
- `pytest tests/inner/test_acp_executor.py tests/inner/test_acp_executor_timeout_config.py tests/runtime/test_acp_spawn_env.py tests/test_acp_cli_harnesses.py tests/onboarding/test_acp_auth.py tests/spec` → **682 passed**.
- `pre-commit run --files <changed>` → clean (ruff format, ruff check, pyrefly).
- **Pre-existing failures, unrelated to this PR**: `tests/cli/test_configure_models.py`
  has 5 `databricks`-related failures on `main`. Verified by stashing this branch's
  changes: baseline is the same 5 (115 passed → 116 with this PR, the +1 being a new
  dispatch case). No new failures introduced.

**Manual verification against a real `devin acp`** (v3000.4.16), driving the real
`AcpExecutor`:

| Case | Delegated | omnigent executed | Policy gate | Result |
|---|---|---|---|---|
| opt-in, ALLOW | `terminal/create`, `output`, `wait_for_exit`, `release` | ✅ `exit=0`, `MEDIATED-Darwin` | 1 | agent reported *omnigent's* output |
| opt-in, DENY | (none) | ❌ never ran | 1 | *"the tool execution was rejected"* |
| no opt-in | (none) | — | 1 | unchanged; agent's own shell |

Warm model switch, same session: `swe-1-7-medium` → `swe-1-7` mid-conversation, with
a token planted *before* the switch still recalled *after* it.

`omni setup` now renders `Grok Build  ✓ ACP · own auth` next to Goose (captured from
a real run against a copy of a real config).

## Demo

N/A — the one user-visible surface is a new `omni setup` row, shown as text above.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered what unit tests can't: whether a real third-party ACP
agent actually honours the client capabilities we advertise. No automated test
spawns a live vendor ACP subprocess, so the ALLOW/DENY/no-opt-in matrix and the warm
model switch were driven against a real `devin acp` in-process through
`AcpExecutor`.

Every change is capability-gated with the fallback covered by a test:

| Change | Gate | Fallback (tested) |
|---|---|---|
| `terminal/*` mediation | per-agent opt-in **and** an os_env to execute with | agent uses its own shell, as today |
| Warm model switch | agent advertises a `model` config option | rejection latches off; turn still completes |
| Cached-read tokens | key present in `result.usage` | omitted, as today |
| Setup rows | derived from the catalog | dynamic `acp:*` rows unchanged |

Two deliberate non-goals, documented in code rather than guessed at: `/model
default`/`reset` does not revert an ACP agent to its launch model (a cleared
override arrives as `None`, which is treated as "leave alone"), and
`usage_update.used` is still unread — it is cumulative context fill rather than
per-turn cost, and there is no mid-turn consumer for it.

## Changelog

Omnigent can now run an ACP agent's shell commands itself — so tool policies apply — and `/model` switches an ACP agent mid-conversation without losing the chat
