### PR TITLE
fix(claude-sdk): emit CompactionInProgressEvent at PreCompact signal

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2844,6 +2844,9 @@ class ClaudeSDKExecutor(Executor):
                         elif getattr(system_msg, "hook_event_name", None) == "PreCompact":
                             compaction_occurred = True
                             logger.info("Claude SDK compaction detected (PreCompact hook)")
+                            from omnigent.inner.executor import CompactionStarted
+
+                            yield CompactionStarted()
                         else:
                             logger.info("Claude CLI system message: %s", data)
             finally:

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -229,6 +229,16 @@ class ToolCallComplete(ExecutorEvent):
 
 
 @dataclass
+class CompactionStarted(ExecutorEvent):
+    """The harness detected that compaction is about to begin.
+
+    Emitted as soon as the compaction signal is received, before the
+    compacted state is available.  Allows clients to show a progress
+    indicator while compaction is in flight.
+    """
+
+
+@dataclass
 class CompactionComplete(ExecutorEvent):
     """The harness compacted its internal context.
 

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -47,6 +47,7 @@ from fastapi import Response
 from omnigent.errors import ElicitationDeclinedError
 from omnigent.inner.executor import (
     CompactionComplete,
+    CompactionStarted,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -1021,17 +1022,17 @@ class ExecutorAdapter(HarnessApp):
             # payload to populate TurnComplete.usage on the Omnigent side.
             if event.usage is not None:
                 ctx.provider_usage = event.usage
-        elif isinstance(event, CompactionComplete):
-            from omnigent.server.schemas import (
-                CompactionCompletedEvent,
-                CompactionInProgressEvent,
-            )
+        elif isinstance(event, CompactionStarted):
+            from omnigent.server.schemas import CompactionInProgressEvent
 
             ctx.emit(
                 CompactionInProgressEvent(
                     type="response.compaction.in_progress",
                 )
             )
+        elif isinstance(event, CompactionComplete):
+            from omnigent.server.schemas import CompactionCompletedEvent
+
             ctx.emit(
                 CompactionCompletedEvent(
                     type="response.compaction.completed",

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4500,9 +4500,9 @@ def test_precompact_hook_emits_compaction_started_before_complete() -> None:
         completed = [e for e in events if isinstance(e, CompactionComplete)]
         assert len(started) == 1, "expected exactly one CompactionStarted"
         assert len(completed) == 1, "expected exactly one CompactionComplete"
-        assert events.index(started[0]) < events.index(
-            completed[0]
-        ), "CompactionStarted must precede CompactionComplete"
+        assert events.index(started[0]) < events.index(completed[0]), (
+            "CompactionStarted must precede CompactionComplete"
+        )
 
     _run(_t())
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4397,10 +4397,112 @@ def test_precompact_hook_emits_compaction_complete_with_session_messages() -> No
         assert ce.compacted_messages[0]["role"] == "user"
         assert ce.compacted_messages[1]["role"] == "assistant"
         mock_get_msgs.assert_called_once_with("claude-uuid-123", directory=None)
-        # CompactionComplete before TurnComplete
+        # CompactionStarted before CompactionComplete before TurnComplete
+        from omnigent.inner.executor import CompactionStarted
+
+        started_events = [e for e in events if isinstance(e, CompactionStarted)]
+        assert len(started_events) == 1
         turn_completes = [e for e in events if isinstance(e, TurnComplete)]
         assert len(turn_completes) == 1
+        assert events.index(started_events[0]) < events.index(compaction_events[0])
         assert events.index(compaction_events[0]) < events.index(turn_completes[0])
+
+    _run(_t())
+
+
+def test_precompact_hook_emits_compaction_started_before_complete() -> None:
+    """CompactionStarted is yielded when PreCompact fires, before CompactionComplete.
+
+    This ensures clients see the in-progress signal while compaction is
+    still happening, rather than both events arriving back-to-back after
+    the turn ends.
+    """
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import CompactionComplete, CompactionStarted
+
+    class _ResultMessage:
+        def __init__(self, session_id, result):
+            self.session_id = session_id
+            self.result = result
+            self.content = []
+            self.model = "claude-test"
+            self.usage = type(
+                "U",
+                (),
+                {"input_tokens": 500, "output_tokens": 100},
+            )()
+
+    class _SystemMessage:
+        def __init__(self, subtype, data, hook_event_name=None):
+            self.subtype = subtype
+            self.data = data
+            self.hook_event_name = hook_event_name
+
+    class _FakeSDK:
+        AssistantMessage = type("AssistantMessage", (), {})
+        UserMessage = type("UserMessage", (), {})
+        SystemMessage = _SystemMessage
+        ResultMessage = _ResultMessage
+        StreamEvent = type("StreamEvent", (), {})
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+        messages: list = []
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return
+
+            async def query(self, prompt, session_id="default"):
+                _FakeSDK.messages = [
+                    _SystemMessage(
+                        subtype="hook_started",
+                        data={"hook_event": "PreCompact"},
+                        hook_event_name="PreCompact",
+                    ),
+                    _ResultMessage("claude-uuid-456", "compacted result"),
+                ]
+
+            async def receive_response(self):
+                for message in _FakeSDK.messages:
+                    yield message
+
+            async def disconnect(self):
+                return None
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._ensure_sdk",
+                return_value=_FakeSDK,
+            ),
+            patch(
+                "claude_agent_sdk.get_session_messages",
+                return_value=[],
+            ),
+        ):
+            events = [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hi", "session_id": "s1"}],
+                    [],
+                    "",
+                )
+            ]
+
+        started = [e for e in events if isinstance(e, CompactionStarted)]
+        completed = [e for e in events if isinstance(e, CompactionComplete)]
+        assert len(started) == 1, "expected exactly one CompactionStarted"
+        assert len(completed) == 1, "expected exactly one CompactionComplete"
+        assert events.index(started[0]) < events.index(
+            completed[0]
+        ), "CompactionStarted must precede CompactionComplete"
 
     _run(_t())
 


### PR DESCRIPTION
## Summary

- Add `CompactionStarted` inner executor event, yielded immediately when the Claude SDK fires its `PreCompact` hook during a streaming turn
- Translate `CompactionStarted` → `CompactionInProgressEvent` in `_executor_adapter.py`, separate from the `CompactionCompletedEvent` emitted on `CompactionComplete`
- Previously both events were emitted back-to-back after compaction finished, so clients never actually saw the in-progress state

## Test Plan

- Start a Claude SDK session and drive the context toward compaction threshold; verify `response.compaction.in_progress` arrives noticeably before `response.compaction.completed` in the SSE stream
- N/A for automated tests — compaction requires a real Claude SDK session at the context limit

## Demo

N/A — non-visual change

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Compaction requires a real Claude SDK session at the context limit; not exercised by unit tests.