### PR TITLE
perf(host): cut host-launched session-create latency

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, Literal, Protocol, SupportsIndex, SupportsInt, cast
 
 import websockets.asyncio.client
-from websockets.exceptions import InvalidStatus, InvalidURI
+from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
 from omnigent.env_credentials import env_names_with_omnigent_prefix
@@ -110,6 +110,7 @@ from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_LAUNCH_HARNESS_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
     RUNNER_SLICE_KEY_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
@@ -614,6 +615,7 @@ def _build_runner_env(
     parent_pid: int,
     initial_auth_token: str | None = None,
     host_id: str | None = None,
+    harness: str | None = None,
 ) -> dict[str, str]:
     """
     Build the environment for a spawned runner subprocess.
@@ -640,6 +642,9 @@ def _build_runner_env(
     :param initial_auth_token: Current host bearer for the runner's initial
         server connection. The runner consumes and removes it before spawning
         any children. ``None`` leaves the legacy auth path unchanged.
+    :param harness: Canonical harness of the launching session, e.g.
+        ``"claude-native"``; lets the runner start harness-specific prewarms
+        at boot. ``None`` (unknown / older server) omits the stamp.
     :returns: The runner subprocess environment.
     """
     extra_names = {
@@ -691,6 +696,8 @@ def _build_runner_env(
         # there). The runner forwards this to databricks_request_headers, which
         # emits the routing header only on a host-sharded deployment.
         env[RUNNER_SLICE_KEY_ENV_VAR] = host_id
+    if harness:
+        env[RUNNER_LAUNCH_HARNESS_ENV_VAR] = harness
     return env
 
 
@@ -856,6 +863,19 @@ class HostProcess:
         )
         self._zygote: ZygoteManager | None = ZygoteManager() if self._zygote_enabled else None
         self._zygote_disabled = False
+        # Warms the zygote at daemon start so the first launch doesn't pay
+        # its one-time import; see run().
+        self._zygote_prestart_task: asyncio.Task[ZygoteManager | None] | None = None
+        # Inbound frames are handled on their own tasks (see
+        # _start_frame_task) so one slow handler — a model-options CLI exec,
+        # an npm install — can't head-of-line block a launch or a stat behind
+        # it. Launch/stop keep their arrival order relative to each other via
+        # this lock: a session DELETE racing a slow create must not have its
+        # stop overtake the launch it targets.
+        self._runner_lifecycle_lock = asyncio.Lock()
+        # Strong refs to in-flight frame tasks (create_task results are
+        # otherwise GC-able); each discards itself on completion.
+        self._frame_tasks: set[asyncio.Task[None]] = set()
 
     def _tracked_runner_pids(self) -> set[int]:
         """PIDs of runners this host spawned and still tracks directly.
@@ -1309,6 +1329,7 @@ class HostProcess:
             parent_pid=os.getpid(),
             initial_auth_token=initial_auth_token,
             host_id=self._identity.host_id,
+            harness=frame.harness,
         )
 
         # Embed the session id so operators can find all logs for a session
@@ -1379,6 +1400,36 @@ class HostProcess:
             runner_id=runner_id,
         )
 
+    def _ensure_zygote_started(self) -> ZygoteManager | None:
+        """Start (or reuse) the runner zygote, latching the fallback on failure.
+
+        Blocking — the first call pays the zygote's one-time import of the
+        runner graph — so call it from a worker thread.
+        ``ZygoteManager.start`` is idempotent under its own lock, so the
+        boot-time prewarm (see :meth:`run`) and a concurrent launch can both
+        call this safely.
+
+        :returns: The started zygote, or ``None`` when the zygote is disabled
+            (opt-out, non-POSIX, or a prior failure) or failed to start now.
+        """
+        zygote = self._zygote
+        if zygote is None or self._zygote_disabled:
+            return None
+        try:
+            zygote.start()
+        except ZygoteUnavailable as exc:
+            # Spawning the zygote itself is broken; retrying on every
+            # launch would only add a doomed spawn to each, so disable
+            # it for the daemon's life and fall back to direct Popen.
+            _logger.warning(
+                "Runner zygote failed to start (%s); disabling it and "
+                "falling back to direct spawn",
+                exc,
+            )
+            self._zygote_disabled = True
+            return None
+        return zygote
+
     def _spawn_runner_proc(
         self,
         env: dict[str, str],
@@ -1407,62 +1458,49 @@ class HostProcess:
         try:
             env[PROCESS_LOG_FILE_ENV_VAR] = str(log_path)
 
-            zygote = self._zygote
-            if zygote is not None and not self._zygote_disabled:
+            zygote = self._ensure_zygote_started()
+            if zygote is not None:
                 try:
-                    zygote.start()
-                except ZygoteUnavailable as exc:
-                    # Spawning the zygote itself is broken; retrying on every
-                    # launch would only add a doomed spawn to each, so disable
-                    # it for the daemon's life and fall back.
-                    _logger.warning(
-                        "Runner zygote failed to start (%s); disabling it and "
-                        "falling back to direct spawn",
-                        exc,
+                    # The runner's OS parent will be the zygote, so its
+                    # getppid()-based orphan check must watch the zygote pid.
+                    zygote_env = dict(env)
+                    zygote_env[RUNNER_PARENT_PID_ENV_VAR] = str(zygote.pid)
+                    proc = zygote.fork_runner(zygote_env, str(log_path), str(workspace))
+                    _logger.info(
+                        "Forked runner via zygote (zygote pid=%s, runner pid=%s)",
+                        zygote.pid,
+                        proc.pid,
                     )
-                    self._zygote_disabled = True
-                else:
-                    try:
-                        # The runner's OS parent will be the zygote, so its
-                        # getppid()-based orphan check must watch the zygote pid.
-                        zygote_env = dict(env)
-                        zygote_env[RUNNER_PARENT_PID_ENV_VAR] = str(zygote.pid)
-                        proc = zygote.fork_runner(zygote_env, str(log_path), str(workspace))
-                        _logger.info(
-                            "Forked runner via zygote (zygote pid=%s, runner pid=%s)",
-                            zygote.pid,
-                            proc.pid,
+                    return proc, log_path
+                except ZygoteUnavailable as exc:
+                    if zygote.is_running():
+                        # Alive but its control channel failed. Do NOT stop
+                        # it: healthy runners already forked from it would
+                        # see their parent die and self-terminate via the
+                        # orphan watchdog. Disable for future launches; the
+                        # still-running zygote is reaped on daemon shutdown
+                        # (see run()'s finally).
+                        _logger.warning(
+                            "Runner zygote unavailable (%s); disabling it "
+                            "and falling back to direct spawn",
+                            exc,
                         )
-                        return proc, log_path
-                    except ZygoteUnavailable as exc:
-                        if zygote.is_running():
-                            # Alive but its control channel failed. Do NOT stop
-                            # it: healthy runners already forked from it would
-                            # see their parent die and self-terminate via the
-                            # orphan watchdog. Disable for future launches; the
-                            # still-running zygote is reaped on daemon shutdown
-                            # (see run()'s finally).
-                            _logger.warning(
-                                "Runner zygote unavailable (%s); disabling it "
-                                "and falling back to direct spawn",
-                                exc,
-                            )
-                            self._zygote_disabled = True
-                        else:
-                            # The zygote process died — its forked runners are
-                            # already self-terminating via their own orphan
-                            # watchdogs, so nothing depends on this instance.
-                            # Reap it and let the next launch's start() respawn
-                            # a fresh one instead of losing copy-on-write
-                            # forking for the rest of the daemon's life.
-                            _logger.warning(
-                                "Runner zygote died (%s); falling back to "
-                                "direct spawn and respawning the zygote on "
-                                "the next launch",
-                                exc,
-                            )
-                            with contextlib.suppress(Exception):
-                                zygote.stop()
+                        self._zygote_disabled = True
+                    else:
+                        # The zygote process died — its forked runners are
+                        # already self-terminating via their own orphan
+                        # watchdogs, so nothing depends on this instance.
+                        # Reap it and let the next launch's start() respawn
+                        # a fresh one instead of losing copy-on-write
+                        # forking for the rest of the daemon's life.
+                        _logger.warning(
+                            "Runner zygote died (%s); falling back to "
+                            "direct spawn and respawning the zygote on "
+                            "the next launch",
+                            exc,
+                        )
+                        with contextlib.suppress(Exception):
+                            zygote.stop()
 
             with child_logging_popen_kwargs(env) as logging_kwargs:
                 proc = subprocess.Popen(
@@ -2494,6 +2532,15 @@ class HostProcess:
         self._reaper_task = asyncio.create_task(
             self._orphan_reaper_loop(), name="host-orphan-reaper"
         )
+        # Warm the runner zygote now: start() blocks on its one-time import
+        # of the runner graph (~1-2s), which otherwise lands inside the first
+        # session launch of the daemon's life. Best-effort — a failure
+        # latches the same direct-Popen fallback the launch path uses.
+        if self._zygote is not None and not self._zygote_disabled:
+            self._zygote_prestart_task = asyncio.create_task(
+                asyncio.to_thread(self._ensure_zygote_started),
+                name="host-zygote-prestart",
+            )
         backoff = _RECONNECT_BASE_S
         try:
             while True:
@@ -2626,6 +2673,11 @@ class HostProcess:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await self._reaper_task
                 self._reaper_task = None
+            if self._zygote_prestart_task is not None:
+                self._zygote_prestart_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._zygote_prestart_task
+                self._zygote_prestart_task = None
             for watcher in list(self._watcher_tasks):
                 watcher.cancel()
             for watcher in list(self._watcher_tasks):
@@ -2876,7 +2928,15 @@ class HostProcess:
                 # reconnect loop's silent-connect streak keys off this.
                 self._conn_frame_received = True
                 if isinstance(raw, str):
-                    await self._handle_raw_message(ws, raw)
+                    # Each frame is handled on its own task so a slow handler
+                    # (a model-options CLI exec, a long git walk) can't
+                    # head-of-line block the frames behind it — measured
+                    # 0.3-1.3s of added session-create latency when a launch
+                    # or stat queued behind one. Responses correlate by
+                    # request_id, so completion order doesn't matter; the one
+                    # ordering that does (launch vs stop) is preserved by
+                    # _runner_lifecycle_lock in _dispatch_host_frame.
+                    self._start_frame_task(ws, raw)
         finally:
             readiness_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -2938,6 +2998,39 @@ class HostProcess:
                 configured = latest
                 gateway = latest_gateway
 
+    def _start_frame_task(self, ws: websockets.asyncio.client.ClientConnection, raw: str) -> None:
+        """Handle one inbound frame on its own task, off the receive loop.
+
+        :param ws: The open tunnel connection, passed through to the handler.
+        :param raw: The raw text frame received off the socket.
+        :returns: None.
+        """
+        task = asyncio.create_task(self._run_frame_handler(ws, raw), name="host-frame")
+        self._frame_tasks.add(task)
+        task.add_done_callback(self._frame_tasks.discard)
+
+    async def _run_frame_handler(
+        self, ws: websockets.asyncio.client.ClientConnection, raw: str
+    ) -> None:
+        """Run one frame handler, containing its failures.
+
+        A handler failure must not tear down the tunnel — every queued frame
+        (and the reconnect churn) would pay for one bad request. The server
+        side times out or retries its unanswered request.
+
+        :param ws: The open tunnel connection the handler replies on.
+        :param raw: The raw text frame received off the socket.
+        :returns: None.
+        """
+        try:
+            await self._handle_raw_message(ws, raw)
+        except ConnectionClosed:
+            # The tunnel died while this frame was in flight; the reconnect
+            # loop owns recovery.
+            _logger.debug("dropped frame result: tunnel closed mid-handling")
+        except Exception:
+            _logger.exception("host frame handler failed")
+
     async def _handle_raw_message(
         self, ws: websockets.asyncio.client.ClientConnection, raw: str
     ) -> None:
@@ -2995,9 +3088,18 @@ class HostProcess:
         :returns: None.
         """
         if isinstance(frame, HostLaunchRunnerFrame):
-            await ws.send(encode_host_frame(await self._handle_launch(frame)))
+            # Frames run on concurrent tasks, but launch/stop must keep their
+            # arrival order relative to each other (a stop for a session must
+            # not overtake the launch it targets). The lock is this task's
+            # first await, and tasks start in frame-arrival order, so waiters
+            # queue FIFO in that same order — keep it first.
+            async with self._runner_lifecycle_lock:
+                launch_result = await self._handle_launch(frame)
+            await ws.send(encode_host_frame(launch_result))
         elif isinstance(frame, HostStopRunnerFrame):
-            await ws.send(encode_host_frame(await self._handle_stop(frame)))
+            async with self._runner_lifecycle_lock:
+                stop_result = await self._handle_stop(frame)
+            await ws.send(encode_host_frame(stop_result))
         elif isinstance(frame, HostRunnerStatusFrame):
             await ws.send(encode_host_frame(await self._handle_runner_status(frame)))
         elif isinstance(frame, HostStatFrame):

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -23,11 +23,13 @@ logins, then a local server). The caller maps each detection's
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import os
 import shlex
 import socket
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -617,8 +619,50 @@ def _ollama_reachable() -> bool:
         return False
 
 
+# One-shot prewarmed detection result, produced by
+# :func:`prewarm_detect_providers` and consumed by the next
+# :func:`detect_providers` call. Guarded by ``_prewarm_lock``.
+_prewarm_lock = threading.Lock()
+_prewarmed_detection: concurrent.futures.Future[list[DetectedProvider]] | None = None
+
+
+def prewarm_detect_providers() -> None:
+    """Start :func:`detect_providers` on a background thread.
+
+    The next ``detect_providers()`` call consumes the result instead of
+    re-running the sweep — on macOS the Claude Keychain fallback shells out
+    to ``claude auth status`` (~0.6-0.9s), which a claude-native runner
+    would otherwise pay inside terminal creation while the user watches the
+    "Starting up…" spinner.
+
+    One-shot by design: the result is a point-in-time snapshot, so only the
+    first detection after the prewarm uses it and later calls run fresh.
+    Call it only from short-lived processes (the runner) where the prewarm
+    and its consumer are seconds apart. No-op when a prewarm is already
+    pending.
+    """
+    global _prewarmed_detection
+    with _prewarm_lock:
+        if _prewarmed_detection is not None:
+            return
+        future: concurrent.futures.Future[list[DetectedProvider]] = concurrent.futures.Future()
+        _prewarmed_detection = future
+
+    def _run() -> None:
+        try:
+            future.set_result(_detect_providers_now())
+        except BaseException as exc:  # the future must always complete
+            future.set_exception(exc)
+
+    threading.Thread(target=_run, name="ambient-detect-prewarm", daemon=True).start()
+
+
 def detect_providers() -> list[DetectedProvider]:
     """Detect credentials already present on the machine.
+
+    Consumes (one-shot) a pending :func:`prewarm_detect_providers` result
+    when one exists, waiting for it to finish if needed; otherwise runs the
+    sweep inline.
 
     Checks, in a stable priority order:
 
@@ -646,6 +690,22 @@ def detect_providers() -> list[DetectedProvider]:
     :returns: One :class:`DetectedProvider` per credential found, in the
         priority order above. Empty when nothing is detected.
     """
+    global _prewarmed_detection
+    with _prewarm_lock:
+        prewarmed = _prewarmed_detection
+        _prewarmed_detection = None
+    if prewarmed is not None:
+        try:
+            return prewarmed.result()
+        except Exception:
+            # A failed speculative sweep must never make detection worse —
+            # fall through to a fresh one.
+            pass
+    return _detect_providers_now()
+
+
+def _detect_providers_now() -> list[DetectedProvider]:
+    """Run the ambient-credential sweep (see :func:`detect_providers`)."""
     detected: list[DetectedProvider] = []
 
     # 1. Environment API keys.

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1731,6 +1731,29 @@ def _install_crash_logging() -> None:
     sys.excepthook = _log_uncaught
 
 
+def _maybe_prewarm_ambient_detection() -> None:
+    """Prewarm ambient provider detection for claude-native launches.
+
+    Terminal auto-create resolves the session's provider config, and on a
+    machine with no explicit provider that runs ambient detection — on macOS
+    a ``claude auth status`` subprocess (~0.6-0.9s) — inside the
+    user-visible "Starting up…" window. Starting the sweep at boot overlaps
+    it with tunnel connect and session init instead.
+
+    Gated on the launch-harness stamp the host injects (absent for CLI-local
+    runners and hosts that predate it), so other harnesses don't pay a
+    speculative subprocess on every launch.
+    """
+    from omnigent.harness_plugins import CLAUDE_NATIVE_CODING_AGENT
+    from omnigent.runner.identity import RUNNER_LAUNCH_HARNESS_ENV_VAR
+
+    if os.environ.get(RUNNER_LAUNCH_HARNESS_ENV_VAR) != CLAUDE_NATIVE_CODING_AGENT.harness:
+        return
+    from omnigent.onboarding.ambient import prewarm_detect_providers
+
+    prewarm_detect_providers()
+
+
 def main() -> None:
     """Console entry point for the runner tunnel process.
 
@@ -1747,6 +1770,7 @@ def main() -> None:
 
     configure_process_logging("runner", force=True)
     _install_crash_logging()
+    _maybe_prewarm_ambient_detection()
     try:
         asyncio.run(_run_tunnel_from_env())
     except RuntimeError as exc:

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -30,6 +30,11 @@ RUNNER_DELEGATED_AUTH_ENV_VAR = "OMNIGENT_RUNNER_DELEGATED_AUTH"
 # host injects it when spawning the runner; absent for CLI-local runners, which
 # then leave routing to the default.
 RUNNER_SLICE_KEY_ENV_VAR = "OMNIGENT_RUNNER_SLICE_KEY"
+# Canonical harness of the session this runner is being launched for (e.g.
+# "claude-native"), stamped by the host from the launch frame so the runner
+# can start harness-specific prewarms before session init arrives. Absent
+# for CLI-local runners and hosts that predate the stamp.
+RUNNER_LAUNCH_HARNESS_ENV_VAR = "OMNIGENT_RUNNER_LAUNCH_HARNESS"
 RUNNER_TUNNEL_TOKEN_HEADER = "X-Omnigent-Runner-Tunnel-Token"
 # Sentinel ``Origin`` header that the project's own non-browser WebSocket
 # clients (runner -> server tunnel, host/daemon -> server tunnel,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -52,6 +52,7 @@ from omnigent.host.frames import (
     HostStoreSecretFrame,
     HostStoreSecretResultFrame,
     decode_host_frame,
+    encode_host_frame,
 )
 from omnigent.host.identity import HostIdentity
 from omnigent.host.runner_zygote import ZygoteUnavailable
@@ -59,6 +60,7 @@ from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_LAUNCH_HARNESS_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
     RUNNER_WORKSPACE_ENV_VAR,
@@ -66,6 +68,22 @@ from omnigent.runner.identity import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _no_real_zygote(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep these tests from forking a real runner zygote.
+
+    ``HostProcess.run()`` prewarms the zygote at daemon start, so without
+    this opt-out every test that drives ``run()`` would spawn a real
+    ``python -m omnigent.runner._zygote`` (a 1-2s import of the runner
+    graph). Zygote behavior itself is exercised via ``_FakeZygote`` here
+    and with real ``ZygoteManager`` instances in ``test_runner_zygote.py``
+    (which this construction-time gate does not affect).
+    """
+    from omnigent.runner._zygote import ZYGOTE_ENABLED_ENV_VAR
+
+    monkeypatch.setenv(ZYGOTE_ENABLED_ENV_VAR, "0")
 
 
 async def test_handle_model_options_uses_host_claude_configuration(
@@ -3413,6 +3431,30 @@ def test_build_runner_env_carries_host_id() -> None:
     )
 
 
+def test_build_runner_env_carries_launch_harness() -> None:
+    """The runner is told its session's harness so it can prewarm at boot.
+
+    claude-native runners use the stamp to start ambient provider detection
+    (a ~0.6-0.9s ``claude auth status`` subprocess on macOS) during boot
+    instead of inside terminal auto-create. With no harness (an older server
+    that doesn't resolve one), the env var is omitted.
+    """
+
+    def _env(*, harness: str | None) -> dict[str, str]:
+        return _build_runner_env(
+            {},
+            server_url="http://127.0.0.1:6767",
+            runner_id="runner_abc",
+            binding_token="tok",
+            workspace="/ws",
+            parent_pid=123,
+            harness=harness,
+        )
+
+    assert _env(harness="claude-native")[RUNNER_LAUNCH_HARNESS_ENV_VAR] == "claude-native"
+    assert RUNNER_LAUNCH_HARNESS_ENV_VAR not in _env(harness=None)
+
+
 async def test_run_retries_on_login_redirect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -4082,6 +4124,7 @@ class _FakeZygote:
         """
         self._fail_at = fail_at
         self._running = running
+        self.start_calls = 0
         self.stop_calls = 0
 
     @property
@@ -4095,6 +4138,7 @@ class _FakeZygote:
 
     def start(self) -> None:
         """Raise when scripted to fail at start."""
+        self.start_calls += 1
         if self._fail_at == "start":
             raise ZygoteUnavailable("scripted start failure")
 
@@ -4208,6 +4252,194 @@ def test_zygote_start_failure_disables_it(
     assert host._zygote_disabled is True
     assert zygote.stop_calls == 0
     assert len(popen_argvs) == 1
+
+
+async def test_run_prestarts_zygote_before_first_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run() warms the zygote so the first launch skips its cold import.
+
+    The zygote's one-time import of the runner graph (~1-2s) otherwise lands
+    inside the first session launch of the daemon's life, extending that
+    session's "Starting up…" window.
+    """
+    host = _make_host_process()
+    zygote = _FakeZygote(fail_at="none", running=True)
+    host._zygote = zygote  # type: ignore[assignment]
+    host._zygote_disabled = False
+
+    async def _fake_connect(self_: HostProcess) -> None:
+        # Hold the "connection" open until the prestart thread has run, then
+        # shut the daemon down.
+        for _ in range(500):
+            if zygote.start_calls:
+                break
+            await asyncio.sleep(0.01)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(HostProcess, "_connect_and_serve", _fake_connect)
+    # Keep run()'s shutdown sweep from reaping unrelated pytest children.
+    monkeypatch.setattr(HostProcess, "_reap_orphans_once", lambda self_: 0)
+
+    await host.run()
+
+    assert zygote.start_calls == 1
+    # run()'s finally still reaps the prewarmed zygote on shutdown.
+    assert zygote.stop_calls == 1
+
+
+class _CollectingWs:
+    """Duck-typed tunnel connection capturing every frame sent on it."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, data: str) -> None:
+        """Record one outbound frame."""
+        self.sent.append(data)
+
+
+async def _drain_frame_tasks(host: HostProcess) -> None:
+    """Await every in-flight frame task (handler failures are contained)."""
+    await asyncio.gather(*list(host._frame_tasks))
+
+
+async def test_slow_frame_does_not_head_of_line_block(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A slow handler must not delay the frames queued behind it.
+
+    The receive loop used to await each frame inline, so a create's own
+    background ``host.model_options`` CLI exec (measured 650-794ms) parked
+    the launch frame sent ~20ms later behind it on every session create —
+    0.3-1.3s of added "Starting up…" latency. Frames now run on their own
+    tasks: a stat arriving behind a parked handler completes immediately.
+    """
+    host = _make_host_process()
+    ws = _CollectingWs()
+    slow_started = asyncio.Event()
+    release_slow = asyncio.Event()
+
+    async def _parked_model_options(
+        self_: HostProcess, frame: HostModelOptionsFrame
+    ) -> HostModelOptionsResultFrame:
+        slow_started.set()
+        await release_slow.wait()
+        return HostModelOptionsResultFrame(request_id=frame.request_id, status="ok")
+
+    monkeypatch.setattr(HostProcess, "_handle_model_options", _parked_model_options)
+
+    host._start_frame_task(
+        ws,  # type: ignore[arg-type] — duck-typed ws
+        encode_host_frame(HostModelOptionsFrame(request_id="req_slow", harness="claude-native")),
+    )
+    await slow_started.wait()
+    host._start_frame_task(
+        ws,  # type: ignore[arg-type] — duck-typed ws
+        encode_host_frame(HostStatFrame(request_id="req_stat", path=str(tmp_path))),
+    )
+
+    # The stat result lands while the model-options handler is still parked.
+    for _ in range(500):
+        if ws.sent:
+            break
+        await asyncio.sleep(0.01)
+    assert ws.sent, "stat frame never answered while a slow frame was in flight"
+    assert '"req_stat"' in ws.sent[0]
+
+    release_slow.set()
+    await _drain_frame_tasks(host)
+    assert any('"req_slow"' in frame for frame in ws.sent)
+
+
+async def test_stop_frame_never_overtakes_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner lifecycle frames keep their arrival order under concurrency.
+
+    A session DELETE racing a slow create sends a stop while the launch is
+    mid-flight; if the stop ran first it would no-op on an unknown runner
+    and leave the launched runner orphaned. The lifecycle lock serializes
+    launch/stop in arrival order while other frames stay concurrent.
+    """
+    host = _make_host_process()
+    ws = _CollectingWs()
+    order: list[str] = []
+    release_launch = asyncio.Event()
+
+    async def _parked_launch(
+        self_: HostProcess, frame: HostLaunchRunnerFrame
+    ) -> HostLaunchRunnerResultFrame:
+        order.append("launch:start")
+        await release_launch.wait()
+        order.append("launch:end")
+        return HostLaunchRunnerResultFrame(
+            request_id=frame.request_id, status="launched", runner_id="runner_x"
+        )
+
+    async def _recording_stop(
+        self_: HostProcess, frame: HostStopRunnerFrame
+    ) -> HostStopRunnerResultFrame:
+        order.append("stop")
+        return HostStopRunnerResultFrame(request_id=frame.request_id, status="stopped")
+
+    monkeypatch.setattr(HostProcess, "_handle_launch", _parked_launch)
+    monkeypatch.setattr(HostProcess, "_handle_stop", _recording_stop)
+
+    host._start_frame_task(
+        ws,  # type: ignore[arg-type] — duck-typed ws
+        encode_host_frame(
+            HostLaunchRunnerFrame(request_id="rq1", binding_token="tok", workspace="/w")
+        ),
+    )
+    host._start_frame_task(
+        ws,  # type: ignore[arg-type] — duck-typed ws
+        encode_host_frame(HostStopRunnerFrame(request_id="rq2", runner_id="runner_x")),
+    )
+    await asyncio.sleep(0.05)
+    # The stop is parked behind the lifecycle lock, not run concurrently.
+    assert order == ["launch:start"]
+
+    release_launch.set()
+    await _drain_frame_tasks(host)
+    assert order == ["launch:start", "launch:end", "stop"]
+
+
+async def test_frame_handler_failure_is_contained(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A crashing handler is logged; the tunnel and later frames survive.
+
+    Pre-concurrency, a handler exception propagated out of the receive loop
+    and tore the tunnel down (a reconnect for one bad request).
+    """
+    host = _make_host_process()
+    ws = _CollectingWs()
+
+    def _boom(self_: HostProcess, frame: HostStatFrame) -> HostStatResultFrame:
+        raise RuntimeError("scripted stat failure")
+
+    monkeypatch.setattr(HostProcess, "_handle_stat", _boom)
+    with caplog.at_level(logging.ERROR, logger="omnigent.host.connect"):
+        host._start_frame_task(
+            ws,  # type: ignore[arg-type] — duck-typed ws
+            encode_host_frame(HostStatFrame(request_id="req_boom", path=str(tmp_path))),
+        )
+        await _drain_frame_tasks(host)
+
+    assert ws.sent == []
+    assert any("host frame handler failed" in record.message for record in caplog.records)
+
+    # A later frame on the same connection is still handled.
+    host._start_frame_task(
+        ws,  # type: ignore[arg-type] — duck-typed ws
+        encode_host_frame(HostListDirFrame(request_id="req_ls", path=str(tmp_path))),
+    )
+    await _drain_frame_tasks(host)
+    assert ws.sent and '"req_ls"' in ws.sent[0]
 
 
 def test_direct_spawn_keeps_the_workspace_off_sys_path(

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -747,3 +747,53 @@ def test_vertex_claude_not_detected_when_incomplete(
     for var, val in env.items():
         monkeypatch.setenv(var, val)
     assert detect_providers() == []
+
+
+def test_prewarm_detect_providers_is_consumed_once(
+    clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prewarmed sweep serves exactly the next detection, then expires.
+
+    One-shot semantics keep staleness bounded: only the runner-boot consumer
+    (seconds after the prewarm) sees the snapshot; every later call runs a
+    fresh sweep, exactly as before the prewarm existed.
+    """
+    sweeps: list[str] = []
+    sentinel = [
+        DetectedProvider(name="claude", kind="subscription", family="anthropic", source="test")
+    ]
+
+    def _fake_sweep() -> list[DetectedProvider]:
+        sweeps.append("sweep")
+        return sentinel
+
+    monkeypatch.setattr(ambient, "_detect_providers_now", _fake_sweep)
+    monkeypatch.setattr(ambient, "_prewarmed_detection", None)
+
+    ambient.prewarm_detect_providers()
+    # Consumes the prewarmed future — no second sweep.
+    assert detect_providers() == sentinel
+    assert sweeps == ["sweep"]
+    # The next call is fresh, not the stale snapshot.
+    assert detect_providers() == sentinel
+    assert sweeps == ["sweep", "sweep"]
+
+
+def test_prewarm_detect_providers_failure_falls_back_to_fresh_sweep(
+    clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crashed speculative sweep must not poison the real detection."""
+    sweeps: list[str] = []
+
+    def _flaky_sweep() -> list[DetectedProvider]:
+        sweeps.append("sweep")
+        if len(sweeps) == 1:
+            raise RuntimeError("scripted prewarm failure")
+        return []
+
+    monkeypatch.setattr(ambient, "_detect_providers_now", _flaky_sweep)
+    monkeypatch.setattr(ambient, "_prewarmed_detection", None)
+
+    ambient.prewarm_detect_providers()
+    assert detect_providers() == []
+    assert sweeps == ["sweep", "sweep"]

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -2379,3 +2379,31 @@ async def test_install_signal_handlers_degrades_when_wakeup_fd_unusable(
 
     # First failure marks the loop degraded; SIGTERM is skipped, not retried.
     assert attempts == [signal.SIGINT]
+
+
+def test_maybe_prewarm_ambient_detection_gates_on_launch_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only claude-native launches prewarm ambient detection at boot.
+
+    Terminal auto-create resolves provider config with an ambient sweep (a
+    ~0.6-0.9s ``claude auth status`` subprocess on macOS); the boot prewarm
+    overlaps that with runner boot. Other harnesses never resolve it, so
+    they must not pay a speculative subprocess on every launch.
+    """
+    from omnigent.onboarding import ambient
+    from omnigent.runner._entry import _maybe_prewarm_ambient_detection
+    from omnigent.runner.identity import RUNNER_LAUNCH_HARNESS_ENV_VAR
+
+    prewarms: list[str] = []
+    monkeypatch.setattr(ambient, "prewarm_detect_providers", lambda: prewarms.append("prewarm"))
+
+    monkeypatch.delenv(RUNNER_LAUNCH_HARNESS_ENV_VAR, raising=False)
+    _maybe_prewarm_ambient_detection()
+    monkeypatch.setenv(RUNNER_LAUNCH_HARNESS_ENV_VAR, "codex-native")
+    _maybe_prewarm_ambient_detection()
+    assert prewarms == []
+
+    monkeypatch.setenv(RUNNER_LAUNCH_HARNESS_ENV_VAR, "claude-native")
+    _maybe_prewarm_ambient_detection()
+    assert prewarms == ["prewarm"]


### PR DESCRIPTION
## Related issue

None — this came out of a profiling pass on web session-create latency; there is no tracking issue. Measurements and fixes below.

## Summary

Creating a claude-native session from the web UI paid three serial, avoidable costs between the create POST and the terminal appearing, measured on an instrumented rig (timestamped probes in the server, host daemon, runner, and browser sharing one clock):

- **Host tunnel head-of-line blocking** — the host daemon handled tunnel frames strictly serially, so every create's launch frame queued behind that same create's background `host.model_options` CLI exec (650–794ms), and workspace validation's `host.stat` (2–9ms uncontended) queued behind landing-page prefetches for up to 1.3s. Frames now run on their own tasks; launch/stop keep their arrival order via a lifecycle lock (a DELETE racing a slow create must not have its stop overtake the launch it targets); a crashing handler is logged instead of tearing the tunnel down.
- **Ambient provider detection inside terminal create** — auto-create resolved provider credentials with an ambient sweep (a ~0.7s `claude auth status` subprocess on macOS) inside the user-visible "Starting up…" window. The host now stamps the session's harness into the runner env (`OMNIGENT_RUNNER_LAUNCH_HARNESS`), and claude-native runners start the sweep on a background thread at boot so it overlaps tunnel connect; the launch-config resolve consumes it one-shot. Other harnesses pay nothing.
- **Zygote cold import on the first launch** — the first session of a host daemon's life paid the runner zygote's one-time import (~1.5s) inline, inside that session's spin-up. `run()` now pre-starts the zygote at daemon boot via a helper shared with the launch path (same failure latching).

ELI5: the host answered requests one at a time at a single window, ran a slow credential check while you watched the spinner, and only warmed up its engine when the first customer walked in. Now it serves requests concurrently, runs the credential check before it's needed, and warms the engine at opening time.

```
before:  recv → handle(model_options ~700ms) → handle(launch) → handle(stat) → …
after:   recv → task(model_options) ─┐
         recv → task(launch)         ├─ concurrent; launch/stop stay FIFO via lock
         recv → task(stat)           ┘
```

Same rig, pristine main vs this branch:

| Serial leg | main | this PR |
|---|---|---|
| Workspace validation (`host.stat` behind the queue) | 1,508–5,003ms | 2–5ms |
| Launch frame sent → host handler starts | 1,185–1,712ms | 8–17ms |
| Zygote import at first launch | 1,532ms | 0ms |
| Click → chat page open | 1.6–2.0s | 0.18–0.24s |
| Click → "Starting up…" cleared | 5.9–8.3s | 3.6–4.9s |

## Test Plan

- `tests/host/test_connect.py`, `tests/onboarding/test_ambient.py`, `tests/runner/test_runner_entry.py`: 375 pass locally, including 12 new tests — slow frame does not head-of-line block, stop never overtakes launch, handler crash is contained, launch-harness env stamp, prewarm consumed once / failure falls back to a fresh sweep, prewarm gated to claude-native launches, `run()` pre-starts the zygote and still reaps it on shutdown. `test_connect.py` also gains an autouse fixture disabling the real zygote so `run()`-driving tests don't fork one.
- Instrumented rig (real `omnigent server` + `omnigent host` + claude CLI, Playwright driving the real landing page) A/B against pristine main on the same machine/day — table above.
- Live deployment: Databricks App + a connected Mac host running this branch; the first-ever session of the daemon's life logged `Forked runner via zygote` (no cold import) and created end-to-end (create POST 1.69s over WAN).

## Demo

N/A — host/runner-side performance change; no visual surface changed (the user-visible effect is the timing table above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests exercise the new mechanisms directly (concurrent dispatch, lifecycle ordering, crash containment, env stamp, prewarm semantics, boot prestart). The latency wins themselves were verified manually on an instrumented rig and a live Databricks App deployment, since wall-clock improvements aren't assertable in unit tests.

## Changelog

Creating a session from the web UI is faster end-to-end: the chat page opens immediately and the terminal is ready sooner — including the first session after a host restart, which no longer pays a multi-second warmup.
