### PR TITLE
fix(acp): resolve acp:<slug> client-side for remote server compatibility

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6493,10 +6493,24 @@ def _materialize_harness_launcher_file(
     if acp_agent is not None:
         if canonical != "acp":
             raise click.ClickException("An ephemeral ACP agent requires the acp harness.")
-        executor["acp_agent"] = {
+        # Embed all fields that affect spawn so the remote server sees the same
+        # agent config as the client. Preserve session_id_mode, send_model,
+        # omnigent_mcp, env_passthrough, and model.
+        agent_dict: dict[str, object] = {
             "name": acp_agent.name,
             "command": acp_agent.command,
         }
+        if acp_agent.model is not None:
+            agent_dict["model"] = acp_agent.model
+        if acp_agent.session_id_mode != "server":
+            agent_dict["session_id_mode"] = acp_agent.session_id_mode
+        if acp_agent.send_model:
+            agent_dict["send_model"] = acp_agent.send_model
+        if not acp_agent.omnigent_mcp:
+            agent_dict["omnigent_mcp"] = acp_agent.omnigent_mcp
+        if acp_agent.env_passthrough:
+            agent_dict["env_passthrough"] = list(acp_agent.env_passthrough)
+        executor["acp_agent"] = agent_dict
 
     raw = {
         "name": display_name,
@@ -7572,6 +7586,17 @@ def run(
             raise click.ClickException("--from-openclaw cannot be combined with --harness.")
         acp_agent = _resolve_openclaw_run_agent(from_openclaw)
         harness = f"acp:{acp_agent.slug}"
+    # Client-side harness resolution for acp:<slug>: resolve the slug before
+    # embedding in the spec so it works with remote servers. The server would resolve
+    # the slug from ITS config (if present), but fails when the agent is only
+    # configured locally on the client. Embedding the resolved agent avoids this gap.
+    # Preserve the existing config-lookup path as fallback; specs authored by hand
+    # still use it.
+    if acp_agent is None and harness is not None and harness.startswith("acp:"):
+        from omnigent.onboarding.acp_auth import resolve_acp_agent
+
+        slug = harness.split(":", 1)[1]
+        acp_agent = resolve_acp_agent(slug)
     direct_server_cli = (
         target is None
         and server_from_cli

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1614,10 +1614,25 @@ def _build_acp_spawn_env(
         omnigent_mcp = embedded.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("executor acp_agent omnigent_mcp must be a boolean")
+        session_id_mode = embedded.get("session_id_mode", "server")
+        if session_id_mode not in ("server", "client"):
+            raise ValueError(
+                f"executor acp_agent session_id_mode must be 'server' or 'client', "
+                f"got {session_id_mode!r}"
+            )
+        send_model = embedded.get("send_model", False)
+        if not isinstance(send_model, bool):
+            raise ValueError("executor acp_agent send_model must be a boolean")
+        model = embedded.get("model")
+        if model is not None and not isinstance(model, str):
+            raise ValueError("executor acp_agent model must be a string or null")
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
             command=command.strip(),
+            model=model,
+            session_id_mode=session_id_mode,
+            send_model=send_model,
             omnigent_mcp=omnigent_mcp,
             env_passthrough=parse_env_passthrough(embedded.get("env_passthrough")),
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3106,6 +3106,188 @@ def test_run_from_openclaw_forwards_server(
     assert run_chat.call_args.kwargs["server_url"] == "https://example.com"
 
 
+def test_run_harness_acp_slug_resolves_client_side(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--harness acp:<slug> resolves the slug client-side and embeds the agent.
+
+    When connecting to a remote server, the local client resolves acp:<slug>
+    to find the configured agent, then embeds it in the temp spec so the
+    remote server doesn't need to resolve a local config. Fixes the bug where
+    --harness acp:devin --server <remote> failed because the server couldn't
+    resolve acp:devin from its own config.
+    """
+    import yaml
+
+    from omnigent.runtime.workflow import _build_acp_spawn_env
+    from omnigent.spec import load
+
+    config_home = tmp_path / "omnigent-config"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"acp": {"agents": [{"name": "Devin", "command": "devin --acp", "slug": "devin"}]}}
+        )
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--harness", "acp:devin", "-p", "hello"],
+    )
+
+    assert result.exit_code == 0, result.output
+    run_chat.assert_called_once()
+    generated = Path(run_chat.call_args.kwargs["target"])
+    raw = yaml.safe_load(generated.read_text())
+    # The agent must be embedded in the spec so a remote server can use it
+    assert raw["executor"]["harness"] == "acp:devin"
+    assert raw["executor"]["acp_agent"] == {
+        "name": "Devin",
+        "command": "devin --acp",
+    }
+    # Verify the embedded agent is properly used at runtime
+    env = _build_acp_spawn_env(load(generated))
+    assert env["HARNESS_ACP_COMMAND"] == "devin --acp"
+    assert env["HARNESS_ACP_NAME"] == "Devin"
+
+
+def test_run_harness_acp_slug_embeds_with_remote_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Embedding acp_agent enables --harness acp:<slug> --server <remote> to work.
+
+    The local runner resolves the slug from local config, embeds it in the
+    spec sent to the server, and the server uses the embedded agent instead
+    of trying to resolve a non-existent slug from its own config.
+    """
+    import yaml
+
+    from omnigent.runtime.workflow import _build_acp_spawn_env
+    from omnigent.spec import load
+
+    config_home = tmp_path / "omnigent-config"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "acp": {
+                    "agents": [
+                        {
+                            "name": "Local Agent",
+                            "command": "agent stdio",
+                            "slug": "local-agent",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "run",
+            "--harness",
+            "acp:local-agent",
+            "--server",
+            "https://remote.example.com",
+            "-p",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    run_chat.assert_called_once()
+    generated = Path(run_chat.call_args.kwargs["target"])
+    raw = yaml.safe_load(generated.read_text())
+    # Agent is embedded so the remote server can use it
+    assert raw["executor"]["acp_agent"]["name"] == "Local Agent"
+    assert raw["executor"]["acp_agent"]["command"] == "agent stdio"
+    # Verify it works through the full spawn path
+    env = _build_acp_spawn_env(load(generated))
+    assert env["HARNESS_ACP_COMMAND"] == "agent stdio"
+
+
+def test_run_harness_acp_slug_embeds_all_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All ACP agent fields survive --harness acp:<slug> embedding round-trip.
+
+    What breaks if this fails: Qwen-shaped agents with `session_id_mode: client`
+    + `send_model: true`, agents with `omnigent_mcp: false` or `env_passthrough`
+    settings lose these critical config knobs when embedded, causing silent
+    runtime behavior changes (e.g., Qwen spawns with server-side session ids,
+    auth env vars unreachable due to deny-by-default passthrough).
+    """
+    import yaml
+
+    from omnigent.runtime.workflow import _build_acp_spawn_env
+    from omnigent.spec import load
+
+    config_home = tmp_path / "omnigent-config"
+    config_home.mkdir()
+    # Configure a Qwen-shaped agent with non-default settings
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "acp": {
+                    "agents": [
+                        {
+                            "name": "Qwen",
+                            "command": "qwen --acp",
+                            "session_id_mode": "client",
+                            "send_model": True,
+                            "model": "qwen-vl-max",
+                            "env_passthrough": ["QWEN_API_KEY"],
+                            "slug": "qwen",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--harness", "acp:qwen", "-p", "test"],
+    )
+
+    assert result.exit_code == 0, result.output
+    run_chat.assert_called_once()
+    generated = Path(run_chat.call_args.kwargs["target"])
+    raw = yaml.safe_load(generated.read_text())
+    # All fields are embedded
+    acp_agent = raw["executor"]["acp_agent"]
+    assert acp_agent["name"] == "Qwen"
+    assert acp_agent["command"] == "qwen --acp"
+    assert acp_agent["session_id_mode"] == "client"
+    assert acp_agent["send_model"] is True
+    assert acp_agent["model"] == "qwen-vl-max"
+    assert acp_agent["env_passthrough"] == ["QWEN_API_KEY"]
+    # Verify spawn env respects the embedded fields
+    env = _build_acp_spawn_env(load(generated))
+    assert env["HARNESS_ACP_COMMAND"] == "qwen --acp"
+    assert env["HARNESS_ACP_SESSION_ID_MODE"] == "client"
+    assert env["HARNESS_ACP_SEND_MODEL"] == "1"
+    assert env["HARNESS_ACP_MODEL"] == "qwen-vl-max"
+    assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == "QWEN_API_KEY"
+
+
 def _capture_profile_env_at_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> dict[str, str | None]:

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -199,3 +199,119 @@ def test_embedded_agent_forwards_env_passthrough(_isolate_config: Path) -> None:
     )
     env = _build_acp_spawn_env(spec)
     assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == "XAI_API_KEY"
+
+
+def test_embedded_agent_overrides_config_lookup(_isolate_config: Path) -> None:
+    """An embedded agent is used even when the slug is configured.
+
+    When a one-shot embedded agent is present, it takes precedence over a
+    config-based lookup so the client-side resolution can work with remote
+    servers: the local runner resolves acp:<slug> and embeds it, bypassing
+    the need for the server to have that agent configured.
+    """
+    _write_acp_config(_isolate_config)  # write config with goose and others
+    # Now pass an embedded agent with a different command
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:goose",
+            acp_agent={
+                "name": "Different Goose",
+                "command": "goose acp --custom-flag",
+            },
+        )
+    )
+    # The embedded command is used, not the one from config
+    assert env["HARNESS_ACP_COMMAND"] == "goose acp --custom-flag"
+    assert env["HARNESS_ACP_NAME"] == "Different Goose"
+
+
+@pytest.mark.parametrize(
+    "agent_fields",
+    [
+        # Qwen-shaped agent: client-side session id + send model
+        {
+            "name": "Qwen",
+            "command": "qwen --acp",
+            "session_id_mode": "client",
+            "send_model": True,
+            "model": "qwen-vl-max",
+            "expected_session_id_mode": "client",
+            "expected_send_model": True,
+            "expected_model": "qwen-vl-max",
+        },
+        # Agent with MCP disabled
+        {
+            "name": "Custom",
+            "command": "custom acp",
+            "omnigent_mcp": False,
+            "expected_omnigent_mcp": False,
+        },
+        # Agent with environment passthrough
+        {
+            "name": "GrokAgent",
+            "command": "grok agent stdio",
+            "env_passthrough": ["XAI_API_KEY"],
+            "expected_env_passthrough": "XAI_API_KEY",
+        },
+        # Agent with model only
+        {
+            "name": "TestAgent",
+            "command": "test --acp",
+            "model": "test-model-v1",
+            "expected_model": "test-model-v1",
+        },
+    ],
+)
+def test_embedded_agent_round_trip_preserves_all_fields(
+    agent_fields: dict,
+) -> None:
+    """Embedded agents preserve all fields through the round-trip.
+
+    What breaks if this fails: an agent configured with non-default values
+    (e.g. Qwen with `session_id_mode: client`, OpenClaw with
+    `omnigent_mcp: false`) silently loses these settings when launched via
+    `--harness acp:<slug>`, causing incorrect spawn behavior at runtime.
+    Example: Qwen expects the runner to generate the session id but switches
+    to server mode, fails to send the model, and breaks Qwen's response
+    generation.
+    """
+    agent_dict = {
+        "name": agent_fields["name"],
+        "command": agent_fields["command"],
+    }
+    # Add optional fields that were declared
+    for field in ("model", "session_id_mode", "send_model", "omnigent_mcp", "env_passthrough"):
+        if field in agent_fields:
+            agent_dict[field] = agent_fields[field]
+
+    env = _build_acp_spawn_env(_make_spec(harness="acp:test", acp_agent=agent_dict))
+
+    # Core fields always present
+    assert env["HARNESS_ACP_COMMAND"] == agent_fields["command"]
+    assert env["HARNESS_ACP_NAME"] == agent_fields["name"]
+
+    # session_id_mode preservation
+    if "expected_session_id_mode" in agent_fields:
+        assert env["HARNESS_ACP_SESSION_ID_MODE"] == agent_fields["expected_session_id_mode"], (
+            f"session_id_mode not preserved: got {env.get('HARNESS_ACP_SESSION_ID_MODE')}"
+        )
+
+    # send_model preservation
+    if "expected_send_model" in agent_fields:
+        if agent_fields["expected_send_model"]:
+            assert env["HARNESS_ACP_SEND_MODEL"] == "1"
+        else:
+            assert "HARNESS_ACP_SEND_MODEL" not in env
+
+    # omnigent_mcp preservation
+    if "expected_omnigent_mcp" in agent_fields:
+        expected_mcp = "1" if agent_fields["expected_omnigent_mcp"] else "0"
+        assert env["HARNESS_ACP_OMNIGENT_MCP"] == expected_mcp
+
+    # model preservation
+    if "expected_model" in agent_fields:
+        assert env["HARNESS_ACP_MODEL"] == agent_fields["expected_model"]
+
+    # env_passthrough preservation
+    if "expected_env_passthrough" in agent_fields:
+        assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == agent_fields["expected_env_passthrough"]


### PR DESCRIPTION
## Related issue

No filed issue — this is a standalone capability enhancement to make ACP harnesses work with remote servers.

## Summary

Make `omnigent run --harness acp:<slug> --server <remote>` work by resolving the slug client-side at launch time and embedding the ACP agent in the temporary spec. Previously, the server would fail because it couldn't resolve `acp:<slug>` from its own local config when the agent was only configured locally on the client.

The fix is additive and capability-gated: the existing config-lookup path remains as fallback for specs authored by hand.

**Regression fix**: Embed all ACP agent fields (name, command, model, session_id_mode, send_model, omnigent_mcp, env_passthrough) in the temporary spec so the remote server sees the same agent config as the client. Agents with non-default settings (e.g., Qwen with `session_id_mode: client` and `send_model: true`, agents with `omnigent_mcp: false`) now preserve their critical config knobs across embedding.

## Test Plan

Run the new ACP-specific tests with proper environment isolation:
```bash
OMNIGENT_CONFIG_HOME=/tmp/test-config OMNIGENT_DATA_DIR=/tmp/test-data \
  uv run pytest \
    tests/cli/test_cli.py::test_run_harness_acp_slug_resolves_client_side \
    tests/cli/test_cli.py::test_run_harness_acp_slug_embeds_with_remote_server \
    tests/cli/test_cli.py::test_run_harness_acp_slug_embeds_all_fields \
    tests/runtime/test_acp_spawn_env.py::test_embedded_agent_overrides_config_lookup \
    tests/runtime/test_acp_spawn_env.py::test_embedded_agent_round_trip_preserves_all_fields \
    -xvs
```

Run all ACP-related tests:
```bash
uv run pytest tests/runtime/test_acp_spawn_env.py tests/inner/test_acp_executor.py tests/test_acp_cli_harnesses.py -q
```

Verify existing behavior is preserved:
```bash
uv run pytest tests/spec -q
uv run pytest tests/cli -q  # (5 pre-existing databricks failures in test_configure_models.py)
```

## Demo

N/A (non-visual change)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Existing tests cover this change
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

Tests added for the client-side resolution logic verify:
1. `--harness acp:<slug>` resolves the slug and embeds it in the spec
2. All ACP agent fields (name, command, model, session_id_mode, send_model, omnigent_mcp, env_passthrough) survive the round-trip through embedding
3. Embedded agent takes precedence over config-lookup
4. Qwen-shaped agents with `session_id_mode: client` and `send_model: true` preserve their settings
5. Agents with `omnigent_mcp: false` and `env_passthrough` preserve their settings

Parametrized tests cover non-default values for all fields. All existing ACP tests pass unchanged, confirming backward compatibility.

## Changelog

`omnigent run --harness acp:<slug>` now works with remote servers by resolving the slug client-side and embedding the full agent config in the spec. ACP agent settings (session_id_mode, send_model, omnigent_mcp, env_passthrough) are now preserved through embedding.
