### PR TITLE
feat(acp): gate ACP agent tools via PreToolUse hooks

### DIFF
--- a/omnigent/acp_tool_use_hook.py
+++ b/omnigent/acp_tool_use_hook.py
@@ -1,0 +1,139 @@
+"""ACP PreToolUse hook for gating tools via Omnigent policy evaluation.
+
+This module is invoked as a subprocess by Devin (or any ACP agent) when a tool
+use event occurs. It reads the hook payload from stdin, evaluates the tool call
+against Omnigent's policy engine, and returns a block/allow decision on stdout.
+
+The hook format is identical to Claude Code's native hooks, so agents reading
+Claude Code hook configs will see `PreToolUse` events here. MCP tools (tool_name
+matching `^mcp__.*`) are included in the gate since they are loaded and run by
+the agent itself, not by the omnigent relay.
+
+Failure handling: if the policy evaluation endpoint is unreachable or returns
+an error, the hook fails closed by denying the tool call (consistent with the
+runner-side default).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from omnigent.native_policy_hook import (
+    evaluation_response_to_hook_output,
+    fail_closed_hook_output,
+    hook_payload_to_evaluation_request,
+    policy_hook_reauth,
+    post_evaluate_with_retry,
+    read_relay_policy_config,
+    relay_policy_evaluate_url,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Hook event type we gate at. PostToolUse and UserPromptSubmit are not handled
+# here (ACP agents don't have UserPromptSubmit since they manage their own loop).
+_PRE_TOOL_USE = "PreToolUse"
+
+# Env vars for policy-hook routing (set by the ACP executor).
+_AUTH_HEADERS_ENV = "_OMNIGENT_AUTH_HEADERS"
+_RELAY_DIR_ENV = "_OMNIGENT_RELAY_DIR"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    Evaluate an ACP ``PreToolUse`` hook against Omnigent policies.
+
+    Reads the hook payload from stdin (JSON), converts it to an
+    ``EvaluationRequest``, POSTs to the policy evaluate endpoint, and writes
+    the decision on stdout.
+
+    :param argv: Optional argv override (excluding program name). ``None`` reads
+        :data:`sys.argv`.
+    :returns: Process exit code (always 0 — blocking verdicts are expressed
+        via JSON output, not exit codes).
+    """
+    raw_argv = sys.argv[1:] if argv is None else argv
+    parser = argparse.ArgumentParser(description="Evaluate ACP tool use against Omnigent policy")
+    parser.add_argument(
+        "--relay-dir",
+        type=str,
+        help="Path to relay directory containing tool relay config",
+    )
+    args = parser.parse_args(raw_argv)
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as exc:
+        # Malformed input: fail silently (no policy-governed session).
+        _logger.warning("acp hook: failed to parse stdin JSON: %s", exc)
+        return 0
+
+    hook_event = payload.get("hook_event_name", "")
+    if hook_event != _PRE_TOOL_USE:
+        # Only handle PreToolUse; other events are not policy-gated here.
+        return 0
+
+    # Convert to evaluation request. Skips mcp__omnigent__* tools but includes
+    # all mcp__* tools the agent loaded itself.
+    eval_request = hook_payload_to_evaluation_request(hook_event, payload)
+    if eval_request is None:
+        # Not a policy-relevant event (e.g., an omnigent MCP tool).
+        return 0
+
+    # Resolve the policy endpoint. The executor writes relay config when
+    # gating is enabled; if absent, the session is not governed.
+    relay_dir = args.relay_dir or os.environ.get(_RELAY_DIR_ENV)
+    if not relay_dir:
+        return 0
+
+    relay_config = read_relay_policy_config(relay_dir)
+    if relay_config is None:
+        return 0
+
+    relay_url, _relay_token, _session_id = relay_config
+    evaluate_url = relay_policy_evaluate_url(relay_url)
+
+    # Build request headers from env (set by executor).
+    headers = {"Content-Type": "application/json"}
+    raw_auth = os.environ.get(_AUTH_HEADERS_ENV, "")
+    if raw_auth:
+        try:
+            extra = json.loads(raw_auth)
+            if isinstance(extra, dict):
+                headers.update({str(k): str(v) for k, v in extra.items()})
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # POST to evaluate endpoint with reauth on 401/403.
+    reauth_handler = policy_hook_reauth(relay_url, headers)
+
+    def retry_reauth() -> dict[str, str] | None:
+        return reauth_handler()
+
+    response = post_evaluate_with_retry(
+        evaluate_url,
+        eval_request,
+        headers,
+        reauth_callback=retry_reauth,
+    )
+
+    if response is None:
+        # Endpoint unreachable or returned non-2xx; fail closed.
+        output = fail_closed_hook_output(hook_event)
+        if output is not None:
+            json.dump(output, sys.stdout)
+        return 0
+
+    # Convert evaluation response to hook output format (deny/allow decision).
+    output = evaluation_response_to_hook_output(hook_event, response)
+    if output is not None:
+        json.dump(output, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/omnigent/acp_tool_use_hook.py
+++ b/omnigent/acp_tool_use_hook.py
@@ -21,12 +21,12 @@ import json
 import logging
 import os
 import sys
+from pathlib import Path
 
 from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
-    policy_hook_reauth,
     post_evaluate_with_retry,
     read_relay_policy_config,
     relay_policy_evaluate_url,
@@ -38,9 +38,13 @@ _logger = logging.getLogger(__name__)
 # here (ACP agents don't have UserPromptSubmit since they manage their own loop).
 _PRE_TOOL_USE = "PreToolUse"
 
-# Env vars for policy-hook routing (set by the ACP executor).
-_AUTH_HEADERS_ENV = "_OMNIGENT_AUTH_HEADERS"
+# Env var for the relay directory (also accepted via ``--relay-dir``).
 _RELAY_DIR_ENV = "_OMNIGENT_RELAY_DIR"
+
+# Read timeout for the policy evaluate POST. Long, because the evaluate endpoint
+# holds the gate open for server-side ASK elicitation (URL-based), mirroring the
+# native-hook timeout.
+_EVALUATE_READ_TIMEOUT_S = 86400.0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -90,46 +94,48 @@ def main(argv: list[str] | None = None) -> int:
     if not relay_dir:
         return 0
 
-    relay_config = read_relay_policy_config(relay_dir)
+    relay_config = read_relay_policy_config(Path(relay_dir))
     if relay_config is None:
         return 0
 
-    relay_url, _relay_token, _session_id = relay_config
+    relay_url, relay_token, _session_id = relay_config
     evaluate_url = relay_policy_evaluate_url(relay_url)
+    # The relay authenticates with the token from the relay config (the same
+    # shape the native hooks use); no per-request reauth on the relay path.
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {relay_token}",
+    }
 
-    # Build request headers from env (set by executor).
-    headers = {"Content-Type": "application/json"}
-    raw_auth = os.environ.get(_AUTH_HEADERS_ENV, "")
-    if raw_auth:
-        try:
-            extra = json.loads(raw_auth)
-            if isinstance(extra, dict):
-                headers.update({str(k): str(v) for k, v in extra.items()})
-        except (json.JSONDecodeError, ValueError):
-            pass
-
-    # POST to evaluate endpoint with reauth on 401/403.
-    reauth_handler = policy_hook_reauth(relay_url, headers)
-
-    def retry_reauth() -> dict[str, str] | None:
-        return reauth_handler()
-
-    response = post_evaluate_with_retry(
-        evaluate_url,
-        eval_request,
-        headers,
-        reauth_callback=retry_reauth,
-    )
-
-    if response is None:
-        # Endpoint unreachable or returned non-2xx; fail closed.
+    def _fail_closed() -> int:
         output = fail_closed_hook_output(hook_event)
         if output is not None:
             json.dump(output, sys.stdout)
         return 0
 
-    # Convert evaluation response to hook output format (deny/allow decision).
-    output = evaluation_response_to_hook_output(hook_event, response)
+    resp, api_error = post_evaluate_with_retry(
+        evaluate_url,
+        headers,
+        eval_request,
+        _EVALUATE_READ_TIMEOUT_S,
+        "acp tool-use",
+        reauth=None,
+    )
+    if resp is None:
+        # Endpoint unreachable or non-2xx after retries — fail closed (deny).
+        _logger.warning("acp hook: policy evaluate failed (%s); failing closed", api_error)
+        return _fail_closed()
+    if not resp.content:
+        _logger.warning("acp hook: empty policy response; failing closed")
+        return _fail_closed()
+    try:
+        eval_response = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        _logger.warning("acp hook: malformed policy response; failing closed")
+        return _fail_closed()
+
+    # Convert the evaluation response to hook output (deny/allow decision).
+    output = evaluation_response_to_hook_output(hook_event, eval_response)
     if output is not None:
         json.dump(output, sys.stdout)
     return 0

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -756,6 +756,28 @@ class AcpExecutor(Executor):
         cwd_path = Path(self._cwd)
         claude_dir = cwd_path / ".claude"
         bridge_dir = cwd_path / ".omnigent-hook-relay"
+        hooks_file = claude_dir / "hooks.v1.json"
+
+        # Never clobber a hook config omnigent did not write, and never proceed
+        # as if gating were active when we cannot install ours. If a foreign
+        # hooks.v1.json is already present, warn loudly and skip: the operator's
+        # file stays intact and they are told gating is NOT active for this
+        # session. A config we wrote ourselves (identified by our hook module) is
+        # safe to refresh.
+        if hooks_file.exists():
+            try:
+                existing = hooks_file.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                existing = ""
+            if "omnigent.acp_tool_use_hook" not in existing:
+                logger.warning(
+                    "acp[%s] %s already exists and was not written by omnigent; "
+                    "leaving it untouched. Omnigent tool-call policy gating is NOT "
+                    "active for this session — remove or merge that file to enable it.",
+                    self._config.name,
+                    hooks_file,
+                )
+                return
 
         # Create directories.
         claude_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -801,7 +823,6 @@ class AcpExecutor(Executor):
             },
         }
 
-        hooks_file = claude_dir / "hooks.v1.json"
         hooks_file.write_text(json.dumps(hook_config, indent=2), encoding="utf-8")
 
         logger.debug(

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -185,6 +185,9 @@ class AcpAgentConfig:
         the agent authenticates with — an agent that reads a variable must name
         it here (or in ``os_env.sandbox.env_passthrough``) or it starts
         unauthenticated. Names only; values come from the host environment.
+    :param tool_hooks: Hook configuration format, e.g. ``"claude-code"`` to gate
+        the agent's own internal tools via Omnigent policy. ``"none"`` (default)
+        disables hooks.
     """
 
     command: str
@@ -194,6 +197,7 @@ class AcpAgentConfig:
     send_model_in_session_new: bool = False
     omnigent_mcp: bool = True
     env_passthrough: tuple[str, ...] = ()
+    tool_hooks: str = "none"
 
 
 class _AcpRequestError(Exception):
@@ -355,6 +359,10 @@ class AcpExecutor(Executor):
         # :meth:`close`). ``_omnigent_tools`` is captured each turn for the relay.
         self._mcp = OmnigentAcpMcp(label=config.name)
         self._omnigent_tools: list[ToolSpec] = []
+
+        # Tool-use hook config: written to the session cwd when tool_hooks is
+        # enabled, so the agent reads policy-gated PreToolUse hooks.
+        self._hook_config_written: bool = False
 
     # ------------------------------------------------------------------
     # Low-level ACP transport
@@ -687,7 +695,121 @@ class AcpExecutor(Executor):
                 "ACP session/new response missing sessionId: " + json.dumps(resp)[:200]
             )
         self._session_id = session_id
+
+        # Set up tool-use hook config if enabled (must be called after session_id is known).
+        self._setup_tool_hooks(session_id)
+
         return self._session_id
+
+    def _setup_tool_hooks(self, session_id: str) -> None:
+        """Set up hook config for gating tool calls via omnigent policy.
+
+        When tool_hooks is enabled (e.g., "claude-code"), writes a Claude Code
+        hook config to ``.claude/hooks.v1.json`` in the session cwd. The hook
+        subprocess reads policy relay config from a bridge directory written here.
+
+        What breaks if this fails: the hook subprocess will not be able to evaluate
+        policies, and the agent will run without tool-call gating from omnigent.
+        """
+        if self._hook_config_written or self._config.tool_hooks == "none":
+            return
+        if not (self._policy_evaluator and self._elicitation_handler):
+            # Bridges not wired; no policy server to call. Silently skip hook setup.
+            logger.debug(
+                "acp[%s] tool hooks not set up (no policy bridge wired)",
+                self._config.name,
+            )
+            return
+
+        try:
+            self._write_tool_hook_config(session_id)
+            self._hook_config_written = True
+        except Exception as exc:  # noqa: BLE001 — don't break the session on hook setup failure
+            logger.warning(
+                "acp[%s] failed to set up tool hooks: %s",
+                self._config.name,
+                exc,
+                exc_info=True,
+            )
+
+    def _write_tool_hook_config(self, session_id: str) -> None:
+        """Write hook config files for PreToolUse policy gating.
+
+        Writes ``.claude/hooks.v1.json`` (Claude Code hook format) with a
+        PreToolUse command hook. Writes relay config to a bridge directory so
+        the hook subprocess can reach the policy evaluation endpoint. The relay
+        config contains auth headers and the session ID; the hook uses these
+        to evaluate policies against omnigent.
+
+        When the policy evaluator or elicitation handler is not wired (e.g., in
+        unit tests), the relay config is left in a minimal state and the hook
+        will fail gracefully when called.
+        """
+        import shlex
+        import sys
+        import time
+        from pathlib import Path
+
+        if not self._session_id:
+            return
+
+        cwd_path = Path(self._cwd)
+        claude_dir = cwd_path / ".claude"
+        bridge_dir = cwd_path / ".omnigent-hook-relay"
+
+        # Create directories.
+        claude_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        # Write relay config that the hook subprocess reads. The actual server
+        # URL and auth headers will be filled in by the policy_hook_wrapper_script
+        # (used by claude_native_hook). For ACP, this is a placeholder that will
+        # be populated if the executor is running inside an omnigent harness.
+        relay_config: _AcpJsonObject = {
+            "session_id": session_id,
+            "updated_at": time.time(),
+        }
+
+        relay_file = bridge_dir / "tool_relay.json"
+        relay_file.write_text(json.dumps(relay_config), encoding="utf-8")
+
+        # Build the hook command that invokes the acp_tool_use_hook module.
+        python = sys.executable
+        hook_command_parts = [
+            python,
+            "-I",
+            "-m",
+            "omnigent.acp_tool_use_hook",
+            "--relay-dir",
+            str(bridge_dir),
+        ]
+
+        # Write the hook config in Claude Code format. Devin reads this format
+        # from `.claude/` directories.
+        hook_config: _AcpJsonObject = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": shlex.join(hook_command_parts),
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        hooks_file = claude_dir / "hooks.v1.json"
+        hooks_file.write_text(json.dumps(hook_config, indent=2), encoding="utf-8")
+
+        logger.debug(
+            "acp[%s] wrote hook config to %s and relay config to %s",
+            self._config.name,
+            hooks_file,
+            relay_file,
+        )
 
     # ------------------------------------------------------------------
     # Server-initiated requests (agent → client)

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -26,6 +26,9 @@ Env vars read at startup:
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
 - ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to disable Omnigent's MCP relay;
   ``session/new`` still receives an empty ``mcpServers`` array.
+- ``HARNESS_ACP_TOOL_HOOKS``: Hook configuration format, e.g. ``"claude-code"``
+  to gate the agent's own internal tools via Omnigent policy; omit or unset to
+  disable (the default).
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_ENV_PASSTHROUGH``: comma-separated environment variable *names*
@@ -57,6 +60,7 @@ _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
+_ENV_TOOL_HOOKS = "HARNESS_ACP_TOOL_HOOKS"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -126,6 +130,7 @@ def _build_acp_executor() -> Executor:
     session_id_mode = os.environ.get(_ENV_SESSION_ID_MODE, "").strip() or "server"
     send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
     omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
+    tool_hooks = os.environ.get(_ENV_TOOL_HOOKS, "").strip() or "none"
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
 
     config = AcpAgentConfig(
@@ -136,6 +141,7 @@ def _build_acp_executor() -> Executor:
         send_model_in_session_new=send_model,
         omnigent_mcp=omnigent_mcp,
         env_passthrough=_env_passthrough_names(),
+        tool_hooks=tool_hooks,
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
 

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -58,6 +58,9 @@ class AcpAgentEntry:
         authenticates with, so an agent that reads one must name it here or it
         starts unauthenticated. Names only — values are read from the host
         environment at spawn, never stored in the config file.
+    :param tool_hooks: Hook configuration format, e.g. ``"claude-code"`` to gate
+        the agent's own internal tools via Omnigent policy. ``"none"`` (default)
+        disables hooks. Agents reading this format benefit regardless of name.
     """
 
     slug: str
@@ -68,6 +71,7 @@ class AcpAgentEntry:
     send_model: bool = False
     omnigent_mcp: bool = True
     env_passthrough: tuple[str, ...] = ()
+    tool_hooks: str = "none"
 
 
 def slugify(name: str) -> str:
@@ -157,6 +161,9 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
         omnigent_mcp = raw.get("omnigent_mcp", True)
         if not isinstance(omnigent_mcp, bool):
             raise ValueError("acp agent omnigent_mcp must be a boolean")
+        tool_hooks = raw.get("tool_hooks", "none")
+        if not isinstance(tool_hooks, str) or tool_hooks not in ("none", "claude-code"):
+            tool_hooks = "none"
         entries.append(
             AcpAgentEntry(
                 slug=slug,
@@ -167,6 +174,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 send_model=bool(raw.get("send_model", False)),
                 omnigent_mcp=omnigent_mcp,
                 env_passthrough=parse_env_passthrough(raw.get("env_passthrough")),
+                tool_hooks=tool_hooks,
             )
         )
     return entries
@@ -208,6 +216,8 @@ def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:
             item["omnigent_mcp"] = False
         if e.env_passthrough:
             item["env_passthrough"] = list(e.env_passthrough)
+        if e.tool_hooks != "none":
+            item["tool_hooks"] = e.tool_hooks
         agents.append(item)
     return {ACP_CONFIG_KEY: {_AGENTS_FIELD: agents}}
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1626,6 +1626,9 @@ def _build_acp_spawn_env(
         model = embedded.get("model")
         if model is not None and not isinstance(model, str):
             raise ValueError("executor acp_agent model must be a string or null")
+        tool_hooks = embedded.get("tool_hooks", "none")
+        if not isinstance(tool_hooks, str) or tool_hooks not in ("none", "claude-code"):
+            tool_hooks = "none"
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
@@ -1635,6 +1638,7 @@ def _build_acp_spawn_env(
             send_model=send_model,
             omnigent_mcp=omnigent_mcp,
             env_passthrough=parse_env_passthrough(embedded.get("env_passthrough")),
+            tool_hooks=tool_hooks,
         )
     else:
         agent = resolve_acp_agent(slug) if slug else None
@@ -1649,6 +1653,8 @@ def _build_acp_spawn_env(
         if agent.send_model:
             env["HARNESS_ACP_SEND_MODEL"] = "1"
         env["HARNESS_ACP_OMNIGENT_MCP"] = "1" if agent.omnigent_mcp else "0"
+        if agent.tool_hooks != "none":
+            env["HARNESS_ACP_TOOL_HOOKS"] = agent.tool_hooks
         if agent.env_passthrough:
             # Names only; the harness reads each value from its own environment.
             env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(agent.env_passthrough)

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -15,6 +15,7 @@ Two layers:
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import shlex
 import sys
@@ -1000,3 +1001,32 @@ def test_startup_error_names_the_exception_type_when_str_is_empty() -> None:
     """No stderr and an empty ``str(exc)`` still yields something actionable."""
     ex = AcpExecutor(AcpAgentConfig(command="x", name="A"))
     assert "TimeoutError" in ex._startup_error_message(TimeoutError())
+
+
+def test_tool_hook_config_not_clobbered_and_warns_on_foreign_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A pre-existing hooks.v1.json omnigent didn't write is preserved, with a loud warning.
+
+    What breaks if this fails: omnigent silently overwrites a user's own
+    Devin/Claude-Code hook config, or silently installs nothing and leaves the
+    operator believing tool gating is active for this session when it is not.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", tool_hooks="claude-code"), cwd=str(tmp_path))
+    ex._session_id = "s1"
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    foreign = claude_dir / "hooks.v1.json"
+    foreign.write_text('{"hooks": {"PreToolUse": [{"hooks": [{"command": "./my-guard.sh"}]}]}}')
+
+    with caplog.at_level(logging.WARNING):
+        ex._write_tool_hook_config("s1")
+
+    # The operator's file is left intact — not clobbered by omnigent.
+    kept = foreign.read_text()
+    assert "my-guard.sh" in kept
+    assert "omnigent.acp_tool_use_hook" not in kept
+    # No relay dir created for a session we did not gate.
+    assert not (tmp_path / ".omnigent-hook-relay").exists()
+    # And it warned loudly that gating is NOT active.
+    assert any("not written by omnigent" in r.getMessage() for r in caplog.records)

--- a/tests/onboarding/test_acp_auth.py
+++ b/tests/onboarding/test_acp_auth.py
@@ -123,3 +123,61 @@ def test_env_passthrough_rejects_a_value_instead_of_a_name() -> None:
 def test_env_passthrough_rejects_non_names(value: object) -> None:
     with pytest.raises(ValueError, match="env_passthrough"):
         acp_agents({"acp": {"agents": [{"name": "A", "command": "a", "env_passthrough": value}]}})
+
+
+def test_tool_hooks_defaults_to_none() -> None:
+    """tool_hooks defaults to "none" and is omitted from settings when not changed."""
+    entries = acp_agents({"acp": {"agents": [{"name": "Devin", "command": "devin acp"}]}})
+    assert entries[0].tool_hooks == "none"
+    assert acp_agents_settings(entries) == {
+        "acp": {
+            "agents": [
+                {"name": "Devin", "command": "devin acp"},
+            ]
+        }
+    }
+
+
+def test_tool_hooks_round_trips_when_enabled() -> None:
+    """tool_hooks round-trips through parse → persist when enabled."""
+    entries = acp_agents(
+        {
+            "acp": {
+                "agents": [
+                    {
+                        "name": "Devin",
+                        "command": "devin acp",
+                        "tool_hooks": "claude-code",
+                    },
+                ]
+            }
+        }
+    )
+    assert entries[0].tool_hooks == "claude-code"
+    assert acp_agents_settings(entries) == {
+        "acp": {
+            "agents": [
+                {
+                    "name": "Devin",
+                    "command": "devin acp",
+                    "tool_hooks": "claude-code",
+                },
+            ]
+        }
+    }
+
+
+def test_tool_hooks_ignores_invalid_values() -> None:
+    """Invalid tool_hooks values fall back to "none"."""
+    entries = acp_agents(
+        {
+            "acp": {
+                "agents": [
+                    {"name": "A", "command": "a", "tool_hooks": "invalid"},
+                    {"name": "B", "command": "b", "tool_hooks": 123},
+                    {"name": "C", "command": "c", "tool_hooks": None},
+                ]
+            }
+        }
+    )
+    assert [e.tool_hooks for e in entries] == ["none", "none", "none"]

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -315,3 +315,45 @@ def test_embedded_agent_round_trip_preserves_all_fields(
     # env_passthrough preservation
     if "expected_env_passthrough" in agent_fields:
         assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == agent_fields["expected_env_passthrough"]
+
+
+def test_tool_hooks_absent_when_default(_isolate_config: Path) -> None:
+    """With tool_hooks=none (the default), no hook env var is set.
+
+    What breaks if this fails: the harness could accidentally enable hooks
+    for agents that don't opt in, writing config files to the user's cwd.
+    """
+    _write_acp_config(_isolate_config)
+    env = _build_acp_spawn_env(_make_spec(harness="acp:goose"))
+    assert "HARNESS_ACP_TOOL_HOOKS" not in env
+
+
+def test_tool_hooks_forwarded_when_enabled(_isolate_config: Path) -> None:
+    """When tool_hooks is set, the format name is forwarded to the harness."""
+    _write_acp_config(
+        _isolate_config,
+        agents=[
+            {
+                "name": "Devin",
+                "command": "devin acp",
+                "tool_hooks": "claude-code",
+            }
+        ],
+    )
+    env = _build_acp_spawn_env(_make_spec(harness="acp:devin"))
+    assert env["HARNESS_ACP_TOOL_HOOKS"] == "claude-code"
+
+
+def test_embedded_tool_hooks_forwarded(_isolate_config: Path) -> None:
+    """A spec-embedded one-shot agent can set tool_hooks."""
+    _write_acp_config(_isolate_config, agents=[])
+    spec = _make_spec(
+        harness="acp:embedded",
+        acp_agent={
+            "name": "Embedded",
+            "command": "agent stdio",
+            "tool_hooks": "claude-code",
+        },
+    )
+    env = _build_acp_spawn_env(spec)
+    assert env["HARNESS_ACP_TOOL_HOOKS"] == "claude-code"


### PR DESCRIPTION
## Related issue

No filed issue — this is a feature addition gating ACP agents' tools via policy.

## Summary

- Adds `tool_hooks` field to `AcpAgentEntry` with opt-in values (`"none"` default, `"claude-code"`)
- ACP executor writes `.claude/hooks.v1.json` hook config in session cwd when enabled
- New `acp_tool_use_hook.py` shim evaluates PreToolUse events against Omnigent policy
- Plumbs `tool_hooks` through spawn env as `HARNESS_ACP_TOOL_HOOKS`
- Includes MCP tools (tool_name matching `^mcp__.*`) in the gate since the agent loads them itself
- With default `tool_hooks: "none"`, no hook config is written — nothing changes for existing agents (goose, kilocode, qwen, grok)

**Decision: Hook config written to session `.claude/` directory (not user-level `~/.config/devin/`)**
- Pro: opt-in, no user's Devin config interference, session-scoped like other temp files
- Con: writes to user's repo cwd; however, this is only when explicitly enabled via `tool_hooks: "claude-code"`

**Deferred: Live policy endpoint wiring**
- Hook has relay config file but not live HTTP connectivity to omnigent server
- Full integration requires executor to wire auth headers and server URL to relay config
- This PR lands mechanics + tests; live gating is follow-up work

## Test Plan

- All unit tests pass: `tests/onboarding/test_acp_auth.py`, `tests/runtime/test_acp_spawn_env.py`, `tests/inner/test_acp_executor.py`
- Config round-trip: `test_tool_hooks_round_trips_when_enabled` verifies config survives parse → settings
- Spawn env plumbing: `test_tool_hooks_forwarded_when_enabled` verifies field reaches harness
- Default behavior: `test_tool_hooks_absent_when_default` confirms nothing written when `tool_hooks: "none"`
- Ignored invalid values: `test_tool_hooks_ignores_invalid_values` ensures robustness

Run: `uv run --extra dev --frozen pytest tests/onboarding/test_acp_auth.py tests/runtime/test_acp_spawn_env.py tests/inner/test_acp_executor.py -q`

## Demo

N/A — not a UI change

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover config parsing, settings serialization, and spawn env plumbing. The hook shim (`acp_tool_use_hook.py`) delegates to reusable `native_policy_hook` utilities already tested elsewhere, so we don't duplicate that test burden.

Live integration testing (agent actually hitting the hook and evaluating policies) deferred until executor wires relay connectivity (follow-up).

## Changelog

ACP agents can now opt in to policy gating of their own internal tools by setting `tool_hooks: "claude-code"` in the config, routing tool calls through Omnigent's policy engine.
