### PR TITLE
Use real client name for Codex app-server readiness check

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1208,12 +1208,12 @@ class CodexNativeAppServer:
                 if self.listen_url and self.listen_url.startswith("ws://"):
                     client = CodexAppServerClient(
                         ws_url=self.listen_url,
-                        client_name="omnigent-probe",
+                        client_name="omnigent-codex-native",
                     )
                 else:
                     client = CodexAppServerClient(
                         self.socket_path,
-                        client_name="omnigent-probe",
+                        client_name="omnigent-codex-native",
                     )
                 await client.connect()
                 await client.close()


### PR DESCRIPTION
## Summary

_wait_until_ready (the Codex app-server readiness check) is the first client to connect to a freshly-launched app-server, and the app-server adopts the initialize client name as the originator it reports to the model gateway. Using client_name="omnigent-probe" there means that name surfaces as the gateway user_agent for the process's real model calls — so genuine Codex-via-Omnigent traffic gets mislabeled as a synthetic "probe" in the gateway usage table.

This switches the readiness check to the real omnigent-codex-native client name so gateway usage attribution reflects actual usage. omnigent-probe no longer appears in the codebase.


## Test Plan

View OTEL traces

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
