### PR TITLE
fix(acp): report cached-read tokens instead of dropping them

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -999,21 +999,32 @@ class AcpExecutor(Executor):
     def _usage_from_result(result: _AcpJsonObject) -> dict[str, int] | None:
         """Map an agent's final ``result.usage`` to Omnigent's usage keys.
 
-        ACP does not standardize usage, but agents that report it (Goose) use
-        ``{totalTokens, inputTokens, outputTokens}``; Omnigent's
-        ``TurnComplete.usage`` uses ``{input_tokens, output_tokens, total_tokens}``.
+        ACP does not standardize usage, but agents that report it (Goose, Devin)
+        use ``{totalTokens, inputTokens, outputTokens}`` plus an optional
+        ``cachedReadTokens``; Omnigent's ``TurnComplete.usage`` uses
+        ``{input_tokens, output_tokens, total_tokens, cache_read_input_tokens}``.
         Absent → ``None`` (usage simply isn't shown for agents that don't report).
+
+        ``cachedReadTokens`` is kept as its own key rather than folded into
+        ``input_tokens``: cache reads are real consumption but billed at a
+        fraction of the rate, so collapsing them would overstate cost — in one
+        measured turn 10,944 of 15,637 input tokens were cache reads.
+        ``cache_read_input_tokens`` is the key the rest of the stack already
+        speaks, so it renders without any UI change.
         """
         usage = result.get("usage")
         if not isinstance(usage, dict):
             return None
         out: dict[str, int] = {}
-        if isinstance(usage.get("inputTokens"), int):
-            out["input_tokens"] = usage["inputTokens"]
-        if isinstance(usage.get("outputTokens"), int):
-            out["output_tokens"] = usage["outputTokens"]
-        if isinstance(usage.get("totalTokens"), int):
-            out["total_tokens"] = usage["totalTokens"]
+        for acp_key, omni_key in (
+            ("inputTokens", "input_tokens"),
+            ("outputTokens", "output_tokens"),
+            ("totalTokens", "total_tokens"),
+            ("cachedReadTokens", "cache_read_input_tokens"),
+        ):
+            value = usage.get(acp_key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                out[omni_key] = value
         return out or None
 
     def _handle_session_update(self, update: _AcpJsonObject) -> list[ExecutorEvent]:

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -227,6 +227,46 @@ def test_usage_update_sets_context_window() -> None:
     assert ex.max_context_tokens() == 200000
 
 
+def test_usage_maps_cached_reads_to_the_canonical_key() -> None:
+    """
+    ``cachedReadTokens`` surfaces as its own ``cache_read_input_tokens``.
+
+    Cache reads are real consumption billed at a fraction of the input rate, so
+    folding them into ``input_tokens`` (or dropping them, as before) misreports
+    cost — in a measured Devin turn 10,944 of 15,637 input tokens were cache
+    reads. ``cache_read_input_tokens`` is the key the SSE layer and AgentInfo
+    already render, so no UI change is needed.
+
+    **What breaks if this fails**: a future token budget computes ~3x the real
+    consumption and fires almost immediately.
+    """
+    usage = AcpExecutor._usage_from_result(
+        {
+            "usage": {
+                "totalTokens": 15675,
+                "inputTokens": 15637,
+                "outputTokens": 38,
+                "cachedReadTokens": 10944,
+            }
+        }
+    )
+    assert usage == {
+        "total_tokens": 15675,
+        "input_tokens": 15637,
+        "output_tokens": 38,
+        "cache_read_input_tokens": 10944,
+    }
+
+
+def test_usage_omits_absent_and_non_integer_fields() -> None:
+    """Agents that report a subset (or garbage) still yield usable usage."""
+    assert AcpExecutor._usage_from_result({"usage": {"totalTokens": 10}}) == {"total_tokens": 10}
+    # ``True`` is an int subclass — it must not be mistaken for a token count.
+    assert AcpExecutor._usage_from_result({"usage": {"inputTokens": True}}) is None
+    assert AcpExecutor._usage_from_result({"usage": {"totalTokens": "nope"}}) is None
+    assert AcpExecutor._usage_from_result({}) is None
+
+
 def test_in_progress_tool_update_emits_nothing() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x"))
     ex._handle_session_update({"sessionUpdate": "tool_call", "toolCallId": "c3", "title": "t"})


### PR DESCRIPTION
## Related issue

No filed issue — found while measuring token usage for a real ACP agent (Devin).

## Summary

`_usage_from_result` mapped only `inputTokens` / `outputTokens` / `totalTokens`, so
an agent's `cachedReadTokens` was silently discarded.

Cache reads are real consumption billed at a fraction of the input rate, so
dropping them misreports a turn. In one measured Devin turn **10,944 of 15,637
input tokens were cache reads** — reporting the turn as if all 15,637 were fresh
input overstates it roughly 3x.

- Map it to `cache_read_input_tokens`, the key the rest of the stack already
  speaks (`claude_native_bridge` produces it, `web/src/lib/sse.ts` maps it to
  `cacheReadInputTokens`, `AgentInfo.tsx` renders it as "Cache read") — so it
  displays with **no UI change**.
- Keep it **distinct** from `input_tokens` rather than folded in: the two are
  priced differently, and collapsing them destroys the information any future
  cost policy would need.
- Tighten the value check while here: `bool` is an `int` subclass, so a stray
  `true` would previously have been reported as a token count.

## Test Plan

- New: `test_usage_maps_cached_reads_to_the_canonical_key` (the exact payload shape
  measured from a live `devin acp`) and
  `test_usage_omits_absent_and_non_integer_fields` (subset reporting, the `bool`
  case, and non-integer garbage).
- `pytest tests/inner/test_acp_executor.py` → **52 passed**.
- `ruff check` / `ruff format` clean.

## Demo

N/A — non-visual; the value flows into the existing "Cache read" row.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by unit tests against the real wire payload.

## Changelog

ACP agents now report cached-read tokens, so token usage reflects what was actually billed
