### PR TITLE
feat(web): automatic dev sharding + bare workspace URL for npm run dev

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,14 @@ The Vite dev server proxies `/v1` and `/api` to `http://localhost:6767`. Set
 OMNIGENT_URL=http://localhost:9000 pnpm run dev
 ```
 
+To develop against a Databricks workspace-hosted server, point `OMNIGENT_URL`
+at the bare workspace origin — the dev proxy fills in the `/api/2.0/omnigent`
+mount and authenticates with your `databricks auth login` token automatically:
+
+```bash
+OMNIGENT_URL=https://my-workspace.databricks.com pnpm run dev
+```
+
 Additional `omnigent server` options:
 
 | Flag                  | Default                | Description                          |

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -12,7 +12,7 @@ import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
-import { getOmnigentHostConfig, resolveWebSocketUrl } from "@/lib/host";
+import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import {
   readTerminalThemeMode,
@@ -211,11 +211,11 @@ export function TerminalView({
         if (cancelled) return;
         // Route this WS to the replica holding the session's runner tunnel
         // (key = the session's host_id). A browser WS can't set request
-        // headers, so the key rides the query string. Only when a host
-        // fetcher is installed — an unsharded server needs no key, and a
-        // hostless session yields none.
+        // headers, so the key rides the query string. Only against a
+        // Databricks workspace-hosted server — an unsharded server needs no key,
+        // and a hostless session yields none.
         const computedHostId = (() => {
-          if (keylessRef.current || !getOmnigentHostConfig().fetcher) return undefined;
+          if (keylessRef.current || !isDatabricksWorkspace()) return undefined;
           const h = getSessionHost(sessionId);
           return h && !isHostKeyless(h) ? h : undefined;
         })();

--- a/web/src/lib/host.test.ts
+++ b/web/src/lib/host.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getCliServerUrl, setOmnigentHostConfig } from "./host";
 
@@ -22,5 +22,34 @@ describe("getCliServerUrl", () => {
   it("handles an empty string suffix the same as no suffix", () => {
     setOmnigentHostConfig({ cliServerUrlSuffix: "" });
     expect(getCliServerUrl()).toBe(window.location.origin);
+  });
+});
+
+describe("isDatabricksWorkspace", () => {
+  // `hostConfig` and the inlined `import.meta.env` are module state, so each case
+  // resets modules and re-imports for a clean slate (the `setOmnigentHostConfig`
+  // guard won't let an empty config clear an installed fetcher otherwise).
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("is false for a bare local / self-hosted server (no fetcher, no flag)", async () => {
+    const { isDatabricksWorkspace } = await import("./host");
+    expect(isDatabricksWorkspace()).toBe(false);
+  });
+
+  it("is true when embedded (a host fetcher is installed)", async () => {
+    const { isDatabricksWorkspace, setOmnigentHostConfig: setConfig } = await import("./host");
+    setConfig({ fetcher: (path, init) => fetch(path, init) });
+    expect(isDatabricksWorkspace()).toBe(true);
+  });
+
+  it("is true in standalone dev against a workspace (VITE_DATABRICKS_WORKSPACE)", async () => {
+    // `npm run dev` at a workspace URL installs no fetcher; the build-time flag
+    // is the only signal that the server is a Databricks workspace.
+    vi.stubEnv("VITE_DATABRICKS_WORKSPACE", "true");
+    const { isDatabricksWorkspace } = await import("./host");
+    expect(isDatabricksWorkspace()).toBe(true);
   });
 });

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -135,6 +135,18 @@ export function getOmnigentHostConfig(): OmnigentHostConfig {
 }
 
 /**
+ * True when host-scoped traffic must carry the host_id slice key: either the
+ * embed host fetcher is installed (managed UI) or the standalone dev bundle
+ * was pointed at a Databricks workspace via `npm run dev` (vite.config.ts sets
+ * `VITE_DATABRICKS_WORKSPACE=true`). No fetcher is installed in the dev case,
+ * so the flag is the signal. False for a bare local / self-hosted server
+ * (single replica, no sharding), where emitting the key would just dirty the log.
+ */
+export function isDatabricksWorkspace(): boolean {
+  return hostConfig.fetcher != null || import.meta.env.VITE_DATABRICKS_WORKSPACE === "true";
+}
+
+/**
  * The host-provided user search function, or `undefined` when none is
  * configured. Consumers use the absence to stay inert (plain text input).
  */

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -224,6 +224,7 @@ describe("authenticatedFetch", () => {
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
         hostFetch: fetchMock,
+        isDatabricksWorkspace: vi.fn(() => true),
       }));
 
       fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
@@ -234,6 +235,37 @@ describe("authenticatedFetch", () => {
       const init = fetchMock.mock.calls[0][1] as RequestInit;
       const headers = new Headers(init.headers);
       expect(headers.get("X-Databricks-Omnigent-Slice-Key")).toBe("host_123");
+    });
+
+    it("stamps the slice-key header in standalone dev against a workspace", async () => {
+      // `npm run dev` pointed at a workspace URL installs no fetcher, but it's
+      // still a Databricks workspace (sharded) — the VITE_DATABRICKS_WORKSPACE
+      // build flag drives the key so dev traffic reaches the right replica (no
+      // manual step).
+      vi.stubEnv("VITE_DATABRICKS_WORKSPACE", "true");
+      vi.doMock("./sessionHost", () => ({
+        getSessionHost: vi.fn(() => null),
+        setSessionHost: vi.fn(),
+        isHostKeyless: vi.fn(() => false),
+        markHostKeyless: vi.fn(),
+        clearHostKeyless: vi.fn(),
+        modalHostId: vi.fn(() => null),
+        resolveModalHost: vi.fn(),
+        isModalHostResolved: vi.fn(() => true),
+      }));
+      vi.doMock("./host", () => ({
+        getOmnigentHostConfig: vi.fn(() => ({})),
+        hostFetch: fetchMock,
+        isDatabricksWorkspace: vi.fn(() => true),
+      }));
+
+      fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+      const { authenticatedFetch } = await import("./identity");
+
+      await authenticatedFetch("/v1/hosts/host_abc/runners", { method: "POST" });
+
+      const headers = new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers);
+      expect(headers.get("X-Databricks-Omnigent-Slice-Key")).toBe("host_abc");
     });
 
     it("retries keyless on wrong_replica 400 response", async () => {
@@ -250,6 +282,7 @@ describe("authenticatedFetch", () => {
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
         hostFetch: fetchMock,
+        isDatabricksWorkspace: vi.fn(() => true),
       }));
 
       const wrongReplicaResponse = {

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -16,7 +16,7 @@
  */
 
 import { getCachedServerInfo } from "./capabilities";
-import { getOmnigentHostConfig, hostFetch } from "./host";
+import { getOmnigentHostConfig, hostFetch, isDatabricksWorkspace } from "./host";
 import {
   clearHostKeyless,
   getSessionHost,
@@ -382,9 +382,10 @@ export async function authenticatedFetch(
   // Pin host- and session-scoped requests to the replica holding that host's
   // runner tunnel (key = host_id). Derived centrally so no call site has to
   // thread it; a caller that set the header explicitly wins, and non-host-scoped
-  // requests get no key (any replica). Only when a host fetcher is installed —
-  // a single-replica deployment doesn't shard by host, so the key would just
-  // dirty its logs.
+  // requests get no key (any replica). Only against a Databricks workspace-hosted
+  // server — the embedded (managed) UI, or `npm run dev` pointed at a workspace URL.
+  // A standalone/self-hosted server has no Dicer, so the key would just dirty
+  // its logs (see isDatabricksWorkspace).
   const url = typeof input === "string" ? input : input.toString();
   // Resolve this session's host BEFORE deriving the slice key below, so a fresh
   // session sub-path request keys to the right replica on the first attempt
@@ -400,7 +401,7 @@ export async function authenticatedFetch(
   // The host this request is FOR, even when we deliberately send it keyless
   // (demoted). Lets the retry logic below demote/un-demote the right host.
   let derivedHostId: string | null = null;
-  if (!headers.has(SLICE_KEY_HEADER) && getOmnigentHostConfig().fetcher) {
+  if (!headers.has(SLICE_KEY_HEADER) && isDatabricksWorkspace()) {
     // Key by the request's OWN host when it's host-scoped; otherwise (a
     // cross-host / DB-backed read) fall back to the modal host as a
     // cache-affinity hint. The distinction matters: a host-scoped request whose

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -8,6 +8,13 @@ interface ImportMetaEnv {
   readonly VITE_OTEL_EXPORTER_OTLP_ENDPOINT?: string;
   /** Service name reported for browser spans. Defaults to `omni-web`. */
   readonly VITE_OTEL_SERVICE_NAME?: string;
+  /**
+   * `"true"` when the dev proxy targets a Databricks workspace-hosted server
+   * (behind the multi-replica sharding layer), set by `vite.config.ts` from
+   * `OMNIGENT_URL`. Signals the standalone dev bundle to emit the host_id slice
+   * key on host-scoped traffic; see `isDatabricksWorkspace` in `host.ts`.
+   */
+  readonly VITE_DATABRICKS_WORKSPACE?: string;
 }
 
 interface ImportMeta {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,30 @@ import react from "@vitejs/plugin-react";
 import type { Plugin, ProxyOptions } from "vite";
 import { defineConfig } from "vitest/config";
 
-const OMNIGENT_URL = process.env.OMNIGENT_URL ?? "http://localhost:6767";
+// Databricks workspace-hosted omnigent is mounted behind the api-proxy at this
+// path; a local / self-hosted server mounts at the root. Mirrors the Python
+// WORKSPACE_API_PATH (omnigent/cli_auth.py) so both sides agree on the shape of
+// a workspace URL.
+const WORKSPACE_API_PATH = "/api/2.0/omnigent";
+
+function isWorkspaceHost(hostname: string): boolean {
+  return hostname.endsWith(".databricks.com") || hostname.endsWith(".azuredatabricks.net");
+}
+
+// Resolve the proxy target. Point OMNIGENT_URL at a bare workspace origin
+// (https://<ws>.databricks.com) and the api-proxy mount is filled in
+// automatically, so the browser's relative /v1/... paths reach the
+// workspace-hosted server without hand-typing the /api/2.0/omnigent prefix. An
+// explicit non-root path is respected (a custom mount, or a local server).
+function resolveTarget(raw: string): string {
+  const url = new URL(raw);
+  if (isWorkspaceHost(url.hostname) && (url.pathname === "" || url.pathname === "/")) {
+    url.pathname = WORKSPACE_API_PATH;
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+const OMNIGENT_URL = resolveTarget(process.env.OMNIGENT_URL ?? "http://localhost:6767");
 
 let cachedToken: string | null | undefined;
 
@@ -112,15 +135,25 @@ function createProxyConfig(target: string, useAuth: boolean): Record<string, Pro
 }
 
 const parsed = new URL(OMNIGENT_URL);
-const useAuth =
-  !!process.env.OMNIGENT_AUTH_TOKEN ||
-  parsed.hostname.endsWith(".databricks.com") ||
-  parsed.hostname.endsWith(".azuredatabricks.net");
+const useAuth = !!process.env.OMNIGENT_AUTH_TOKEN || isWorkspaceHost(parsed.hostname);
+
+// A Databricks workspace-hosted server sits behind the multi-replica sharding
+// layer, so the dev bundle must emit the host_id slice key on host-scoped
+// traffic — same as the embedded (managed) UI — or requests scatter across
+// replicas and a host's runner tunnel becomes unreachable ("host is offline").
+// Surface it to the browser as a build-time flag (inlined into import.meta.env);
+// the embed path keys off its host fetcher instead (see isDatabricksWorkspace in
+// host.ts). Keyed off the resolved mount so pointing at a bare workspace origin
+// turns it on.
+const isDatabricksWorkspaceEnv = parsed.pathname.replace(/\/$/, "") === WORKSPACE_API_PATH;
+if (isDatabricksWorkspaceEnv) process.env.VITE_DATABRICKS_WORKSPACE = "true";
 
 if (useAuth) {
   const token = resolveToken(parsed.origin);
   if (token) {
-    console.log(`[dev-proxy] target=${OMNIGENT_URL} (authenticated)`);
+    console.log(
+      `[dev-proxy] target=${OMNIGENT_URL} (authenticated${isDatabricksWorkspaceEnv ? ", databricks-workspace" : ""})`,
+    );
   } else {
     console.error(
       `\n[dev-proxy] ERROR: No auth token for ${parsed.origin}.\n` +


### PR DESCRIPTION
## Summary

A dev-experience follow-up to the host_id slice-key sharding (#2037, now merged): point `OMNIGENT_URL` at a bare Databricks workspace origin and `npm run dev` just works against a sharded workspace — no manual, easy-to-forget setup.

- **Bare workspace URL just works.** `vite.config.ts` auto-fills the `/api/2.0/omnigent` api-proxy mount when `OMNIGENT_URL` is a workspace origin, so the browser's relative `/v1/...` paths resolve (mirrors the Python `WORKSPACE_API_PATH`). An explicit mount, or a local server, is respected unchanged.
- **Automatic dev sharding.** A workspace target is multi-replica, so the standalone dev bundle must emit the `host_id` slice key on host-scoped traffic like the embedded (managed) UI does — otherwise requests scatter across replicas and a session's host reads offline. A build-time `VITE_DATABRICKS_WORKSPACE` flag plus a unified `isDatabricksWorkspace()` gate (host fetcher installed **or** the dev flag) drives it.

## Test Plan

`identity` / `host` / `TerminalView` unit tests cover the `isDatabricksWorkspace()` gate; oxlint + ruff clean.

This pull request and its description were written by Isaac.