### PR TITLE
fix(web): self-heal the chat stream when it dies silently

### DIFF
--- a/tests/e2e_ui/chat/test_stale_stream.py
+++ b/tests/e2e_ui/chat/test_stale_stream.py
@@ -19,10 +19,13 @@ import re
 import signal
 import subprocess
 import time
+from urllib.parse import urlparse
 
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import _server_state, configure_mock_llm
 
 
 def _find_runner_pids() -> list[int]:
@@ -122,3 +125,106 @@ def test_stale_banner_on_runner_crash(
     indicator = page.locator('[data-testid="disconnected-indicator"]')
     expect(indicator).to_be_visible(timeout=20_000)
     expect(indicator).to_contain_text("disconnected")
+
+
+def test_silent_stream_stall_self_heals(
+    page: Page,
+    seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """
+    Freeze the server mid-view so the chat stream goes byte-silent
+    without closing, and assert the client notices and reconnects.
+
+    SIGSTOP models the half-open socket an app ingress leaves behind
+    when it reaps an idle connection without a close frame: heartbeats
+    stop but the client's ``reader.read()`` never resolves. The 45 s
+    stall guard must declare the transport dead (console warning) and
+    issue a fresh ``/stream`` open — without the guard the tab waits
+    forever and only a manual reload recovers. After SIGCONT the
+    reconnect completes and a real turn must still round-trip.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` of a pre-created
+        session bound to the running runner.
+    :param mock_llm_server_url: Mock LLM base URL, to script the
+        post-recovery turn.
+    """
+    live_server, session_id = seeded_session
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "back from the stall"}],
+        key="silent-stall-recover",
+        match="Say hello",
+    )
+    stream_path = f"/v1/sessions/{session_id}/stream"
+
+    # Listeners attach before goto so the initial open can't be missed.
+    stream_opens: list[str] = []
+    stall_warnings: list[str] = []
+    page.on(
+        "request",
+        lambda req: (
+            stream_opens.append(req.url) if urlparse(req.url).path == stream_path else None
+        ),
+    )
+    page.on(
+        "console",
+        lambda msg: stall_warnings.append(msg.text) if "no stream bytes" in msg.text else None,
+    )
+
+    page.goto(f"{live_server}/c/{session_id}")
+    expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
+    for _ in range(100):
+        if stream_opens:
+            break
+        page.wait_for_timeout(100)
+    assert stream_opens, "the chat page never opened its live stream"
+
+    # Freeze the whole server process: the established stream stays open
+    # but goes byte-silent — no events, no heartbeats, no close.
+    server_pid = int(_server_state["pid"])
+    os.kill(server_pid, signal.SIGSTOP)
+    try:
+        # The stall guard trips after 45 s of silence; poll to 70 s.
+        # wait_for_timeout (not time.sleep) keeps dispatching this
+        # page's console/request callbacks while we wait.
+        for _ in range(700):
+            if stall_warnings:
+                break
+            page.wait_for_timeout(100)
+    finally:
+        os.kill(server_pid, signal.SIGCONT)
+    assert stall_warnings, (
+        "the client never declared the byte-silent stream dead within 70s -- "
+        "without the stall guard it blocks in reader.read() forever and the "
+        "transcript freezes until a manual reload"
+    )
+
+    # The recycle issues a fresh /stream open (it may have been pending
+    # since the freeze — the request itself is the reconnect signal).
+    for _ in range(150):
+        if len(stream_opens) >= 2:
+            break
+        page.wait_for_timeout(100)
+    assert len(stream_opens) >= 2, "the stall guard tripped but no reconnect was attempted"
+
+    # The freeze also severed the runner tunnel; wait for it to
+    # re-register before proving the chat is usable end-to-end.
+    runner_id = str(_server_state["runner_id"])
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            status = httpx.get(f"{live_server}/v1/runners/{runner_id}/status", timeout=2)
+            if status.status_code == 200 and status.json().get("online") is True:
+                break
+        except httpx.HTTPError:
+            pass
+        page.wait_for_timeout(500)
+
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    composer.fill("Say hello")
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(
+        page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    ).to_be_visible(timeout=15_000)

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -1,8 +1,80 @@
-// Vitest cases for `parseEvent` — the raw-SSE-JSON → typed-event mapping.
+// Vitest cases for `parseEvent` — the raw-SSE-JSON → typed-event mapping —
+// and `withStallGuard` — the byte-level silence watchdog.
 
-import { describe, expect, it } from "vitest";
-import { parseEvent } from "./sse";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseEvent, withStallGuard } from "./sse";
 import type { SessionStatusEvent, SessionSupersededEvent, TextDelta } from "./events";
+
+describe("withStallGuard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** An upstream byte stream the test feeds, plus a cancel probe. */
+  function upstream(): {
+    stream: ReadableStream<Uint8Array>;
+    push: (s: string) => void;
+    cancelled: () => boolean;
+  } {
+    let ctrl: ReadableStreamDefaultController<Uint8Array> | null = null;
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        ctrl = c;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    return {
+      stream,
+      push: (s) => ctrl!.enqueue(new TextEncoder().encode(s)),
+      cancelled: () => cancelled,
+    };
+  }
+
+  it("passes chunks through while bytes flow, then trips on silence", async () => {
+    const up = upstream();
+    let stalled = 0;
+    const reader = withStallGuard(up.stream, {
+      stallMs: 1_000,
+      onStall: () => (stalled += 1),
+    }).getReader();
+
+    // Bytes inside the window pass through and re-arm the timer.
+    up.push("a");
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("a");
+    await vi.advanceTimersByTimeAsync(900);
+    up.push("b");
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("b");
+    expect(stalled).toBe(0);
+
+    // Silence past the window: the upstream is cancelled and the guarded
+    // stream ends cleanly (done, not an error) — the same shape as a
+    // transport drop, which consumers answer with a reconnect.
+    const pending = reader.read();
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect((await pending).done).toBe(true);
+    expect(stalled).toBe(1);
+    expect(up.cancelled()).toBe(true);
+  });
+
+  it("propagates a consumer cancel upstream without tripping", async () => {
+    const up = upstream();
+    let stalled = 0;
+    const guarded = withStallGuard(up.stream, { stallMs: 1_000, onStall: () => (stalled += 1) });
+
+    await guarded.cancel();
+    expect(up.cancelled()).toBe(true);
+
+    // The armed timer was cleared: silence after cancel is not a stall.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(stalled).toBe(0);
+  });
+});
 
 describe("parseEvent — response.output_text.delta", () => {
   it("parses a plain delta with no streaming identifiers", () => {

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -79,6 +79,86 @@ export interface SseStreamResult {
   sawDone: boolean;
 }
 
+// The server heartbeats the session live-tail every 15 s of queue idleness
+// (`_SESSION_STREAM_HEARTBEAT_INTERVAL_S`), so a healthy connection is never
+// byte-silent for long. `fetch` has no read timeout: on a half-open socket
+// (laptop sleep, network path change, a proxy reaping the connection without
+// a close) `reader.read()` blocks forever and the transcript silently
+// freezes. Three missed heartbeats in a row trip the guard; one late
+// heartbeat doesn't.
+export const SSE_STALL_TIMEOUT_MS = 45_000;
+
+/**
+ * Wrap an SSE byte stream with a silence watchdog.
+ *
+ * Chunks pass through unchanged; a stall timer is armed while a read is
+ * pending on the wire. If no bytes arrive within `stallMs` the upstream
+ * reader is cancelled, which ends the wrapped stream cleanly — consumers
+ * see the same shape as a transport drop without `[DONE]`, so the chat
+ * pump's reconnect loop answers with its usual re-subscribe + snapshot
+ * reconcile.
+ *
+ * @param source The fetch response body to guard.
+ * @param opts.stallMs Silence window before the stream is declared dead;
+ *   defaults to {@link SSE_STALL_TIMEOUT_MS}.
+ * @param opts.onActivity Called on every received chunk — a liveness stamp
+ *   for callers that want to judge staleness on external signals (tab
+ *   visibility, network regained) without waiting out the full window.
+ * @param opts.onStall Called once when the guard trips.
+ * @returns The guarded stream to consume in place of `source`.
+ */
+export function withStallGuard(
+  source: ReadableStream<Uint8Array>,
+  opts: { stallMs?: number; onActivity?: () => void; onStall?: () => void } = {},
+): ReadableStream<Uint8Array> {
+  const stallMs = opts.stallMs ?? SSE_STALL_TIMEOUT_MS;
+  const reader = source.getReader();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      // Cancelling the reader resolves the pending read as `done`, which
+      // closes the wrapped stream through the normal path below.
+      timer = setTimeout(() => {
+        timer = null;
+        opts.onStall?.();
+        reader.cancel().catch(() => {});
+      }, stallMs);
+      let result: ReadableStreamReadResult<Uint8Array>;
+      try {
+        result = await reader.read();
+      } catch (err) {
+        clearTimer();
+        reader.releaseLock();
+        controller.error(err);
+        return;
+      }
+      clearTimer();
+      if (result.done) {
+        // Release the source on every terminal path: a consumer that
+        // re-reads the same body (a rebind against a mocked response)
+        // must find it unlocked, exactly as it did before the guard
+        // sat between it and the raw stream.
+        reader.releaseLock();
+        controller.close();
+        return;
+      }
+      opts.onActivity?.();
+      controller.enqueue(result.value);
+    },
+    async cancel(reason) {
+      clearTimer();
+      await reader.cancel(reason);
+      reader.releaseLock();
+    },
+  });
+}
+
 /**
  * Parse an SSE byte stream into typed events.
  *

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -33,6 +33,7 @@ import type { ConversationItem } from "@/lib/conversationItems";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
 import { buildBubbles } from "@/lib/renderItems";
 import { INITIAL_WINDOW_ITEMS, SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
+import { SSE_STALL_TIMEOUT_MS } from "@/lib/sse";
 import { getCurrentAuthorId } from "@/lib/identity";
 import { PRESENCE_IDLE_AFTER_MS } from "@/lib/presenceIdle";
 import type {
@@ -54,6 +55,7 @@ import {
   isStaleCompletedResponse,
   initChatStore,
   pumpStreamEvents,
+  SSE_STALE_RECYCLE_MS,
   setPendingInitialPrompt,
   startStreamPump,
   useChatStore,
@@ -169,12 +171,23 @@ function closeOpenEmptyStreams(): void {
 
 function mockResponse(
   body: unknown,
-  init?: { ok?: boolean; status?: number; bodyStream?: ReadableStream<Uint8Array> | null },
+  init?: {
+    ok?: boolean;
+    status?: number;
+    bodyStream?: ReadableStream<Uint8Array> | null;
+    contentType?: string;
+  },
 ): Response {
   return {
     ok: init?.ok ?? true,
     status: init?.status ?? 200,
     statusText: "OK",
+    // Stream responses default to the SSE content type the pump's
+    // non-SSE-answer guard expects; JSON handlers don't care.
+    headers: new Headers({
+      "content-type":
+        init?.contentType ?? (init?.bodyStream ? "text/event-stream" : "application/json"),
+    }),
     json: async () => body,
     text: async () => JSON.stringify(body),
     body: init?.bodyStream ?? null,
@@ -7847,6 +7860,152 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     sinks[0]!.push("data: [DONE]\n\n");
     sinks[0]!.close();
     await vi.advanceTimersByTimeAsync(1);
+    await loop;
+  });
+
+  it("recycles a byte-silent stream via the stall guard and reconciles the gap", async () => {
+    const preGap = [userMessage("stall_pre", "before the stall")];
+    seedSession("conv_stall", preGap);
+    const sinks = routeStreamOpens();
+    const controller = new AbortController();
+    useChatStore.setState({
+      conversationId: "conv_stall",
+      abortController: controller,
+      blocks: itemsToBlocks(preGap),
+    });
+
+    const loop = startStreamPump("conv_stall", controller, setState, getState);
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    // An item commits while the socket is half-open: no bytes, no close.
+    const gapItem = userMessage("stall_gap", "committed during the stall");
+    seedSessionItems("conv_stall", [...preGap, gapItem]);
+
+    // Nothing arrives for the full stall window. The guard must declare
+    // the transport dead and the loop must re-subscribe — a hung read
+    // never ends on its own, so pre-guard this tab stayed frozen forever.
+    await vi.advanceTimersByTimeAsync(SSE_STALL_TIMEOUT_MS + 1_000);
+    await drainAsync();
+    expect(sinks).toHaveLength(2);
+
+    // The reconnect reconciled the committed snapshot: the gap item is in.
+    expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toContain(gapItem.id);
+
+    const last = sinks[1]!;
+    last.push("data: [DONE]\n\n");
+    last.close();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("keeps a heartbeat-alive stream connected across many stall windows", async () => {
+    seedSession("conv_hb", []);
+    const sinks = routeStreamOpens();
+    const controller = new AbortController();
+    useChatStore.setState({ conversationId: "conv_hb", abortController: controller });
+
+    const loop = startStreamPump("conv_hb", controller, setState, getState);
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    // Several stall windows of wall clock, with a heartbeat inside each
+    // one: the guard must keep re-arming rather than tripping.
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 8; i += 1) {
+      sinks[0]!.push(sse("session.heartbeat", {}));
+      await vi.advanceTimersByTimeAsync(20_000);
+    }
+    /* oxlint-enable no-await-in-loop */
+    expect(sinks).toHaveLength(1);
+
+    sinks[0]!.push("data: [DONE]\n\n");
+    sinks[0]!.close();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("backs off when the stream open answers with a non-SSE content type", async () => {
+    seedSession("conv_html", []);
+    let opens = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/[^/]+\/stream$/.test(url)) {
+        opens += 1;
+        // An expired auth ingress: the fetch follows its redirect to a 200
+        // text/html login page instead of the SSE body.
+        const html = pushableStream();
+        html.push("<!doctype html><title>Login</title>");
+        html.close();
+        return mockResponse(null, { bodyStream: html.stream, contentType: "text/html" });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    useChatStore.setState({ conversationId: "conv_html", abortController: controller });
+
+    const loop = startStreamPump("conv_html", controller, setState, getState);
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    // Rejected as a failed open → retried WITH backoff. Pumping the HTML
+    // instead would read as a clean drop and reconnect with no delay — a
+    // hot loop hammering the login page (dozens of opens in this window).
+    expect(opens).toBeGreaterThan(1);
+    expect(opens).toBeLessThan(10);
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(6_000);
+    await loop;
+  });
+
+  it("recycles a stale stream on tab-visible / network-online, but never a fresh one", async () => {
+    seedSession("conv_wake", []);
+    // Sinks that honor the fetch abort signal like the real fetch does:
+    // aborting the attempt severs the in-flight body read.
+    const sinks: StreamSink[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/[^/]+\/stream$/.test(url)) {
+        const sink = pushableStream();
+        sinks.push(sink);
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    useChatStore.setState({ conversationId: "conv_wake", abortController: controller });
+
+    const loop = startStreamPump("conv_wake", controller, setState, getState);
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    // Fresh bytes → a visibility return must NOT churn the connection.
+    sinks[0]!.push(sse("session.heartbeat", {}));
+    await drainAsync();
+    document.dispatchEvent(new Event("visibilitychange"));
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    // Silent past the stale window but before the stall guard's own
+    // ceiling: the wake check must recycle NOW, not wait out the guard.
+    await vi.advanceTimersByTimeAsync(SSE_STALE_RECYCLE_MS + 1_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await drainAsync();
+    expect(sinks).toHaveLength(2);
+
+    // Same staleness discovered via the browser regaining network.
+    await vi.advanceTimersByTimeAsync(SSE_STALE_RECYCLE_MS + 1_000);
+    window.dispatchEvent(new Event("online"));
+    await drainAsync();
+    expect(sinks).toHaveLength(3);
+
+    const last = sinks[2]!;
+    last.push("data: [DONE]\n\n");
+    last.close();
+    await drainAsync(2);
     await loop;
   });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -81,7 +81,13 @@ import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { conversationRegistry, type ConversationEntry } from "./conversationRegistry";
 import { createInitialConversationState, isConversationStateKey } from "./conversationState";
 import { getStreamSlotManager, type StreamSlot } from "./streamSlots";
-import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
+import {
+  SSE_STALL_TIMEOUT_MS,
+  parseEvent,
+  parseSseStream,
+  withStallGuard,
+  type SseStreamResult,
+} from "@/lib/sse";
 import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
@@ -3805,10 +3811,48 @@ const presenceIdle = createPresenceIdleTracker({
     for (const controller of [...presenceAttemptControllers]) controller.abort();
   },
 });
+
+// ── Stream liveness ─────────────────────────────────────────────────
+// When bytes last arrived on each live stream attempt (heartbeats
+// included), stamped from the moment the attempt starts. Lets the fast
+// paths below tell a stream that is merely quiet from one that is
+// probably dead — tracked per attempt, since background conversations
+// hold streams of their own.
+const streamAttemptActivity = new Map<AbortController, number>();
+
+// Two missed 15 s server heartbeats plus slack. Deliberately shorter than
+// the stall guard's own window (`SSE_STALL_TIMEOUT_MS`): the guard is the
+// ceiling; these event-driven checks make the common cases immediate.
+export const SSE_STALE_RECYCLE_MS = 35_000;
+
+/**
+ * Recycle every live stream attempt that looks dead — no bytes for
+ * `SSE_STALE_RECYCLE_MS` while its connection is supposedly up.
+ *
+ * Fired on the two moments a half-open socket is most likely to be
+ * discovered: the tab becoming visible again (wake from sleep) and the
+ * browser regaining network. Aborting only the per-attempt controller
+ * funnels each pump into its normal reconnect + snapshot reconcile
+ * (background pumps add their own jitter); a healthy stream (fresh
+ * bytes) is left untouched, so alt-tabbing never churns connections.
+ */
+function recycleStreamIfStale(): void {
+  const now = Date.now();
+  // Copy first: aborting settles each attempt's `finally`, which deletes
+  // from this map while we iterate it.
+  for (const [attempt, lastActivityAt] of [...streamAttemptActivity]) {
+    if (now - lastActivityAt > SSE_STALE_RECYCLE_MS) attempt.abort();
+  }
+}
+
 if (typeof document !== "undefined") {
-  document.addEventListener("visibilitychange", () =>
-    presenceIdle.handleVisibilityChange(document.hidden),
-  );
+  document.addEventListener("visibilitychange", () => {
+    presenceIdle.handleVisibilityChange(document.hidden);
+    if (!document.hidden) recycleStreamIfStale();
+  });
+}
+if (typeof window !== "undefined") {
+  window.addEventListener("online", () => recycleStreamIfStale());
 }
 
 /**
@@ -3878,6 +3922,9 @@ export async function startStreamPump(
       const onOuterAbort = () => attempt.abort();
       controller.signal.addEventListener("abort", onOuterAbort);
       presenceAttemptControllers.add(attempt);
+      // Stamped from attempt start so the wake fast-path can also recycle
+      // an open that has hung past the stale window, not just a dead body.
+      streamAttemptActivity.set(attempt, Date.now());
       try {
         const idle = presenceIdle.idleNow();
         let streamRes: Response;
@@ -3939,12 +3986,26 @@ export async function startStreamPump(
           failedOpens += 1;
           continue;
         }
+        // An auth layer in front of the server (e.g. an expired app-ingress
+        // session) can answer with a redirect the fetch follows to a 200
+        // text/html login page. Pumping that body would end instantly
+        // without `[DONE]` and reconnect with no backoff — a hot loop that
+        // leaves the transcript silently frozen. Treat a non-SSE content
+        // type as a failed open so it backs off like any other bad answer.
+        const contentType = streamRes.headers.get("content-type") ?? "";
+        if (!contentType.toLowerCase().includes("text/event-stream")) {
+          void streamRes.body.cancel().catch(() => {});
+          console.warn(`Session ${id}: stream open returned '${contentType}', will retry`);
+          failedOpens += 1;
+          continue;
+        }
 
         const reconnecting = hasConnected;
         hasConnected = true;
         failedOpens = 0;
         consecutive404s = 0;
         presenceIdle.noteReported(idle);
+        streamAttemptActivity.set(attempt, Date.now());
         if (reconnecting) {
           dropEphemeralInFlightBlocks(id, set);
         } else {
@@ -3952,9 +4013,25 @@ export async function startStreamPump(
           // a previous stream bind so the debug panel starts clean.
           clearSseLog(id);
         }
+        // Guard the byte stream with a silence watchdog: the server
+        // heartbeats every 15 s, so a longer gap means a half-open socket
+        // (laptop sleep, network path change, proxy reap). The guard ends
+        // the stream like a transport drop, and this loop's reconnect +
+        // reconcile resupplies whatever committed during the dead window —
+        // without it the pump blocks in read() forever and the transcript
+        // silently freezes until a page reload.
+        const guardedBody = withStallGuard(streamRes.body, {
+          onActivity: () => {
+            streamAttemptActivity.set(attempt, Date.now());
+          },
+          onStall: () =>
+            console.warn(
+              `Session ${id}: no stream bytes in ${SSE_STALL_TIMEOUT_MS} ms; reconnecting`,
+            ),
+        });
         // Start the pump, then reconcile the snapshot concurrently (race-safe
         // via itemId dedup) — mirrors bindStream's stream-then-snapshot order.
-        const pumpPromise = pumpStreamEvents(id, streamRes.body, controller, set, get);
+        const pumpPromise = pumpStreamEvents(id, guardedBody, controller, set, get);
         if (reconnecting) {
           await reconcileOnReconnect(id, set, get);
         }
@@ -3971,6 +4048,7 @@ export async function startStreamPump(
       } finally {
         controller.signal.removeEventListener("abort", onOuterAbort);
         presenceAttemptControllers.delete(attempt);
+        streamAttemptActivity.delete(attempt);
       }
     }
   } finally {


### PR DESCRIPTION
<!-- AI-written description following .github/pull_request_template.md -->

## Related issue

N/A — diagnosed from a live session where the chat transcript froze while the embedded terminal stayed live; no tracking issue exists.

## Summary

The chat transcript is fed by a long-lived SSE fetch (`GET /v1/sessions/{id}/stream`). When that connection half-opens (the Apps ingress reaping an idle stream without a close reaching the client, laptop sleep, a network path change), `reader.read()` blocks forever: the server keeps publishing turn events into a dead subscriber, the transcript silently freezes, and only a new tab (fresh socket) heals it. The terminal pane rides a WebSocket with close-code-driven reconnects, so the two panes drift out of sync. The server already heartbeats the stream every 15 s precisely so clients can detect this — the web client just never used the signal.

- **Stall guard** — new `withStallGuard` in `web/src/lib/sse.ts`: 45 s of byte-silence (3 missed heartbeats) cancels the read, ending the stream like a transport drop, so the pump's existing reconnect + snapshot-reconcile loop resupplies whatever committed during the dead window.
- **Wake fast-path** — `chatStore.ts` stamps last-byte time; on tab-visible / network-online, a stream silent >35 s is recycled immediately instead of waiting out the guard. A fresh stream is never churned.
- **Non-SSE answer guard** — a stream open answered with a `text/html` login page (expired auth ingress session) now counts as a failed open with backoff, instead of reading as a clean drop and reconnecting against the login page in a zero-delay hot loop.

ELI5: the chat pane listens on a phone line that can go dead without a dial tone. Now it hangs up and redials if it hears nothing for 45 seconds (the server normally hums every 15), redials instantly when you come back to the tab, and notices when a login page answers the call instead of the server.

```mermaid
sequenceDiagram
  participant W as web chat pump
  participant S as server
  S-->>W: events + session.heartbeat every 15s
  Note over W,S: path dies silently (no close delivered)
  W->>W: 45s byte-silence trips the stall guard<br/>(or instantly on tab-visible / online)
  W->>S: reopen /stream + snapshot reconcile
  S-->>W: missed items backfilled, live tail resumes
```

## Test Plan

- Six new unit tests: the guard trips on silence and an item committed during the gap is reconciled in; heartbeats keep one connection alive across eight stall windows; an HTML login answer backs off (bounded opens) instead of hot-looping; visibility/online recycle a stale stream but never a fresh one; a consumer cancel propagates upstream without tripping the guard.
- `vitest run src/lib/sse.test.ts src/store/chatStore.test.ts` → 334 passed; `tsc -b`, `oxlint`, and pre-commit all green.
- Repro recipe for reviewers: open a session, `kill -STOP` the server for ≥45 s → the console logs `no stream bytes in 45000 ms; reconnecting` and a fresh `/stream` request fires; `kill -CONT` → the transcript catches up. On `main`, nothing ever fires — the tab stays wedged on the dead read.

## Demo

N/A — no visual change; the fix is connection liveness. The observable behavior is the console warning plus the automatic `/stream` reopen in the Network tab (see Test Plan).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage exercises the stall guard, the reconnect loop's new branches, and the wake fast-path under fake timers (including the "healthy stream is left alone" cases). `tests/e2e_ui/chat/test_stale_stream.py::test_silent_stream_stall_self_heals` drives the real server through a silent stall (SIGSTOP, so the stream goes byte-silent without a close) and asserts the client declares it dead, reopens `/stream`, and completes a real turn after SIGCONT.

## Changelog

The chat transcript now detects a silently dead live connection and reconnects on its own — worst case 45 s, instantly on tab refocus — instead of freezing until the page is reloaded.
