### PR TITLE
feat(acp): apply /model to a live session without losing the transcript

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -119,6 +119,13 @@ _UPDATE_AGENT_THOUGHT_CHUNK = "agent_thought_chunk"
 _UPDATE_TOOL_CALL = "tool_call"
 _UPDATE_TOOL_CALL_UPDATE = "tool_call_update"
 _UPDATE_USAGE = "usage_update"
+_UPDATE_CONFIG_OPTION = "config_option_update"
+
+# ACP ``session/set_config_option`` — the standard warm-switch method. The
+# option id for the model, and the param name the agent expects (``configId``,
+# not ``optionId``).
+_AGENT_METHOD_SET_CONFIG_OPTION = "session/set_config_option"
+_CONFIG_OPTION_MODEL = "model"
 
 # ACP tool-call lifecycle statuses (the terminal ones close a tool card).
 _TOOL_STATUS_COMPLETED = "completed"
@@ -290,6 +297,14 @@ class AcpExecutor(Executor):
         # operates on a *copied* tree whose path diverges from the agent's cwd.
         self._fs_delegation: bool = os_env is not None and not bool(getattr(os_env, "fork", False))
         self._os_environment: OSEnvironment | None = None
+
+        # Session config options the agent advertises (``mode``, ``model``, …)
+        # and the live model value, both learned from ``config_option_update``.
+        self._config_option_ids: set[str] = set()
+        self._active_model: str | None = None
+        # Latches off once an agent proves it can't warm-switch, so we don't
+        # retry a failing request on every turn.
+        self._model_switch_supported: bool = True
 
         # Parsed argv; the first token is the binary we resolve / sandbox.
         self._argv: list[str] = shlex.split(config.command)
@@ -1071,14 +1086,92 @@ class AcpExecutor(Executor):
             if isinstance(size, int) and size > 0:
                 self._context_window = size
 
+        elif update_type == _UPDATE_CONFIG_OPTION:
+            self._note_config_options(update.get("configOptions"))
+
         return events
+
+    def _note_config_options(self, options: object) -> None:
+        """Record which session config options the agent exposes, and their values.
+
+        ACP agents advertise settable options (``mode``, ``model``, …) via
+        ``config_option_update``. Tracking the ids tells us whether a warm model
+        switch is possible at all; tracking ``model``'s ``currentValue`` is the
+        only trustworthy record of which model is live — an agent's own
+        self-report is unreliable.
+        """
+        if not isinstance(options, list):
+            return
+        for opt in options:
+            if not isinstance(opt, dict):
+                continue
+            opt_id = opt.get("id")
+            if not isinstance(opt_id, str):
+                continue
+            self._config_option_ids.add(opt_id)
+            if opt_id == _CONFIG_OPTION_MODEL:
+                current = opt.get("currentValue")
+                if isinstance(current, str) and current:
+                    self._active_model = current
+
+    async def _apply_model_override(self, session_id: str, model: str | None) -> None:
+        """Warm-switch the agent's model via ACP ``session/set_config_option``.
+
+        Standard ACP (not a vendor extension), so this works for any agent that
+        exposes a ``model`` session config option. The transcript is preserved —
+        the session is not recreated — so a ``/model`` pick mid-conversation keeps
+        the history the agent has already built up.
+
+        No-ops when the model is unset, already active, or the agent never
+        advertised a ``model`` option. A failed attempt latches the feature off
+        for this process rather than re-requesting on every turn, and never fails
+        the turn: an agent that can't switch should still answer on the model it
+        has.
+
+        :param session_id: The live ACP session to reconfigure.
+        :param model: Requested model id, or ``None`` to leave it alone.
+        """
+        if not model or model == self._active_model or not self._model_switch_supported:
+            return
+        # Before the first ``config_option_update`` we don't know what's settable;
+        # attempting is harmless because a rejection just latches the feature off.
+        if self._config_option_ids and _CONFIG_OPTION_MODEL not in self._config_option_ids:
+            self._model_switch_supported = False
+            logger.info(
+                "acp[%s] agent exposes no %r config option; leaving model as-is",
+                self._config.name,
+                _CONFIG_OPTION_MODEL,
+            )
+            return
+
+        response = await self._rpc(
+            _AGENT_METHOD_SET_CONFIG_OPTION,
+            {"sessionId": session_id, "configId": _CONFIG_OPTION_MODEL, "value": model},
+        )
+        if "error" in response:
+            self._model_switch_supported = False
+            logger.warning(
+                "acp[%s] model switch to %s rejected (%s); continuing on the current model",
+                self._config.name,
+                model,
+                response["error"].get("message", response["error"]),
+            )
+            return
+        # The agent echoes its options back; trust that over our request so
+        # ``_active_model`` reflects what the agent actually holds.
+        result = response.get("result")
+        if isinstance(result, dict):
+            self._note_config_options(result.get("configOptions"))
+        if self._active_model != model:
+            self._active_model = model
+        logger.info("acp[%s] model switched to %s (transcript kept)", self._config.name, model)
 
     async def run_turn(
         self,
         messages: list[Message],
         tools: list[ToolSpec],
         system_prompt: str,
-        config: ExecutorConfig | None = None,  # noqa: ARG002 — unused; required by the interface
+        config: ExecutorConfig | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         """Run one turn of the agent loop via ACP.
 
@@ -1100,6 +1193,16 @@ class AcpExecutor(Executor):
         except Exception as exc:  # noqa: BLE001
             yield ExecutorError(message=self._startup_error_message(exc), retryable=False)
             return
+
+        # Apply a ``/model`` pick to the live session before prompting, so the
+        # switch takes effect on this turn with the transcript intact. Never fatal
+        # — an agent that can't switch answers on the model it already has.
+        requested_model = config.model if config is not None else None
+        try:
+            await self._apply_model_override(session_id, requested_model)
+        except Exception as exc:  # noqa: BLE001
+            self._model_switch_supported = False
+            logger.warning("acp[%s] model switch failed: %s", self._config.name, exc)
 
         # A fresh ACP session holds no prior context. Captured before the latch
         # flips so we know whether to replay history into this turn.

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -1091,7 +1091,7 @@ class AcpExecutor(Executor):
 
         return events
 
-    def _note_config_options(self, options: object) -> None:
+    def _note_config_options(self, options: object) -> str | None:
         """Record which session config options the agent exposes, and their values.
 
         ACP agents advertise settable options (``mode``, ``model``, …) via
@@ -1099,9 +1099,14 @@ class AcpExecutor(Executor):
         switch is possible at all; tracking ``model``'s ``currentValue`` is the
         only trustworthy record of which model is live — an agent's own
         self-report is unreliable.
+
+        :returns: The echoed ``model`` ``currentValue`` when the payload carried a
+            model option, else ``None`` — lets a caller distinguish "the agent
+            reported its model" from "no model option present".
         """
         if not isinstance(options, list):
-            return
+            return None
+        model_value: str | None = None
         for opt in options:
             if not isinstance(opt, dict):
                 continue
@@ -1113,6 +1118,8 @@ class AcpExecutor(Executor):
                 current = opt.get("currentValue")
                 if isinstance(current, str) and current:
                     self._active_model = current
+                    model_value = current
+        return model_value
 
     async def _apply_model_override(self, session_id: str, model: str | None) -> None:
         """Warm-switch the agent's model via ACP ``session/set_config_option``.
@@ -1157,14 +1164,23 @@ class AcpExecutor(Executor):
                 response["error"].get("message", response["error"]),
             )
             return
-        # The agent echoes its options back; trust that over our request so
-        # ``_active_model`` reflects what the agent actually holds.
+        # The agent echoes its options back; trust the echoed ``currentValue``
+        # over our request, since an agent may normalize or silently reject the
+        # id. Fall back to the requested model only when the agent echoed no model
+        # option at all (some accept the switch without echoing options) — never
+        # overwrite an echoed value with the request, or a later turn would skip a
+        # switch it should retry.
         result = response.get("result")
-        if isinstance(result, dict):
+        echoed_model = (
             self._note_config_options(result.get("configOptions"))
-        if self._active_model != model:
+            if isinstance(result, dict)
+            else None
+        )
+        if echoed_model is None:
             self._active_model = model
-        logger.info("acp[%s] model switched to %s (transcript kept)", self._config.name, model)
+        logger.info(
+            "acp[%s] model set to %s (transcript kept)", self._config.name, self._active_model
+        )
 
     async def run_turn(
         self,
@@ -1227,8 +1243,10 @@ class AcpExecutor(Executor):
                     )
                 break
 
-        # On a fresh session, replay prior conversation so a model switch (which
-        # respawns the subprocess) or a session reset doesn't drop the thread.
+        # On a fresh session, replay prior conversation so a subprocess restart
+        # (after the agent process exits) or a session reset doesn't drop the
+        # thread. A ``/model`` switch no longer respawns — it reconfigures the
+        # live session (see ``_apply_model_override``) — so it never reaches here.
         if fresh_session and latest_user_idx is not None and latest_user_idx > 0:
             history_prefix = self._history_prefix(messages[:latest_user_idx])
             user_text = f"{history_prefix}\n\nuser: {user_text}" if user_text else history_prefix

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -285,6 +285,124 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
 
 
 # ---------------------------------------------------------------------------
+# warm model switch (session/set_config_option)
+# ---------------------------------------------------------------------------
+
+
+def _model_option(current: str, *values: str) -> dict:
+    """A ``config_option_update`` payload advertising a settable model."""
+    return {
+        "sessionUpdate": "config_option_update",
+        "configOptions": [
+            {
+                "id": "model",
+                "currentValue": current,
+                "options": [{"value": v} for v in values],
+            }
+        ],
+    }
+
+
+def test_config_option_update_records_options_and_active_model() -> None:
+    """
+    The agent's ``currentValue`` is the only trustworthy record of the live model.
+
+    **What breaks if this fails**: we'd re-request a switch already in effect, or
+    trust the model's own self-report — which lies (Devin reported ``FAMILY=SWE``
+    after a confirmed switch to Gemini).
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium", "swe-1-7-medium", "gemini-3-1-pro"))
+    assert ex._active_model == "swe-1-7-medium"
+    assert "model" in ex._config_option_ids
+
+
+@pytest.mark.asyncio
+async def test_model_override_switches_warm_via_set_config_option() -> None:
+    """
+    A new model is applied with ``session/set_config_option`` using ``configId``.
+
+    ``configId`` is the parameter name the agent expects; ``optionId`` fails with
+    ``missing field 'configId'``. The session is NOT recreated, so the transcript
+    survives the switch.
+
+    **What breaks if this fails**: ``/model`` silently does nothing mid-session,
+    or the switch drops the conversation by respawning.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_rpc(method, params, timeout=30.0):
+        calls.append((method, params))
+        return {"result": {"configOptions": [{"id": "model", "currentValue": params["value"]}]}}
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "gemini-3-1-pro-low")
+
+    assert calls == [
+        (
+            "session/set_config_option",
+            {"sessionId": "s1", "configId": "model", "value": "gemini-3-1-pro-low"},
+        )
+    ]
+    assert ex._active_model == "gemini-3-1-pro-low"
+
+
+@pytest.mark.asyncio
+async def test_model_override_noops_when_already_active_or_unset() -> None:
+    """No redundant round-trip when the model is unchanged or unspecified."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+    ex._rpc = AsyncMock()  # type: ignore[assignment]
+
+    await ex._apply_model_override("s1", None)
+    await ex._apply_model_override("s1", "swe-1-7-medium")
+    ex._rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_override_skipped_when_agent_has_no_model_option() -> None:
+    """
+    An agent advertising options but no ``model`` one is left alone.
+
+    **What breaks if this fails**: every turn sends a doomed request to agents
+    that simply don't support switching (goose, kilocode, …).
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(
+        {"sessionUpdate": "config_option_update", "configOptions": [{"id": "mode"}]}
+    )
+    ex._rpc = AsyncMock()  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "some-model")
+    ex._rpc.assert_not_awaited()
+    assert ex._model_switch_supported is False
+
+
+@pytest.mark.asyncio
+async def test_model_override_rejection_latches_off_and_does_not_raise() -> None:
+    """
+    A rejected switch is logged and disabled, never fatal.
+
+    **What breaks if this fails**: an agent that doesn't implement
+    ``session/set_config_option`` fails the whole turn instead of answering on
+    the model it already has.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("m1"))
+    ex._rpc = AsyncMock(return_value={"error": {"code": -32601, "message": "unsupported"}})  # type: ignore[assignment]
+
+    await ex._apply_model_override("s1", "m2")
+    assert ex._model_switch_supported is False
+    assert ex._active_model == "m1"  # unchanged
+
+    # Latched off: a later turn must not retry.
+    ex._rpc.reset_mock()
+    await ex._apply_model_override("s1", "m3")
+    ex._rpc.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # interrupt → session/cancel
 # ---------------------------------------------------------------------------
 

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -402,6 +402,62 @@ async def test_model_override_rejection_latches_off_and_does_not_raise() -> None
     ex._rpc.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_model_override_trusts_echoed_value_over_request() -> None:
+    """
+    When the agent echoes a ``currentValue`` that differs from the request, we
+    record the echo — not the request.
+
+    An agent may normalize the id or silently keep its current model while still
+    returning success. ``currentValue`` is the only trustworthy record, so
+    ``_active_model`` must reflect it. Because the request was not actually
+    reached, the next turn must be free to retry it.
+
+    **What breaks if this fails**: ``_active_model`` reflects a model the agent
+    never switched to, so a later ``/model`` for the requested id is wrongly
+    skipped as already-active.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+
+    async def fake_rpc(method, params, timeout=30.0):
+        # Agent accepts the call but reports a different (normalized) id.
+        return {"result": {"configOptions": [{"id": "model", "currentValue": "gemini-3-1-pro"}]}}
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "gemini-3-1-pro-low")
+
+    # Echo wins over the request.
+    assert ex._active_model == "gemini-3-1-pro"
+    # The requested id was not reached, so a later turn still attempts it.
+    calls: list[str] = []
+
+    async def tracking_rpc(method, params, timeout=30.0):
+        calls.append(params["value"])
+        return {"result": {"configOptions": [{"id": "model", "currentValue": params["value"]}]}}
+
+    ex._rpc = tracking_rpc  # type: ignore[assignment]
+    await ex._apply_model_override("s1", "gemini-3-1-pro-low")
+    assert calls == ["gemini-3-1-pro-low"]
+
+
+@pytest.mark.asyncio
+async def test_model_override_falls_back_to_request_when_no_option_echoed() -> None:
+    """
+    When the agent accepts the switch but echoes no model option, record the
+    requested model.
+
+    **What breaks if this fails**: ``_active_model`` is left stale after a
+    successful switch, so the same switch is re-requested every turn.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(_model_option("swe-1-7-medium"))
+    ex._rpc = AsyncMock(return_value={"result": {}})  # type: ignore[assignment]
+
+    await ex._apply_model_override("s1", "gemini-3-1-pro-low")
+    assert ex._active_model == "gemini-3-1-pro-low"
+
+
 # ---------------------------------------------------------------------------
 # interrupt → session/cancel
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

No filed issue — found while testing `/model` against a real ACP agent.

## Summary

**`/model` silently did nothing for a running ACP agent.** The pick reached the
executor as `ExecutorConfig.model` (see the comment in
`runtime/harnesses/_executor_adapter.py`: "threaded into cfg.model so the inner
executor's per-turn precedence picks it up") but `AcpExecutor.run_turn` ignored the
whole `config` argument. The agent kept running whatever model it launched with
until the process was respawned — and respawning costs the conversation.

ACP standardises `session/set_config_option`, so switch the **live** session
instead: the agent keeps its context and the new model applies from that turn on.

- Track the session config options the agent advertises via `config_option_update`,
  and gate the switch on it exposing a `model` option.
- `currentValue` from that notification is also the only trustworthy record of which
  model is live — an agent's own self-report is not. Measured: Devin reported
  `FAMILY=SWE` *after* a confirmed switch to Gemini.
- A rejection latches the feature off for the process instead of re-requesting every
  turn, and never fails the turn: an agent that cannot switch should still answer on
  the model it has.

Note for anyone implementing against this: the parameter is **`configId`**, not
`optionId` — the latter fails with ``missing field `configId` ``.

**Effort comes along for free** on agents that encode it in the model id
(`swe-1-7-medium`, `gpt-5-3-codex-xhigh`, `gemini-3-1-pro-low`), since effort is
then just a model pick.

## Test Plan

- New tests in `tests/inner/test_acp_executor.py`: `config_option_update` records
  options and the active model; a new model switches via `session/set_config_option`
  with the right param name; no redundant round-trip when unchanged or unset; agents
  advertising options but no `model` one are left alone; a rejection latches off and
  does not raise (and does not retry on a later turn).
- `pytest tests/inner/test_acp_executor.py tests/runtime/test_acp_spawn_env.py tests/test_acp_cli_harnesses.py` → **80 passed**.
- `ruff check` / `ruff format` clean.

**Manual verification against a real `devin acp`**, driving the real `AcpExecutor`
with `ExecutorConfig(model=...)` — exactly what a REPL `/model` pick produces:

```
turn 1 (no override)     active_model='swe-1-7-medium'   plants token PAPAYA-31
turn 2 (/model swe-1-7)  active_model='swe-1-7'          reply: "PAPAYA-31"

model actually switched: True      (from config_option_update.currentValue)
transcript survived:     True
```

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered what unit tests cannot: whether a real third-party ACP
agent actually applies `session/set_config_option` and keeps its transcript across
the switch. The mocked tests pin the request shape and every fallback; the live run
above pins the behaviour.

One deliberate limitation, documented in the code rather than guessed at: clearing
the override (`/model default` / `reset`) does **not** revert an ACP agent to its
launch model. A cleared override arrives as `None`, which is treated as "leave the
model alone" — inventing revert semantics for an agent that owns its own model
selection seemed worse than doing nothing predictable.

## Changelog

`/model` now switches an ACP agent's model mid-conversation instead of being ignored, and keeps the chat history
