### PR TITLE
feat(web): let bulk session delete clean up worktree branches

### DIFF
--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1425,11 +1425,36 @@ describe("useBulkDeleteConversations", () => {
       .mockResolvedValueOnce(mockResponse({ deleted: true })); // delete conv_b
 
     const { queryClient, rendered } = renderBulkDeleteHook();
-    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    rendered.result.current.mutate({ ids: ["conv_a", "conv_b"] });
     await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
 
     const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
     expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_keep"]);
+  });
+
+  it("appends ?delete_branch=true only for ids in deleteBranchIds", async () => {
+    // conv_a opts into branch cleanup, conv_b does not.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_a
+      .mockResolvedValueOnce(mockResponse({ deleted: true })) // delete conv_a
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_b
+      .mockResolvedValueOnce(mockResponse({ deleted: true })); // delete conv_b
+
+    const { rendered } = renderBulkDeleteHook();
+    rendered.result.current.mutate({
+      ids: ["conv_a", "conv_b"],
+      deleteBranchIds: new Set(["conv_a"]),
+    });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    // Each session deletes independently, so the per-session flag must ride
+    // only on the DELETE for the id the user ticked.
+    const deleteUrls = fetchMock.mock.calls
+      .map((call) => call[0] as string)
+      .filter((url) => url.startsWith("/v1/sessions/conv_") && !url.includes("/events"));
+    expect(deleteUrls).toContain("/v1/sessions/conv_a?delete_branch=true");
+    expect(deleteUrls).toContain("/v1/sessions/conv_b");
+    expect(deleteUrls).not.toContain("/v1/sessions/conv_b?delete_branch=true");
   });
 
   it("evicts succeeded ids from cache even when some deletes fail", async () => {
@@ -1441,7 +1466,7 @@ describe("useBulkDeleteConversations", () => {
       .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 })); // delete conv_b fails
 
     const { queryClient, rendered } = renderBulkDeleteHook();
-    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    rendered.result.current.mutate({ ids: ["conv_a", "conv_b"] });
     await waitFor(() => expect(rendered.result.current.isError).toBe(true));
 
     // conv_a was successfully deleted and should be evicted; conv_b stays.

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -959,11 +959,22 @@ export function useBulkArchiveConversations() {
  * the cached lists in `onMutate` so the sidebar repaints immediately,
  * and only the ones whose delete failed are restored. Returns the
  * succeeded / failed session IDs.
+ *
+ * `deleteBranchIds` opts individual worktree sessions into git cleanup:
+ * a session whose id is in the set is deleted with `?delete_branch=true`
+ * (the server removes its worktree and branch). Ids absent from the set
+ * — or all ids when it's omitted — delete without touching any branch.
  */
 export function useBulkDeleteConversations() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (ids: string[]) => {
+    mutationFn: async ({
+      ids,
+      deleteBranchIds,
+    }: {
+      ids: string[];
+      deleteBranchIds?: ReadonlySet<string>;
+    }) => {
       const results = await Promise.allSettled(
         ids.map(async (id) => {
           try {
@@ -971,7 +982,7 @@ export function useBulkDeleteConversations() {
           } catch {
             // Best-effort stop
           }
-          await deleteConversation(id);
+          await deleteConversation(id, deleteBranchIds?.has(id) ?? false);
         }),
       );
       const succeeded: string[] = [];
@@ -989,11 +1000,11 @@ export function useBulkDeleteConversations() {
       }
       return { succeeded, failed };
     },
-    onMutate: (ids) => paintConversationsDeleted(queryClient, ids),
-    onSuccess: (_data, ids) => {
+    onMutate: ({ ids }) => paintConversationsDeleted(queryClient, ids),
+    onSuccess: (_data, { ids }) => {
       finalizeDeletedConversations(queryClient, ids);
     },
-    onError: (error, ids, snapshot) => {
+    onError: (error, { ids }, snapshot) => {
       // Partial failure: the sessions that did delete stay gone; the rest
       // come back. A non-bulk error (nothing reported) restores everything.
       const bulk = error instanceof BulkConversationMutationError ? error : null;

--- a/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
+++ b/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
@@ -1,0 +1,223 @@
+// Tests for the branch checkbox list in the sidebar's bulk-delete modal
+// (selection mode). Contract: worktree sessions among the selection each get
+// a checkbox listing their local git branch; ticking one opts that session
+// into `?delete_branch=true`. Checkboxes default unchecked (branch deletion is
+// irreversible), and a "Select all" toggle flips the whole list at once. The
+// per-session branch flags ride along in `bulkDelete.mutate({ ids,
+// deleteBranchIds })`. See BulkActionBar in Sidebar.tsx.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Controllable bulk-delete mutation, declared via vi.hoisted so the vi.mock
+// factory (hoisted above imports) can reference it and tests can assert the
+// payload passed to mutate.
+const mocks = vi.hoisted(() => ({
+  bulkDelete: { mutate: vi.fn(), isPending: false, isError: false },
+}));
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+  }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
+  useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  setConversationPinned: vi.fn(() => Promise.resolve({})),
+  PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => mocks.bulkDelete,
+  useBulkMoveToProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: [] }),
+  useProjectSessions: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectConfig: () => ({ data: undefined, isLoading: false }),
+  useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+import { type Conversation, useConversations } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+
+// Two worktree sessions (git_branch set) and one plain session. Owner
+// (owner unset → owned by viewer), idle → selectable + deletable.
+const WORKTREE_A: Conversation = {
+  id: "conv_a",
+  object: "conversation",
+  title: "Alpha",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_000,
+  labels: {},
+  permission_level: null,
+  status: "idle",
+  git_branch: "feat/alpha",
+};
+const WORKTREE_B: Conversation = {
+  ...WORKTREE_A,
+  id: "conv_b",
+  title: "Beta",
+  git_branch: "feat/beta",
+};
+const PLAIN: Conversation = {
+  ...WORKTREE_A,
+  id: "conv_c",
+  title: "Gamma",
+  git_branch: null,
+};
+
+function mockConversations(conversations: Conversation[]) {
+  const dataResult = {
+    data: {
+      pages: [
+        {
+          data: conversations,
+          first_id: conversations[0]?.id ?? null,
+          last_id: conversations.at(-1)?.id ?? null,
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useConversations>;
+  useConvMock.mockImplementation(() => dataResult);
+}
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar open={true} onClose={vi.fn()} />
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Enter selection mode and select every row, then open the delete modal. */
+function selectAllAndOpenDeleteDialog() {
+  fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+  fireEvent.click(screen.getByRole("link", { name: /Alpha/ }));
+  fireEvent.click(screen.getByRole("link", { name: /Beta/ }));
+  fireEvent.click(screen.getByRole("link", { name: /Gamma/ }));
+  fireEvent.click(screen.getByTestId("bulk-delete"));
+  return screen.getByRole("dialog");
+}
+
+beforeEach(() => {
+  mocks.bulkDelete.mutate.mockReset();
+  mockConversations([WORKTREE_A, WORKTREE_B, PLAIN]);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("bulk-delete branch list", () => {
+  it("lists a branch checkbox only for the selected worktree sessions", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+
+    // Two worktree sessions selected → two checkboxes; the plain session
+    // (git_branch null) contributes none.
+    expect(within(dialog).getAllByTestId("bulk-delete-branch-checkbox")).toHaveLength(2);
+    expect(within(dialog).getByText("feat/alpha")).toBeInTheDocument();
+    expect(within(dialog).getByText("feat/beta")).toBeInTheDocument();
+    expect(within(dialog).queryByText("feat/gamma")).not.toBeInTheDocument();
+  });
+
+  it("defaults every branch unchecked, so a plain confirm deletes no branch", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+
+    for (const box of within(dialog).getAllByTestId("bulk-delete-branch-checkbox")) {
+      expect(box).not.toBeChecked();
+    }
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /Delete 3 session/ }));
+
+    expect(mocks.bulkDelete.mutate).toHaveBeenCalledWith({
+      ids: ["conv_a", "conv_b", "conv_c"],
+      deleteBranchIds: new Set(),
+    });
+  });
+
+  it("threads only the ticked branches into deleteBranchIds", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+
+    // Tick just conv_b's branch.
+    fireEvent.click(within(dialog).getAllByTestId("bulk-delete-branch-checkbox")[1]);
+    fireEvent.click(within(dialog).getByRole("button", { name: /Delete 3 session/ }));
+
+    expect(mocks.bulkDelete.mutate).toHaveBeenCalledWith({
+      ids: ["conv_a", "conv_b", "conv_c"],
+      deleteBranchIds: new Set(["conv_b"]),
+    });
+  });
+
+  it("Select all ticks every branch; the flags reach deleteBranchIds", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+
+    fireEvent.click(within(dialog).getByTestId("bulk-delete-branch-toggle-all"));
+    for (const box of within(dialog).getAllByTestId("bulk-delete-branch-checkbox")) {
+      expect(box).toBeChecked();
+    }
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /Delete 3 session/ }));
+
+    expect(mocks.bulkDelete.mutate).toHaveBeenCalledWith({
+      ids: ["conv_a", "conv_b", "conv_c"],
+      deleteBranchIds: new Set(["conv_a", "conv_b"]),
+    });
+  });
+
+  it("omits the branch list entirely when no selected session has a worktree", () => {
+    mockConversations([PLAIN]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+    fireEvent.click(screen.getByRole("link", { name: /Gamma/ }));
+    fireEvent.click(screen.getByTestId("bulk-delete"));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).queryByTestId("bulk-delete-branch-checkbox")).not.toBeInTheDocument();
+    expect(within(dialog).queryByTestId("bulk-delete-branch-toggle-all")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
+++ b/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
@@ -1,10 +1,12 @@
-// Tests for the branch checkbox list in the sidebar's bulk-delete modal
-// (selection mode). Contract: worktree sessions among the selection each get
-// a checkbox listing their local git branch; ticking one opts that session
-// into `?delete_branch=true`. Checkboxes default unchecked (branch deletion is
-// irreversible), and a "Select all" toggle flips the whole list at once. The
-// per-session branch flags ride along in `bulkDelete.mutate({ ids,
-// deleteBranchIds })`. See BulkActionBar in Sidebar.tsx.
+// Tests for the branch table in the sidebar's bulk-delete modal (selection
+// mode). Contract: worktree sessions among the selection each get a table row
+// with a checkbox and their local git branch; ticking one opts that session
+// into `?delete_branch=true`. Row checkboxes default unchecked (branch deletion
+// is irreversible). The header checkbox is tri-state — unchecked when no row is
+// ticked, indeterminate ([-]) for a partial selection, checked when all rows
+// are ticked — and toggling it flips the whole table at once. The per-session
+// branch flags ride along in `bulkDelete.mutate({ ids, deleteBranchIds })`. See
+// BulkActionBar in Sidebar.tsx.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
@@ -191,7 +193,7 @@ describe("bulk-delete branch list", () => {
     });
   });
 
-  it("Select all ticks every branch; the flags reach deleteBranchIds", () => {
+  it("toggling the header checkbox ticks every branch; the flags reach deleteBranchIds", () => {
     renderSidebar();
     const dialog = selectAllAndOpenDeleteDialog();
 
@@ -206,6 +208,39 @@ describe("bulk-delete branch list", () => {
       ids: ["conv_a", "conv_b", "conv_c"],
       deleteBranchIds: new Set(["conv_a", "conv_b"]),
     });
+  });
+
+  it("re-toggling the header checkbox when all are ticked clears every branch", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+    const header = within(dialog).getByTestId("bulk-delete-branch-toggle-all");
+
+    fireEvent.click(header); // none → all
+    fireEvent.click(header); // all → none
+    for (const box of within(dialog).getAllByTestId("bulk-delete-branch-checkbox")) {
+      expect(box).not.toBeChecked();
+    }
+  });
+
+  it("drives the header checkbox tri-state from the row selection", () => {
+    renderSidebar();
+    const dialog = selectAllAndOpenDeleteDialog();
+    const header = within(dialog).getByTestId("bulk-delete-branch-toggle-all");
+    const rows = within(dialog).getAllByTestId("bulk-delete-branch-checkbox");
+
+    // Nothing ticked → unchecked, not indeterminate.
+    expect(header).not.toBeChecked();
+    expect(header).not.toBePartiallyChecked();
+
+    // One of two ticked → indeterminate ([-]), not checked.
+    fireEvent.click(rows[0]);
+    expect(header).toBePartiallyChecked();
+    expect(header).not.toBeChecked();
+
+    // Both ticked → checked, no longer indeterminate.
+    fireEvent.click(rows[1]);
+    expect(header).toBeChecked();
+    expect(header).not.toBePartiallyChecked();
   });
 
   it("omits the branch list entirely when no selected session has a worktree", () => {

--- a/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
+++ b/web/src/shell/Sidebar.bulkDeleteBranch.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@/hooks/useConversations", () => ({
     isPending: false,
     isError: false,
   }),
+  useLeaveSession: () => ({ mutate: vi.fn(), isPending: false }),
   usePinnedConversations: () => ({
     data: { conversations: [], filterHonored: true },
     isSuccess: true,

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -15,7 +15,6 @@ import {
   useState,
 } from "react";
 import {
-  AlertTriangleIcon,
   ArchiveIcon,
   ArchiveRestoreIcon,
   CheckIcon,
@@ -4346,6 +4345,34 @@ function BulkActionBar({
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [moveSearch, setMoveSearch] = useState("");
+  // Worktree sessions among the selection each carry one local git branch
+  // (git_branch); the delete modal lists them so each branch can be opted
+  // into cleanup individually. `branchesToDelete` holds the session ids whose
+  // branch the user ticked — default empty (opt-in, matching single-session
+  // delete, since branch deletion is irreversible).
+  const [branchesToDelete, setBranchesToDelete] = useState<Set<string>>(new Set());
+
+  const worktreeSelected = useMemo(
+    () => ownedSelected.filter((c) => c.git_branch),
+    [ownedSelected],
+  );
+  const allBranchesSelected =
+    worktreeSelected.length > 0 && worktreeSelected.every((c) => branchesToDelete.has(c.id));
+
+  function toggleBranch(id: string, checked: boolean) {
+    setBranchesToDelete((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }
+
+  function toggleAllBranches() {
+    setBranchesToDelete(
+      allBranchesSelected ? new Set() : new Set(worktreeSelected.map((c) => c.id)),
+    );
+  }
 
   function handleMoveToProject(project: string) {
     const ids = ownedSelected.map((c) => c.id);
@@ -4398,7 +4425,7 @@ function BulkActionBar({
     // observer never fire.
     if (activeId && ids.includes(activeId)) navigate("/", { replace: true });
     onDeselectAll();
-    bulkDelete.mutate(ids);
+    bulkDelete.mutate({ ids, deleteBranchIds: branchesToDelete });
   }
 
   return (
@@ -4562,7 +4589,15 @@ function BulkActionBar({
         )}
       </div>
 
-      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+      <Dialog
+        open={confirmDeleteOpen}
+        onOpenChange={(open) => {
+          setConfirmDeleteOpen(open);
+          // Reset the branch selection on close so it doesn't carry over to
+          // the next delete.
+          if (!open) setBranchesToDelete(new Set());
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete {ownedSelected.length} session(s)?</DialogTitle>
@@ -4571,15 +4606,58 @@ function BulkActionBar({
               be undone.
             </DialogDescription>
           </DialogHeader>
-          <p className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-sm text-muted-foreground">
-            <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
-            Branches are not cleaned up. Use single-session delete for branch surgery.
-          </p>
+          {worktreeSelected.length > 0 && (
+            <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm text-muted-foreground">
+                  Optionally delete the local git branches for these worktree sessions. These
+                  actions are <span className="font-semibold text-destructive">irreversible</span>.
+                </p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="shrink-0"
+                  onClick={toggleAllBranches}
+                  data-testid="bulk-delete-branch-toggle-all"
+                >
+                  {allBranchesSelected ? "Clear all" : "Select all"}
+                </Button>
+              </div>
+              <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
+                {worktreeSelected.map((c) => (
+                  <li key={c.id}>
+                    <label className="flex cursor-pointer items-start gap-2 text-ui">
+                      <input
+                        type="checkbox"
+                        data-testid="bulk-delete-branch-checkbox"
+                        checked={branchesToDelete.has(c.id)}
+                        onChange={(e) => toggleBranch(c.id, e.target.checked)}
+                        className="mt-0.5 size-4 shrink-0 accent-destructive"
+                      />
+                      <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="flex min-w-0 flex-col">
+                        <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
+                          {c.git_branch}
+                        </code>
+                        <span className="truncate text-sm text-muted-foreground">
+                          {conversationDisplayLabel(c)}
+                        </span>
+                      </span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <DialogFooter className="border-t-0 bg-transparent">
             <Button
               type="button"
               variant="ghost"
-              onClick={() => setConfirmDeleteOpen(false)}
+              onClick={() => {
+                setConfirmDeleteOpen(false);
+                setBranchesToDelete(new Set());
+              }}
               disabled={bulkDelete.isPending}
             >
               Cancel

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4598,7 +4598,7 @@ function BulkActionBar({
           if (!open) setBranchesToDelete(new Set());
         }}
       >
-        <DialogContent>
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Delete {ownedSelected.length} session(s)?</DialogTitle>
             <DialogDescription>
@@ -4608,22 +4608,20 @@ function BulkActionBar({
           </DialogHeader>
           {worktreeSelected.length > 0 && (
             <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
-              <div className="flex items-start justify-between gap-2">
-                <p className="text-sm text-muted-foreground">
-                  Optionally delete the local git branches for these worktree sessions. These
-                  actions are <span className="font-semibold text-destructive">irreversible</span>.
-                </p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="shrink-0"
-                  onClick={toggleAllBranches}
-                  data-testid="bulk-delete-branch-toggle-all"
-                >
-                  {allBranchesSelected ? "Clear all" : "Select all"}
-                </Button>
-              </div>
+              <p className="text-sm text-muted-foreground">
+                Optionally delete the local git branches for these worktree sessions. These actions
+                are <span className="font-semibold text-destructive">irreversible</span>.
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="self-start"
+                onClick={toggleAllBranches}
+                data-testid="bulk-delete-branch-toggle-all"
+              >
+                {allBranchesSelected ? "Clear all" : "Select all"}
+              </Button>
               <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
                 {worktreeSelected.map((c) => (
                   <li key={c.id}>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4358,6 +4358,10 @@ function BulkActionBar({
   );
   const allBranchesSelected =
     worktreeSelected.length > 0 && worktreeSelected.every((c) => branchesToDelete.has(c.id));
+  // Drives the header checkbox's indeterminate ([-]) state: some but not all
+  // branches ticked.
+  const someBranchesSelected =
+    !allBranchesSelected && worktreeSelected.some((c) => branchesToDelete.has(c.id));
 
   function toggleBranch(id: string, checked: boolean) {
     setBranchesToDelete((prev) => {
@@ -4612,40 +4616,62 @@ function BulkActionBar({
                 Optionally delete the local git branches for these worktree sessions. These actions
                 are <span className="font-semibold text-destructive">irreversible</span>.
               </p>
-              <Button
-                type="button"
-                variant="outline"
-                size="xs"
-                className="self-start"
-                onClick={toggleAllBranches}
-                data-testid="bulk-delete-branch-toggle-all"
-              >
-                {allBranchesSelected ? "Clear all" : "Select all"}
-              </Button>
-              <ul className="flex max-h-56 flex-col gap-3 overflow-y-auto">
-                {worktreeSelected.map((c) => (
-                  <li key={c.id}>
-                    <label className="flex cursor-pointer items-start gap-2 text-ui">
-                      <input
-                        type="checkbox"
-                        data-testid="bulk-delete-branch-checkbox"
-                        checked={branchesToDelete.has(c.id)}
-                        onChange={(e) => toggleBranch(c.id, e.target.checked)}
-                        className="mt-0.5 size-4 shrink-0 accent-destructive"
-                      />
-                      <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-                      <span className="flex min-w-0 flex-col">
-                        <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
-                          {c.git_branch}
-                        </code>
-                        <span className="truncate text-sm text-muted-foreground">
-                          {conversationDisplayLabel(c)}
-                        </span>
-                      </span>
-                    </label>
-                  </li>
-                ))}
-              </ul>
+              <div className="max-h-56 overflow-y-auto">
+                <table className="w-full border-collapse text-left text-ui">
+                  <thead>
+                    <tr className="border-b border-destructive/20 text-sm text-muted-foreground">
+                      <th scope="col" className="w-8 py-1.5 pr-2 font-medium">
+                        <input
+                          type="checkbox"
+                          ref={(el) => {
+                            if (el) el.indeterminate = someBranchesSelected;
+                          }}
+                          checked={allBranchesSelected}
+                          onChange={toggleAllBranches}
+                          aria-label="Select all branches"
+                          data-testid="bulk-delete-branch-toggle-all"
+                          className="mt-1 size-4 shrink-0 accent-destructive"
+                        />
+                      </th>
+                      <th scope="col" className="py-1.5 pr-3 font-medium">
+                        Branch
+                      </th>
+                      <th scope="col" className="py-1.5 font-medium">
+                        Session
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {worktreeSelected.map((c) => (
+                      <tr key={c.id} className="align-top">
+                        <td className="py-2 pr-2">
+                          <input
+                            type="checkbox"
+                            data-testid="bulk-delete-branch-checkbox"
+                            checked={branchesToDelete.has(c.id)}
+                            onChange={(e) => toggleBranch(c.id, e.target.checked)}
+                            aria-label={`Delete branch ${c.git_branch}`}
+                            className="mt-0.5 size-4 shrink-0 cursor-pointer accent-destructive"
+                          />
+                        </td>
+                        <td className="py-2 pr-3">
+                          <span className="flex items-start gap-1.5">
+                            <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                            <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
+                              {c.git_branch}
+                            </code>
+                          </span>
+                        </td>
+                        <td className="py-2 text-sm text-muted-foreground">
+                          <span className="line-clamp-2 break-all">
+                            {conversationDisplayLabel(c)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
           <DialogFooter className="border-t-0 bg-transparent">

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4614,7 +4614,7 @@ function BulkActionBar({
               </p>
               <Button
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="xs"
                 className="self-start"
                 onClick={toggleAllBranches}
@@ -4622,7 +4622,7 @@ function BulkActionBar({
               >
                 {allBranchesSelected ? "Clear all" : "Select all"}
               </Button>
-              <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
+              <ul className="flex max-h-56 flex-col gap-3 overflow-y-auto">
                 {worktreeSelected.map((c) => (
                   <li key={c.id}>
                     <label className="flex cursor-pointer items-start gap-2 text-ui">


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; this is a UX improvement to the existing bulk-delete flow. -->

N/A

## Summary

- Multi-session delete previously showed a dead-end warning — *"Branches are not cleaned up. Use single-session delete for branch surgery."* — forcing users to delete worktree sessions one at a time to clean up their branches.
- The bulk delete already fires **N independent `DELETE` requests**, so the confirm modal now shows a **table** of the selected worktree sessions (Branch / Session columns), each row with a checkbox (default **unchecked**, since branch deletion is irreversible). Ticked branches ride along as `?delete_branch=true` on that session's own request — the same per-branch cleanup the single-session flow offers.
- The table header carries a **tri-state checkbox**: unchecked when no row is ticked, indeterminate (`[-]`) for a partial selection, checked when all are — and toggling it selects/clears every row.
- Sessions without a worktree contribute no row, and the table is hidden entirely when nothing in the selection has a branch.

No server change was needed: `DELETE /v1/sessions/{id}?delete_branch=true` already applies per session, and `git_branch` is already present on each list-sourced conversation (no extra fetch).

## Test Plan

Automated (green on the changed files):

- `web oxlint`, `web TypeScript type check`, `web prettier` via `pre-commit`
- `vitest run` — full web suite passes (only the pre-existing, local-only `NewChatDialog` "This machine" cases fail, unrelated to this change)
- New coverage in `Sidebar.bulkDeleteBranch.test.tsx` + `useConversations.test.ts`:
  - a branch row only for worktree sessions; unchecked by default
  - per-branch threading into `deleteBranchIds`, and only ticked ids get `?delete_branch=true`
  - header checkbox tri-state (unchecked → indeterminate → checked) driven by row selection, and toggling it selects/clears all
  - the table is omitted when no selected session has a worktree

Manual (for the reviewer):

1. `just dev`, open a session list with **≥2 worktree sessions** (those showing a branch in their row tooltip).
2. **Select sessions** → tick two or more → trash icon.
3. Confirm the table lists one row per selected worktree session (branch + title), all unchecked, and the header checkbox is unchecked. Non-worktree sessions show no row.
4. Tick one row → header shows `[-]`; tick the rest → header shows checked. Toggle the header to select/clear all.
5. Confirm delete and verify only the ticked sessions' local branches are removed (`git branch`), the rest delete untouched.
6. Select only non-worktree sessions → the table doesn't appear.

## Demo

<!-- Reviewer: please attach a short recording of the new modal when checking out. -->

Modal table (worktree sessions in the selection):

```
Delete 3 session(s)?
This will permanently delete the selected sessions and all their history…

┌─ Optionally delete the local git branches … irreversible. ──────────────┐
│  [-]    Branch              Session                                      │
│  ☑      ⎇ feat/alpha        Alpha                                        │
│  ☐      ⎇ feat/beta         Beta                                         │
└──────────────────────────────────────────────────────────────────────┘

                                          [ Cancel ]  [ Delete 3 session(s) ]
```

(Header checkbox shown mid-selection: `[-]` indeterminate.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the hook (per-session `?delete_branch=true` threading) and the modal table (row present only for worktree sessions, unchecked default, subset selection, tri-state header checkbox, and omission when no worktree is selected). The actual git worktree/branch removal is server-side and already covered there; this PR only threads the existing per-session flag through the bulk path.

## Changelog

Multi-session delete now shows a table of worktree branches you can pick to clean up (with a tri-state select-all header), instead of blocking branch cleanup behind single-session delete
