### PR TITLE
fix(pi): serve gpt-oss over Responses instead of hiding it from Pi

### DIFF
--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -12,16 +12,25 @@ from omnigent.model_metadata import ModelMetadata
 if TYPE_CHECKING:
     from omnigent.model_catalog import ModelEntry
 
-# These system models omit the finish reason Pi requires on Chat Completions.
-# ``glm-`` avoids matching vendor-direct ids without a system.ai alias.
-SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "glm-")
+# These system models omit the finish reason Pi requires on Chat Completions, or
+# stream typed-array content there. Probed: the gateway's Responses surface
+# answers each of these with plain ``output_text``/``reasoning_text`` and real
+# ``function_call`` items. ``glm-`` avoids matching vendor-direct ids without a
+# system.ai alias.
+SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = (
+    "kimi",
+    "inkling",
+    "qwen3",
+    "glm-",
+    "gpt-oss",
+)
 
 
 # Pi's openai-completions reader appends ``delta.content`` with ``+=``, so an
-# endpoint streaming typed-array content renders as ``[object Object]``. Gemini
-# 2.5 and gpt-oss stream it on every wire they offer; DeepSeek streams reasoning
-# as ``content: [{"type": "reasoning", ...}]`` and offers no Responses fallback.
-PI_UNPARSEABLE_MODEL_FRAGMENTS: tuple[str, ...] = ("gemini-2-5", "gpt-oss", "deepseek")
+# endpoint streaming typed-array content renders as ``[object Object]``. Both of
+# these stream it there and offer no Responses surface to fall back to: that
+# surface reports Gemini 2.5 unavailable and DeepSeek "not enabled".
+PI_UNPARSEABLE_MODEL_FRAGMENTS: tuple[str, ...] = ("gemini-2-5", "deepseek")
 
 
 def unsupported_in_pi(model_id_lower: str) -> bool:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1322,6 +1322,9 @@ def _databricks_provider_without_catalog(
         ("system.ai.gemini-3-5-flash", "omnigent-mlflow", "openai-completions"),
         ("databricks-gemini-3-5-flash", "omnigent-completions", "openai-completions"),
         ("databricks-llama-4-maverick", "omnigent-completions", "openai-completions"),
+        # Probed: chat completions streams typed-array content for gpt-oss, while
+        # Responses answers with output_text/reasoning_text and function_call.
+        ("system.ai.gpt-oss-120b", "omnigent-openai", "openai-responses"),
     ],
 )
 def test_uncataloged_non_claude_model_routed_by_family(


### PR DESCRIPTION
## Related issue

No Omnigent issue filed. Found while investigating the DeepSeek `[object Object]` report that
#4746 fixes; this PR is **stacked on #4746** and targets its branch, so merge that one first.

Closes #

## Summary

`gpt-oss` was hidden from Pi entirely. It does not need to be: only its *chat completions* surface
is unparseable, and it has a working Responses surface.

- Chat completions streams gpt-oss reasoning as typed-array `delta.content`, which Pi's
  `openai-completions` reader concatenates into `[object Object]`. That is why it was excluded.
- The gateway's Responses surface does **not** share the flaw. Probed live: `system.ai.gpt-oss-120b`
  and `-20b` both answer with plain `output_text` / `reasoning_text`, and with tools present emit
  real `function_call` items and no array content, matching `kimi-k3` exactly on the surface kimi
  already uses in production.
- So route them like `kimi` / `glm` / `inkling` / `qwen3` instead of dropping them. Two models come
  back to Pi users.

Gemini 2.5 stays excluded: its Responses surface reports the model unavailable, and its chat
endpoint is **deprecated** in the workspaces checked (`BAD_REQUEST: This endpoint
databricks-gemini-2-5-pro is deprecated`).

## Test Plan

```bash
pytest tests/test_pi_native_credentials.py tests/test_model_catalog.py tests/inner/test_pi_executor.py
# 310 passed
```

Live probes against the AI Gateway (profile `ai-oss`), tools present, which is the case upstream
[pi#7062](https://github.com/earendil-works/pi/issues/7062) calls out as the trigger:

```
model                     codex /responses                                        mlflow /chat/completions
system.ai.gpt-oss-120b    OK  output_text + reasoning_text + function_call        ARRAY content (breaks Pi)
system.ai.gpt-oss-20b     OK  output_text + reasoning_text + function_call        ARRAY content (breaks Pi)
system.ai.kimi-k3         OK  output_text + reasoning_text + function_call        (control: already routed here)
```

Routing over the live 48-model workspace catalog, before and after:

```
before (this branch's base): 48 entries -> 45 kept, 3 dropped   (gemini-2-5 x2, gpt-oss x2)
after:                       48 entries -> 46 kept, 2 dropped   (gemini-2-5 x2)

system.ai.gpt-oss-120b    -> databricks-openai   (Responses)   <-- was DROPPED
system.ai.gpt-oss-20b     -> databricks-openai   (Responses)   <-- was DROPPED
system.ai.kimi-k3         -> databricks-openai   (unchanged)
system.ai.gemini-3-5-flash -> databricks-mlflow  (unchanged)
system.ai.llama-4-maverick -> databricks-mlflow  (unchanged)
```

## Demo

`N/A` (non-visual; the user-visible effect is two models reappearing in the Pi model picker, covered
by the routing table above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The claim this PR rests on is about the gateway's wire behaviour, which unit tests cannot observe,
so it was verified live: both gpt-oss models were probed on the Responses surface with a function
tool attached and returned `error: null`, `function_call`, and `reasoning_text` with no array
content, identical to the `kimi-k3` control already routed there. The unit test added to
`test_uncataloged_non_claude_model_routed_by_family` pins the resulting provider and API so the
routing cannot silently regress.

## Changelog

`gpt-oss` models are available in the Pi harness again, served over the Responses API instead of
being hidden.

---

### Correction to a follow-up noted in #4746

#4746's description originally flagged the catalog parser's Responses match as a latent bug
affecting roughly 35 models. Investigating it **disproved that**, and the numbers were wrong.
#4746 has since been corrected; repeated here because this PR is where the probing happened:

- Only **10** models would actually change provider, not ~35 (Claude is caught by an earlier
  `"claude"` branch, and the `gpt-5*` family already uses the `openai/` spelling).
- All 10 are rejected by the Responses surface: **"The responses API is not enabled"** for all eight
  `gemini-3-*` variants, `gemma-3-12b`, and `llama-4-maverick`, despite each advertising
  `mlflow/v1/responses`.
- All 10 stream clean *string* `delta.content` on chat completions today, so they work as routed.

Widening the match would move ten working models onto a surface that refuses them. The exact-
spelling match is **load-bearing**: `supported_api_types` does not distinguish a real Responses
passthrough at the codex gateway from an mlflow-internal route.
`SYSTEM_AI_RESPONSES_KEYWORDS` encodes per-model gateway facts the catalog does not express.

`gpt-oss` moving into that keyword list, which this PR does, is the one change the probe supported.

This pull request and its description were written by Isaac.
