### PR TITLE
fix(web): don't re-stamp replayed pending messages at promotion time

### DIFF
--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4711,7 +4711,7 @@ function committedUserBlock(
       // Client clock — see blockStream.ctx; keeps server-stamped
       // `createdAtS` comparisons single-clock. A promoted optimistic
       // bubble keeps its send-time stamp rather than re-stamping now.
-      clientCreatedAtS: createdAtS ?? Math.floor(Date.now() / 1000),
+      ...(createdAtS !== undefined ? { clientCreatedAtS: createdAtS } : {}),
     },
     content,
     stableKey,


### PR DESCRIPTION
## Related issue

Closes #4372 (blocking review feedback)

## Summary

`committedUserBlock` fell back to `Date.now()` when no `createdAtS` was provided. On the replayed-pending path — where `toPending()` intentionally omits `createdAtS` — this caused consumed messages to briefly display the consume time instead of no timestamp, violating the PR's stated invariant that replayed entries show no re-stamped time.

Changed the unconditional `clientCreatedAtS: createdAtS ?? Math.floor(Date.now() / 1000)` to a conditional spread `...(createdAtS !== undefined ? { clientCreatedAtS: createdAtS } : {})`, so the field stays absent when no real stamp exists. The rendering pipeline already handles `undefined` gracefully by hiding the timestamp. The streaming path in `blockStream.ts` still stamps `Date.now()`, which is correct for fresh items.

## Test Plan

- Existing `renderItems.test.ts` (138 tests) and `blockStream.test.ts` (62 tests) all pass
- Manual verification: open a session with a pending message queued → reload → the replayed pending bubble shows no timestamp → when the server consumes it, the promoted bubble still shows no timestamp (instead of the wrong consume time) → on next reload, `itemsToBlocks` hydrates the correct server `created_at`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The bug only manifests in the narrow window where a pending message survives a page reload and is then consumed while still on screen. Existing `renderItems` and `blockStream` test suites verify that `clientCreatedAtS` is correctly propagated (or absent) through the rendering pipeline. Manual verification confirms the replayed-pending → promotion path no longer re-stamps.