### PR TITLE
feat: add token-budget policy for token usage enforcement

### DIFF
--- a/omnigent/policies/builtins/token_budget.py
+++ b/omnigent/policies/builtins/token_budget.py
@@ -1,0 +1,261 @@
+"""Built-in token-budget policy.
+
+A single factory, :func:`token_budget`, that gates a session on its
+cumulative LLM token usage at the **request** phase (before the LLM
+turn, so text-only turns are budgeted too) and the **tool-call** phase
+(the point a native ``PreToolUse`` hook can block before the action
+runs):
+
+- ``ask_thresholds_tokens`` (optional, soft, **request + tool-call
+  phases**): a list of warning checkpoints. The first time the session's
+  cumulative tokens cross each checkpoint, the turn (request phase) or
+  the tool call (tool-call phase) is parked for user approval (ASK).
+  Each checkpoint prompts at most once *per approval* — the
+  highest-approved checkpoint is remembered in ``session_state``, so
+  approving lets usage continue to the next checkpoint. A decline blocks
+  that one turn / tool call but does not record the checkpoint, so the
+  next request or tool call over the same threshold re-asks until
+  approved. (Both phases have a server-side approval round-trip that
+  applies the ASK's ``state_updates`` only on accept — the request
+  phase parks the whole turn before it reaches the model, so text-only
+  turns are warned too.)
+- ``max_tokens`` (optional, hard, **request + tool-call phases**): once
+  cumulative usage reaches this, the policy DENYs, blocking the whole
+  turn at the request phase, or each tool call. Both phases have a
+  server-side approval round-trip.
+
+It reads cumulative token usage from ``event["context"]["usage"]``,
+summing ``input_tokens`` + ``output_tokens`` + ``cache_read_input_tokens``
++ ``cache_creation_input_tokens`` (to reflect actual token consumption
+at the model, even though cached reads are billed at a lower rate). When
+token usage is not reported by the executor, the gate **fails closed**
+by ASKing, so operators can decide whether to allow unmetered spend.
+
+**Why tokens, not cost**: Cost budgets (``cost_budget``) depend on
+catalog pricing, and ACP agents' models frequently have none, so cost
+cannot enforce there. Tokens are the vendor-neutral fallback, measuring
+actual LLM consumption regardless of pricing availability.
+
+**Additive behavior**: With no budget configured, behavior is identical
+to today for every harness. The policy is stateless, firing only on
+configured thresholds.
+
+**Advisory, not a hard cap**: Executors self-report usage; an executor
+that reports nothing cannot be metered. This gate surfaces that
+unavailability explicitly (ASK for approval) rather than silently
+treating missing usage as zero consumption.
+
+YAML usage::
+
+    policies:
+      token_budget:
+        type: function
+        function:
+          path: omnigent.policies.builtins.token_budget.token_budget
+          arguments:
+            max_tokens: 200000
+            ask_thresholds_tokens: [100000, 150000]
+
+The factory must be referenced via ``function: {path, arguments}`` with
+a non-empty ``arguments`` block (the registry declares it
+``kind: "factory"``).
+"""
+
+from __future__ import annotations
+
+from omnigent.policies.schema import (
+    PolicyCallable,
+    PolicyEvent,
+    PolicyResponse,
+)
+
+_ALLOW: PolicyResponse = {"result": "ALLOW"}
+
+# session_state key recording the highest ``ask_thresholds_tokens``
+# checkpoint the user has already approved continuing past (a token
+# count; 0 when none). Set when an ASK is approved so each checkpoint
+# prompts at most once. Shared with the engine, which routes it to the
+# ROOT conversation so the approval covers the whole spawn tree (the
+# budget is per-session, but a sub-agent runs as its own conversation).
+_ASK_APPROVED_KEY = "token_budget_ask_approved"
+
+# Phases the budget gate fires on. ``tool_call`` is the native
+# ``PreToolUse`` block point; ``request`` runs before the LLM turn so
+# text-only turns (no tool call) are budgeted too. Every other phase
+# abstains (ALLOW).
+_GATED_PHASES = frozenset({"request", "tool_call"})
+
+
+def _session_tokens(event: PolicyEvent) -> int:
+    """Read cumulative session tokens from a policy event.
+
+    Sums input_tokens + output_tokens + cache_read_input_tokens +
+    cache_creation_input_tokens (to reflect actual token consumption at
+    the model, even though cached reads are billed at a lower rate).
+    Falls back to reading ``total_tokens`` when available. Defensively
+    handles malformed usage payloads.
+
+    :param event: Policy event dict.
+    :returns: ``total_tokens`` or the sum of components (int >= 0).
+    """
+    context = event.get("context") or {}
+    usage = context.get("usage") or {}
+
+    # Try explicit total_tokens first.
+    if "total_tokens" in usage:
+        raw = usage.get("total_tokens")
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            pass
+
+    # Sum all components: input + output + cached reads.
+    try:
+        input_tk = int(usage.get("input_tokens", 0))
+        output_tk = int(usage.get("output_tokens", 0))
+        cache_read_tk = int(usage.get("cache_read_input_tokens", 0))
+        cache_create_tk = int(usage.get("cache_creation_input_tokens", 0))
+        return max(0, input_tk + output_tk + cache_read_tk + cache_create_tk)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _usage_has_tokens(usage: dict[str, object]) -> bool:
+    """Return whether the usage dict contains any token data.
+
+    Returns True when at least one of the token counters is present and
+    non-zero (input_tokens, output_tokens, total_tokens,
+    cache_read_input_tokens, cache_creation_input_tokens).
+
+    :param usage: The usage dict from ``event["context"]["usage"]``.
+    :returns: True when token data is present.
+    """
+    return bool(
+        usage.get("input_tokens")
+        or usage.get("output_tokens")
+        or usage.get("total_tokens")
+        or usage.get("cache_read_input_tokens")
+        or usage.get("cache_creation_input_tokens")
+    )
+
+
+def token_budget(
+    max_tokens: int | None = None,
+    ask_thresholds_tokens: list[int] | None = None,
+) -> PolicyCallable:
+    """Factory: gate a session on cumulative LLM token usage.
+
+    The hard limit (when set) gates BOTH the ``request`` phase (blocking
+    the whole turn before the LLM runs, so text-only turns are budgeted
+    too) and the ``tool_call`` phase: once the limit is reached, DENY.
+    The soft warning checkpoints (ASK "continue?"; recorded on approve so
+    they don't re-prompt, re-asked after a decline) fire on BOTH the
+    ``request`` and ``tool_call`` phases — both have a server-side
+    approval round-trip (see ``evaluate``). Abstains (ALLOW) on every
+    other phase and whenever usage is not available.
+
+    :param max_tokens: Optional hard limit in tokens. Once cumulative
+        session tokens reach this, the whole turn (request phase) or each
+        tool call (tool_call phase) is DENYed. Must be ``> 0`` if
+        provided. Either this or *ask_thresholds_tokens* must be set.
+    :param ask_thresholds_tokens: Optional soft warning checkpoints in
+        tokens, e.g. ``[50000, 100000]``. Each ASKs for approval the
+        first time cumulative tokens cross it (approval remembered via
+        ``session_state``, so an approved checkpoint prompts at most
+        once; a decline blocks the one turn / tool call and re-asks next
+        time). ``None`` or ``[]`` disables the soft gate. Every value must
+        be ``> 0`` and strictly less than *max_tokens* when both are set.
+        Order does not matter — they are sorted internally.
+    :returns: A policy callable implementing the token budget gate.
+    :raises ValueError: If neither *max_tokens* nor *ask_thresholds_tokens*
+        is provided, *max_tokens* is not positive, any
+        *ask_thresholds_tokens* value is not in ``(0, max_tokens)`` when
+        both are set.
+    """
+    if max_tokens is None and not ask_thresholds_tokens:
+        raise ValueError("token_budget requires max_tokens and/or ask_thresholds_tokens")
+    if max_tokens is not None and max_tokens <= 0:
+        raise ValueError(f"max_tokens must be > 0, got {max_tokens!r}")
+    thresholds = sorted({int(t) for t in (ask_thresholds_tokens or [])})
+    for t in thresholds:
+        if max_tokens is not None and not (0 < t < max_tokens):
+            raise ValueError(
+                f"each ask_thresholds_tokens value must be in "
+                f"(0, max_tokens={max_tokens}), got {t!r}"
+            )
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Evaluate the session token budget for a request or tool call.
+
+        Gates the ``request`` phase (before the LLM turn, so text-only
+        turns are budgeted too) and the ``tool_call`` phase (the native
+        ``PreToolUse`` block) — abstains on every other phase.
+
+        - ``tokens >= max_tokens`` → DENY (block turn / tool call).
+          This hard gate runs on BOTH gated phases.
+        - the highest soft checkpoint newly crossed and not yet
+          approved → ASK ("continue?") carrying a ``state_updates``
+          write of the crossed value, applied only on approve so the
+          checkpoint (and lower ones) won't re-prompt once approved.
+          This soft gate runs on BOTH gated phases: each has a
+          server-side approval round-trip that parks the turn (request)
+          or tool call (tool_call) and persists the ASK's
+          ``state_updates`` only on accept. Firing on ``request`` means
+          text-only turns are warned too, and the recorded checkpoint
+          stops the first tool call of the same turn from re-asking.
+
+        :param event: Policy event dict.
+        :returns: DENY when over budget; ASK when a new soft checkpoint
+            is newly crossed; ALLOW otherwise.
+        """
+        phase = event.get("type")
+        if not isinstance(phase, str) or phase not in _GATED_PHASES:
+            return _ALLOW
+        context = event.get("context") or {}
+        usage = context.get("usage") or {}
+        if not _usage_has_tokens(usage):
+            # Fail closed: no usage data available.
+            return {
+                "result": "ASK",
+                "reason": (
+                    "No token usage was reported for this turn. "
+                    "The token budget cannot be enforced without usage data. "
+                    "Approve to continue without budget enforcement, or request "
+                    "a configuration change to ensure usage is reported."
+                ),
+            }
+        tokens = _session_tokens(event)
+        if max_tokens is not None and tokens >= max_tokens:
+            return {
+                "result": "DENY",
+                "reason": f"Token budget exceeded: {tokens:,} tokens reached the hard limit "
+                f"of {max_tokens:,} tokens.",
+            }
+        if thresholds:
+            # Highest checkpoint the tokens have crossed so far.
+            crossed = max((t for t in thresholds if tokens >= t), default=None)
+            if crossed is not None:
+                state = event.get("session_state") or {}
+                approved_value = state.get(_ASK_APPROVED_KEY, 0)
+                approved_up_to = (
+                    int(approved_value) if isinstance(approved_value, int | float | str) else 0
+                )
+                if crossed > approved_up_to:
+                    limit_str = f" (limit {max_tokens:,})" if max_tokens is not None else ""
+                    return {
+                        "result": "ASK",
+                        "reason": (
+                            f"Session tokens {tokens:,} passed the {crossed:,} "
+                            f"warning threshold{limit_str}. Continue?"
+                        ),
+                        # Applied only on approve → this and every lower
+                        # checkpoint won't re-prompt; higher ones still will.
+                        # A declined ASK leaves this unset, so the next
+                        # request or tool call over the same threshold re-asks.
+                        "state_updates": [
+                            {"key": _ASK_APPROVED_KEY, "action": "set", "value": crossed},
+                        ],
+                    }
+        return _ALLOW
+
+    return evaluate

--- a/omnigent/policies/builtins/token_budget.py
+++ b/omnigent/policies/builtins/token_budget.py
@@ -63,6 +63,8 @@ a non-empty ``arguments`` block (the registry declares it
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from omnigent.policies.schema import (
     PolicyCallable,
     PolicyEvent,
@@ -86,14 +88,32 @@ _ASK_APPROVED_KEY = "token_budget_ask_approved"
 _GATED_PHASES = frozenset({"request", "tool_call"})
 
 
+def _as_int(value: object) -> int:
+    """Coerce a usage counter (statically ``object``) to a non-negative int.
+
+    Usage values may be missing, ``None``, or non-numeric on a malformed
+    payload, so narrow before ``int()`` rather than catching at the call site.
+    ``bool`` is an ``int`` subclass but never a token count, so it maps to 0.
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return max(0, int(value))
+    if isinstance(value, str):
+        try:
+            return max(0, int(value))
+        except ValueError:
+            return 0
+    return 0
+
+
 def _session_tokens(event: PolicyEvent) -> int:
     """Read cumulative session tokens from a policy event.
 
-    Sums input_tokens + output_tokens + cache_read_input_tokens +
-    cache_creation_input_tokens (to reflect actual token consumption at
-    the model, even though cached reads are billed at a lower rate).
-    Falls back to reading ``total_tokens`` when available. Defensively
-    handles malformed usage payloads.
+    Prefers ``total_tokens`` when present; otherwise sums input_tokens +
+    output_tokens + cache_read_input_tokens + cache_creation_input_tokens (to
+    reflect actual consumption at the model, even though cached reads are
+    billed at a lower rate). Malformed values coerce to 0.
 
     :param event: Policy event dict.
     :returns: ``total_tokens`` or the sum of components (int >= 0).
@@ -101,26 +121,18 @@ def _session_tokens(event: PolicyEvent) -> int:
     context = event.get("context") or {}
     usage = context.get("usage") or {}
 
-    # Try explicit total_tokens first.
     if "total_tokens" in usage:
-        raw = usage.get("total_tokens")
-        try:
-            return max(0, int(raw))
-        except (TypeError, ValueError):
-            pass
+        return _as_int(usage.get("total_tokens"))
 
-    # Sum all components: input + output + cached reads.
-    try:
-        input_tk = int(usage.get("input_tokens", 0))
-        output_tk = int(usage.get("output_tokens", 0))
-        cache_read_tk = int(usage.get("cache_read_input_tokens", 0))
-        cache_create_tk = int(usage.get("cache_creation_input_tokens", 0))
-        return max(0, input_tk + output_tk + cache_read_tk + cache_create_tk)
-    except (TypeError, ValueError):
-        return 0
+    return (
+        _as_int(usage.get("input_tokens"))
+        + _as_int(usage.get("output_tokens"))
+        + _as_int(usage.get("cache_read_input_tokens"))
+        + _as_int(usage.get("cache_creation_input_tokens"))
+    )
 
 
-def _usage_has_tokens(usage: dict[str, object]) -> bool:
+def _usage_has_tokens(usage: Mapping[str, object]) -> bool:
     """Return whether the usage dict contains any token data.
 
     Returns True when at least one of the token counters is present and

--- a/tests/spec/test_token_budget_policy.py
+++ b/tests/spec/test_token_budget_policy.py
@@ -189,9 +189,7 @@ class TestTokenBudgetPolicy:
 
     def test_allows_below_soft_threshold(self) -> None:
         """ALLOW when below soft threshold."""
-        evaluator = token_budget(
-            max_tokens=100000, ask_thresholds_tokens=[50000, 75000]
-        )
+        evaluator = token_budget(max_tokens=100000, ask_thresholds_tokens=[50000, 75000])
         event = {
             "type": "request",
             "context": {"usage": {"total_tokens": 25000}},
@@ -270,9 +268,7 @@ class TestTokenBudgetPolicy:
 
     def test_hard_limit_takes_precedence_over_soft(self) -> None:
         """Hard limit DENY takes precedence when both would fire."""
-        evaluator = token_budget(
-            max_tokens=100000, ask_thresholds_tokens=[50000]
-        )
+        evaluator = token_budget(max_tokens=100000, ask_thresholds_tokens=[50000])
         event = {
             "type": "request",
             "context": {"usage": {"total_tokens": 100000}},
@@ -324,9 +320,7 @@ class TestTokenBudgetPolicy:
 
     def test_multiple_soft_thresholds_sorted(self) -> None:
         """Multiple soft thresholds are sorted and checked in order."""
-        evaluator = token_budget(
-            max_tokens=200000, ask_thresholds_tokens=[100000, 50000, 150000]
-        )
+        evaluator = token_budget(max_tokens=200000, ask_thresholds_tokens=[100000, 50000, 150000])
         event = {
             "type": "request",
             "context": {"usage": {"total_tokens": 75000}},

--- a/tests/spec/test_token_budget_policy.py
+++ b/tests/spec/test_token_budget_policy.py
@@ -1,0 +1,396 @@
+"""Tests for the built-in token-budget policy.
+
+What breaks if these tests fail:
+- Token budget enforcement (soft warnings, hard blocks)
+- Soft checkpoint approval tracking
+- Handling of missing/unavailable usage data
+- Policy factory validation
+- REQUEST and TOOL_CALL phase firing
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.policies.builtins.token_budget import (
+    _session_tokens,
+    _usage_has_tokens,
+    token_budget,
+)
+
+
+class TestSessionTokens:
+    """Test token extraction from policy events."""
+
+    def test_read_total_tokens_when_present(self) -> None:
+        """Uses explicit total_tokens when available."""
+        event = {"context": {"usage": {"total_tokens": 1500}}}
+        assert _session_tokens(event) == 1500
+
+    def test_read_sum_of_input_and_output(self) -> None:
+        """Sums input_tokens + output_tokens when total_tokens absent."""
+        event = {"context": {"usage": {"input_tokens": 1000, "output_tokens": 500}}}
+        assert _session_tokens(event) == 1500
+
+    def test_includes_cached_reads(self) -> None:
+        """Includes cache_read_input_tokens in the sum."""
+        event = {
+            "context": {
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 500,
+                    "cache_read_input_tokens": 200,
+                }
+            }
+        }
+        assert _session_tokens(event) == 1700
+
+    def test_includes_cache_creation(self) -> None:
+        """Includes cache_creation_input_tokens in the sum."""
+        event = {
+            "context": {
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 500,
+                    "cache_creation_input_tokens": 100,
+                }
+            }
+        }
+        assert _session_tokens(event) == 1600
+
+    def test_prefers_total_tokens_over_sum(self) -> None:
+        """total_tokens takes precedence even when components present."""
+        event = {
+            "context": {
+                "usage": {
+                    "total_tokens": 2000,
+                    "input_tokens": 1000,
+                    "output_tokens": 500,
+                    "cache_read_input_tokens": 100,
+                }
+            }
+        }
+        assert _session_tokens(event) == 2000
+
+    def test_handles_missing_usage(self) -> None:
+        """Returns 0 when no usage data present."""
+        event = {"context": {}}
+        assert _session_tokens(event) == 0
+
+    def test_handles_malformed_usage(self) -> None:
+        """Defaults to 0 on type errors."""
+        event = {"context": {"usage": {"total_tokens": "not_a_number"}}}
+        assert _session_tokens(event) == 0
+
+    def test_negative_tokens_clamped_to_zero(self) -> None:
+        """Negative token counts are clamped to 0."""
+        event = {"context": {"usage": {"total_tokens": -100}}}
+        assert _session_tokens(event) == 0
+
+
+class TestUsageHasTokens:
+    """Test usage availability detection."""
+
+    def test_returns_true_when_total_tokens_present(self) -> None:
+        """Detects total_tokens."""
+        usage = {"total_tokens": 500}
+        assert _usage_has_tokens(usage) is True
+
+    def test_returns_true_when_input_tokens_present(self) -> None:
+        """Detects input_tokens."""
+        usage = {"input_tokens": 100}
+        assert _usage_has_tokens(usage) is True
+
+    def test_returns_true_when_output_tokens_present(self) -> None:
+        """Detects output_tokens."""
+        usage = {"output_tokens": 200}
+        assert _usage_has_tokens(usage) is True
+
+    def test_returns_true_when_cache_read_present(self) -> None:
+        """Detects cache_read_input_tokens."""
+        usage = {"cache_read_input_tokens": 50}
+        assert _usage_has_tokens(usage) is True
+
+    def test_returns_true_when_cache_creation_present(self) -> None:
+        """Detects cache_creation_input_tokens."""
+        usage = {"cache_creation_input_tokens": 75}
+        assert _usage_has_tokens(usage) is True
+
+    def test_returns_false_when_no_usage(self) -> None:
+        """Returns False when usage dict absent."""
+        usage = {}
+        assert _usage_has_tokens(usage) is False
+
+    def test_returns_false_when_all_tokens_zero(self) -> None:
+        """Returns False when all token counts are 0."""
+        usage = {
+            "total_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        }
+        assert _usage_has_tokens(usage) is False
+
+
+class TestTokenBudgetFactory:
+    """Test the token_budget factory function."""
+
+    def test_factory_returns_callable(self) -> None:
+        """Factory returns a callable."""
+        evaluator = token_budget(max_tokens=100000)
+        assert callable(evaluator)
+
+    def test_factory_validates_on_construction(self) -> None:
+        """Factory validates config at construction time."""
+        with pytest.raises(ValueError, match="requires max_tokens and/or ask_thresholds_tokens"):
+            token_budget()
+
+    def test_max_tokens_must_be_positive(self) -> None:
+        """Raises when max_tokens <= 0."""
+        with pytest.raises(ValueError, match="max_tokens must be > 0"):
+            token_budget(max_tokens=0)
+
+    def test_ask_thresholds_must_be_positive(self) -> None:
+        """Raises when thresholds contain non-positive values."""
+        with pytest.raises(ValueError):
+            token_budget(ask_thresholds_tokens=[0, 100000], max_tokens=200000)
+
+    def test_thresholds_must_be_below_hard_limit(self) -> None:
+        """Raises when threshold >= hard limit."""
+        with pytest.raises(ValueError, match="must be in"):
+            token_budget(ask_thresholds_tokens=[100000, 200000], max_tokens=100000)
+
+
+class TestTokenBudgetPolicy:
+    """Test token budget policy evaluation."""
+
+    def test_allows_on_non_gated_phases(self) -> None:
+        """Abstains (ALLOW) on non-gated phases."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {"type": "response", "context": {"usage": {"total_tokens": 50000}}}
+        result = evaluator(event)
+        assert result["result"] == "ALLOW"
+
+    def test_asks_when_usage_unavailable_on_request(self) -> None:
+        """Fails closed (ASK) when no usage data on request phase."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {"type": "request", "context": {"usage": {}}}
+        result = evaluator(event)
+        assert result["result"] == "ASK"
+        assert "usage" in result["reason"].lower()
+
+    def test_asks_when_usage_unavailable_on_tool_call(self) -> None:
+        """Fails closed (ASK) when no usage data on tool_call phase."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {"type": "tool_call", "context": {"usage": {}}}
+        result = evaluator(event)
+        assert result["result"] == "ASK"
+
+    def test_allows_below_soft_threshold(self) -> None:
+        """ALLOW when below soft threshold."""
+        evaluator = token_budget(
+            max_tokens=100000, ask_thresholds_tokens=[50000, 75000]
+        )
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 25000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "ALLOW"
+
+    def test_asks_at_soft_threshold_request_phase(self) -> None:
+        """ASK when crossing soft threshold on request phase."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 50000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "ASK"
+        assert "crossed" in result["reason"].lower() or "passed" in result["reason"].lower()
+
+    def test_asks_at_soft_threshold_tool_call_phase(self) -> None:
+        """ASK when crossing soft threshold on tool_call phase."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "tool_call",
+            "context": {"usage": {"total_tokens": 50000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "ASK"
+
+    def test_soft_threshold_not_re_asked_after_approval(self) -> None:
+        """Soft checkpoint not re-asked after approval."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 50000}},
+            "session_state": {"token_budget_ask_approved": 50000},
+        }
+        result = evaluator(event)
+        assert result["result"] == "ALLOW"
+
+    def test_denies_at_hard_limit_request_phase(self) -> None:
+        """DENY when reaching hard limit on request phase."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 100000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "DENY"
+        assert "exceeded" in result["reason"].lower() or "reached" in result["reason"].lower()
+
+    def test_denies_at_hard_limit_tool_call_phase(self) -> None:
+        """DENY when reaching hard limit on tool_call phase."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "tool_call",
+            "context": {"usage": {"total_tokens": 100000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "DENY"
+
+    def test_denies_above_hard_limit(self) -> None:
+        """DENY when exceeding hard limit."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 150000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "DENY"
+
+    def test_hard_limit_takes_precedence_over_soft(self) -> None:
+        """Hard limit DENY takes precedence when both would fire."""
+        evaluator = token_budget(
+            max_tokens=100000, ask_thresholds_tokens=[50000]
+        )
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 100000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "DENY"
+
+    def test_soft_only_no_hard_limit(self) -> None:
+        """Policy works with only soft thresholds (no hard limit)."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 100000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        # Exceeds soft threshold, so ASK (no hard limit to DENY)
+        assert result["result"] == "ASK"
+
+    def test_hard_only_no_soft_thresholds(self) -> None:
+        """Policy works with only hard limit (no soft thresholds)."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 100000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "DENY"
+
+    def test_token_count_from_components(self) -> None:
+        """Correctly sums token components."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "request",
+            "context": {
+                "usage": {
+                    "input_tokens": 60000,
+                    "output_tokens": 50000,
+                    "cache_read_input_tokens": 0,
+                }
+            },
+            "session_state": {},
+        }
+        result = evaluator(event)
+        # 60k + 50k = 110k, which >= 100k, so should DENY
+        assert result["result"] == "DENY"
+
+    def test_multiple_soft_thresholds_sorted(self) -> None:
+        """Multiple soft thresholds are sorted and checked in order."""
+        evaluator = token_budget(
+            max_tokens=200000, ask_thresholds_tokens=[100000, 50000, 150000]
+        )
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 75000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        # Crosses the 50000 threshold (the lowest one <= 75000)
+        assert result["result"] == "ASK"
+        assert "50000" in result["reason"] or "50,000" in result["reason"]
+
+    def test_soft_threshold_re_asks_on_decline(self) -> None:
+        """Soft threshold re-asks if not approved."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 60000}},
+            "session_state": {"token_budget_ask_approved": 0},
+        }
+        result = evaluator(event)
+        # Crosses 50000 threshold, not approved (approved_up_to=0), so ASK
+        assert result["result"] == "ASK"
+
+    def test_handles_malformed_state(self) -> None:
+        """Handles malformed session_state gracefully."""
+        evaluator = token_budget(max_tokens=100000)
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 50000}},
+            "session_state": {"token_budget_ask_approved": "not_a_number"},
+        }
+        result = evaluator(event)
+        # Should treat malformed state as 0 and allow
+        assert result["result"] == "ALLOW"
+
+    def test_includes_all_cached_token_types(self) -> None:
+        """Token count includes all cached read types."""
+        evaluator = token_budget(max_tokens=100)
+        event = {
+            "type": "request",
+            "context": {
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 30,
+                    "cache_creation_input_tokens": 25,
+                }
+            },
+            "session_state": {},
+        }
+        result = evaluator(event)
+        # 30 + 20 + 30 + 25 = 105, which >= 100, so should DENY
+        assert result["result"] == "DENY"
+
+    def test_state_updates_on_ask(self) -> None:
+        """ASK includes state_updates for approved checkpoint."""
+        evaluator = token_budget(ask_thresholds_tokens=[50000])
+        event = {
+            "type": "request",
+            "context": {"usage": {"total_tokens": 50000}},
+            "session_state": {},
+        }
+        result = evaluator(event)
+        assert result["result"] == "ASK"
+        assert result["state_updates"] is not None
+        assert len(result["state_updates"]) == 1
+        assert result["state_updates"][0]["key"] == "token_budget_ask_approved"
+        assert result["state_updates"][0]["value"] == 50000


### PR DESCRIPTION
## Summary

Implement a **token budget** policy primitive that warns (ASK) at soft thresholds and blocks (DENY) at a hard limit based on cumulative reported token usage in a session.

**Why tokens, not cost**: Cost budgets (`cost_budget`) depend on catalog pricing. ACP agents' models frequently have no catalog pricing, so cost cannot enforce there. Tokens are the vendor-neutral fallback — measuring actual LLM consumption regardless of pricing availability.

This change implements a policy factory that mirrors `cost_budget`'s design:
- Fires on **REQUEST** phase (before LLM turn, text-only turns budgeted) and **TOOL_CALL** phase (native PreToolUse hook point)
- Supports `ask_thresholds_tokens` (list of soft warning checkpoints) and `max_tokens` (hard limit)
- Accumulates token usage from `event["context"]["usage"]` (sums input + output + cache reads to reflect actual model consumption)
- Remembers approved checkpoints in session_state so soft thresholds prompt at most once per approval
- **Fails closed** (ASK) when token usage is unavailable, surfacing that explicitly rather than silently treating missing usage as zero
- **Additive**: with no budget configured, behavior identical to today for all harnesses
- **Advisory, not a hard cap**: executors self-report usage; an executor reporting nothing cannot be metered

## Implementation Details

**Design**: Built on existing policy/state machinery (FunctionPolicy, StateUpdate, session_state) with no new subsystems.

**Configuration** (YAML):
```yaml
guardrails:
  policies:
    token_budget:
      type: function
      function:
        path: omnigent.policies.builtins.token_budget.token_budget
        arguments:
          max_tokens: 200000
          ask_thresholds_tokens: [100000, 150000]
```

**Session State Keys**:
- `token_budget_ask_approved`: Highest soft checkpoint the user approved (int; routed to ROOT conversation so approvals cover spawn tree)

**Token Accounting**:
- Sums `input_tokens` + `output_tokens` + `cache_read_input_tokens` + `cache_creation_input_tokens` (reflecting actual token consumption at model, even though cached reads bill at lower rate)
- Falls back to explicit `total_tokens` if present
- Defensive against malformed/missing usage data

**Behavior**:
- Hard limit (DENY): blocks turn/tool call when cumulative tokens >= hard limit on REQUEST/TOOL_CALL phases
- Soft checkpoints (ASK): warns when crossing each threshold, recorded on approval so re-asks only if exceeded again after decline
- Missing usage: ASKs for approval before allowing unmetered spend

## Test Plan

- ✅ 39 unit tests covering:
  - Token extraction from payloads (total_tokens, component sum, cached tokens)
  - Usage availability detection (all token types)
  - Factory validation (limits positive, thresholds below hard limit)
  - Soft checkpoint tracking and re-asking on decline
  - Hard limit enforcement on both gated phases
  - State management and state_updates
  - Malformed payload handling
- ✅ All tests pass; all spec tests pass (611 total)
- ✅ Ruff lint clean

## Type of change

- [x] New feature (non-breaking addition)
- [x] Tests added
- [ ] Breaking change
- [ ] Documentation update

## Test coverage

- [x] Unit tests added
- [x] Not applicable

## Coverage notes

**Deferred to follow-up**:
- **Integration tests** (engine + policy interaction): The policy is self-contained and tested in isolation. Integration tests would verify engine invocation on REQUEST/TOOL_CALL phases; that belongs in the engine test suite.
- **E2E with harnesses**: Requires live harness deployment and real executor token reporting. Better served by focused E2E test suite once policy is wired to engine.
- **Multiple soft thresholds (list support)**: Already implemented and tested (3 new tests verify list sorting and multi-threshold behavior).

**No filed issue**: This is a spec follow-up to the larger token-budget task.

**Demo**: N/A (policy behavior visible only through approval prompts in session; not visual).

## What breaks if this fails

- Token budget soft warnings (ASK) don't fire
- Hard token limits don't block turns / tool calls
- Soft checkpoint approval tracking lost
- Missing usage not surfaced to user
- Policy fails closed unexpectedly or silently passes through
