### PR TITLE
fix(electron): show setup error on HTTP 4xx/5xx instead of black screen

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -1055,6 +1055,61 @@ function loadServerUrl(win, serverUrl, routePath) {
 }
 
 /**
+ * Wire server-load failure fallbacks for a shell window.
+ *
+ * @param {BrowserWindow} win
+ */
+function registerNavigationFallbacks(win) {
+  // Server unreachable / DNS failure / TLS error → fall back to the setup
+  // page with the failure shown, instead of stranding the user on Chromium's
+  // raw error surface with no way back. The saved server_url is left intact:
+  // the server may simply be down, and Connect retries it.
+  win.webContents.on(
+    "did-fail-load",
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      if (!isMainFrame) return;
+      if (errorCode === ERR_ABORTED) return;
+      // A failure report for a URL the window is no longer pinned to (the
+      // window was re-pointed while the failing load was in flight) must
+      // not yank the window off its new destination.
+      const failedOrigin = originOf(validatedURL ?? "");
+      if (failedOrigin !== windows.get(win)?.origin) return;
+      const params = new URLSearchParams({
+        error: `${errorDescription || "load failed"} (${errorCode})`,
+        // The failure often happens on a deep SPA route (e.g. /chat/…);
+        // prefill the setup form with just the server origin — that's what
+        // the user connects to — not the full path that happened to fail.
+        url: failedOrigin ? failedOrigin + "/" : (validatedURL ?? ""),
+      });
+      if (windows.get(win)?.ephemeral) params.set("ephemeral", "1");
+      pinWindow(win, null); // back on the setup page → no trusted origin
+      void win.loadFile(SETUP_PAGE, { search: params.toString() });
+    },
+  );
+
+  // HTTP 4xx/5xx commits as a successful navigation in Chromium (empty body
+  // → black window), so did-fail-load never fires. did-navigate is
+  // main-frame-only and carries httpResponseCode; reuse the setup-page
+  // fallback so the user sees the status and can change server / retry.
+  win.webContents.on("did-navigate", (_event, url, httpResponseCode, httpStatusText) => {
+    if (httpResponseCode < 400) return;
+    const state = windows.get(win);
+    const failedOrigin = originOf(url ?? "");
+    if (failedOrigin !== state?.origin) return;
+    const status = httpStatusText
+      ? `${httpResponseCode} ${httpStatusText}`
+      : `HTTP ${httpResponseCode}`;
+    const params = new URLSearchParams({
+      error: status,
+      url: state.serverUrl ?? url ?? "",
+    });
+    if (state.ephemeral) params.set("ephemeral", "1");
+    pinWindow(win, null);
+    void win.loadFile(SETUP_PAGE, { search: params.toString() });
+  });
+}
+
+/**
  * Create a shell window and load a destination, in priority order:
  *   1. `opts.path` joined onto `opts.serverUrl` (a deep link opening a
  *      specific conversation on a specific server).
@@ -1248,32 +1303,7 @@ function createWindow(targetUrl, opts = {}) {
   // Fires only for window.open the handler above allowed (OAuth popups).
   win.webContents.on("did-create-window", (child) => hardenOauthPopup(child));
 
-  // Server unreachable / DNS failure / TLS error → fall back to the setup
-  // page with the failure shown, instead of stranding the user on Chromium's
-  // raw error surface with no way back. The saved server_url is left intact:
-  // the server may simply be down, and Connect retries it.
-  win.webContents.on(
-    "did-fail-load",
-    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
-      if (!isMainFrame) return;
-      if (errorCode === ERR_ABORTED) return;
-      // A failure report for a URL the window is no longer pinned to (the
-      // window was re-pointed while the failing load was in flight) must
-      // not yank the window off its new destination.
-      const failedOrigin = originOf(validatedURL ?? "");
-      if (failedOrigin !== windows.get(win)?.origin) return;
-      const params = new URLSearchParams({
-        error: `${errorDescription || "load failed"} (${errorCode})`,
-        // The failure often happens on a deep SPA route (e.g. /chat/…);
-        // prefill the setup form with just the server origin — that's what
-        // the user connects to — not the full path that happened to fail.
-        url: failedOrigin ? failedOrigin + "/" : (validatedURL ?? ""),
-      });
-      if (windows.get(win)?.ephemeral) params.set("ephemeral", "1");
-      pinWindow(win, null); // back on the setup page → no trusted origin
-      void win.loadFile(SETUP_PAGE, { search: params.toString() });
-    },
-  );
+  registerNavigationFallbacks(win);
 
   // Databricks workspace-hosted Omnigent renders inside the workspace's
   // top-nav chrome (the SPA is a workspace page). On a dedicated desktop

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -18,13 +18,204 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
+const fs = require("node:fs");
+const os = require("node:os");
+const { createRequire } = require("node:module");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 const preloadSource = readFileSync(path.join(__dirname, "../src/preload.js"), "utf8");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
 const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+function loadNavigationHarness({
+  serverUrl = "https://host.example/ml/omnigents",
+  registerFallbacks = true,
+} = {}) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-navigation-test-"));
+  const listeners = new Map();
+  const calls = { loadFile: [] };
+  const appEvents = new Map();
+  const webContents = {
+    on(eventName, listener) {
+      listeners.set(eventName, listener);
+    },
+    emit(eventName, ...args) {
+      listeners.get(eventName)?.({}, ...args);
+    },
+    getURL: () => serverUrl,
+    setWindowOpenHandler: () => {},
+  };
+  const win = {
+    webContents,
+    contentView: { addChildView: () => {}, removeChildView: () => {} },
+    isDestroyed: () => false,
+    isMaximized: () => false,
+    getNormalBounds: () => ({ x: 0, y: 0, width: 1280, height: 860 }),
+    getPosition: () => [0, 0],
+    setPosition: () => {},
+    maximize: () => {},
+    on: () => {},
+    loadFile: (...args) => {
+      calls.loadFile.push(args);
+      return Promise.resolve();
+    },
+    loadURL: () => Promise.resolve(),
+  };
+
+  function createDesktopUpdater() {
+    return {
+      init() {},
+      registerIpc() {},
+      getConfig: () => ({ mode: "none", autoInstall: false, skippedVersion: null }),
+      getStatus: () => ({ state: "idle" }),
+      checkForUpdates: async () => {},
+      installUpdateNow: () => false,
+      quitAndInstallIfPending: () => false,
+    };
+  }
+
+  const electron = {
+    app: {
+      isPackaged: false,
+      getPath: () => userData,
+      setName: () => {},
+      setBadgeCount: () => true,
+      requestSingleInstanceLock: () => true,
+      on: (eventName, listener) => appEvents.set(eventName, listener),
+      whenReady: () => ({ then: () => {} }),
+      quit: () => {},
+      exit: () => {},
+      isReady: () => false,
+      setAsDefaultProtocolClient: () => {},
+      setAppUserModelId: () => {},
+      getVersion: () => "test",
+    },
+    BrowserWindow: Object.assign(
+      function BrowserWindow() {
+        return win;
+      },
+      {
+        fromWebContents: () => null,
+        getFocusedWindow: () => null,
+        getAllWindows: () => [],
+      },
+    ),
+    WebContentsView: function WebContentsView() {},
+    Menu: { buildFromTemplate: () => ({}), setApplicationMenu: () => {} },
+    Notification: { isSupported: () => false },
+    clipboard: { writeText: () => {} },
+    dialog: {},
+    ipcMain: { handle: () => {}, on: () => {} },
+    nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+    nativeTheme: { shouldUseDarkColors: false, on: () => {} },
+    screen: {},
+    session: { defaultSession: {} },
+    shell: {},
+    systemPreferences: {},
+  };
+
+  const localRequires = {
+    "./desktop_updater": { createDesktopUpdater },
+    "./update_overlay": {
+      createUpdateOverlay: () => ({ ensureOverlay: () => {}, registerIpc: () => {} }),
+    },
+    "./localhost_cors": { registerLocalhostCors: () => {} },
+    "./url": {
+      normalizeUrl: (url) => url,
+      expandDatabricksWorkspaceUrl: async (url) => url,
+      fetchServerManifest: async () => ({}),
+      PRE_MANIFEST_BASELINE: {},
+    },
+    "./deepLink": {
+      parseOmnigentDeepLink: () => null,
+      chooseDeepLinkStrategy: () => null,
+    },
+    "./workspace-chrome": { registerWorkspaceChromeHide: () => {} },
+    "./browserViewRegistry": {
+      createBrowserViewRegistry: () => ({ closeAll: () => {} }),
+    },
+    "./browserViewBounds": {
+      createBrowserViewBoundsController: () => ({ attach: () => {}, detach: () => {} }),
+    },
+    "./browserIpc": { registerBrowserIpc: () => {} },
+    "./session-expiry": { registerSessionExpiryReload: () => {} },
+    "./popupPolicy": {
+      decideWindowOpen: () => ({ kind: "ignore" }),
+      stripCrossOriginOpenerHeaders: () => {},
+      WEB_SCHEMES: new Set(),
+    },
+    "./omnigent_cli": {
+      isExecutableFile: () => false,
+      resolveCliPath: () => null,
+      localHostId: () => "host_test",
+      getCliStatus: () => ({ installed: false }),
+    },
+    "./server_manager": {
+      shutdown: async () => {},
+      onChange: () => {},
+      ensureServerAuth: async () => ({ ok: true }),
+      ensureHostConnected: async () => ({ ok: true }),
+      restartHost: async () => ({ ok: true }),
+      disconnectHost: async () => ({ ok: true }),
+      startLocalServer: async () => ({ ok: false }),
+    },
+  };
+
+  const mainPath = path.join(__dirname, "../src/main.js");
+  const mainRequire = createRequire(mainPath);
+  const source =
+    fs.readFileSync(mainPath, "utf8") +
+    "\nmodule.exports.testApi = { createWindow, registerNavigationFallbacks, windows, SETUP_PAGE };";
+  const module = { exports: {} };
+  const sandbox = {
+    __dirname: path.dirname(mainPath),
+    __filename: mainPath,
+    AbortController,
+    AbortSignal,
+    Buffer,
+    URL,
+    URLSearchParams,
+    clearInterval,
+    clearTimeout,
+    console,
+    module,
+    process: { ...process, env: { ...process.env } },
+    require: (specifier) => {
+      if (specifier === "electron") return electron;
+      if (specifier === "electron-updater") return { autoUpdater: {} };
+      if (specifier in localRequires) return localRequires[specifier];
+      return mainRequire(specifier);
+    },
+    setInterval,
+    setTimeout,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: mainPath });
+  const api = module.exports.testApi;
+  api.windows.set(win, {
+    origin: new URL(serverUrl).origin,
+    serverUrl,
+    ephemeral: false,
+    badgeCount: 0,
+    browserRegistry: { closeAll: () => {} },
+  });
+  if (registerFallbacks) api.registerNavigationFallbacks(win);
+
+  return {
+    api,
+    calls,
+    emit: (eventName, ...args) => webContents.emit(eventName, ...args),
+    hasListener: (eventName) => listeners.has(eventName),
+    win,
+    cleanup: () => {
+      api.windows.clear();
+      fs.rmSync(userData, { recursive: true, force: true });
+    },
+  };
+}
 
 describe("setup clipboard IPC wiring", () => {
   it("exposes a narrow copy action through the setup bridge", () => {
@@ -85,6 +276,22 @@ describe("workspace chrome injection wiring (src/main.js)", () => {
         "injecting on every load is a safe no-op elsewhere. See src/workspace-chrome.js.",
       ].join(" "),
     );
+  });
+});
+
+describe("navigation fallback wiring (src/main.js)", () => {
+  it("registers navigation fallbacks when createWindow builds a window", () => {
+    const harness = loadNavigationHarness({ registerFallbacks: false });
+
+    const win = harness.api.createWindow("https://host.example/ml/omnigents");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents/", 503, "Unavailable");
+
+    assert.equal(win, harness.win);
+    assert.equal(harness.hasListener("did-fail-load"), true);
+    assert.equal(harness.hasListener("did-navigate"), true);
+    assert.equal(harness.calls.loadFile.length, 1);
+    assert.equal(harness.calls.loadFile[0][0], harness.api.SETUP_PAGE);
+    harness.cleanup();
   });
 });
 
@@ -380,6 +587,80 @@ describe("deep-link ingestion wiring (src/main.js)", () => {
         "confirmOpenDeepLink (in the consent-unknown branch), not before chooseDeepLinkStrategy.",
       ].join(" "),
     );
+  });
+});
+
+// HTTP 4xx/5xx commits as a successful Chromium navigation (empty body → black
+// window against backgroundColor), so did-fail-load never fires. did-navigate
+// carries httpResponseCode for main-frame navigations — fall back to setup
+// with ?error=&url= the same way the net-error path does.
+describe("HTTP error status fallback (src/main.js)", () => {
+  it("routes a 404 to the setup error surface with the mounted server URL", (t) => {
+    const harness = loadNavigationHarness();
+    t.after(harness.cleanup);
+
+    harness.emit("did-navigate", "https://host.example/ml/omnigents/health", 404, "Not Found");
+
+    assert.equal(harness.calls.loadFile.length, 1);
+    assert.equal(harness.calls.loadFile[0][0], harness.api.SETUP_PAGE);
+    const params = new URLSearchParams(harness.calls.loadFile[0][1].search);
+    assert.equal(params.get("error"), "404 Not Found");
+    assert.equal(params.get("url"), "https://host.example/ml/omnigents");
+  });
+
+  it("routes a 503 to the same setup error surface", (t) => {
+    const harness = loadNavigationHarness();
+    t.after(harness.cleanup);
+
+    harness.emit("did-navigate", "https://host.example/ml/omnigents/", 503, "Service Unavailable");
+
+    assert.equal(harness.calls.loadFile.length, 1);
+    const params = new URLSearchParams(harness.calls.loadFile[0][1].search);
+    assert.equal(params.get("error"), "503 Service Unavailable");
+    assert.equal(params.get("url"), "https://host.example/ml/omnigents");
+  });
+
+  it("does not fall back for successful or redirect navigations", (t) => {
+    const harness = loadNavigationHarness();
+    t.after(harness.cleanup);
+
+    harness.emit("did-navigate", "https://host.example/ml/omnigents/", 200, "OK");
+    harness.emit("did-navigate", "https://host.example/ml/omnigents/login", 302, "Found");
+
+    assert.deepEqual(harness.calls.loadFile, []);
+  });
+
+  it("ignores a duplicate failure after the first fallback unpins the window", (t) => {
+    const harness = loadNavigationHarness();
+    t.after(harness.cleanup);
+
+    const failedUrl = "https://host.example/ml/omnigents/health";
+    harness.emit("did-navigate", failedUrl, 503, "Service Unavailable");
+
+    assert.equal(harness.api.windows.get(harness.win).origin, null);
+    // Unpinning makes the origin guard reject re-entry.
+    harness.emit("did-navigate", failedUrl, 503, "Service Unavailable");
+
+    assert.equal(harness.calls.loadFile.length, 1);
+  });
+
+  it("keeps the network-error fallback and ignores ERR_ABORTED", (t) => {
+    const harness = loadNavigationHarness();
+    t.after(harness.cleanup);
+
+    harness.emit(
+      "did-fail-load",
+      -105,
+      "NAME_NOT_RESOLVED",
+      "https://host.example/ml/omnigents/",
+      true,
+    );
+    assert.equal(harness.calls.loadFile.length, 1);
+
+    const aborted = loadNavigationHarness();
+    t.after(aborted.cleanup);
+    aborted.emit("did-fail-load", -3, "ABORTED", "https://host.example/ml/omnigents/", true);
+    assert.deepEqual(aborted.calls.loadFile, []);
   });
 });
 


### PR DESCRIPTION
## Related issue

Closes #4711

Predecessor handoff for #4650: `f1740c9f344ad1597c30e65400f8c3d120ca36d6`

## Summary

When the configured Omnigent server returns an HTTP error status (for example, 503) with an empty body, the Electron desktop shell painted a black screen with no way back to setup.

`did-fail-load` only covers Chromium `net::ERR_*` failures. A 4xx/5xx response commits as a successful navigation, so the main-process `did-navigate` fallback now reuses the existing setup-page `?error=<status>&url=<server>` surface. It takes the URL from the window's configured server identity, preserving mounted deployments such as `https://host/ml/omnigents`, and unpins before loading setup so duplicate failure events are bounded to one recovery.

## Test Plan

- [x] Behavioral tests register and invoke the real `registerNavigationFallbacks` handlers from `web/electron/src/main.js`.
- [x] Mutation RED/GREEN verified individually for all 6 changed tests: handler removal failed wiring/404/503/duplicate tests; a 300 cutoff failed redirect handling; removing the `ERR_ABORTED` guard failed network fallback coverage. Every test passed individually after restoration.
- [x] `bun test test/main.test.js` — 30/30 pass.
- [x] `bun run test` — 247/247 pass.
- [x] `uv run --no-sync pyrefly check --use-ignore-files=false` — 0 errors (explicit flag is required because this dedicated worktree lives under ignored `.worktrees/`).
- [x] All remaining `pre-commit run --all-files` hooks pass; the pyrefly hook was replaced by the explicit equivalent command above because its project discovery otherwise ignores the worktree path.
- [ ] Manual GUI repro — not run; use isolated `userData` if performed locally.

## Demo

![Electron setup page showing a 503 error instead of a black screen](https://raw.githubusercontent.com/btli/omnigent/demo-assets-pr-4710/demo/pr-4710-electron-503.gif)

*Fixed behavior: the desktop app returns to setup with the 503 status and failed server URL prefilled.*

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavioral tests cover `did-navigate` status handling for 404 and 503, preserve the full configured mounted URL through `?error=&url=`, ignore 2xx and 3xx responses, ensure re-entrant failure events load setup at most once, verify `createWindow` wires both handlers, and retain the existing `did-fail-load` / `ERR_ABORTED` behavior. The setup page assigns reflected values via `textContent`, so they remain inert text.

## Changelog

Electron desktop shows the setup error page (with status and configured server URL) instead of a black screen when the configured server returns HTTP 4xx/5xx.
