### PR TITLE
feat(acp): mediate agent shell through omnigent via ACP terminal delegation

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -179,6 +179,12 @@ class AcpAgentConfig:
     :param omnigent_mcp: Expose Omnigent's builtin tools to the agent via
         ``session/new.mcpServers`` (the shared ``serve-mcp`` relay). On by
         default; the global ``OMNIGENT_ACP_MCP=0`` kill switch also disables it.
+    :param terminal_delegation: Advertise ``clientCapabilities.terminal`` so the
+        agent delegates shell execution to Omnigent (gated by TOOL_CALL policy,
+        run through the OSEnvironment) instead of executing it itself. **Off by
+        default**: honouring the capability changes how a compliant agent runs
+        every command, so each agent opts in once verified. Requires an os_env —
+        without one there is nothing to execute with.
     :param env_passthrough: Environment variable *names* this agent may read at
         spawn, e.g. ``("XAI_API_KEY",)``. The spawn env is deny-by-default and
         this executor drives an arbitrary agent, so it cannot infer the family
@@ -193,6 +199,7 @@ class AcpAgentConfig:
     session_id_mode: str = "server"
     send_model_in_session_new: bool = False
     omnigent_mcp: bool = True
+    terminal_delegation: bool = False
     env_passthrough: tuple[str, ...] = ()
 
 
@@ -296,7 +303,20 @@ class AcpExecutor(Executor):
         # an os_env is configured and it isn't a ``fork`` env — a forked env
         # operates on a *copied* tree whose path diverges from the agent's cwd.
         self._fs_delegation: bool = os_env is not None and not bool(getattr(os_env, "fork", False))
+        # Advertise ``clientCapabilities.terminal`` only when the agent opted in
+        # *and* an os_env can execute. Delegation puts every command through the
+        # TOOL_CALL policy + elicitation gate and the spec's sandbox rather than
+        # trusting the agent to ask — but it also changes how a compliant agent
+        # runs commands, so it stays opt-in per agent rather than flipping on for
+        # every already-working ACP agent at once.
+        self._terminal_delegation: bool = self._fs_delegation and bool(config.terminal_delegation)
         self._os_environment: OSEnvironment | None = None
+        # Completed delegated commands, keyed by the id we handed the agent.
+        # ``OSEnvironment.shell`` runs to completion, so a terminal is created
+        # already-exited; ``terminal/output`` and ``terminal/wait_for_exit`` then
+        # serve the stored record.
+        self._terminals: dict[str, _AcpJsonObject] = {}
+        self._terminal_seq: int = 0
 
         # Session config options the agent advertises (``mode``, ``model``, …)
         # and the live model value, both learned from ``config_option_update``.
@@ -624,7 +644,7 @@ class AcpExecutor(Executor):
                             "readTextFile": self._fs_delegation,
                             "writeTextFile": self._fs_delegation,
                         },
-                        "terminal": False,
+                        "terminal": self._terminal_delegation,
                     },
                 },
                 timeout=_INIT_TIMEOUT_SECONDS,
@@ -702,6 +722,9 @@ class AcpExecutor(Executor):
         - ``fs/read_text_file`` / ``fs/write_text_file`` — when fs delegation is
           advertised, execute through the Omnigent OSEnvironment so the spec's
           sandbox read/write roots are enforced. Off → never arrive.
+        - ``terminal/*`` — when terminal delegation is advertised, run the command
+          ourselves after the same policy + elicitation gate. This is the one path
+          that governs an agent's shell use without relying on the agent to ask.
         - anything else — reply with JSON-RPC ``method not found`` so the agent
           fails loudly rather than acting on empty data.
         """
@@ -720,6 +743,14 @@ class AcpExecutor(Executor):
                 result = await self._handle_fs_read(params)
             elif method == "fs/write_text_file" and self._fs_delegation:
                 result = await self._handle_fs_write(params)
+            elif method == "terminal/create" and self._terminal_delegation:
+                result = await self._handle_terminal_create(params)
+            elif method == "terminal/output" and self._terminal_delegation:
+                result = await self._handle_terminal_output(params)
+            elif method == "terminal/wait_for_exit" and self._terminal_delegation:
+                result = await self._handle_terminal_wait(params)
+            elif method in ("terminal/release", "terminal/kill") and self._terminal_delegation:
+                result = await self._handle_terminal_release(params)
             else:
                 error = {
                     "code": -32601,
@@ -750,6 +781,106 @@ class AcpExecutor(Executor):
                 raise _AcpRequestError(-32603, "omnigent: no os_env for fs delegation")
             self._os_environment = env
         return self._os_environment
+
+    # ------------------------------------------------------------------
+    # Terminal delegation (agent → client, when terminal capability advertised)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _terminal_command(params: _AcpJsonObject) -> str:
+        """Join ACP ``{command, args?}`` into one shell command string.
+
+        :raises _AcpRequestError: When ``command`` is missing or not a string.
+        """
+        command = params.get("command")
+        if not isinstance(command, str) or not command.strip():
+            raise _AcpRequestError(-32602, "terminal/create requires a string 'command'")
+        args = params.get("args")
+        if isinstance(args, list) and args:
+            return shlex.join([command, *[str(a) for a in args]])
+        return command
+
+    async def _handle_terminal_create(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/create`` — the tool-mediation gate for shell.
+
+        The command runs through :meth:`_authorize` first, so a DENY verdict (or a
+        refused approval card) means it never executes. Execution then goes
+        through :meth:`OSEnvironment.shell`, inheriting the spec's sandbox.
+
+        A denial is reported as a *failed command* (exit 126 + explanation) rather
+        than a JSON-RPC error: the agent reads it as an ordinary tool failure and
+        can adapt, instead of treating the transport as broken and retrying.
+        """
+        command = self._terminal_command(params)
+        self._terminal_seq += 1
+        terminal_id = f"omnigent-term-{self._terminal_seq}"
+
+        if not await self._authorize("Run shell command", {"command": command}):
+            logger.info("acp[%s] terminal/create denied: %s", self._config.name, command)
+            self._terminals[terminal_id] = {
+                "output": "omnigent: command denied by policy",
+                "exitCode": 126,
+            }
+            return {"terminalId": terminal_id}
+
+        env = await self._ensure_os_environment()
+        result = await env.shell(command)
+        if "error" in result:
+            raise _AcpRequestError(-32603, str(result["error"]))
+        stdout = str(result.get("stdout", ""))
+        stderr = str(result.get("stderr", ""))
+        output = stdout + (("\n" if stdout and stderr else "") + stderr if stderr else "")
+        if result.get("timed_out"):
+            output = f"{output}\nomnigent: command timed out".lstrip("\n")
+        exit_code = result.get("exit_code")
+        self._terminals[terminal_id] = {
+            "output": output,
+            "exitCode": exit_code if isinstance(exit_code, int) else 0,
+        }
+        logger.info(
+            "acp[%s] terminal/create executed by omnigent (exit=%s): %s",
+            self._config.name,
+            exit_code,
+            command,
+        )
+        return {"terminalId": terminal_id}
+
+    def _terminal_record(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Look up a stored terminal by ``terminalId``.
+
+        :raises _AcpRequestError: When the id is unknown — better a loud error
+            than silently reporting empty output for a command that ran.
+        """
+        terminal_id = params.get("terminalId")
+        record = self._terminals.get(terminal_id) if isinstance(terminal_id, str) else None
+        if record is None:
+            raise _AcpRequestError(-32602, f"unknown terminalId {terminal_id!r}")
+        return record
+
+    async def _handle_terminal_output(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/output`` from the stored command result."""
+        record = self._terminal_record(params)
+        return {
+            "output": record["output"],
+            "truncated": False,
+            "exitStatus": {"exitCode": record["exitCode"]},
+        }
+
+    async def _handle_terminal_wait(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/wait_for_exit`` — already exited when created."""
+        return {"exitCode": self._terminal_record(params)["exitCode"]}
+
+    async def _handle_terminal_release(self, params: _AcpJsonObject) -> _AcpJsonObject:
+        """Serve ACP ``terminal/release`` / ``terminal/kill`` by dropping the record.
+
+        The command has already run to completion, so there is nothing to kill;
+        releasing just frees the stored output. Unknown ids are tolerated here so
+        a duplicate release can't fail a turn.
+        """
+        terminal_id = params.get("terminalId")
+        if isinstance(terminal_id, str):
+            self._terminals.pop(terminal_id, None)
+        return {}
 
     async def _handle_fs_read(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
@@ -830,6 +961,19 @@ class AcpExecutor(Executor):
         operation the adapter installs both, so destructive actions are gated.
         """
         tool_name, tool_input = self._extract_tool_call(params)
+        return await self._authorize(tool_name, tool_input)
+
+    async def _authorize(self, tool_name: str, tool_input: _AcpJsonObject) -> bool:
+        """Run one tool through TOOL_CALL policy, then human-consent elicitation.
+
+        Shared by the agent's own ``session/request_permission`` and by the
+        delegated ``terminal/*`` handlers, so a command the agent would have run
+        silently is gated identically to one it asked about.
+
+        :param tool_name: Display name for the policy verdict and approval card.
+        :param tool_input: Tool arguments the policy inspects.
+        :returns: ``True`` to proceed.
+        """
         handler = getattr(self, "_elicitation_handler", None)
         policy_eval = getattr(self, "_policy_evaluator", None)
 

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -26,6 +26,10 @@ Env vars read at startup:
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
 - ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to disable Omnigent's MCP relay;
   ``session/new`` still receives an empty ``mcpServers`` array.
+- ``HARNESS_ACP_TERMINAL``: ``"1"`` to advertise the ACP ``terminal``
+  capability, so the agent delegates shell execution to Omnigent (policy-gated,
+  run through the os_env) instead of running commands itself. Off by default —
+  it changes how a compliant agent executes every command, so agents opt in.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_ENV_PASSTHROUGH``: comma-separated environment variable *names*
@@ -57,6 +61,7 @@ _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
+_ENV_TERMINAL = "HARNESS_ACP_TERMINAL"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -126,6 +131,7 @@ def _build_acp_executor() -> Executor:
     session_id_mode = os.environ.get(_ENV_SESSION_ID_MODE, "").strip() or "server"
     send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
     omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
+    terminal_delegation = _env_enabled(_ENV_TERMINAL, default=False)
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
 
     config = AcpAgentConfig(
@@ -135,6 +141,7 @@ def _build_acp_executor() -> Executor:
         session_id_mode=session_id_mode,
         send_model_in_session_new=send_model,
         omnigent_mcp=omnigent_mcp,
+        terminal_delegation=terminal_delegation,
         env_passthrough=_env_passthrough_names(),
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -52,6 +52,11 @@ class AcpAgentEntry:
     :param session_id_mode: ``"server"`` (default) or ``"client"``.
     :param send_model: Send the model in ``session/new`` (Qwen-shaped agents).
     :param omnigent_mcp: Lend Omnigent's builtin MCP relay in ``session/new``.
+    :param terminal_delegation: Advertise the ACP ``terminal`` capability so the
+        agent delegates shell execution to Omnigent — policy-gated and run through
+        the session's os_env — instead of executing commands itself. Off by
+        default: it changes how a compliant agent runs every command, so it is
+        enabled per agent once verified.
     :param env_passthrough: Environment variable *names* the agent may read at
         spawn, e.g. ``("XAI_API_KEY",)``. The spawn env is deny-by-default and
         the executor cannot know which variable an arbitrary agent
@@ -67,6 +72,7 @@ class AcpAgentEntry:
     session_id_mode: str = "server"
     send_model: bool = False
     omnigent_mcp: bool = True
+    terminal_delegation: bool = False
     env_passthrough: tuple[str, ...] = ()
 
 
@@ -157,6 +163,9 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
         omnigent_mcp = raw.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("acp agent omnigent_mcp must be a boolean")
+        terminal_delegation = raw.get("terminal_delegation", False)
+        if not isinstance(terminal_delegation, bool):
+            raise ValueError("acp agent terminal_delegation must be a boolean")
         entries.append(
             AcpAgentEntry(
                 slug=slug,
@@ -166,6 +175,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 session_id_mode=mode if mode in ("server", "client") else "server",
                 send_model=bool(raw.get("send_model", False)),
                 omnigent_mcp=omnigent_mcp,
+                terminal_delegation=terminal_delegation,
                 env_passthrough=parse_env_passthrough(raw.get("env_passthrough")),
             )
         )
@@ -206,6 +216,8 @@ def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:
             item["send_model"] = True
         if not e.omnigent_mcp:
             item["omnigent_mcp"] = False
+        if e.terminal_delegation:
+            item["terminal_delegation"] = True
         if e.env_passthrough:
             item["env_passthrough"] = list(e.env_passthrough)
         agents.append(item)

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1626,6 +1626,9 @@ def _build_acp_spawn_env(
         model = embedded.get("model")
         if model is not None and not isinstance(model, str):
             raise ValueError("executor acp_agent model must be a string or null")
+        terminal_delegation = embedded.get("terminal_delegation", False)
+        if not isinstance(terminal_delegation, bool):
+            raise ValueError("executor acp_agent terminal_delegation must be a boolean")
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
@@ -1634,6 +1637,7 @@ def _build_acp_spawn_env(
             session_id_mode=session_id_mode,
             send_model=send_model,
             omnigent_mcp=omnigent_mcp,
+            terminal_delegation=terminal_delegation,
             env_passthrough=parse_env_passthrough(embedded.get("env_passthrough")),
         )
     else:
@@ -1649,6 +1653,10 @@ def _build_acp_spawn_env(
         if agent.send_model:
             env["HARNESS_ACP_SEND_MODEL"] = "1"
         env["HARNESS_ACP_OMNIGENT_MCP"] = "1" if agent.omnigent_mcp else "0"
+        if agent.terminal_delegation:
+            # Only set when opted in, so an agent that never declared it keeps
+            # running its own shell exactly as before.
+            env["HARNESS_ACP_TERMINAL"] = "1"
         if agent.env_passthrough:
             # Names only; the harness reads each value from its own environment.
             env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(agent.env_passthrough)

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -499,6 +499,133 @@ async def test_model_override_falls_back_to_request_when_no_option_echoed() -> N
 
 
 # ---------------------------------------------------------------------------
+# terminal delegation (agent → client shell mediation)
+# ---------------------------------------------------------------------------
+
+
+def _os_env() -> OSEnvSpec:
+    """A minimal non-fork os_env, which is what enables delegation."""
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+class _Deny:
+    action = "POLICY_ACTION_DENY"
+
+
+def test_terminal_capability_tracks_os_env() -> None:
+    """
+    ``terminal`` needs both the per-agent opt-in and an os_env to execute with.
+
+    Opt-in matters for compatibility: honouring the capability changes how a
+    compliant agent runs *every* command, so it must not switch on for the ACP
+    agents that already work (goose, kilocode, qwen, grok) just because the
+    harness always supplies a default os_env.
+
+    **What breaks if this fails**: advertising without an OSEnvironment makes the
+    agent delegate shell to a client that cannot run it, so every command fails;
+    advertising without the opt-in silently changes execution for every existing
+    ACP agent.
+    """
+    opted_in = AcpAgentConfig(command="x", terminal_delegation=True)
+    default = AcpAgentConfig(command="x")
+    # Needs BOTH the opt-in and an os_env to execute with.
+    assert AcpExecutor(opted_in)._terminal_delegation is False
+    assert AcpExecutor(default, os_env=_os_env())._terminal_delegation is False
+    assert AcpExecutor(opted_in, os_env=_os_env())._terminal_delegation is True
+
+
+@pytest.mark.asyncio
+async def test_terminal_create_denied_by_policy_never_executes() -> None:
+    """
+    A DENY verdict stops the command running and reports a failed exit.
+
+    This is the whole point of mediation: the agent asked us to run something, so
+    policy decides — not the agent's own permission mode.
+
+    **What breaks if this fails**: a DENY-ed shell command executes anyway,
+    meaning omnigent's policy engine is advisory for delegated shell.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    ex._policy_evaluator = AsyncMock(return_value=_Deny())
+    shell = AsyncMock()
+    ex._os_environment = type("E", (), {"shell": shell})()  # type: ignore[assignment]
+
+    result = await ex._handle_terminal_create({"command": "rm", "args": ["-rf", "/"]})
+
+    shell.assert_not_awaited()
+    out = await ex._handle_terminal_output(result)
+    assert out["exitStatus"]["exitCode"] == 126
+    assert "denied by policy" in out["output"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_create_allowed_runs_through_os_environment() -> None:
+    """
+    An allowed command executes via the OSEnvironment (so the sandbox applies).
+
+    **What breaks if this fails**: delegated commands bypass the spec's sandbox
+    read/write roots, or don't run at all and the agent sees empty output.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    shell = AsyncMock(return_value={"stdout": "hi", "stderr": "", "exit_code": 0})
+    ex._os_environment = type("E", (), {"shell": shell})()  # type: ignore[assignment]
+
+    created = await ex._handle_terminal_create({"command": "echo", "args": ["hi"]})
+    shell.assert_awaited_once_with("echo hi")
+
+    assert (await ex._handle_terminal_wait(created))["exitCode"] == 0
+    assert (await ex._handle_terminal_output(created))["output"] == "hi"
+    # Release drops the record; a second release must not raise.
+    await ex._handle_terminal_release(created)
+    await ex._handle_terminal_release(created)
+
+
+@pytest.mark.asyncio
+async def test_terminal_stderr_is_folded_into_output() -> None:
+    """Both streams reach the agent — stderr alone would otherwise be invisible."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    ex._os_environment = type(  # type: ignore[assignment]
+        "E", (), {"shell": AsyncMock(return_value={"stdout": "o", "stderr": "e", "exit_code": 2})}
+    )()
+    created = await ex._handle_terminal_create({"command": "x"})
+    out = await ex._handle_terminal_output(created)
+    assert out["output"] == "o\ne"
+    assert out["exitStatus"]["exitCode"] == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_methods_unsupported_without_delegation() -> None:
+    """
+    With no os_env, ``terminal/*`` is answered ``method not found`` — unchanged.
+
+    **What breaks if this fails**: agents that would have used their own shell
+    start delegating to a client that can't execute, regressing every existing
+    ACP agent that runs without an os_env.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    sent: list[dict] = []
+    ex._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await ex._respond_to_agent_request(
+        {"id": 7, "method": "terminal/create", "params": {"command": "echo hi"}}
+    )
+    assert sent[0]["error"]["code"] == -32601
+
+
+@pytest.mark.asyncio
+async def test_terminal_unknown_id_is_an_error() -> None:
+    """An unknown terminalId must fail loudly, not report empty output."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", terminal_delegation=True), os_env=_os_env())
+    with pytest.raises(acp_executor_module._AcpRequestError):
+        await ex._handle_terminal_output({"terminalId": "nope"})
+
+
+# ---------------------------------------------------------------------------
 # interrupt → session/cancel
 # ---------------------------------------------------------------------------
 

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -126,6 +126,41 @@ def test_send_model_flag_forwarded(_isolate_config: Path) -> None:
     assert env["HARNESS_ACP_SEND_MODEL"] == "1"
 
 
+def test_terminal_delegation_absent_unless_opted_in(_isolate_config: Path) -> None:
+    """
+    ``HARNESS_ACP_TERMINAL`` is set only for agents that declared it.
+
+    **What breaks if this fails**: every existing ACP agent starts delegating
+    shell execution to Omnigent the moment this ships, changing how they run
+    commands without anyone opting in.
+    """
+    _write_acp_config(
+        _isolate_config,
+        [
+            {"name": "Plain", "command": "plain acp"},
+            {"name": "Mediated", "command": "mediated acp", "terminal_delegation": True},
+        ],
+    )
+    plain = _build_acp_spawn_env(_make_spec(harness="acp:plain"), cwd=None, workdir=None)
+    assert "HARNESS_ACP_TERMINAL" not in plain
+
+    mediated = _build_acp_spawn_env(_make_spec(harness="acp:mediated"), cwd=None, workdir=None)
+    assert mediated["HARNESS_ACP_TERMINAL"] == "1"
+
+
+def test_embedded_agent_forwards_terminal_delegation() -> None:
+    """An embedded one-shot agent carries the opt-in too (remote-server path)."""
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:embedded",
+            acp_agent={"name": "E", "command": "e acp", "terminal_delegation": True},
+        ),
+        cwd=None,
+        workdir=None,
+    )
+    assert env["HARNESS_ACP_TERMINAL"] == "1"
+
+
 def test_omnigent_mcp_flag_forwarded(_isolate_config: Path) -> None:
     _write_acp_config(_isolate_config)
     env = _build_acp_spawn_env(_make_spec(harness="acp:openclaw"))


### PR DESCRIPTION
## Related issue

No filed issue — found while wiring a new ACP-speaking vendor CLI (`devin acp`)
through the generic ACP harness and checking whether Omnigent's tool policy
actually applied to it.

## Summary

**Omnigent could not gate an ACP agent's shell commands.** An ACP agent runs its
own tools and decides for itself whether to ask permission, so the TOOL_CALL policy
only ever saw what the agent chose to surface. Measured against a real `devin acp`:
a shell command that *modified a file* produced 6 `tool_call` cards and **zero**
`session/request_permission` — the cards render after the fact, nothing gates them.

ACP already has the answer, and it's the client's call: the client advertises a
`terminal` capability and a compliant agent delegates execution back to us. We were
hardcoding it to `false`.

```
                    before                        after (opt-in)
agent wants to      agent runs it itself;         terminal/create -> omnigent
run a command       omnigent sees a card          policy ALLOW/ASK/DENY, then WE run it
                    after the fact                DENY -> never runs (exit 126)
```

- Implement the client side of `terminal/create`, `terminal/output`,
  `terminal/wait_for_exit`, `terminal/release` and `terminal/kill` on top of the
  existing `OSEnvironment`, so a delegated command inherits the spec's sandbox.
- Route every delegated command through the **same** policy + elicitation gate that
  `session/request_permission` already uses — factored out as `_authorize` rather
  than duplicated.
- A DENY reports an ordinary *failed command* (exit 126 + reason) instead of a
  JSON-RPC error, so the agent adapts instead of treating the transport as broken
  and retrying.

**Opt-in per agent** (`terminal_delegation`, default off). Honouring the capability
changes how a compliant agent executes *every* command, and the harness always
supplies a default `os_env`, so keying off `os_env` alone would have silently
switched behaviour for every existing ACP agent (goose, kilocode, qwen, grok). It
therefore requires **both** the opt-in and an `os_env` to execute with.

## Test Plan

- New tests in `tests/inner/test_acp_executor.py`: capability requires both opt-in
  and `os_env`; DENY never executes and reports exit 126; ALLOW runs through the
  `OSEnvironment`; stderr folded into output; `terminal/*` answered
  `method not found` without delegation (the no-regression case); unknown
  `terminalId` errors loudly. Plus `tests/runtime/test_acp_spawn_env.py`: the env
  var is set only for opted-in agents, and the embedded-agent path carries it.
- `pytest tests/inner/test_acp_executor.py tests/runtime/test_acp_spawn_env.py tests/onboarding/test_acp_auth.py tests/test_acp_cli_harnesses.py` → **95 passed**.
- `ruff check` / `ruff format` / `pyrefly` clean.

**Manual verification against a real `devin acp`** (v3000.4.16), driving the real
`AcpExecutor` in-process:

| Case | Delegated to omnigent | omnigent executed | Policy gate | Result |
|---|---|---|---|---|
| opt-in, ALLOW | `terminal/create`, `output`, `wait_for_exit`, `release` | ✅ `exit=0`, `MEDIATED-Darwin` | 1 | agent reported *omnigent's* output |
| opt-in, DENY | (none) | ❌ never ran | 1 | *"the tool execution was rejected"* |
| no opt-in | (none) | — | 1 | unchanged; agent's own shell |

## Demo

N/A — non-visual (tool cards render as before; the change is who executes).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered what unit tests cannot: whether a real third-party ACP
agent actually honours the `terminal` capability we advertise, and what it does with
a denial. No automated test spawns a live vendor ACP subprocess, so the
ALLOW / DENY / no-opt-in matrix above was driven against a real `devin acp` through
`AcpExecutor`.

Two notes on scope:
- `OSEnvironment.shell` runs to completion, so a terminal is created
  already-exited and `terminal/output` / `terminal/wait_for_exit` serve the stored
  record. True incremental output streaming is not implemented; the docstring says
  so.
- Sandboxing a generic ACP agent is still opt-in and unchanged by this PR — see the
  existing `_sandbox_launch` note about per-agent write roots.

## Changelog

Omnigent can now run an ACP agent's shell commands itself, so tool policies and sandboxing apply to them
