### PR TITLE
docs: holistic touch interaction spec and design (gesture dispatcher + left rail)

### DIFF
--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -63,8 +63,9 @@ Migration of the five hooks to
 `touch-action: none` on handles (TR-6, TR-9) and TR-6's robustness
 outcomes: clean abort on `pointercancel`/capture loss, unmount cleanup,
 first-pointer-wins, and iframe-overlay shielding during drags (the
-existing mouse paths already overlay iframes; keep that). Coarse-pointer
-hit-target padding on handles (TR-7); `useResizableColumn` gains the
+existing mouse paths already overlay iframes; keep that). Invisible
+hit-target padding on handles on all devices (TR-7); `useResizableColumn`
+gains the
 keyboard path the other hooks already have (TR-8). No API change for
 consumers — five small, independently reviewable PRs.
 
@@ -80,14 +81,14 @@ routes through the dispatcher as a `resize`-intent claimant.
 
 Generalizes the train's `useRowGesture` (commit `8dd70928c` and successors
 on `feature/mobile-slide-actions-v2` / `train/polly/session-row-gesture-fix`
-— recover the hardening: drift tolerance, the disjoint-region math now
-normative in TR-11's threshold table, WebView haptics). One instance owns
+— recover the hardening: drift tolerance, the threshold constants now
+normative in TR-11's table, WebView haptics). One instance owns
 one contended surface's pointer stream and awards it to a single intent
 (TR-10). Timing and thresholds are TR-11/TR-12's; the state machine:
 
 ```
 pointerdown (pointerType touch|pen; mouse passes through unchanged)
-  └─ undecided ──(vertical-first movement)──────────────► release to scroll
+  └─ undecided ──(vertical-first ≥ SCROLL_ACTIVATION_PX)──► release to scroll
        │        ──(horizontal-first ≥ SWIPE_ACTIVATION_PX)► swipe
        │        ──(stationary within HOLD_DRIFT_PX for HOLD_MS)► armed
        │              ├─(moves > DRAG_TOLERANCE_PX)───────► drag (menu suppressed)
@@ -100,7 +101,9 @@ with a haptic cue — not on release. Award is exclusive and
 first-crossed-wins per TR-11 — there is no geometric disjointness between
 hold and swipe; crossing any award threshold cancels hold eligibility. A
 second touch pointer joining an undecided sequence cancels it and yields
-to browser pinch-zoom (TR-28). While undecided the dispatcher buffers via
+to browser pinch-zoom; one joining an already-awarded sequence is ignored
+— first pointer keeps ownership (TR-11, TR-28). While undecided the
+dispatcher buffers via
 refs — no React state churn, passive listeners on scroll containers
 (TR-16(a)/(b) are component-test assertions).
 
@@ -115,7 +118,9 @@ Integration points, in order:
 2. **Edge ownership table** — a small module implementing TR-14's
    normative matrix (start-edge → rail open; end-edge → released to
    browser/OS; Android back → dismissal stack; browser back → per-layer
-   history entries, one `popstate` closes one token-matched layer).
+   history entries, one `popstate` closes one token-matched layer, and
+   non-popstate dismissals — scrim tap, Escape, close button, Android back
+   — consume their layer's entry so back never no-ops on an orphan).
    `__omnigentNativeHandleBack` (Android) and the iOS edge-pan handoff
    both resolve through it (TR-28); iOS edge-pan only ever OPENS the rail
    — dismissal on iOS is tap/scrim/keyboard per TR-24.
@@ -164,9 +169,10 @@ extensions above it; it does not fork the contract. Mobile gets:
   (TR-25);
 - safe-area insets applied once at the rail boundary from the existing
   `--omnigent-safe-*` vars (TR-26);
-- Android back and iOS edge-pan dismiss rail layers per TR-14's dismissal
-  stack (TR-24); displaced header controls (the #3589/#4551 strip) get
-  rail homes (TR-27).
+- Android back and browser back dismiss rail layers per TR-14's dismissal
+  stack; iOS has no edge-dismissal gesture — dismissal there is scrim tap,
+  rail anchor, close button, or keyboard (TR-24); displaced header
+  controls (the #3589/#4551 strip) get rail homes (TR-27).
 
 Migration runs the rail behind a temporary fallback alongside the FAB/drawer
 path, then removes the duplicates once task coverage is proven.

--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -96,8 +96,12 @@ pointerdown (pointerType touch|pen; mouse passes through unchanged)
 ```
 
 The menu opens AT `MENU_HOLD_MS` while the finger is still down (TR-12),
-with a haptic cue — not on release. While undecided the dispatcher buffers
-via refs — no React state churn, passive listeners on scroll containers
+with a haptic cue — not on release. Award is exclusive and
+first-crossed-wins per TR-11 — there is no geometric disjointness between
+hold and swipe; crossing any award threshold cancels hold eligibility. A
+second touch pointer joining an undecided sequence cancels it and yields
+to browser pinch-zoom (TR-28). While undecided the dispatcher buffers via
+refs — no React state churn, passive listeners on scroll containers
 (TR-16(a)/(b) are component-test assertions).
 
 Integration points, in order:
@@ -110,8 +114,11 @@ Integration points, in order:
    review defects encoded as regression tests (TR-29).
 2. **Edge ownership table** — a small module implementing TR-14's
    normative matrix (start-edge → rail open; end-edge → released to
-   browser/OS; back → dismissal stack). `__omnigentNativeHandleBack`
-   (Android) and the iOS edge-pan handoff both resolve through it (TR-28).
+   browser/OS; Android back → dismissal stack; browser back → per-layer
+   history entries, one `popstate` closes one token-matched layer).
+   `__omnigentNativeHandleBack` (Android) and the iOS edge-pan handoff
+   both resolve through it (TR-28); iOS edge-pan only ever OPENS the rail
+   — dismissal on iOS is tap/scrim/keyboard per TR-24.
    Per-surface `touch-action`/`overscroll-behavior` claims land per TR-28's
    baseline table.
 3. **Editor/table surfaces** — `TableBubbleMenu`'s mouse-only table

--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -99,7 +99,10 @@ pointerdown (pointerType touch|pen; mouse passes through unchanged)
 The menu opens AT `MENU_HOLD_MS` while the finger is still down (TR-12),
 with a haptic cue — not on release. Award is exclusive and
 first-crossed-wins per TR-11 — there is no geometric disjointness between
-hold and swipe; crossing any award threshold cancels hold eligibility. A
+hold and swipe. On a hold-offering surface TR-11's two-radius rule
+replaces the first two branches above: nothing awards inside the
+`HOLD_DRIFT_PX` circle, exiting it pre-arm awards by dominant axis, and
+the activation radii govern only motion-trending (no-hold) surfaces. A
 second touch pointer joining an undecided sequence cancels it and yields
 to browser pinch-zoom; one joining an already-awarded sequence is ignored
 — first pointer keeps ownership (TR-11, TR-28). While undecided the
@@ -123,7 +126,8 @@ Integration points, in order:
    — consume their layer's entry so back never no-ops on an orphan).
    `__omnigentNativeHandleBack` (Android) and the iOS edge-pan handoff
    both resolve through it (TR-28); iOS edge-pan only ever OPENS the rail
-   — dismissal on iOS is tap/scrim/keyboard per TR-24.
+   — closing is the on-surface start-directed swipe (all platforms,
+   TR-14) or tap/scrim/keyboard per TR-24.
    Per-surface `touch-action`/`overscroll-behavior` claims land per TR-28's
    baseline table.
 3. **Editor/table surfaces** — `TableBubbleMenu`'s mouse-only table
@@ -165,13 +169,15 @@ extensions above it; it does not fork the contract. Mobile gets:
   FAB→tab mappings in `AppShell` and the per-tool `MobilePanelDrawer`
   states collapse into one open/close machine;
 - expansion by tap / start-edge swipe (dispatcher client, TR-14) /
-  keyboard, with `WorkspacePanel`'s ARIA + roving tabindex inherited
-  (TR-25);
+  keyboard, and collapse by tap / start-directed swipe on the open rail
+  or scrim (TR-14) / keyboard, with `WorkspacePanel`'s ARIA + roving
+  tabindex inherited (TR-25);
 - safe-area insets applied once at the rail boundary from the existing
   `--omnigent-safe-*` vars (TR-26);
 - Android back and browser back dismiss rail layers per TR-14's dismissal
-  stack; iOS has no edge-dismissal gesture — dismissal there is scrim tap,
-  rail anchor, close button, or keyboard (TR-24); displaced header
+  stack; iOS has no edge-dismissal gesture, but the on-surface
+  swipe-to-close applies there too (TR-14) — plus scrim tap, rail anchor,
+  close button, or keyboard (TR-24); displaced header
   controls (the #3589/#4551 strip) get rail homes (TR-27).
 
 Migration runs the rail behind a temporary fallback alongside the FAB/drawer

--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -100,9 +100,13 @@ The menu opens AT `MENU_HOLD_MS` while the finger is still down (TR-12),
 with a haptic cue — not on release. Award is exclusive and
 first-crossed-wins per TR-11 — there is no geometric disjointness between
 hold and swipe. On a hold-offering surface TR-11's two-radius rule
-replaces the first two branches above: nothing awards inside the
-`HOLD_DRIFT_PX` circle, exiting it pre-arm awards by dominant axis, and
-the activation radii govern only motion-trending (no-hold) surfaces. A
+replaces the first two branches above: no motion-based award inside the
+`HOLD_DRIFT_PX` circle, exiting it pre-arm awards by dominant axis
+(horizontal-first falls back to scroll release where the surface offers
+no swipe; |dx| == |dy| ties resolve vertical-first), a native `pan-y`
+`pointercancel` still releases to scroll earlier than the circle bound
+(TR-11's caveat from `c21fec929`), and the activation radii govern only
+motion-trending (no-hold) surfaces. A
 second touch pointer joining an undecided sequence cancels it and yields
 to browser pinch-zoom; one joining an already-awarded sequence is ignored
 — first pointer keeps ownership (TR-11, TR-28). While undecided the

--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -1,0 +1,153 @@
+# Touch Interaction Design
+
+Status: proposed. Architecture and phasing for
+[touch-interaction-spec.md](touch-interaction-spec.md). Requirements are
+referenced as `TR-n`.
+
+## Shape of the solution
+
+Three layers, built bottom-up. Each layer ships independently and is useful
+without the ones above it.
+
+```
+Phase 2   Left rail (single mobile nav surface)          TR-20..25
+             │ consumes
+Phase 1   Gesture dispatcher (one owner per surface)     TR-9..19, 26..27
+             │ consumes
+Phase 0   Input capability + pointer-event foundation    TR-1..8
+```
+
+## Phase 0 — foundation (no behavior redesign)
+
+### `useInputCapabilities`
+
+One hook (plus a matching CSS custom-media/utility story) wrapping:
+
+```ts
+interface InputCapabilities {
+  coarsePrimary: boolean;   // (pointer: coarse)
+  anyCoarse: boolean;       // (any-pointer: coarse)
+  hoverPrimary: boolean;    // (hover: hover)
+}
+```
+
+Backed by `matchMedia` with change listeners, so convertibles and
+mouse-attach events update live (TR-1). All existing touch-conditional
+logic migrates from width checks to this hook (TR-2). The abandoned-train
+commit that moved row gestures to coarse-pointer gating is the prototype;
+resurrect its approach, not its diff.
+
+### Breakpoint consolidation
+
+One module exports the canonical breakpoints; `useIsMobileViewport` and the
+JS `MD_BREAKPOINT` constants consume it; the stray `767px`/`767.98px`
+variants are unified (TR-3). The Android `NativeBridgeScript` width probe is
+replaced by reading the web layer's signal (TR-4).
+
+### Resize hooks → pointer events
+
+Mechanical migration of the five hooks to
+`pointerdown`/`pointermove`/`pointerup` + `setPointerCapture`, with
+`touch-action: none` on handles (TR-5, TR-8). Coarse-pointer hit-target
+padding on handles (TR-6); `useResizableColumn` gains the keyboard path the
+other hooks already have (TR-7). No API change for consumers — this is five
+small, independently reviewable PRs.
+
+## Phase 1 — the gesture dispatcher
+
+### Core: `useGestureDispatcher`
+
+Generalizes the train's `useRowGesture` (commit `8dd70928c` and successors
+on `feature/mobile-slide-actions-v2` / `train/polly/session-row-gesture-fix`
+— recover the hardening: drift tolerance, disjoint-region thresholds,
+WebView haptic hook). One instance owns one surface's pointer stream and
+awards it to a single intent (TR-9):
+
+```
+pointerdown
+  └─ undecided ──(axis-locked horizontal ≥ swipe threshold)──► swipe
+       │        ──(vertical movement first)────────────────► release to scroll
+       │        ──(hold ≥ holdMs, still within tolerance)──► hold
+       │              └─(then moves past drag tolerance)───► drag
+       │              └─(released without drag)────────────► context menu
+       └─(fine pointer)──► mouse semantics unchanged
+```
+
+Thresholds live in one exported constants module with the disjointness
+documented (TR-10). While undecided the dispatcher buffers via refs — no
+React state churn, passive listeners where possible (TR-15).
+
+Integration points, in order:
+
+1. **Session rows** — replaces the direct dnd-kit TouchSensor + Radix
+   long-press contention: the dispatcher decides, then *drives* dnd-kit
+   (activate drag programmatically) and the context menu (controlled open)
+   rather than letting their timers race (TR-11, TR-12, TR-17). #3985's
+   swipe actions become the first swipe consumer (TR-16), with the #3154
+   review defects encoded as regression tests (TR-28).
+2. **Resize handles** — Phase 0's pointer hooks register as `resize` intent
+   claimants so an active resize excludes other consumers (TR-8).
+3. **Edge ownership table** — a small module declaring who owns each edge
+   and the back-dismissal stack (TR-13). `__omnigentNativeHandleBack`
+   (Android) and the iOS edge-pan handoff both resolve through it (TR-26).
+   Per-surface `touch-action`/`overscroll-behavior` claims are declared
+   alongside (TR-27).
+
+### What the dispatcher is *not*
+
+Not a global event bus and not a wrapper around every click. Plain taps,
+buttons, and inputs never route through it. It exists only where ≥2 gesture
+consumers contend for the same pointer stream (rows, edges, handles).
+
+## Phase 2 — the left rail (gated)
+
+**Go/no-go gate:** Phase 2 starts only after Phase 1's row arbitration has
+landed and survived on main, and mobile-nav pain still justifies it. If
+cancelled, Phases 0–1 stand alone (this is the debate's decided asymmetry:
+the dispatcher is designed against the rail topology from day one via the
+edge-ownership table, so the rail is a consumer, not a rewrite).
+
+### Model
+
+Adapt, don't invent: the desktop `WorkspacePanel` Radix `Tabs` rail is
+already the navigation model (TR-20). Mobile gets:
+
+- a narrow persistent rail anchor (icon column) instead of the full-screen
+  sidebar overlay + top-right FAB (TR-21);
+- one destination set shared with desktop via the existing `railTabs`
+  contract — the six hand-maintained FAB→tab mappings in `AppShell` and the
+  per-tool `MobilePanelDrawer` states collapse into one open/close machine;
+- expansion by tap / edge-swipe (dispatcher client, TR-13) / keyboard, with
+  `WorkspacePanel`'s ARIA + roving tabindex inherited (TR-23);
+- safe-area insets applied once at the rail boundary from the existing
+  `--omnigent-safe-*` vars (TR-24);
+- Android back and iOS edge-pan dismiss rail layers per the ownership table
+  (TR-22); displaced header controls (the #3589/#4551 strip) get rail homes
+  (TR-25).
+
+Migration runs the rail behind a temporary fallback alongside the FAB/drawer
+path, then removes the duplicates once task coverage is proven.
+
+## Delivery mechanics
+
+- Every PR cites the TR-ns it satisfies; reviewers judge against the spec.
+- Phase 0 is parallelizable (capability hook, breakpoint consolidation, five
+  hook migrations ≈ seven small PRs).
+- Phase 1 lands the dispatcher core with the session-row integration as its
+  proving consumer, then #3985 rebases onto it instead of shipping a bespoke
+  swipe.
+- Salvage before rewrite: audit `feature/mobile-slide-actions-v2` and
+  `train/polly/session-row-gesture-fix` for reusable recognizer/test code;
+  cherry-pick with history noted in PR descriptions.
+- UI-visible PRs carry demo media and `tests/e2e_ui` coverage per repo
+  policy (TR-29).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Dispatcher becomes a framework nobody else adopts | Scope it to contended surfaces only; three named integration points, no speculative API |
+| Phase 2 stalls like #1395 | Hard gate + fallback path; Phases 0–1 are complete deliverables on their own |
+| Threshold tuning churn | Constants in one module, values + rationale documented, changed only with device-matrix retest |
+| Native shells drift from the ownership table | Table is the single source; shell PRs that add gesture heuristics are rejected per TR-26 |
+| Scroll perf regression on long session lists | TR-15 gates; profile on low-end Android in review |

--- a/docs/touch-interaction-design.md
+++ b/docs/touch-interaction-design.md
@@ -10,11 +10,11 @@ Three layers, built bottom-up. Each layer ships independently and is useful
 without the ones above it.
 
 ```
-Phase 2   Left rail (single mobile nav surface)          TR-20..25
+Phase 2   Left rail (single mobile nav surface)          TR-22..27
              │ consumes
-Phase 1   Gesture dispatcher (one owner per surface)     TR-9..19, 26..27
+Phase 1   Gesture dispatcher (one owner per surface)     TR-10..21, 28
              │ consumes
-Phase 0   Input capability + pointer-event foundation    TR-1..8
+Phase 0   Input capability + pointer-event foundation    TR-1..9
 ```
 
 ## Phase 0 — foundation (no behavior redesign)
@@ -32,26 +32,47 @@ interface InputCapabilities {
 ```
 
 Backed by `matchMedia` with change listeners, so convertibles and
-mouse-attach events update live (TR-1). All existing touch-conditional
-logic migrates from width checks to this hook (TR-2). The abandoned-train
-commit that moved row gestures to coarse-pointer gating is the prototype;
-resurrect its approach, not its diff.
+mouse-attach events update live (TR-1). Per TR-2 this hook gates
+*affordances only* — persistent vs hover-revealed controls (TR-5), hit
+targets, swipe hints. Gesture recognition never reads it: recognizers
+branch on the live sequence's `PointerEvent.pointerType`, so a touch on a
+fine-primary laptop still gets gesture semantics. The abandoned-train
+commit that moved row gestures off viewport width is the prototype;
+resurrect its approach, generalized from capability-gating to
+pointerType-binding.
 
 ### Breakpoint consolidation
 
 One module exports the canonical breakpoints; `useIsMobileViewport` and the
 JS `MD_BREAKPOINT` constants consume it; the stray `767px`/`767.98px`
-variants are unified (TR-3). The Android `NativeBridgeScript` width probe is
-replaced by reading the web layer's signal (TR-4).
+variants are unified (TR-3). The Android `NativeBridgeScript` back handler
+stops hardcoding its own `innerWidth < 768` copy and consumes the web
+layer's signal (TR-4).
+
+### Hover-affordance fallback
+
+The sidebar row/folder action buttons (`md:opacity-0
+md:group-hover:opacity-100`) render persistently (or behind a visible
+menu) when `hoverPrimary` is false (TR-5). Small, self-contained PR;
+unblocks touch laptops immediately.
 
 ### Resize hooks → pointer events
 
-Mechanical migration of the five hooks to
+Migration of the five hooks to
 `pointerdown`/`pointermove`/`pointerup` + `setPointerCapture`, with
-`touch-action: none` on handles (TR-5, TR-8). Coarse-pointer hit-target
-padding on handles (TR-6); `useResizableColumn` gains the keyboard path the
-other hooks already have (TR-7). No API change for consumers — this is five
-small, independently reviewable PRs.
+`touch-action: none` on handles (TR-6, TR-9) and TR-6's robustness
+outcomes: clean abort on `pointercancel`/capture loss, unmount cleanup,
+first-pointer-wins, and iframe-overlay shielding during drags (the
+existing mouse paths already overlay iframes; keep that). Coarse-pointer
+hit-target padding on handles (TR-7); `useResizableColumn` gains the
+keyboard path the other hooks already have (TR-8). No API change for
+consumers — five small, independently reviewable PRs.
+
+Isolated handles do NOT register with the gesture dispatcher — pointer
+capture plus `touch-action: none` fully arbitrates a handle nothing else
+contends for. Only a handle that overlaps another recognizer's territory
+(e.g. a future rail-edge handle sitting inside the `EDGE_ZONE_PX` strip)
+routes through the dispatcher as a `resize`-intent claimant.
 
 ## Phase 1 — the gesture dispatcher
 
@@ -59,45 +80,54 @@ small, independently reviewable PRs.
 
 Generalizes the train's `useRowGesture` (commit `8dd70928c` and successors
 on `feature/mobile-slide-actions-v2` / `train/polly/session-row-gesture-fix`
-— recover the hardening: drift tolerance, disjoint-region thresholds,
-WebView haptic hook). One instance owns one surface's pointer stream and
-awards it to a single intent (TR-9):
+— recover the hardening: drift tolerance, the disjoint-region math now
+normative in TR-11's threshold table, WebView haptics). One instance owns
+one contended surface's pointer stream and awards it to a single intent
+(TR-10). Timing and thresholds are TR-11/TR-12's; the state machine:
 
 ```
-pointerdown
-  └─ undecided ──(axis-locked horizontal ≥ swipe threshold)──► swipe
-       │        ──(vertical movement first)────────────────► release to scroll
-       │        ──(hold ≥ holdMs, still within tolerance)──► hold
-       │              └─(then moves past drag tolerance)───► drag
-       │              └─(released without drag)────────────► context menu
-       └─(fine pointer)──► mouse semantics unchanged
+pointerdown (pointerType touch|pen; mouse passes through unchanged)
+  └─ undecided ──(vertical-first movement)──────────────► release to scroll
+       │        ──(horizontal-first ≥ SWIPE_ACTIVATION_PX)► swipe
+       │        ──(stationary within HOLD_DRIFT_PX for HOLD_MS)► armed
+       │              ├─(moves > DRAG_TOLERANCE_PX)───────► drag (menu suppressed)
+       │              └─(still stationary at MENU_HOLD_MS)► context menu opens
+       │                    └─ sequence consumed: no drag; menu takes focus
 ```
 
-Thresholds live in one exported constants module with the disjointness
-documented (TR-10). While undecided the dispatcher buffers via refs — no
-React state churn, passive listeners where possible (TR-15).
+The menu opens AT `MENU_HOLD_MS` while the finger is still down (TR-12),
+with a haptic cue — not on release. While undecided the dispatcher buffers
+via refs — no React state churn, passive listeners on scroll containers
+(TR-16(a)/(b) are component-test assertions).
 
 Integration points, in order:
 
 1. **Session rows** — replaces the direct dnd-kit TouchSensor + Radix
    long-press contention: the dispatcher decides, then *drives* dnd-kit
    (activate drag programmatically) and the context menu (controlled open)
-   rather than letting their timers race (TR-11, TR-12, TR-17). #3985's
-   swipe actions become the first swipe consumer (TR-16), with the #3154
-   review defects encoded as regression tests (TR-28).
-2. **Resize handles** — Phase 0's pointer hooks register as `resize` intent
-   claimants so an active resize excludes other consumers (TR-8).
-3. **Edge ownership table** — a small module declaring who owns each edge
-   and the back-dismissal stack (TR-13). `__omnigentNativeHandleBack`
-   (Android) and the iOS edge-pan handoff both resolve through it (TR-26).
-   Per-surface `touch-action`/`overscroll-behavior` claims are declared
-   alongside (TR-27).
+   rather than letting their timers race (TR-12, TR-13, TR-18). #3985's
+   swipe actions become the first swipe consumer (TR-17), with the #3154
+   review defects encoded as regression tests (TR-29).
+2. **Edge ownership table** — a small module implementing TR-14's
+   normative matrix (start-edge → rail open; end-edge → released to
+   browser/OS; back → dismissal stack). `__omnigentNativeHandleBack`
+   (Android) and the iOS edge-pan handoff both resolve through it (TR-28).
+   Per-surface `touch-action`/`overscroll-behavior` claims land per TR-28's
+   baseline table.
+3. **Editor/table surfaces** — `TableBubbleMenu`'s mouse-only table
+   row/column manipulation and context actions gain touch paths (TR-21):
+   long-press via the dispatcher where the surface is contended (selection
+   vs. menu), plain visible controls where it is not. Scheduled at the end
+   of Phase 1; independent of the sidebar work.
+4. **Contended resize handles only** — per the Phase 0 rule above, only
+   handles overlapping another recognizer register `resize` claims (TR-9).
 
 ### What the dispatcher is *not*
 
 Not a global event bus and not a wrapper around every click. Plain taps,
-buttons, and inputs never route through it. It exists only where ≥2 gesture
-consumers contend for the same pointer stream (rows, edges, handles).
+buttons, inputs, and uncontended resize handles never route through it. It
+exists only where ≥2 gesture consumers contend for the same pointer stream
+(rows, edges, contended handles, contended editor surfaces).
 
 ## Phase 2 — the left rail (gated)
 
@@ -109,21 +139,27 @@ edge-ownership table, so the rail is a consumer, not a rewrite).
 
 ### Model
 
-Adapt, don't invent: the desktop `WorkspacePanel` Radix `Tabs` rail is
-already the navigation model (TR-20). Mobile gets:
+Extend, don't invent: the desktop `WorkspacePanel` Radix `Tabs` rail is
+already the navigation model. Per TR-22 the mobile rail's destination set
+is the `railTabs` contract's actual six tabs — Files, Changes, Agents
+(subagents), Shells (terminals), Tasks (todos), **Browser** (a first-class
+full-screen panel on mobile, not dropped) — plus two rail-level extensions
+that are not workspace tabs: **Sessions** (today's full-screen sidebar
+list) and **Settings**. The rail composes `railTabs` and adds the two
+extensions above it; it does not fork the contract. Mobile gets:
 
 - a narrow persistent rail anchor (icon column) instead of the full-screen
-  sidebar overlay + top-right FAB (TR-21);
-- one destination set shared with desktop via the existing `railTabs`
-  contract — the six hand-maintained FAB→tab mappings in `AppShell` and the
-  per-tool `MobilePanelDrawer` states collapse into one open/close machine;
-- expansion by tap / edge-swipe (dispatcher client, TR-13) / keyboard, with
-  `WorkspacePanel`'s ARIA + roving tabindex inherited (TR-23);
+  sidebar overlay + top-right FAB (TR-23) — the six hand-maintained
+  FAB→tab mappings in `AppShell` and the per-tool `MobilePanelDrawer`
+  states collapse into one open/close machine;
+- expansion by tap / start-edge swipe (dispatcher client, TR-14) /
+  keyboard, with `WorkspacePanel`'s ARIA + roving tabindex inherited
+  (TR-25);
 - safe-area insets applied once at the rail boundary from the existing
-  `--omnigent-safe-*` vars (TR-24);
-- Android back and iOS edge-pan dismiss rail layers per the ownership table
-  (TR-22); displaced header controls (the #3589/#4551 strip) get rail homes
-  (TR-25).
+  `--omnigent-safe-*` vars (TR-26);
+- Android back and iOS edge-pan dismiss rail layers per TR-14's dismissal
+  stack (TR-24); displaced header controls (the #3589/#4551 strip) get
+  rail homes (TR-27).
 
 Migration runs the rail behind a temporary fallback alongside the FAB/drawer
 path, then removes the duplicates once task coverage is proven.
@@ -131,8 +167,8 @@ path, then removes the duplicates once task coverage is proven.
 ## Delivery mechanics
 
 - Every PR cites the TR-ns it satisfies; reviewers judge against the spec.
-- Phase 0 is parallelizable (capability hook, breakpoint consolidation, five
-  hook migrations ≈ seven small PRs).
+- Phase 0 is parallelizable (capability hook, breakpoint consolidation,
+  hover-affordance fallback, five hook migrations ≈ eight small PRs).
 - Phase 1 lands the dispatcher core with the session-row integration as its
   proving consumer, then #3985 rebases onto it instead of shipping a bespoke
   swipe.
@@ -140,14 +176,14 @@ path, then removes the duplicates once task coverage is proven.
   `train/polly/session-row-gesture-fix` for reusable recognizer/test code;
   cherry-pick with history noted in PR descriptions.
 - UI-visible PRs carry demo media and `tests/e2e_ui` coverage per repo
-  policy (TR-29).
+  policy (TR-31).
 
 ## Risks
 
 | Risk | Mitigation |
 |---|---|
-| Dispatcher becomes a framework nobody else adopts | Scope it to contended surfaces only; three named integration points, no speculative API |
+| Dispatcher becomes a framework nobody else adopts | Scope it to contended surfaces only; four named integration points, no speculative API |
 | Phase 2 stalls like #1395 | Hard gate + fallback path; Phases 0–1 are complete deliverables on their own |
-| Threshold tuning churn | Constants in one module, values + rationale documented, changed only with device-matrix retest |
-| Native shells drift from the ownership table | Table is the single source; shell PRs that add gesture heuristics are rejected per TR-26 |
-| Scroll perf regression on long session lists | TR-15 gates; profile on low-end Android in review |
+| Threshold tuning churn | TR-11's table: values, ranges, and invariants in one module, changed only with device-matrix retest |
+| Native shells drift from the ownership table | TR-14's table is the single source; shell PRs that add gesture heuristics are rejected per TR-28 |
+| Scroll perf regression on long session lists | TR-16's testable gates (passive-listener + no-commit assertions, Moto G-class fps budget) |

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -135,11 +135,22 @@ changes bindings, not the spec (TR-30).
   MOTION-TRENDING: `SCROLL_ACTIVATION_PX` / `SWIPE_ACTIVATION_PX` decide
   directly per TR-13. On a surface that offers a hold intent the sequence
   is STATIONARY-TRENDING: while total travel stays inside the
-  `HOLD_DRIFT_PX` circle nothing awards (finger wobble can never demote a
-  forming hold to scroll), hold arms at `HOLD_MS` per TR-12, and crossing
-  the circle before arming ends hold eligibility and awards by dominant
-  axis at the crossing — vertical-first releases to native scroll,
-  horizontal-first awards `swipe` where the surface offers it. Invariants
+  `HOLD_DRIFT_PX` circle no motion-based award occurs and the dispatcher
+  does not release the sequence to scroll — time-based arming (`HOLD_MS`),
+  the menu award (`MENU_HOLD_MS`), and post-arm drag conversion
+  (`DRAG_TOLERANCE_PX`) proceed per TR-12. Crossing the circle before
+  arming ends hold eligibility and awards by dominant axis at the
+  crossing: vertical-first releases to native scroll; horizontal-first
+  awards `swipe` where the surface offers it and releases to native
+  scroll (no award) where it does not; an exact tie (|dx| == |dy|)
+  resolves as vertical-first. This bound covers the dispatcher's OWN
+  arbitration only: on surfaces declaring `touch-action: pan-y` (TR-28)
+  the browser may claim a vertical pan at its native slop (≈10 px) and
+  fire `pointercancel` before the circle bound is reached — `c21fec929`'s
+  own caveat ("native pan-y still wins earlier"). The dispatcher MUST
+  treat that `pointercancel` as a release to scroll; surfaces MUST NOT
+  suppress native vertical pan during the undecided phase to defeat this,
+  since TR-16(a)'s passive-listener gate forbids it. Invariants
   DOMINATE tuning ranges: a retune is legal only if it satisfies every
   invariant AND passes the device-matrix retest required by the design
   doc; the ranges are guidance, not a grant.
@@ -155,7 +166,7 @@ changes bindings, not the spec (TR-30).
   | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe` when horizontal-first on a motion-trending sequence (see TR-13) | 8–16 | `> DRAG_TOLERANCE_PX`; `< HOLD_DRIFT_PX` |
   | `SCROLL_ACTIVATION_PX` | 10 | vertical travel that releases a motion-trending sequence to native scroll when vertical-first (see TR-13); inert inside a hold circle | 8–16 | `< HOLD_DRIFT_PX` |
   | `HOLD_MS` | 250 | stationary hold that arms drag-or-menu (dnd-kit parity on main) | 200–350 | `< MENU_HOLD_MS` |
-  | `HOLD_DRIFT_PX` | 20 | radius of the hold circle on hold-offering surfaces (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius): nothing awards inside it; crossing it pre-arm ends hold eligibility and awards by dominant axis | 16–24 | `> max(SCROLL_ACTIVATION_PX, SWIPE_ACTIVATION_PX)` |
+  | `HOLD_DRIFT_PX` | 20 | radius of the hold circle on hold-offering surfaces (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius): no motion-based award inside it; crossing it pre-arm ends hold eligibility and awards by dominant axis, with the no-swipe fallback and tie-break per the two-radius rule | 16–24 | `> max(SCROLL_ACTIVATION_PX, SWIPE_ACTIVATION_PX)` |
   | `MENU_HOLD_MS` | 500 | stationary hold that opens the context menu (replaces Radix's ~700 ms default) | 400–700 | `> HOLD_MS` |
   | `DRAG_TOLERANCE_PX` | 8 | movement after arming that converts hold → drag (dnd-kit parity) | 5–10 | `< SWIPE_ACTIVATION_PX` |
   | `EDGE_ZONE_PX` | 24 | width of the screen-edge strip that recognizes edge-swipe | 16–32 | — |

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -123,12 +123,23 @@ changes bindings, not the spec (TR-30).
   long-press-drag (reorder), edge-swipe, or resize.
 - **TR-11** Recognition thresholds are normative, defined once in an
   exported constants module. Award is EXCLUSIVE and first-crossed-wins:
-  the dispatcher evaluates each move against the thresholds below, the
+  the dispatcher evaluates each move against the thresholds below and the
   first award (scroll release, swipe, drag, menu) ends arbitration for the
-  sequence, and hold arming is eligible only while no award has occurred
-  and total travel stays within `HOLD_DRIFT_PX`. There is NO geometric
-  disjointness guarantee between hold and swipe regions — exclusivity
-  comes from this precedence rule, not from region math. Invariants
+  sequence. There is NO geometric disjointness guarantee between hold and
+  swipe regions — exclusivity comes from this precedence rule, not from
+  region math.
+
+  Two-radius rule (the train's model in `c21fec929`): which radii govern
+  an undecided sequence depends on the surface's intent set. On a surface
+  with NO hold intent (no drag, no long-press menu) the sequence is
+  MOTION-TRENDING: `SCROLL_ACTIVATION_PX` / `SWIPE_ACTIVATION_PX` decide
+  directly per TR-13. On a surface that offers a hold intent the sequence
+  is STATIONARY-TRENDING: while total travel stays inside the
+  `HOLD_DRIFT_PX` circle nothing awards (finger wobble can never demote a
+  forming hold to scroll), hold arms at `HOLD_MS` per TR-12, and crossing
+  the circle before arming ends hold eligibility and awards by dominant
+  axis at the crossing — vertical-first releases to native scroll,
+  horizontal-first awards `swipe` where the surface offers it. Invariants
   DOMINATE tuning ranges: a retune is legal only if it satisfies every
   invariant AND passes the device-matrix retest required by the design
   doc; the ranges are guidance, not a grant.
@@ -141,10 +152,10 @@ changes bindings, not the spec (TR-30).
 
   | Constant | Value | Meaning | Tuning range | Invariant |
   |---|---|---|---|---|
-  | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe` when horizontal-first (see TR-13) | 8–16 | `> DRAG_TOLERANCE_PX` |
-  | `SCROLL_ACTIVATION_PX` | 10 | vertical travel that releases an undecided sequence to native scroll when vertical-first (see TR-13) | 8–16 | crossing it cancels hold eligibility |
+  | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe` when horizontal-first on a motion-trending sequence (see TR-13) | 8–16 | `> DRAG_TOLERANCE_PX`; `< HOLD_DRIFT_PX` |
+  | `SCROLL_ACTIVATION_PX` | 10 | vertical travel that releases a motion-trending sequence to native scroll when vertical-first (see TR-13); inert inside a hold circle | 8–16 | `< HOLD_DRIFT_PX` |
   | `HOLD_MS` | 250 | stationary hold that arms drag-or-menu (dnd-kit parity on main) | 200–350 | `< MENU_HOLD_MS` |
-  | `HOLD_DRIFT_PX` | 20 | total travel that cancels hold eligibility (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius) | 16–24 | crossing any award threshold also cancels hold |
+  | `HOLD_DRIFT_PX` | 20 | radius of the hold circle on hold-offering surfaces (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius): nothing awards inside it; crossing it pre-arm ends hold eligibility and awards by dominant axis | 16–24 | `> max(SCROLL_ACTIVATION_PX, SWIPE_ACTIVATION_PX)` |
   | `MENU_HOLD_MS` | 500 | stationary hold that opens the context menu (replaces Radix's ~700 ms default) | 400–700 | `> HOLD_MS` |
   | `DRAG_TOLERANCE_PX` | 8 | movement after arming that converts hold → drag (dnd-kit parity) | 5–10 | `< SWIPE_ACTIVATION_PX` |
   | `EDGE_ZONE_PX` | 24 | width of the screen-edge strip that recognizes edge-swipe | 16–32 | — |
@@ -161,10 +172,12 @@ changes bindings, not the spec (TR-30).
   (right-click parity) — the current main-branch behavior, where dnd-kit's
   250 ms sensor permanently shadows Radix's long-press, is a defect this
   requirement forbids.
-- **TR-13** Axis lock: while a sequence is undecided, vertical-first
-  movement of at least `SCROLL_ACTIVATION_PX` releases it to native scroll
-  and horizontal-first movement
-  (|dx| > |dy| at award time) is eligible for `swipe`. A slow or hesitant
+- **TR-13** Axis lock: while a motion-trending sequence is undecided,
+  vertical-first movement of at least `SCROLL_ACTIVATION_PX` releases it
+  to native scroll and horizontal-first movement
+  (|dx| > |dy| at award time) is eligible for `swipe`; on hold-offering
+  surfaces the `HOLD_DRIFT_PX` circle governs the undecided phase first
+  (TR-11's two-radius rule). A slow or hesitant
   swipe MUST NOT convert into a drag, and vertical scrolling MUST never be
   hijacked by a horizontal consumer.
 - **TR-14** Edge and back ownership is a single normative table; native
@@ -174,6 +187,7 @@ changes bindings, not the spec (TR-30).
   | Input | Owner | Notes |
   |---|---|---|
   | Start-edge swipe (within `EDGE_ZONE_PX`) | Rail/sidebar open (dispatcher) | iOS `UIScreenEdgePanGestureRecognizer` delegates its drag here; WebKit back-forward gestures stay disabled |
+  | Start-directed swipe on the open rail/sidebar or its scrim | Rail/sidebar close (dispatcher) | On-surface gesture, not an edge zone — it does not contend with OS edge gestures, so it applies on every platform including iOS; the dismissal consumes the layer's history entry per the close-path reconciliation below |
   | End-edge swipe | Released to browser/OS (back-forward where the platform provides it) | No app consumer may claim it without amending this table |
   | Android hardware/system back | Dismissal stack below, then WebView history | Routed via `__omnigentNativeHandleBack` (Android shell only) |
   | Browser back (`popstate`) | Topmost history-participating layer, else normal history navigation | Each dismissible layer pushes ONE history entry on open; `popstate` closes exactly one layer, matched by a state token so re-entrant pops cannot loop; transient popovers that don't push are not browser-back-dismissible. Close-path reconciliation: any NON-popstate dismissal of a history-participating layer (scrim tap, Escape, close button, Android back) MUST also consume that layer's history entry — e.g. `history.back()` with the resulting token-matched pop treated as already-handled — so no orphaned entry survives and a later back press never visibly no-ops |
@@ -189,6 +203,7 @@ changes bindings, not the spec (TR-30).
   | Long-press drag (reorder) | Move up/down commands in the row menu |
   | Drag-to-ungroup | Ungroup command in the row/folder menu |
   | Edge-swipe rail open | Tap on the persistent rail anchor; keyboard shortcut |
+  | Swipe-to-close rail | Scrim tap; close button; `Escape` |
   | Resize drag | Arrow keys on the focusable separator |
   | Back/dismiss gestures | Visible close/back buttons on each layer |
 
@@ -252,14 +267,17 @@ changes bindings, not the spec (TR-30).
   mobile (full-screen panel), not silently dropped.
 - **TR-23** The rail MUST be a narrow collapsed anchor on phones (not the
   current full-screen `fixed inset-0` session list pinned open), expanding
-  into the content panel; expansion/collapse is reachable by tap, by
-  start-edge swipe (via the dispatcher, per TR-14), and by keyboard.
+  into the content panel; expansion is reachable by tap, by start-edge
+  swipe (via the dispatcher, per TR-14), and by keyboard; collapse by
+  tap, by a start-directed swipe on the open rail or its scrim (TR-14,
+  all platforms), and by keyboard.
 - **TR-24** Hardware/system back (Android) and browser back (via the
   history participation defined in TR-14) MUST dismiss rail layers in the
-  order defined by TR-14's dismissal stack. iOS has NO edge dismissal
+  order defined by TR-14's dismissal stack. iOS has NO EDGE dismissal
   gesture — TR-14 assigns the start edge exclusively to opening the rail
-  and releases the end edge to the OS — so on iOS dismissal is by tap on
-  the scrim or rail anchor, the close button, or keyboard.
+  and releases the end edge to the OS — but the on-surface swipe-to-close
+  (TR-14) applies on iOS like every other platform; dismissal is also by
+  tap on the scrim or rail anchor, the close button, or keyboard.
 - **TR-25** The rail MUST inherit the tab semantics, ARIA labels, and
   roving-tabindex keyboard behavior of the existing `WorkspacePanel` Radix
   tabs; screen-reader users get one nav landmark, not a stack of bespoke
@@ -282,8 +300,9 @@ changes bindings, not the spec (TR-30).
   | Surface | `touch-action` | `overscroll-behavior` | Notes |
   |---|---|---|---|
   | Chat transcript scroller | `pan-y pinch-zoom` | `contain` | no pull-to-refresh reload mid-session |
-  | Session list rows | `pan-y pinch-zoom` (dispatcher claims horizontal) | `contain` | swipe/hold per TR-11..13; a second pointer joining cancels the sequence and yields to pinch-zoom |
-  | Rail anchor + edge zone | `pan-y pinch-zoom` | `contain` | start-edge swipe per TR-14; second pointer yields to pinch-zoom |
+  | Session list rows | `pan-y pinch-zoom` (dispatcher claims horizontal) | `contain` | swipe/hold per TR-11..13; second pointer per TR-11's multi-pointer rule (undecided → yields to pinch-zoom; awarded → ignored) |
+  | Rail anchor + edge zone | `pan-y pinch-zoom` | `contain` | start-edge swipe per TR-14; second pointer per TR-11's multi-pointer rule |
+  | Open rail/sidebar overlay + scrim | `pan-y pinch-zoom` | `contain` | start-directed swipe-to-close per TR-14 |
   | Resize handles | `none` | — | TR-9 |
   | Text/editor content | browser default | default | selection untouched |
   | Embedded browser panel | browser default inside the frame | `contain` at the boundary | |

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -1,0 +1,207 @@
+# Touch Interaction Specification
+
+Status: proposed. Owns the end-state for touch input across the omnigent web
+app, the Android/iOS WebView shells, and touch-capable desktop viewports.
+Companion doc: [touch-interaction-design.md](touch-interaction-design.md)
+(architecture and phasing).
+
+## Why this spec exists
+
+Touch work has repeatedly been attempted as isolated PRs and abandoned. The
+session-row swipe train (#3154 → #3985, with #4060/#4065 absorbed into #4057
+and then closed) produced working gesture-arbitration code — a unified row
+gesture recognizer with coarse-pointer gating — that now lives only on
+abandoned branches, paid for two-to-three times as duplicate commits across
+rebased trains. The train did not fail on engineering; it failed because no
+agreed end-state existed to make each PR's scope defensible in review.
+
+This spec is that end-state. Every touch PR should be traceable to a
+requirement below, and reviewers should judge PRs against this contract
+rather than re-litigating the approach.
+
+## Root causes (verified on main)
+
+1. **No pointer-capability detection.** There are zero uses of
+   `pointer: coarse`, `any-pointer`, `hover: none`, or `maxTouchPoints` in
+   `web/src`. "Mobile" is inferred from viewport width alone.
+2. **Drifting breakpoint encodings.** The md boundary is written at least
+   four ways: `max-width: 767.98px` (`useIsMobileViewport`),
+   `max-width: 767px` (`ChatPage`), `min-width: 768px` negated
+   (`AppShell`, `Sidebar`), a JS constant `MD_BREAKPOINT = 768`
+   (`useResizablePanel`, `useResizableCommentsPanel`), and
+   `window.innerWidth < 768` evaluated once at injection time in the Android
+   bridge (`NativeBridgeScript.kt`).
+3. **Mouse-only resize.** All five resize hooks (`useResizablePanel`,
+   `useResizableSidebar`, `useResizableInlinePanel`,
+   `useResizableCommentsPanel`, `useResizableColumn`) start on `onMouseDown`
+   and listen to window `mousemove`/`mouseup`. A touch user cannot resize any
+   rail or panel on any device, including touch laptops shown the desktop
+   layout.
+4. **Unarbitrated gesture stack.** A session row simultaneously hosts native
+   scroll, dnd-kit's 250 ms touch-hold drag sensor, Radix's ~700 ms
+   long-press context menu (unreachable by touch — the drag sensor always
+   wins), an experimental 12 px horizontal swipe (#3985), and iOS edge-pan
+   handing its drag into the same sidebar. Each consumer was written ad hoc
+   with no shared owner of the pointer stream.
+5. **Dual mobile navigation topology.** Desktop models Files / Changes /
+   Agents / Shells / Tasks / Browser as one tabbed rail (`WorkspacePanel`);
+   mobile fragments the same destinations into a top-right FAB and per-tool
+   full-screen `MobilePanelDrawer`s with hand-maintained FAB→tab mappings in
+   `AppShell`. Fixes get re-derived per surface (safe-area insets fixed
+   serially on four surfaces; the contested header strip that killed #3589
+   was relieved, not resolved, by #4551).
+
+## Requirements
+
+Requirements are numbered `TR-n` (touch requirement). "Coarse pointer" means
+the primary pointer matches `pointer: coarse` (a finger); capability, never
+viewport width, gates touch behavior.
+
+### Foundation: capability detection
+
+- **TR-1** The web app MUST expose a single shared input-capability primitive
+  reporting at least: primary pointer coarseness, hover capability, and any
+  additional pointer types (`any-pointer`), reactive to changes (e.g. a
+  convertible flipping modes, attaching a mouse).
+- **TR-2** All touch-conditional behavior MUST gate on capability, not
+  viewport width. Viewport width remains a *layout* concern only.
+- **TR-3** There MUST be exactly one canonical encoding of each layout
+  breakpoint, consumed by both CSS/media-query and JS call sites. The four
+  drifting md encodings are consolidated onto it.
+- **TR-4** The Android bridge's width check MUST NOT be evaluated once at
+  injection time; native shells consume the web layer's capability/layout
+  signal rather than re-deriving it.
+
+### Resize
+
+- **TR-5** Every user-resizable surface (sidebar, right rail, inline panels,
+  comments panel, column resizers) MUST be resizable via touch and stylus:
+  pointer events (`pointerdown`/`pointermove`/`pointerup` with
+  `setPointerCapture`), not mouse events.
+- **TR-6** Resize handles MUST have a coarse-pointer hit target of at least
+  24 CSS px (44 px preferred where layout permits) without changing their
+  visual weight on fine-pointer devices.
+- **TR-7** Existing keyboard resize paths (arrow keys on separators) MUST be
+  preserved; hooks that lack a keyboard path (`useResizableColumn`) MUST
+  gain one.
+- **TR-8** During an active resize drag, no other gesture consumer
+  (scroll, swipe, drag-and-drop, text selection) may activate
+  (`touch-action` and pointer capture enforced).
+
+### Gesture arbitration (the dispatcher)
+
+- **TR-9** Each interactive surface MUST have exactly one owner of its
+  pointer stream — a gesture dispatcher that observes the stream and awards
+  it to at most one intent: scroll, horizontal swipe, long-press (menu),
+  long-press-drag (reorder), edge-swipe, or resize.
+- **TR-10** Intent thresholds MUST be defined in one place with documented
+  values (activation distances, hold durations, axis-lock angles, drift
+  tolerances) such that competing regions are disjoint (e.g. the recognizer
+  math from the abandoned train: hold-drag tolerance vs. swipe activation
+  kept non-overlapping).
+- **TR-11** The long-press context menu MUST be reachable by touch on every
+  surface that offers it to mouse users (right-click parity). The current
+  main-branch behavior — dnd-kit's 250 ms sensor permanently shadowing
+  Radix's 700 ms long-press — is a defect this requirement forbids.
+- **TR-12** A slow or hesitant swipe MUST NOT convert into a drag, and
+  vertical scrolling MUST never be hijacked by a horizontal consumer
+  (axis-lock before award).
+- **TR-13** Edge gestures MUST have a single ownership table: which surface
+  owns the left edge, the right edge, and hardware/browser back, in which
+  stacking order. iOS edge-pan, Android back routing
+  (`__omnigentNativeHandleBack`), and browser back/forward gestures resolve
+  against this table rather than per-surface heuristics.
+- **TR-14** Every gesture MUST have a non-gesture equivalent (visible
+  control, kebab menu, or keyboard path). Gestures are accelerators, never
+  the only route to a function.
+- **TR-15** The dispatcher MUST NOT regress scroll performance: passive
+  listeners wherever the consumer cannot preventDefault, no per-move React
+  state updates while undecided, and no synchronous layout reads in the move
+  path.
+
+### Session-row touch actions (from #3985 / #3154 / #4057 / #4060 / #4065)
+
+- **TR-16** Session rows MUST support swipe-revealed actions on
+  coarse-pointer devices, arbitrated by the dispatcher (TR-9), with the
+  specific review defects from #3154 excluded by acceptance tests: no row
+  background bleed, correct action icon placement on narrow screens, no
+  icon/content overlap.
+- **TR-17** Row long-press MUST open the row/folder context menu when the
+  press ends without drag movement; drag movement past tolerance converts to
+  reorder and MUST suppress the menu (the #4065 requirement).
+- **TR-18** Drag-to-ungroup (the #4057 drop zone) and any future drop
+  targets MUST work with touch drag; drop targets MUST meet coarse-pointer
+  hit-target size.
+- **TR-19** Row gestures gate on pointer capability, not viewport width
+  (already prototyped in the abandoned train), so foldables and touch
+  laptops at ≥768 px get working row gestures.
+
+### Mobile navigation (left rail)
+
+- **TR-20** Mobile navigation MUST converge on a single persistent left-rail
+  model that adapts the existing desktop `WorkspacePanel` tab contract:
+  one canonical destination set (Sessions, Files/Changes, Agents, Shells,
+  Tasks, Settings) with one open/close state machine, replacing the
+  scattered FAB + per-tool `MobilePanelDrawer` topology.
+- **TR-21** The rail MUST be a narrow collapsed anchor on phones (not the
+  current full-screen `fixed inset-0` session list pinned open), expanding
+  into the content panel; expansion/collapse is reachable by tap, by
+  edge-swipe (via the dispatcher, per TR-13), and by keyboard.
+- **TR-22** Hardware/system back (Android), the iOS edge gesture, and
+  browser back MUST dismiss rail layers in a defined order consistent with
+  TR-13's ownership table.
+- **TR-23** The rail MUST inherit the tab semantics, ARIA labels, and
+  roving-tabindex keyboard behavior of the existing `WorkspacePanel` Radix
+  tabs; screen-reader users get one nav landmark, not a stack of bespoke
+  overlays.
+- **TR-24** Safe-area insets MUST be applied once at the rail/shell
+  boundary (the `--omnigent-safe-*` CSS vars from the native bridges), not
+  re-derived per drawer (the #4723 class of bug).
+- **TR-25** Header-strip controls displaced by the contested-strip problem
+  (#3589/#4551) get a defined home in the rail model; the header strip's
+  drag-surface role is preserved.
+
+### Native shell interop
+
+- **TR-26** Web-side gesture ownership (TR-13) is the single source of
+  truth; Android's back callback and iOS's edge-pan recognizer delegate to
+  it. Shell code MUST NOT grow new gesture heuristics of its own.
+- **TR-27** WebView-hosted browser-native behaviors (pull-to-refresh, text
+  selection, back-forward swipe where enabled) MUST be explicitly claimed or
+  released per surface via `touch-action` / `overscroll-behavior`, not left
+  to default.
+
+### Accessibility and quality gates
+
+- **TR-28** All touch behavior MUST be covered by component tests that
+  simulate pointer sequences (pointerdown/move/up with timing), including
+  the specific historical defects listed in TR-16/TR-17 as regression
+  tests.
+- **TR-29** Touch changes to visible UI require demo media on the PR per
+  the repo PR template, and `tests/e2e_ui` coverage (or the maintainer skip
+  label) where the judge requires it.
+
+## Non-goals
+
+- No new gesture *vocabulary* beyond what the PR train already established
+  (swipe actions, long-press menu, long-press drag, edge-swipe, resize).
+  Pinch-zoom, multi-finger gestures, and haptics beyond the existing
+  WebView haptic hook are out of scope.
+- No native-app rewrites: Android/iOS shells keep their bridge architecture;
+  only their delegation points change.
+- Desktop mouse/keyboard interaction is unchanged except where hooks gain
+  pointer-event equivalence.
+
+## Decision record
+
+A three-vendor adversarial debate (2026-08-13) argued dispatcher+rail vs.
+dispatcher-only vs. rail-only. All seats endorsed the foundation layer
+(TR-1..8). The dissent worth preserving: *committing the rail in-spec risks
+scope creep; product evidence for the nav redesign is thinner than for the
+gesture defects.* It is absorbed by phasing (see the design doc): the rail
+phase has its own go/no-go gate, and if it is cancelled the earlier phases
+stand alone. The asymmetry that decided the debate: a dispatcher designed
+against the rail topology degrades gracefully to today's topology, but a
+dispatcher designed against the FAB/drawer topology must be rewritten when
+the rail lands — and the edge-ownership table (TR-13) is the part that
+changes.

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -133,11 +133,18 @@ changes bindings, not the spec (TR-30).
   invariant AND passes the device-matrix retest required by the design
   doc; the ranges are guidance, not a grant.
 
+  Multi-pointer rule: a second touch pointer joining an UNDECIDED sequence
+  cancels it and yields the stream to browser pinch-zoom (TR-28); a second
+  pointer joining a sequence that has already been awarded (swipe, drag,
+  menu, resize) is ignored — the award stands and the first pointer keeps
+  ownership until it ends the sequence.
+
   | Constant | Value | Meaning | Tuning range | Invariant |
   |---|---|---|---|---|
   | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe` when horizontal-first (see TR-13) | 8–16 | `> DRAG_TOLERANCE_PX` |
+  | `SCROLL_ACTIVATION_PX` | 10 | vertical travel that releases an undecided sequence to native scroll when vertical-first (see TR-13) | 8–16 | crossing it cancels hold eligibility |
   | `HOLD_MS` | 250 | stationary hold that arms drag-or-menu (dnd-kit parity on main) | 200–350 | `< MENU_HOLD_MS` |
-  | `HOLD_DRIFT_PX` | 20 | total travel that cancels hold eligibility (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius) | 8–20 | crossing any award threshold also cancels hold |
+  | `HOLD_DRIFT_PX` | 20 | total travel that cancels hold eligibility (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius) | 16–24 | crossing any award threshold also cancels hold |
   | `MENU_HOLD_MS` | 500 | stationary hold that opens the context menu (replaces Radix's ~700 ms default) | 400–700 | `> HOLD_MS` |
   | `DRAG_TOLERANCE_PX` | 8 | movement after arming that converts hold → drag (dnd-kit parity) | 5–10 | `< SWIPE_ACTIVATION_PX` |
   | `EDGE_ZONE_PX` | 24 | width of the screen-edge strip that recognizes edge-swipe | 16–32 | — |
@@ -155,7 +162,8 @@ changes bindings, not the spec (TR-30).
   250 ms sensor permanently shadows Radix's long-press, is a defect this
   requirement forbids.
 - **TR-13** Axis lock: while a sequence is undecided, vertical-first
-  movement releases it to native scroll and horizontal-first movement
+  movement of at least `SCROLL_ACTIVATION_PX` releases it to native scroll
+  and horizontal-first movement
   (|dx| > |dy| at award time) is eligible for `swipe`. A slow or hesitant
   swipe MUST NOT convert into a drag, and vertical scrolling MUST never be
   hijacked by a horizontal consumer.
@@ -168,7 +176,7 @@ changes bindings, not the spec (TR-30).
   | Start-edge swipe (within `EDGE_ZONE_PX`) | Rail/sidebar open (dispatcher) | iOS `UIScreenEdgePanGestureRecognizer` delegates its drag here; WebKit back-forward gestures stay disabled |
   | End-edge swipe | Released to browser/OS (back-forward where the platform provides it) | No app consumer may claim it without amending this table |
   | Android hardware/system back | Dismissal stack below, then WebView history | Routed via `__omnigentNativeHandleBack` (Android shell only) |
-  | Browser back (`popstate`) | Topmost history-participating layer, else normal history navigation | Each dismissible layer pushes ONE history entry on open; `popstate` closes exactly one layer, matched by a state token so re-entrant pops cannot loop; transient popovers that don't push are not browser-back-dismissible |
+  | Browser back (`popstate`) | Topmost history-participating layer, else normal history navigation | Each dismissible layer pushes ONE history entry on open; `popstate` closes exactly one layer, matched by a state token so re-entrant pops cannot loop; transient popovers that don't push are not browser-back-dismissible. Close-path reconciliation: any NON-popstate dismissal of a history-participating layer (scrim tap, Escape, close button, Android back) MUST also consume that layer's history entry — e.g. `history.back()` with the resulting token-matched pop treated as already-handled — so no orphaned entry survives and a later back press never visibly no-ops |
   | Dismissal stack (top → bottom) | modal dialogs → context menus/popovers → expanded rail panel or `MobilePanelDrawer` → rail/sidebar overlay → in-app history → browser history/app exit | One layer per back press |
 
 - **TR-15** Every gesture MUST have a non-gesture equivalent. The parity
@@ -212,8 +220,10 @@ changes bindings, not the spec (TR-30).
 - **TR-18** Row long-press follows TR-12 exactly (menu at `MENU_HOLD_MS`,
   drag conversion suppresses the menu).
 - **TR-19** Drag-to-ungroup (the #4057 drop zone) and any future drop
-  targets MUST work with touch drag; drop targets MUST meet coarse-pointer
-  hit-target size (TR-7).
+  targets MUST work with touch drag; drop targets MUST present a hit
+  target of at least 44 CSS px in the drop-approach axis on all devices
+  (TR-7's sizing rule covers resize handles only, so the size is stated
+  here directly).
 - **TR-20** Row gestures bind to `pointerType` per TR-2 — never to viewport
   width — so foldables and touch laptops at ≥ 768 px get working row
   gestures (already prototyped in the abandoned train's coarse-pointer

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -23,14 +23,16 @@ rather than re-litigating the approach.
 
 1. **No pointer-capability detection.** There are zero uses of
    `pointer: coarse`, `any-pointer`, `hover: none`, or `maxTouchPoints` in
-   `web/src`. "Mobile" is inferred from viewport width alone.
+   `web/src`. "Mobile" is inferred from viewport width alone, and
+   hover-revealed controls have no touch fallback.
 2. **Drifting breakpoint encodings.** The md boundary is written at least
-   four ways: `max-width: 767.98px` (`useIsMobileViewport`),
+   five ways: `max-width: 767.98px` (`useIsMobileViewport`),
    `max-width: 767px` (`ChatPage`), `min-width: 768px` negated
    (`AppShell`, `Sidebar`), a JS constant `MD_BREAKPOINT = 768`
-   (`useResizablePanel`, `useResizableCommentsPanel`), and
-   `window.innerWidth < 768` evaluated once at injection time in the Android
-   bridge (`NativeBridgeScript.kt`).
+   (`useResizablePanel`, `useResizableCommentsPanel`), and a hardcoded
+   `window.innerWidth < 768` in the Android bridge's back handler
+   (`NativeBridgeScript.kt`) — a fifth independent copy of the breakpoint,
+   derived without reference to the web layer's definition.
 3. **Mouse-only resize.** All five resize hooks (`useResizablePanel`,
    `useResizableSidebar`, `useResizableInlinePanel`,
    `useResizableCommentsPanel`, `useResizableColumn`) start on `onMouseDown`
@@ -40,144 +42,243 @@ rather than re-litigating the approach.
 4. **Unarbitrated gesture stack.** A session row simultaneously hosts native
    scroll, dnd-kit's 250 ms touch-hold drag sensor, Radix's ~700 ms
    long-press context menu (unreachable by touch — the drag sensor always
-   wins), an experimental 12 px horizontal swipe (#3985), and iOS edge-pan
-   handing its drag into the same sidebar. Each consumer was written ad hoc
-   with no shared owner of the pointer stream.
+   wins), and iOS edge-pan handing its drag into the same sidebar; the open
+   #3985 PR proposes adding a 12 px horizontal swipe to the same rows. Each
+   consumer was written ad hoc with no shared owner of the pointer stream.
 5. **Dual mobile navigation topology.** Desktop models Files / Changes /
-   Agents / Shells / Tasks / Browser as one tabbed rail (`WorkspacePanel`);
-   mobile fragments the same destinations into a top-right FAB and per-tool
-   full-screen `MobilePanelDrawer`s with hand-maintained FAB→tab mappings in
-   `AppShell`. Fixes get re-derived per surface (safe-area insets fixed
-   serially on four surfaces; the contested header strip that killed #3589
-   was relieved, not resolved, by #4551).
+   Agents / Shells / Tasks / Browser as one tabbed rail (`WorkspacePanel`,
+   via the `railTabs` contract); mobile fragments the same destinations into
+   a top-right FAB and per-tool full-screen `MobilePanelDrawer`s with
+   hand-maintained FAB→tab mappings in `AppShell`. Fixes get re-derived per
+   surface (safe-area insets fixed serially on four surfaces; the contested
+   header strip that killed #3589 was relieved, not resolved, by #4551).
 
 ## Requirements
 
-Requirements are numbered `TR-n` (touch requirement). "Coarse pointer" means
-the primary pointer matches `pointer: coarse` (a finger); capability, never
-viewport width, gates touch behavior.
+Requirements are numbered `TR-n` (touch requirement). Directional terms are
+LOGICAL: "start" = left in LTR, right in RTL; "end" is the opposite. The app
+is LTR-only today; requirements use logical directions so an RTL locale
+changes bindings, not the spec (TR-30).
 
-### Foundation: capability detection
+### Foundation: capability detection and input model
 
 - **TR-1** The web app MUST expose a single shared input-capability primitive
-  reporting at least: primary pointer coarseness, hover capability, and any
-  additional pointer types (`any-pointer`), reactive to changes (e.g. a
-  convertible flipping modes, attaching a mouse).
-- **TR-2** All touch-conditional behavior MUST gate on capability, not
-  viewport width. Viewport width remains a *layout* concern only.
+  reporting at least: primary-pointer coarseness (`pointer: coarse`), hover
+  capability (`hover: hover`), and presence of any coarse pointer
+  (`any-pointer: coarse`), reactive to changes (a convertible flipping
+  modes, a mouse attaching or detaching).
+- **TR-2** Capability queries gate AFFORDANCES and defaults (hit-target
+  sizing, persistent vs hover-revealed controls, whether swipe hints render)
+  — never per-event handling. Gesture RECOGNITION binds to the active
+  sequence's `PointerEvent.pointerType`: `touch` and `pen` sequences get
+  gesture semantics, `mouse` sequences keep mouse semantics — on every
+  device, regardless of what the capability queries report. A touch laptop
+  whose primary pointer is a fine trackpad (`any-pointer: coarse`, primary
+  fine) therefore still gets working touch gestures the moment a finger
+  touches the screen.
 - **TR-3** There MUST be exactly one canonical encoding of each layout
-  breakpoint, consumed by both CSS/media-query and JS call sites. The four
-  drifting md encodings are consolidated onto it.
-- **TR-4** The Android bridge's width check MUST NOT be evaluated once at
-  injection time; native shells consume the web layer's capability/layout
-  signal rather than re-deriving it.
+  breakpoint, consumed by both CSS/media-query and JS call sites. The five
+  drifting md encodings are consolidated onto it. Viewport width remains a
+  *layout* concern only.
+- **TR-4** Native shells MUST consume the web layer's layout/capability
+  signal instead of re-deriving breakpoints. The Android back handler's
+  hardcoded `innerWidth < 768` check is replaced by that signal.
+- **TR-5** Controls revealed only on hover (e.g. the sidebar row and folder
+  action buttons, `md:opacity-0 md:group-hover:opacity-100`) MUST be
+  reachable on hover-less / coarse-pointer devices: persistent visibility,
+  or an equivalent touch path (row menu, swipe action). This is what makes
+  TR-19's touch-laptop audience real — today those devices can reveal no
+  row action at all.
 
 ### Resize
 
-- **TR-5** Every user-resizable surface (sidebar, right rail, inline panels,
-  comments panel, column resizers) MUST be resizable via touch and stylus:
-  pointer events (`pointerdown`/`pointermove`/`pointerup` with
-  `setPointerCapture`), not mouse events.
-- **TR-6** Resize handles MUST have a coarse-pointer hit target of at least
+- **TR-6** Every user-resizable surface (sidebar, right rail, inline panels,
+  comments panel, column resizers) MUST be resizable via touch and stylus.
+  The normative mechanism is pointer events
+  (`pointerdown`/`pointermove`/`pointerup` with `setPointerCapture`); an
+  equivalent mechanism is acceptable if it meets the same outcomes,
+  including: drag continues when the pointer leaves the handle; `pointercancel`
+  and capture loss abort cleanly to the pre-drag size or last applied size
+  (never a half-state); listeners are removed on unmount; a second
+  concurrent pointer is ignored (first pointer wins); drags over embedded
+  iframes keep receiving moves (overlay shield or capture).
+- **TR-7** Resize handles MUST have a coarse-pointer hit target of at least
   24 CSS px (44 px preferred where layout permits) without changing their
   visual weight on fine-pointer devices.
-- **TR-7** Existing keyboard resize paths (arrow keys on separators) MUST be
+- **TR-8** Existing keyboard resize paths (arrow keys on separators) MUST be
   preserved; hooks that lack a keyboard path (`useResizableColumn`) MUST
   gain one.
-- **TR-8** During an active resize drag, no other gesture consumer
+- **TR-9** During an active resize drag, no other gesture consumer
   (scroll, swipe, drag-and-drop, text selection) may activate
-  (`touch-action` and pointer capture enforced).
+  (`touch-action: none` on the handle and pointer capture enforced).
 
 ### Gesture arbitration (the dispatcher)
 
-- **TR-9** Each interactive surface MUST have exactly one owner of its
+- **TR-10** Each contended surface MUST have exactly one owner of its
   pointer stream — a gesture dispatcher that observes the stream and awards
   it to at most one intent: scroll, horizontal swipe, long-press (menu),
   long-press-drag (reorder), edge-swipe, or resize.
-- **TR-10** Intent thresholds MUST be defined in one place with documented
-  values (activation distances, hold durations, axis-lock angles, drift
-  tolerances) such that competing regions are disjoint (e.g. the recognizer
-  math from the abandoned train: hold-drag tolerance vs. swipe activation
-  kept non-overlapping).
-- **TR-11** The long-press context menu MUST be reachable by touch on every
-  surface that offers it to mouse users (right-click parity). The current
-  main-branch behavior — dnd-kit's 250 ms sensor permanently shadowing
-  Radix's 700 ms long-press — is a defect this requirement forbids.
-- **TR-12** A slow or hesitant swipe MUST NOT convert into a drag, and
-  vertical scrolling MUST never be hijacked by a horizontal consumer
-  (axis-lock before award).
-- **TR-13** Edge gestures MUST have a single ownership table: which surface
-  owns the left edge, the right edge, and hardware/browser back, in which
-  stacking order. iOS edge-pan, Android back routing
-  (`__omnigentNativeHandleBack`), and browser back/forward gestures resolve
-  against this table rather than per-surface heuristics.
-- **TR-14** Every gesture MUST have a non-gesture equivalent (visible
-  control, kebab menu, or keyboard path). Gestures are accelerators, never
-  the only route to a function.
-- **TR-15** The dispatcher MUST NOT regress scroll performance: passive
-  listeners wherever the consumer cannot preventDefault, no per-move React
-  state updates while undecided, and no synchronous layout reads in the move
-  path.
+- **TR-11** Recognition thresholds are normative, defined once in an
+  exported constants module, and MUST keep competing activation regions
+  disjoint. Initial values (tunable only within the stated ranges, and only
+  with the device-matrix retest required by the design doc):
+
+  | Constant | Value | Meaning | Tuning range | Invariant |
+  |---|---|---|---|---|
+  | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe`, axis-locked (see TR-13) | 8–16 | `< HOLD_DRIFT_PX / √2` |
+  | `HOLD_MS` | 250 | stationary hold that arms drag-or-menu (dnd-kit parity on main) | 200–350 | `< MENU_HOLD_MS` |
+  | `HOLD_DRIFT_PX` | 25 | max travel while holding before the hold cancels (the train's 25/√2 ≈ 17.7 per-axis bound keeps swipe and hold disjoint) | 20–30 | `/√2 > SWIPE_ACTIVATION_PX` |
+  | `MENU_HOLD_MS` | 500 | stationary hold that opens the context menu (replaces Radix's ~700 ms default) | 400–700 | `> HOLD_MS` |
+  | `DRAG_TOLERANCE_PX` | 8 | movement after arming that converts hold → drag (dnd-kit parity) | 5–10 | `< SWIPE_ACTIVATION_PX` |
+  | `EDGE_ZONE_PX` | 24 | width of the screen-edge strip that recognizes edge-swipe | 16–32 | — |
+
+- **TR-12** Long-press sequencing is exact: a `touch`/`pen` press that stays
+  within `HOLD_DRIFT_PX` arms at `HOLD_MS`; movement past
+  `DRAG_TOLERANCE_PX` after arming awards `drag` (reorder) and permanently
+  suppresses the menu for that sequence (#4065's requirement); remaining
+  stationary until `MENU_HOLD_MS` opens the context menu at that moment
+  (not on release), with a haptic cue where the platform supports it; once
+  the menu is open the sequence is consumed — no drag can start from it,
+  and the menu takes focus per its normal keyboard/AT contract. The menu
+  MUST be reachable by touch on every surface that offers it to mouse users
+  (right-click parity) — the current main-branch behavior, where dnd-kit's
+  250 ms sensor permanently shadows Radix's long-press, is a defect this
+  requirement forbids.
+- **TR-13** Axis lock: while a sequence is undecided, vertical-first
+  movement releases it to native scroll and horizontal-first movement
+  (|dx| > |dy| at award time) is eligible for `swipe`. A slow or hesitant
+  swipe MUST NOT convert into a drag, and vertical scrolling MUST never be
+  hijacked by a horizontal consumer.
+- **TR-14** Edge and back ownership is a single normative table; native
+  shells and web surfaces resolve against it rather than per-surface
+  heuristics:
+
+  | Input | Owner | Notes |
+  |---|---|---|
+  | Start-edge swipe (within `EDGE_ZONE_PX`) | Rail/sidebar open (dispatcher) | iOS `UIScreenEdgePanGestureRecognizer` delegates its drag here; WebKit back-forward gestures stay disabled |
+  | End-edge swipe | Released to browser/OS (back-forward where the platform provides it) | No app consumer may claim it without amending this table |
+  | Android hardware/system back, browser back | Dismissal stack below, then history | Routed via `__omnigentNativeHandleBack` |
+  | Dismissal stack (top → bottom) | modal dialogs → context menus/popovers → expanded rail panel or `MobilePanelDrawer` → rail/sidebar overlay → in-app history → browser history/app exit | One layer per back press |
+
+- **TR-15** Every gesture MUST have a non-gesture equivalent. The parity
+  matrix is normative:
+
+  | Gesture | Non-gesture equivalent |
+  |---|---|
+  | Row swipe action | Same action in the row's kebab/context menu |
+  | Long-press context menu | Kebab button (visible per TR-5), `Shift+F10`/menu key |
+  | Long-press drag (reorder) | Move up/down commands in the row menu |
+  | Drag-to-ungroup | Ungroup command in the row/folder menu |
+  | Edge-swipe rail open | Tap on the persistent rail anchor; keyboard shortcut |
+  | Resize drag | Arrow keys on the focusable separator |
+  | Back/dismiss gestures | Visible close/back buttons on each layer |
+
+  Additionally, every gesture-reachable function MUST remain reachable with
+  a touch screen reader active (VoiceOver/TalkBack intercept swipe and
+  long-press before the app sees them), which the parity matrix guarantees
+  only if the equivalents are exposed to AT — see TR-29.
+- **TR-16** The dispatcher MUST NOT regress scroll performance, verified by
+  testable gates: (a) no non-passive move listeners on scroll containers
+  while a sequence is undecided; (b) no React state commits per
+  `pointermove` while undecided (both assertable in component tests); and
+  (c) a manual gate on a named low-end Android reference device
+  (Moto G-class): scrolling a 500-row session list holds ≥ 55 fps average
+  with no input-latency spike over 100 ms.
 
 ### Session-row touch actions (from #3985 / #3154 / #4057 / #4060 / #4065)
 
-- **TR-16** Session rows MUST support swipe-revealed actions on
-  coarse-pointer devices, arbitrated by the dispatcher (TR-9), with the
+- **TR-17** Session rows MUST support swipe-revealed actions for
+  `touch`/`pen` sequences, arbitrated by the dispatcher (TR-10), with the
   specific review defects from #3154 excluded by acceptance tests: no row
   background bleed, correct action icon placement on narrow screens, no
-  icon/content overlap.
-- **TR-17** Row long-press MUST open the row/folder context menu when the
-  press ends without drag movement; drag movement past tolerance converts to
-  reorder and MUST suppress the menu (the #4065 requirement).
-- **TR-18** Drag-to-ungroup (the #4057 drop zone) and any future drop
+  icon/content overlap. Reveal direction is logical (swipe toward start
+  reveals end-side actions) per TR-30.
+- **TR-18** Row long-press follows TR-12 exactly (menu at `MENU_HOLD_MS`,
+  drag conversion suppresses the menu).
+- **TR-19** Drag-to-ungroup (the #4057 drop zone) and any future drop
   targets MUST work with touch drag; drop targets MUST meet coarse-pointer
-  hit-target size.
-- **TR-19** Row gestures gate on pointer capability, not viewport width
-  (already prototyped in the abandoned train), so foldables and touch
-  laptops at ≥768 px get working row gestures.
+  hit-target size (TR-7).
+- **TR-20** Row gestures bind to `pointerType` per TR-2 — never to viewport
+  width — so foldables and touch laptops at ≥ 768 px get working row
+  gestures (already prototyped in the abandoned train's coarse-pointer
+  gating commit).
+
+### Context-menu and editor surfaces beyond the sidebar
+
+- **TR-21** Every surface offering a mouse-only context menu or
+  mouse-only manipulation MUST gain a touch path. The known inventory at
+  time of writing: sidebar row/folder Radix menus (covered by TR-12),
+  and the editor's `TableBubbleMenu` (mouse-only table row/column
+  manipulation and context actions). The design doc assigns each an
+  implementation phase; new mouse-only surfaces added later inherit this
+  requirement.
 
 ### Mobile navigation (left rail)
 
-- **TR-20** Mobile navigation MUST converge on a single persistent left-rail
-  model that adapts the existing desktop `WorkspacePanel` tab contract:
-  one canonical destination set (Sessions, Files/Changes, Agents, Shells,
-  Tasks, Settings) with one open/close state machine, replacing the
-  scattered FAB + per-tool `MobilePanelDrawer` topology.
-- **TR-21** The rail MUST be a narrow collapsed anchor on phones (not the
+- **TR-22** Mobile navigation MUST converge on a single persistent
+  start-side rail that EXTENDS the existing desktop `railTabs` contract —
+  one open/close state machine replacing the scattered FAB +
+  per-tool `MobilePanelDrawer` topology. The destination set is the
+  contract's actual six tabs — Files, Changes, Agents (subagents), Shells
+  (terminals), Tasks (todos), Browser — plus two rail-level extensions that
+  are not workspace tabs: Sessions (the session list, today's full-screen
+  sidebar) and Settings. Browser remains a first-class destination on
+  mobile (full-screen panel), not silently dropped.
+- **TR-23** The rail MUST be a narrow collapsed anchor on phones (not the
   current full-screen `fixed inset-0` session list pinned open), expanding
   into the content panel; expansion/collapse is reachable by tap, by
-  edge-swipe (via the dispatcher, per TR-13), and by keyboard.
-- **TR-22** Hardware/system back (Android), the iOS edge gesture, and
-  browser back MUST dismiss rail layers in a defined order consistent with
-  TR-13's ownership table.
-- **TR-23** The rail MUST inherit the tab semantics, ARIA labels, and
+  start-edge swipe (via the dispatcher, per TR-14), and by keyboard.
+- **TR-24** Hardware/system back (Android), the iOS edge gesture, and
+  browser back MUST dismiss rail layers in the order defined by TR-14's
+  dismissal stack.
+- **TR-25** The rail MUST inherit the tab semantics, ARIA labels, and
   roving-tabindex keyboard behavior of the existing `WorkspacePanel` Radix
   tabs; screen-reader users get one nav landmark, not a stack of bespoke
   overlays.
-- **TR-24** Safe-area insets MUST be applied once at the rail/shell
+- **TR-26** Safe-area insets MUST be applied once at the rail/shell
   boundary (the `--omnigent-safe-*` CSS vars from the native bridges), not
   re-derived per drawer (the #4723 class of bug).
-- **TR-25** Header-strip controls displaced by the contested-strip problem
+- **TR-27** Header-strip controls displaced by the contested-strip problem
   (#3589/#4551) get a defined home in the rail model; the header strip's
   drag-surface role is preserved.
 
-### Native shell interop
+### Native shell and browser interop
 
-- **TR-26** Web-side gesture ownership (TR-13) is the single source of
+- **TR-28** Web-side gesture ownership (TR-14) is the single source of
   truth; Android's back callback and iOS's edge-pan recognizer delegate to
-  it. Shell code MUST NOT grow new gesture heuristics of its own.
-- **TR-27** WebView-hosted browser-native behaviors (pull-to-refresh, text
-  selection, back-forward swipe where enabled) MUST be explicitly claimed or
-  released per surface via `touch-action` / `overscroll-behavior`, not left
-  to default.
+  it. Shell code MUST NOT grow new gesture heuristics of its own. Per
+  surface, browser-native behaviors are explicitly claimed or released via
+  `touch-action` / `overscroll-behavior` — the normative baseline:
+
+  | Surface | `touch-action` | `overscroll-behavior` | Notes |
+  |---|---|---|---|
+  | Chat transcript scroller | `pan-y pinch-zoom` | `contain` | no pull-to-refresh reload mid-session |
+  | Session list rows | `pan-y` (dispatcher claims horizontal) | `contain` | swipe/hold handled per TR-11..13 |
+  | Rail anchor + edge zone | `pan-y` | `contain` | start-edge swipe per TR-14 |
+  | Resize handles | `none` | — | TR-9 |
+  | Text/editor content | browser default | default | selection untouched |
+  | Embedded browser panel | browser default inside the frame | `contain` at the boundary | |
+
+  Browser pinch-zoom MUST remain available app-wide (no
+  `user-scalable=no`, no global `touch-action` that defeats zoom);
+  surfaces claiming `pinch-zoom` away must justify it in review.
 
 ### Accessibility and quality gates
 
-- **TR-28** All touch behavior MUST be covered by component tests that
-  simulate pointer sequences (pointerdown/move/up with timing), including
-  the specific historical defects listed in TR-16/TR-17 as regression
-  tests.
-- **TR-29** Touch changes to visible UI require demo media on the PR per
+- **TR-29** All touch behavior MUST be covered by component tests that
+  simulate pointer sequences (pointerdown/move/up with `pointerType` and
+  timing), including the historical defects in TR-17 as regression tests
+  and the TR-16(a)/(b) performance assertions. Keyboard acceptance tests
+  cover the TR-15 parity matrix (reorder, resize separator values via
+  `aria-valuenow`, menu invocation, focus order and announcements), and a
+  manual AT pass (VoiceOver + TalkBack) verifies every parity-matrix row
+  with the screen reader active.
+- **TR-30** Directional requirements use logical start/end semantics
+  (rail side, swipe reveal direction, edge ownership). The app is LTR-only
+  today; if an RTL locale ships, the bindings flip and TR-17/TR-22/TR-14
+  acceptance tests run mirrored — no requirement in this spec may hardcode
+  physical left/right except the OS-owned end-edge behavior in TR-14.
+- **TR-31** Touch changes to visible UI require demo media on the PR per
   the repo PR template, and `tests/e2e_ui` coverage (or the maintainer skip
   label) where the judge requires it.
 
@@ -185,8 +286,9 @@ viewport width, gates touch behavior.
 
 - No new gesture *vocabulary* beyond what the PR train already established
   (swipe actions, long-press menu, long-press drag, edge-swipe, resize).
-  Pinch-zoom, multi-finger gestures, and haptics beyond the existing
-  WebView haptic hook are out of scope.
+  Multi-finger gestures and new haptics beyond the existing WebView haptic
+  hook are out of scope. Browser pinch-zoom is not an app gesture and is
+  explicitly preserved (TR-28).
 - No native-app rewrites: Android/iOS shells keep their bridge architecture;
   only their delegation points change.
 - Desktop mouse/keyboard interaction is unchanged except where hooks gain
@@ -196,12 +298,12 @@ viewport width, gates touch behavior.
 
 A three-vendor adversarial debate (2026-08-13) argued dispatcher+rail vs.
 dispatcher-only vs. rail-only. All seats endorsed the foundation layer
-(TR-1..8). The dissent worth preserving: *committing the rail in-spec risks
+(TR-1..9). The dissent worth preserving: *committing the rail in-spec risks
 scope creep; product evidence for the nav redesign is thinner than for the
 gesture defects.* It is absorbed by phasing (see the design doc): the rail
 phase has its own go/no-go gate, and if it is cancelled the earlier phases
 stand alone. The asymmetry that decided the debate: a dispatcher designed
 against the rail topology degrades gracefully to today's topology, but a
 dispatcher designed against the FAB/drawer topology must be rewritten when
-the rail lands — and the edge-ownership table (TR-13) is the part that
+the rail lands — and the edge-ownership table (TR-14) is the part that
 changes.

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -87,7 +87,7 @@ changes bindings, not the spec (TR-30).
   action buttons, `md:opacity-0 md:group-hover:opacity-100`) MUST be
   reachable on hover-less / coarse-pointer devices: persistent visibility,
   or an equivalent touch path (row menu, swipe action). This is what makes
-  TR-19's touch-laptop audience real — today those devices can reveal no
+  TR-20's touch-laptop audience real — today those devices can reveal no
   row action at all.
 
 ### Resize
@@ -102,9 +102,12 @@ changes bindings, not the spec (TR-30).
   (never a half-state); listeners are removed on unmount; a second
   concurrent pointer is ignored (first pointer wins); drags over embedded
   iframes keep receiving moves (overlay shield or capture).
-- **TR-7** Resize handles MUST have a coarse-pointer hit target of at least
-  24 CSS px (44 px preferred where layout permits) without changing their
-  visual weight on fine-pointer devices.
+- **TR-7** Resize handles MUST have an invisible hit target of at least
+  24 CSS px (44 px preferred where layout permits) on ALL devices — touch
+  and pen alike, regardless of what capability queries report — without
+  changing their visual weight. Pen-first devices commonly expose a fine
+  pointer, and a 1 px visual handle is impractical to acquire with either
+  input.
 - **TR-8** Existing keyboard resize paths (arrow keys on separators) MUST be
   preserved; hooks that lack a keyboard path (`useResizableColumn`) MUST
   gain one.
@@ -119,15 +122,22 @@ changes bindings, not the spec (TR-30).
   it to at most one intent: scroll, horizontal swipe, long-press (menu),
   long-press-drag (reorder), edge-swipe, or resize.
 - **TR-11** Recognition thresholds are normative, defined once in an
-  exported constants module, and MUST keep competing activation regions
-  disjoint. Initial values (tunable only within the stated ranges, and only
-  with the device-matrix retest required by the design doc):
+  exported constants module. Award is EXCLUSIVE and first-crossed-wins:
+  the dispatcher evaluates each move against the thresholds below, the
+  first award (scroll release, swipe, drag, menu) ends arbitration for the
+  sequence, and hold arming is eligible only while no award has occurred
+  and total travel stays within `HOLD_DRIFT_PX`. There is NO geometric
+  disjointness guarantee between hold and swipe regions — exclusivity
+  comes from this precedence rule, not from region math. Invariants
+  DOMINATE tuning ranges: a retune is legal only if it satisfies every
+  invariant AND passes the device-matrix retest required by the design
+  doc; the ranges are guidance, not a grant.
 
   | Constant | Value | Meaning | Tuning range | Invariant |
   |---|---|---|---|---|
-  | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe`, axis-locked (see TR-13) | 8–16 | `< HOLD_DRIFT_PX / √2` |
+  | `SWIPE_ACTIVATION_PX` | 12 | horizontal travel that awards `swipe` when horizontal-first (see TR-13) | 8–16 | `> DRAG_TOLERANCE_PX` |
   | `HOLD_MS` | 250 | stationary hold that arms drag-or-menu (dnd-kit parity on main) | 200–350 | `< MENU_HOLD_MS` |
-  | `HOLD_DRIFT_PX` | 25 | max travel while holding before the hold cancels (the train's 25/√2 ≈ 17.7 per-axis bound keeps swipe and hold disjoint) | 20–30 | `/√2 > SWIPE_ACTIVATION_PX` |
+  | `HOLD_DRIFT_PX` | 20 | total travel that cancels hold eligibility (the train's hold tolerance in `c21fec929`; its 25 px circle was the separate scroll-fallback radius) | 8–20 | crossing any award threshold also cancels hold |
   | `MENU_HOLD_MS` | 500 | stationary hold that opens the context menu (replaces Radix's ~700 ms default) | 400–700 | `> HOLD_MS` |
   | `DRAG_TOLERANCE_PX` | 8 | movement after arming that converts hold → drag (dnd-kit parity) | 5–10 | `< SWIPE_ACTIVATION_PX` |
   | `EDGE_ZONE_PX` | 24 | width of the screen-edge strip that recognizes edge-swipe | 16–32 | — |
@@ -157,7 +167,8 @@ changes bindings, not the spec (TR-30).
   |---|---|---|
   | Start-edge swipe (within `EDGE_ZONE_PX`) | Rail/sidebar open (dispatcher) | iOS `UIScreenEdgePanGestureRecognizer` delegates its drag here; WebKit back-forward gestures stay disabled |
   | End-edge swipe | Released to browser/OS (back-forward where the platform provides it) | No app consumer may claim it without amending this table |
-  | Android hardware/system back, browser back | Dismissal stack below, then history | Routed via `__omnigentNativeHandleBack` |
+  | Android hardware/system back | Dismissal stack below, then WebView history | Routed via `__omnigentNativeHandleBack` (Android shell only) |
+  | Browser back (`popstate`) | Topmost history-participating layer, else normal history navigation | Each dismissible layer pushes ONE history entry on open; `popstate` closes exactly one layer, matched by a state token so re-entrant pops cannot loop; transient popovers that don't push are not browser-back-dismissible |
   | Dismissal stack (top → bottom) | modal dialogs → context menus/popovers → expanded rail panel or `MobilePanelDrawer` → rail/sidebar overlay → in-app history → browser history/app exit | One layer per back press |
 
 - **TR-15** Every gesture MUST have a non-gesture equivalent. The parity
@@ -181,9 +192,14 @@ changes bindings, not the spec (TR-30).
   testable gates: (a) no non-passive move listeners on scroll containers
   while a sequence is undecided; (b) no React state commits per
   `pointermove` while undecided (both assertable in component tests); and
-  (c) a manual gate on a named low-end Android reference device
-  (Moto G-class): scrolling a 500-row session list holds ≥ 55 fps average
-  with no input-latency spike over 100 ms.
+  (c) a manual gate on the named reference configuration — Moto G Power
+  (2023), Android 13, current stable Chrome — running a scripted,
+  repeatable benchmark: populate 500 session rows, 5 s warm-up, then 30 s
+  of scripted fling scrolls traced with Perfetto/Chrome tracing; pass =
+  mean fps ≥ 55 over the scripted window AND p95 input latency < 100 ms.
+  The script and trace config are committed alongside the dispatcher;
+  substituting hardware requires amending this requirement, not ad-hoc
+  judgment.
 
 ### Session-row touch actions (from #3985 / #3154 / #4057 / #4060 / #4065)
 
@@ -228,9 +244,12 @@ changes bindings, not the spec (TR-30).
   current full-screen `fixed inset-0` session list pinned open), expanding
   into the content panel; expansion/collapse is reachable by tap, by
   start-edge swipe (via the dispatcher, per TR-14), and by keyboard.
-- **TR-24** Hardware/system back (Android), the iOS edge gesture, and
-  browser back MUST dismiss rail layers in the order defined by TR-14's
-  dismissal stack.
+- **TR-24** Hardware/system back (Android) and browser back (via the
+  history participation defined in TR-14) MUST dismiss rail layers in the
+  order defined by TR-14's dismissal stack. iOS has NO edge dismissal
+  gesture — TR-14 assigns the start edge exclusively to opening the rail
+  and releases the end edge to the OS — so on iOS dismissal is by tap on
+  the scrim or rail anchor, the close button, or keyboard.
 - **TR-25** The rail MUST inherit the tab semantics, ARIA labels, and
   roving-tabindex keyboard behavior of the existing `WorkspacePanel` Radix
   tabs; screen-reader users get one nav landmark, not a stack of bespoke
@@ -253,8 +272,8 @@ changes bindings, not the spec (TR-30).
   | Surface | `touch-action` | `overscroll-behavior` | Notes |
   |---|---|---|---|
   | Chat transcript scroller | `pan-y pinch-zoom` | `contain` | no pull-to-refresh reload mid-session |
-  | Session list rows | `pan-y` (dispatcher claims horizontal) | `contain` | swipe/hold handled per TR-11..13 |
-  | Rail anchor + edge zone | `pan-y` | `contain` | start-edge swipe per TR-14 |
+  | Session list rows | `pan-y pinch-zoom` (dispatcher claims horizontal) | `contain` | swipe/hold per TR-11..13; a second pointer joining cancels the sequence and yields to pinch-zoom |
+  | Rail anchor + edge zone | `pan-y pinch-zoom` | `contain` | start-edge swipe per TR-14; second pointer yields to pinch-zoom |
   | Resize handles | `none` | — | TR-9 |
   | Text/editor content | browser default | default | selection untouched |
   | Embedded browser panel | browser default inside the frame | `contain` at the boundary | |

--- a/docs/touch-interaction-spec.md
+++ b/docs/touch-interaction-spec.md
@@ -149,8 +149,10 @@ changes bindings, not the spec (TR-30).
   fire `pointercancel` before the circle bound is reached — `c21fec929`'s
   own caveat ("native pan-y still wins earlier"). The dispatcher MUST
   treat that `pointercancel` as a release to scroll; surfaces MUST NOT
-  suppress native vertical pan during the undecided phase to defeat this,
-  since TR-16(a)'s passive-listener gate forbids it. Invariants
+  suppress native vertical pan during the undecided phase to defeat this
+  — TR-28's normative `pan-y pinch-zoom` baseline for these surfaces
+  forbids that suppression via `touch-action`, and TR-16(a) separately
+  forbids the non-passive-listener equivalent. Invariants
   DOMINATE tuning ranges: a retune is legal only if it satisfies every
   invariant AND passes the device-matrix retest required by the design
   doc; the ranges are guidance, not a grant.


### PR DESCRIPTION
Part of #4790

## Related issue

Closes # <!-- Docs change; no issue required per template. -->

## Summary

- Adds `docs/touch-interaction-spec.md`: a holistic touch-interaction specification (TR-1..29) capturing the requirements scattered across the touch PR train — session-row swipe actions (#3154 → #3985), row long-press/drag arbitration (#4057/#4060/#4065), the contested header strip (#3589/#4551), mobile shells parity (#1395), drawer safe-area (#4723), the five mouse-only resize hooks, and the missing pointer-capability detection.
- Adds `docs/touch-interaction-design.md`: a three-phase architecture — Phase 0 input-capability + pointer-event foundation, Phase 1 unified gesture dispatcher (resurrecting the abandoned `useRowGesture` work from `8dd70928c`/`c21fec929`), Phase 2 gated left-rail mobile navigation adapting the existing `WorkspacePanel` tab model.
- Motivation: the prior touch PRs were built without an agreed end-state and were repeatedly rewritten or abandoned (duplicate SHAs of the same fixes stranded across rebased trains). These docs are the contract future touch PRs cite, so reviewers judge diffs against requirements instead of re-litigating the approach.

ELI5: the app keeps guessing "is this a phone?" by screen width and lets five different pieces of code fight over every finger-drag. The spec says: detect *touch* directly, give each surface one referee for gestures, and give mobile one navigation rail — built in that order.

```
Phase 2   Left rail (single mobile nav surface)
             │ consumes
Phase 1   Gesture dispatcher (one owner per surface)
             │ consumes
Phase 0   Input capability + pointer-event foundation
```

## Test Plan

Docs-only change; no code paths affected. Verified all file/line and commit citations against `main` (`ce6dba9c8`) and the abandoned branches (`feature/mobile-slide-actions-v2`, `train/polly/session-row-gesture-fix`) during a three-vendor codebase investigation. `pre-commit` hooks ran clean on commit.

## Demo

N/A (docs only).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only PR; no executable behavior to test. Citations were manually verified against the repository at the referenced commits.