### PR TITLE
feat(setup): show builtin ACP CLI harnesses in `omni setup`

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -2136,6 +2136,40 @@ def _launch_goose_configure() -> str | None:
     return "Provider not detected yet"
 
 
+def _show_acp_cli_harness(name: str) -> None:
+    """Show install + sign-in instructions for one builtin ACP CLI harness.
+
+    These harnesses own their credentials (``OWN_AUTH``) and install out-of-band,
+    so there is nothing for Omnigent to store or run on the user's behalf — the
+    drill-in reports what it can and names the two commands. Read-only: it
+    changes no config, which is why it's a display rather than a manage loop.
+
+    :param name: The :data:`ACP_CLI_HARNESSES` row key, e.g. ``"grok"``.
+    """
+    from omnigent._platform import resolve_cli_binary
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+    from omnigent.onboarding.interactive import console
+
+    row = ACP_CLI_HARNESSES.get(name)
+    if row is None:  # defensive: a stale key from a concurrent config change
+        return
+
+    installed = resolve_cli_binary(row.binary) is not None
+    console.print(f"\n  [bold]{row.label}[/bold] — ACP agent (owns its own auth)")
+    if installed:
+        console.print(f"    ✓ `{row.binary}` found on PATH")
+    else:
+        hint = row.install.install_hint or row.binary
+        console.print(
+            f"    ○ `{row.binary}` not found. Install with:\n        [bold]{hint}[/bold]"
+        )
+    if row.login_command:
+        console.print(f"    Sign in with:\n        [bold]{row.login_command}[/bold]")
+    if row.install.auth_hint:
+        console.print(f"    {row.install.auth_hint}")
+    console.print(f"    Launch with: [bold]omnigent run --harness {name}[/bold]\n")
+
+
 def _manage_goose_harness() -> None:
     """Run the level-2 loop for Goose: ensure the CLI, then guide ``goose configure``.
 
@@ -3475,6 +3509,7 @@ def _run_configure_harnesses_interactive() -> None:
     _ACP_IMPORT = "\x00acp-import-openclaw"
     _ACP_ADD = "\x00acp-add"
     _ACP_AGENT_PREFIX = "\x00acp-agent:"
+    _ACP_CLI_PREFIX = "\x00acp-cli:"
     families = [ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE]
 
     # Status glyph + Rich color per readiness kind: "ready" is a configured,
@@ -3752,6 +3787,39 @@ def _run_configure_harnesses_interactive() -> None:
                     (_GOOSE, "Goose", "Not configured", "warn", "Open to run `goose configure`."),
                 )
 
+        # Builtin ACP CLI harnesses (omnigent/acp_cli_harnesses.py) — vendor CLIs
+        # that speak ACP on stdio. Derived from the catalog so adding a row there
+        # surfaces it here too; without this they were addressable via
+        # `--harness <name>` but invisible in setup, making a shipped harness less
+        # discoverable than a user's own `acp:` entry.
+        from omnigent._platform import resolve_cli_binary
+        from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+        for _acp_cli_name, _acp_cli_row in sorted(ACP_CLI_HARNESSES.items()):
+            _acp_cli_key = _ACP_CLI_PREFIX + _acp_cli_name
+            if resolve_cli_binary(_acp_cli_row.binary) is None:
+                rows.append(
+                    (
+                        _acp_cli_key,
+                        _acp_cli_row.label,
+                        "Not installed",
+                        "missing",
+                        _install_hint(_acp_cli_row.install.install_hint or _acp_cli_row.binary),
+                    )
+                )
+            else:
+                # The vendor owns its auth, so we can report the binary is present
+                # but not whether it is signed in.
+                rows.append(
+                    (
+                        _acp_cli_key,
+                        _acp_cli_row.label,
+                        "ACP · own auth",
+                        "ready",
+                        "Select for install and sign-in instructions.",
+                    )
+                )
+
         # Copilot — GitHub token (github-copilot-sdk extra is soft).
         if copilot_github_token_configured(config) or any(
             os.environ.get(v) for v in COPILOT_TOKEN_ENV_VARS
@@ -3939,6 +4007,8 @@ def _run_configure_harnesses_interactive() -> None:
             _add_acp_agent()
         elif isinstance(selected_target, str) and selected_target.startswith(_ACP_AGENT_PREFIX):
             _manage_acp_agent(selected_target[len(_ACP_AGENT_PREFIX) :])
+        elif isinstance(selected_target, str) and selected_target.startswith(_ACP_CLI_PREFIX):
+            _show_acp_cli_harness(selected_target[len(_ACP_CLI_PREFIX) :])
         elif selected_target == _HERMES:
             _manage_hermes_harness()
         elif selected_target == _KIRO:

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1698,6 +1698,9 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "Antigravity",
         "Qwen Code",
         "Goose",
+        # Builtin ACP CLI rows (ACP_CLI_HARNESSES) render after Goose, the other
+        # ACP-family builtin, and before the non-ACP harnesses.
+        "Grok Build",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1825,7 +1828,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["13", "", "", "q"]) + "\n"
+    stdin = "\n".join(["14", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1847,7 +1850,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["13", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["14", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1864,7 +1867,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["13", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["14", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2055,10 +2058,13 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        ("10", "_manage_copilot_harness"),
-        ("11", "_manage_kiro_harness"),
-        ("12", "_manage_kimi_harness"),
-        ("14", "_add_acp_agent"),
+        # 10 is the builtin ACP CLI row (Grok Build); every row after it shifted
+        # down by one when that block landed.
+        ("10", "_show_acp_cli_harness"),
+        ("11", "_manage_copilot_harness"),
+        ("12", "_manage_kiro_harness"),
+        ("13", "_manage_kimi_harness"),
+        ("15", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -156,6 +156,10 @@ def test_catalog_row_is_fully_registered(name: str) -> None:
     assert steps
     if row.login_command is not None and row.install.package is not None:
         assert any(step.command == row.login_command for step in steps)
+    # `omni setup` renders a row per catalog entry and needs somewhere to point a
+    # user who hasn't installed the CLI. Without one the row would say "Not
+    # installed" with no way to fix it.
+    assert row.install.install_hint or row.install.package
 
 
 @pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
@@ -168,3 +172,49 @@ def test_catalog_row_spawn_env_builds(name: str) -> None:
     if row.args:
         assert argv[-len(row.args) :] == list(row.args)
     assert env["HARNESS_ACP_NAME"] == row.label
+
+
+# ---------------------------------------------------------------------------
+# `omni setup` drill-in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
+def test_setup_drill_in_names_install_and_login(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    Selecting a builtin ACP row in ``omni setup`` names how to install and sign in.
+
+    These rows own their auth and install out-of-band, so the drill-in is the only
+    place a user learns the two commands. Without it the row is a dead end — which
+    is what shipped before: ``grok`` was addressable via ``--harness grok`` but
+    absent from setup entirely, making a builtin *less* discoverable than a
+    user-configured ``acp:`` entry.
+
+    **What breaks if this fails**: a user picks the harness in setup and is told
+    nothing about how to make it work.
+    """
+    from omnigent import cli_config
+
+    row = ACP_CLI_HARNESSES[name]
+    # Force the "not installed" branch so the install hint has to be shown.
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _binary: None)
+    cli_config._show_acp_cli_harness(name)
+
+    out = capsys.readouterr().out
+    assert row.label in out
+    assert (row.install.install_hint or row.binary) in out
+    if row.login_command:
+        assert row.login_command in out
+    # Tells the user how to actually launch it.
+    assert f"--harness {name}" in out
+
+
+def test_setup_drill_in_ignores_unknown_row() -> None:
+    """A stale key (concurrent config change) must not raise."""
+    from omnigent import cli_config
+
+    cli_config._show_acp_cli_harness("definitely-not-a-row")


### PR DESCRIPTION
## Related issue

No filed issue — found while adding a new ACP-speaking vendor CLI and noticing a
shipped harness was harder to discover than a user-configured one.

## Summary

Builtin ACP CLI harnesses (`ACP_CLI_HARNESSES`) were registry-complete but
invisible. `grok` is in `harness_labels()`, `valid_harnesses()` and the live
`GET /v1/harnesses` catalog, and `onboarding/harness_install.py` even generates it
a *"Sign in to Grok Build"* step — but the `omni setup` overview builds its rows by
hand and never read the catalog, so the row **and that setup step** were
unreachable.

Net effect: a *shipped* harness was less discoverable than a user's own `acp:`
config entry, which is backwards.

- Render one row per catalog entry, next to Goose (the other ACP-family builtin).
- Add a drill-in naming the install hint, the vendor login command, and how to
  launch it.
- Derived from the catalog, so a future row surfaces here with no extra wiring.

These rows own their auth (`OWN_AUTH`), so the status reports whether the binary is
on `PATH` and deliberately claims nothing about sign-in state.

Before / after in `omni setup` → *Configure harnesses*:

```
  … Qwen Code            … Qwen Code
    Goose                  Goose
    Copilot          ->    Grok Build   ✓ ACP · own auth     <- new
    Kiro                   Copilot
                           Kiro
```

## Test Plan

- New `test_setup_drill_in_names_install_and_login`, parametrized over the **real**
  catalog, so a new row is covered automatically. It forces the "not installed"
  branch to assert the install hint is shown, plus
  `test_setup_drill_in_ignores_unknown_row` for a stale key.
- `test_catalog_row_is_fully_registered` now also asserts a row has somewhere to
  point a user who hasn't installed the CLI (`install_hint` or `package`) —
  otherwise the row would say "Not installed" with no remedy.
- The overview's row indices shift by one after Goose, so the scripted-stdin
  dispatch tests are updated, and they now pin the new row's dispatch too.
- `pytest tests/cli/test_configure_models.py tests/test_acp_cli_harnesses.py` →
  **124 passed, 5 failed**.
- **Those 5 failures are pre-existing on `main`**, all `databricks`-related.
  Verified by stashing this change: baseline is the same 5 (115 passed → 116 with
  this PR, the +1 being the new dispatch case). No new failures.
- Verified visually by driving the real `omni setup` under a PTY against a copy of
  a real config: `Grok Build  ✓ ACP · own auth` renders in position.

## Demo

Captured from a real `omni setup` run (text UI):

```
  Configure harnesses
       Qwen Code               ✗ Not installed
       Goose                   ✓ openrouter
       Grok Build              ✓ ACP · own auth
       Copilot                 ✗ Not installed
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the rendered TUI, which the unit tests can't assert:
the row's position and status text were captured from a real `omni setup` run under
a PTY (against a copy of a real config, in an isolated `OMNIGENT_CONFIG_HOME`).
Automated coverage handles the drill-in content and the dispatch mapping.

## Changelog

Built-in ACP agents like Grok Build now appear in `omni setup` instead of being invisible
