### PR TITLE
perf(terminal): attach web terminals over loopback when the runner is local

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1508,6 +1508,35 @@ async def _run_tunnel_from_env() -> None:
     # drains its session streams and closes cleanly — the server then sees an
     # end-of-stream, not an abrupt drop that renders a scary error banner.
     tunnel_shutdown_event = asyncio.Event()
+    # Loopback direct-attach listener: lets a browser on this machine attach
+    # to terminals with zero relay legs. Best-effort — any failure keeps the
+    # runner relay-only. Windows never runs the web terminal bridges, so the
+    # listener is POSIX-only like the bridges themselves.
+    direct_attach_listener = None
+    direct_attach_token: str | None = None
+    if sys.platform != "win32":
+        try:
+            from omnigent.runner.direct_attach import (
+                allowed_origin_for_server,
+                create_direct_attach_app,
+                new_direct_attach_token,
+                start_direct_attach_listener,
+            )
+
+            attach_handler = getattr(app.state, "terminal_attach_handler", None)
+            allowed_origin = allowed_origin_for_server(server_url)
+            if attach_handler is not None and allowed_origin is not None:
+                direct_attach_token = new_direct_attach_token()
+                direct_attach_listener = await start_direct_attach_listener(
+                    create_direct_attach_app(
+                        attach_handler,
+                        token=direct_attach_token,
+                        allowed_origins=frozenset({allowed_origin}),
+                    )
+                )
+        except Exception:  # noqa: BLE001 — optimization only; never block the tunnel
+            _logger.warning("direct-attach listener setup failed", exc_info=True)
+            direct_attach_listener = None
     tunnel_task = asyncio.create_task(
         serve_tunnel(
             cast("_ASGIApp", app),  # FastAPI is ASGI-compatible; cast narrows for mypy
@@ -1521,6 +1550,12 @@ async def _run_tunnel_from_env() -> None:
             on_activity=_mark_activity,
             shutdown_event=tunnel_shutdown_event,
             on_graceful_shutdown=getattr(app.state, "drain_session_streams", None),
+            direct_attach_port=(
+                direct_attach_listener.port if direct_attach_listener is not None else None
+            ),
+            direct_attach_token=(
+                direct_attach_token if direct_attach_listener is not None else None
+            ),
         ),
         name=f"runner-ws-tunnel:{runner_id}",
     )
@@ -1613,6 +1648,9 @@ async def _run_tunnel_from_env() -> None:
         if idle_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
+        if direct_attach_listener is not None:
+            with contextlib.suppress(Exception):
+                await direct_attach_listener.stop()
         await _lifespan_cm.__aexit__(None, None, None)
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7791,6 +7791,12 @@ def create_runner_app(
             on_client_interaction=entry.instance.note_client_interaction,
         )
 
+    # Reused by the loopback direct-attach listener (see
+    # ``omnigent.runner.direct_attach``): same attach handler served on a
+    # token-gated 127.0.0.1 port so a same-machine browser can skip the
+    # server relay.
+    app.state.terminal_attach_handler = terminal_resource_attach_ws
+
     async def _require_os_env(session_id: str) -> AgentSpec | None:
         spec = await _resolve_session_agent_spec(session_id)
         if spec is not None and getattr(spec, "os_env", None) is None:

--- a/omnigent/runner/direct_attach.py
+++ b/omnigent/runner/direct_attach.py
@@ -1,0 +1,243 @@
+"""Loopback listener for relay-free browser terminal attach.
+
+The runner normally reaches browsers only through the server relay:
+browser → server WS → runner tunnel → tmux, which costs two WAN round
+trips per keystroke even when the browser and the runner share a
+machine. This module serves the runner's *existing* terminal-attach
+handler on ``127.0.0.1`` so a same-machine browser can attach with
+zero WAN legs. The server learns the endpoint from the tunnel hello
+advert and hands owners a ``direct_attach_url``; the web client
+probes it and silently falls back to the relay when unreachable
+(other machines, Safari's mixed-content policy, listener down).
+
+Security model
+--------------
+
+- Binds ``127.0.0.1`` only — never a routable interface.
+- Every handshake must present the per-process bearer token
+  (``?token=``, high-entropy, held only in runner memory, the tunnel
+  hello, and the owner-gated terminals API response).
+- Browser handshakes must carry an allow-listed ``Origin`` (the
+  server origin the runner is tunneled to); requests without an
+  ``Origin`` header (curl, native tools) pass on the token alone.
+  This blocks DNS-rebinding-style pages, which present a foreign
+  origin, from driving the port even if a token ever leaked.
+- Authorization-wise the token equals owner-level write attach: the
+  server discloses it only to callers who hold ``LEVEL_OWNER`` on the
+  session, mirroring the relay's write-attach gate.
+
+CORS never applies on this path: WebSocket handshakes are exempt from
+CORS preflight, and the client performs no HTTP fetches against the
+listener — reachability is tested via the ``/probe`` WebSocket route,
+which validates and closes without touching any terminal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import secrets
+from collections.abc import Awaitable, Callable
+from typing import Final
+from urllib.parse import urlsplit
+
+import uvicorn
+from fastapi import FastAPI, Query, WebSocket
+from starlette import status
+
+_logger = logging.getLogger(__name__)
+
+# Bind loopback by literal IPv4 address, matching the URL the server
+# composes for browsers. "localhost" is avoided: it can resolve to ::1
+# and leave the advertised 127.0.0.1 URL pointing at nothing.
+DIRECT_ATTACH_BIND_HOST: Final[str] = "127.0.0.1"
+
+# Bound on how long a listener startup may take before the runner gives
+# up and continues relay-only. Startup is a local socket bind; seconds
+# means something is wrong, and the listener must never delay the tunnel.
+_STARTUP_TIMEOUT_S: Final[float] = 5.0
+_STARTUP_POLL_S: Final[float] = 0.01
+
+_SHUTDOWN_TIMEOUT_S: Final[float] = 2.0
+
+# The attach handler contract shared with ``runner/app.py``'s
+# ``terminal_resource_attach_ws`` route.
+AttachHandler = Callable[..., Awaitable[None]]
+
+
+def new_direct_attach_token() -> str:
+    """Return a fresh high-entropy, URL-safe direct-attach bearer token."""
+    return secrets.token_urlsafe(32)
+
+
+def allowed_origin_for_server(server_url: str) -> str | None:
+    """Derive the browser Origin allowed on the listener from *server_url*.
+
+    The standalone web UI is served by the omnigent server itself, so a
+    legitimate browser handshake carries that server's origin. Path,
+    query, and userinfo are dropped; scheme and host:port are kept.
+
+    :param server_url: The runner's server base URL, e.g.
+        ``"https://omnigents.example.databricksapps.com"`` or
+        ``"http://127.0.0.1:6767"``.
+    :returns: The origin string (``scheme://host[:port]``), or ``None``
+        when *server_url* has no usable scheme/host (origin checks then
+        reject all browser handshakes rather than guessing).
+    """
+    parts = urlsplit(server_url)
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        return None
+    host = parts.netloc.rsplit("@", 1)[-1]
+    return f"{parts.scheme}://{host}"
+
+
+def _handshake_authorized(
+    websocket: WebSocket,
+    *,
+    token: str,
+    allowed_origins: frozenset[str],
+) -> bool:
+    """Validate a direct-listener WebSocket handshake before accepting.
+
+    :param websocket: The not-yet-accepted WebSocket.
+    :param token: The listener's bearer token.
+    :param allowed_origins: Origins allowed for browser handshakes.
+    :returns: ``True`` when the handshake may proceed.
+    """
+    supplied = websocket.query_params.get("token", "")
+    try:
+        token_ok = bool(supplied) and secrets.compare_digest(supplied, token)
+    except TypeError:
+        # Non-ASCII garbage in the query param; definitionally wrong.
+        token_ok = False
+    if not token_ok:
+        return False
+    origin = websocket.headers.get("origin")
+    if origin is None:
+        # Non-browser client (no Origin header); the token is the gate.
+        return True
+    return origin in allowed_origins
+
+
+def create_direct_attach_app(
+    attach_handler: AttachHandler,
+    *,
+    token: str,
+    allowed_origins: frozenset[str],
+) -> FastAPI:
+    """Build the minimal ASGI app served on the loopback listener.
+
+    Exposes exactly two WebSocket routes and nothing else — the
+    runner's full RPC surface stays tunnel-only:
+
+    - ``/probe``: validates the handshake, accepts, closes. Lets the
+      browser test reachability without touching any terminal (a real
+      attach forks a tmux client and seeds a capture, so probing the
+      attach route itself would cost real work per page load).
+    - ``/v1/sessions/{sid}/resources/terminals/{tid}/attach``: the same
+      path shape and handler as the tunnel-dispatched attach route, so
+      the browser-facing wire protocol is identical on both paths.
+
+    :param attach_handler: The runner app's attach coroutine
+        (``app.state.terminal_attach_handler``).
+    :param token: Bearer token required on every handshake.
+    :param allowed_origins: Browser origins allowed to connect.
+    :returns: The FastAPI app for :func:`start_direct_attach_listener`.
+    """
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+
+    def _authorized(websocket: WebSocket) -> bool:
+        return _handshake_authorized(
+            websocket,
+            token=token,
+            allowed_origins=allowed_origins,
+        )
+
+    @app.websocket("/probe")
+    async def probe(websocket: WebSocket) -> None:
+        """Accept and immediately close so a client can test reachability."""
+        if not _authorized(websocket):
+            # Close before accept rejects the handshake (HTTP 403).
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        await websocket.accept()
+        await websocket.close()
+
+    @app.websocket("/v1/sessions/{session_id}/resources/terminals/{terminal_id}/attach")
+    async def direct_terminal_attach(
+        websocket: WebSocket,
+        session_id: str,
+        terminal_id: str,
+        read_only: bool = Query(default=False),
+        transport: str | None = Query(default=None),
+    ) -> None:
+        """Token-gated wrapper around the runner's attach handler."""
+        if not _authorized(websocket):
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        await attach_handler(
+            websocket,
+            session_id,
+            terminal_id,
+            read_only=read_only,
+            transport=transport,
+        )
+
+    return app
+
+
+class DirectAttachListener:
+    """A running loopback listener: the uvicorn server, its task, and port."""
+
+    def __init__(self, server: uvicorn.Server, task: asyncio.Task[None], port: int) -> None:
+        self._server = server
+        self._task = task
+        self.port = port
+
+    async def stop(self) -> None:
+        """Signal the server to exit and await it briefly (best-effort)."""
+        self._server.should_exit = True
+        with contextlib.suppress(asyncio.TimeoutError, Exception):
+            await asyncio.wait_for(self._task, timeout=_SHUTDOWN_TIMEOUT_S)
+        if not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+
+
+async def start_direct_attach_listener(app: FastAPI) -> DirectAttachListener | None:
+    """Serve *app* on an ephemeral 127.0.0.1 port.
+
+    :param app: The app from :func:`create_direct_attach_app`.
+    :returns: The running listener, or ``None`` when startup failed —
+        callers continue relay-only; the listener is an optimization
+        and must never block or break the runner.
+    """
+    config = uvicorn.Config(
+        app,
+        host=DIRECT_ATTACH_BIND_HOST,
+        port=0,
+        log_level="warning",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve(), name="runner-direct-attach")
+    deadline = asyncio.get_running_loop().time() + _STARTUP_TIMEOUT_S
+    while not server.started:
+        if task.done() or asyncio.get_running_loop().time() >= deadline:
+            _logger.warning("direct-attach listener failed to start; relay-only")
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+            return None
+        await asyncio.sleep(_STARTUP_POLL_S)
+    try:
+        sockets = server.servers[0].sockets
+        port = int(sockets[0].getsockname()[1])
+    except (IndexError, AttributeError, OSError):
+        _logger.warning("direct-attach listener has no bound socket; relay-only")
+        await DirectAttachListener(server, task, 0).stop()
+        return None
+    _logger.info("direct-attach listener on %s:%d", DIRECT_ATTACH_BIND_HOST, port)
+    return DirectAttachListener(server, task, port)

--- a/omnigent/runner/direct_attach.py
+++ b/omnigent/runner/direct_attach.py
@@ -35,7 +35,6 @@ which validates and closes without touching any terminal.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
@@ -187,6 +186,23 @@ def create_direct_attach_app(
     return app
 
 
+async def _await_quietly(task: asyncio.Task[None]) -> None:
+    """Await a finished or cancelled listener task without ever raising.
+
+    The listener is best-effort, so a server that died on its own is
+    logged rather than propagated into the runner's startup or shutdown.
+    ``asyncio.wait`` never re-raises the task's own failure, so the
+    outcome is read back off the task instead of caught.
+
+    :param task: The listener task, already exiting or cancelled.
+    """
+    await asyncio.wait({task}, timeout=_SHUTDOWN_TIMEOUT_S)
+    if not task.done() or task.cancelled():
+        return
+    if (exc := task.exception()) is not None:
+        _logger.warning("direct-attach listener exited with an error", exc_info=exc)
+
+
 class DirectAttachListener:
     """A running loopback listener: the uvicorn server, its task, and port."""
 
@@ -198,12 +214,12 @@ class DirectAttachListener:
     async def stop(self) -> None:
         """Signal the server to exit and await it briefly (best-effort)."""
         self._server.should_exit = True
-        with contextlib.suppress(asyncio.TimeoutError, Exception):
-            await asyncio.wait_for(self._task, timeout=_SHUTDOWN_TIMEOUT_S)
+        # asyncio.wait never re-raises the task's own failure, so a listener
+        # that already died cannot break the caller's shutdown path.
+        await asyncio.wait({self._task}, timeout=_SHUTDOWN_TIMEOUT_S)
         if not self._task.done():
             self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._task
+        await _await_quietly(self._task)
 
 
 async def start_direct_attach_listener(app: FastAPI) -> DirectAttachListener | None:
@@ -228,8 +244,7 @@ async def start_direct_attach_listener(app: FastAPI) -> DirectAttachListener | N
         if task.done() or asyncio.get_running_loop().time() >= deadline:
             _logger.warning("direct-attach listener failed to start; relay-only")
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await task
+            await _await_quietly(task)
             return None
         await asyncio.sleep(_STARTUP_POLL_S)
     try:

--- a/omnigent/runner/transports/ws_tunnel/frames.py
+++ b/omnigent/runner/transports/ws_tunnel/frames.py
@@ -64,6 +64,13 @@ class HelloFrame:
         ``DISABLE_TELEMETRY=true``, or ``telemetry: false`` in
         config.yaml).  The server honours this on a best-effort basis
         by skipping telemetry events for sessions on this runner.
+    :param direct_attach_port: Loopback TCP port of the runner's
+        direct terminal-attach listener, or ``None`` when the runner
+        does not run one. Lets a browser on the same machine attach
+        without the server relay.
+    :param direct_attach_token: Per-process bearer token guarding the
+        direct-attach listener. Only meaningful alongside
+        *direct_attach_port*; both travel together or not at all.
     """
 
     runner_version: str
@@ -71,6 +78,8 @@ class HelloFrame:
     harnesses: list[str] = field(default_factory=list)
     envs: list[str] = field(default_factory=list)
     telemetry_opt_out: bool = False
+    direct_attach_port: int | None = None
+    direct_attach_token: str | None = None
 
 
 @dataclass
@@ -201,16 +210,21 @@ def encode_frame(frame: Frame) -> str:
     The output is what goes onto the WebSocket as a text message.
     """
     if isinstance(frame, HelloFrame):
-        return json.dumps(
-            {
-                "kind": FrameKind.HELLO.value,
-                "runner_version": frame.runner_version,
-                "frame_protocol_version": frame.frame_protocol_version,
-                "harnesses": list(frame.harnesses),
-                "envs": list(frame.envs),
-                "telemetry_opt_out": frame.telemetry_opt_out,
-            }
-        )
+        payload: dict[str, object] = {
+            "kind": FrameKind.HELLO.value,
+            "runner_version": frame.runner_version,
+            "frame_protocol_version": frame.frame_protocol_version,
+            "harnesses": list(frame.harnesses),
+            "envs": list(frame.envs),
+            "telemetry_opt_out": frame.telemetry_opt_out,
+        }
+        # Emitted only when the listener is actually up, so old servers
+        # (which ignore unknown keys) and advert-less runners share one
+        # wire shape.
+        if frame.direct_attach_port is not None and frame.direct_attach_token:
+            payload["direct_attach_port"] = frame.direct_attach_port
+            payload["direct_attach_token"] = frame.direct_attach_token
+        return json.dumps(payload)
     if isinstance(frame, RequestFrame):
         return json.dumps(
             {
@@ -373,12 +387,25 @@ def _decode_hello(msg: _JsonObject) -> HelloFrame:
     :param msg: Decoded frame object.
     :returns: Typed hello frame.
     """
+    # The direct-attach advert is optional and its two fields only mean
+    # anything together — a half-present pair decodes as absent.
+    raw_port = msg.get("direct_attach_port")
+    raw_token = msg.get("direct_attach_token")
+    direct_port = (
+        raw_port if isinstance(raw_port, int) and not isinstance(raw_port, bool) else None
+    )
+    direct_token = raw_token if isinstance(raw_token, str) and raw_token else None
+    if direct_port is None or direct_token is None:
+        direct_port = None
+        direct_token = None
     return HelloFrame(
         runner_version=_required_str(msg, "runner_version"),
         frame_protocol_version=_required_int(msg, "frame_protocol_version"),
         harnesses=_optional_str_list(msg, "harnesses"),
         envs=_optional_str_list(msg, "envs"),
         telemetry_opt_out=_optional_bool(msg, "telemetry_opt_out", False),
+        direct_attach_port=direct_port,
+        direct_attach_token=direct_token,
     )
 
 

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -277,6 +277,8 @@ async def serve_tunnel(
     on_activity: Callable[[], None] | None = None,
     shutdown_event: asyncio.Event | None = None,
     on_graceful_shutdown: Callable[[], None] | None = None,
+    direct_attach_port: int | None = None,
+    direct_attach_token: str | None = None,
 ) -> None:
     """Keep a runner WebSocket tunnel connected to a server.
 
@@ -374,6 +376,8 @@ async def serve_tunnel(
                 shutdown_event=shutdown_event,
                 on_graceful_shutdown=on_graceful_shutdown,
                 on_connected=_mark_connected,
+                direct_attach_port=direct_attach_port,
+                direct_attach_token=direct_attach_token,
                 **activity_kwargs,
             )
             # A graceful shutdown drains and closes the connection cleanly,
@@ -630,6 +634,8 @@ async def _serve_tunnel_once(
     shutdown_event: asyncio.Event | None = None,
     on_graceful_shutdown: Callable[[], None] | None = None,
     on_connected: Callable[[], None] | None = None,
+    direct_attach_port: int | None = None,
+    direct_attach_token: str | None = None,
 ) -> None:
     """Serve one WebSocket connection until it closes.
 
@@ -711,7 +717,12 @@ async def _serve_tunnel_once(
     ) as ws:
         if on_connected is not None:
             on_connected()
-        await _send_hello(ws.send, runner_version)
+        await _send_hello(
+            ws.send,
+            runner_version,
+            direct_attach_port=direct_attach_port,
+            direct_attach_token=direct_attach_token,
+        )
         _logger.info("runner %s connected to %s", runner_id, tunnel_url)
         try:
             if shutdown_event is None:
@@ -849,12 +860,21 @@ async def _graceful_drain(
 async def _send_hello(
     send_text: Callable[[str], Awaitable[None]],
     runner_version: str,
+    *,
+    direct_attach_port: int | None = None,
+    direct_attach_token: str | None = None,
 ) -> None:
     """Send the runner's opening hello frame.
 
     :param send_text: Async WebSocket text sender.
     :param runner_version: Runner version string for the hello
         frame, e.g. ``"0.1.0"``.
+    :param direct_attach_port: Loopback port of the runner's direct
+        terminal-attach listener, advertised to the server so it can
+        hand browsers a same-machine attach URL. ``None`` when the
+        listener is not running.
+    :param direct_attach_token: Bearer token guarding that listener;
+        travels only alongside *direct_attach_port*.
     :returns: None.
     """
     # Signal host-side telemetry opt-out to the server so it can honour
@@ -873,6 +893,8 @@ async def _send_hello(
                 runner_version=runner_version,
                 frame_protocol_version=1,
                 telemetry_opt_out=_tel_opt_out,
+                direct_attach_port=direct_attach_port,
+                direct_attach_token=direct_attach_token,
                 harnesses=[
                     "claude-native",
                     "claude-sdk",

--- a/omnigent/runtime/__init__.py
+++ b/omnigent/runtime/__init__.py
@@ -359,6 +359,24 @@ def get_runner_ws_factory() -> Any:
     return _globals._runner_ws_factory
 
 
+def set_runner_direct_attach_resolver(resolver: Any) -> None:
+    """Set the conversation-id → direct-attach-endpoint resolver.
+
+    The resolver is a callable ``(conversation_id: str) ->
+    DirectAttachEndpoint | None`` built by
+    :func:`omnigent.server._runner_ws_tunnel.make_direct_attach_resolver`.
+    The terminals API uses it to expose a loopback attach URL for
+    browsers on the same machine as the runner. Leave unset (``None``)
+    when the server has no runner tunnels.
+    """
+    _globals._runner_direct_attach_resolver = resolver
+
+
+def get_runner_direct_attach_resolver() -> Any:
+    """Return the direct-attach resolver, or ``None`` if unset."""
+    return _globals._runner_direct_attach_resolver
+
+
 def set_runner_id(runner_id: str | None) -> None:
     """Set the stable runner UUID for conversation affinity."""
     _globals._runner_id = runner_id

--- a/omnigent/runtime/_globals.py
+++ b/omnigent/runtime/_globals.py
@@ -80,6 +80,13 @@ _runner_router: RunnerRouter | None = None
 # terminal-attach proxy to bridge xterm.js frames to the runner WS.
 _runner_ws_factory: Any | None = None  # Callable[[str], AsyncContextManager[ClientConnection]]
 
+# Resolver from conversation id to the pinned runner's advertised
+# loopback direct-attach endpoint (see
+# ``omnigent.server._runner_ws_tunnel.make_direct_attach_resolver``).
+# Lets the terminals API hand a same-machine browser a relay-free
+# attach URL; ``None`` outside tunnel-serving deployments.
+_runner_direct_attach_resolver: Any | None = None  # Callable[[str], DirectAttachEndpoint | None]
+
 # Optional fixed runner id for the legacy/test direct runner-client
 # path. Production dispatch uses _runner_router and conversation
 # affinity instead of this process-wide id.

--- a/omnigent/server/_runner_ws_tunnel.py
+++ b/omnigent/server/_runner_ws_tunnel.py
@@ -39,6 +39,7 @@ import logging
 import re
 import secrets
 from collections.abc import Callable
+from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING
 
@@ -85,6 +86,57 @@ class WrongReplicaWSError(RuntimeError):
 # construction, so the captured value feeds
 # ``router.client_for_existing_conversation()``.
 _RUNNER_PATH_RE = re.compile(r"^/v1/sessions/(?P<conv>[^/?]+)/resources/terminals/[^/?]+/attach")
+
+
+@dataclass(frozen=True)
+class DirectAttachEndpoint:
+    """A runner's advertised loopback terminal-attach listener.
+
+    :param port: Loopback TCP port on the runner's machine,
+        e.g. ``52341``.
+    :param token: Per-runner-process bearer token the listener
+        requires on every handshake.
+    """
+
+    port: int
+    token: str
+
+
+def make_direct_attach_resolver(
+    router: RunnerRouter,
+    registry: TunnelRegistry,
+) -> Callable[[str], DirectAttachEndpoint | None]:
+    """Build a resolver from conversation id to its runner's direct-attach advert.
+
+    Mirrors :func:`make_tunnel_ws_factory`'s routing (pinned runner →
+    live tunnel session) but only reads the hello advert; installed via
+    :func:`omnigent.runtime.set_runner_direct_attach_resolver` so the
+    terminals API can hand same-machine browsers a relay-free attach URL.
+
+    :param router: Routes conversation ids to pinned runner ids.
+    :param registry: Tunnel registry that owns the live runner sessions.
+    :returns: Callable returning the advert, or ``None`` when the
+        conversation has no pinned runner, the runner is offline, or it
+        advertised no listener.
+    """
+
+    def resolver(conversation_id: str) -> DirectAttachEndpoint | None:
+        try:
+            routed = router.client_for_existing_conversation(conversation_id)
+        except OmnigentError:
+            return None
+        if routed is None:
+            return None
+        session = registry.get(routed.runner_id)
+        if session is None:
+            return None
+        port = session.hello.direct_attach_port
+        token = session.hello.direct_attach_token
+        if port is None or not token:
+            return None
+        return DirectAttachEndpoint(port=port, token=token)
+
+    return resolver
 
 
 def make_tunnel_ws_factory(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -36,6 +36,7 @@ from omnigent.runtime import (
     get_terminal_registry,
     pending_elicitations,
     set_harness_process_manager,
+    set_runner_direct_attach_resolver,
     set_runner_router,
     set_runner_ws_factory,
 )
@@ -1024,9 +1025,18 @@ def create_app(
         # Install the tunnel-backed WS factory so browser terminal
         # attach can proxy frames over the same persistent WebSocket
         # the runner already uses for HTTP.
-        from omnigent.server._runner_ws_tunnel import make_tunnel_ws_factory
+        from omnigent.server._runner_ws_tunnel import (
+            make_direct_attach_resolver,
+            make_tunnel_ws_factory,
+        )
 
         set_runner_ws_factory(make_tunnel_ws_factory(runner_router, tunnel_registry))
+        # Companion resolver: lets the terminals API surface a runner's
+        # advertised loopback attach endpoint so a browser on the same
+        # machine can skip the relay entirely.
+        set_runner_direct_attach_resolver(
+            make_direct_attach_resolver(runner_router, tunnel_registry)
+        )
 
         # MCP execution moved to the runner (designs/RUNNER_MCP.md);
         # SessionFilesystemRegistry moved to the runner. Both
@@ -1148,6 +1158,7 @@ def create_app(
             _uninstall_subagent_block_notifier()
             set_resource_registry(None)
             set_runner_ws_factory(None)
+            set_runner_direct_attach_resolver(None)
             set_runner_router(None)
             await runner_router.aclose()
 

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -826,12 +826,93 @@ def register_resources_routes(
             for key, value in request.query_params.items()
             if key in ("limit", "after", "before", "order")
         }
-        return await _proxy_get_to_runner(
+        page = await _proxy_get_to_runner(
             session_id,
             path,
             conv,
             params=forwarded or None,
         )
+        await _annotate_direct_attach(page, session_id, request)
+        return page
+
+    async def _caller_owns_session(session_id: str, request: Request) -> bool:
+        """Return whether the requester holds owner-level access.
+
+        Non-raising variant of the owner gate used for optional
+        enrichment: an interactive (write) attach requires owner level
+        (see ``terminal_attach._authorize_terminal_attach``), so the
+        direct-attach token — which grants write attach without a
+        server-side check — may only be disclosed to owners. Mirrors
+        the relay's permissions-disabled behavior: no permission store
+        means single-user mode, where the caller is the owner.
+
+        :param session_id: Session/conversation identifier.
+        :param request: The incoming request carrying auth context.
+        :returns: ``True`` when disclosure is allowed.
+        """
+        if permission_store is None:
+            return True
+        user_id = _get_user_id(request, auth_provider)
+        if user_id is None:
+            return False
+        try:
+            await _require_access_and_level(
+                user_id,
+                session_id,
+                LEVEL_OWNER,
+                permission_store,
+                conversation_store,
+            )
+        except OmnigentError:
+            return False
+        return True
+
+    async def _annotate_direct_attach(
+        page: dict[str, Any],
+        session_id: str,
+        request: Request,
+    ) -> None:
+        """Add ``metadata.direct_attach_url`` to each terminal item.
+
+        Best-effort enrichment for browsers running on the same machine
+        as the session's runner: when the runner advertised a loopback
+        attach listener over its tunnel and the caller is the session
+        owner, each terminal gains a ``ws://127.0.0.1:...`` URL the
+        client may *try* before the relay path. Any miss — no resolver
+        installed, runner offline, no advert, non-owner caller — leaves
+        the payload untouched, so the relay path is unaffected.
+
+        :param page: The runner's ``PaginatedList`` JSON, mutated in place.
+        :param session_id: Session/conversation identifier.
+        :param request: The incoming request carrying auth context.
+        """
+        from omnigent.runtime import get_runner_direct_attach_resolver
+
+        resolver = get_runner_direct_attach_resolver()
+        if resolver is None:
+            return
+        endpoint = resolver(session_id)
+        if endpoint is None:
+            return
+        if not await _caller_owns_session(session_id, request):
+            return
+        items = page.get("data")
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            terminal_id = item.get("id")
+            if not isinstance(terminal_id, str) or not terminal_id:
+                continue
+            metadata = item.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+                item["metadata"] = metadata
+            metadata["direct_attach_url"] = (
+                f"ws://127.0.0.1:{endpoint.port}/v1/sessions/{session_id}"
+                f"/resources/terminals/{terminal_id}/attach?token={endpoint.token}"
+            )
 
     @router.post(
         "/sessions/{session_id}/resources/terminals",

--- a/tests/e2e/omnigent/test_session_resources_e2e.py
+++ b/tests/e2e/omnigent/test_session_resources_e2e.py
@@ -485,3 +485,110 @@ def test_session_resources_e2e(
             assert body["stdout"].strip() == "e2e_shell_test"
             assert body["exit_code"] == 0
             assert body["timed_out"] is False
+
+
+def test_direct_attach_e2e(
+    mock_credentials_env: dict[str, str],
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    tmp_path: Path,
+) -> None:
+    """Loopback direct attach works end-to-end against a real runner.
+
+    Boots the real server + a real tunneled runner subprocess, then
+    verifies the whole direct-attach chain: the runner's loopback
+    listener starts and is advertised over the tunnel hello; the
+    terminals API surfaces a ``direct_attach_url``; a WebSocket client
+    on that URL (with the server's Origin) reaches the real tmux
+    terminal with zero relay legs; and the listener rejects wrong
+    tokens and foreign origins before accepting the handshake.
+
+    :param mock_credentials_env: Mock credentials env from conftest.
+    :param omnigent_python: Python interpreter fixture.
+    :param omnigent_repo_root: Repo root fixture.
+    :param tmp_path: Pytest temp directory for the agent YAML
+        and SQLite database.
+    """
+    import asyncio
+
+    import websockets
+    from websockets.exceptions import InvalidStatus
+
+    from omnigent.runner.identity import token_bound_runner_id
+
+    python = omnigent_python
+    repo_root = omnigent_repo_root
+    port = _find_free_port()
+
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    yaml_path = agent_dir / "config.yaml"
+    yaml_path.write_text(_AGENT_YAML)
+    db_path = tmp_path / "test.db"
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+    env = dict(mock_credentials_env)
+    base_url = f"http://127.0.0.1:{port}"
+
+    with _omnigent_server(
+        python=python,
+        agent_path=agent_dir,
+        port=port,
+        env=env,
+        cwd=repo_root,
+        db_path=db_path,
+        runner_id=runner_id,
+        binding_token=binding_token,
+    ) as proc:
+        _wait_for_health(port, timeout=_BOOT_TIMEOUT, proc=proc, runner_id=runner_id)
+
+        with httpx.Client(base_url=base_url, timeout=_API_TIMEOUT) as client:
+            session_id = _create_session(client, yaml_path, runner_id)
+
+            resp = client.get(f"/v1/sessions/{session_id}/resources/terminals")
+            assert resp.status_code == 200
+            (terminal,) = resp.json()["data"]
+            direct_url = terminal["metadata"].get("direct_attach_url")
+            assert isinstance(direct_url, str) and direct_url.startswith("ws://127.0.0.1:"), (
+                f"terminals API did not surface a loopback direct_attach_url; "
+                f"metadata={terminal['metadata']!r}"
+            )
+            # The listener is its own port, not the server's.
+            assert f":{port}/" not in direct_url
+
+        async def _exercise_direct_attach() -> None:
+            # Real attach through the loopback listener: the control
+            # bridge seeds the current pane and echoes typed input, so
+            # typing into the REPL composer must come back as output.
+            async with websockets.connect(
+                f"{direct_url}&transport=control",
+                origin=base_url,
+            ) as ws:
+                await ws.send(json.dumps({"type": "resize", "cols": 100, "rows": 30}))
+                await ws.send(b"DIRECT-OK")
+                collected = b""
+                deadline = time.monotonic() + 15.0
+                while time.monotonic() < deadline and b"DIRECT-OK" not in collected:
+                    try:
+                        msg = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                    except TimeoutError:
+                        continue
+                    if isinstance(msg, bytes):
+                        collected += msg
+                assert b"DIRECT-OK" in collected, (
+                    f"typed input never echoed through the direct attach; "
+                    f"got {len(collected)} bytes: {collected[-500:]!r}"
+                )
+
+            # Wrong token: rejected before accept (HTTP 403 denial).
+            bad_token_url = direct_url.split("?", 1)[0] + "?token=wrong"
+            with pytest.raises(InvalidStatus):
+                async with websockets.connect(bad_token_url, origin=base_url):
+                    pass
+
+            # Foreign browser origin: rejected despite the valid token.
+            with pytest.raises(InvalidStatus):
+                async with websockets.connect(direct_url, origin="https://evil.example"):
+                    pass
+
+        asyncio.run(_exercise_direct_attach())

--- a/tests/e2e_ui/shells/test_terminal_direct_attach.py
+++ b/tests/e2e_ui/shells/test_terminal_direct_attach.py
@@ -1,0 +1,181 @@
+"""E2E: the web terminal attaches over loopback when the runner is local.
+
+A relayed attach costs two WAN legs per keystroke (browser → server →
+runner tunnel → tmux). When the browser and the runner share a machine the
+runner's loopback listener (``omnigent/runner/direct_attach.py``) serves the
+same attach handler directly, and the client swaps onto it — see
+``resolveInitialAttachUrl`` / ``watchDirectUpgrade`` in
+``web/src/lib/terminals.ts``.
+
+The e2e harness is exactly the local shape: server, runner, and browser all
+on one box, with the page served from ``http://127.0.0.1:<port>``. Both
+halves of the contract are therefore observable here:
+
+- the terminal ends up on the loopback socket, and
+- it still connects and stays connected when that socket is unreachable
+  (a different machine, denied Local Network Access, Safari, or a dead
+  listener) — the failure mode that would otherwise break the terminal for
+  every remote user.
+
+Relay and direct sockets share the loopback host in this harness, so they
+are told apart by port (the listener picks its own ephemeral port, never the
+server's) plus the direct URL's mandatory ``token``.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from urllib.parse import urlsplit
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Rewrites off-server ``ws://`` dials to a dead port so the runner's loopback
+# listener is unreachable while the relay keeps working. Faithful to the real
+# failure modes: the browser's own connect fails, rather than a faked event.
+_BLOCK_LOOPBACK_DIALS = """
+(() => {
+  const Native = window.WebSocket;
+  const Blocked = function (url, protocols) {
+    let target = url;
+    try {
+      const parsed = new URL(url, location.href);
+      if (parsed.protocol === "ws:" && parsed.port !== location.port) {
+        parsed.port = "1";
+        target = parsed.toString();
+      }
+    } catch (err) {
+      /* leave non-URL inputs to the native constructor */
+    }
+    return protocols === undefined ? new Native(target) : new Native(target, protocols);
+  };
+  Blocked.prototype = Native.prototype;
+  Blocked.CONNECTING = Native.CONNECTING;
+  Blocked.OPEN = Native.OPEN;
+  Blocked.CLOSING = Native.CLOSING;
+  Blocked.CLOSED = Native.CLOSED;
+  window.WebSocket = Blocked;
+})();
+"""
+
+
+def _open_new_shell(page: Page) -> None:
+    """Create a shell via the tab strip's "+" -> Shell menu.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    """
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+
+def _capture_attach_sockets(page: Page) -> list[str]:
+    """Record the URL of every terminal-attach WebSocket the page opens.
+
+    Registered before navigation so the attach socket — opened
+    asynchronously once the shell's xterm mounts — cannot slip through.
+
+    :param page: Playwright page, not yet navigated.
+    :returns: A list that fills in as sockets open.
+    """
+    attach_urls: list[str] = []
+
+    def _on_ws(ws: object) -> None:
+        url = ws.url  # type: ignore[attr-defined]
+        if "/attach" in url:
+            attach_urls.append(url)
+
+    page.on("websocket", _on_ws)
+    return attach_urls
+
+
+def _is_direct_attach(url: str, base_url: str) -> bool:
+    """Is *url* the runner's loopback attach socket rather than the relay?
+
+    :param url: An observed attach WebSocket URL.
+    :param base_url: The harness server's base URL.
+    :returns: True for a token-bearing loopback socket on a non-server port.
+    """
+    parts = urlsplit(url)
+    return (
+        parts.scheme == "ws"
+        and parts.hostname == "127.0.0.1"
+        and parts.port != urlsplit(base_url).port
+        and "token=" in (parts.query or "")
+    )
+
+
+def _connected_terminal(page: Page) -> object:
+    """Wait for the newest terminal view to report a live attach.
+
+    :param page: Playwright page with a shell opening.
+    :returns: The terminal-view locator, connected.
+    """
+    rail = page.get_by_role("complementary", name="Workspace")
+    terminal_view = rail.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+    return terminal_view
+
+
+def test_terminal_upgrades_to_loopback_attach_when_runner_is_local(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """A same-machine runner ends up serving the terminal over loopback.
+
+    The client connects via the relay first (never blocking the terminal on a
+    permission prompt) and swaps to the direct socket once the loopback probe
+    succeeds, so this polls for the direct socket instead of demanding it on
+    the first dial. A regression that dropped the advert, the probe, or the
+    re-dial leaves every attach on the relay and fails here.
+    """
+    base_url, session_id = terminal_session
+
+    attach_urls = _capture_attach_sockets(page)
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    terminal_view = _connected_terminal(page)
+
+    deadline = time.monotonic() + 60
+    while not any(_is_direct_attach(u, base_url) for u in attach_urls):
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                "terminal never attached over the runner's loopback listener; "
+                f"attach sockets seen: {attach_urls!r}"
+            )
+        page.wait_for_timeout(250)
+
+    # The swap must leave a working terminal, not a dead pane.
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+
+def test_terminal_falls_back_to_relay_when_loopback_is_unreachable(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """An unreachable loopback listener leaves the terminal on the relay.
+
+    This is the path every remote browser takes, so it must degrade in
+    silence: the terminal connects over the relay and never lands on a
+    direct socket. A regression that dialed direct unconditionally, or failed
+    the attach when the probe failed, hangs the terminal here.
+    """
+    base_url, session_id = terminal_session
+
+    attach_urls = _capture_attach_sockets(page)
+    page.add_init_script(_BLOCK_LOOPBACK_DIALS)
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    terminal_view = _connected_terminal(page)
+
+    # Give the background upgrade room to (wrongly) succeed before asserting.
+    page.wait_for_timeout(3_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected")
+
+    relayed = [u for u in attach_urls if urlsplit(u).port == urlsplit(base_url).port]
+    assert relayed, f"terminal did not attach over the relay; saw: {attach_urls!r}"
+    assert not any(_is_direct_attach(u, base_url) for u in attach_urls), (
+        f"terminal used a direct socket despite an unreachable listener: {attach_urls!r}"
+    )

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -16,12 +16,18 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
 from omnigent.entities.session_resources import SessionResourceView
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
+from omnigent.runner.direct_attach import (
+    allowed_origin_for_server,
+    create_direct_attach_app,
+    start_direct_attach_listener,
+)
 from omnigent.runner.resource_registry import (
     OMNIGENT_REPL_TERMINAL_ROLE,
     QWEN_NATIVE_TERMINAL_ROLE,
@@ -705,3 +711,130 @@ def test_runner_resource_attach_closes_4404_when_pty_ends(
         "Without 4404, the client's reconnect loop will spin on 'Claude "
         "session connection closed by server; reconnecting...' indefinitely."
     )
+
+
+# ── Loopback direct-attach listener (runner/direct_attach.py) ─────────
+
+
+def _make_direct_app(
+    events: list[tuple[str, str, bool, str | None]],
+) -> FastAPI:
+    """A direct-attach app whose attach handler records its arguments.
+
+    The stub stands in for the runner app's real
+    ``terminal_resource_attach_ws`` so these tests pin the listener's
+    auth gate and parameter forwarding without touching tmux.
+    """
+
+    async def stub_handler(
+        websocket: object,
+        session_id: str,
+        terminal_id: str,
+        read_only: bool = False,
+        transport: str | None = None,
+    ) -> None:
+        events.append((session_id, terminal_id, read_only, transport))
+        await websocket.accept()  # type: ignore[attr-defined]
+        await websocket.close()  # type: ignore[attr-defined]
+
+    return create_direct_attach_app(
+        stub_handler,
+        token="sekret-token",
+        allowed_origins=frozenset({"https://app.example"}),
+    )
+
+
+def test_direct_attach_probe_accepts_valid_token_without_origin() -> None:
+    """Non-browser handshakes (no Origin header) pass on the token alone."""
+    app = _make_direct_app([])
+    with TestClient(app).websocket_connect("/probe?token=sekret-token"):
+        pass
+
+
+def test_direct_attach_probe_accepts_allow_listed_origin() -> None:
+    app = _make_direct_app([])
+    with TestClient(app).websocket_connect(
+        "/probe?token=sekret-token",
+        headers={"origin": "https://app.example"},
+    ):
+        pass
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/probe",
+        "/probe?token=wrong",
+        "/v1/sessions/conv1/resources/terminals/t1/attach",
+        "/v1/sessions/conv1/resources/terminals/t1/attach?token=wrong",
+    ],
+)
+def test_direct_attach_rejects_missing_or_wrong_token(path: str) -> None:
+    events: list[tuple[str, str, bool, str | None]] = []
+    app = _make_direct_app(events)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with TestClient(app).websocket_connect(path):
+            pass
+    assert exc_info.value.code == 1008
+    assert events == []
+
+
+def test_direct_attach_rejects_foreign_origin_despite_valid_token() -> None:
+    """A DNS-rebinding-style page presents its own origin — refused."""
+    events: list[tuple[str, str, bool, str | None]] = []
+    app = _make_direct_app(events)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv1/resources/terminals/t1/attach?token=sekret-token",
+            headers={"origin": "https://evil.example"},
+        ):
+            pass
+    assert exc_info.value.code == 1008
+    assert events == []
+
+
+def test_direct_attach_forwards_attach_params_to_handler() -> None:
+    """The attach wrapper hands session/terminal/query through unchanged."""
+    events: list[tuple[str, str, bool, str | None]] = []
+    app = _make_direct_app(events)
+    with contextlib.suppress(WebSocketDisconnect):
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv1/resources/terminals/terminal_bash_s1/attach"
+            "?token=sekret-token&read_only=true&transport=control",
+            headers={"origin": "https://app.example"},
+        ):
+            pass
+    assert events == [("conv1", "terminal_bash_s1", True, "control")]
+
+
+def test_allowed_origin_for_server_strips_path_and_keeps_port() -> None:
+    assert (
+        allowed_origin_for_server("https://omnigents.example.databricksapps.com/some/base")
+        == "https://omnigents.example.databricksapps.com"
+    )
+    assert allowed_origin_for_server("http://127.0.0.1:6767") == "http://127.0.0.1:6767"
+    assert allowed_origin_for_server("not a url") is None
+    assert allowed_origin_for_server("ftp://example.com") is None
+
+
+@pytest.mark.asyncio
+async def test_direct_attach_listener_serves_probe_on_loopback() -> None:
+    """The uvicorn listener binds 127.0.0.1:0 and answers the probe route."""
+    import websockets
+
+    events: list[tuple[str, str, bool, str | None]] = []
+    listener = await start_direct_attach_listener(_make_direct_app(events))
+    assert listener is not None, "listener failed to start on loopback"
+    try:
+        assert listener.port > 0
+        # Valid token: the handshake completes (the route accepts then
+        # closes, which is the probe contract).
+        async with websockets.connect(f"ws://127.0.0.1:{listener.port}/probe?token=sekret-token"):
+            pass
+        # Wrong token: rejected before accept — an HTTP 403 handshake
+        # denial, which the client surfaces as InvalidStatus.
+        with pytest.raises(websockets.exceptions.InvalidStatus):
+            async with websockets.connect(f"ws://127.0.0.1:{listener.port}/probe?token=wrong"):
+                pass
+    finally:
+        await listener.stop()

--- a/tests/runner/transports/ws_tunnel/test_frames.py
+++ b/tests/runner/transports/ws_tunnel/test_frames.py
@@ -44,6 +44,47 @@ def test_hello_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.harnesses == ["claude-sdk", "codex"]
     assert decoded.envs == ["os_sandbox"]
+    assert decoded.direct_attach_port is None
+    assert decoded.direct_attach_token is None
+
+
+def test_hello_round_trip_with_direct_attach_advert() -> None:
+    f = HelloFrame(
+        runner_version="0.1.2",
+        frame_protocol_version=1,
+        direct_attach_port=54321,
+        direct_attach_token="tok_abc",
+    )
+    decoded = decode_frame(encode_frame(f))
+    assert isinstance(decoded, HelloFrame)
+    assert decoded.direct_attach_port == 54321
+    assert decoded.direct_attach_token == "tok_abc"
+
+
+def test_hello_without_advert_omits_direct_attach_keys_on_wire() -> None:
+    """Advert-less hellos keep the pre-advert wire shape byte-compatible."""
+    wire = json.loads(encode_frame(HelloFrame(runner_version="0.1.2", frame_protocol_version=1)))
+    assert "direct_attach_port" not in wire
+    assert "direct_attach_token" not in wire
+
+
+def test_hello_decode_drops_half_present_direct_attach_advert() -> None:
+    """Port and token only mean anything together; a lone field is noise."""
+    wire = json.loads(
+        encode_frame(
+            HelloFrame(
+                runner_version="0.1.2",
+                frame_protocol_version=1,
+                direct_attach_port=54321,
+                direct_attach_token="tok_abc",
+            )
+        )
+    )
+    del wire["direct_attach_token"]
+    decoded = decode_frame(json.dumps(wire))
+    assert isinstance(decoded, HelloFrame)
+    assert decoded.direct_attach_port is None
+    assert decoded.direct_attach_token is None
 
 
 def test_request_round_trip_with_body_and_query_string() -> None:

--- a/tests/runner/transports/ws_tunnel/test_ws_attach_e2e.py
+++ b/tests/runner/transports/ws_tunnel/test_ws_attach_e2e.py
@@ -33,7 +33,11 @@ from omnigent.runner.transports.ws_tunnel.serve import (
     _handle_tunnel_frame,
     _RunnerWSChannel,
 )
-from omnigent.server._runner_ws_tunnel import _TunneledWSConn
+from omnigent.server._runner_ws_tunnel import (
+    DirectAttachEndpoint,
+    _TunneledWSConn,
+    make_direct_attach_resolver,
+)
 
 
 class _FakeWS:
@@ -280,3 +284,65 @@ async def test_open_ws_channel_session_guard_rejects_stale_session() -> None:
         registry.open_ws_channel("runner-replace", "stale01", session=session_old)
     with contextlib.suppress(KeyError):
         registry.deregister("runner-replace")
+
+
+# ── Direct-attach resolver (hello advert → terminals API) ─────────────
+
+
+class _StubRoutedClient:
+    def __init__(self, runner_id: str) -> None:
+        self.runner_id = runner_id
+
+
+class _StubRouter:
+    """Router stub returning a fixed runner id for any conversation."""
+
+    def __init__(self, runner_id: str | None) -> None:
+        self._runner_id = runner_id
+
+    def client_for_existing_conversation(self, conversation_id: str) -> _StubRoutedClient | None:
+        del conversation_id
+        if self._runner_id is None:
+            return None
+        return _StubRoutedClient(self._runner_id)
+
+
+@pytest.mark.asyncio
+async def test_direct_attach_resolver_reads_hello_advert() -> None:
+    """A registered runner's hello advert resolves to its endpoint."""
+    registry = TunnelRegistry()
+    server_ws, _runner_ws = _make_pair()
+    hello = HelloFrame(
+        runner_version="0.1.0-test",
+        frame_protocol_version=1,
+        direct_attach_port=54321,
+        direct_attach_token="tok_abc",
+    )
+    registry.register("runner-direct-1", server_ws, hello)
+    try:
+        resolver = make_direct_attach_resolver(_StubRouter("runner-direct-1"), registry)
+
+        endpoint = resolver("conv1")
+
+        assert endpoint == DirectAttachEndpoint(port=54321, token="tok_abc")
+    finally:
+        registry.deregister("runner-direct-1")
+
+
+@pytest.mark.asyncio
+async def test_direct_attach_resolver_misses_resolve_to_none() -> None:
+    """No pinned runner, offline runner, or advert-less hello → None."""
+    registry = TunnelRegistry()
+    server_ws, _runner_ws = _make_pair()
+    no_advert_hello = HelloFrame(runner_version="0.1.0-test", frame_protocol_version=1)
+    registry.register("runner-direct-2", server_ws, no_advert_hello)
+    try:
+        assert make_direct_attach_resolver(_StubRouter(None), registry)("conv1") is None
+        assert (
+            make_direct_attach_resolver(_StubRouter("runner-offline"), registry)("conv1") is None
+        )
+        assert (
+            make_direct_attach_resolver(_StubRouter("runner-direct-2"), registry)("conv1") is None
+        )
+    finally:
+        registry.deregister("runner-direct-2")

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -15,7 +15,14 @@ from fastapi.responses import JSONResponse
 
 from omnigent.entities import DEFAULT_ENVIRONMENT_ID, Conversation, ConversationItem, PagedList
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.runtime import _globals, session_stream, set_runner_client, set_runner_router
+from omnigent.runtime import (
+    _globals,
+    session_stream,
+    set_runner_client,
+    set_runner_direct_attach_resolver,
+    set_runner_router,
+)
+from omnigent.server._runner_ws_tunnel import DirectAttachEndpoint
 from omnigent.server.routes.sessions import _ancestor_session_ids, create_sessions_router
 from omnigent.server.schemas import SessionEventInput
 
@@ -428,11 +435,14 @@ class _FakeRunnerRouter:
 def runner_globals_reset() -> Iterator[None]:
     prior_client = _globals._runner_client
     prior_router = _globals._runner_router
+    prior_direct = _globals._runner_direct_attach_resolver
     set_runner_client(None)
     set_runner_router(None)
+    set_runner_direct_attach_resolver(None)
     yield
     set_runner_client(prior_client)
     set_runner_router(prior_router)
+    set_runner_direct_attach_resolver(prior_direct)
 
 
 @pytest.fixture
@@ -1050,6 +1060,85 @@ async def test_list_terminals_forwards_pagination_params_to_runner(
     # here means the proxy dropped the whole query string — the
     # refresh-flips-tab-order regression.
     assert fake_runner.get_params == [{"order": "asc", "limit": "1000"}]
+
+
+def _terminals_only_payload() -> dict[str, object]:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "terminal_runner_s1",
+                "object": "session.resource",
+                "type": "terminal",
+                "session_id": "79b22ebd2309e48fdeb450c65611d51b",
+                "name": "runner:s1",
+                "metadata": {
+                    "terminal_name": "runner",
+                    "session_key": "s1",
+                    "running": True,
+                },
+            },
+        ],
+        "first_id": "terminal_runner_s1",
+        "last_id": "terminal_runner_s1",
+        "has_more": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_terminals_adds_direct_attach_url_when_advertised(
+    client: httpx.AsyncClient,
+) -> None:
+    """A runner-advertised loopback listener surfaces per-terminal URLs.
+
+    Permissions are disabled in this harness (single-user mode), which
+    the disclosure gate treats as owner — mirroring the relay's
+    write-attach behavior.
+    """
+    fake_runner = _FakeRunnerClient(payload=_terminals_only_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+    set_runner_direct_attach_resolver(
+        lambda conversation_id: DirectAttachEndpoint(port=54321, token="tok_abc")
+    )
+
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals")
+
+    assert resp.status_code == 200
+    (item,) = resp.json()["data"]
+    assert item["metadata"]["direct_attach_url"] == (
+        "ws://127.0.0.1:54321/v1/sessions/79b22ebd2309e48fdeb450c65611d51b"
+        "/resources/terminals/terminal_runner_s1/attach?token=tok_abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_terminals_without_resolver_leaves_payload_untouched(
+    client: httpx.AsyncClient,
+) -> None:
+    fake_runner = _FakeRunnerClient(payload=_terminals_only_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals")
+
+    assert resp.status_code == 200
+    (item,) = resp.json()["data"]
+    assert "direct_attach_url" not in item["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_list_terminals_without_runner_advert_leaves_payload_untouched(
+    client: httpx.AsyncClient,
+) -> None:
+    """A resolver miss (runner offline / no listener) adds nothing."""
+    fake_runner = _FakeRunnerClient(payload=_terminals_only_payload())
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+    set_runner_direct_attach_resolver(lambda conversation_id: None)
+
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals")
+
+    assert resp.status_code == 200
+    (item,) = resp.json()["data"]
+    assert "direct_attach_url" not in item["metadata"]
 
 
 @pytest.mark.asyncio

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -23,6 +23,7 @@ import {
 const terminalSessionMock = vi.hoisted(() => ({
   instances: [] as {
     url: string;
+    container: HTMLDivElement;
     nativeSelection: boolean;
     onState: (state: ConnectionState) => void;
     dispose: ReturnType<typeof vi.fn>;
@@ -41,7 +42,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
     focus = vi.fn();
 
     constructor(
-      _container: HTMLDivElement,
+      container: HTMLDivElement,
       url: string,
       onState: (state: ConnectionState) => void,
       _isDark?: boolean,
@@ -51,6 +52,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
     ) {
       terminalSessionMock.instances.push({
         url,
+        container,
         nativeSelection,
         onState,
         dispose: this.dispose,
@@ -197,6 +199,43 @@ describe("hidden pre-warmed surface", () => {
     // No reveal edge — the session's own WS-open focus owns this case;
     // an extra explicit call would steal focus on every reconnect.
     expect(terminalSessionMock.instances[0].focus).not.toHaveBeenCalled();
+  });
+});
+
+describe("late direct-attach advert", () => {
+  it("retires the outgoing session when the advert lands on a live terminal", async () => {
+    // The runner's loopback advert reaches the client on a terminals
+    // refetch — after the terminal has already dialed. That prop change
+    // re-runs the attach ref for the SAME mount node (React 18 hands the
+    // node back rather than remounting, and skips the ref's cleanup), so
+    // the attach itself has to retire its predecessor. Without that,
+    // xterm stacks a second instance inside one node — two helper
+    // textareas, two renderers, two live bridges.
+    const { rerender } = render(
+      <TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />,
+    );
+    await act(async () => {});
+    expect(terminalSessionMock.instances).toHaveLength(1);
+    const relayed = terminalSessionMock.instances[0];
+
+    rerender(
+      <TerminalView
+        sessionId="conv_abc"
+        terminalId="terminal_bash_s1"
+        directAttachUrl={
+          "ws://127.0.0.1:54321/v1/sessions/conv_abc" +
+          "/resources/terminals/terminal_bash_s1/attach?token=t"
+        }
+      />,
+    );
+    await act(async () => {});
+
+    // Same node, so this is a re-attach rather than a remount — which is
+    // exactly why the predecessor cannot be left running.
+    const readvertised = terminalSessionMock.instances.at(-1)!;
+    expect(readvertised).not.toBe(relayed);
+    expect(readvertised.container).toBe(relayed.container);
+    expect(relayed.dispose).toHaveBeenCalled();
   });
 });
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
+import { resolveInitialAttachUrl, watchDirectUpgrade, withAttachParams } from "@/lib/terminals";
 import {
   readTerminalThemeMode,
   resolveTerminalIsDark,
@@ -92,6 +93,15 @@ interface TerminalViewProps {
    * Default true.
    */
   active?: boolean;
+  /**
+   * Loopback attach URL advertised by the session's runner (from the
+   * terminal resource's ``metadata.direct_attach_url``). When set, each
+   * connection attempt probes it first and uses it if the listener
+   * answers — a browser on the runner's machine then attaches with zero
+   * relay legs. Unreachable or absent falls back to the relay URL; the
+   * page URL and all HTTP traffic are unaffected either way.
+   */
+  directAttachUrl?: string;
 }
 
 export function TerminalView({
@@ -105,6 +115,7 @@ export function TerminalView({
   resumePending = false,
   transport,
   active = true,
+  directAttachUrl,
 }: TerminalViewProps) {
   // Control mode: xterm owns the buffer + mouse, so plain drag selects and
   // the normal copy gesture works — no forced-selection modifier, no hint bar.
@@ -207,21 +218,43 @@ export function TerminalView({
       // is the one that actually opens the WS.
       let terminalSession: TerminalSession | null = null;
       let cancelled = false;
-      queueMicrotask(() => {
+      const upgradeCtl = new AbortController();
+      void (async () => {
+        // The awaited microtask preserves the StrictMode-collapse
+        // behavior queueMicrotask provided; the URL resolution (when a
+        // direct URL exists) adds real async time, so re-check
+        // `cancelled` after every await.
+        await Promise.resolve();
         if (cancelled) return;
         // Route this WS to the replica holding the session's runner tunnel
         // (key = the session's host_id). A browser WS can't set request
         // headers, so the key rides the query string. Only against a
         // Databricks workspace-hosted server — an unsharded server needs no key,
-        // and a hostless session yields none.
+        // and a hostless session yields none. The direct URL needs no key: it
+        // bypasses the server entirely.
         const computedHostId = (() => {
           if (keylessRef.current || !isDatabricksWorkspace()) return undefined;
           const h = getSessionHost(sessionId);
           return h && !isHostKeyless(h) ? h : undefined;
         })();
+        const relayUrl = buildAttachUrl(
+          sessionId,
+          terminalId,
+          readOnly,
+          computedHostId,
+          transport,
+        );
+        const directUrl = directAttachUrl
+          ? withAttachParams(directAttachUrl, readOnly, transport)
+          : undefined;
+        // Never keep the user waiting on the direct path: this resolves
+        // direct only when the loopback listener is already known
+        // reachable; otherwise it returns the relay URL immediately.
+        const url = await resolveInitialAttachUrl(directUrl, relayUrl);
+        if (cancelled) return;
         terminalSession = new TerminalSession(
           node,
-          buildAttachUrl(sessionId, terminalId, readOnly, computedHostId, transport),
+          url,
           notifyState,
           isDarkRef.current,
           notifyActivity,
@@ -229,9 +262,22 @@ export function TerminalView({
           controlMode,
         );
         sessionRef.current = terminalSession;
-      });
+        // Relay-connected with a direct URL on offer: negotiate the
+        // loopback upgrade in the background. In Chrome this is what
+        // raises the Local Network Access prompt; the probe socket
+        // waits out the user's decision behind the live relay session.
+        // On success, re-dial — the known-good cache makes the remount
+        // pick the direct URL.
+        if (directUrl !== undefined && url === relayUrl) {
+          const upgraded = await watchDirectUpgrade(directUrl, upgradeCtl.signal);
+          if (cancelled || !upgraded) return;
+          disposeActiveSession();
+          setConnectAttempt((attempt) => attempt + 1);
+        }
+      })();
       return () => {
         cancelled = true;
+        upgradeCtl.abort();
         terminalSession?.dispose();
         sessionRef.current = null;
         onStateChangeRef.current?.(null);
@@ -242,10 +288,12 @@ export function TerminalView({
       terminalId,
       readOnly,
       transport,
+      directAttachUrl,
       controlMode,
       notifyState,
       notifyActivity,
       notifyInput,
+      disposeActiveSession,
     ],
   );
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -237,13 +237,7 @@ export function TerminalView({
           const h = getSessionHost(sessionId);
           return h && !isHostKeyless(h) ? h : undefined;
         })();
-        const relayUrl = buildAttachUrl(
-          sessionId,
-          terminalId,
-          readOnly,
-          computedHostId,
-          transport,
-        );
+        const relayUrl = buildAttachUrl(sessionId, terminalId, readOnly, computedHostId, transport);
         const directUrl = directAttachUrl
           ? withAttachParams(directAttachUrl, readOnly, transport)
           : undefined;

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -161,6 +161,13 @@ export function TerminalView({
   // 4400 wrong-replica close. If keyless still fails with 4400, the host is
   // genuinely unreachable — stop retrying.
   const keylessRef = useRef(false);
+  // Bumped by every attach so an in-flight attach can tell it has been
+  // superseded — a ref callback can re-run for the *same* node, which
+  // leaves no other way to retire the previous attempt's async work.
+  const attachGenerationRef = useRef(0);
+  // Abort handle for the outgoing attach's direct-upgrade probe, which
+  // otherwise holds a loopback socket open for its full timeout.
+  const upgradeCtlRef = useRef<AbortController | null>(null);
 
   // Stable dispatcher: updates local state and notifies the parent.
   const notifyState = useCallback((next: ConnectionState) => {
@@ -200,6 +207,17 @@ export function TerminalView({
   const attachSession = useCallback(
     (node: HTMLDivElement | null) => {
       if (node === null) return;
+      // React re-runs a ref callback for the *same* node whenever the
+      // callback's identity changes — here, when the runner's
+      // direct-attach advert lands after mount. Retire the previous
+      // attach before touching the node: otherwise xterm stacks a
+      // second instance inside it (two helper textareas, two
+      // renderers) and the superseded upgrade watcher later re-dials
+      // on top of the session that replaced it.
+      const generation = (attachGenerationRef.current += 1);
+      upgradeCtlRef.current?.abort();
+      disposeActiveSession();
+      node.replaceChildren();
       // Reset to ``connecting`` for every fresh attach so a stale
       // overlay from a previous mount doesn't flash during the
       // handshake. The session's WS ``open`` handler transitions us
@@ -219,13 +237,17 @@ export function TerminalView({
       let terminalSession: TerminalSession | null = null;
       let cancelled = false;
       const upgradeCtl = new AbortController();
+      upgradeCtlRef.current = upgradeCtl;
+      // Superseded by a later attach on this node? React 18 never calls
+      // the ref cleanup, so `cancelled` alone can't catch that case.
+      const superseded = () => cancelled || attachGenerationRef.current !== generation;
       void (async () => {
         // The awaited microtask preserves the StrictMode-collapse
         // behavior queueMicrotask provided; the URL resolution (when a
-        // direct URL exists) adds real async time, so re-check
-        // `cancelled` after every await.
+        // direct URL exists) adds real async time, so re-check after
+        // every await.
         await Promise.resolve();
-        if (cancelled) return;
+        if (superseded()) return;
         // Route this WS to the replica holding the session's runner tunnel
         // (key = the session's host_id). A browser WS can't set request
         // headers, so the key rides the query string. Only against a
@@ -245,7 +267,7 @@ export function TerminalView({
         // direct only when the loopback listener is already known
         // reachable; otherwise it returns the relay URL immediately.
         const url = await resolveInitialAttachUrl(directUrl, relayUrl);
-        if (cancelled) return;
+        if (superseded()) return;
         terminalSession = new TerminalSession(
           node,
           url,
@@ -264,7 +286,7 @@ export function TerminalView({
         // pick the direct URL.
         if (directUrl !== undefined && url === relayUrl) {
           const upgraded = await watchDirectUpgrade(directUrl, upgradeCtl.signal);
-          if (cancelled || !upgraded) return;
+          if (superseded() || !upgraded) return;
           disposeActiveSession();
           setConnectAttempt((attempt) => attempt + 1);
         }

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -22,6 +22,13 @@ import {
   useTerminals,
   type TerminalInfo,
 } from "./useTerminals";
+import {
+  clearDirectAttachCaches,
+  directProbeUrl,
+  resolveInitialAttachUrl,
+  watchDirectUpgrade,
+  withAttachParams,
+} from "@/lib/terminals";
 
 // useTerminals reads runner liveness to treat an offline runner as zero
 // terminals. Mock it so we can drive that signal directly; it defaults to
@@ -122,6 +129,187 @@ describe("terminalInfoFromResource", () => {
       metadata: { terminal_transport: "garbage" },
     });
     expect(junk?.transport).toBeUndefined();
+  });
+
+  it("lifts metadata.direct_attach_url only for loopback ws:// URLs", () => {
+    const direct = terminalInfoFromResource({
+      id: "terminal_bash_s1",
+      type: "terminal",
+      name: "bash:s1",
+      metadata: { direct_attach_url: "ws://127.0.0.1:54321/v1/x/attach?token=t" },
+    });
+    expect(direct?.directAttachUrl).toBe("ws://127.0.0.1:54321/v1/x/attach?token=t");
+
+    // Anything that could steer the terminal socket at a non-loopback
+    // host is dropped, even from our own server.
+    for (const bad of [
+      "wss://127.0.0.1:54321/attach?token=t",
+      "ws://evil.example:54321/attach?token=t",
+      "ws://localhost:54321/attach?token=t",
+      42,
+      null,
+    ]) {
+      const info = terminalInfoFromResource({
+        id: "terminal_bash_s1",
+        type: "terminal",
+        name: "bash:s1",
+        metadata: { direct_attach_url: bad },
+      });
+      expect(info?.directAttachUrl).toBeUndefined();
+    }
+  });
+});
+
+describe("direct attach URL helpers", () => {
+  beforeEach(() => {
+    clearDirectAttachCaches();
+  });
+
+  it("withAttachParams appends per-attach params after the token", () => {
+    const base = "ws://127.0.0.1:54321/v1/x/attach?token=t";
+    expect(withAttachParams(base, false, undefined)).toBe(base);
+    expect(withAttachParams(base, true, undefined)).toBe(`${base}&read_only=true`);
+    expect(withAttachParams(base, false, "control")).toBe(`${base}&transport=control`);
+    expect(withAttachParams(base, true, "pty")).toBe(`${base}&read_only=true&transport=pty`);
+  });
+
+  it("directProbeUrl swaps the path for /probe and keeps the token", () => {
+    expect(directProbeUrl("ws://127.0.0.1:54321/v1/x/attach?token=t&read_only=true")).toBe(
+      "ws://127.0.0.1:54321/probe?token=t&read_only=true",
+    );
+    expect(directProbeUrl("not a url")).toBeNull();
+  });
+});
+
+describe("resolveInitialAttachUrl / watchDirectUpgrade", () => {
+  /** WebSocket stub whose fate is decided by the test. */
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+    static behavior: "open" | "error" | "hang" = "open";
+    url: string;
+    closed = false;
+    private listeners = new Map<string, () => void>();
+    constructor(url: string) {
+      this.url = url;
+      FakeWebSocket.instances.push(this);
+      queueMicrotask(() => {
+        const behavior = FakeWebSocket.behavior;
+        if (behavior === "hang") return;
+        this.listeners.get(behavior === "open" ? "open" : "error")?.();
+      });
+    }
+    addEventListener(type: string, listener: () => void): void {
+      this.listeners.set(type, listener);
+    }
+    close(): void {
+      this.closed = true;
+    }
+  }
+
+  /** Stub the Permissions API's local-network-access answer. */
+  function stubPermission(state: "granted" | "denied" | "prompt" | "missing"): void {
+    const base = globalThis.navigator ?? {};
+    const permissions =
+      state === "missing"
+        ? undefined
+        : {
+            query: async (desc: { name: string }) => {
+              expect(desc.name).toBe("local-network-access");
+              return { state };
+            },
+          };
+    vi.stubGlobal("navigator", Object.assign(Object.create(base), { permissions }));
+  }
+
+  beforeEach(() => {
+    clearDirectAttachCaches();
+    FakeWebSocket.instances = [];
+    FakeWebSocket.behavior = "open";
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    stubPermission("missing");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const DIRECT = "ws://127.0.0.1:54321/v1/x/attach?token=t";
+  const RELAY = "wss://server.example/v1/x/attach";
+
+  it("returns the relay URL when no direct URL is offered", async () => {
+    expect(await resolveInitialAttachUrl(undefined, RELAY)).toBe(RELAY);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("returns the relay immediately when permission state is unknown or prompt", async () => {
+    // Never stall the first paint behind a permission prompt: the
+    // initial dial is relay; the upgrade happens in the background.
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(RELAY);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    stubPermission("prompt");
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(RELAY);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("dials direct on first connect when permission is granted and the probe opens", async () => {
+    stubPermission("granted");
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(DIRECT);
+    // The probe dialed the side-effect-free /probe route, not the
+    // attach route, and closed its socket after settling.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0].url).toBe("ws://127.0.0.1:54321/probe?token=t");
+    expect(FakeWebSocket.instances[0].closed).toBe(true);
+  });
+
+  it("falls back to the relay when granted but nothing is listening", async () => {
+    stubPermission("granted");
+    FakeWebSocket.behavior = "error";
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(RELAY);
+  });
+
+  it("watchDirectUpgrade succeeds on Allow and primes the next dial to go direct", async () => {
+    // Prompt state: the background probe carries the LNA prompt; the
+    // user clicking Allow completes the handshake.
+    stubPermission("prompt");
+    expect(await watchDirectUpgrade(DIRECT)).toBe(true);
+    // The known-good cache now routes the re-dial straight to direct
+    // without consulting the permission API again.
+    stubPermission("missing");
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(DIRECT);
+  });
+
+  it("watchDirectUpgrade skips probing entirely when permission is denied", async () => {
+    stubPermission("denied");
+    expect(await watchDirectUpgrade(DIRECT)).toBe(false);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("watchDirectUpgrade settles false on abort and on a blocked handshake", async () => {
+    FakeWebSocket.behavior = "hang";
+    const ctl = new AbortController();
+    const pending = watchDirectUpgrade(DIRECT, ctl.signal);
+    await Promise.resolve();
+    ctl.abort();
+    expect(await pending).toBe(false);
+    expect(FakeWebSocket.instances[0].closed).toBe(true);
+
+    FakeWebSocket.behavior = "error";
+    expect(await watchDirectUpgrade(DIRECT)).toBe(false);
+  });
+
+  it("falls back to the relay when the WebSocket constructor throws", async () => {
+    // Safari throws a synchronous SecurityError for ws:// from an
+    // https page; the resolver must treat it as an ordinary miss.
+    stubPermission("granted");
+    vi.stubGlobal(
+      "WebSocket",
+      class {
+        constructor() {
+          throw new Error("SecurityError");
+        }
+      },
+    );
+    expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(RELAY);
   });
 });
 

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -301,14 +301,9 @@ describe("resolveInitialAttachUrl / watchDirectUpgrade", () => {
     // Safari throws a synchronous SecurityError for ws:// from an
     // https page; the resolver must treat it as an ordinary miss.
     stubPermission("granted");
-    vi.stubGlobal(
-      "WebSocket",
-      class {
-        constructor() {
-          throw new Error("SecurityError");
-        }
-      },
-    );
+    vi.stubGlobal("WebSocket", function ThrowingWebSocket() {
+      throw new Error("SecurityError");
+    });
     expect(await resolveInitialAttachUrl(DIRECT, RELAY)).toBe(RELAY);
   });
 });

--- a/web/src/lib/terminals.ts
+++ b/web/src/lib/terminals.ts
@@ -10,6 +10,219 @@ export interface TerminalInfo {
   running: boolean;
   /** Web-attach transport, when supplied by the server. */
   transport?: "control" | "pty";
+  /**
+   * Loopback attach URL advertised by the session's runner, when the
+   * server disclosed one (owner-level callers only). Lets a browser on
+   * the same machine as the runner attach with zero relay legs; the
+   * view probes it and silently falls back to the relay when
+   * unreachable (other machines, Safari, listener down).
+   */
+  directAttachUrl?: string;
+}
+
+/**
+ * Validate a server-provided direct-attach URL.
+ *
+ * Only loopback ``ws://127.0.0.1:...`` URLs are honored — anything else
+ * (including ``wss://``, hostnames, or non-string junk) is dropped so a
+ * misbehaving server can never steer the terminal WebSocket at an
+ * arbitrary host.
+ */
+export function parseDirectAttachUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.startsWith("ws://127.0.0.1:")) return undefined;
+  return value;
+}
+
+/**
+ * Append the per-attach params to a direct-attach URL.
+ *
+ * The server-provided URL always carries ``?token=...``, so extra
+ * params join with ``&``. Mirrors ``buildAttachPath``'s param policy:
+ * only emit what is set.
+ */
+export function withAttachParams(
+  directAttachUrl: string,
+  readOnly: boolean,
+  transport?: string,
+): string {
+  const params = new URLSearchParams();
+  if (readOnly) params.set("read_only", "true");
+  if (transport) params.set("transport", transport);
+  const qs = params.toString();
+  return qs ? `${directAttachUrl}&${qs}` : directAttachUrl;
+}
+
+/**
+ * Probe budget when the local-network permission is already granted (or
+ * the browser needs none): a live loopback listener answers in
+ * single-digit milliseconds, so this only pads for scheduling jitter.
+ */
+export const DIRECT_PROBE_TIMEOUT_MS = 1_500;
+/**
+ * Probe budget while the browser is showing its Local Network Access
+ * prompt. Chrome parks the WebSocket in CONNECTING until the user
+ * decides, so this probe deliberately outwaits a human: it either opens
+ * (Allow), errors (Block / nothing listening), or times out (prompt
+ * ignored). It runs in the background behind a live relay connection,
+ * so patience here costs the user nothing.
+ */
+export const DIRECT_UPGRADE_TIMEOUT_MS = 120_000;
+
+/** Probe URLs that completed a handshake this page lifetime. */
+const directKnownGood = new Set<string>();
+
+/** Derive the listener's side-effect-free ``/probe`` URL from an attach URL. */
+export function directProbeUrl(directAttachUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(directAttachUrl);
+  } catch {
+    return null;
+  }
+  return `${url.protocol}//${url.host}/probe${url.search}`;
+}
+
+/**
+ * Open a WebSocket to *probeUrl* and report whether the handshake
+ * completed within *timeoutMs*.
+ *
+ * WebSocket handshakes are exempt from CORS, so the failure modes are
+ * "nothing listening", an auth rejection, or a browser policy block
+ * (Safari's mixed-content rule; Chrome's Local Network Access denial) —
+ * all of which resolve ``false`` and leave the caller on the relay
+ * path. While Chrome's LNA prompt is showing, the socket sits in
+ * CONNECTING; the caller picks *timeoutMs* to either give up fast
+ * (permission granted, listener should answer instantly) or outwait the
+ * prompt. Never throws. An aborted *signal* settles ``false``.
+ */
+export function probeDirectAttach(
+  probeUrl: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let ws: WebSocket;
+    try {
+      // Safari throws a synchronous SecurityError for ws:// from an
+      // https page; treat it as an ordinary probe failure.
+      ws = new WebSocket(probeUrl);
+    } catch {
+      resolve(false);
+      return;
+    }
+    let settled = false;
+    const settle = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      try {
+        ws.close();
+      } catch {
+        /* noop */
+      }
+      resolve(ok);
+    };
+    const onAbort = () => settle(false);
+    const timer = window.setTimeout(() => settle(false), timeoutMs);
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort);
+    ws.addEventListener("open", () => settle(true));
+    ws.addEventListener("error", () => settle(false));
+    ws.addEventListener("close", () => settle(false));
+  });
+}
+
+/**
+ * Browser Local Network Access permission state for loopback dials,
+ * or ``"unknown"`` where the Permissions API can't answer (Firefox,
+ * Safari, older Chrome, or a query-name the browser doesn't know).
+ */
+export type LocalNetworkPermission = "granted" | "denied" | "prompt" | "unknown";
+
+/**
+ * Query Chrome's Local Network Access permission without triggering a
+ * prompt. Best-effort: any Permissions API absence or rejection maps to
+ * ``"unknown"`` so callers fall back to probing behavior.
+ */
+export async function queryLocalNetworkPermission(): Promise<LocalNetworkPermission> {
+  try {
+    const permissions = (
+      globalThis.navigator as Navigator & {
+        permissions?: { query(desc: { name: string }): Promise<{ state: string }> };
+      }
+    ).permissions;
+    if (!permissions?.query) return "unknown";
+    const status = await permissions.query({ name: "local-network-access" });
+    if (status.state === "granted" || status.state === "denied" || status.state === "prompt") {
+      return status.state;
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Pick the URL for the *initial* terminal connection, never keeping the
+ * user waiting on a permission prompt: dial direct only when the
+ * loopback listener is already known-reachable (a prior probe
+ * succeeded, or the local-network permission is granted and the
+ * listener answers a quick probe). Everything else connects via the
+ * relay immediately — {@link watchDirectUpgrade} then negotiates the
+ * upgrade in the background.
+ */
+export async function resolveInitialAttachUrl(
+  directUrl: string | undefined,
+  relayUrl: string,
+): Promise<string> {
+  if (!directUrl) return relayUrl;
+  const probeUrl = directProbeUrl(directUrl);
+  if (probeUrl === null) return relayUrl;
+  if (directKnownGood.has(probeUrl)) {
+    if (await probeDirectAttach(probeUrl, DIRECT_PROBE_TIMEOUT_MS)) return directUrl;
+    directKnownGood.delete(probeUrl);
+    return relayUrl;
+  }
+  if ((await queryLocalNetworkPermission()) === "granted") {
+    if (await probeDirectAttach(probeUrl, DIRECT_PROBE_TIMEOUT_MS)) {
+      directKnownGood.add(probeUrl);
+      return directUrl;
+    }
+  }
+  return relayUrl;
+}
+
+/**
+ * Background half of the direct upgrade: patiently probe the loopback
+ * listener so Chrome raises its Local Network Access prompt, and report
+ * whether the direct path became usable. ``true`` means the handshake
+ * completed (the user allowed access, or no permission was needed) and
+ * the URL is cached known-good — the caller should re-dial the terminal
+ * via {@link resolveInitialAttachUrl}. ``false`` means denied, blocked,
+ * unreachable, timed out, or aborted: stay on the relay.
+ */
+export async function watchDirectUpgrade(
+  directUrl: string,
+  signal?: AbortSignal,
+  timeoutMs: number = DIRECT_UPGRADE_TIMEOUT_MS,
+): Promise<boolean> {
+  const probeUrl = directProbeUrl(directUrl);
+  if (probeUrl === null) return false;
+  if ((await queryLocalNetworkPermission()) === "denied") return false;
+  if (await probeDirectAttach(probeUrl, timeoutMs, signal)) {
+    directKnownGood.add(probeUrl);
+    return true;
+  }
+  return false;
+}
+
+/** Test hook: forget known-good listeners. */
+export function clearDirectAttachCaches(): void {
+  directKnownGood.clear();
 }
 
 /** TanStack Query key for a conversation's terminal resources. */
@@ -43,5 +256,6 @@ export function terminalInfoFromResource(resource: Record<string, unknown>): Ter
     session: typeof sessionKey === "string" ? sessionKey : "",
     running: typeof running === "boolean" ? running : false,
     transport,
+    directAttachUrl: parseDirectAttachUrl(metadata.direct_attach_url),
   };
 }

--- a/web/src/lib/terminals.ts
+++ b/web/src/lib/terminals.ts
@@ -152,7 +152,7 @@ export async function queryLocalNetworkPermission(): Promise<LocalNetworkPermiss
   try {
     const permissions = (
       globalThis.navigator as Navigator & {
-        permissions?: { query(desc: { name: string }): Promise<{ state: string }> };
+        permissions?: { query: (desc: { name: string }) => Promise<{ state: string }> };
       }
     ).permissions;
     if (!permissions?.query) return "unknown";

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -197,6 +197,7 @@ export function MainTerminalView({
                     readOnly={readOnly}
                     transport={activeTerminal.transport}
                     active={visible}
+                    directAttachUrl={activeTerminal.directAttachUrl}
                     onStateChange={(state) => {
                       setTerminalConnectionState(activeTerminal.id, state);
                     }}

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -244,6 +244,7 @@ export function TerminalsPanel({
                 terminalId={activeTerminal.id}
                 readOnly={readOnly}
                 transport={activeTerminal.transport}
+                directAttachUrl={activeTerminal.directAttachUrl}
                 onStateChange={(state) => {
                   setTerminalConnectionState(activeTerminal.id, state);
                 }}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -488,6 +488,7 @@ function RailTerminalView({
         terminalId={terminal.id}
         readOnly={readOnly}
         transport={terminal.transport}
+        directAttachUrl={terminal.directAttachUrl}
         onStateChange={(state) => setTerminalConnectionState(terminal.id, state)}
         onActivity={() => markTerminalActive(terminal.id)}
       />


### PR DESCRIPTION
## Related issue

Closes #4762

## Summary

Every keystroke in the web terminal round-trips the browser to the server and
back down the runner tunnel, so a WAN-hosted server costs 2× RTT (~250 ms echo
measured against a Databricks App) versus <10 ms locally. When the runner is on
the same machine as the browser — the ordinary `omnigent host` shape — that
detour is pure overhead.

- **Runner** starts a loopback-only listener (`127.0.0.1`, ephemeral port) that
  serves the *existing* terminal-attach handler, and adverts its port plus a
  per-boot token in the tunnel hello.
- **Server** surfaces the resulting `ws://127.0.0.1:<port>/…?token=…` as
  `direct_attach_url` in the terminals response — to session **owners only**,
  mirroring the relay's write-attach gate.
- **Web** connects over the relay *first*, then hot-swaps to the direct socket
  once Chrome's Local Network Access permission is granted, so the terminal is
  never blocked on a permission prompt.

Everything degrades silently to today's relay path: no advert, a non-owner
caller, a blocked handshake, a dead listener, or Safari (no LNA support, and
`ws://` from an `https://` page is mixed content) all keep the current
behaviour. No flags, no config.

**ELI5:** the browser and the terminal are often on the same laptop, but they
were mailing letters to each other via a datacenter across the country. Now they
just walk down the hall — and if the hallway is blocked for any reason, they go
back to mailing letters without telling you.

```mermaid
graph LR
    B[Browser]
    S[omnigent server<br/>WAN]
    R[Runner]
    T[tmux]
    B -- "1. relay attach, always works" --> S
    S -- tunnel --> R
    R --> T
    B -. "2. hot-swap after LNA grant<br/>ws://127.0.0.1, 0 WAN legs" .-> R
```

### Security model

The listener is deliberately narrow — see the module docstring in
`omnigent/runner/direct_attach.py`:

- Binds `127.0.0.1` **only**, never a routable interface.
- Every handshake must present the per-process, high-entropy bearer token,
  compared with `secrets.compare_digest`. The token lives only in runner
  memory, the tunnel hello, and the owner-gated terminals response.
- Browser handshakes must additionally carry an allow-listed `Origin` (the
  server origin the runner is tunneled to), which blocks DNS-rebinding-style
  pages even if a token ever leaked. Requests with no `Origin` (curl, native
  tools) pass on the token alone.
- Exactly two WS routes are exposed — `/probe` and the attach path. The
  runner's full RPC surface stays tunnel-only.
- Client-side, `parseDirectAttachUrl` accepts only `ws://127.0.0.1:` URLs, so a
  misbehaving server cannot steer the terminal WebSocket at an arbitrary host.

Reachability is tested via `/probe`, which validates and closes without
touching a terminal — a real attach forks a tmux client and seeds a capture, so
probing the attach route itself would cost real work per page load.

## Test Plan

Automated (all run locally on this branch):

- `pytest tests/server/routes/test_session_resources.py tests/runner/test_terminal_resource_attach_ws.py tests/runner/transports/ws_tunnel/test_frames.py tests/runner/transports/ws_tunnel/test_ws_attach_e2e.py` → **201 passed**, including
  `test_direct_attach_listener_serves_probe_on_loopback`.
- `pnpm vitest run` over the 8 terminal suites → **96 passed**; `tsc -b` clean.

Manual, against a real Databricks App deployment (WAN server, runner on my
laptop):

1. Deployed this branch as a Databricks App and connected a local
   `omnigent host` to it, then created a host-launched session.
2. Confirmed the served bundle carries the feature
   (`local-network-access`, `direct_attach_url`, `ws://127.0.0.1:` all present
   in the served chunk).
3. Attached to the advertised loopback URL: **opened in 16 ms** and streamed the
   real Claude Code TUI (2159-byte first frame).
4. Attached with a **wrong token** → rejected, HTTP 403.
5. Verified at the OS level that the browser really holds a loopback socket —
   `lsof -nP -iTCP -sTCP:ESTABLISHED` shows a Chrome helper process paired with
   the runner's listener:
   ```
   python3.1 13718  TCP 127.0.0.1:58458->127.0.0.1:58479 (ESTABLISHED)  <- runner
   Google    61666  TCP 127.0.0.1:58479->127.0.0.1:58458 (ESTABLISHED)  <- Chrome
   ```
6. Handshake timing on the two paths from the same machine:

   | path | median | min / max |
   | --- | --- | --- |
   | direct (loopback) | **8.2 ms** | 7 / 20 |
   | relay (via app) | **678.9 ms** | 640 / 776 |

7. Safari (no LNA) stays on the relay and behaves exactly as before —
   confirms the silent fallback.

## Demo

No visual change to demo: the terminal renders identically on both paths — the
only observable difference is latency, quantified in the table above. The
frontend diff is transport selection (which URL the WebSocket dials), not
rendering.

The behavioural difference is visible in DevTools → Network → Socket, where a
second WebSocket to `ws://127.0.0.1:<port>/…` replaces the
`wss://<server>/…/attach` one after the permission grant.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New coverage lands in the existing suites: `test_session_resources.py` (the
owner gate on `direct_attach_url` and its absence for non-owners),
`test_terminal_resource_attach_ws.py` (listener serves `/probe` on loopback,
token and Origin rejection), `test_frames.py` + `test_ws_attach_e2e.py` (the
hello advert round-trip), `test_session_resources_e2e.py`, and
`web/src/hooks/useTerminals.test.ts` (URL parsing, probe/upgrade state machine,
relay fallback).

Manual verification covers what unit tests structurally cannot: Chrome's Local
Network Access prompt and grant, a genuine browser→loopback TCP connection, and
the real WAN latency delta. Steps and results are enumerated in the Test Plan
above.

## Changelog

Web terminals now attach directly over loopback when the runner is on the same machine as the browser, cutting keystroke echo from ~250 ms to under 10 ms against a remote server.
