### PR TITLE
fix(runner): fence spec-cache writes against a racing agent-cache reset

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2344,6 +2344,10 @@ def create_runner_app(
 
     _version_cache: dict[str, int] = {}  # conversation_id → last seen agent_version
     _spec_cache: dict[str, _SpecEntry] = {}  # agent_id → cached AgentSpec for terminal tools
+    # Agent-keyed analogue of _session_cache_generations. This cache is shared
+    # by every conversation, so a resolution parked across an invalidation must
+    # discard its write instead of reinstating the retired bundle for everyone.
+    _spec_cache_generations: dict[str, int] = {}
     _resp_to_conv: dict[str, str] = {}  # harness response_id → conversation_id
     _live_response_id: dict[str, str] = {}
     app.state.live_response_id = _live_response_id
@@ -2433,6 +2437,18 @@ def create_runner_app(
     def _session_cache_generation_is_current(session_id: str, generation: int) -> bool:
         """True only when the captured generation still matches — fill may write."""
         return _session_cache_generations.get(session_id, 0) == generation
+
+    def _spec_cache_generation(agent_id: str) -> int:
+        """Return (and materialize) the generation an agent-spec fill starts under."""
+        return _spec_cache_generations.setdefault(agent_id, 0)
+
+    def _spec_cache_generation_is_current(agent_id: str, generation: int) -> bool:
+        """True only when the captured generation still matches — fill may write."""
+        return _spec_cache_generations.get(agent_id, 0) == generation
+
+    # The spec caches are closure state, but their invalidation ordering is
+    # worth asserting directly rather than inferring from a turn's output.
+    app.state.spec_caches = {"agent": _spec_cache, "session": _session_spec_cache}
 
     _codex_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _pi_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
@@ -6516,6 +6532,9 @@ def create_runner_app(
         if _dispatched_agent_id:
             _session_agent_ids[conv] = _dispatched_agent_id
 
+        # Captured before the resolver awaits below: every memoizing write in
+        # this block is fenced on it, so a reset landing mid-resolve is not undone.
+        _turn_session_generation = _session_cache_generation(conv)
         cached_spec_entry = _session_spec_cache.get(conv)
         cached_spec = _unwrap_resolved_spec(cached_spec_entry)
         cached_spec_workdir = _resolved_spec_workdir(cached_spec_entry)
@@ -6524,13 +6543,19 @@ def create_runner_app(
             if _aid:
                 try:
                     resolved = await spec_resolver(_aid, conv)
+                    # This turn keeps what it resolved; only caching is fenced.
+                    _generation_current = _session_cache_generation_is_current(
+                        conv, _turn_session_generation
+                    )
                     if isinstance(resolved, ResolvedSpec):
                         cached_spec = _unwrap_resolved_spec(resolved)
                         cached_spec_workdir = _resolved_spec_workdir(resolved)
-                        _session_spec_cache[conv] = resolved
+                        if _generation_current:
+                            _session_spec_cache[conv] = resolved
                     elif resolved is not None:
                         cached_spec = resolved
-                        _session_spec_cache[conv] = resolved
+                        if _generation_current:
+                            _session_spec_cache[conv] = resolved
                 except (httpx.HTTPError, RuntimeError):
                     _logger.warning(
                         "Spec resolution failed for %s",
@@ -6567,12 +6592,14 @@ def create_runner_app(
                 cached_spec_entry = sub_entry
                 cached_spec = _unwrap_resolved_spec(sub_entry)
                 cached_spec_workdir = _resolved_spec_workdir(sub_entry)
-                _session_spec_cache[conv] = sub_entry
+                if _session_cache_generation_is_current(conv, _turn_session_generation):
+                    _session_spec_cache[conv] = sub_entry
 
         cached_spec = _spec_with_workdir_paths(cached_spec, cached_spec_workdir)
         if cached_spec is not None:
             cached_spec_entry = _rewrap_like(cached_spec_entry, cached_spec, cached_spec_workdir)
-            _session_spec_cache[conv] = cached_spec_entry
+            if _session_cache_generation_is_current(conv, _turn_session_generation):
+                _session_spec_cache[conv] = cached_spec_entry
 
         harness_name: str | None = None
         spawn_env: dict[str, str] | None = None
@@ -7052,6 +7079,7 @@ def create_runner_app(
                 _turn_spec_entry = _session_entry
                 _turn_spec = _unwrap_resolved_spec(_session_entry)
             if _turn_spec is None and spec_resolver is not None:
+                _eager_generation = _spec_cache_generation(_turn_agent_id)
                 try:
                     _resolved_turn_spec = await spec_resolver(_turn_agent_id, conv_id)
                     _turn_spec = _unwrap_resolved_spec(_resolved_turn_spec)
@@ -7069,7 +7097,10 @@ def create_runner_app(
                     )
                 else:
                     if _resolved_turn_spec is not None and _turn_spec is not None:
-                        _spec_cache[_turn_agent_id] = _resolved_turn_spec
+                        # This turn keeps what it resolved; only the shared cache
+                        # is fenced.
+                        if _spec_cache_generation_is_current(_turn_agent_id, _eager_generation):
+                            _spec_cache[_turn_agent_id] = _resolved_turn_spec
                         _turn_spec_entry = _resolved_turn_spec
             _turn_spec_resolved = True
             _turn_mcp = ProxyMcpManager(conv_id, server_client)
@@ -7107,6 +7138,7 @@ def create_runner_app(
                 _turn_spec_entry = cached
                 _turn_spec = _unwrap_resolved_spec(cached)
                 return cached, None
+            _lazy_generation = _spec_cache_generation(_turn_agent_id)
             try:
                 resolved = await spec_resolver(_turn_agent_id, conv_id)
             except (httpx.HTTPError, RuntimeError) as exc:
@@ -7122,7 +7154,8 @@ def create_runner_app(
                     "Failed to resolve the agent spec for this turn.",
                 )
             if resolved is not None:
-                _spec_cache[_turn_agent_id] = resolved
+                if _spec_cache_generation_is_current(_turn_agent_id, _lazy_generation):
+                    _spec_cache[_turn_agent_id] = resolved
                 _turn_spec_entry = resolved
                 _turn_spec = _unwrap_resolved_spec(resolved)
                 return resolved, None
@@ -9940,6 +9973,7 @@ def create_runner_app(
         _session_sub_agent_resolved.pop(session_id, None)
         if agent_id:
             _spec_cache.pop(agent_id, None)
+            _spec_cache_generations[agent_id] = _spec_cache_generations.get(agent_id, 0) + 1
 
     async def _invalidate_session_agent_state(session_id: str, new_agent_id: str | None) -> None:
         """Clear all agent-derived caches and release the harness subprocess.

--- a/tests/runner/test_spec_cache_invalidation_race.py
+++ b/tests/runner/test_spec_cache_invalidation_race.py
@@ -1,0 +1,176 @@
+"""Regression: an agent-cache reset must survive an in-flight spec resolution.
+
+The runner memoizes resolved agent specs in two caches -- one keyed by agent id
+and shared by every conversation, one keyed by session id -- and a reset drops
+both. Each cache had an unconditional write after awaiting the spec resolver, so
+a resolution that started before a reset could complete afterwards and re-install
+the bundle the reset had just retired. The next read was then served a spec the
+reset was supposed to have discarded.
+
+The rule under test: once a reset for a session completes, no later write may
+re-populate either cache from a resolution that began before it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from omnigent.runner import create_runner_app
+from omnigent.spec.types import AgentSpec
+from tests.runner.conftest import (
+    _FakeProcessManager,
+    _runner_client,
+    _ScriptedHarnessClient,
+    _sse,
+)
+from tests.runner.helpers import NullServerClient
+
+_AGENT_ID = "0e36e3219954d2deaef06b8e2a936f38"
+_CONV = "4e92b5a0c0ee6db3f874f9c4a3f855a5"
+
+
+def _turn_body() -> dict[str, Any]:
+    """A sessions-native user turn that resolves the agent spec."""
+    return {
+        "type": "message",
+        "role": "user",
+        "agent_id": _AGENT_ID,
+        "model": "test-agent",
+        "input": [{"type": "input_text", "text": "hi"}],
+        "harness": "openai-agents",
+        "has_mcp_servers": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_cache_reset_is_not_undone_by_an_in_flight_resolution() -> None:
+    """A resolution that raced a reset must not re-populate either spec cache."""
+    entered_resolver = asyncio.Event()
+    release_resolver = asyncio.Event()
+    superseded = AgentSpec(spec_version=1, name="before-reset")
+    current = AgentSpec(spec_version=1, name="after-reset")
+    resolutions = 0
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Block inside the first resolution so a reset can land mid-flight.
+
+        Only that first resolution predates the reset, so only its bundle is the
+        one no cache may end up holding. A resolution started afterwards is
+        current and may legitimately be memoized.
+        """
+        del agent_id, session_id
+        nonlocal resolutions
+        resolutions += 1
+        if resolutions == 1:
+            entered_resolver.set()
+            await release_resolver.wait()
+            return superseded
+        return current
+
+    harness_client = _ScriptedHarnessClient(
+        [_sse({"type": "response.created", "response": {"id": "resp_1"}})]
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(harness_client),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    caches = app.state.spec_caches
+
+    async with _runner_client(app) as client:
+        turn = asyncio.create_task(client.post(f"/v1/sessions/{_CONV}/events", json=_turn_body()))
+        await asyncio.wait_for(entered_resolver.wait(), timeout=5)
+
+        reset = await client.post(
+            f"/v1/sessions/{_CONV}/agent-cache/reset",
+            json={"agent_id": _AGENT_ID},
+        )
+        assert reset.status_code == 200
+        assert _CONV not in caches["session"], "the reset must drop the session entry"
+
+        # Let the raced resolution finish and attempt its now-stale write.
+        release_resolver.set()
+        assert (await asyncio.wait_for(turn, timeout=5)).status_code == 202
+        await asyncio.sleep(0.1)
+
+    assert caches["session"].get(_CONV) is not superseded, (
+        "the resolution that raced the reset re-installed the superseded bundle "
+        "in the session cache"
+    )
+    assert caches["agent"].get(_AGENT_ID) is not superseded, (
+        "the resolution that raced the reset re-installed the superseded bundle "
+        "in the shared agent cache"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_agent_cache_reset_is_not_undone_by_an_in_flight_resolution() -> None:
+    """A resolution that raced a reset must not re-populate the agent-keyed cache.
+
+    Only the eager MCP path writes that cache, and it resolves only when both
+    caches are unset as it starts, so the two resolutions before it return
+    ``None`` and leave them that way. A session-scoped generation cannot fence
+    this write: it answers whether this session's agent changed, not whether
+    this agent did.
+    """
+    entered_resolver = asyncio.Event()
+    release_resolver = asyncio.Event()
+    superseded = AgentSpec(spec_version=1, name="before-reset")
+    resolutions = 0
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec | None:
+        """Resolve nothing for turn setup, then race the reset in the eager path.
+
+        A turn resolves three times here -- turn setup, the harness config, and
+        the eager MCP path -- and only the last writes the shared cache. Turn
+        setup gets ``None`` so it leaves the session entry unset; the harness
+        config still needs a spec or the turn aborts before the eager path.
+        """
+        del agent_id, session_id
+        nonlocal resolutions
+        resolutions += 1
+        if resolutions == 1:
+            return None
+        if resolutions == 2:
+            return AgentSpec(spec_version=1, name="harness-selection")
+        entered_resolver.set()
+        await release_resolver.wait()
+        return superseded
+
+    harness_client = _ScriptedHarnessClient(
+        [_sse({"type": "response.created", "response": {"id": "resp_1"}})]
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(harness_client),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    caches = app.state.spec_caches
+
+    async with _runner_client(app) as client:
+        turn = asyncio.create_task(client.post(f"/v1/sessions/{_CONV}/events", json=_turn_body()))
+        await asyncio.wait_for(entered_resolver.wait(), timeout=5)
+
+        reset = await client.post(
+            f"/v1/sessions/{_CONV}/agent-cache/reset",
+            json={"agent_id": _AGENT_ID},
+        )
+        assert reset.status_code == 200
+        assert _AGENT_ID not in caches["agent"], "the reset must drop the agent entry"
+
+        # Let the raced resolution finish and attempt its now-stale write.
+        release_resolver.set()
+        assert (await asyncio.wait_for(turn, timeout=5)).status_code == 202
+        await asyncio.sleep(0.1)
+
+    assert resolutions == 3, (
+        "the turn no longer makes the three resolutions this scenario assumes, "
+        "so the raced write is not the eager MCP path's -- re-derive the setup"
+    )
+    assert caches["agent"].get(_AGENT_ID) is not superseded, (
+        "the resolution that raced the reset re-installed the superseded bundle "
+        "in the shared agent cache"
+    )

--- a/tests/runner/test_spec_cache_invalidation_race.py
+++ b/tests/runner/test_spec_cache_invalidation_race.py
@@ -45,6 +45,17 @@ def _turn_body() -> dict[str, Any]:
     }
 
 
+def _lazy_turn_body() -> dict[str, Any]:
+    """A streaming turn that resolves the spec only when a tool call needs it.
+
+    Without the MCP hint the eager fill is skipped entirely, so the first
+    resolution of the shared cache happens mid-stream, in the lazy path.
+    """
+    body = _turn_body()
+    del body["has_mcp_servers"]
+    return body
+
+
 @pytest.mark.asyncio
 async def test_agent_cache_reset_is_not_undone_by_an_in_flight_resolution() -> None:
     """A resolution that raced a reset must not re-populate either spec cache."""
@@ -173,4 +184,79 @@ async def test_shared_agent_cache_reset_is_not_undone_by_an_in_flight_resolution
     assert caches["agent"].get(_AGENT_ID) is not superseded, (
         "the resolution that raced the reset re-installed the superseded bundle "
         "in the shared agent cache"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lazy_agent_cache_fill_is_not_undone_by_an_in_flight_resolution() -> None:
+    """The dispatch-time fill of the shared cache must be fenced as well.
+
+    The eager fill runs only for a turn that declares MCP servers. A streaming
+    turn without that hint resolves nothing up front: the shared cache is
+    written when a tool call arrives and has to be classified, and that is the
+    other unguarded write after an await.
+    """
+    entered_resolver = asyncio.Event()
+    release_resolver = asyncio.Event()
+    superseded = AgentSpec(spec_version=1, name="before-reset")
+    resolutions = 0
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Race the reset from the lazy path, the turn's only resolution."""
+        del agent_id, session_id
+        nonlocal resolutions
+        resolutions += 1
+        entered_resolver.set()
+        await release_resolver.wait()
+        return superseded
+
+    harness_client = _ScriptedHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+            # A runner builtin: classifying it for local dispatch is what pulls
+            # the spec in, so the fill happens mid-stream.
+            _sse(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "function_call",
+                        "status": "action_required",
+                        "name": "sys_os_read",
+                        "call_id": "call_1",
+                        "arguments": "{}",
+                    },
+                }
+            ),
+        ]
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(harness_client),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    caches = app.state.spec_caches
+
+    async with _runner_client(app) as client:
+        turn = asyncio.create_task(
+            client.post(f"/v1/sessions/{_CONV}/events?stream=true", json=_lazy_turn_body())
+        )
+        await asyncio.wait_for(entered_resolver.wait(), timeout=5)
+
+        reset = await client.post(
+            f"/v1/sessions/{_CONV}/agent-cache/reset",
+            json={"agent_id": _AGENT_ID},
+        )
+        assert reset.status_code == 200
+
+        # Let the raced resolution finish and attempt its now-stale write.
+        release_resolver.set()
+        assert (await asyncio.wait_for(turn, timeout=5)).status_code == 200
+
+    assert resolutions == 1, (
+        "the streaming turn no longer resolves the spec exactly once, so the "
+        "raced write may not be the lazy path's -- re-derive the setup"
+    )
+    assert caches["agent"].get(_AGENT_ID) is not superseded, (
+        "the dispatch-time resolution that raced the reset re-installed the "
+        "superseded bundle in the shared agent cache"
     )


### PR DESCRIPTION
## Related issue

Closes #3951

## Summary

`_spec_cache` (agent id → resolved spec, shared by every conversation on the runner) and `_session_spec_cache` (session id → resolved spec) are both dropped by an agent-cache reset, but the writes that follow an awaited spec resolution did not re-examine the cache. A resolution that began before a reset could finish after it and re-install the bundle the reset had just retired, so the next read was served a spec that was meant to be gone.

**ELI5:** two people share a whiteboard. One erases it because the plan changed; the other, who copied the old plan just before the erase, writes it back afterwards. Everyone who reads the board next follows the old plan.

```
resolution starts ───── await resolver ─────▶ write   (unconditional)
                             │
   reset drops both caches ──┘
                               superseded bundle lands after the reset
```

- **Session cache: extend the guard that is already there.** `_session_cache_generations` (added by #5544 for #3728) fences the write in `_resolve_session_spec_entry`, but not the writes a turn makes during setup. Capture the same generation before the resolver is awaited and fence those four writes on it.
- **Shared agent cache: add the agent-keyed analogue.** This cache has no guard, and the issue says why a session-scoped one cannot serve it — it answers "did the agent of this session change while I waited", not "did this agent change". `_spec_cache_generations` is bumped where the reset drops the agent's entry, and the eager and lazy fills are fenced on it.
- Both fences skip only the write. The turn still uses whatever it resolved, so a raced turn is never left without a spec.
- Publish the caches on `app.state`, next to the locks and registries already there, so a test can assert the invalidation ordering directly instead of inferring it from a turn's output.

**Why two counters and not one.** Reusing `_session_cache_generations` for the shared cache would key an agent-wide invalidation on one session's generation: a reset in session A would not fence a resolution in session B holding the same agent, which is the multi-conversation half of the issue. The agent-keyed counter is bumped in the same place the agent entry is dropped, so it is exactly as wide as the invalidation it guards.

## Test Plan

`tests/runner/test_spec_cache_invalidation_race.py` covers both races through the runner's ASGI app — the turn endpoint plus `/agent-cache/reset` — rather than calling closure internals. Each test blocks a resolution, resets while it is blocked, releases it, and asserts the raced bundle is not what the cache ends up holding. A resolution that *starts* after the reset is current, so the assertion names the superseded bundle specifically, not an empty cache.

The two writes need different setups. The shared cache is only written when the session entry is absent as the resolver starts (the issue calls this out), so that test returns `None` for turn setup to leave the entry unset and drives the eager MCP path. It also asserts the turn made exactly the three resolutions the scenario assumes, so a future change to that ordering fails the test instead of silently passing it.

```
OMNIGENT_SKIP_WEB_UI=true uv run pytest \
  tests/runner/test_spec_cache_invalidation_race.py -q
OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/runner/ -q
```

Each fence was reverted on its own, keeping the `app.state` line so the test fails on its assertion rather than on a missing attribute:

- with the fix: `2 passed`
- session fence reverted: `AssertionError: the resolution that raced the reset re-installed the superseded bundle in the session cache`
- agent fence reverted: `AssertionError: the resolution that raced the reset re-installed the superseded bundle in the shared agent cache`

Both halves are therefore load-bearing: neither test passes on the other's fence alone.

`tests/runner/` is 1755 passed, 6 failed, 1 skipped, 4 xfailed. The same 6 fail identically on the rebase base with only `omnigent/runner/app.py` reverted, so none of them come from this change — they are local-environment failures on this macOS checkout (an ambiguous `~/.databrickscfg` profile, and pi cwd threading). `pre-commit` passes on both changed files: ruff format, ruff check, pyrefly, and the repo's custom hooks.

## Demo

Race-condition fix with no UI surface, so there is nothing to screenshot — what the fix produces is the absence of a rare interleaving. The observable difference is in the regression tests, run against the same tests with only the guards reverted:

```
# guards reverted (main's behaviour)
AssertionError: the resolution that raced the reset re-installed the
superseded bundle in the session cache
AssertionError: the resolution that raced the reset re-installed the
superseded bundle in the shared agent cache

# with the fix
2 passed
```

Kept as **Bug fix** rather than reclassified: it fixes a real defect (#3951), so labelling it a refactor would misrepresent the risk to reviewers. Happy to add a terminal recording if that is preferred over the output above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests assert the invariant the issue states: once a reset completes, no later write may re-populate either cache from a resolution that began before it. Each fails on unfixed code for that reason and no other, and each is pinned to the specific cache it covers, so a partial fix cannot make both pass.

## Changelog

A session no longer keeps running on an agent spec that a cache reset had already retired.

## Issues

Resolves [OMNI-2282](https://linear.app/omnigent/issue/OMNI-2282/the-runner-wide-agent-spec-cache-can-publish-a-superseded-tool-spec)
