### PR TITLE
fix(pi): make DeepSeek work by asking the gateway for no reasoning

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -58,6 +58,7 @@ from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from
 from omnigent.model_metadata import ModelWireAPI
 from omnigent.onboarding.provider_config import CHAT_WIRE_API, RESPONSES_WIRE_API
 from omnigent.pi_model_compatibility import (
+    PI_REASONING_OFF_LEVEL_MAP,
     SYSTEM_AI_RESPONSES_KEYWORDS,
     databricks_model_aliases,
     enrich_databricks_model_catalog,
@@ -808,7 +809,10 @@ def _build_models_json(
                     "supportsDeveloperRole": False,
                     "supportsStore": False,
                     "supportsStrictMode": False,
-                    "supportsReasoningEffort": False,
+                    # Gates reasoning_effort, which Pi sends only for entries
+                    # declaring reasoning: true — today just DeepSeek, whose
+                    # unreadable reasoning channel this switches off.
+                    "supportsReasoningEffort": True,
                     "supportsUsageInStreaming": False,
                 },
                 "models": provider_models["databricks-mlflow"],
@@ -824,7 +828,9 @@ def _build_models_json(
                     "supportsDeveloperRole": False,
                     "supportsStore": False,
                     "supportsStrictMode": False,
-                    "supportsReasoningEffort": False,
+                    # See the mlflow provider above: reaches only reasoning: true
+                    # entries, where it turns the unreadable channel off.
+                    "supportsReasoningEffort": True,
                     # Gemini/Qwen/Llama/inkling models reject stream_options
                     # (which carries include_usage) with 400 "unknown field".
                     "supportsUsageInStreaming": False,
@@ -856,6 +862,7 @@ def _build_models_json(
             entry: _JsonObject = {"id": model, "input": ["text", "image"]}
             if pi_model_is_reasoning(model):
                 entry["reasoning"] = True
+                entry["thinkingLevelMap"] = dict(PI_REASONING_OFF_LEVEL_MAP)
             provider["models"] = [*provider["models"], entry]
     return config
 

--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -17,13 +17,20 @@ if TYPE_CHECKING:
 SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "glm-")
 
 
+# Pi's openai-completions reader appends ``delta.content`` with ``+=``, so an
+# endpoint streaming typed-array content renders as ``[object Object]``. Gemini
+# 2.5 and gpt-oss stream it on every wire they offer; DeepSeek streams reasoning
+# as ``content: [{"type": "reasoning", ...}]`` and offers no Responses fallback.
+PI_UNPARSEABLE_MODEL_FRAGMENTS: tuple[str, ...] = ("gemini-2-5", "gpt-oss", "deepseek")
+
+
 def unsupported_in_pi(model_id_lower: str) -> bool:
     """Return whether Pi cannot parse the model's response content.
 
-    These endpoints return typed-array content that Pi renders as
-    ``[object Object]``; their available alternate wires do not fix it.
+    :param model_id_lower: A lowercased model id.
+    :returns: ``True`` when no wire the model offers yields parseable content.
     """
-    return "gemini-2-5" in model_id_lower or "gpt-oss" in model_id_lower
+    return any(fragment in model_id_lower for fragment in PI_UNPARSEABLE_MODEL_FRAGMENTS)
 
 
 class DatabricksPiSurface(Enum):
@@ -70,9 +77,10 @@ def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
     return DatabricksPiSurface.COMPLETIONS
 
 
-# DeepSeek streams its chain of thought on ``reasoning_content``; Pi only reads
-# that channel when the model entry sets ``reasoning``. GLM/kimi/inkling route
-# through the Responses API instead and do not need it.
+# Pi only reads a reasoning channel when the model entry sets ``reasoning``.
+# Reaches only an explicitly forced ``-m`` selection now that DeepSeek is
+# unparseable above: the gateway streams its reasoning as typed-array content
+# rather than ``reasoning_content``, which the flag does not make readable.
 PI_REASONING_MODEL_FRAGMENTS: tuple[str, ...] = ("deepseek",)
 
 

--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -18,10 +18,10 @@ SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "gl
 
 
 # Pi's openai-completions reader appends ``delta.content`` with ``+=``, so an
-# endpoint streaming typed-array content renders as ``[object Object]``. Gemini
-# 2.5 and gpt-oss stream it on every wire they offer; DeepSeek streams reasoning
-# as ``content: [{"type": "reasoning", ...}]`` and offers no Responses fallback.
-PI_UNPARSEABLE_MODEL_FRAGMENTS: tuple[str, ...] = ("gemini-2-5", "gpt-oss", "deepseek")
+# endpoint streaming typed-array content renders as ``[object Object]``. These
+# stream it on every wire they offer, and unlike DeepSeek they expose no way to
+# turn the offending channel off. See :data:`PI_REASONING_OFF_LEVEL_MAP`.
+PI_UNPARSEABLE_MODEL_FRAGMENTS: tuple[str, ...] = ("gemini-2-5", "gpt-oss")
 
 
 def unsupported_in_pi(model_id_lower: str) -> bool:
@@ -77,11 +77,19 @@ def databricks_pi_surface_for_model(model_id: str) -> DatabricksPiSurface:
     return DatabricksPiSurface.COMPLETIONS
 
 
-# Pi only reads a reasoning channel when the model entry sets ``reasoning``.
-# Reaches only an explicitly forced ``-m`` selection now that DeepSeek is
-# unparseable above: the gateway streams its reasoning as typed-array content
-# rather than ``reasoning_content``, which the flag does not make readable.
+# DeepSeek's chat surface streams reasoning as typed-array content, which Pi
+# concatenates into ``[object Object]``, and it serves no Responses wire. The
+# gateway does suppress that channel for ``reasoning_effort: "none"``, leaving
+# plain string content Pi reads correctly.
 PI_REASONING_MODEL_FRAGMENTS: tuple[str, ...] = ("deepseek",)
+
+# Pi sends ``reasoning_effort`` only for an entry with ``reasoning: true`` under a
+# provider whose compat sets ``supportsReasoningEffort``, taking the value from
+# this map. Every level maps to "none" on purpose: mapping only "off" would let a
+# user's thinking level put the unreadable channel back.
+PI_REASONING_OFF_LEVEL_MAP: dict[str, str] = dict.fromkeys(
+    ("off", "minimal", "low", "medium", "high", "xhigh"), "none"
+)
 
 
 class PiModelEntry(TypedDict):
@@ -90,6 +98,7 @@ class PiModelEntry(TypedDict):
     id: str
     input: NotRequired[list[str]]
     reasoning: NotRequired[bool]
+    thinkingLevelMap: NotRequired[dict[str, str]]
     # Omitted when the catalog reports no limit; Pi then applies its own
     # defaults (128000 / 16384).
     contextWindow: NotRequired[int]
@@ -97,10 +106,10 @@ class PiModelEntry(TypedDict):
 
 
 def pi_model_is_reasoning(model_id: str) -> bool:
-    """Return whether *model_id* needs Pi's ``reasoning: true`` model flag.
+    """Return whether *model_id* needs Pi's reasoning model flags.
 
     :param model_id: A model id, e.g. ``"system.ai.deepseek-v3"``.
-    :returns: ``True`` when Pi must read the reasoning channel.
+    :returns: ``True`` when Pi must be told the model reasons.
     """
     lower = model_id.lower()
     return any(fragment in lower for fragment in PI_REASONING_MODEL_FRAGMENTS)
@@ -130,6 +139,7 @@ def pi_model_json_entry(model: ModelEntry) -> PiModelEntry:
         entry["maxTokens"] = model.metadata.max_output_tokens
     if pi_model_is_reasoning(model.id):
         entry["reasoning"] = True
+        entry["thinkingLevelMap"] = dict(PI_REASONING_OFF_LEVEL_MAP)
     return entry
 
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -51,11 +51,13 @@ from omnigent.onboarding.provider_config import (
     load_config,
 )
 from omnigent.pi_model_compatibility import (
+    PI_REASONING_OFF_LEVEL_MAP,
     SYSTEM_AI_RESPONSES_KEYWORDS,
     DatabricksPiSurface,
     PiModelEntry,
     databricks_pi_surface_for_model,
     enrich_databricks_model_catalog,
+    pi_model_is_reasoning,
     pi_model_json_entry,
     unsupported_in_pi,
 )
@@ -333,10 +335,9 @@ class PiProviderConfig:
         """Add the selected model to *additional* under *surface*'s provider."""
         provider_id = _SURFACE_PROVIDER_IDS[surface]
         entry: _PiModelEntry = {"id": self.model, "input": ["text", "image"]}
-        # DeepSeek streams on reasoning_content; Pi only reads that channel when
-        # the model entry declares reasoning.
-        if "deepseek" in self.model.lower():
+        if pi_model_is_reasoning(self.model):
             entry["reasoning"] = True
+            entry["thinkingLevelMap"] = dict(PI_REASONING_OFF_LEVEL_MAP)
         existing = additional.get(provider_id)
         if existing is not None:
             # Copy rather than mutate: the payload is shared with
@@ -484,7 +485,10 @@ def _databricks_openai_provider(
             "supportsDeveloperRole": False,
             "supportsStore": False,
             "supportsStrictMode": False,
-            "supportsReasoningEffort": False,
+            # Gates reasoning_effort, which Pi sends only for entries declaring
+            # reasoning: true — today just DeepSeek, whose unreadable reasoning
+            # channel this switches off via its thinkingLevelMap.
+            "supportsReasoningEffort": True,
             # stream_options is OpenAI-specific; Gemini and other non-OpenAI
             # models reject it with 400.
             "supportsUsageInStreaming": False,

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1322,6 +1322,7 @@ def _databricks_provider_without_catalog(
         ("system.ai.gemini-3-5-flash", "omnigent-mlflow", "openai-completions"),
         ("databricks-gemini-3-5-flash", "omnigent-completions", "openai-completions"),
         ("databricks-llama-4-maverick", "omnigent-completions", "openai-completions"),
+        ("databricks-deepseek-v3", "omnigent-completions", "openai-completions"),
     ],
 )
 def test_uncataloged_non_claude_model_routed_by_family(
@@ -1345,21 +1346,25 @@ def test_uncataloged_non_claude_model_routed_by_family(
     assert provider.unroutable_model_warning() is None
 
 
-def test_deepseek_is_refused_with_user_warning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DeepSeek is left unregistered rather than answering ``[object Object]``.
+def test_deepseek_pins_reasoning_effort_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DeepSeek asks the gateway for no reasoning, so Pi gets readable content.
 
-    The gateway streams its reasoning as typed-array ``delta.content``, which Pi
-    concatenates into one ``[object Object]`` per token, and it serves no
-    Responses wire to fall back to ("responses API is not enabled").
+    Its chat surface streams reasoning as typed-array ``delta.content`` that Pi
+    concatenates into ``[object Object]``, and it serves no Responses wire. Pi
+    only sends ``reasoning_effort`` for an entry declaring ``reasoning``, and
+    takes the value from ``thinkingLevelMap``; every level maps to "none" so a
+    user's thinking level cannot put the unreadable channel back.
     """
     provider = _databricks_provider_without_catalog(monkeypatch, "databricks-deepseek-v3")
 
     cfg = provider.to_models_config()
-    assert cfg["providers"]["omnigent"]["models"] == []
-    assert list(cfg["providers"]) == ["omnigent"]
-    warning = provider.unroutable_model_warning()
-    assert warning is not None
-    assert "databricks-deepseek-v3" in warning
+    completions = cfg["providers"]["omnigent-completions"]
+    assert completions["compat"]["supportsReasoningEffort"] is True
+    entry = completions["models"][0]
+    assert entry.get("reasoning") is True
+    assert set(entry["thinkingLevelMap"].values()) == {"none"}
+    assert "off" in entry["thinkingLevelMap"] and "high" in entry["thinkingLevelMap"]
+    assert provider.unroutable_model_warning() is None
 
 
 def test_uncataloged_claude_model_stays_on_primary(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1322,7 +1322,6 @@ def _databricks_provider_without_catalog(
         ("system.ai.gemini-3-5-flash", "omnigent-mlflow", "openai-completions"),
         ("databricks-gemini-3-5-flash", "omnigent-completions", "openai-completions"),
         ("databricks-llama-4-maverick", "omnigent-completions", "openai-completions"),
-        ("databricks-deepseek-v3", "omnigent-completions", "openai-completions"),
     ],
 )
 def test_uncataloged_non_claude_model_routed_by_family(
@@ -1346,15 +1345,21 @@ def test_uncataloged_non_claude_model_routed_by_family(
     assert provider.unroutable_model_warning() is None
 
 
-def test_uncataloged_deepseek_declares_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DeepSeek streams on reasoning_content; Pi needs ``reasoning: true``.
+def test_deepseek_is_refused_with_user_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DeepSeek is left unregistered rather than answering ``[object Object]``.
 
-    Without the flag Pi sees empty content and the turn never completes.
+    The gateway streams its reasoning as typed-array ``delta.content``, which Pi
+    concatenates into one ``[object Object]`` per token, and it serves no
+    Responses wire to fall back to ("responses API is not enabled").
     """
     provider = _databricks_provider_without_catalog(monkeypatch, "databricks-deepseek-v3")
 
-    entry = provider.to_models_config()["providers"]["omnigent-completions"]["models"][0]
-    assert entry.get("reasoning") is True
+    cfg = provider.to_models_config()
+    assert cfg["providers"]["omnigent"]["models"] == []
+    assert list(cfg["providers"]) == ["omnigent"]
+    warning = provider.unroutable_model_warning()
+    assert warning is not None
+    assert "databricks-deepseek-v3" in warning
 
 
 def test_uncataloged_claude_model_stays_on_primary(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Related issue

No Omnigent issue filed. Reported in Slack; upstream root cause is
[earendil-works/pi#7062](https://github.com/earendil-works/pi/issues/7062) (still open).

Closes #

## Summary

DeepSeek turns in Pi answered with a wall of `[object Object]` before the real reply. This makes
DeepSeek work rather than hiding it.

- **Cause.** Databricks chat completions streams DeepSeek's reasoning as a typed array:
  `delta.content = [{"type": "reasoning", "summary": [{"text": "We", "type": "summary_text"}]}]`.
  Pi's `openai-completions` reader does `currentBlock.text += choice.delta.content`
  (`openai-completions.js:171`), so each reasoning token coerces to `[object Object]`. An array of
  length 1 sails through the `.length > 0` guard.
- **No surface to route to.** The Responses wire answers *"The responses API is not enabled for
  model `system.ai.deepseek-v4-flash-0731`"*, and the `/serving-endpoints` alias streams the same
  array content. Omnigent has no interception point either: `models.json` only hands Pi a base URL
  and a token.
- **But the channel has an off switch.** `reasoning_effort: "none"` suppresses it and returns plain
  string content with `finish_reason: stop`.

Pi sends `reasoning_effort` only when three things hold at once, all of them ours to set:

| Pi requirement | Where Omnigent sets it |
| --- | --- |
| entry declares `reasoning: true` | `pi_model_json_entry` (already did) |
| provider `compat.supportsReasoningEffort` | the mlflow + completions provider blocks |
| value read from `thinkingLevelMap` | new `PI_REASONING_OFF_LEVEL_MAP` on the entry |

Every thinking level maps to `"none"`, not just `off`, because mapping only `off` would let a user's
thinking level put the unreadable channel back.

<details>
<summary>Why the compat flip is contained</summary>

`supportsReasoningEffort` is read in exactly two places in Pi (`openai-completions.js:442` and
`:446`), and **both** also require `model.reasoning`. Only DeepSeek gets `reasoning: true` from
`pi_model_is_reasoning`, so no other model on those providers changes behaviour.

```
gateway   delta.content = [{type: "reasoning", summary: [{text: "We"}]}]
                          |
Pi        block.text += <array>          -> "[object Object]" x N, then "ACK"

with reasoning_effort: "none"
gateway   delta.content = "ACK"          (string, finish_reason stop)
                          |
Pi        block.text += "ACK"            -> "ACK"
```
</details>

The trade is DeepSeek's visible reasoning, which Pi cannot render here anyway. It stays a usable
chat model rather than a hidden or garbled one.

Both surfaces that render a `models.json` now derive these flags from `pi_model_is_reasoning`. The
native path had inlined its own `"deepseek" in model` check, which is how it drifted from the shared
helper in the first place.

## Test Plan

```bash
pytest tests/test_pi_native_credentials.py tests/test_model_catalog.py tests/inner/test_pi_executor.py
# 310 passed
```

**End to end with real Pi (0.73.0) against the real gateway**, driven by the `models.json` this
branch generates, same prompt both times:

```
config                                    [object Object] count   assistant text
main today (supportsReasoningEffort off)             222          "[object Object][object Object]..."
this branch, default thinking                          0          "ACK"
this branch, --thinking high                           0          "ACK"
```

```bash
# reproduce: generate omnigent's own models.json, then drive real Pi through it
PI_CODING_AGENT_DIR=<dir with generated models.json> \
  pi -p "Reply with exactly: ACK" --provider databricks-completions \
     --model databricks-deepseek-v4-flash-0731 --no-tools --no-session --mode json < /dev/null
```

Generated entry and compat for DeepSeek:

```json
{"id": "databricks-deepseek-v4-flash-0731", "input": ["text", "image"], "reasoning": true,
 "thinkingLevelMap": {"off": "none", "minimal": "none", "low": "none",
                      "medium": "none", "high": "none", "xhigh": "none"}}
compat: {"supportsReasoningEffort": true, ...}
```

Gateway probes behind the reasoning above (profile `ai-oss`):

```bash
# array content on chat completions (the bug)
databricks api post /ai-gateway/mlflow/v1/chat/completions --profile ai-oss \
  --json '{"model":"system.ai.deepseek-v4-flash-0731","messages":[{"role":"user","content":"say ACK"}],"stream":true,"max_tokens":40}'
# -> "delta":{"content":[{"summary":[{"text":"We","type":"summary_text"}],"type":"reasoning"}]}

# no Responses wire to route to instead
databricks api post /ai-gateway/codex/v1/responses --profile ai-oss --json '{"model":"system.ai.deepseek-v4-flash-0731","input":"say ACK","stream":true}'
# -> Error: The responses API is not enabled for model 'system.ai.deepseek-v4-flash-0731'.

# the off switch
databricks api post /serving-endpoints/chat/completions --profile ai-oss \
  --json '{"model":"databricks-deepseek-v4-flash-0731","messages":[{"role":"user","content":"say ACK"}],"stream":true,"max_tokens":48,"reasoning_effort":"none"}'
# -> 0 array chunks, "content":"ACK", finish_reason stop
```

Also probed and rejected: `thinking: {type: "disabled"}`, `chat_template_kwargs: {thinking: false}`,
and `reasoning: {enabled: false}` are all ignored by the endpoint (23, 23, and 19 array chunks
respectively). `reasoning_effort: "none"` is the only one that works, which is why the fix goes
through `thinkingLevelMap` rather than a `thinkingFormat`.

## Demo

`N/A` (non-visual). The behavioural before/after is the count table above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests pin the generated flags (`reasoning`, every `thinkingLevelMap` value, and the provider's
`supportsReasoningEffort`) so the routing cannot silently regress. They cannot observe the gateway's
wire behaviour, so that was verified live: the array-content repro, the absent Responses wire, the
three parameter spellings the endpoint ignores, and finally a real Pi run against Omnigent's own
generated `models.json` going from 222 `[object Object]` to zero at two thinking levels.

**Not verified:** the interactive TUI path. `pi_native_credentials.py` carries a comment that in TUI
mode Pi applies the session thinking level before the compat check, which previously caused gateway
400s and is why `defaultThinkingLevel` is suppressed there. The headless path is what these runs
cover, so a reviewer running `omnigent pi -m system.ai.deepseek-v3` interactively is worth having.

## Changelog

DeepSeek models work in the Pi harness again instead of answering with a wall of `[object Object]`.

---

### Follow-up investigated, hypothesis disproved

An earlier revision of this description flagged the catalog parser's Responses match as a latent bug
affecting roughly 35 models. Probing disproved it; recorded so it is not retried:

`omnigent/model_catalog.py` matches the Responses surface on the exact `openai/v1/responses`
spelling while matching chat by substring, and workspaces do advertise a second spelling,
`mlflow/v1/responses`. But only **10** models would change provider (not ~35: Claude is caught by an
earlier branch and `gpt-5*` already uses the `openai/` spelling), and **all 10 are rejected** by the
Responses surface with *"The responses API is not enabled"* (all eight `gemini-3-*` variants,
`gemma-3-12b`, `llama-4-maverick`) while streaming clean string content on chat completions today.
Widening the match would move ten working models onto a surface that refuses them, so the exact
match is load-bearing: `supported_api_types` does not distinguish a real Responses passthrough from
an mlflow-internal route.

The probe did surface one real win, sent as #4749 stacked on this PR: `gpt-oss` is broken only on
chat completions and answers correctly on Responses, so it is routed there instead of hidden.

This pull request and its description were written by Isaac.
