### PR TITLE
fix(host): generate host_id when config.yaml provides only a host name

### DIFF
--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -80,6 +80,12 @@ def load_or_create_host_identity(
     ``name`` to the machine's hostname, writes the section back,
     and returns the identity.
 
+    A *partial* host section is completed rather than discarded: a
+    config.yaml that names the host (``host: {name: my-box}``) but
+    omits ``host_id`` keeps that name and only the missing
+    ``host_id`` is generated — the user-provided name is never
+    clobbered by the machine hostname.
+
     Environment override: when :data:`HOST_ID_ENV_VAR` and
     :data:`HOST_NAME_ENV_VAR` are both set (a server-managed sandbox
     host), that identity is returned directly without reading or
@@ -109,17 +115,26 @@ def load_or_create_host_identity(
             cfg = yaml.safe_load(f) or {}
 
     host_section = cfg.get("host")
-    if isinstance(host_section, dict) and "host_id" in host_section and "name" in host_section:
-        return HostIdentity(
-            host_id=_normalize_host_id(host_section["host_id"]),
-            name=host_section["name"],
-        )
+    if not isinstance(host_section, dict):
+        host_section = {}
 
-    host_id = uuid.uuid4().hex
-    name = socket.gethostname()
+    host_id = host_section.get("host_id")
+    name = host_section.get("name")
+
+    # Fully specified: honor the config as-is, nothing to persist.
+    if host_id and name:
+        return HostIdentity(host_id=_normalize_host_id(host_id), name=name)
+
+    # Otherwise complete the section, preserving any provided value and
+    # generating only what's missing, then persist so the identity is
+    # stable across calls.
+    host_id = _normalize_host_id(host_id) if host_id else uuid.uuid4().hex
+    name = name or socket.gethostname()
     identity = HostIdentity(host_id=host_id, name=name)
 
-    cfg["host"] = {"host_id": identity.host_id, "name": identity.name}
+    host_section["host_id"] = identity.host_id
+    host_section["name"] = identity.name
+    cfg["host"] = host_section
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 import signal
+import socket
 import subprocess
 import time
 import uuid
@@ -263,6 +264,102 @@ def test_host_connect_and_list(
     resp = http_client.get(f"/v1/hosts/{host_id}")
     if resp.status_code == 200:
         assert resp.json()["status"] == "offline", "Host should be offline after daemon is killed"
+
+
+def _wait_for_host_online_by_name(
+    client: httpx.Client,
+    host_name: str,
+    timeout: float = 30.0,
+) -> dict[str, object]:
+    """Poll GET /v1/hosts until a host with *host_name* is online.
+
+    Used when the host_id isn't known in advance (the daemon generates it),
+    so the test matches on the seeded name instead.
+
+    :param client: HTTP client pointed at the server.
+    :param host_name: Host name to wait for.
+    :param timeout: Max seconds to wait.
+    :returns: The matching host dict from the list response.
+    :raises AssertionError: If no such host appears online.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = client.get("/v1/hosts")
+            if resp.status_code == 200:
+                for host in resp.json().get("hosts", []):
+                    if host["name"] == host_name and host["status"] == "online":
+                        return host
+        except httpx.ConnectError:
+            pass
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"Host named {host_name!r} did not appear online within {timeout}s")
+
+
+def test_host_name_only_config_generates_host_id(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+    mock_llm_server_url: str,
+) -> None:
+    """
+    A config.yaml that names the host but omits host_id must register
+    end-to-end under the provided name with a freshly generated id.
+
+    Regression for the name-only path: the daemon used to overwrite the
+    chosen name with the machine hostname and mint a fresh id, so the
+    host showed up under the wrong name. It should now keep the name and
+    generate + persist only the missing host_id.
+    """
+    omni_dir = tmp_path / ".omnigent"
+    omni_dir.mkdir(parents=True, exist_ok=True)
+    config_path = omni_dir / "config.yaml"
+    # Unique name so the (owner, name) host row doesn't collide with the
+    # session-scoped server's other host rows.
+    host_name = f"e2e-nameonly-{uuid.uuid4().hex[:12]}"
+    config_path.write_text(
+        yaml.safe_dump({"host": {"name": host_name}}, default_flow_style=False, sort_keys=True)
+    )
+
+    daemon_log = tmp_path / "host-daemon.log"
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+        "OPENAI_API_KEY": "mock-key",
+        PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
+    }
+    with open(daemon_log, "w") as log_fh:
+        proc = subprocess.Popen(
+            [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", live_server],
+            env=apply_runner_env(env),
+            cwd=compat_runner_cwd(),
+            stdout=subprocess.DEVNULL,
+            stderr=log_fh,
+        )
+    try:
+        host = _wait_for_host_online_by_name(http_client, host_name, timeout=30.0)
+        # The provided name survived — not replaced by the machine hostname.
+        assert host["name"] == host_name
+        assert host["name"] != socket.gethostname()
+
+        # The daemon generated + persisted a bare 32-char hex host_id.
+        cfg = yaml.safe_load(config_path.read_text())
+        persisted_id = cfg["host"]["host_id"]
+        assert isinstance(persisted_id, str) and len(persisted_id) == 32
+        int(persisted_id, 16)  # raises ValueError if not valid hex
+        # The name is kept in the persisted config too.
+        assert cfg["host"]["name"] == host_name
+
+        # The registered host_id is exactly what was written to config.yaml.
+        assert host["host_id"] == persisted_id
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
 
 def test_host_launch_runner_and_session_round_trip(

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -291,6 +291,7 @@ def _wait_for_host_online_by_name(
                     if host["name"] == host_name and host["status"] == "online":
                         return host
         except httpx.ConnectError:
+            # The API may be temporarily unreachable during startup; retry until timeout.
             pass
         time.sleep(POLL_INTERVAL_S)
     raise AssertionError(f"Host named {host_name!r} did not appear online within {timeout}s")

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -102,6 +102,52 @@ def test_create_preserves_existing_config(tmp_path: Path) -> None:
     assert data["profile"] == "oss", "Existing 'profile' key should survive host section creation"
 
 
+def test_name_only_config_gets_generated_host_id(tmp_path: Path) -> None:
+    """
+    A config.yaml that names the host but omits host_id should keep the
+    provided name and get a freshly generated host_id — the name must
+    not be clobbered by the machine hostname.
+
+    If the name comes back as the hostname, the partial section was
+    discarded instead of completed.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"server": "http://example.com", "host": {"name": "my-custom-host"}})
+    )
+
+    identity = load_or_create_host_identity(config_path)
+
+    assert identity.name == "my-custom-host", (
+        "provided host name must be preserved, not replaced by the hostname"
+    )
+    assert len(identity.host_id) == 32, "a host_id should be generated when absent"
+    int(identity.host_id, 16)  # raises ValueError if not valid hex
+
+    # The generated id is persisted so it's stable across calls.
+    with open(config_path) as f:
+        data = yaml.safe_load(f)
+    assert data["host"]["host_id"] == identity.host_id
+    assert data["host"]["name"] == "my-custom-host"
+    assert data["server"] == "http://example.com", "existing keys must survive"
+
+
+def test_name_only_config_host_id_stable_across_calls(tmp_path: Path) -> None:
+    """
+    Once a host_id is generated for a name-only config, a second call
+    must return the same id (the persisted section is read, not
+    regenerated).
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"host": {"name": "my-custom-host"}}))
+
+    first = load_or_create_host_identity(config_path)
+    second = load_or_create_host_identity(config_path)
+
+    assert first.host_id == second.host_id
+    assert first.name == second.name == "my-custom-host"
+
+
 def test_env_override_returns_identity_without_touching_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes [OMNI-2427](https://linear.app/omnigent/issue/OMNI-2427/generate-host-id-even-if-host-name-is-provided-via-configyaml) — generate a host id even when a host name is provided via `config.yaml`. (Tracked in Linear; no GitHub issue.)

## Summary

- A self-hoster who hand-writes a `host:` section in `~/.omnigent/config.yaml` to name their machine (`host: {name: my-box}`) but omits `host_id` lost that name: `load_or_create_host_identity` only honored the section when it had **both** `host_id` and `name`, so a name-only section fell through to the create path, which overwrote the chosen name with the machine hostname and minted a fresh id.
- Now a *partial* host section is completed rather than discarded — any provided value is kept, only the missing field is generated, and the result is persisted so the id stays stable across calls.
- This mirrors `set_sandbox_host_name` in the sandbox bootstrap path, which already does `setdefault('host_id', uuid.uuid4().hex)` to fill in the id while preserving the name.

## Test Plan

- Unit — `uv run --extra dev pytest tests/host/test_identity.py -v` — all 8 pass, including two new cases:
  - a name-only config keeps its name and gets a generated 32-char hex `host_id`, persisted alongside existing top-level keys;
  - the generated id is stable across a second call.
- End-to-end (against a booted local server + mock LLM) — `uv run --extra dev python -m pytest tests/e2e/test_host_e2e.py::test_host_connect_and_list tests/e2e/test_host_e2e.py::test_host_name_only_config_generates_host_id -o addopts="" -v` — both pass. The new e2e test seeds a name-only `config.yaml`, spawns the real host daemon, and asserts the host registers via `GET /v1/hosts` under the provided name (not the machine hostname) with a generated `host_id` that matches what the daemon persisted back to `config.yaml`. `test_host_connect_and_list` (which seeds both id + name) still passes, confirming the fully-specified path is unaffected.
- Manual, real `omnigent host` CLI (isolated `HOME`, unreachable `--server` so identity resolves + persists before the connect attempt) — before/after against a name-only `config.yaml`:
  - installed binary (no fix): `name` rewritten to the machine hostname `ip-10-90-37-30`;
  - this branch: prints `Connecting … as 'edwin-realcli-test' (<hex>)` and writes back `host_id: <bare 32-hex>` with `name: edwin-realcli-test` preserved.

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two unit tests cover the name-only path (name preserved + id generated) and its stability across calls. A new e2e test (`test_host_name_only_config_generates_host_id`) exercises the same path through the real host daemon against a booted local server, verifying registration under the provided name and a persisted generated id. Manual verification additionally ran the real `omnigent host` CLI on a name-only config (isolated HOME) and confirmed the before/after in the Test Plan. All run locally and pass.

## Changelog

A host name set in `config.yaml` is now kept when no `host_id` is present — the id is generated instead of overwriting your chosen name.

This pull request and its description were written by Isaac.
