### PR TITLE
fix(web): don't flash the picker's Up tooltip when it opens

### DIFF
--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -15,6 +15,8 @@ The desktop Workspace rail renders ``FilesPanel`` in its ``frameless``
    becomes a button that opens the workspace directory browser, and picking a
    directory re-roots the file tree there — through the real server, runner,
    and filesystem, not a stub.
+4. Opening that browser does not flash a tooltip over the listing: the
+   popover focuses its first icon button, and only a hover may label it.
 
 None of them send a message — the header is rail state, not a function of any
 turn — so they all stay fast, LLM-free checks.
@@ -317,3 +319,49 @@ def test_files_panel_browses_to_a_directory_outside_the_workspace(
     path_button.click()
     page.get_by_test_id("workspace-picker-workspace").click()
     expect(rail.get_by_text("sentinel.txt")).to_have_count(0, timeout=30_000)
+
+
+def test_opening_the_directory_browser_does_not_flash_a_header_tooltip(
+    page: Page,
+    seeded_session: tuple[str, str],
+    tmp_path: Path,
+    _drop_routes: None,
+) -> None:
+    """Opening the browser leaves its header tooltips hidden; hovering an icon
+    still shows one.
+
+    The picker's popover focuses its first tabbable child — the Up button — so
+    a tooltip that opens on any focus would cover the listing the click was
+    meant to reveal. Only a deliberate hover should surface the label, which is
+    a real-browser distinction (focus rings and hover delays), hence an e2e
+    test rather than a jsdom one.
+    """
+    base_url, session_id = seeded_session
+
+    outside = tmp_path / "outside-workspace"
+    outside.mkdir()
+
+    _bind_host_with_listing(page, session_id, entry=outside)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+
+    path_button = rail.get_by_test_id("browse-location-path")
+    expect(path_button).to_be_visible(timeout=30_000)
+    path_button.click()
+
+    picker = page.get_by_test_id("workspace-picker")
+    expect(picker).to_be_visible(timeout=15_000)
+
+    # The focus that used to trigger the tooltip has landed, so a tooltip that
+    # opens on focus would already be on screen. Matching on text (the button
+    # carries the same string as its aria-label) finds only the tooltip.
+    up = picker.get_by_test_id("workspace-picker-up")
+    expect(up).to_be_focused()
+    expect(page.get_by_text("Up one level", exact=True)).to_have_count(0)
+
+    # A deliberate hover is still answered.
+    up.hover()
+    expect(page.get_by_text("Up one level", exact=True)).to_be_visible(timeout=15_000)

--- a/web/src/shell/WorkspacePicker.test.tsx
+++ b/web/src/shell/WorkspacePicker.test.tsx
@@ -10,6 +10,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   basename,
   joinPath,
@@ -636,5 +637,43 @@ describe("WorkspacePicker back-to-workspace", () => {
     );
 
     expect(screen.getByTestId("workspace-picker-workspace")).toBeDisabled();
+  });
+});
+
+// The picker opens inside popovers and dialogs, which focus their first
+// tabbable child — the header's Up button. That focus must not reveal its
+// tooltip, or merely opening the picker throws a black label over the listing.
+describe("WorkspacePicker header tooltips", () => {
+  beforeEach(() => {
+    useHostFilesystemMock.mockReset();
+    useHostFilesystemMock.mockReturnValue(
+      result({
+        data: { entries: [dir("src", "/Users/corey/repo/src")], truncated: false },
+        isLoading: false,
+        isPlaceholderData: false,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("stays hidden when opening the picker focuses the Up button", async () => {
+    render(
+      <Popover>
+        <PopoverTrigger data-testid="open-picker">Working folder</PopoverTrigger>
+        <PopoverContent>
+          <WorkspacePicker hostId="host_1" initialPath="/Users/corey/repo" />
+        </PopoverContent>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByTestId("open-picker"));
+    const up = await screen.findByTestId("workspace-picker-up");
+    // Radix's own autofocus is what used to trip the tooltip; assert it landed
+    // so the test would notice if the focus behaviour changed instead.
+    expect(up).toHaveFocus();
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -220,7 +220,18 @@ function PickerIconButton({
     // under the app-root provider. Mirrors FilesPanel's hidden-files toggle.
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger asChild>
+        <TooltipTrigger
+          asChild
+          // Opening the picker focuses its first button, and Radix pops a
+          // tooltip on any focus — a label thrown over the listing nobody asked
+          // for. Only a keyboard focus ring reveals it (Radix skips its own
+          // handler once the event's default is prevented).
+          onFocus={(event) => {
+            if (!(event.target as HTMLElement).matches(":focus-visible")) {
+              event.preventDefault();
+            }
+          }}
+        >
           <span className="shrink-0">
             <button
               type="button"


### PR DESCRIPTION
## Related issue

Closes #4741

## Summary

Clicking the working-folder path opened the directory browser with an "Up one
level" tooltip already covering the top of the listing — the one thing the click
was meant to reveal. Nobody hovered anything.

Two Radix behaviours compose badly: the picker's `Popover`/`Dialog` auto-focuses
its first tabbable child (the header's **Up** button), and `TooltipTrigger` opens
on *any* focus — instantly, via `data-state="instant-open"`, so the 600 ms
`delayDuration` doesn't apply either.

The fix gates that focus-driven open on `:focus-visible` in `PickerIconButton`,
which every picker header icon goes through. A mouse-initiated open no longer
matches, so no tooltip; a keyboard `Tab` does, so keyboard users still get the
label they can't hover for. `preventDefault()` is Radix's own escape hatch here —
`composeEventHandlers` skips its handler once the event's default is prevented —
so focus semantics are untouched (unlike `onOpenAutoFocus`, which would break
Tab-into-content for a non-modal popover).

One change covers every mount point: the Files-rail popover and the
new-session / fork / resume / switch-host / project / scheduled-task dialogs.

## Test Plan

- `pnpm --filter @omnigent/web test src/shell/WorkspacePicker.test.tsx` — 54
  passing, including a new jsdom regression test that mounts the picker in a real
  `Popover`, asserts Radix's autofocus landed on Up, and asserts no `role="tooltip"`.
  Reverting the fix fails it.
- `tests/e2e_ui/files/test_files_panel_header.py::test_opening_the_directory_browser_does_not_flash_a_header_tooltip`
  — real Chromium: opens the browser from the Files rail, asserts Up is focused
  and "Up one level" has count 0, then hovers Up and asserts the label appears.
  A/B'd against a bundle built without the fix: the new test fails there.
- `tsc -b` and `pre-commit run --all-files` clean.
- Manually, against the deployed app: local dev UI proxied to a real workspace,
  clicked the working-folder path in the Files rail and the new-session
  "Working directory" chip — no tooltip on open, label on hover after ~0.6 s,
  and `Tab` + `Enter` still shows it on the focused Up button.

## Demo

![Workspace picker: the Up tooltip before and after the fix](https://raw.githubusercontent.com/dbczumar/omnigent/pr-demo-assets/pr-demos/up-level-tooltip.png)

**Left** — before: clicking the working-folder path drops the "Up one level" label
over the first row (`deploy`), with nothing hovered. **Middle** — after: the
listing opens clean. **Right** — after: a deliberate hover on ↑ still brings the
label back.

All three are the real UI against a live workspace, same session and same crop.
The "before" panel is this branch with only the `:focus-visible` guard removed, so
the panels differ by exactly this change. The image is hosted on a branch of the
author's fork rather than committed here, to keep binaries out of the tree.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The keyboard half of the behaviour can only be pinned in a real browser: jsdom
accepts `:focus-visible` in `matches()` but always returns `false`, so it cannot
tell a keyboard focus from a mouse one. Hence the split — jsdom guards the
mouse-open path (no tooltip), Chromium guards both that and the hover that must
still work. Keyboard `Tab` → tooltip was checked by hand rather than pinned,
since asserting Chromium's `:focus-visible` heuristic would be testing the
browser.

## Changelog

Opening the workspace folder browser no longer flashes an "Up one level" tooltip over the listing
