### PR TITLE
perf(server): collapse the per-event access-control reads into one checkout

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, contextmanager
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -553,6 +554,54 @@ def clear_engine_cache() -> None:
 # ── Managed session ────────────────────────────────────
 
 
+# Ambient per-engine sessions for a read-only "share one checkout" scope. When
+# active (see :func:`shared_read_scope`), ``managed_session()`` reuses the
+# scope's session for its engine instead of opening a fresh pool checkout,
+# collapsing several back-to-back reads (e.g. the access-control check's
+# permission + conversation lookups) into a single connection round-trip.
+# Keyed by ``id(engine)`` so distinct engines (split-DB) still get independent
+# checkouts. Unset outside a scope, so it is a strict no-op for every ordinary
+# caller.
+_shared_read_sessions: ContextVar[dict[int, Session] | None] = ContextVar(
+    "omnigent_shared_read_sessions", default=None
+)
+
+
+@contextmanager
+def shared_read_scope() -> Iterator[None]:
+    """Collapse back-to-back reads into one pool checkout per engine.
+
+    Within this scope, ``managed_session()`` reuses a single session per
+    engine rather than checking out a fresh pooled connection (plus a
+    ``pool_pre_ping`` round-trip) on every store call. Intended for a short,
+    strictly READ-ONLY burst — an access-control check, a snapshot assembly —
+    where the per-call checkout dominates the actual query time.
+
+    Nesting reuses the outer scope. Write makers (``immediate=True``) never
+    participate, so they keep their own ``BEGIN IMMEDIATE`` isolation even
+    when nested here. Never hold this open across network I/O: it pins a
+    pooled connection for the scope's whole duration.
+    """
+    if _shared_read_sessions.get() is not None:
+        # Already inside a scope — the outer one owns the sessions.
+        yield
+        return
+    sessions: dict[int, Session] = {}
+    token = _shared_read_sessions.set(sessions)
+    try:
+        yield
+        for session in sessions.values():
+            session.commit()
+    except BaseException:
+        for session in sessions.values():
+            session.rollback()
+        raise
+    finally:
+        for session in sessions.values():
+            session.close()
+        _shared_read_sessions.reset(token)
+
+
 def make_managed_session_maker(
     engine: Engine,
     *,
@@ -592,7 +641,27 @@ def make_managed_session_maker(
         Commits on clean exit, rolls back on exception. For SQLite
         backends, enables foreign key enforcement and sets a
         busy timeout before yielding.
+
+        Inside a :func:`shared_read_scope` (and only for read makers), the
+        scope's per-engine session is reused instead of a fresh checkout;
+        the scope — not this block — owns its commit/close.
         """
+        if not immediate:
+            shared = _shared_read_sessions.get()
+            if shared is not None:
+                key = id(engine)
+                session = shared.get(key)
+                if session is None:
+                    session = factory()
+                    # Register before the PRAGMAs: those executes force the pool
+                    # checkout, so if one raises the scope must already track the
+                    # session to close it (otherwise the connection would leak).
+                    shared[key] = session
+                    if is_sqlite:
+                        session.execute(text("PRAGMA foreign_keys = ON"))
+                        session.execute(text("PRAGMA busy_timeout = 20000"))  # 20s
+                yield session
+                return
         with factory() as session:
             try:
                 if is_sqlite:

--- a/omnigent/server/routes/_auth_helpers.py
+++ b/omnigent/server/routes/_auth_helpers.py
@@ -23,6 +23,7 @@ import dataclasses
 
 from fastapi import Request
 
+from omnigent.db.utils import shared_read_scope
 from omnigent.entities import Conversation
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import (
@@ -290,52 +291,58 @@ def _require_access_and_level_sync(
             code=ErrorCode.UNAUTHORIZED,
         )
 
-    # Single round-trip: admin flag + the user's and public grants on the
-    # conversation the caller asked about. The displayed level is the direct
-    # grant (no parent walk), matching get_permission_level exactly.
-    access = permission_store.resolve_access(user_id, conversation_id)
-    level = resolved_level(access)
+    # One read-only burst: the permission resolve, the conversation lookup,
+    # and any parent-chain walk all share a single pool checkout instead of
+    # one per store call. On the per-streamed-event path this is re-run for a
+    # session whose data is stable for the turn, so the checkout — plus
+    # ``pool_pre_ping`` — is the cost that matters.
+    with shared_read_scope():
+        # Single round-trip: admin flag + the user's and public grants on the
+        # conversation the caller asked about. The displayed level is the direct
+        # grant (no parent walk), matching get_permission_level exactly.
+        access = permission_store.resolve_access(user_id, conversation_id)
+        level = resolved_level(access)
 
-    # Admins bypass the conversation lookup entirely (mirrors
-    # check_session_access's admin short-circuit, which never reads the
-    # conversation). A missing conversation is left for the snapshot builder
-    # to 404 on, exactly as today.
-    if access.is_admin:
-        return SessionAccess(level=level, conversation=None)
+        # Admins bypass the conversation lookup entirely (mirrors
+        # check_session_access's admin short-circuit, which never reads the
+        # conversation). A missing conversation is left for the snapshot builder
+        # to 404 on, exactly as today.
+        if access.is_admin:
+            return SessionAccess(level=level, conversation=None)
 
-    conv = conversation_store.get_conversation(conversation_id)
-    if conv is None:
-        raise OmnigentError(
-            "Conversation not found",
-            code=ErrorCode.NOT_FOUND,
-        )
+        conv = conversation_store.get_conversation(conversation_id)
+        if conv is None:
+            raise OmnigentError(
+                "Conversation not found",
+                code=ErrorCode.NOT_FOUND,
+            )
 
-    if conv.parent_conversation_id is None:
-        # Top-level session: the access-governing grant lives on this same
-        # conversation, so reuse the rows already fetched — no extra reads.
-        allowed = resolved_allows(access, required_level)
-    else:
-        # Sub-agent: access delegates to the parent chain. Defer to the
-        # canonical recursive checker (its own reads); sub-agents are rare
-        # and the parent's grants are a different conversation's rows.
-        allowed = check_session_access(
-            user_id,
-            conv.parent_conversation_id,
-            required_level,
-            permission_store,
-            conversation_store,
-        )
-    if allowed:
-        return SessionAccess(level=level, conversation=conv)
+        if conv.parent_conversation_id is None:
+            # Top-level session: the access-governing grant lives on this same
+            # conversation, so reuse the rows already fetched — no extra reads.
+            allowed = resolved_allows(access, required_level)
+        else:
+            # Sub-agent: access delegates to the parent chain. Defer to the
+            # canonical recursive checker (its own reads); sub-agents are rare
+            # and the parent's grants are a different conversation's rows.
+            allowed = check_session_access(
+                user_id,
+                conv.parent_conversation_id,
+                required_level,
+                permission_store,
+                conversation_store,
+            )
+        if allowed:
+            return SessionAccess(level=level, conversation=conv)
 
-    # Denied — distinguish "has some access but not enough" (403) from
-    # "no access at all" (404, to avoid leaking session existence).
-    if conv.parent_conversation_id is None:
-        has_any = resolved_allows(access, 1)
-    else:
-        has_any = check_session_access(
-            user_id, conv.parent_conversation_id, 1, permission_store, conversation_store
-        )
+        # Denied — distinguish "has some access but not enough" (403) from
+        # "no access at all" (404, to avoid leaking session existence).
+        if conv.parent_conversation_id is None:
+            has_any = resolved_allows(access, 1)
+        else:
+            has_any = check_session_access(
+                user_id, conv.parent_conversation_id, 1, permission_store, conversation_store
+            )
     if has_any:
         level_name = _LEVEL_NAMES.get(required_level, str(required_level))
         raise OmnigentError(

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from alembic import command
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event, text
 
 from omnigent.db.utils import (
     _LAKEBASE_POOL_RECYCLE_SECONDS,
@@ -20,6 +20,7 @@ from omnigent.db.utils import (
     _initialize_or_verify_schema,
     _install_lakebase_token_refresh,
     _resolve_lakebase_token_provider,
+    _shared_read_sessions,
     build_search_snippet,
     builtin_agent_id,
     clear_engine_cache,
@@ -27,7 +28,9 @@ from omnigent.db.utils import (
     generate_agent_id,
     generate_item_id,
     get_or_create_engine,
+    make_managed_session_maker,
     set_lakebase_token_provider,
+    shared_read_scope,
     strip_nul_bytes,
 )
 from omnigent.entities.conversation import (
@@ -686,3 +689,183 @@ def test_build_search_snippet_no_match_returns_none() -> None:
     """No occurrence (or empty query) yields None so the caller shows no preview."""
     assert build_search_snippet("no match here", "xyz") is None
     assert build_search_snippet("anything", "") is None
+
+
+# ── shared_read_scope (collapse read checkouts) ─────────
+
+
+def _count_checkouts(engine: Any) -> tuple[list[int], Any]:
+    """Attach a pool-checkout counter to ``engine``.
+
+    :returns: ``(count_list, detach)`` — append-per-checkout list plus a
+        zero-arg callable that removes the listener.
+    """
+    count: list[int] = []
+
+    def _on_checkout(_dbapi: Any, _record: Any, _proxy: Any) -> None:
+        count.append(1)
+
+    event.listen(engine, "checkout", _on_checkout)
+    return count, lambda: event.remove(engine, "checkout", _on_checkout)
+
+
+def test_shared_read_scope_reuses_one_session_per_engine(db_uri: str) -> None:
+    """Inside the scope, every ``managed_session()`` on an engine is the same
+    Session; outside it, each call yields a fresh one."""
+    engine = get_or_create_engine(db_uri)
+    maker = make_managed_session_maker(engine)
+
+    with shared_read_scope():
+        with maker() as s1, maker() as s2:
+            assert s1 is s2, "reads in a scope must share one session"
+
+    with maker() as a:
+        pass
+    with maker() as b:
+        assert a is not b, "without a scope each call opens its own session"
+
+
+def test_shared_read_scope_collapses_checkouts(db_uri: str) -> None:
+    """N back-to-back reads cost one pool checkout in a scope, N without."""
+    engine = get_or_create_engine(db_uri)
+    maker = make_managed_session_maker(engine)
+    count, detach = _count_checkouts(engine)
+    try:
+        with shared_read_scope():
+            for _ in range(3):
+                with maker() as session:
+                    session.execute(text("SELECT 1"))
+        assert len(count) == 1, f"a scope must share one checkout, got {len(count)}"
+
+        count.clear()
+        for _ in range(3):
+            with maker() as session:
+                session.execute(text("SELECT 1"))
+        assert len(count) == 3, f"without a scope each read checks out, got {len(count)}"
+    finally:
+        detach()
+
+
+def test_shared_read_scope_is_noop_outside(db_uri: str) -> None:
+    """With no active scope the context var is unset and behaviour is unchanged."""
+    assert _shared_read_sessions.get() is None
+    engine = get_or_create_engine(db_uri)
+    maker = make_managed_session_maker(engine)
+    with maker() as session:
+        session.execute(text("SELECT 1"))
+    assert _shared_read_sessions.get() is None
+
+
+def test_shared_read_scope_write_maker_bypasses_reuse(db_uri: str) -> None:
+    """A write maker (``immediate=True``) keeps its own session even in a scope,
+    so it never loses its ``BEGIN IMMEDIATE`` write isolation."""
+    engine = get_or_create_engine(db_uri)
+    read_maker = make_managed_session_maker(engine)
+    write_maker = make_managed_session_maker(engine, immediate=True)
+
+    with shared_read_scope():
+        with read_maker() as r1:
+            pass
+        with write_maker() as w1:
+            assert w1 is not r1, "write makers must not join the read scope"
+        with read_maker() as r2:
+            assert r2 is r1, "read makers still reuse the scope's session"
+
+
+def test_shared_read_scope_distinct_engines_get_distinct_sessions(
+    db_uri: str, tmp_path: Path
+) -> None:
+    """Each engine gets its own reused session (split-DB stays correct)."""
+    engine_a = get_or_create_engine(db_uri)
+    engine_b = get_or_create_engine(f"sqlite:///{tmp_path / 'other.db'}")
+    maker_a = make_managed_session_maker(engine_a)
+    maker_b = make_managed_session_maker(engine_b)
+
+    with shared_read_scope():
+        with maker_a() as sa, maker_b() as sb:
+            assert sa is not sb, "distinct engines must not share a session"
+        with maker_a() as sa2:
+            assert sa2 is sa, "same engine reuses within the scope"
+
+
+def test_shared_read_scope_cleans_up_on_error(db_uri: str) -> None:
+    """An exception rolls the scope back and always resets the context var."""
+    engine = get_or_create_engine(db_uri)
+    maker = make_managed_session_maker(engine)
+
+    # An explicit try/except (rather than pytest.raises) keeps the post-scope
+    # assertions on a control-flow path static analysers can see as reachable.
+    raised = False
+    try:
+        with shared_read_scope():
+            with maker() as session:
+                session.execute(text("SELECT 1"))
+            raise RuntimeError("boom")
+    except RuntimeError:
+        raised = True
+
+    assert raised, "the scope must propagate the exception"
+    assert _shared_read_sessions.get() is None, "the scope must reset its context var"
+
+
+def test_shared_read_scope_nesting_reuses_outer(db_uri: str) -> None:
+    """A nested scope defers to the outer one rather than opening a second layer."""
+    engine = get_or_create_engine(db_uri)
+    maker = make_managed_session_maker(engine)
+    with shared_read_scope():
+        with maker() as outer:
+            pass
+        with shared_read_scope():
+            with maker() as inner:
+                assert inner is outer, "nested scope reuses the outer session"
+
+
+def test_shared_read_scope_closes_session_when_init_fails(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure while initializing the scope's session must not leak its
+    checked-out connection — the session is registered before the PRAGMAs run,
+    so the scope's cleanup closes it and the pool checkout is returned."""
+    from sqlalchemy.orm import Session as _Session
+
+    engine = get_or_create_engine(db_uri)
+    if engine.dialect.name != "sqlite":
+        # The init-time checkout this guards against is the SQLite PRAGMA path;
+        # other dialects run no execute between session creation and registration.
+        pytest.skip("exercises the SQLite-only PRAGMA-init checkout path")
+    maker = make_managed_session_maker(engine)
+
+    counts = {"out": 0, "in": 0}
+
+    def _out(*_a: Any) -> None:
+        counts["out"] += 1
+
+    def _in(*_a: Any) -> None:
+        counts["in"] += 1
+
+    event.listen(engine, "checkout", _out)
+    event.listen(engine, "checkin", _in)
+
+    real_execute = _Session.execute
+
+    def _boom(self: _Session, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        # Fail the second PRAGMA — the first has already forced the checkout.
+        if "busy_timeout" in str(statement):
+            raise RuntimeError("simulated PRAGMA failure")
+        return real_execute(self, statement, *args, **kwargs)
+
+    monkeypatch.setattr(_Session, "execute", _boom)
+
+    try:
+        with pytest.raises(RuntimeError, match="simulated PRAGMA failure"):
+            with shared_read_scope():
+                with maker():
+                    pass
+    finally:
+        event.remove(engine, "checkout", _out)
+        event.remove(engine, "checkin", _in)
+
+    assert counts["out"] >= 1, "the test must actually force a pool checkout"
+    assert counts["out"] == counts["in"], (
+        f"a session that failed mid-init leaked its checkout: {counts}"
+    )

--- a/tests/server/routes/test_auth_helpers.py
+++ b/tests/server/routes/test_auth_helpers.py
@@ -228,3 +228,38 @@ async def test_missing_conversation_raises_404(
         )
 
     assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_access_check_shares_a_single_pool_checkout(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """The permission resolve + conversation + metadata reads share one checkout.
+
+    On the per-streamed-event path this check re-runs for a session whose data
+    is stable for the turn, so the pool checkout (plus ``pool_pre_ping``) is the
+    cost that matters. The stores share one engine here, so the read burst must
+    collapse to a single checkout rather than one per store call.
+    """
+    from sqlalchemy import event
+
+    conv = conv_store.create_conversation()
+    perm_store.ensure_user(ALICE)
+    perm_store.grant(ALICE, conv.id, LEVEL_OWNER)
+
+    engine = conv_store._engine
+    checkouts: list[int] = []
+
+    def _on_checkout(_dbapi: object, _record: object, _proxy: object) -> None:
+        checkouts.append(1)
+
+    event.listen(engine, "checkout", _on_checkout)
+    try:
+        access = await require_access_and_level(ALICE, conv.id, LEVEL_READ, perm_store, conv_store)
+    finally:
+        event.remove(engine, "checkout", _on_checkout)
+
+    assert access.conversation is not None and access.conversation.id == conv.id
+    assert len(checkouts) == 1, (
+        f"the access-control read burst must share one checkout, got {len(checkouts)}"
+    )


### PR DESCRIPTION
## Related issue

Closes #3004

## Summary

Every event posted to `POST /v1/sessions/{id}/events` runs an access-control
check before it does anything else, and that check's reads dominate at scale.
For a session whose permissions/metadata are stable for the turn, each streamed
chunk re-pays: `resolve_access` (`session_permissions` + `users`) **plus**
`get_conversation` — which internally reads the conversation row + labels in one
checkout and the metadata row in a **separate** one. That's **three distinct pool
checkouts**, each with a `pool_pre_ping` liveness round-trip, per event — the
bulk of the ~16 queries / ~10 checkouts per event measured in #3004.

**`shared_read_scope()`** (`db/utils.py`): a read-only, per-request scope in
which `managed_session()` reuses **one session per engine** instead of a fresh
checkout on every store call. Wrapped around the access-control burst, so the
permission + conversation + metadata reads collapse to **one checkout**
(single-DB); split-DB deployments keep independent checkouts per engine. Write
makers (`immediate=True`) never participate, so `BEGIN IMMEDIATE` isolation is
untouched, and the scope is a strict no-op everywhere it isn't activated. It is
deliberately kept off any path that spans runner network I/O, so it never pins a
pooled connection across a multi-second turn.

**No ACL semantics change** — the same rows are read, just once per request over
a single connection.

### ELI5

The access check used to walk up to the DB counter three separate times per
event (permissions, then the conversation + labels, then its metadata), queuing
anew each time. Now it grabs one connection and does all three reads before
letting go.

```mermaid
flowchart LR
  subgraph Before["Before: 3 checkouts / event"]
    A1[resolve_access] --> B1[checkout + pre_ping]
    A2[conv + labels] --> B2[checkout + pre_ping]
    A3[metadata] --> B3[checkout + pre_ping]
  end
  subgraph After["After: 1 checkout / event"]
    C1[resolve_access] --> D[one shared checkout]
    C2[conv + labels] --> D
    C3[metadata] --> D
  end
```

### Scope note

An earlier revision also threaded the already-loaded conversation into runner
routing to spare the router's own `get_conversation` on forwarding events. That
was dropped: `_get_runner_client_impl` / `client_for_session_resources` already
carry an optional `conversation` param, but the call-site facade
(`_get_runner_client`) is a narrow, heavily-mocked seam that many integration
tests replace with a fixed `(session_id, runner_router)` signature — threading a
new kwarg through it broke ~15 test doubles for a saving that only helps
runner-forwarding events (not the per-chunk hot path). The checkout collapse
above is the win; the routing tweak can be revisited separately if wanted.

## Test Plan

- **New unit tests** (`tests/db/test_utils.py`): `shared_read_scope` reuses one
  session per engine, collapses N reads to a single pool checkout (vs N without
  the scope), is a no-op outside a scope, bypasses write makers, keys sessions
  per engine (split-DB), cleans up its context var on error, nests safely, and
  closes a partially-initialized session on init failure so a failed PRAGMA
  can't leak a pool checkout. **8 passed.**
- **New integration test** (`tests/server/routes/test_auth_helpers.py`):
  `require_access_and_level` against real SQLite-backed stores issues **exactly
  one** pool checkout for the resolve + conversation + metadata burst, and still
  returns the correct `SessionAccess`. **10 passed** (whole file).
- Ran green locally (Postgres-driver / `asgiref` tests skipped — those optional
  deps aren't installed in the sandbox and fail identically on `main`):

```
uv run --extra dev pytest \
  tests/db/test_utils.py \
  tests/server/routes/test_auth_helpers.py \
  tests/server/integration/test_sessions_endpoints.py \
  tests/server/integration/test_sessions_child_sessions.py
```

`test_sessions_endpoints.py` + `test_sessions_child_sessions.py` = **258 passed**.
`ruff format`, `ruff check`, and `pyrefly check` clean on the changed files.

### Live multi-user e2e (real HTTP server)

Beyond the suites, I stood up a **real `uvicorn` server on a TCP port** in
header (multi-user) auth mode and drove it over real HTTP as two distinct users
(`alice`, `bob`, via `X-Forwarded-Email`). Alice creates a session over HTTP,
shares EDIT with bob, and bob accesses it.

**The collapse, proven live** — pool checkouts for one identical authenticated
`GET /v1/sessions/{id}`, with `shared_read_scope` active vs. monkeypatched to a
no-op (the pre-#4737 baseline) on the same running server:

| | pool checkouts for the GET |
|---|---|
| `shared_read_scope` **ON** (this PR) | **12** |
| **OFF** (pre-#4737 baseline) | 14 |

The two differ by exactly **2** — the ACL burst going **3 checkouts → 1**. (The
other ~11 checkouts are the snapshot build; identical in both, so the delta
isolates the collapse.)

**Behavior identical** on the live server (the scope changes cost, never
semantics): alice reads her own session (200); bob is 404 before the share,
**immediately** 200 after, and **immediately** 404 after alice revokes.

## Demo

N/A (non-visual; server-side performance change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit + integration tests assert the checkout collapse directly (one
pool checkout for the ACL burst) and the scope's invariants (reuse, nesting,
write-maker bypass, per-engine keying, error cleanup). Manual verification = the
live multi-user run above against a real HTTP server, showing the per-request
ACL burst drop from 3 pool checkouts to 1 with auth behavior unchanged.

