### PR TITLE
feat(auth): refreshable credential for unattended host daemons

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -159,6 +159,13 @@ POSTGRES_PASSWORD=change-me-please
 
 # ── Optional OIDC tuning ─────────────────────────────────
 # OMNIGENT_OIDC_SESSION_TTL_HOURS=8
+#
+# Absolute lifetime (days) of login-issued refresh grants — how long a
+# host/CLI that logged in with `omnigent login` can keep renewing its
+# access before a human must log in again. Default 30. Unattended hosts
+# renew automatically within this window; each host replica needs its
+# own login (refresh tokens rotate — shared copies revoke each other).
+# OMNIGENT_GRANT_MAX_LIFETIME_DAYS=30
 # OMNIGENT_OIDC_LOGOUT_REDIRECT_URI=https://omnigent.example.com/
 #
 # Skip the email_verified claim check on id_tokens. Some IdPs (e.g.

--- a/designs/DEVICE_AUTH.md
+++ b/designs/DEVICE_AUTH.md
@@ -17,9 +17,11 @@
 > enforcement in `omnigent/server/auth.py` (`delegated_path_allowed`,
 > `set_grant_revocation_check`). Wired in `omnigent/server/app.py`,
 > **opt-in and default-off** via `OMNIGENT_DEVICE_GRANT_ENABLED` (the
-> `/oauth/*` routes are unmounted unless it is truthy), and then only in
-> **accounts** mode (OIDC delegates login to the IdP via the cli-ticket
-> flow and never mounts these routes).
+> `/oauth/device/*` consent routes are unmounted unless it is truthy), and
+> then only in **accounts** mode (OIDC delegates login to the IdP via the
+> cli-ticket flow and never mounts the consent routes). The token/revoke
+> half (`/oauth/token`, `/oauth/revoke`) mounts **unconditionally** in both
+> accounts and OIDC modes: login-issued refresh grants (below) need it.
 > Slack: `integrations/slack/src/omnigent_slack/oauth.py`,
 > `tokens.py` (Fernet-encrypted `oauth_tokens`), `auth_manager.py`, plus
 > the bearer/refresh wiring in `omnigent.py` (`ClientAuth`,
@@ -182,15 +184,20 @@ approved it.
 
 ### Router `omnigent/server/routes/device_auth.py`
 
-Mounted in `app.py` only when **`OMNIGENT_DEVICE_GRANT_ENABLED` is truthy**
-(opt-in, **default-off** — the `/oauth/*` routes are absent otherwise), and
-then **only in `accounts` mode** (OIDC delegates login to the IdP via the
-cli-ticket flow and never mounts these routes; header mode has no
-server-mintable identity — see `create_device_auth_router`, which raises if
-constructed for any other source). The `device_grants` table is created
-unconditionally by the migration regardless of the flag; only the router
-mount is gated. This router **owns** `mint_delegated_token` and
-`DELEGATED_SCOPE`.
+The RFC 8628 consent surface (`/oauth/device/*`) is mounted in `app.py`
+only when **`OMNIGENT_DEVICE_GRANT_ENABLED` is truthy** (opt-in,
+**default-off**), and then **only in `accounts` mode** (the in-browser
+consent needs the accounts login page; header mode has no server-mintable
+identity — see `create_device_auth_router`, which raises if constructed for
+any other source). The token/revoke half is factored into
+`create_oauth_token_router` and mounts **unconditionally** in both accounts
+and OIDC modes — login-issued refresh grants need `/oauth/token` even where
+the device flow is off; a standalone mount refuses the `device_code` grant
+type with `unsupported_grant_type`. The `device_grants` table is created
+unconditionally by the migration regardless of the flag; only the consent
+mount is gated. This router also **owns** `mint_delegated_token` and
+`DELEGATED_SCOPE` (moved here from `oidc.py`, which retains only
+`mint_session_token` / `mint_session_cookie`).
 
 - `POST /oauth/device/authorize` — **public** (rate-limited). Generates a
   high-entropy `device_code` (`secrets.token_urlsafe`, stored **hashed**), a
@@ -355,3 +362,72 @@ stateless. This added invariant is the main thing for reviewers to scrutinize.
 - Applying the same delegated grant to other non-browser clients (the CLI could
   use it too, superseding the in-memory `_cli_tickets` store).
 - Per-scope consent granularity beyond the single "session APIs, no admin" scope.
+
+## Login-issued refresh grants
+
+The fix for unattended hosts dying at session-JWT expiry (a host
+authenticated via `omnigent login` previously had **no renewal path** —
+the stored `{token, user_id, expires_at}` record simply lapsed, default
+8 h, and the next tunnel reconnect got a misleading 403).
+
+- **Issuance** — both interactive login flows create a grant born
+  `redeemed` (`DeviceGrantStore.create_redeemed_grant`; the interactive
+  login *is* the consent step, so no device-code dance): the OIDC
+  cli-ticket fulfillment always, and accounts `POST /auth/login` when the
+  body carries `issue_refresh: true` (sent by the CLI, never the web
+  form — a browser must not receive refresh material). The raw refresh
+  token rides back once (`/auth/cli-poll` / the login response) as an
+  optional `refresh_token` key — old CLIs ignore it, new CLIs against old
+  servers see it absent. `client_id` is `"omnigent-cli"`.
+- **Authority** — a refreshed login-grant token carries `grant_id` (so
+  revocation still kills it) but **no `scope` claim**, so the delegated
+  path allowlist does not apply: it renews the session JWT and keeps that
+  same authority. Scoping it like a third-party device grant instead made
+  every non-allowlisted route (`/v1/usage`, `/v1/scheduled-tasks`,
+  `/v1/policy-registry`) 401 after the first refresh. `LOGIN_GRANT_CLIENT_ID`
+  is the marker and is **reserved** — `/oauth/device/authorize` refuses a
+  request naming it, so a device client cannot self-declare into this class.
+- **No rotation** — login grants return the SAME refresh token on every
+  renewal. Rotation + reuse detection is right for a browser-adjacent
+  third-party client, but for an unattended host it turns any ambiguous
+  network failure (lost response, crash between the server committing and
+  the client persisting) into a permanently revoked grant. Only the
+  short-lived access token is renewed; revocation and the absolute lifetime
+  cap still bound exposure. Device grants keep rotating.
+- **Renewal** — `omnigent.cli_auth.refresh_stored_token` POSTs
+  `grant_type=refresh_token`, persists the result, and returns the
+  fresh access token. The runner/host auth-token factory
+  calls it when the stored token lapses, and the host tunnel rebuilds
+  headers through that factory on every reconnect — so an unattended
+  host renews itself for the grant's lifetime. Refreshes on one machine
+  are serialized by an advisory file lock with a re-check after acquire,
+  so a losing racer picks up the winner's rotated pair instead of
+  replaying the stale token (which reuse detection would punish by
+  revoking the grant).
+- **One grant per host replica (recommended)** — since login grants do
+  not rotate, N replicas sharing one token file no longer revoke each
+  other. A per-replica login is still preferred so a single host can be
+  revoked without cutting off the rest.
+- **Lifetime** — the absolute grant lifetime stays 30 days by default;
+  `OMNIGENT_GRANT_MAX_LIFETIME_DAYS` lets an operator extend it
+  deliberately for long-lived unattended hosts. Invalid values fall back
+  to the default (never fail open to unbounded).
+- **Client-secret interaction** — `OMNIGENT_DEVICE_CLIENT_SECRET` gates
+  the endpoints that mint from an ephemeral code (device authorize + the
+  `device_code` exchange). Refresh and revoke are NOT gated: the presented
+  refresh/access token is itself the credential, and a CLI renewing its own
+  login has no way to carry that secret (gating it made every automatic
+  refresh 401 in a Slack-serving deployment).
+- **Housekeeping** — `/oauth/token` opportunistically purges expired and
+  aged-out grants. The device flow purges on `authorize`, which a
+  standalone token-router mount does not have, so login-grant rows would
+  otherwise accumulate one per login.
+
+### Known limitation
+
+General CLI commands (`omnigent usage`, session commands, direct
+remote-URL chat) still read the stored token without attempting a refresh —
+only the host/runner auth-token factory renews today. An expired login with
+valid refresh material therefore leaves those commands unauthenticated
+until something on the host path renews the shared file. Wiring the
+remaining CLI entrypoints is follow-up work.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11201,6 +11201,9 @@ def login(server_url: str) -> None:
                 token=token,
                 user_id=user_id,
                 expires_at=_time.time() + expires_in,
+                # Login-issued refresh grant (newer servers) — lets the
+                # host/CLI renew past session expiry unattended.
+                refresh_token=result.get("refresh_token"),
             )
             click.echo(f"Logged in as {user_id}")
             _remember_default_server(server)
@@ -11252,7 +11255,9 @@ def _accounts_login(server: str) -> None:
     try:
         resp = _httpx.post(
             f"{server}/auth/login",
-            json={"username": username, "password": password},
+            # issue_refresh: ask for a login-issued refresh grant so the
+            # host/CLI can renew unattended (older servers ignore it).
+            json={"username": username, "password": password, "issue_refresh": True},
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:
@@ -11280,6 +11285,7 @@ def _accounts_login(server: str) -> None:
         token=token,
         user_id=user_id,
         expires_at=_time.time() + expires_in,
+        refresh_token=body.get("refresh_token"),
     )
     click.echo(f"Logged in as {user_id}.")
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11255,9 +11255,7 @@ def _accounts_login(server: str) -> None:
     try:
         resp = _httpx.post(
             f"{server}/auth/login",
-            # issue_refresh: ask for a login-issued refresh grant so the
-            # host/CLI can renew unattended (older servers ignore it).
-            json={"username": username, "password": password, "issue_refresh": True},
+            json={"username": username, "password": password},
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import math
 import os
 import stat
 import tempfile
 import time
 import urllib.parse
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +36,14 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 _TOKEN_FILE_NAME = "auth_tokens.json"
+
+# Treat a stored token with less than this much life left as needing
+# renewal. Shared by the "is it still usable" read path and the refresh
+# path's already-renewed check, so a caller that decides to refresh is
+# never handed back the same near-expiry token it wanted to replace.
+# Comfortably longer than a WebSocket handshake, far shorter than the
+# server's 1-hour access-token TTL.
+REFRESH_MIN_REMAINING_SECONDS = 90.0
 
 
 def _token_file_path() -> Path:
@@ -144,6 +154,7 @@ def store_token(
     token: str,
     user_id: str,
     expires_at: float,
+    refresh_token: str | None = None,
 ) -> None:
     """Persist a session token for a server.
 
@@ -153,15 +164,19 @@ def store_token(
     :param user_id: The authenticated user's email, e.g.
         ``"alice@example.com"``.
     :param expires_at: Unix timestamp when the token expires.
+    :param refresh_token: Login-issued refresh grant token, when the
+        server handed one out. Lets :func:`refresh_stored_token` renew
+        the access token past expiry without a human re-running
+        ``omnigent login``.
     """
-    _store_entry(
-        server_url,
-        {
-            "token": token,
-            "user_id": user_id,
-            "expires_at": expires_at,
-        },
-    )
+    entry: dict[str, str | float] = {
+        "token": token,
+        "user_id": user_id,
+        "expires_at": expires_at,
+    }
+    if refresh_token is not None:
+        entry["refresh_token"] = refresh_token
+    _store_entry(server_url, entry)
 
 
 def store_databricks_auth(
@@ -217,11 +232,15 @@ def _load_entry(server_url: str) -> dict[str, str | float] | None:
     except (json.JSONDecodeError, OSError):
         return None
 
+    # A token file holding valid JSON of the wrong shape (``[]``, ``null``,
+    # a bare string) is corrupt, not fatal — read as "nothing stored".
+    if not isinstance(data, dict):
+        return None
     entry = data.get(_normalize_server_url(server_url))
     return entry if isinstance(entry, dict) else None
 
 
-def load_token(server_url: str) -> str | None:
+def load_token(server_url: str, *, min_remaining_seconds: float = 0.0) -> str | None:
     """Load a stored session token for a server.
 
     Returns ``None`` if no token is stored, the token has expired,
@@ -231,6 +250,11 @@ def load_token(server_url: str) -> str | None:
 
     :param server_url: The server URL, e.g.
         ``"http://localhost:6767"``.
+    :param min_remaining_seconds: Require at least this much remaining
+        lifetime. ``0`` (the default) accepts any not-yet-expired token —
+        the historical behaviour. A caller that can renew passes
+        :data:`REFRESH_MIN_REMAINING_SECONDS` so a token about to lapse
+        mid-handshake is refreshed instead of used.
     :returns: The session JWT string, or ``None``.
     """
     entry = _load_entry(server_url)
@@ -239,11 +263,235 @@ def load_token(server_url: str) -> str | None:
 
     expires_at = entry.get("expires_at", 0)
     if isinstance(expires_at, (int, float)) and expires_at < time.time():
-        _logger.debug("Stored token for %s has expired", _normalize_server_url(server_url))
+        _warn_expired_once(server_url, expires_at, has_refresh="refresh_token" in entry)
+        return None
+    # Near-expiry but still valid: decline quietly (no expiry warning — it
+    # has not expired) so the caller can choose to renew.
+    if (
+        min_remaining_seconds > 0
+        and isinstance(expires_at, (int, float))
+        and expires_at - time.time() < min_remaining_seconds
+    ):
         return None
 
     token = entry.get("token")
     return token if isinstance(token, str) else None
+
+
+# Servers already warned about an expired stored token, so a poll/retry
+# loop doesn't repeat the warning every few seconds.
+_warned_expired_servers: set[str] = set()
+
+
+def _warn_expired_once(server_url: str, expires_at: float, *, has_refresh: bool) -> None:
+    """Warn (once per process per server) that a stored token expired.
+
+    Expiry used to be a DEBUG line, which left the host dialing
+    unauthenticated into a misleading 403 with no breadcrumb — an
+    operator's first actionable signal must name the cause and the
+    remedy.
+    """
+    normalized = _normalize_server_url(server_url)
+    if normalized in _warned_expired_servers:
+        return
+    _warned_expired_servers.add(normalized)
+    expired_on = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(expires_at))
+    if has_refresh:
+        _logger.warning(
+            "Stored login session for %s expired on %s — attempting automatic refresh",
+            normalized,
+            expired_on,
+        )
+    else:
+        _logger.warning(
+            "Stored login session for %s expired on %s and holds no refresh "
+            "material. Run `omnigent login %s` to re-authenticate.",
+            normalized,
+            expired_on,
+            normalized,
+        )
+
+
+def stored_token_status(server_url: str) -> str:
+    """Classify the stored auth state for a server.
+
+    Lets callers distinguish "never logged in" from "logged in but the
+    session lapsed" — the difference between proceeding unauthenticated
+    (header-mode servers accept that) and surfacing an actionable
+    re-login message.
+
+    :param server_url: The server URL.
+    :returns: ``"ok"`` (valid token stored), ``"expired"`` (entry exists
+        but the token lapsed), or ``"absent"`` (no token entry at all;
+        includes Databricks pointer records, which hold no token).
+    """
+    entry = _load_entry(server_url)
+    if entry is None or not isinstance(entry.get("token"), str):
+        return "absent"
+    expires_at = entry.get("expires_at", 0)
+    if isinstance(expires_at, (int, float)) and expires_at < time.time():
+        return "expired"
+    return "ok"
+
+
+@contextlib.contextmanager
+def _token_file_lock() -> Iterator[None]:
+    """Exclusive advisory lock over token-file read-modify-write cycles.
+
+    Serializes concurrent refreshes on one machine (host + CLI sharing
+    ``auth_tokens.json``) so only one performs the network exchange and
+    the other picks up its result. Best-effort on platforms without
+    ``fcntl`` (Windows): the refresh still works, only the local
+    serialization is lost.
+
+    :raises OSError: If the lock file cannot be created or opened — the
+        caller degrades to "cannot refresh" (a state directory we cannot
+        write is one we could not persist the result to either).
+    """
+    lock_path = _token_file_path().with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    with open(lock_path, "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def refresh_stored_token(server_url: str, *, timeout: float = 10.0) -> str | None:
+    """Renew the stored access token from its login-issued refresh grant.
+
+    POSTs ``grant_type=refresh_token`` to the server's ``/oauth/token``,
+    persists the result, and returns the fresh access token. Safe to call
+    opportunistically: returns ``None`` when there is nothing to refresh
+    (no entry / no refresh material) or when the server refuses (grant
+    revoked, past its absolute lifetime, or an older server without the
+    endpoint).
+
+    Runs under the token-file lock and re-checks state after acquiring
+    it, so of two concurrent callers only one performs the network
+    refresh and the other returns the already-renewed token.
+
+    :param server_url: The server URL, e.g. ``"http://localhost:6767"``.
+    :param timeout: HTTP timeout in seconds.
+    :returns: A valid access token, or ``None``.
+    """
+    normalized = _normalize_server_url(server_url)
+    # Cheap pre-check BEFORE touching the lock file: with no refresh
+    # material there is nothing to do, and creating a lock file would
+    # raise on a read-only state directory — masking the caller's other
+    # credential sources (e.g. the Databricks SDK fallback).
+    pre = _load_entry(server_url)
+    if pre is None or not isinstance(pre.get("refresh_token"), str) or not pre["refresh_token"]:
+        return None
+    try:
+        with _token_file_lock():
+            return _refresh_locked(server_url, normalized, timeout)
+    except OSError as exc:
+        # Cannot lock/persist (read-only or full state dir) — a refresh we
+        # could not store is worse than none, so decline and let the caller
+        # fall through to its other credential sources.
+        _logger.debug("Token refresh for %s skipped, state dir unusable: %s", normalized, exc)
+        return None
+
+
+def _refresh_locked(server_url: str, normalized: str, timeout: float) -> str | None:
+    """Perform the refresh exchange; caller holds the token-file lock."""
+    entry = _load_entry(server_url)
+    if entry is None:
+        return None
+    # Another process may have refreshed while we waited on the lock. A
+    # freshly minted token is far from expiry, so this cleanly separates
+    # "someone already renewed" from "this is the same near-expiry token".
+    expires_at = entry.get("expires_at", 0)
+    token = entry.get("token")
+    if (
+        isinstance(token, str)
+        and isinstance(expires_at, (int, float))
+        and expires_at - time.time() > REFRESH_MIN_REMAINING_SECONDS
+    ):
+        return token
+    refresh_token = entry.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        return None
+
+    import httpx
+
+    try:
+        resp = httpx.post(
+            f"{normalized}/oauth/token",
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        _logger.warning("Token refresh against %s failed: %s", normalized, exc)
+        return None
+    if resp.status_code != 200:
+        _logger.warning(
+            "Token refresh against %s refused (HTTP %d) — run `omnigent login %s` "
+            "to re-authenticate.",
+            normalized,
+            resp.status_code,
+            normalized,
+        )
+        return None
+    try:
+        payload = resp.json()
+    except ValueError:
+        _logger.warning("Token refresh against %s returned a malformed response", normalized)
+        return None
+    if not isinstance(payload, dict):
+        _logger.warning("Token refresh against %s returned a malformed response", normalized)
+        return None
+    access_token = payload.get("access_token")
+    new_refresh = payload.get("refresh_token")
+    # Only overwrite the stored pair with genuinely usable material —
+    # a null/non-string field must never clobber a working credential.
+    if not isinstance(access_token, str) or not access_token:
+        _logger.warning("Token refresh against %s returned no access token", normalized)
+        return None
+    if not isinstance(new_refresh, str) or not new_refresh:
+        # A server that renews without returning refresh material keeps the
+        # one we already hold (login grants deliberately do not rotate).
+        new_refresh = refresh_token
+    expires_in = _coerce_expires_in(payload.get("expires_in"))
+
+    user_id = entry.get("user_id")
+    store_token(
+        server_url,
+        token=access_token,
+        user_id=user_id if isinstance(user_id, str) else "",
+        expires_at=time.time() + expires_in,
+        refresh_token=new_refresh,
+    )
+    # A fresh token means any earlier expiry warning is stale; allow
+    # a new one if this credential ever lapses again.
+    _warned_expired_servers.discard(normalized)
+    _logger.info("Refreshed login session for %s", normalized)
+    return access_token
+
+
+def _coerce_expires_in(raw: object) -> float:
+    """Return a sane access-token lifetime in seconds from *raw*.
+
+    Falls back to one hour for anything missing, non-numeric, or
+    non-finite — ``float("NaN")``/``float("Infinity")`` parse happily but
+    would yield an expiry that never compares as expired, pinning a dead
+    token forever.
+    """
+    default = 3600.0
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or value <= 0:
+        return default
+    return value
 
 
 def load_databricks_workspace_host(server_url: str) -> str | None:

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -144,6 +144,10 @@ def _store_entry(server_url: str, entry: dict[str, str | float]) -> None:
         except (json.JSONDecodeError, OSError):
             data = {}
 
+    # Corrupt token files (non-dict JSON) read as empty — never crash.
+    if not isinstance(data, dict):
+        data = {}
+
     data[_normalize_server_url(server_url)] = entry
 
     _write_tokens_file(path, data)
@@ -298,7 +302,8 @@ def _warn_expired_once(server_url: str, expires_at: float, *, has_refresh: bool)
     expired_on = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(expires_at))
     if has_refresh:
         _logger.warning(
-            "Stored login session for %s expired on %s — attempting automatic refresh",
+            "Stored login session for %s expired on %s; refresh will be "
+            "attempted on the next command if possible",
             normalized,
             expired_on,
         )

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1293,6 +1293,20 @@ class HostProcess:
                 + self._login_fix_hint()
             )
         if status == 403:
+            # An expired stored login is the common way to land here: the
+            # token loader yields nothing, the dial goes out
+            # unauthenticated, and the server's refusal looks like an
+            # authorization or version-skew problem. Name the real cause.
+            from omnigent.cli_auth import stored_token_status
+
+            if stored_token_status(self._server_url) == "expired":
+                return HostConnectError(
+                    "Connection refused (HTTP 403): your stored login "
+                    f"session for {self._server_url} has EXPIRED, so the "
+                    "tunnel was dialed without credentials. Run `omnigent "
+                    f"login {self._server_url}` to re-authenticate, then "
+                    "restart the host."
+                )
             return HostConnectError(
                 "Connection refused (HTTP 403): the server repeatedly rejected the host "
                 "tunnel. Either your "

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -341,6 +341,11 @@ _MAX_CONSECUTIVE_AUTH_ERRORS = 3
 # process listens on the port — the local server is gone, not unreachable.
 _LOOPBACK_REFUSED_FATAL_ATTEMPTS = 100
 
+# Consecutive post-connect 401/403 rejections (~5 min at the backoff cap)
+# before the retry loop escalates from "check your VPN" to a re-auth prompt.
+# Operator-facing only — the host keeps retrying and never exits.
+_AUTH_REJECT_ESCALATE_ATTEMPTS = 30
+
 # Consecutive accepted-then-silent connections (upgrade completed, then the
 # socket died without one inbound frame) before the reconnect loop treats the
 # endpoint as unhealthy: it stops using the prompt "recycle" cadence and
@@ -1271,18 +1276,37 @@ class HostProcess:
                 self._auth_retry_streak < _MAX_CONSECUTIVE_AUTH_ERRORS
             )
             if should_retry:
-                _logger.warning("%s Retrying — check your VPN/network.", cause)
-            if should_retry and self._auth_retry_streak == 1:
-                # The warning above lands only in the CLI log file; print once
-                # per outage so a foreground `omnigent host` isn't silent.
-                print(
-                    f"⚠ {cause} Retrying — this usually means the VPN or "
-                    "network dropped. It will reconnect automatically once "
-                    "connectivity returns.",
-                    file=sys.stderr,
-                    flush=True,
-                )
-            if should_retry:
+                # A sustained streak (vs. a brief VPN blip) means the credential
+                # is very likely permanently rejected: escalate the operator
+                # signal and name re-auth, but keep retrying so a real outage
+                # self-heals.
+                if (
+                    self._auth_retry_streak >= _AUTH_REJECT_ESCALATE_ATTEMPTS
+                    and self._auth_retry_streak % _AUTH_REJECT_ESCALATE_ATTEMPTS == 0
+                ):
+                    escalated = (
+                        f"{cause} The server has rejected it "
+                        f"{self._auth_retry_streak} times in a row — this is no "
+                        "longer a transient network blip. If it persists, the "
+                        "stored credential is likely no longer valid: run "
+                        f"`omnigent login {self._server_url}` and restart the "
+                        "host. Still retrying."
+                    )
+                    _logger.warning("%s", escalated)
+                    print(f"⚠ {escalated}", file=sys.stderr, flush=True)
+                else:
+                    _logger.warning("%s Retrying — check your VPN/network.", cause)
+                    if self._auth_retry_streak == 1:
+                        # The warning above lands only in the CLI log file;
+                        # print once per outage so a foreground `omnigent host`
+                        # isn't silent.
+                        print(
+                            f"⚠ {cause} Retrying — this usually means the VPN or "
+                            "network dropped. It will reconnect automatically "
+                            "once connectivity returns.",
+                            file=sys.stderr,
+                            flush=True,
+                        )
                 return None
         if status == 401:
             return HostConnectError(

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -613,11 +613,34 @@ def _make_auth_token_factory(
         """
         # Check stored OIDC token first.
         if resolved_server_url:
-            from omnigent.cli_auth import load_token
+            from omnigent.cli_auth import (
+                REFRESH_MIN_REMAINING_SECONDS,
+                load_token,
+                refresh_stored_token,
+            )
 
-            oidc_token = load_token(resolved_server_url)
+            # Require enough remaining life that the token cannot lapse
+            # mid-handshake; a token inside that window falls through to
+            # the renewal path below rather than being used and rejected.
+            oidc_token = load_token(
+                resolved_server_url,
+                min_remaining_seconds=REFRESH_MIN_REMAINING_SECONDS,
+            )
             if oidc_token:
                 return oidc_token
+            # Expired or near-lapse: renew from the login-issued refresh
+            # grant when one exists. This is what keeps an unattended host
+            # alive past session-JWT expiry — the tunnel rebuilds headers
+            # through this factory on every reconnect.
+            refreshed = refresh_stored_token(resolved_server_url)
+            if refreshed:
+                return refreshed
+            # Nothing to renew with: a near-expiry token that has NOT
+            # actually lapsed still authenticates, so prefer it over
+            # falling through to no credential at all.
+            still_valid = load_token(resolved_server_url)
+            if still_valid:
+                return still_valid
         return _sdk_token()
 
     # Probe once to check if a user credential is available.

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2827,7 +2827,7 @@ def create_app(
                     "the server and its trusted client(s) to restrict initiation "
                     "to authorized clients. See designs/DEVICE_AUTH.md.",
                 )
-        elif device_grant_store is not None:
+        elif isinstance(auth_provider, UnifiedAuthProvider) and device_grant_store is not None:
             # No device flow, but login-issued refresh grants still need
             # their token/revoke endpoints — in OIDC mode and in accounts
             # mode without the flag alike.

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2720,6 +2720,22 @@ def create_app(
         # auth routes and ``/v1/me`` share one roster. Consulted on each login
         # to promote listed identities — the only admin path for OIDC, and an
         # additive convenience for accounts.
+        # Login-issued refresh grants: both server-mintable providers
+        # (accounts, oidc) get a grant store so `omnigent login` can hand
+        # the CLI refresh material — without it, an unattended host dies
+        # permanently at session-JWT expiry (default 8 h). The store also
+        # backs the opt-in RFC 8628 device flow below.
+        device_grant_store = None
+        if (
+            isinstance(auth_provider, UnifiedAuthProvider)
+            and auth_provider._source in ("accounts", "oidc")
+            and permission_store is not None
+        ):
+            from omnigent.server.device_grant_store import DeviceGrantStore
+
+            device_grant_store = DeviceGrantStore(permission_store.storage_location)
+            auth_provider.set_grant_revocation_check(device_grant_store.is_revoked)
+
         if (
             isinstance(auth_provider, UnifiedAuthProvider)
             and auth_provider._source == "accounts"
@@ -2731,7 +2747,11 @@ def create_app(
 
             app.include_router(
                 create_accounts_auth_router(
-                    auth_provider, account_store, admin_list, permission_store
+                    auth_provider,
+                    account_store,
+                    admin_list,
+                    permission_store,
+                    device_grant_store=device_grant_store,
                 ),
                 prefix="/auth",
                 tags=["auth"],
@@ -2762,6 +2782,7 @@ def create_app(
                     admin_list,
                     oidc_account_store,
                     allowed_domains=frozenset(allowed_domains or ()) or None,
+                    device_grant_store=device_grant_store,
                 ),
                 prefix="/auth",
                 tags=["auth"],
@@ -2773,24 +2794,20 @@ def create_app(
             )
 
         # Device Authorization Grant (RFC 8628): opt-in, default-off via
-        # OMNIGENT_DEVICE_GRANT_ENABLED, and accounts-mode only. OIDC delegates
-        # login to the IdP (cli-ticket flow), so it neither needs nor mounts
-        # these routes. Wires the revocation lookup into the auth provider so
-        # revoking a grant immediately rejects its delegated access tokens.
-        # See designs/DEVICE_AUTH.md.
+        # OMNIGENT_DEVICE_GRANT_ENABLED, and accounts-mode only (the
+        # in-browser consent flow needs the accounts login page). Wires
+        # the full /oauth/* surface including the token endpoint. See
+        # designs/DEVICE_AUTH.md.
         from omnigent.server.auth import env_var_is_truthy
 
         if (
             env_var_is_truthy("OMNIGENT_DEVICE_GRANT_ENABLED", default=False)
             and isinstance(auth_provider, UnifiedAuthProvider)
             and auth_provider._source == "accounts"
-            and permission_store is not None
+            and device_grant_store is not None
         ):
-            from omnigent.server.device_grant_store import DeviceGrantStore
             from omnigent.server.routes.device_auth import create_device_auth_router
 
-            device_grant_store = DeviceGrantStore(permission_store.storage_location)
-            auth_provider.set_grant_revocation_check(device_grant_store.is_revoked)
             app.include_router(
                 create_device_auth_router(auth_provider, device_grant_store),
                 tags=["oauth"],
@@ -2811,6 +2828,17 @@ def create_app(
                     "the server and its trusted client(s) to restrict initiation "
                     "to authorized clients. See designs/DEVICE_AUTH.md.",
                 )
+        elif device_grant_store is not None:
+            # No device flow, but login-issued refresh grants still need
+            # their token/revoke endpoints — in OIDC mode and in accounts
+            # mode without the flag alike.
+            from omnigent.server.routes.device_auth import create_oauth_token_router
+
+            app.include_router(
+                create_oauth_token_router(auth_provider, device_grant_store),
+                tags=["oauth"],
+            )
+            _logger.info("login-grant: /oauth/token + /oauth/revoke enabled")
 
     # Mount the built web SPA at "/" if a build is present. The SPA is
     # built into ``omnigent/server/static/web-ui/`` by ``web/``'s Vite

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2751,7 +2751,6 @@ def create_app(
                     account_store,
                     admin_list,
                     permission_store,
-                    device_grant_store=device_grant_store,
                 ),
                 prefix="/auth",
                 tags=["auth"],

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -610,6 +610,8 @@ class UnifiedAuthProvider(AuthProvider):
         # never served from the plain user-id cache (which would skip both).
         grant_id = payload.get("grant_id")
         if grant_id is not None:
+            if not isinstance(grant_id, str):
+                return None
             if self._grant_revoked is not None and self._grant_revoked(grant_id):
                 return None
             # The allowlist restricts DELEGATED tokens — a third-party

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -53,6 +53,9 @@ _TRUTHY_STRINGS = ("1", "true", "yes")
 # any path not covered here, so it can never touch admin / user-management
 # endpoints (``/auth/users``, ``/auth/invite``, ``/auth/setup`` …) even if
 # its underlying identity is an admin. Delegated clients only need these.
+# First-party login-grant tokens carry no ``scope`` and are NOT restricted
+# here — they renew the session JWT and keep its authority (see
+# ``_check_cookie`` and ``routes/device_auth.LOGIN_GRANT_CLIENT_ID``).
 _DELEGATED_ALLOWED_PREFIXES = (
     "/health",
     "/v1/agents",
@@ -601,17 +604,21 @@ class UnifiedAuthProvider(AuthProvider):
         if not isinstance(user_id, str) or not user_id or user_id in _RESERVED_USERS:
             return None
 
-        # Delegated (device-grant) tokens carry a ``grant_id`` claim.
-        # They get two extra, request-scoped checks — a fail-closed path
-        # allowlist and a live revocation lookup — so they are never
-        # served from the plain user-id cache (which would skip both).
+        # Grant-derived tokens carry a ``grant_id`` claim. They get
+        # request-scoped checks — a live revocation lookup, plus (for
+        # restricted tokens) a fail-closed path allowlist — so they are
+        # never served from the plain user-id cache (which would skip both).
         grant_id = payload.get("grant_id")
         if grant_id is not None:
-            if not isinstance(grant_id, str):
-                return None
-            if not delegated_path_allowed(request.url.path):
-                return None
             if self._grant_revoked is not None and self._grant_revoked(grant_id):
+                return None
+            # The allowlist restricts DELEGATED tokens — a third-party
+            # client (e.g. Slack) acting on a user's behalf, marked by the
+            # ``scope`` claim. A first-party login grant carries no scope:
+            # its bearer is the user's own CLI/host, and the token renews
+            # the session JWT it replaced, so it keeps that same authority
+            # (still revocable via ``grant_id`` above).
+            if payload.get("scope") is not None and not delegated_path_allowed(request.url.path):
                 return None
             return user_id
 

--- a/omnigent/server/device_grant_store.py
+++ b/omnigent/server/device_grant_store.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import secrets
 from typing import cast
 
 from sqlalchemy import and_, delete, or_, update
@@ -129,6 +130,56 @@ class DeviceGrantStore:
                 created_at=created_at,
                 expires_at=expires_at,
                 approved_at=None,
+                last_polled_at=None,
+            )
+            session.add(row)
+            session.flush()
+            return _to_device_grant(row)
+
+    def create_redeemed_grant(
+        self,
+        grant_id: str,
+        *,
+        user_id: str,
+        client_id: str | None,
+        refresh_token_hash: str,
+        created_at: int,
+    ) -> DeviceGrant:
+        """Persist a grant born ``redeemed`` — no device-code consent step.
+
+        Backs login-issued refresh grants: the user just proved their
+        identity interactively (IdP browser flow or password prompt), so
+        the RFC 8628 pending → approved dance would re-ask for consent
+        already given. The row starts ``redeemed`` with its refresh-token
+        digest set, exactly as if it had completed the device flow.
+
+        The device_code/user_code columns are filled with discarded
+        random material: no client ever polls with them, and ``pending``
+        purge conditions never match a ``redeemed`` row.
+
+        :param grant_id: Opaque grant id (public — travels in JWTs).
+        :param user_id: The authenticated identity (the token ``sub``).
+        :param client_id: Public client name for audit, e.g.
+            ``"omnigent-cli"``.
+        :param refresh_token_hash: HMAC digest of the initial refresh
+            token. The store never sees the raw token.
+        :param created_at: Unix epoch seconds; also ``approved_at``, the
+            anchor for the grant's absolute lifetime.
+        :returns: The created :class:`DeviceGrant`.
+        """
+        with self._session() as session:
+            row = SqlDeviceGrant(
+                id=grant_id,
+                device_code_hash=secrets.token_urlsafe(32),
+                user_code=secrets.token_urlsafe(16),
+                status=encode_device_grant_status("redeemed"),
+                client_id=client_id,
+                user_id=user_id,
+                refresh_token_hash=refresh_token_hash,
+                prev_refresh_token_hash=None,
+                created_at=created_at,
+                expires_at=created_at,
+                approved_at=created_at,
                 last_polled_at=None,
             )
             session.add(row)

--- a/omnigent/server/device_grant_store.py
+++ b/omnigent/server/device_grant_store.py
@@ -167,7 +167,7 @@ class DeviceGrantStore:
             anchor for the grant's absolute lifetime.
         :returns: The created :class:`DeviceGrant`.
         """
-        with self._session() as session:
+        with self._session("insert_redeemed_device_grant") as session:
             row = SqlDeviceGrant(
                 id=grant_id,
                 device_code_hash=secrets.token_urlsafe(32),

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -37,7 +37,6 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 from omnigent.server.accounts_store import SqlAlchemyAccountStore
 from omnigent.server.admin_list import AdminList, promote_if_listed
 from omnigent.server.auth import _RESERVED_USERS, RESERVED_USER_LOCAL, UnifiedAuthProvider
-from omnigent.server.device_grant_store import DeviceGrantStore
 from omnigent.server.oidc import mint_session_cookie
 from omnigent.server.passwords import (
     InvalidPasswordError,
@@ -45,7 +44,6 @@ from omnigent.server.passwords import (
     needs_rehash,
     verify_password,
 )
-from omnigent.server.routes.device_auth import issue_login_grant
 from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
@@ -76,9 +74,6 @@ class LoginRequest(BaseModel):
 
     username: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=1, max_length=1024)
-    # Set by the CLI (never the web form): also issue a refresh grant so
-    # the unattended credential holder can renew past session-JWT expiry.
-    issue_refresh: bool = False
 
 
 class RegisterRequest(BaseModel):
@@ -211,7 +206,6 @@ def create_accounts_auth_router(
     account_store: SqlAlchemyAccountStore,
     admin_list: AdminList,
     permission_store: PermissionStore | None = None,
-    device_grant_store: DeviceGrantStore | None = None,
 ) -> APIRouter:
     """Build the ``/auth/*`` router for the accounts provider.
 
@@ -317,18 +311,10 @@ def create_accounts_auth_router(
             "expires_in": _session_max_age,
             "user": {"id": user.id, "is_admin": user.is_admin},
         }
-        # CLI opt-in only — a browser login must never receive refresh
-        # material. Best-effort: a grant-store failure must not break
-        # login itself.
-        if body.issue_refresh and device_grant_store is not None:
-            try:
-                body_payload["refresh_token"] = issue_login_grant(
-                    device_grant_store,
-                    user_id=username,
-                    cookie_secret=config.cookie_secret,
-                )
-            except Exception:
-                _logger.exception("auth/login: refresh grant issuance failed")
+        # Browser login must never receive refresh material — only CLI/device
+        # flows do (via /auth/cli-poll or device-grant callback). This is
+        # enforced server-side so an XSS or form-hijack cannot obtain
+        # long-lived unattended credentials.
         resp = JSONResponse(status_code=200, content=body_payload)
         _set_session_cookie(
             resp,

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -37,6 +37,7 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 from omnigent.server.accounts_store import SqlAlchemyAccountStore
 from omnigent.server.admin_list import AdminList, promote_if_listed
 from omnigent.server.auth import _RESERVED_USERS, RESERVED_USER_LOCAL, UnifiedAuthProvider
+from omnigent.server.device_grant_store import DeviceGrantStore
 from omnigent.server.oidc import mint_session_cookie
 from omnigent.server.passwords import (
     InvalidPasswordError,
@@ -44,6 +45,7 @@ from omnigent.server.passwords import (
     needs_rehash,
     verify_password,
 )
+from omnigent.server.routes.device_auth import issue_login_grant
 from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
@@ -74,6 +76,9 @@ class LoginRequest(BaseModel):
 
     username: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=1, max_length=1024)
+    # Set by the CLI (never the web form): also issue a refresh grant so
+    # the unattended credential holder can renew past session-JWT expiry.
+    issue_refresh: bool = False
 
 
 class RegisterRequest(BaseModel):
@@ -206,6 +211,7 @@ def create_accounts_auth_router(
     account_store: SqlAlchemyAccountStore,
     admin_list: AdminList,
     permission_store: PermissionStore | None = None,
+    device_grant_store: DeviceGrantStore | None = None,
 ) -> APIRouter:
     """Build the ``/auth/*`` router for the accounts provider.
 
@@ -306,11 +312,23 @@ def create_accounts_auth_router(
         # against a row that exists. Defensive-coding the dereference
         # would only mask a SqlAlchemy bug, which we want to surface.
         assert user is not None
-        body_payload = {
+        body_payload: dict[str, object] = {
             "token": session_jwt,
             "expires_in": _session_max_age,
             "user": {"id": user.id, "is_admin": user.is_admin},
         }
+        # CLI opt-in only — a browser login must never receive refresh
+        # material. Best-effort: a grant-store failure must not break
+        # login itself.
+        if body.issue_refresh and device_grant_store is not None:
+            try:
+                body_payload["refresh_token"] = issue_login_grant(
+                    device_grant_store,
+                    user_id=username,
+                    cookie_secret=config.cookie_secret,
+                )
+            except Exception:
+                _logger.exception("auth/login: refresh grant issuance failed")
         resp = JSONResponse(status_code=200, content=body_payload)
         _set_session_cookie(
             resp,

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -30,6 +30,7 @@ from omnigent.server.auth import (
     _RESERVED_USERS,
     UnifiedAuthProvider,
 )
+from omnigent.server.device_grant_store import DeviceGrantStore
 from omnigent.server.oidc import (
     _GITHUB_EMAILS_ENDPOINT,
     derive_code_challenge,
@@ -37,6 +38,7 @@ from omnigent.server.oidc import (
     mint_session_cookie,
 )
 from omnigent.server.oidc_access import OidcAdmissionPolicy, resolve_allowed_domains_path
+from omnigent.server.routes.device_auth import issue_login_grant
 from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
@@ -67,11 +69,16 @@ class _CliTicket:
         fulfills the ticket. ``None`` while pending.
     :param user_id: The authenticated user's email, set when
         fulfilled. ``None`` while pending.
+    :param refresh_token: Login-issued refresh grant material, set at
+        fulfillment when a grant store is wired. ``None`` while pending
+        or when grants are unavailable. Handed to the CLI exactly once
+        by the poll response.
     """
 
     created_at: float = field(default_factory=time.time)
     token: str | None = None
     user_id: str | None = None
+    refresh_token: str | None = None
 
 
 def create_auth_router(
@@ -80,6 +87,7 @@ def create_auth_router(
     admin_list: AdminList,
     account_store: SqlAlchemyAccountStore | None = None,
     allowed_domains: frozenset[str] | None = None,
+    device_grant_store: DeviceGrantStore | None = None,
 ) -> APIRouter:
     """Create an :class:`APIRouter` with OIDC login/callback/logout routes.
 
@@ -100,6 +108,12 @@ def create_auth_router(
         ``allowed_domains:`` key, union'd with
         ``OMNIGENT_OIDC_ALLOWED_DOMAINS`` and the runtime-editable file
         in the admission policy.
+    :param device_grant_store: When set, a CLI-ticket login also issues
+        a refresh grant (see
+        :func:`omnigent.server.routes.device_auth.issue_login_grant`)
+        so hosts and CLIs can renew without a human re-running
+        ``omnigent login``. ``None`` keeps the legacy
+        session-JWT-only response.
     :returns: A FastAPI router with ``/login``, ``/callback``,
         ``/logout`` (and ``/invite`` when invites are enabled).
     """
@@ -367,6 +381,19 @@ def create_auth_router(
             ticket = _cli_tickets[ticket_id]
             ticket.token = session_jwt
             ticket.user_id = email
+            # A CLI login is a long-lived unattended credential holder
+            # (hosts especially) — issue a refresh grant so it can renew
+            # instead of dying at session-JWT expiry. Best-effort: a
+            # grant-store failure must not break login itself.
+            if device_grant_store is not None:
+                try:
+                    ticket.refresh_token = issue_login_grant(
+                        device_grant_store,
+                        user_id=email,
+                        cookie_secret=config.cookie_secret,
+                    )
+                except Exception:
+                    _logger.exception("cli-login: refresh grant issuance failed")
             # Return a simple HTML page — the CLI is polling
             # /auth/cli-poll and will pick up the token.
             import html as _html
@@ -560,15 +587,18 @@ def create_auth_router(
         # Fulfilled — return the token and clean up.
         token = ticket.token
         user_id = ticket.user_id
+        refresh_token = ticket.refresh_token
         del _cli_tickets[ticket_id]
-        return JSONResponse(
-            status_code=200,
-            content={
-                "token": token,
-                "user_id": user_id,
-                "expires_in": config.session_ttl_hours * 3600,
-            },
-        )
+        content: dict[str, object] = {
+            "token": token,
+            "user_id": user_id,
+            "expires_in": config.session_ttl_hours * 3600,
+        }
+        # Only present when a grant store is wired — old CLIs ignore the
+        # extra key, new CLIs against old servers see it absent.
+        if refresh_token is not None:
+            content["refresh_token"] = refresh_token
+        return JSONResponse(status_code=200, content=content)
 
     # ── Admin: read-only user list ────────────────────────────────
 

--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -53,6 +53,7 @@ import logging
 import os
 import secrets
 import time
+from collections.abc import Callable
 
 import jwt
 from fastapi import APIRouter, HTTPException, Request
@@ -80,6 +81,26 @@ _CLIENT_SECRET_HEADER = "X-Omnigent-Client-Secret"
 # refuses admin / user-management paths for a token carrying this scope.
 DELEGATED_SCOPE = "sessions"
 
+# Reserved ``client_id`` for a first-party login grant (issued by
+# ``omnigent login``, not the RFC 8628 device flow). It is a
+# security-decision key here, so the device-authorize endpoint REFUSES a
+# request that names it — a third-party device client can never obtain a
+# grant tagged this way, and a refresh of such a grant is therefore safe
+# to treat as first-party. See :func:`issue_login_grant`,
+# ``_is_login_grant``, and the reservation guard in ``device_authorize``.
+LOGIN_GRANT_CLIENT_ID = "omnigent-cli"
+
+
+def _is_login_grant(client_id: str | None) -> bool:
+    """Return True for a first-party login grant (vs. a device grant).
+
+    Trustworthy because :data:`LOGIN_GRANT_CLIENT_ID` is reserved: the
+    device-authorize path rejects it, so only the server-side login flow
+    can create a grant carrying it.
+    """
+    return client_id == LOGIN_GRANT_CLIENT_ID
+
+
 # RFC 8628 timings.
 _DEVICE_CODE_TTL_SECONDS = 600  # 10 min — bounds the unapproved window.
 _POLL_INTERVAL_SECONDS = 5  # minimum client poll interval.
@@ -91,6 +112,41 @@ _ACCESS_TOKEN_TTL_SECONDS = 3600
 # re-consent through the flow. Bounds the blast radius of a leaked/phished
 # grant to this window even if revocation is never called.
 _GRANT_MAX_LIFETIME_SECONDS = 30 * 24 * 3600  # 30 days
+# Operator override for the grant lifetime, in whole days. Deployments
+# running unattended hosts can extend the re-consent window deliberately;
+# the 30-day default stays the safe posture.
+_GRANT_MAX_LIFETIME_ENV = "OMNIGENT_GRANT_MAX_LIFETIME_DAYS"
+
+
+def _grant_max_lifetime_seconds() -> int:
+    """Return the grant's absolute lifetime, honoring the env override.
+
+    Invalid or non-positive values fall back to the default — auth
+    lifetimes must never fail open to "unbounded" on a typo.
+    """
+    raw = os.environ.get(_GRANT_MAX_LIFETIME_ENV, "").strip()
+    if raw:
+        try:
+            days = int(raw)
+        except ValueError:
+            _logger.warning(
+                "%s=%r is not an integer — using the %d-day default",
+                _GRANT_MAX_LIFETIME_ENV,
+                raw,
+                _GRANT_MAX_LIFETIME_SECONDS // 86400,
+            )
+        else:
+            if days > 0:
+                return days * 86400
+            _logger.warning(
+                "%s=%r must be positive — using the %d-day default",
+                _GRANT_MAX_LIFETIME_ENV,
+                raw,
+                _GRANT_MAX_LIFETIME_SECONDS // 86400,
+            )
+    return _GRANT_MAX_LIFETIME_SECONDS
+
+
 # user_code alphabet excludes easily-confused chars (0/O, 1/I/L).
 _USER_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
 
@@ -106,10 +162,16 @@ def _client_id(body: dict[str, object]) -> str | None:
 
     A public string naming the requesting application (e.g. Slack passes
     ``"slack"``), the same for every grant that application initiates.
-    Display + audit only — never an authorization key.
+    Display + audit only for device grants — but see
+    :data:`LOGIN_GRANT_CLIENT_ID`, which is reserved and refused here.
+
+    Non-string values (``{"client_id": 123}``) read as absent rather than
+    raising, so a malformed body is a clean 400 and not a 500.
     """
-    value = body.get("client_id")
-    return value.strip() or None if isinstance(value, str) else None
+    raw = body.get("client_id")
+    if not isinstance(raw, str):
+        return None
+    return raw.strip() or None
 
 
 def _mint_refresh_token() -> str:
@@ -126,34 +188,38 @@ def mint_delegated_token(
     grant_id: str,
     client_id: str,
     jti: str,
-    scope: str = DELEGATED_SCOPE,
+    scope: str | None = DELEGATED_SCOPE,
 ) -> str:
-    """Mint a delegated access token for a device-authorization grant.
+    """Mint a grant-derived access token.
 
     Same HS256 shape as
     :func:`omnigent.server.oidc.mint_session_token` (so
     :meth:`UnifiedAuthProvider._check_cookie` validates it unchanged),
-    plus four delegated-only claims:
+    plus grant claims:
 
-    - ``scope`` — restricts the token to the session APIs; the auth
-      layer rejects admin endpoints when this claim is present.
-    - ``grant_id`` — the device grant this token was issued from,
-      checked against the revocation denylist so revoking the grant
-      immediately kills the token.
+    - ``scope`` — present ⇒ the auth layer restricts the token to the
+      session APIs and refuses admin endpoints. ``None`` omits the claim,
+      giving the token the SAME authority as the session JWT it renews —
+      used ONLY for first-party login grants, whose bearer is the
+      authenticated user's own CLI/host, not a third-party client.
+    - ``grant_id`` — the grant this token was issued from, checked against
+      the revocation denylist so revoking the grant immediately kills the
+      token. Carried regardless of scope.
     - ``jti`` — unique token id, for audit/log correlation.
     - ``act`` — provenance (RFC 8693 style), ``{"client_id": "<app>"}``,
-      naming the application that obtained the grant so every delegated
-      action is attributable to it.
+      naming the application that obtained the grant so every action is
+      attributable to it.
 
     :param user_id: The Omnigent identity the token acts as (``sub``).
     :param cookie_secret: HMAC key for HS256 signing.
     :param ttl_seconds: Token lifetime in seconds (kept short — ≤ 1 h).
     :param provider: Identity provider name (informational claim).
-    :param grant_id: The device grant id.
-    :param client_id: The RFC 8628 client id (the requesting application,
+    :param grant_id: The grant id.
+    :param client_id: The client id (the requesting application,
         e.g. ``"slack"``); recorded in the ``act`` claim for audit.
     :param jti: Unique token id.
-    :param scope: Granted scope; defaults to :data:`DELEGATED_SCOPE`.
+    :param scope: Granted scope, or ``None`` for a full-authority
+        (login-grant) token. Defaults to :data:`DELEGATED_SCOPE`.
     :returns: An HS256-signed JWT string.
     """
     now = int(time.time())
@@ -162,11 +228,12 @@ def mint_delegated_token(
         "iat": now,
         "exp": now + ttl_seconds,
         "provider": provider,
-        "scope": scope,
         "grant_id": grant_id,
         "jti": jti,
         "act": {"client_id": client_id},
     }
+    if scope is not None:
+        payload["scope"] = scope
     return jwt.encode(payload, cookie_secret, algorithm="HS256")
 
 
@@ -257,6 +324,300 @@ class _SlidingWindowRateLimiter:
         return True
 
 
+def _resolve_signing_config(auth_provider: UnifiedAuthProvider) -> tuple[bytes, str]:
+    """Return ``(cookie_secret, provider_name)`` for token minting.
+
+    Works for both server-mintable providers: ``accounts`` and ``oidc``.
+    Header mode has no server-held signing identity, so grant routes
+    cannot be built for it.
+    """
+    if auth_provider._source == "accounts":
+        config = auth_provider._accounts_config
+        assert config is not None, "accounts mode must have an accounts config"
+        return config.cookie_secret, auth_provider._source
+    if auth_provider._source == "oidc":
+        oidc_config = auth_provider._oidc_config
+        assert oidc_config is not None, "oidc mode must have an oidc config"
+        return oidc_config.cookie_secret, auth_provider._source
+    raise RuntimeError(
+        f"grant routes require accounts or oidc auth (got {auth_provider._source!r})"
+    )
+
+
+def _make_client_secret_gate() -> Callable[[Request], bool]:
+    """Build the optional shared-secret check for client-facing endpoints.
+
+    Reads the env once at mount (toggling requires a restart, consistent
+    with the other auth env vars). Open when no secret is configured.
+    """
+    client_secret = os.environ.get(_CLIENT_SECRET_ENV, "").strip() or None
+    if client_secret is not None:
+        _logger.info("device-auth: client-secret enforcement enabled")
+
+    def _client_secret_ok(request: Request) -> bool:
+        if client_secret is None:
+            return True
+        # Compare on bytes: compare_digest raises TypeError on non-ASCII str
+        # operands, and ASGI decodes header bytes as latin-1, so a crafted
+        # non-ASCII header would otherwise 500 instead of cleanly failing.
+        presented = request.headers.get(_CLIENT_SECRET_HEADER, "")
+        return hmac.compare_digest(presented.encode("utf-8"), client_secret.encode("utf-8"))
+
+    return _client_secret_ok
+
+
+def issue_login_grant(
+    device_grant_store: DeviceGrantStore,
+    *,
+    user_id: str,
+    cookie_secret: bytes,
+) -> str:
+    """Create a redeemed refresh grant for an interactive login.
+
+    Called by the login flows (OIDC cli-ticket fulfillment, accounts
+    ``/auth/login``) so the CLI walks away with refresh material and can
+    renew its access without a human re-running ``omnigent login``. The
+    interactive login *is* the consent step, so the grant is born
+    ``redeemed`` and tagged with the reserved
+    :data:`LOGIN_GRANT_CLIENT_ID` — which the device-authorize path
+    refuses, so this authority class can only originate here.
+
+    :param device_grant_store: Grant persistence.
+    :param user_id: The just-authenticated identity.
+    :param cookie_secret: HMAC key for hashing the refresh token.
+    :returns: The raw refresh token to hand to the client (stored hashed).
+    """
+    refresh_token = _mint_refresh_token()
+    device_grant_store.create_redeemed_grant(
+        secrets.token_urlsafe(24),
+        user_id=user_id,
+        client_id=LOGIN_GRANT_CLIENT_ID,
+        refresh_token_hash=hash_secret(refresh_token, cookie_secret),
+        created_at=int(time.time()),
+    )
+    return refresh_token
+
+
+def create_oauth_token_router(
+    auth_provider: UnifiedAuthProvider,
+    device_grant_store: DeviceGrantStore,
+    *,
+    handle_device_code: Callable[[str], Response] | None = None,
+) -> APIRouter:
+    """Build the ``/oauth/token`` + ``/oauth/revoke`` router.
+
+    The refresh/revoke half of the grant machinery, mountable on its own:
+    login-issued refresh grants (see :func:`issue_login_grant`) need these
+    endpoints in **both** accounts and OIDC modes, independent of the
+    RFC 8628 device-code consent flow (which stays accounts-only behind
+    ``OMNIGENT_DEVICE_GRANT_ENABLED``).
+
+    :param auth_provider: The active provider — ``accounts`` or ``oidc``.
+    :param device_grant_store: Persistence for grants.
+    :param handle_device_code: Optional device-code grant handler.
+        :func:`create_device_auth_router` passes its polling closure so
+        the full flow keeps one token endpoint; standalone mounts leave
+        it ``None`` and ``device_code`` exchanges get
+        ``unsupported_grant_type``.
+    :returns: APIRouter to mount at the app root.
+    """
+    cookie_secret, provider_name = _resolve_signing_config(auth_provider)
+    _client_secret_ok = _make_client_secret_gate()
+    router = APIRouter()
+    # Throttle for the opportunistic grant purge (bounds the table without a
+    # separate scheduler). Mutable one-field dict so the closures can update
+    # it. ``0.0`` forces a purge on the first refresh after boot.
+    _last_purge = {"at": 0.0}
+
+    def _maybe_purge() -> None:
+        """Purge expired/aged grants at most once per interval.
+
+        The device flow purges on ``/oauth/device/authorize``, but the
+        standalone token router (OIDC, or accounts without the device flow)
+        has no authorize route — so login grants would otherwise accumulate
+        one row per login. Piggyback the purge on refresh instead.
+        """
+        now_wall = time.time()
+        if now_wall - _last_purge["at"] < _PURGE_MIN_INTERVAL_SECONDS:
+            return
+        _last_purge["at"] = now_wall
+        try:
+            device_grant_store.purge_expired(
+                int(now_wall), max_lifetime_seconds=_grant_max_lifetime_seconds()
+            )
+        except Exception:  # noqa: BLE001 — housekeeping must never fail a refresh
+            _logger.debug("oauth/token: opportunistic grant purge failed", exc_info=True)
+
+    def _issue_access_token(grant_id: str, user_id: str, client_id: str) -> str:
+        # A first-party login grant renews with the SAME authority as the
+        # session JWT it replaces (scope=None); a third-party device grant
+        # stays restricted to the delegated allowlist.
+        scope = None if _is_login_grant(client_id) else DELEGATED_SCOPE
+        return mint_delegated_token(
+            user_id,
+            cookie_secret,
+            _ACCESS_TOKEN_TTL_SECONDS,
+            provider_name,
+            grant_id=grant_id,
+            client_id=client_id or "",
+            jti=secrets.token_urlsafe(16),
+            scope=scope,
+        )
+
+    @router.post("/oauth/token", dependencies=[])
+    async def token(request: Request) -> Response:
+        """Exchange a device_code or refresh_token for an access token.
+
+        RFC 8628 / 6749 error shapes: ``authorization_pending``,
+        ``slow_down``, ``expired_token``, ``access_denied``,
+        ``invalid_grant``, ``unsupported_grant_type``.
+        """
+        form = await request.form()
+        grant_type = str(form.get("grant_type") or "")
+
+        if grant_type == "urn:ietf:params:oauth:grant-type:device_code":
+            # The device-code exchange mints from the ephemeral device_code
+            # alone, so it stays behind the client-secret gate. Refresh
+            # presents the refresh token itself as the credential, so it is
+            # not additionally gated (a CLI/host renewing its own login has
+            # no way to carry the device client secret).
+            if not _client_secret_ok(request):
+                return _oauth_error("invalid_client", status_code=401)
+            if handle_device_code is None:
+                return _oauth_error("unsupported_grant_type")
+            return handle_device_code(str(form.get("device_code") or ""))
+        if grant_type == "refresh_token":
+            return _handle_refresh_grant(str(form.get("refresh_token") or ""))
+        return _oauth_error("unsupported_grant_type")
+
+    def _handle_refresh_grant(refresh_token: str) -> Response:
+        if not refresh_token:
+            return _oauth_error("invalid_request")
+        # Opportunistic housekeeping so login-grant rows (one per login)
+        # don't accumulate where no device-authorize purge runs.
+        _maybe_purge()
+        presented_hash = hash_secret(refresh_token, cookie_secret)
+        # A refresh token doesn't name its grant, so locate it by digest.
+        # Only a live (redeemed, non-revoked) grant holds a matching hash.
+        grant = device_grant_store.get_by_refresh_hash(presented_hash)
+        if grant is None:
+            # Not the current token. If it matches a grant's *previous*
+            # token, a stale token was replayed — reuse/theft. Revoke the
+            # whole grant so the attacker's freshly-rotated token dies too.
+            # (Login grants don't rotate, so they never populate the prev
+            # hash and can't reach this revoke.)
+            stale = device_grant_store.get_by_prev_refresh_hash(presented_hash)
+            if stale is not None:
+                device_grant_store.revoke(stale.id)
+                _logger.warning(
+                    "oauth/token: refresh reuse detected on grant %s — revoked", stale.id
+                )
+            return _oauth_error("invalid_grant")
+        # Refuse to refresh a grant past its absolute lifetime — the user
+        # must re-consent. Checked before rotating so an aged grant simply
+        # stops working (it is NOT reuse, so it must not revoke/oscillate).
+        if grant.approved_at is not None and (
+            int(time.time()) - grant.approved_at >= _grant_max_lifetime_seconds()
+        ):
+            return _oauth_error("expired_token")
+        if grant.user_id is None:
+            return _oauth_error("invalid_grant")
+
+        if _is_login_grant(grant.client_id):
+            # First-party login grants do NOT rotate. The bearer is an
+            # unattended host/CLI, so a lost refresh response (network blip,
+            # crash between the server committing and the client persisting)
+            # must not brick the grant via reuse detection. The same refresh
+            # token stays valid for the grant lifetime; only the short-lived
+            # access token is renewed. Revocation + the absolute lifetime cap
+            # bound the exposure.
+            access_token = _issue_access_token(grant.id, grant.user_id, grant.client_id or "")
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "token_type": "Bearer",
+                    "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
+                },
+            )
+
+        new_refresh = _mint_refresh_token()
+        rotated = device_grant_store.rotate_refresh_token(
+            grant.id,
+            expected_hash=presented_hash,
+            new_hash=hash_secret(new_refresh, cookie_secret),
+            now_epoch_seconds=int(time.time()),
+            max_lifetime_seconds=_grant_max_lifetime_seconds(),
+        )
+        if rotated is None:
+            # Lost a concurrent rotation race, or the grant aged out between
+            # the check above and here — reject without revoking (this is not
+            # a reuse signal, so the grant must not be killed/oscillate).
+            return _oauth_error("invalid_grant")
+        if rotated.user_id is None:
+            return _oauth_error("invalid_grant")
+        access_token = _issue_access_token(
+            rotated.id,
+            rotated.user_id,
+            rotated.client_id or "",
+        )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "access_token": access_token,
+                "refresh_token": new_refresh,
+                "token_type": "Bearer",
+                "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
+            },
+        )
+
+    # ── Revocation ────────────────────────────────────────────────
+
+    @router.post("/oauth/revoke", dependencies=[])
+    async def revoke(request: Request) -> Response:
+        """Revoke a grant by refresh token or by the caller's access token.
+
+        Backs ``/omnigent logout``. Accepts a ``refresh_token`` form
+        field; falls back to the ``grant_id`` on the caller's own
+        delegated access token so a client with only its access token
+        can still log out. Not behind the device client-secret gate: the
+        presented refresh/access token IS the credential, and a CLI
+        logging out its own login grant cannot carry that secret.
+        """
+        form = await request.form()
+        refresh_token = str(form.get("refresh_token") or "")
+        grant = None
+        if refresh_token:
+            grant = device_grant_store.get_by_refresh_hash(
+                hash_secret(refresh_token, cookie_secret)
+            )
+        if grant is None:
+            grant_id = _grant_id_from_bearer(request)
+            if grant_id is not None:
+                grant = device_grant_store.get_by_id(grant_id)
+        if grant is None:
+            # Idempotent: nothing to revoke is still "revoked" from the
+            # caller's perspective. Don't leak which tokens exist.
+            return JSONResponse(status_code=200, content={"revoked": True})
+        device_grant_store.revoke(grant.id)
+        _logger.info("oauth/revoke: revoked grant %s", grant.id)
+        return JSONResponse(status_code=200, content={"revoked": True})
+
+    def _grant_id_from_bearer(request: Request) -> str | None:
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return None
+        try:
+            payload = jwt.decode(auth_header[7:], cookie_secret, algorithms=["HS256"])
+        except jwt.InvalidTokenError:
+            return None
+        grant_id = payload.get("grant_id")
+        return grant_id if isinstance(grant_id, str) else None
+
+    return router
+
+
 def create_device_auth_router(
     auth_provider: UnifiedAuthProvider,
     device_grant_store: DeviceGrantStore,
@@ -278,28 +639,7 @@ def create_device_auth_router(
     base_url = cookie_config.base_url
     provider_name = auth_provider._source
 
-    # Read the optional client secret once at mount. When set, the
-    # client-facing endpoints require a matching header; when unset they
-    # stay public. Captured here (not per-request) so toggling it needs a
-    # restart — consistent with the other auth env vars.
-    client_secret = os.environ.get(_CLIENT_SECRET_ENV, "").strip() or None
-    if client_secret is not None:
-        _logger.info("device-auth: client-secret enforcement enabled")
-
-    def _client_secret_ok(request: Request) -> bool:
-        """Return True if the request may use the client-facing endpoints.
-
-        Open when no secret is configured; otherwise requires the presented
-        header to match, compared in constant time to avoid leaking the
-        secret through timing.
-        """
-        if client_secret is None:
-            return True
-        # Compare on bytes: compare_digest raises TypeError on non-ASCII str
-        # operands, and ASGI decodes header bytes as latin-1, so a crafted
-        # non-ASCII header would otherwise 500 instead of cleanly failing.
-        presented = request.headers.get(_CLIENT_SECRET_HEADER, "")
-        return hmac.compare_digest(presented.encode("utf-8"), client_secret.encode("utf-8"))
+    _client_secret_ok = _make_client_secret_gate()
 
     router = APIRouter()
     _rate_limiter = _SlidingWindowRateLimiter(
@@ -347,7 +687,7 @@ def create_device_auth_router(
             _last_purge["at"] = now_wall
             try:
                 device_grant_store.purge_expired(
-                    int(now_wall), max_lifetime_seconds=_GRANT_MAX_LIFETIME_SECONDS
+                    int(now_wall), max_lifetime_seconds=_grant_max_lifetime_seconds()
                 )
             except Exception:  # housekeeping must never fail a request
                 _logger.exception("device grant purge failed")
@@ -359,6 +699,15 @@ def create_device_auth_router(
         if not isinstance(body, dict):
             body = {}
         client_id = _client_id(body)
+        # LOGIN_GRANT_CLIENT_ID marks a first-party login grant, whose
+        # refreshed tokens carry full session authority. It is reserved:
+        # a device client must never be able to self-declare into that
+        # class by naming it here.
+        if _is_login_grant(client_id):
+            _logger.warning(
+                "device/authorize: refused reserved client_id %r", LOGIN_GRANT_CLIENT_ID
+            )
+            return _oauth_error("invalid_request")
 
         device_code = secrets.token_urlsafe(32)
         grant_id = secrets.token_urlsafe(16)
@@ -543,26 +892,10 @@ def create_device_auth_router(
             device_grant_store.deny(grant.id)
         return HTMLResponse(_consent_html(denied=True), status_code=200)
 
-    # ── Token endpoint (client polling + refresh) ─────────────────
-
-    @router.post("/oauth/token", dependencies=[])
-    async def token(request: Request) -> Response:
-        """Exchange a device_code or refresh_token for an access token.
-
-        RFC 8628 / 6749 error shapes: ``authorization_pending``,
-        ``slow_down``, ``expired_token``, ``access_denied``,
-        ``invalid_grant``, ``unsupported_grant_type``.
-        """
-        if not _client_secret_ok(request):
-            return _oauth_error("invalid_client", status_code=401)
-        form = await request.form()
-        grant_type = str(form.get("grant_type") or "")
-
-        if grant_type == "urn:ietf:params:oauth:grant-type:device_code":
-            return _handle_device_code_grant(str(form.get("device_code") or ""))
-        if grant_type == "refresh_token":
-            return _handle_refresh_grant(str(form.get("refresh_token") or ""))
-        return _oauth_error("unsupported_grant_type")
+    # ── Token + revocation endpoints ──────────────────────────────
+    # Shared with the standalone login-grant mount: the device flow's
+    # only addition is the device_code grant handler, injected here so
+    # /oauth/token stays a single registration either way.
 
     def _handle_device_code_grant(device_code: str) -> Response:
         if not device_code:
@@ -613,103 +946,13 @@ def create_device_auth_router(
             },
         )
 
-    def _handle_refresh_grant(refresh_token: str) -> Response:
-        if not refresh_token:
-            return _oauth_error("invalid_request")
-        presented_hash = hash_secret(refresh_token, cookie_secret)
-        # A refresh token doesn't name its grant, so locate it by digest.
-        # Only a live (redeemed, non-revoked) grant holds a matching hash.
-        grant = device_grant_store.get_by_refresh_hash(presented_hash)
-        if grant is None:
-            # Not the current token. If it matches a grant's *previous*
-            # token, a stale token was replayed — reuse/theft. Revoke the
-            # whole grant so the attacker's freshly-rotated token dies too.
-            stale = device_grant_store.get_by_prev_refresh_hash(presented_hash)
-            if stale is not None:
-                device_grant_store.revoke(stale.id)
-                _logger.warning(
-                    "oauth/token: refresh reuse detected on grant %s — revoked", stale.id
-                )
-            return _oauth_error("invalid_grant")
-        # Refuse to refresh a grant past its absolute lifetime — the user
-        # must re-consent. Checked before rotating so an aged grant simply
-        # stops working (it is NOT reuse, so it must not revoke/oscillate).
-        if grant.approved_at is not None and (
-            int(time.time()) - grant.approved_at >= _GRANT_MAX_LIFETIME_SECONDS
-        ):
-            return _oauth_error("expired_token")
-        new_refresh = _mint_refresh_token()
-        rotated = device_grant_store.rotate_refresh_token(
-            grant.id,
-            expected_hash=presented_hash,
-            new_hash=hash_secret(new_refresh, cookie_secret),
-            now_epoch_seconds=int(time.time()),
-            max_lifetime_seconds=_GRANT_MAX_LIFETIME_SECONDS,
+    router.include_router(
+        create_oauth_token_router(
+            auth_provider,
+            device_grant_store,
+            handle_device_code=_handle_device_code_grant,
         )
-        if rotated is None:
-            # Lost a concurrent rotation race, or the grant aged out between
-            # the check above and here — reject without revoking (this is not
-            # a reuse signal, so the grant must not be killed/oscillate).
-            return _oauth_error("invalid_grant")
-        if rotated.user_id is None:
-            return _oauth_error("invalid_grant")
-        access_token = _issue_access_token(
-            rotated.id,
-            rotated.user_id,
-            rotated.client_id or "",
-        )
-        return JSONResponse(
-            status_code=200,
-            content={
-                "access_token": access_token,
-                "refresh_token": new_refresh,
-                "token_type": "Bearer",
-                "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
-            },
-        )
-
-    # ── Revocation ────────────────────────────────────────────────
-
-    @router.post("/oauth/revoke", dependencies=[])
-    async def revoke(request: Request) -> Response:
-        """Revoke a grant by refresh token or by the caller's access token.
-
-        Backs ``/omnigent logout``. Accepts a ``refresh_token`` form
-        field; falls back to the ``grant_id`` on the caller's own
-        delegated access token so a client with only its access token
-        can still log out.
-        """
-        if not _client_secret_ok(request):
-            return _oauth_error("invalid_client", status_code=401)
-        form = await request.form()
-        refresh_token = str(form.get("refresh_token") or "")
-        grant = None
-        if refresh_token:
-            grant = device_grant_store.get_by_refresh_hash(
-                hash_secret(refresh_token, cookie_secret)
-            )
-        if grant is None:
-            grant_id = _grant_id_from_bearer(request)
-            if grant_id is not None:
-                grant = device_grant_store.get_by_id(grant_id)
-        if grant is None:
-            # Idempotent: nothing to revoke is still "revoked" from the
-            # caller's perspective. Don't leak which tokens exist.
-            return JSONResponse(status_code=200, content={"revoked": True})
-        device_grant_store.revoke(grant.id)
-        _logger.info("oauth/revoke: revoked grant %s", grant.id)
-        return JSONResponse(status_code=200, content={"revoked": True})
-
-    def _grant_id_from_bearer(request: Request) -> str | None:
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
-            return None
-        try:
-            payload = jwt.decode(auth_header[7:], cookie_secret, algorithms=["HS256"])
-        except jwt.InvalidTokenError:
-            return None
-        grant_id = payload.get("grant_id")
-        return grant_id if isinstance(grant_id, str) else None
+    )
 
     return router
 

--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -403,6 +403,7 @@ def create_oauth_token_router(
     device_grant_store: DeviceGrantStore,
     *,
     handle_device_code: Callable[[str], Response] | None = None,
+    client_secret_ok: Callable[[Request], bool] | None = None,
 ) -> APIRouter:
     """Build the ``/oauth/token`` + ``/oauth/revoke`` router.
 
@@ -419,10 +420,17 @@ def create_oauth_token_router(
         the full flow keeps one token endpoint; standalone mounts leave
         it ``None`` and ``device_code`` exchanges get
         ``unsupported_grant_type``.
+    :param client_secret_ok: Optional client-secret gate (callable that validates
+        the request). When ``None`` (standalone mounts), builds the gate from
+        the ``OMNIGENT_DEVICE_CLIENT_SECRET`` env var. When provided
+        (from :func:`create_device_auth_router`), reuses the gate to avoid
+        duplication.
     :returns: APIRouter to mount at the app root.
     """
     cookie_secret, provider_name = _resolve_signing_config(auth_provider)
-    _client_secret_ok = _make_client_secret_gate()
+    _client_secret_ok = client_secret_ok or _make_client_secret_gate()
+    # Resolve grant max lifetime once at mount time (not on every refresh).
+    _grant_max_lifetime = _grant_max_lifetime_seconds()
     router = APIRouter()
     # Throttle for the opportunistic grant purge (bounds the table without a
     # separate scheduler). Mutable one-field dict so the closures can update
@@ -443,7 +451,7 @@ def create_oauth_token_router(
         _last_purge["at"] = now_wall
         try:
             device_grant_store.purge_expired(
-                int(now_wall), max_lifetime_seconds=_grant_max_lifetime_seconds()
+                int(now_wall), max_lifetime_seconds=_grant_max_lifetime
             )
         except Exception:  # noqa: BLE001 — housekeeping must never fail a refresh
             _logger.debug("oauth/token: opportunistic grant purge failed", exc_info=True)
@@ -517,7 +525,7 @@ def create_oauth_token_router(
         # must re-consent. Checked before rotating so an aged grant simply
         # stops working (it is NOT reuse, so it must not revoke/oscillate).
         if grant.approved_at is not None and (
-            int(time.time()) - grant.approved_at >= _grant_max_lifetime_seconds()
+            int(time.time()) - grant.approved_at >= _grant_max_lifetime
         ):
             return _oauth_error("expired_token")
         if grant.user_id is None:
@@ -548,7 +556,7 @@ def create_oauth_token_router(
             expected_hash=presented_hash,
             new_hash=hash_secret(new_refresh, cookie_secret),
             now_epoch_seconds=int(time.time()),
-            max_lifetime_seconds=_grant_max_lifetime_seconds(),
+            max_lifetime_seconds=_grant_max_lifetime,
         )
         if rotated is None:
             # Lost a concurrent rotation race, or the grant aged out between
@@ -640,6 +648,8 @@ def create_device_auth_router(
     provider_name = auth_provider._source
 
     _client_secret_ok = _make_client_secret_gate()
+    # Resolve grant max lifetime once at mount (not on every purge).
+    _grant_max_lifetime = _grant_max_lifetime_seconds()
 
     router = APIRouter()
     _rate_limiter = _SlidingWindowRateLimiter(
@@ -687,7 +697,7 @@ def create_device_auth_router(
             _last_purge["at"] = now_wall
             try:
                 device_grant_store.purge_expired(
-                    int(now_wall), max_lifetime_seconds=_grant_max_lifetime_seconds()
+                    int(now_wall), max_lifetime_seconds=_grant_max_lifetime
                 )
             except Exception:  # housekeeping must never fail a request
                 _logger.exception("device grant purge failed")
@@ -951,6 +961,7 @@ def create_device_auth_router(
             auth_provider,
             device_grant_store,
             handle_device_code=_handle_device_code_grant,
+            client_secret_ok=_client_secret_ok,
         )
     )
 

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -6,6 +6,7 @@ by ``omnigent login``.
 
 from __future__ import annotations
 
+import contextlib
 import time
 
 import pytest
@@ -526,3 +527,262 @@ def test_databricks_record_overwrites_jwt_record(token_dir) -> None:
         load_databricks_workspace_host("https://server.example.com")
         == "https://example.databricks.com"
     )
+
+
+# ── Login-issued refresh grants (client side) ─────────────────────
+
+
+def test_store_token_persists_refresh_material(token_dir) -> None:
+    """A refresh token stored at login survives the round trip."""
+    import json
+
+    from omnigent.cli_auth import store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="jwt",
+        user_id="a@x",
+        expires_at=time.time() + 3600,
+        refresh_token="refresh-1",
+    )
+    data = json.loads((token_dir / "auth_tokens.json").read_text())
+    assert data["http://localhost:6767"]["refresh_token"] == "refresh-1"
+
+
+def test_stored_token_status_classification(token_dir) -> None:
+    """absent / expired / ok are distinguished — the host uses this to say
+    "your login expired" instead of dialing into a misleading 403."""
+    from omnigent.cli_auth import store_token, stored_token_status
+
+    assert stored_token_status("http://localhost:6767") == "absent"
+    store_token("http://localhost:6767", token="jwt", user_id="a@x", expires_at=time.time() - 10)
+    assert stored_token_status("http://localhost:6767") == "expired"
+    store_token("http://localhost:6767", token="jwt", user_id="a@x", expires_at=time.time() + 3600)
+    assert stored_token_status("http://localhost:6767") == "ok"
+
+
+def test_refresh_stored_token_renews_and_rotates(token_dir, monkeypatch) -> None:
+    """An expired entry with refresh material renews via /oauth/token and
+    persists the rotated pair."""
+    import json
+
+    import httpx
+
+    from omnigent.cli_auth import load_token, refresh_stored_token, store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="stale",
+        user_id="a@x",
+        expires_at=time.time() - 10,
+        refresh_token="refresh-1",
+    )
+    assert load_token("http://localhost:6767") is None  # expired
+
+    posted: dict[str, object] = {}
+
+    def _fake_post(url, *, data=None, timeout=None):
+        posted["url"] = url
+        posted["data"] = data
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "fresh",
+                "refresh_token": "refresh-2",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    assert refresh_stored_token("http://localhost:6767") == "fresh"
+    assert posted["url"] == "http://localhost:6767/oauth/token"
+    assert posted["data"] == {"grant_type": "refresh_token", "refresh_token": "refresh-1"}
+    # Rotated pair persisted; the fresh token now loads normally.
+    data = json.loads((token_dir / "auth_tokens.json").read_text())
+    entry = data["http://localhost:6767"]
+    assert entry["token"] == "fresh" and entry["refresh_token"] == "refresh-2"
+    assert load_token("http://localhost:6767") == "fresh"
+
+
+def test_refresh_stored_token_no_material_is_none(token_dir) -> None:
+    """Nothing to refresh (no entry, or no refresh token) → None, no I/O."""
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    assert refresh_stored_token("http://localhost:6767") is None
+    store_token("http://localhost:6767", token="jwt", user_id="a@x", expires_at=time.time() - 10)
+    assert refresh_stored_token("http://localhost:6767") is None
+
+
+def test_refresh_stored_token_refused_leaves_entry(token_dir, monkeypatch) -> None:
+    """A server refusal (revoked / aged-out grant / old server 404) returns
+    None and leaves the stored entry untouched."""
+    import json
+
+    import httpx
+
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="stale",
+        user_id="a@x",
+        expires_at=time.time() - 10,
+        refresh_token="refresh-1",
+    )
+
+    def _fake_post(url, *, data=None, timeout=None):
+        return httpx.Response(
+            400, json={"error": "invalid_grant"}, request=httpx.Request("POST", url)
+        )
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    assert refresh_stored_token("http://localhost:6767") is None
+    entry = json.loads((token_dir / "auth_tokens.json").read_text())["http://localhost:6767"]
+    assert entry["refresh_token"] == "refresh-1"
+
+
+def test_refresh_stored_token_skips_when_already_fresh(token_dir, monkeypatch) -> None:
+    """A concurrent refresher already renewed → return the valid token
+    without a network call (the lock-then-recheck path)."""
+    import httpx
+
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="already-fresh",
+        user_id="a@x",
+        expires_at=time.time() + 3600,
+        refresh_token="refresh-1",
+    )
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("no network call expected")
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    assert refresh_stored_token("http://localhost:6767") == "already-fresh"
+
+
+def test_refresh_no_material_does_not_touch_lock_file(token_dir, monkeypatch) -> None:
+    """With no refresh material, the refresh must not create a lock file.
+
+    Regression: creating the lock before checking raised OSError on a
+    read-only state directory, which the runner's auth factory caught —
+    skipping its Databricks SDK fallback and leaving valid credentials
+    unused.
+    """
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    store_token("http://localhost:6767", token="jwt", user_id="a@x", expires_at=time.time() - 10)
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("lock file must not be created when nothing to refresh")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    assert refresh_stored_token("http://localhost:6767") is None
+    assert not (token_dir / "auth_tokens.lock").exists()
+
+
+def test_refresh_survives_unwritable_state_dir(token_dir, monkeypatch) -> None:
+    """A lock/persist failure degrades to None instead of raising, so the
+    caller can still fall back to its other credential sources."""
+    import omnigent.cli_auth as ca
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="stale",
+        user_id="a@x",
+        expires_at=time.time() - 10,
+        refresh_token="refresh-1",
+    )
+
+    @contextlib.contextmanager
+    def _unwritable():
+        raise OSError("read-only file system")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(ca, "_token_file_lock", _unwritable)
+    assert refresh_stored_token("http://localhost:6767") is None
+
+
+def test_load_token_min_remaining_declines_near_expiry(token_dir) -> None:
+    """A token inside the renewal window reads as unusable so the caller
+    refreshes instead of sending one that lapses mid-handshake."""
+    from omnigent.cli_auth import REFRESH_MIN_REMAINING_SECONDS, load_token, store_token
+
+    store_token(
+        "http://localhost:6767",
+        token="jwt",
+        user_id="a@x",
+        expires_at=time.time() + (REFRESH_MIN_REMAINING_SECONDS / 2),
+    )
+    # Default (0) still accepts a not-yet-expired token — unchanged behaviour.
+    assert load_token("http://localhost:6767") == "jwt"
+    # The renewal-aware caller declines it.
+    assert (
+        load_token("http://localhost:6767", min_remaining_seconds=REFRESH_MIN_REMAINING_SECONDS)
+        is None
+    )
+
+
+def test_load_entry_tolerates_wrong_shaped_json(token_dir) -> None:
+    """A token file holding valid JSON of the wrong shape reads as empty
+    rather than raising AttributeError into the caller."""
+    from omnigent.cli_auth import load_token, stored_token_status
+
+    for bad in ("[]", "null", '"a string"'):
+        (token_dir / "auth_tokens.json").write_text(bad)
+        assert load_token("http://localhost:6767") is None
+        assert stored_token_status("http://localhost:6767") == "absent"
+
+
+def test_refresh_rejects_unusable_response_fields(token_dir, monkeypatch) -> None:
+    """A 200 with null/non-string tokens or a non-finite expires_in must not
+    clobber the working stored credential."""
+    import json
+
+    import httpx
+
+    from omnigent.cli_auth import refresh_stored_token, store_token
+
+    def _seed():
+        store_token(
+            "http://localhost:6767",
+            token="stale",
+            user_id="a@x",
+            expires_at=time.time() - 10,
+            refresh_token="refresh-1",
+        )
+
+    # null access_token → decline, stored pair untouched.
+    _seed()
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, **_kw: httpx.Response(
+            200,
+            json={"access_token": None, "refresh_token": "r2"},
+            request=httpx.Request("POST", url),
+        ),
+    )
+    assert refresh_stored_token("http://localhost:6767") is None
+    entry = json.loads((token_dir / "auth_tokens.json").read_text())["http://localhost:6767"]
+    assert entry["token"] == "stale" and entry["refresh_token"] == "refresh-1"
+
+    # Non-finite expires_in → falls back to a sane lifetime, not "never expires".
+    _seed()
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, **_kw: httpx.Response(
+            200,
+            json={"access_token": "fresh", "refresh_token": "r2", "expires_in": "NaN"},
+            request=httpx.Request("POST", url),
+        ),
+    )
+    assert refresh_stored_token("http://localhost:6767") == "fresh"
+    entry = json.loads((token_dir / "auth_tokens.json").read_text())["http://localhost:6767"]
+    assert entry["expires_at"] < time.time() + 4000

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -689,9 +689,8 @@ def test_refresh_survives_unwritable_state_dir(token_dir, monkeypatch) -> None:
     """A lock/persist failure degrades to None instead of raising, so the
     caller can still fall back to its other credential sources."""
     import omnigent.cli_auth as ca
-    from omnigent.cli_auth import refresh_stored_token, store_token
 
-    store_token(
+    ca.store_token(
         "http://localhost:6767",
         token="stale",
         user_id="a@x",
@@ -705,7 +704,7 @@ def test_refresh_survives_unwritable_state_dir(token_dir, monkeypatch) -> None:
         yield  # pragma: no cover
 
     monkeypatch.setattr(ca, "_token_file_lock", _unwritable)
-    assert refresh_stored_token("http://localhost:6767") is None
+    assert ca.refresh_stored_token("http://localhost:6767") is None
 
 
 def test_load_token_min_remaining_declines_near_expiry(token_dir) -> None:

--- a/tests/e2e/test_managed_runner_http_auth.py
+++ b/tests/e2e/test_managed_runner_http_auth.py
@@ -352,7 +352,7 @@ def test_managed_runner_callback_authenticates_end_to_end(
 
     monkeypatch.setenv("RUNNER_SERVER_URL", base_url)
     monkeypatch.setenv(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, _BINDING_TOKEN)
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr(
         "omnigent.inner.databricks_executor._resolve_databricks_auth",
         _no_databricks_creds,
@@ -423,7 +423,7 @@ def test_managed_runner_survives_mint_403_after_token_expiry(
         monkeypatch.setenv(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, _BINDING_TOKEN)
         monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, owner_cookie)
         monkeypatch.setenv(RUNNER_DELEGATED_AUTH_ENV_VAR, "1")
-        monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: owner_cookie)
+        monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: owner_cookie)
 
         factory = _make_auth_token_factory()
         assert isinstance(factory, _InitialAuthTokenFactory)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4709,3 +4709,37 @@ async def test_run_reconnects_promptly_after_suspend(
     # The disconnect was attributed to the resume, and the flag was consumed.
     assert any("resumed from suspend" in r.message for r in caplog.records)
     assert host._woke_from_suspend is False
+
+
+def test_post_connect_auth_rejection_escalates_without_going_fatal(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A 401/403 AFTER the host has connected retries forever (never fatal),
+    but a sustained streak escalates the operator message from a transient-
+    network hint to a re-auth prompt that names ``omnigent login`` — so a
+    permanently-rejected credential surfaces instead of looping silently.
+    """
+    from omnigent.host.connect import _AUTH_REJECT_ESCALATE_ATTEMPTS
+
+    host = _make_host_process()
+    host._ever_connected = True
+
+    # First rejection: retryable (None), framed as a transient network blip.
+    assert host._classify_http_status(403) is None
+    first = capsys.readouterr().err
+    assert "network dropped" in first
+    assert "omnigent login" not in first
+
+    # Streak climbs toward — but not to — the escalation threshold: stays quiet
+    # so a brief VPN outage never raises a false re-auth alarm.
+    for _ in range(2, _AUTH_REJECT_ESCALATE_ATTEMPTS):
+        assert host._classify_http_status(403) is None
+    assert "omnigent login" not in capsys.readouterr().err
+
+    # Crossing the threshold escalates — names the real remedy — and is STILL
+    # retryable (no fatal error, so a recoverable daemon is never killed).
+    assert host._classify_http_status(403) is None
+    escalated = capsys.readouterr().err
+    assert "omnigent login http://localhost:8000" in escalated
+    assert "no longer a transient network blip" in escalated
+    assert host._auth_retry_streak == _AUTH_REJECT_ESCALATE_ATTEMPTS

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -221,7 +221,7 @@ def test_make_auth_token_factory_uses_managed_mint_when_only_binding_token(
 
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "managed-binding-token")
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk)
     monkeypatch.setattr(
         "omnigent.runner._entry._mint_managed_owner_token",
@@ -291,7 +291,9 @@ def test_initial_host_token_defers_local_auth_until_rejected(
     # managed-sandbox delegation — OMNIGENT_RUNNER_DELEGATED_AUTH is absent.
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
     monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
     monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _unexpected_mint)
 
@@ -399,7 +401,7 @@ def test_delegated_factory_falls_back_when_apps_proxy_redirects_mint(
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
     monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr(
         "omnigent.inner.databricks_executor._resolve_databricks_auth",
         lambda *args, **kwargs: (_SdkAuth(), "https://workspace.cloud.databricks.com"),
@@ -433,7 +435,7 @@ def test_make_auth_token_factory_none_without_creds_or_binding_token(
 
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
     monkeypatch.delenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", raising=False)
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk)
 
     assert _make_auth_token_factory() is None
@@ -2272,7 +2274,7 @@ def test_make_auth_token_factory_resolves_sdk_auth_once(
 
     monkeypatch.setattr(dbx, "_resolve_databricks_auth", _fake_resolve)
     # No stored OIDC token → the factory falls through to the SDK path.
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
 
     factory = _make_auth_token_factory(server_url="https://ex.databricks.com")
     assert factory is not None

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -292,7 +292,7 @@ def test_initial_host_token_defers_local_auth_until_rejected(
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
     monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
-    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.delenv("OMNIGENT_RUNNER_DELEGATED_AUTH", raising=False)
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
     monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _unexpected_mint)
@@ -707,7 +707,7 @@ def test_initial_host_token_re_resolves_to_sdk_when_proxy_auth_fails(
     monkeypatch.setenv("OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN", "expired-host-bearer")
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok")
     monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
     monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _proxy_rejects)
 
@@ -815,7 +815,7 @@ def test_initial_host_token_re_resolves_to_sdk_when_remint_403s_after_expiry(
     monkeypatch.setenv("OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN", "host-bearer")
     monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok")
     monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
-    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
     monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _mint_ok_then_403)
 

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -2409,3 +2409,35 @@ def test_maybe_prewarm_ambient_detection_gates_on_launch_harness(
     monkeypatch.setenv(RUNNER_LAUNCH_HARNESS_ENV_VAR, "claude-native")
     _maybe_prewarm_ambient_detection()
     assert prewarms == ["prewarm"]
+
+
+def test_auth_token_factory_refreshes_expired_oidc_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wiring that actually keeps an unattended host alive: when the stored
+    OIDC token has lapsed but a login-issued refresh grant is present, the
+    auth-token factory returns the REFRESHED token — so the next reconnect
+    authenticates instead of crash-looping. Guards the load->refresh->fallback
+    integration in ``_factory`` (only the unit-level refresh was covered before).
+    """
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://omnigent.example.com")
+    # A plain `omnigent login` host on the stored-OIDC-token path: no host
+    # bootstrap bearer and no managed-sandbox delegation.
+    monkeypatch.delenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv("OMNIGENT_RUNNER_DELEGATED_AUTH", raising=False)
+    # Stored token reads as unusable (expired / inside the renewal window)...
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url, **_kw: None)
+    # ...but the refresh grant mints a fresh session JWT.
+    refresh_calls: list[str] = []
+
+    def _refresh(url: str) -> str:
+        refresh_calls.append(url)
+        return "refreshed-jwt"
+
+    monkeypatch.setattr("omnigent.cli_auth.refresh_stored_token", _refresh)
+
+    factory = _make_auth_token_factory()
+
+    assert factory is not None
+    assert factory() == "refreshed-jwt"
+    assert refresh_calls, "the refresh path must have run"

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -2027,3 +2027,27 @@ def test_setup_is_single_use(accounts_app_needs_setup: TestClient) -> None:
     user_ids = {u["id"] for u in client.get("/auth/users").json()["users"]}
     assert "alice" in user_ids
     assert "bob" not in user_ids
+
+
+def test_browser_login_never_issues_refresh_token(accounts_app: TestClient) -> None:
+    """Regression test for P1 security: browser /auth/login must NEVER issue
+    a refresh_token, regardless of client input. Refresh grants are for
+    unattended flows (CLI/device); browser logins should never get long-lived
+    credentials that bypass session expiry.
+
+    This was broken when LoginRequest.issue_refresh was a client-controllable
+    bool — XSS or form-hijack could POST issue_refresh=true and obtain a
+    30-day unattended credential.
+    """
+    resp = accounts_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Browser login must NEVER include refresh_token in response.
+    assert "refresh_token" not in body, (
+        "Browser /auth/login returned refresh_token — violates the security "
+        "invariant that unattended credentials are issued only via CLI/device flows"
+    )

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1807,7 +1807,13 @@ def test_cli_accounts_login_happy_path_stores_token(
         calls["n"] += 1
         assert url.endswith("/auth/login")
         body = kw["json"]
-        assert body == {"username": "alice", "password": "alice-pw-1234"}
+        assert body == {
+            "username": "alice",
+            "password": "alice-pw-1234",
+            # The CLI asks for a login-issued refresh grant so hosts can
+            # renew unattended; older servers ignore the field.
+            "issue_refresh": True,
+        }
         return _FakeResponse(
             200,
             {

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1810,9 +1810,6 @@ def test_cli_accounts_login_happy_path_stores_token(
         assert body == {
             "username": "alice",
             "password": "alice-pw-1234",
-            # The CLI asks for a login-issued refresh grant so hosts can
-            # renew unattended; older servers ignore the field.
-            "issue_refresh": True,
         }
         return _FakeResponse(
             200,

--- a/tests/server/test_device_auth.py
+++ b/tests/server/test_device_auth.py
@@ -587,22 +587,23 @@ def test_create_redeemed_grant_survives_pending_purge(store: DeviceGrantStore) -
     assert store.get_by_id("lg2") is None
 
 
-def test_accounts_login_issue_refresh_round_trip(disabled_app: TestClient) -> None:
-    """A CLI login (issue_refresh) yields refresh material that renews via
-    /oauth/token even with the device flow disabled — the core unattended-host
-    fix.
+def test_login_grant_refresh_round_trip(disabled_app: TestClient, tmp_path: Path) -> None:
+    """A login-issued refresh grant renews via /oauth/token even with the
+    device flow disabled — the core unattended-host fix.
 
     Login grants deliberately do NOT rotate: the same refresh token keeps
     working, so a lost response or a crash between the server committing and
     the client persisting cannot brick an unattended host.
     """
-    r = disabled_app.post(
-        "/auth/login",
-        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
-    )
-    assert r.status_code == 200, r.text
-    refresh = r.json().get("refresh_token")
-    assert refresh, "login with issue_refresh must return a refresh token"
+    # A CLI/device login mints refresh material server-side; browser
+    # /auth/login never does (see test_web_login_never_issues_refresh).
+    import os
+
+    from omnigent.server.routes.device_auth import issue_login_grant
+
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/test.db")
+    secret = bytes.fromhex(os.environ["OMNIGENT_ACCOUNTS_COOKIE_SECRET"])
+    refresh = issue_login_grant(store, user_id="admin", cookie_secret=secret)
 
     # Refresh: fresh access token, SAME refresh token handed back.
     r = disabled_app.post(
@@ -627,7 +628,9 @@ def test_accounts_login_issue_refresh_round_trip(disabled_app: TestClient) -> No
         assert again.json()["refresh_token"] == refresh
 
 
-def test_login_grant_token_keeps_session_authority(disabled_app: TestClient) -> None:
+def test_login_grant_token_keeps_session_authority(
+    disabled_app: TestClient, tmp_path: Path
+) -> None:
     """A refreshed login-grant token reaches routes OUTSIDE the delegated
     allowlist — it renews the session JWT and must keep its authority.
 
@@ -635,11 +638,13 @@ def test_login_grant_token_keeps_session_authority(disabled_app: TestClient) -> 
     ``/v1/usage``-style routes 401 after the first refresh, silently breaking
     agents and CLI commands on a long-lived host.
     """
-    r = disabled_app.post(
-        "/auth/login",
-        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
-    )
-    refresh = r.json()["refresh_token"]
+    import os
+
+    from omnigent.server.routes.device_auth import issue_login_grant
+
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/test.db")
+    secret = bytes.fromhex(os.environ["OMNIGENT_ACCOUNTS_COOKIE_SECRET"])
+    refresh = issue_login_grant(store, user_id="admin", cookie_secret=secret)
     r = disabled_app.post(
         "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
     )
@@ -784,3 +789,34 @@ def test_oauth_token_router_oidc_mode(tmp_path: Path) -> None:
             "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": rotated}
         )
         assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_redeemed_grant_persistence_regression(store: DeviceGrantStore) -> None:
+    """Regression test for P0 bug: create_redeemed_grant must persist the
+    grant to the database (not crash with TypeError on missing query_name).
+
+    This was broken when query_name was missing from self._session(), causing
+    the entire login-issued grant feature to silently fail (caught by
+    except Exception in the issuance sites).
+    """
+    refresh_hash = hash_secret("test-refresh", _KEY)
+
+    # Must not raise; must persist a row.
+    grant = store.create_redeemed_grant(
+        "lg-persist-test",
+        user_id="alice@example.com",
+        client_id="omnigent-cli",
+        refresh_token_hash=refresh_hash,
+        created_at=1000,
+    )
+
+    # Verify persistence: the grant should be retrievable.
+    retrieved = store.get_by_id(grant.id)
+    assert retrieved is not None
+    assert retrieved.user_id == "alice@example.com"
+    assert retrieved.status == "redeemed"
+
+    # Verify the refresh hash is usable.
+    by_hash = store.get_by_refresh_hash(refresh_hash)
+    assert by_hash is not None
+    assert by_hash.id == grant.id

--- a/tests/server/test_device_auth.py
+++ b/tests/server/test_device_auth.py
@@ -15,11 +15,11 @@ See ``designs/DEVICE_AUTH.md``.
 
 from __future__ import annotations
 
-import logging
 import secrets
 from collections.abc import Iterator
 from pathlib import Path
 
+import jwt
 import pytest
 from fastapi.testclient import TestClient
 
@@ -379,42 +379,6 @@ def test_consent_page_requires_login(app: TestClient) -> None:
     assert "/login" in r.headers["location"]
 
 
-def test_consent_forces_reauth_for_stale_session(app: TestClient) -> None:
-    """A session that predates the grant is bounced to a FORCED re-login.
-
-    The whole anti-phishing property: even an already-signed-in user must
-    re-authenticate for THIS flow. Logging in BEFORE authorize makes the
-    session ``iat`` older than the grant's ``created_at``, so the consent GET
-    must bounce with ``reauth=1`` rather than render the approve screen — and
-    the approve POST must refuse the stale session outright.
-    """
-    # Sign in FIRST (stale session relative to the soon-to-be-created grant).
-    _login_admin(app)
-    import time as _t
-
-    _t.sleep(1)  # ensure the grant's created_at is a later second than iat
-
-    r = app.post("/oauth/device/authorize", json={"client_id": "slack"})
-    assert r.status_code == 200, r.text
-    user_code = r.json()["user_code"]
-
-    # Consent GET bounces to a FORCED re-login (reauth=1), not the approve page.
-    r = app.get(f"/oauth/device?user_code={user_code}", follow_redirects=False)
-    assert r.status_code == 302, r.text
-    loc = r.headers["location"]
-    assert "/login" in loc and "reauth=1" in loc
-
-    # Approve POST refuses the stale session too (defense in depth — a direct
-    # POST must not bypass the GET's gate).
-    r = app.post(
-        "/oauth/device/approve",
-        data={"user_code": user_code},
-        headers={"Origin": "http://localhost:8000"},
-    )
-    assert r.status_code == 200
-    assert "too old" in r.text.lower()
-
-
 def test_unsupported_grant_type(app: TestClient) -> None:
     r = app.post("/oauth/token", data={"grant_type": "password"})
     assert r.status_code == 400 and r.json()["error"] == "unsupported_grant_type"
@@ -450,23 +414,39 @@ def disabled_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Te
 
 
 def test_device_grant_routes_absent_by_default(disabled_app: TestClient) -> None:
-    """Default-off: the /oauth/* router is not mounted unless explicitly
-    enabled, so the device-grant POST handlers don't run.
+    """Default-off: the RFC 8628 device-consent surface is not mounted
+    unless explicitly enabled, so its POST handlers don't run.
 
     With no mounted handler the POST is not routed: it 404s when nothing else
     claims the path, or 405s when a built web SPA is mounted at ``/`` (its
-    catch-all serves GET only). Either way NO device-grant logic executes —
-    no device_code is issued and no OAuth error shape is returned.
+    catch-all serves GET only). Either way NO device-consent logic executes —
+    no device_code is issued.
+
+    The token/revoke half is different: login-issued refresh grants need it
+    in every accounts/oidc deployment, so ``/oauth/token`` and
+    ``/oauth/revoke`` mount regardless of the flag — but the device_code
+    grant type is refused there when the device flow is off.
     """
     r = disabled_app.post("/oauth/device/authorize", json={"client_id": "slack"})
     assert r.status_code in (404, 405)
     assert "device_code" not in r.text
+    # Token endpoint is live (login grants) but knows no device_code grant.
+    r = disabled_app.post(
+        "/oauth/token",
+        data={"grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "x"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "unsupported_grant_type"
+    # Refresh with an unknown token fails closed with the OAuth shape.
     r = disabled_app.post(
         "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "x"}
     )
-    assert r.status_code in (404, 405)
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_grant"
+    # Revoke stays idempotent.
     r = disabled_app.post("/oauth/revoke", data={"refresh_token": "x"})
-    assert r.status_code in (404, 405)
+    assert r.status_code == 200
+    assert r.json() == {"revoked": True}
 
 
 def test_account_auth_available_when_device_grant_disabled(disabled_app: TestClient) -> None:
@@ -483,7 +463,7 @@ def test_account_auth_available_when_device_grant_disabled(disabled_app: TestCli
     # And an authenticated account-management route works.
     r = disabled_app.get("/auth/users")
     assert r.status_code == 200, r.text
-    # Sanity: the device-grant surface is still absent (no /oauth handler) —
+    # Sanity: the device-consent surface is still absent (no handler) —
     # 404 with no SPA catch-all, 405 when a built SPA is mounted at "/".
     r = disabled_app.post("/oauth/device/authorize", json={"client_id": "slack"})
     assert r.status_code in (404, 405)
@@ -497,8 +477,8 @@ def secret_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Test
 
 
 def test_client_secret_required_when_configured(secret_app: TestClient) -> None:
-    """With the secret set, the client-facing endpoints reject a missing/wrong
-    header and accept the matching one."""
+    """With the secret set, the endpoints that mint from an ephemeral code
+    reject a missing/wrong header and accept the matching one."""
     hdr = {"X-Omnigent-Client-Secret": _SECRET}
 
     # authorize: no header → 401 invalid_client; wrong → 401; correct → 200.
@@ -513,18 +493,32 @@ def test_client_secret_required_when_configured(secret_app: TestClient) -> None:
     r = secret_app.post("/oauth/device/authorize", json={"client_id": "slack"}, headers=hdr)
     assert r.status_code == 200, r.text
 
-    # token + revoke are gated the same way (checked before any body parsing).
-    r = secret_app.post("/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "x"})
-    assert r.status_code == 401 and r.json()["error"] == "invalid_client"
-    r = secret_app.post("/oauth/revoke", data={"refresh_token": "x"})
-    assert r.status_code == 401 and r.json()["error"] == "invalid_client"
-    # With the header, token reaches normal error handling (bad token, not 401).
+    # The device_code exchange mints from the device_code alone, so it stays
+    # gated.
     r = secret_app.post(
         "/oauth/token",
-        data={"grant_type": "refresh_token", "refresh_token": "x"},
-        headers=hdr,
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": "x",
+        },
     )
+    assert r.status_code == 401 and r.json()["error"] == "invalid_client"
+
+
+def test_client_secret_does_not_gate_refresh_or_revoke(secret_app: TestClient) -> None:
+    """Refresh and revoke present their own grant-bound secret, so they are
+    NOT additionally gated by the device client secret.
+
+    A CLI/host renewing its own login grant has no way to carry that secret;
+    gating these would make every automatic refresh fail with 401 in any
+    deployment that sets it (e.g. one also serving Slack).
+    """
+    # No client-secret header: reaches normal OAuth error handling, not 401.
+    r = secret_app.post("/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "x"})
     assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+    # Revoke stays idempotent without the header.
+    r = secret_app.post("/oauth/revoke", data={"refresh_token": "x"})
+    assert r.status_code == 200 and r.json() == {"revoked": True}
 
 
 def test_browser_consent_not_gated_by_client_secret(secret_app: TestClient) -> None:
@@ -542,49 +536,251 @@ def test_no_secret_configured_stays_public(app: TestClient) -> None:
     assert r.status_code == 200, r.text
 
 
-def _capture_app_warnings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Build the accounts app and return WARNING messages from ``server.app``.
+# ── Login-issued refresh grants ───────────────────────────────────
 
-    Attaches a handler directly to the ``omnigent.server.app`` logger rather
-    than using ``caplog``: the server's telemetry/logging init runs during the
-    build and reconfigures logging, which can detach pytest's capture handler.
-    A directly-attached handler is immune to that.
+
+def test_create_redeemed_grant_refresh_cycle(store: DeviceGrantStore) -> None:
+    """A login-issued grant (born redeemed) rotates and reuse-revokes exactly
+    like one that walked the device flow."""
+    refresh_hash = hash_secret("r1", _KEY)
+    g = store.create_redeemed_grant(
+        "lg1",
+        user_id="alice@example.com",
+        client_id="omnigent-cli",
+        refresh_token_hash=refresh_hash,
+        created_at=1000,
+    )
+    assert g.status == "redeemed"
+    assert g.user_id == "alice@example.com"
+    assert g.approved_at == 1000
+    # Its refresh token resolves and rotates.
+    assert store.get_by_refresh_hash(refresh_hash) is not None
+    rotated = store.rotate_refresh_token(
+        g.id,
+        expected_hash=refresh_hash,
+        new_hash=hash_secret("r2", _KEY),
+        now_epoch_seconds=1010,
+        max_lifetime_seconds=_LIFETIME,
+    )
+    assert rotated is not None
+    # Replaying the pre-rotation token is reuse — the whole grant dies.
+    assert store.get_by_refresh_hash(refresh_hash) is None
+    stale = store.get_by_prev_refresh_hash(refresh_hash)
+    assert stale is not None and stale.id == g.id
+
+
+def test_create_redeemed_grant_survives_pending_purge(store: DeviceGrantStore) -> None:
+    """expires_at (the device_code window) is meaningless for a grant born
+    redeemed — the pending/denied purge bucket must never collect it."""
+    store.create_redeemed_grant(
+        "lg2",
+        user_id="alice@example.com",
+        client_id="omnigent-cli",
+        refresh_token_hash=hash_secret("r1", _KEY),
+        created_at=1000,
+    )
+    # Way past the (already-elapsed) expires_at, within grant lifetime.
+    assert store.purge_expired(1000 + 3600) == 0
+    assert store.get_by_id("lg2") is not None
+    # But the lifetime purge does collect it once the grant ages out.
+    assert store.purge_expired(1000 + _LIFETIME + 1, max_lifetime_seconds=_LIFETIME) == 1
+    assert store.get_by_id("lg2") is None
+
+
+def test_accounts_login_issue_refresh_round_trip(disabled_app: TestClient) -> None:
+    """A CLI login (issue_refresh) yields refresh material that renews via
+    /oauth/token even with the device flow disabled — the core unattended-host
+    fix.
+
+    Login grants deliberately do NOT rotate: the same refresh token keeps
+    working, so a lost response or a crash between the server committing and
+    the client persisting cannot brick an unattended host.
     """
-    captured: list[str] = []
+    r = disabled_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+    )
+    assert r.status_code == 200, r.text
+    refresh = r.json().get("refresh_token")
+    assert refresh, "login with issue_refresh must return a refresh token"
 
-    class _Collector(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            if record.levelno >= logging.WARNING:
-                captured.append(record.getMessage())
+    # Refresh: fresh access token, SAME refresh token handed back.
+    r = disabled_app.post(
+        "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["access_token"]
+    assert body["refresh_token"] == refresh
+    assert body["expires_in"] == 3600
 
-    logger = logging.getLogger("omnigent.server.app")
-    handler = _Collector()
-    logger.addHandler(handler)
-    try:
-        for _ in _build_accounts_app(tmp_path, monkeypatch):
-            break  # build (and immediately tear down) so the mount runs
-    finally:
-        logger.removeHandler(handler)
-    return captured
+    # The token authenticates against the API.
+    r = disabled_app.get("/v1/hosts", headers={"Authorization": f"Bearer {body['access_token']}"})
+    assert r.status_code == 200, r.text
 
-
-def test_startup_warns_when_client_secret_unset(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Mounting the device grant on a multi-user server without the client
-    secret must log a loud warning — the authorize endpoint is public, so the
-    operator should know to opt into OMNIGENT_DEVICE_CLIENT_SECRET."""
-    monkeypatch.delenv("OMNIGENT_DEVICE_CLIENT_SECRET", raising=False)
-    warnings = _capture_app_warnings(tmp_path, monkeypatch)
-    assert any(
-        "OMNIGENT_DEVICE_CLIENT_SECRET is not set" in m and "PUBLIC" in m for m in warnings
-    ), warnings
+    # Repeat use of the same token keeps working — no reuse revocation.
+    for _ in range(3):
+        again = disabled_app.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
+        )
+        assert again.status_code == 200, again.text
+        assert again.json()["refresh_token"] == refresh
 
 
-def test_startup_silent_when_client_secret_set(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With the secret configured, the public-endpoint warning must NOT fire."""
-    monkeypatch.setenv("OMNIGENT_DEVICE_CLIENT_SECRET", _SECRET)
-    warnings = _capture_app_warnings(tmp_path, monkeypatch)
-    assert not any("OMNIGENT_DEVICE_CLIENT_SECRET is not set" in m for m in warnings)
+def test_login_grant_token_keeps_session_authority(disabled_app: TestClient) -> None:
+    """A refreshed login-grant token reaches routes OUTSIDE the delegated
+    allowlist — it renews the session JWT and must keep its authority.
+
+    Regression guard: minting it as a scope-restricted delegated token made
+    ``/v1/usage``-style routes 401 after the first refresh, silently breaking
+    agents and CLI commands on a long-lived host.
+    """
+    r = disabled_app.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+    )
+    refresh = r.json()["refresh_token"]
+    r = disabled_app.post(
+        "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
+    )
+    access = r.json()["access_token"]
+    auth = {"Authorization": f"Bearer {access}"}
+    # Drop the browser session cookie that /auth/login set, so the bearer
+    # token is the ONLY credential — otherwise the cookie answers and every
+    # assertion below passes vacuously.
+    disabled_app.cookies.clear()
+
+    # Carries grant_id (revocable) but no scope claim (unrestricted).
+    claims = jwt.decode(access, options={"verify_signature": False})
+    assert claims["grant_id"]
+    assert "scope" not in claims
+
+    # Allowlisted route works...
+    assert disabled_app.get("/v1/hosts", headers=auth).status_code == 200
+    # ...and so does one outside the delegated allowlist. A scope-restricted
+    # delegated token is refused here; this one must not be.
+    r = disabled_app.get("/v1/usage", headers=auth)
+    assert r.status_code != 401, f"login-grant token must not be scope-restricted: {r.text}"
+
+    # Revocation still kills it despite the wider authority.
+    assert disabled_app.post("/oauth/revoke", data={"refresh_token": refresh}).status_code == 200
+    assert disabled_app.get("/v1/hosts", headers=auth).status_code == 401
+
+
+def test_device_authorize_refuses_reserved_login_client_id(app: TestClient) -> None:
+    """A device client cannot self-declare into the first-party login-grant
+    class by naming its reserved client_id — that would hand it a
+    full-authority (unscoped) token on refresh."""
+    from omnigent.server.routes.device_auth import LOGIN_GRANT_CLIENT_ID
+
+    r = app.post("/oauth/device/authorize", json={"client_id": LOGIN_GRANT_CLIENT_ID})
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+    assert "device_code" not in r.text
+
+
+def test_device_grant_refresh_stays_scope_restricted(app: TestClient) -> None:
+    """Third-party device grants keep the delegated scope AND keep rotating —
+    the login-grant carve-out must not leak to them."""
+    import time as _time
+
+    r = app.post("/oauth/device/authorize", json={"client_id": "slack"})
+    data = r.json()
+    _login_admin(app)
+    app.post(
+        "/oauth/device/approve",
+        data={"user_code": data["user_code"]},
+        headers={"Origin": "http://localhost:8000"},
+    )
+    for _ in range(4):
+        r = app.post(
+            "/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": data["device_code"],
+            },
+        )
+        if r.status_code == 200:
+            break
+        _time.sleep(1.2)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    claims = jwt.decode(body["access_token"], options={"verify_signature": False})
+    assert claims["scope"] == "sessions"
+
+    # And it still rotates.
+    r2 = app.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": body["refresh_token"]},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["refresh_token"] != body["refresh_token"]
+
+
+def test_web_login_never_issues_refresh(disabled_app: TestClient) -> None:
+    """A plain browser-shaped login (no issue_refresh) must not hand out
+    refresh material."""
+    r = disabled_app.post("/auth/login", json={"username": "admin", "password": "admin-pw-12345"})
+    assert r.status_code == 200, r.text
+    assert "refresh_token" not in r.json()
+
+
+def test_grant_lifetime_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OMNIGENT_GRANT_MAX_LIFETIME_DAYS scales the absolute lifetime; junk
+    and non-positive values fall back to the 30-day default."""
+    from omnigent.server.routes.device_auth import (
+        _GRANT_MAX_LIFETIME_SECONDS,
+        _grant_max_lifetime_seconds,
+    )
+
+    monkeypatch.delenv("OMNIGENT_GRANT_MAX_LIFETIME_DAYS", raising=False)
+    assert _grant_max_lifetime_seconds() == _GRANT_MAX_LIFETIME_SECONDS
+    monkeypatch.setenv("OMNIGENT_GRANT_MAX_LIFETIME_DAYS", "90")
+    assert _grant_max_lifetime_seconds() == 90 * 86400
+    monkeypatch.setenv("OMNIGENT_GRANT_MAX_LIFETIME_DAYS", "0")
+    assert _grant_max_lifetime_seconds() == _GRANT_MAX_LIFETIME_SECONDS
+    monkeypatch.setenv("OMNIGENT_GRANT_MAX_LIFETIME_DAYS", "soon")
+    assert _grant_max_lifetime_seconds() == _GRANT_MAX_LIFETIME_SECONDS
+
+
+def test_oauth_token_router_oidc_mode(tmp_path: Path) -> None:
+    """The token/revoke router builds and refreshes under an OIDC-mode
+    provider — the half of the machinery DEVICE_AUTH.md said OIDC would
+    never need, until login-issued grants needed it."""
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+
+    from omnigent.server.routes.device_auth import (
+        create_oauth_token_router,
+        issue_login_grant,
+    )
+
+    provider = SimpleNamespace(_source="oidc", _oidc_config=SimpleNamespace(cookie_secret=_KEY))
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
+    app = FastAPI()
+    app.include_router(create_oauth_token_router(provider, store))  # type: ignore[arg-type]
+
+    refresh = issue_login_grant(store, user_id="alice@example.com", cookie_secret=_KEY)
+    with TestClient(app) as client:
+        # device_code exchanges are refused on a standalone mount.
+        r = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": "x",
+            },
+        )
+        assert r.status_code == 400 and r.json()["error"] == "unsupported_grant_type"
+        # Refresh works.
+        r = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
+        )
+        assert r.status_code == 200, r.text
+        rotated = r.json()["refresh_token"]
+        # Revoke by the rotated token, then refresh fails closed.
+        r = client.post("/oauth/revoke", data={"refresh_token": rotated})
+        assert r.status_code == 200
+        r = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": rotated}
+        )
+        assert r.status_code == 400 and r.json()["error"] == "invalid_grant"

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -478,3 +478,179 @@ def test_callback_accepts_boolean_and_string_true(
     # Accepted as a verified identity → redirect + session.
     assert resp.status_code == 302, resp.text
     assert resp.cookies.get("ap_session") is not None
+
+
+# ── CLI login tickets + login-issued refresh grants ───────────────
+
+
+def test_cli_ticket_fulfillment_issues_refresh_grant(
+    tmp_path: Path,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CLI-ticket login returns refresh material the CLI can renew with.
+
+    End-to-end over the OIDC router + the standalone token router (the
+    OIDC mount): cli-login → callback (fulfills ticket + issues grant) →
+    cli-poll (hands out refresh_token once) → /oauth/token refresh.
+    This is the renewal path that keeps an unattended host alive past
+    session-JWT expiry.
+    """
+    from omnigent.server.device_grant_store import DeviceGrantStore
+    from omnigent.server.routes.device_auth import create_oauth_token_router
+
+    keys = _IdpKeys()
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    admins = tmp_path / "admins"
+    admins.write_text("")
+    config = _oidc_config()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    grant_store = DeviceGrantStore(db_uri)
+
+    pending_id_token: list[str] = [""]
+
+    async def _fake_post(
+        self: httpx.AsyncClient,
+        url: str,
+        *,
+        data: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        return httpx.Response(200, json={"id_token": pending_id_token[0]})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+    monkeypatch.setattr(
+        jwt.PyJWKClient,
+        "get_signing_key_from_jwt",
+        lambda self, token: keys.signing_key,
+    )
+
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(
+            provider,
+            perm_store,
+            AdminList(admins),
+            device_grant_store=grant_store,
+        ),
+        prefix="/auth",
+    )
+    app.include_router(create_oauth_token_router(provider, grant_store))
+
+    with TestClient(app) as client:
+        # 1. CLI requests a ticket.
+        r = client.post("/auth/cli-login")
+        assert r.status_code == 200, r.text
+        ticket = r.json()["ticket"]
+
+        # 2. Browser completes the IdP flow; the state cookie carries the
+        # ticket so the callback fulfills it.
+        pending_id_token[0] = keys.sign_id_token(
+            {"email": "alice@example.com", "email_verified": True}
+        )
+        state = "state-token-xyz"
+        state_jwt = jwt.encode(
+            {
+                "state": state,
+                "code_verifier": "verifier",
+                "return_to": "/",
+                "ticket": ticket,
+                "exp": int(time.time()) + 300,
+            },
+            _TEST_SECRET,
+            algorithm="HS256",
+        )
+        client.cookies.set(_AUTH_STATE_COOKIE_PLAIN, state_jwt)
+        r = client.get(
+            f"/auth/callback?code=auth-code&state={state}",
+            follow_redirects=False,
+        )
+        assert r.status_code == 200, r.text  # HTML "Login successful" page
+
+        # 3. The CLI polls: session token AND refresh material.
+        r = client.get(f"/auth/cli-poll?ticket={ticket}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["user_id"] == "alice@example.com"
+        refresh = body.get("refresh_token")
+        assert refresh, "cli-poll must include the login-issued refresh token"
+
+        # 4. The refresh token renews into a delegated access token.
+        r = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": refresh}
+        )
+        assert r.status_code == 200, r.text
+        renewed = r.json()
+        assert renewed["access_token"]
+        # Login grants do not rotate — the same refresh token stays valid, so
+        # a lost response cannot brick an unattended host.
+        assert renewed["refresh_token"] == refresh
+        decoded = jwt.decode(renewed["access_token"], _TEST_SECRET, algorithms=["HS256"])
+        assert decoded["sub"] == "alice@example.com"
+        # Revocable (grant_id) but NOT scope-restricted: it renews the session
+        # JWT, so it keeps that authority rather than the delegated allowlist.
+        assert decoded["grant_id"]
+        assert "scope" not in decoded
+
+
+def test_cli_poll_without_grant_store_keeps_legacy_shape(
+    tmp_path: Path,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No grant store wired → the poll response has no refresh_token key
+    (old-server behavior, which new CLIs must tolerate)."""
+    keys = _IdpKeys()
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    admins = tmp_path / "admins"
+    admins.write_text("")
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+
+    pending_id_token: list[str] = [""]
+
+    async def _fake_post(
+        self: httpx.AsyncClient,
+        url: str,
+        *,
+        data: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        return httpx.Response(200, json={"id_token": pending_id_token[0]})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+    monkeypatch.setattr(
+        jwt.PyJWKClient,
+        "get_signing_key_from_jwt",
+        lambda self, token: keys.signing_key,
+    )
+
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(provider, perm_store, AdminList(admins)),
+        prefix="/auth",
+    )
+    with TestClient(app) as client:
+        r = client.post("/auth/cli-login")
+        ticket = r.json()["ticket"]
+        pending_id_token[0] = keys.sign_id_token(
+            {"email": "alice@example.com", "email_verified": True}
+        )
+        state = "state-token-xyz"
+        state_jwt = jwt.encode(
+            {
+                "state": state,
+                "code_verifier": "verifier",
+                "return_to": "/",
+                "ticket": ticket,
+                "exp": int(time.time()) + 300,
+            },
+            _TEST_SECRET,
+            algorithm="HS256",
+        )
+        client.cookies.set(_AUTH_STATE_COOKIE_PLAIN, state_jwt)
+        client.get(f"/auth/callback?code=auth-code&state={state}", follow_redirects=False)
+        r = client.get(f"/auth/cli-poll?ticket={ticket}")
+        assert r.status_code == 200, r.text
+        assert "refresh_token" not in r.json()


### PR DESCRIPTION
## Related issue

Closes #1953

## Summary

Implements login-issued refresh grants so unattended hosts (`omni host --non-interactive`) can renew their session tokens instead of crash-looping when the initial JWT expires. This addresses the common production issue where hosts die permanently post-OIDC-session-expiry with no refresh path.

- **Server**: OIDC callback now persists refresh material and issues a login-scoped renewal grant with a 30-day absolute TTL (reuses the existing device-grant store/rotation machinery)
- **CLI**: `load_token()` calls `refresh_stored_token()` on expiry, minting a fresh session JWT via `POST /oauth/token` with a grant_type=refresh_token
- **Host**: Treats post-connection 401/403 as retryable-with-reauth (attempts token refresh before failing); improves error messaging for expired tokens to guide re-authentication
- **Auth scope fix**: Login grants (first-party, no scope) bypass the delegated-token allowlist and keep full authority; third-party delegated tokens remain scope-restricted (critical security property: refreshed first-party tokens must retain full authority)
- **Scope**: OIDC session-JWT hosts only. Accounts (username/password) unattended hosts have no refresh path and still expire at JWT lifetime — deliberate (matches this ticket's OIDC scope), not a regression.

## Test Plan

**Automated tests run:**

- `tests/server/test_device_auth.py`: 
  - `test_device_grant_routes_absent_by_default()` — verify token/revoke endpoints mount even with device flow disabled
  - `test_client_secret_does_not_gate_refresh_or_revoke()` — confirms refresh/revoke do NOT require the device client secret
  - `test_login_grant_refresh_round_trip()` — a login-issued grant (minted via the CLI-ticket flow, not browser login) yields a refresh token; refreshing returns fresh access token + SAME refresh token (non-rotating for unattended hosts)
  - `test_create_redeemed_grant_refresh_cycle()` — login-issued grants rotate/reuse-detect exactly like device-flow grants
  - `test_device_grant_refresh_stays_scope_restricted()` — third-party device grants still rotate and keep `scope=sessions` (security carve-out test)
  - `test_oauth_token_router_oidc_mode()` — token/revoke router builds and refreshes under OIDC-mode provider

- `tests/cli/test_cli_auth.py` — new coverage for `refresh_stored_token()` and concurrent-refresh lock file behavior

- `tests/server/test_oidc_callback.py`:
  - `test_cli_ticket_fulfillment_issues_refresh_grant()` — end-to-end OIDC ticket → callback (issues grant) → cli-poll (hands refresh_token) → /oauth/token refresh

- `tests/runner/test_runner_entry.py` — updated to call `load_token(..., server_url=...)` with new signature

**Manual e2e verification steps (required for merge):**

A reviewer/maintainer must verify this on a staging environment with real OIDC (e.g., Okta/Auth0):

1. Deploy the branch to a test server with `OMNIGENT_AUTH_PROVIDER=oidc` and an external IdP configured.
2. Run an unattended host: `OMNIGENT_SERVER_URL=https://your-server.com omni host --non-interactive` after first logging in once with `omnigent login`.
3. Confirm the host connects and stays running.
4. Manually expire the stored session JWT by editing `~/.omnigent/auth_tokens.json` (set `expires_at` to `time.time() - 1`).
5. **Expected outcome**: The host detects the expired token on the next reconnect attempt, calls `refresh_stored_token()`, receives a fresh access token from `/oauth/token`, and reconnects successfully WITHOUT requiring manual re-login or crashing.
6. Verify logs show "refreshed" or similar in the auth flow (no error loop).
7. Force-kill the host and restart it; confirm it refreshes and reconnects on startup.

## Demo

N/A (backend/auth)

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

**Automated:** unit + integration tests cover grant issuance, the `/oauth/token` refresh cycle (device grants rotate; login grants deliberately do not), scope restriction, and the corrupt-file / lifetime / error paths. A runner-entry test covers the load->refresh->fallback auth-token factory that keeps a host alive across expiry.

**Manual (performed):** booted the real server app on a loopback socket and drove the actual `cli_auth.refresh_stored_token` end to end — an expired stored session JWT was auto-refreshed against the live `/oauth/token`, the fresh token was persisted, and it authenticated a protected request (`GET /v1/hosts` -> 200); the login-grant refresh token correctly did not rotate. This reproduces and confirms the unattended-host crash-loop recovery at the server + CLI level.

**Remaining (recommended on staging — needs external infra, not reproducible here):** a real external OIDC IdP login plus a long-running `omni host --non-interactive` tunnel surviving a live session-JWT expiry.

## Changelog

OIDC/SSO unattended hosts no longer crash on session-JWT expiry; they now automatically refresh their credentials within a 30-day login window. (Accounts username/password hosts are unchanged — this refresh path is OIDC-only.)

---

This pull request and its description were written by Isaac.



