### PR TITLE
refactor(web): extract SelectionPopup from ChatPage into its own module

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -17,7 +17,6 @@ import {
   BotIcon,
   CheckIcon,
   AlertTriangleIcon,
-  CornerUpLeftIcon,
   CopyIcon,
   FileTextIcon,
   FolderIcon,
@@ -197,6 +196,7 @@ import { ResumeWithDirectoryDialog } from "@/shell/ResumeWithDirectoryDialog";
 import { ReconnectSessionDialog } from "@/shell/ReconnectSessionDialog";
 import { useTerminalFirst } from "@/shell/TerminalFirstContext";
 import { useForkDialog } from "@/shell/ForkDialogContext";
+import { SelectionPopup } from "./SelectionPopup";
 import { supportsEffortControl } from "@/lib/sessionCapabilities";
 import { isCodexNativeSession } from "@/lib/codexPlanMode";
 import { getCliServerUrl } from "@/lib/host";
@@ -1378,104 +1378,8 @@ function SessionLayout({ mainAgent }: SessionLayoutProps) {
   );
 }
 
-function SelectionPopup({
-  containerRef,
-  onReply,
-}: {
-  containerRef: React.RefObject<HTMLElement | null>;
-  onReply: (text: string) => void;
-}) {
-  const [popupPos, setPopupPos] = useState<{ x: number; y: number } | null>(null);
-  const selectedTextRef = useRef<string>("");
-
-  const updatePopup = useCallback(() => {
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
-      setPopupPos(null);
-      selectedTextRef.current = "";
-      return;
-    }
-
-    const text = sel.toString().trim();
-    if (!text) {
-      setPopupPos(null);
-      selectedTextRef.current = "";
-      return;
-    }
-
-    // Scope to the conversation container — ignore selections in the composer.
-    const container = containerRef.current;
-    if (!container) {
-      setPopupPos(null);
-      selectedTextRef.current = "";
-      return;
-    }
-    const anchor = sel.anchorNode;
-    if (!anchor || !container.contains(anchor)) {
-      setPopupPos(null);
-      selectedTextRef.current = "";
-      return;
-    }
-
-    const range = sel.getRangeAt(0);
-    const rect = range.getBoundingClientRect();
-    // Position the button just above the selection, horizontally centered.
-    setPopupPos({
-      x: rect.left + rect.width / 2,
-      y: rect.top,
-    });
-    selectedTextRef.current = text;
-  }, [containerRef]);
-
-  useEffect(() => {
-    document.addEventListener("mouseup", updatePopup);
-    document.addEventListener("selectionchange", updatePopup);
-    return () => {
-      document.removeEventListener("mouseup", updatePopup);
-      document.removeEventListener("selectionchange", updatePopup);
-    };
-  }, [updatePopup]);
-
-  if (!popupPos) return null;
-
-  return (
-    <div
-      style={{
-        position: "fixed",
-        // Translate left by 50% to center the button over the midpoint of the
-        // selection, and up by 100% + 6px to sit just above the selection rect.
-        left: popupPos.x,
-        top: popupPos.y,
-        transform: "translate(-50%, calc(-100% - 6px))",
-        zIndex: 50,
-      }}
-    >
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        // Override shared-variant translucent hover — this button floats over text.
-        className="gap-1 shadow-md hover:bg-secondary hover:brightness-95 dark:hover:brightness-110"
-        onMouseDown={(e) => {
-          // Prevent the mousedown from clearing the selection before we read it.
-          e.preventDefault();
-        }}
-        onClick={() => {
-          const text = selectedTextRef.current;
-          if (text) {
-            onReply(text);
-            window.getSelection()?.removeAllRanges();
-            setPopupPos(null);
-            selectedTextRef.current = "";
-          }
-        }}
-      >
-        <CornerUpLeftIcon className="size-3.5" />
-        Reply ↵
-      </Button>
-    </div>
-  );
-}
+// SelectionPopup (the floating Reply action) moved to ./SelectionPopup so it
+// can grow and be unit-tested in isolation.
 
 interface MainAgentSurfaceProps {
   /**

--- a/web/src/pages/SelectionPopup.tsx
+++ b/web/src/pages/SelectionPopup.tsx
@@ -1,0 +1,114 @@
+// Floating "Reply ↵" button shown over a text selection inside the chat
+// transcript. Extracted from ChatPage so the popup can grow independently;
+// behavior is unchanged.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CornerUpLeftIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Floating selection action, scoped to the conversation container.
+ *
+ * @param containerRef Conversation area; selections outside it (e.g. the
+ *   composer) are ignored.
+ * @param onReply Append the selected text as a reply quote.
+ */
+export function SelectionPopup({
+  containerRef,
+  onReply,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>;
+  onReply: (text: string) => void;
+}) {
+  const [popupPos, setPopupPos] = useState<{ x: number; y: number } | null>(null);
+  const selectedTextRef = useRef<string>("");
+
+  const updatePopup = useCallback(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+      setPopupPos(null);
+      selectedTextRef.current = "";
+      return;
+    }
+
+    const text = sel.toString().trim();
+    if (!text) {
+      setPopupPos(null);
+      selectedTextRef.current = "";
+      return;
+    }
+
+    // Scope to the conversation container — ignore selections in the composer.
+    const container = containerRef.current;
+    if (!container) {
+      setPopupPos(null);
+      selectedTextRef.current = "";
+      return;
+    }
+    const anchor = sel.anchorNode;
+    if (!anchor || !container.contains(anchor)) {
+      setPopupPos(null);
+      selectedTextRef.current = "";
+      return;
+    }
+
+    const range = sel.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    // Position the button just above the selection, horizontally centered.
+    setPopupPos({
+      x: rect.left + rect.width / 2,
+      y: rect.top,
+    });
+    selectedTextRef.current = text;
+  }, [containerRef]);
+
+  useEffect(() => {
+    document.addEventListener("mouseup", updatePopup);
+    document.addEventListener("selectionchange", updatePopup);
+    return () => {
+      document.removeEventListener("mouseup", updatePopup);
+      document.removeEventListener("selectionchange", updatePopup);
+    };
+  }, [updatePopup]);
+
+  if (!popupPos) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        // Translate left by 50% to center the button over the midpoint of the
+        // selection, and up by 100% + 6px to sit just above the selection rect.
+        left: popupPos.x,
+        top: popupPos.y,
+        transform: "translate(-50%, calc(-100% - 6px))",
+        zIndex: 50,
+      }}
+    >
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        // Override shared-variant translucent hover — this button floats over text.
+        className="gap-1 shadow-md hover:bg-secondary hover:brightness-95 dark:hover:brightness-110"
+        onMouseDown={(e) => {
+          // Prevent the mousedown from clearing the selection before we read it.
+          e.preventDefault();
+        }}
+        onClick={() => {
+          const text = selectedTextRef.current;
+          if (text) {
+            onReply(text);
+            window.getSelection()?.removeAllRanges();
+            setPopupPos(null);
+            selectedTextRef.current = "";
+          }
+        }}
+      >
+        <CornerUpLeftIcon className="size-3.5" />
+        Reply ↵
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- Stacked PR 1 of 3.  head: Poorvankbhatia:refactor/extract-selection-popup  →  base: omnigent-ai/omnigent:main -->

## Related issue

Part of #4733 (groundwork; no behaviour change). The final feature PR (#4740)
carries `Closes #4733`.

## Summary

- The floating "Reply ↵" selection action lived inline inside `ChatPage.tsx`.
  Move it verbatim into `web/src/pages/SelectionPopup.tsx` so it can grow (the
  next PR in this stack adds an "Ask sub-agent" action) and be unit-tested in
  isolation.
- No behaviour change: same props (`containerRef`, `onReply`), same
  container-scoped selection detection. `ChatPage` now imports the component and
  drops the now-unused `CornerUpLeftIcon` import.

## Test Plan

- `pnpm --filter web run type-check` and `pnpm --filter web run lint` pass.
- Select text in an assistant response → the "Reply ↵" button still appears and
  quotes the selection into the composer exactly as before; selecting in the
  composer shows nothing.

## Demo

N/A — no visual change (pure extraction; the button looks and behaves exactly as
it did inline).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behaviour is unchanged, so existing ChatPage coverage applies. The extracted
component gains its own unit tests in the "Ask sub-agent" PR that reworks it.
