### PR TITLE
ci(bench): host-session benchmark workflow + job-summary results matrix

### DIFF
--- a/.github/workflows/benchmark-host.yml
+++ b/.github/workflows/benchmark-host.yml
@@ -1,0 +1,118 @@
+name: Benchmark (host sessions)
+
+# Profiles the host-bound session lifecycle — create → host.launch_runner →
+# runner boot → first token (`session_cold_start`), plus restart and the
+# common session actions around it — and renders the journey × metric matrix
+# into the job summary. Informational: no thresholds, so a noisy shared
+# runner can't block a PR; regression *gating* stays with benchmark-pr.yml
+# (store paths) and release.yml (release cuts). The seeded, backend-matrix
+# trend numbers stay with the nightly benchmark.yml; this workflow's value is
+# a fresh matrix on the PRs that actually move these numbers.
+#
+# Uses dev/benchmarks/omnigent (real server + real `omni host` daemon +
+# runner against a zero-latency mock LLM — no agent CLI or credentials).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "omnigent/host/**"
+      - "omnigent/runner/**"
+      - "omnigent/server/**"
+      - "dev/benchmarks/**"
+      - ".github/workflows/benchmark-host.yml"
+  workflow_dispatch:
+    inputs:
+      journeys:
+        description: "Comma-separated journeys (blank = the host-session set)"
+        required: false
+        default: ""
+      iterations:
+        description: "Requests per run (runner journeys stay capped at 5)"
+        required: false
+        default: "100"
+      runs:
+        description: "Timed runs per journey"
+        required: false
+        default: "3"
+
+permissions:
+  contents: read
+
+env:
+  # No web SPA build during `uv sync` (setup.py _build_web_ui): nothing here
+  # serves the bundle, and the build otherwise times out on public npm.
+  OMNIGENT_SKIP_WEB_UI: "true"
+  UV_INDEX_URL: https://pypi.org/simple
+  PIP_INDEX_URL: https://pypi.org/simple
+  # The host-session set: the host-bound lifecycle journeys first, then the
+  # common HTTP session actions a user drives around them. Matches the
+  # journey names in dev/benchmarks/omnigent/journeys.py (ALL_JOURNEYS).
+  DEFAULT_JOURNEYS: >-
+    session_cold_start,session_cold_restart,warm_turn,time_to_first_token,interrupt,create_session,fork_session,list_sessions,get_session,load_conversation_history
+  JOURNEYS: ${{ (github.event_name == 'workflow_dispatch' && inputs.journeys) || '' }}
+  ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '100' }}
+  RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '3' }}
+
+concurrency:
+  # PR pushes cancel the previous run; manual dispatches never cancel each
+  # other (unique run_id).
+  group: benchmark-host-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  benchmark-host:
+    name: Host session benchmark (sqlite)
+    if: github.repository == 'omnigent-ai/omnigent' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v3
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # Same install as the other benchmark workflows so numbers stay
+        # comparable across them.
+        run: uv sync --extra dev --extra databricks
+
+      - name: Run host-session benchmark
+        # Throwaway empty SQLite DB (run.py default): these journeys measure
+        # process spin-up and turn latency, not query scale — corpus-scale
+        # numbers live in the nightly benchmark.yml.
+        run: |
+          uv run --no-sync dev/benchmarks/omnigent/run.py \
+            --journeys "${JOURNEYS:-$DEFAULT_JOURNEYS}" \
+            --iterations "$ITERATIONS" \
+            --runs "$RUNS" \
+            --output benchmark-results-host.json
+
+      - name: Render results matrix to job summary
+        if: always()
+        run: |
+          if [[ -f benchmark-results-host.json ]]; then
+            uv run --no-sync dev/benchmarks/omnigent/report_markdown.py \
+              --title "Host session benchmark" \
+              benchmark-results-host.json >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: benchmark-results-host-${{ github.run_id }}
+          path: benchmark-results-host.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -189,6 +189,17 @@ jobs:
             --network-delay-ms "$NETWORK_DELAY_MS" \
             --output "benchmark-results-${{ matrix.backend }}.json"
 
+      - name: Render results matrix to job summary
+        # The JSON artifact feeds the trend dashboard; this makes the same
+        # numbers readable on the run page without downloading it.
+        if: always()
+        run: |
+          if [[ -f "benchmark-results-${{ matrix.backend }}.json" ]]; then
+            uv run --no-sync dev/benchmarks/omnigent/report_markdown.py \
+              --title "Benchmark results" \
+              "benchmark-results-${{ matrix.backend }}.json" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload benchmark results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/dev/benchmarks/omnigent/report_markdown.py
+++ b/dev/benchmarks/omnigent/report_markdown.py
@@ -1,0 +1,190 @@
+"""Render ``run.py`` JSON reports as GitHub-flavoured markdown result matrices.
+
+Where ``compare.py`` renders a baseline-vs-candidate regression table, this
+renders the absolute numbers of one or more standalone reports — the
+journey × metric matrix a CI job appends to ``$GITHUB_STEP_SUMMARY``. Given
+several reports (e.g. the nightly's sqlite / postgres / mysql legs) it also
+leads with a cross-report P50 matrix so the backends can be compared side by
+side.
+
+Usage::
+
+    report_markdown.py REPORT.json [REPORT.json ...] [--title TEXT]
+
+Prints markdown to stdout. Report labels come from each report's
+``config.backend``; when two reports share a backend the filename stem is
+appended to keep the columns distinguishable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Keep table cells one-line and skimmable: a skip reason is an exception
+# rendering, which can run long and embed newlines that would break the row.
+_MAX_NOTE_LEN = 100
+
+
+def _fmt_ms(value: object) -> str:
+    """Format a millisecond metric, or ``—`` when it is absent."""
+    return f"{value:.1f}" if isinstance(value, (int, float)) else "—"
+
+
+def _fmt_rps(value: object) -> str:
+    """Format a requests-per-second metric, or ``—`` when it is absent."""
+    return f"{value:.0f}" if isinstance(value, (int, float)) else "—"
+
+
+def _one_line(text: str) -> str:
+    """Collapse *text* onto one bounded line so it can live in a table cell."""
+    flattened = " ".join(str(text).split())
+    if len(flattened) > _MAX_NOTE_LEN:
+        return flattened[: _MAX_NOTE_LEN - 1] + "…"
+    return flattened
+
+
+def _journey_note(block: dict) -> str:
+    """The Notes cell for one journey block: skip reason / failure marker."""
+    if block.get("skipped"):
+        return _one_line(f"⚠️ skipped — {block.get('error', 'unknown error')}")
+    summary = block.get("summary") or {}
+    if summary and not summary.get("runs_ok"):
+        return "❌ every run failed"
+    return ""
+
+
+def _runs_cell(block: dict) -> str:
+    """The Runs cell: ``ok/total``, or ``—`` for a skipped journey."""
+    summary = block.get("summary") or {}
+    total = summary.get("runs_total")
+    if not isinstance(total, int):
+        return "—"
+    return f"{summary.get('runs_ok', 0)}/{total}"
+
+
+def _caption(report: dict) -> str:
+    """One italic line of run context under a section heading."""
+    config = report.get("config") or {}
+    parts: list[str] = []
+    iterations = config.get("iterations")
+    runs = config.get("runs")
+    if iterations is not None and runs is not None:
+        parts.append(f"{iterations} iterations × {runs} runs")
+    warmup = config.get("warmup")
+    if warmup is not None:
+        parts.append(f"warmup {warmup}")
+    harness = report.get("harness")
+    if harness:
+        parts.append(str(harness))
+    sha = report.get("git_sha")
+    if sha:
+        parts.append(f"`{str(sha)[:8]}`")
+    return f"_{' · '.join(parts)}_" if parts else ""
+
+
+def _report_section(label: str, report: dict) -> list[str]:
+    """Markdown lines for one report: heading, caption, journey × metric table."""
+    lines = [f"### {label}", ""]
+    caption = _caption(report)
+    if caption:
+        lines.extend([caption, ""])
+    lines.extend(
+        [
+            "| Journey | Mean ms | P50 ms | P95 ms | P99 ms | Req/s | Runs | Notes |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for name, block in (report.get("journeys") or {}).items():
+        summary = block.get("summary") or {}
+        lines.append(
+            f"| {name} "
+            f"| {_fmt_ms(summary.get('avg_mean_ms'))} "
+            f"| {_fmt_ms(summary.get('avg_p50_ms'))} "
+            f"| {_fmt_ms(summary.get('avg_p95_ms'))} "
+            f"| {_fmt_ms(summary.get('avg_p99_ms'))} "
+            f"| {_fmt_rps(summary.get('avg_rps'))} "
+            f"| {_runs_cell(block)} "
+            f"| {_journey_note(block)} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _journey_order(labeled_reports: list[tuple[str, dict]]) -> list[str]:
+    """Union of journey names, keeping each report's insertion order."""
+    ordered: list[str] = []
+    for _, report in labeled_reports:
+        for name in report.get("journeys") or {}:
+            if name not in ordered:
+                ordered.append(name)
+    return ordered
+
+
+def _cross_matrix(labeled_reports: list[tuple[str, dict]]) -> list[str]:
+    """Journey × report P50 matrix so several reports compare side by side."""
+    labels = [label for label, _ in labeled_reports]
+    lines = [
+        "### P50 across reports",
+        "",
+        "| Journey | " + " | ".join(f"{label} P50 ms" for label in labels) + " |",
+        "| --- | " + " | ".join("---:" for _ in labels) + " |",
+    ]
+    for name in _journey_order(labeled_reports):
+        cells = []
+        for _, report in labeled_reports:
+            block = (report.get("journeys") or {}).get(name) or {}
+            cells.append(_fmt_ms((block.get("summary") or {}).get("avg_p50_ms")))
+        lines.append(f"| {name} | " + " | ".join(cells) + " |")
+    lines.append("")
+    return lines
+
+
+def build_markdown(labeled_reports: list[tuple[str, dict]], title: str | None = None) -> str:
+    """Render *labeled_reports* as one markdown document.
+
+    :param labeled_reports: ``(label, report)`` pairs, where *report* is a
+        parsed ``run.py`` JSON report and *label* names it (e.g. its backend).
+    :param title: Optional top-level heading, e.g. ``"Benchmark results"``.
+    :returns: GitHub-flavoured markdown ending in a newline.
+    """
+    lines: list[str] = []
+    if title:
+        lines.extend([f"## {title}", ""])
+    if len(labeled_reports) > 1:
+        lines.extend(_cross_matrix(labeled_reports))
+    for label, report in labeled_reports:
+        lines.extend(_report_section(label, report))
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _label_for(path: Path, report: dict, seen: set[str]) -> str:
+    """Label a report by backend, disambiguating duplicates with the filename."""
+    backend = (report.get("config") or {}).get("backend")
+    label = str(backend) if backend else path.stem
+    if label in seen:
+        label = f"{label} ({path.stem})"
+    seen.add(label)
+    return label
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: render the given report files to stdout."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reports", nargs="+", type=Path, help="run.py JSON report file(s).")
+    parser.add_argument("--title", default=None, help="Optional top-level heading.")
+    args = parser.parse_args(argv)
+
+    labeled: list[tuple[str, dict]] = []
+    seen: set[str] = set()
+    for path in args.reports:
+        report = json.loads(path.read_text())
+        labeled.append((_label_for(path, report, seen), report))
+    sys.stdout.write(build_markdown(labeled, title=args.title))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -613,3 +613,113 @@ def test_seed_creates_listable_corpus(tmp_path: Path) -> None:
     # NOTE: seed() builds the store, which runs migrations to the current head,
     # so this test always exercises the live schema — it is the safety net that
     # a schema change hasn't broken seeding (no revision constant to maintain).
+
+
+# ── report_markdown: the CI job-summary matrix renderer ──────────────────────
+
+
+def _markdown_report(journeys: dict[str, dict], backend: str = "sqlite") -> dict:
+    """A minimal run.py-shaped report carrying just what the renderer reads."""
+    return {
+        "git_sha": "abcdef1234567890",
+        "harness": "openai-agents",
+        "config": {"iterations": 100, "runs": 3, "warmup": 10, "backend": backend},
+        "journeys": journeys,
+    }
+
+
+def _journey_block(**summary: object) -> dict:
+    """A measured journey block with the given summary metrics."""
+    return {"kind": "latency", "runs": [], "summary": {"runs_total": 3, "runs_ok": 3, **summary}}
+
+
+def test_report_markdown_renders_journey_matrix() -> None:
+    """One report renders a journey × metric table with formatted values.
+
+    The renderer feeds $GITHUB_STEP_SUMMARY; a broken cell silently degrades
+    the CI matrix, so assert the exact row content, not just "contains name".
+    """
+    from dev.benchmarks.omnigent.report_markdown import build_markdown
+
+    report = _markdown_report(
+        {
+            "session_cold_start": _journey_block(
+                avg_mean_ms=1234.5,
+                avg_p50_ms=1200.0,
+                avg_p95_ms=1500.25,
+                avg_p99_ms=1600.0,
+                avg_rps=0.8,
+            ),
+        }
+    )
+    md = build_markdown([("sqlite", report)], title="Host session benchmark")
+
+    assert "## Host session benchmark" in md
+    assert "### sqlite" in md
+    # Caption line carries the run context.
+    assert "_100 iterations × 3 runs · warmup 10 · openai-agents · `abcdef12`_" in md
+    assert "| session_cold_start | 1234.5 | 1200.0 | 1500.2 | 1600.0 | 1 | 3/3 |  |" in md
+
+
+def test_report_markdown_marks_skipped_and_failed_journeys() -> None:
+    """Skipped journeys carry the skip reason; all-failed journeys are flagged.
+
+    A skipped journey has an empty summary, and a fully-failed one has counts
+    but no metric keys — both must render as explicit markers, never as fast
+    zeros.
+    """
+    from dev.benchmarks.omnigent.report_markdown import build_markdown
+
+    report = _markdown_report(
+        {
+            "session_cold_start": {
+                "kind": "latency",
+                "runs": [],
+                "summary": {},
+                "skipped": True,
+                "error": "RuntimeError: host not\nready",
+            },
+            "warm_turn": {
+                "kind": "latency",
+                "runs": [],
+                "summary": {"runs_total": 3, "runs_ok": 0},
+            },
+        }
+    )
+    md = build_markdown([("sqlite", report)])
+
+    assert (
+        "| session_cold_start | — | — | — | — | — | — | ⚠️ skipped — RuntimeError: host not ready |"
+        in md
+    )
+    assert "| warm_turn | — | — | — | — | — | 0/3 | ❌ every run failed |" in md
+
+
+def test_report_markdown_cross_report_matrix() -> None:
+    """Multiple reports lead with a journey × report P50 matrix.
+
+    The nightly renders one report per backend; the cross matrix is what
+    makes them comparable at a glance, including journeys missing from one
+    backend (rendered as —).
+    """
+    from dev.benchmarks.omnigent.report_markdown import build_markdown
+
+    sqlite = _markdown_report(
+        {
+            "create_session": _journey_block(avg_p50_ms=12.5),
+            "session_cold_start": _journey_block(avg_p50_ms=1200.0),
+        },
+        backend="sqlite",
+    )
+    postgres = _markdown_report(
+        {"create_session": _journey_block(avg_p50_ms=20.0)}, backend="postgresql"
+    )
+    md = build_markdown([("sqlite", sqlite), ("postgresql", postgres)])
+
+    assert "### P50 across reports" in md
+    assert "| Journey | sqlite P50 ms | postgresql P50 ms |" in md
+    assert "| create_session | 12.5 | 20.0 |" in md
+    assert "| session_cold_start | 1200.0 | — |" in md
+    # Per-report sections still follow the cross matrix.
+    assert "### sqlite" in md
+    assert "### postgresql" in md


### PR DESCRIPTION
## Related issue

None — CI/tooling follow-up to #4752 (host session-create latency work): make those numbers visible in CI on the PRs that move them.

## Summary

- **New `benchmark-host.yml` workflow**: profiles the host-bound session lifecycle — `session_cold_start` (create → `host.launch_runner` → runner boot → first token), `session_cold_restart` — plus the common actions around it (`warm_turn`, `time_to_first_token`, `interrupt`, `create_session`, `fork_session`, `list_sessions`, `get_session`, `load_conversation_history`) using the existing `dev/benchmarks/omnigent` harness (real server + real `omni host` daemon + runner against the zero-latency mock LLM; no agent CLI, no credentials). Triggers on PRs touching `omnigent/host/**`, `omnigent/runner/**`, `omnigent/server/**`, or the harness, and on manual dispatch (journeys/iterations/runs inputs). Informational by design — no thresholds, so shared-runner noise can't block a PR; regression *gating* stays with `benchmark-pr.yml` and `release.yml`, and seeded backend-matrix trend data stays with the nightly `benchmark.yml`.
- **New `dev/benchmarks/omnigent/report_markdown.py`**: renders one or more `run.py` JSON reports as a journey × metric markdown matrix (mean/P50/P95/P99/req/s + run counts, with skipped/failed journeys explicitly marked, never as fast zeros). Given several reports it leads with a journey × report P50 cross-matrix. `compare.py` only renders baseline-vs-candidate diffs; this fills the single-run gap.
- **Nightly `benchmark.yml` now renders its matrix too**: one added step per backend leg appends the same matrix to `$GITHUB_STEP_SUMMARY`, so the sqlite/postgres/mysql numbers are readable on the run page without downloading the JSON artifact.

ELI5: the nightly benchmark already measures how fast sessions start, but the numbers were buried in a JSON file, and PRs that change the host/runner never ran it at all. Now those PRs get a run of the session-lifecycle benchmark, and every benchmark run prints its results as a table right on the run page.

## Test Plan

- New renderer tests added to the existing `tests/benchmarks/test_benchmark_smoke.py` suite (journey matrix content asserted cell-for-cell; skipped/all-failed markers; multi-report cross-matrix with missing journeys as `—`) — suite passes.
- Ran the workflow's exact command locally (scaled down): `uv run --no-sync dev/benchmarks/omnigent/run.py --journeys session_cold_start,create_session,list_sessions --iterations 5 --runs 1 --warmup 1 --output …` then `report_markdown.py` on the real output — see Demo.
- Both workflow files parse (yaml), and `benchmark-host.yml` reuses the pinned action SHAs and idioms of the existing benchmark workflows.
- This PR touches `dev/benchmarks/**`, so `benchmark-pr.yml` runs on it; `benchmark-host.yml` itself runs here too (its own path filter includes it).

## Demo

Actual local output of the new renderer on a real (scaled-down) host-session run:

## Host session benchmark

### sqlite

_5 iterations × 1 runs · warmup 1 · openai-agents · `f75c07ba`_

| Journey | Mean ms | P50 ms | P95 ms | P99 ms | Req/s | Runs | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| session_cold_start | 1606.7 | 1545.9 | 1874.1 | 1874.1 | 1 | 1/1 |  |
| create_session | 32.0 | 30.0 | 41.1 | 41.1 | 31 | 1/1 |  |
| list_sessions | 9.5 | 7.0 | 16.9 | 16.9 | 105 | 1/1 |  |

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The renderer is unit-tested in the existing benchmarks smoke suite. The workflow itself can't be unit-tested; it was verified by running its exact benchmark + render commands locally against a real server/host/runner (Demo above), and it self-triggers on this PR via its `dev/benchmarks/**` path filter so the full job runs here.
