### PR TITLE
fix(web): keep chat above growing composer

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -93,6 +93,59 @@ def _settled_geometry(page: Page, timeout_s: float = 15.0) -> dict:
     raise AssertionError(f"layout never settled; last reading: {previous}")
 
 
+def _scroll_to_distance_from_bottom(page: Page, distance: int) -> dict:
+    """Scroll the transcript to a precise distance from its bottom."""
+    return page.evaluate(
+        """distance => {
+            const form = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            ).closest('form');
+            const scroller = form.parentElement.querySelector('[role="log"] > div');
+            scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+            scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight - distance;
+            scroller.dispatchEvent(new Event('scroll'));
+            return {
+                scrollTop: Math.round(scroller.scrollTop),
+                distanceFromBottom: Math.round(
+                    scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+                ),
+            };
+        }""",
+        distance,
+    )
+
+
+def _append_streamed_output(page: Page, height: int) -> dict:
+    """Grow transcript content without scrolling its container."""
+    return page.evaluate(
+        """height => {
+            const form = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            ).closest('form');
+            const scroller = form.parentElement.querySelector('[role="log"] > div');
+            const content = scroller.firstElementChild;
+            const before = {
+                scrollHeight: scroller.scrollHeight,
+                scrollTop: scroller.scrollTop,
+            };
+            const streamed = document.createElement('div');
+            streamed.dataset.testid = 'streamed-output-probe';
+            streamed.style.flex = '0 0 auto';
+            streamed.style.height = `${height}px`;
+            streamed.textContent = 'Additional streamed output below the reader.';
+            content.append(streamed);
+            return {
+                before,
+                after: {
+                    scrollHeight: scroller.scrollHeight,
+                    scrollTop: scroller.scrollTop,
+                },
+            };
+        }""",
+        height,
+    )
+
+
 def test_composer_growth_reflows_transcript_without_covering_output(
     page: Page,
     seeded_session: tuple[str, str],
@@ -184,3 +237,63 @@ def test_composer_growth_reflows_transcript_without_covering_output(
             shrunk[key],
         )
     assert_clearance(shrunk, "after deleting")
+
+    # Escape bottom lock, then let output stream below the reader without
+    # moving the scroll container. Composer growth must preserve the real
+    # post-stream distance, not the distance cached before content grew.
+    _scroll_to_distance_from_bottom(page, 180)
+    escaped = _settled_geometry(page)
+    assert abs(escaped["distanceFromBottom"] - 180) <= 1, escaped
+
+    appended = _append_streamed_output(page, 240)
+    streamed = _settled_geometry(page)
+    added_height = appended["after"]["scrollHeight"] - appended["before"]["scrollHeight"]
+    assert added_height > 0, appended
+    assert appended["after"]["scrollTop"] == appended["before"]["scrollTop"], appended
+    expected_streamed_distance = escaped["distanceFromBottom"] + added_height
+    assert abs(streamed["distanceFromBottom"] - expected_streamed_distance) <= 1, (
+        escaped,
+        appended,
+        streamed,
+    )
+
+    for _ in range(3):
+        composer.press("Shift+Enter")
+    streamed_grown = _settled_geometry(page)
+    assert abs(streamed_grown["overlap"]) <= 1, streamed_grown
+    assert abs(streamed_grown["distanceFromBottom"] - streamed["distanceFromBottom"]) <= 1, (
+        {
+            "before": {
+                "distance": streamed["distanceFromBottom"],
+                "viewport": streamed["viewport"],
+            },
+            "after": {
+                "distance": streamed_grown["distanceFromBottom"],
+                "viewport": streamed_grown["viewport"],
+            },
+        },
+    )
+
+    # The first genuine user scroll after another content-height change must
+    # replace the reconciled distance instead of being mistaken for a synthetic
+    # content-resize scroll.
+    for _ in range(3):
+        composer.press("Backspace")
+    _settled_geometry(page)
+    _append_streamed_output(page, 120)
+    after_more_output = _settled_geometry(page)
+    user_distance = after_more_output["distanceFromBottom"] + 70
+    _scroll_to_distance_from_bottom(page, user_distance)
+    after_user_scroll = _settled_geometry(page)
+    assert abs(after_user_scroll["distanceFromBottom"] - user_distance) <= 1, after_user_scroll
+
+    for _ in range(3):
+        composer.press("Shift+Enter")
+    after_user_scroll_grown = _settled_geometry(page)
+    assert abs(after_user_scroll_grown["overlap"]) <= 1, after_user_scroll_grown
+    assert (
+        abs(
+            after_user_scroll_grown["distanceFromBottom"] - after_user_scroll["distanceFromBottom"]
+        )
+        <= 1
+    ), (after_user_scroll, after_user_scroll_grown)

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -115,6 +115,59 @@ def _scroll_to_distance_from_bottom(page: Page, distance: int) -> dict:
     )
 
 
+def _scroll_with_pointer_momentum(
+    page: Page,
+    pointer_distance: int,
+    settled_distance: int,
+) -> dict:
+    """Release a touch pointer, then deliver its trailing momentum scroll."""
+    return page.evaluate(
+        """async ({ pointerDistance, settledDistance }) => {
+            const form = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            ).closest('form');
+            const scroller = form.parentElement.querySelector('[role="log"] > div');
+            const setDistance = (distance) => {
+                scroller.scrollTop =
+                    scroller.scrollHeight - scroller.clientHeight - distance;
+                scroller.dispatchEvent(new Event('scroll'));
+            };
+            const distance = () => Math.round(
+                scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+            );
+
+            scroller.dispatchEvent(new PointerEvent('pointerdown', {
+                bubbles: true,
+                buttons: 1,
+                isPrimary: true,
+                pointerId: 1,
+                pointerType: 'touch',
+            }));
+            setDistance(pointerDistance);
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            const whilePressed = distance();
+
+            window.dispatchEvent(new PointerEvent('pointerup', {
+                bubbles: true,
+                isPrimary: true,
+                pointerId: 1,
+                pointerType: 'touch',
+            }));
+            setDistance(settledDistance);
+            await new Promise((resolve) => setTimeout(resolve, 20));
+
+            return {
+                whilePressed,
+                afterRelease: distance(),
+            };
+        }""",
+        {
+            "pointerDistance": pointer_distance,
+            "settledDistance": settled_distance,
+        },
+    )
+
+
 def _click_scroll_to_bottom(page: Page) -> None:
     """Use the conversation's visible library-driven re-lock control."""
     button = page.locator('[role="log"] button:has(svg.lucide-arrow-down)')
@@ -431,4 +484,26 @@ def test_composer_growth_reflows_transcript_without_covering_output(
     send_relocked_grown = _settled_geometry(page)
     assert send_relocked_grown["distanceFromBottom"] <= 1, send_relocked_grown
     assert abs(send_relocked_grown["overlap"]) <= 1, send_relocked_grown
+    expect(composer).to_be_focused()
+
+    # A released touch gesture keeps scrolling through momentum. Every trailing
+    # scroll remains user-driven, so the final settled distance must replace the
+    # finger-down distance before a later composer resize restores anything.
+    page.set_viewport_size({"width": 500, "height": 713})
+    composer.fill("")
+    composer.focus()
+    _settled_geometry(page)
+    momentum = _scroll_with_pointer_momentum(page, 500, 650)
+    assert abs(momentum["whilePressed"] - 500) <= 1, momentum
+    assert abs(momentum["afterRelease"] - 650) <= 1, momentum
+    momentum_settled = _settled_geometry(page)
+    assert abs(momentum_settled["distanceFromBottom"] - 650) <= 1, momentum_settled
+
+    composer.press("Shift+Enter")
+    momentum_grown = _settled_geometry(page)
+    assert abs(momentum_grown["distanceFromBottom"] - 650) <= 1, (
+        momentum_settled,
+        momentum_grown,
+    )
+    assert abs(momentum_grown["overlap"]) <= 1, momentum_grown
     expect(composer).to_be_focused()

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -338,6 +338,31 @@ def test_composer_growth_reflows_transcript_without_covering_output(
 
     assert_clearance(baseline, "baseline")
 
+    # The public near-bottom alias includes readers within 70px, but a reader
+    # who deliberately stopped 50px above bottom is not library-locked. The
+    # bottom bridge must leave native browser anchoring in control.
+    page.locator('[role="log"] > div').first.hover()
+    page.mouse.wheel(0, -50)
+    near_bottom_escaped = _settled_geometry(page)
+    assert abs(near_bottom_escaped["distanceFromBottom"] - 50) <= 1, near_bottom_escaped
+
+    for _ in range(3):
+        composer.press("Shift+Enter")
+    near_bottom_grown = _settled_geometry(page)
+    assert_reader_anchor(
+        near_bottom_escaped,
+        near_bottom_grown,
+        "near-bottom escaped composer growth",
+    )
+    assert abs(near_bottom_grown["overlap"]) <= 1, near_bottom_grown
+    expect(composer).to_be_focused()
+
+    for _ in range(3):
+        composer.press("Backspace")
+    _settled_geometry(page)
+    _scroll_to_distance_from_bottom(page, 0)
+    assert_clearance(_settled_geometry(page), "after near-bottom reset")
+
     # Grow: three Shift+Enter newlines, one line taller each.
     for _ in range(3):
         composer.press("Shift+Enter")

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -115,6 +115,13 @@ def _scroll_to_distance_from_bottom(page: Page, distance: int) -> dict:
     )
 
 
+def _click_scroll_to_bottom(page: Page) -> None:
+    """Use the conversation's visible library-driven re-lock control."""
+    button = page.locator('[role="log"] button:has(svg.lucide-arrow-down)')
+    expect(button).to_be_visible()
+    button.click()
+
+
 def _append_streamed_output(page: Page, height: int) -> dict:
     """Grow transcript content without scrolling its container."""
     return page.evaluate(
@@ -379,4 +386,49 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         same_frame_grown,
     )
     assert abs(same_frame_grown["overlap"]) <= 1, same_frame_grown
+    expect(composer).to_be_focused()
+
+    # A legitimate library re-lock must replace the local escaped-distance
+    # shadow. The next composer resize must keep the transcript at the bottom
+    # instead of restoring the stale reader distance from before the click.
+    composer.fill("")
+    _settled_geometry(page)
+    _scroll_to_distance_from_bottom(page, 400)
+    button_escaped = _settled_geometry(page)
+    assert abs(button_escaped["distanceFromBottom"] - 400) <= 1, button_escaped
+    _click_scroll_to_bottom(page)
+    button_relocked = _settled_geometry(page)
+    assert button_relocked["distanceFromBottom"] <= 1, button_relocked
+
+    composer.press("Shift+Enter")
+    button_relocked_grown = _settled_geometry(page)
+    assert button_relocked_grown["composerHeight"] > button_relocked["composerHeight"], (
+        button_relocked,
+        button_relocked_grown,
+    )
+    assert button_relocked_grown["distanceFromBottom"] <= 1, button_relocked_grown
+    assert abs(button_relocked_grown["overlap"]) <= 1, button_relocked_grown
+    _append_streamed_output(page, 80)
+    button_following_output = _settled_geometry(page)
+    assert button_following_output["distanceFromBottom"] <= 1, button_following_output
+
+    # Sending a multiline message uses ScrollToBottomOnSend while clearing the
+    # draft shrinks the composer. A subsequent draft growth must not resurrect
+    # the stale escaped distance or disable bottom-follow during the active turn.
+    composer.fill("")
+    _settled_geometry(page)
+    _scroll_to_distance_from_bottom(page, 320)
+    send_escaped = _settled_geometry(page)
+    assert abs(send_escaped["distanceFromBottom"] - 320) <= 1, send_escaped
+    composer.fill("round-three line one\nline two\nline three")
+    send_multiline = _settled_geometry(page)
+    assert send_multiline["distanceFromBottom"] >= 319, send_multiline
+    page.get_by_role("button", name="Send", exact=True).click()
+    send_relocked = _settled_geometry(page)
+    assert send_relocked["distanceFromBottom"] <= 1, send_relocked
+
+    composer.fill("next draft\nline two")
+    send_relocked_grown = _settled_geometry(page)
+    assert send_relocked_grown["distanceFromBottom"] <= 1, send_relocked_grown
+    assert abs(send_relocked_grown["overlap"]) <= 1, send_relocked_grown
     expect(composer).to_be_focused()

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -124,25 +124,78 @@ def _append_streamed_output(page: Page, height: int) -> dict:
             ).closest('form');
             const scroller = form.parentElement.querySelector('[role="log"] > div');
             const content = scroller.firstElementChild;
-            const before = {
+            const spacer = content.lastElementChild;
+            const geometry = () => ({
                 scrollHeight: scroller.scrollHeight,
                 scrollTop: scroller.scrollTop,
-            };
+            });
+            const before = geometry();
             const streamed = document.createElement('div');
             streamed.dataset.testid = 'streamed-output-probe';
             streamed.style.flex = '0 0 auto';
             streamed.style.height = `${height}px`;
             streamed.textContent = 'Additional streamed output below the reader.';
-            content.append(streamed);
+            content.insertBefore(streamed, spacer);
             return {
                 before,
-                after: {
-                    scrollHeight: scroller.scrollHeight,
-                    scrollTop: scroller.scrollTop,
-                },
+                after: geometry(),
             };
         }""",
         height,
+    )
+
+
+def _append_output_while_growing_composer(
+    page: Page,
+    initial_height: int,
+    restoring_height: int,
+) -> dict:
+    """Grow output and composer together, then append again during restore."""
+    return page.evaluate(
+        """async ({ initialHeight, restoringHeight }) => {
+            const textarea = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            );
+            const form = textarea.closest('form');
+            const scroller = form.parentElement.querySelector('[role="log"] > div');
+            const content = scroller.firstElementChild;
+            const spacer = content.lastElementChild;
+            const appendProbe = (height, testid) => {
+                const streamed = document.createElement('div');
+                streamed.dataset.testid = testid;
+                streamed.style.flex = '0 0 auto';
+                streamed.style.height = `${height}px`;
+                streamed.textContent = 'Additional streamed output below the reader.';
+                content.insertBefore(streamed, spacer);
+            };
+            const geometry = () => ({
+                clientHeight: scroller.clientHeight,
+                scrollHeight: scroller.scrollHeight,
+                scrollTop: scroller.scrollTop,
+            });
+            const before = geometry();
+
+            appendProbe(initialHeight, 'same-frame-output-probe');
+            const valueSetter = Object.getOwnPropertyDescriptor(
+                HTMLTextAreaElement.prototype,
+                'value'
+            ).set;
+            valueSetter.call(textarea, `${textarea.value}\n\n\n`);
+            textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
+
+            // The first frame delivers the combined content/container resize
+            // and schedules restoration. The second runs while that restore is
+            // active, before its clear frame has completed.
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            appendProbe(restoringHeight, 'during-restore-output-probe');
+
+            return { before, afterDuringRestore: geometry() };
+        }""",
+        {
+            "initialHeight": initial_height,
+            "restoringHeight": restoring_height,
+        },
     )
 
 
@@ -247,7 +300,7 @@ def test_composer_growth_reflows_transcript_without_covering_output(
 
     appended = _append_streamed_output(page, 240)
     streamed = _settled_geometry(page)
-    added_height = appended["after"]["scrollHeight"] - appended["before"]["scrollHeight"]
+    added_height = streamed["viewport"][1] - appended["before"]["scrollHeight"]
     assert added_height > 0, appended
     assert appended["after"]["scrollTop"] == appended["before"]["scrollTop"], appended
     expected_streamed_distance = escaped["distanceFromBottom"] + added_height
@@ -297,3 +350,33 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         )
         <= 1
     ), (after_user_scroll, after_user_scroll_grown)
+
+    # Output and composer growth may land in one ResizeObserver delivery while
+    # a follow-up stream chunk arrives before restoration clears. Preserve the
+    # real distance across both deltas instead of consuming either as resize
+    # bookkeeping.
+    for _ in range(3):
+        composer.press("Backspace")
+    _settled_geometry(page)
+    _scroll_to_distance_from_bottom(page, 180)
+    same_frame_escaped = _settled_geometry(page)
+    assert abs(same_frame_escaped["distanceFromBottom"] - 180) <= 1, same_frame_escaped
+
+    combined = _append_output_while_growing_composer(page, 240, 90)
+    same_frame_grown = _settled_geometry(page)
+    total_added_height = same_frame_grown["viewport"][1] - combined["before"]["scrollHeight"]
+    assert total_added_height > 0, (combined, same_frame_grown)
+    assert same_frame_grown["viewport"][0] < combined["before"]["clientHeight"], (
+        combined,
+        same_frame_grown,
+    )
+    assert page.locator('[data-testid="same-frame-output-probe"]').count() == 1
+    assert page.locator('[data-testid="during-restore-output-probe"]').count() == 1
+    expected_same_frame_distance = same_frame_escaped["distanceFromBottom"] + total_added_height
+    assert abs(same_frame_grown["distanceFromBottom"] - expected_same_frame_distance) <= 1, (
+        same_frame_escaped,
+        combined,
+        same_frame_grown,
+    )
+    assert abs(same_frame_grown["overlap"]) <= 1, same_frame_grown
+    expect(composer).to_be_focused()

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -1,27 +1,21 @@
-"""E2E: growing the composer must leave the transcript above it untouched.
+"""E2E: growing the composer must reflow the transcript above it.
 
 The composer auto-grows by collapsing its textarea to ``height: auto`` and
 reading the content height back (``hooks/useAutoGrowTextarea.ts``). That
 collapse lasts one layout pass, during which the composer is one row tall and
-the transcript's scroll viewport is correspondingly taller — so the browser
-clamps the transcript's ``scrollTop`` against the taller viewport's smaller
-maximum. The clamp survives the composer springing back, which shunted the
-whole transcript down a line on every re-measure: Shift+Enter, and then every
-keystroke once the composer was multi-line.
+the transcript's scroll viewport is correspondingly taller. Without the
+hook's wrapper pin, the browser clamps ``scrollTop`` against that temporary
+viewport and shunts the transcript on every re-measure.
 
-A second, subtler source of movement is the composer's height itself: while it
-was a plain flex sibling, every extra row stole height from the transcript's
-scroll viewport. The messages could be held still through that, but the native
-scrollbar (drawn from ``clientHeight``/``scrollHeight``) and the turn rail
-(centered on the same box) still jittered. The composer now floats its extra
-rows over the transcript instead, so that box never changes.
+The composer's persistent height is different: it belongs in the flex layout.
+As the input grows, the transcript viewport must shrink by the same amount and
+remain bottom-locked, with its bottom edge meeting the composer's top edge.
+Floating the extra rows over an unchanged viewport covers visible output.
 
-Layout regressions like these are invisible below the browser — jsdom has no
-layout, so ``scrollHeight``/``clientHeight`` are 0 there and neither the clamp
-nor the viewport arithmetic happens at all. The assertions pin what has to hold
-at once: the messages, the scroll geometry, and the rail ticks all stay exactly
-where they were, and the transcript stays stuck to the bottom so a streaming
-reply still follows.
+Layout regressions like these are invisible below the browser because jsdom
+has no real scroll geometry. The assertions pin both behaviors: real growth
+reflows the transcript without overlap, while typing at a stable height does
+not move the transcript or knock it loose from bottom lock.
 """
 
 from __future__ import annotations
@@ -35,25 +29,38 @@ from tests.e2e_ui.conftest import seed_committed_turn
 _TEXT_SECTION = '[data-testid="assistant-text-section"]'
 
 # Geometry of the transcript and the composer, read together so a measurement
-# can't straddle a layout change.
-#
-# ``distanceFromBottom`` is 0-or-1 while the transcript is stuck to the bottom
-# (use-stick-to-bottom parks it one pixel short of the maximum) and grows once
-# a clamp has knocked it loose. ``viewport`` is the scroll geometry the native
-# scrollbar is drawn from — any change there moves the thumb, which reads as
-# jitter next to a composer that's only supposed to be growing. ``railTicks``
-# is the left-edge turn minimap, centered on the same box.
+# cannot straddle a layout change. ``distanceFromBottom`` is 0-or-1 while the
+# transcript is stuck to the bottom (use-stick-to-bottom parks it one pixel
+# short of the maximum). ``railTicks`` is the left-edge turn minimap, centered
+# on the transcript viewport.
 _PROBE = """() => {
     const ta = document.querySelector('textarea[aria-label="Message the agent"]');
-    const scroller = ta.closest('form').parentElement.querySelector('[role="log"] > div');
+    const form = ta.closest('form');
+    const card = form.querySelector('[data-composer-card]');
+    const scroller = form.parentElement.querySelector('[role="log"] > div');
     const rail = document.querySelector('.turn-rail-fade');
+    const sections = [...document.querySelectorAll(
+        '[data-testid="assistant-text-section"]')];
+    const composerTop = Math.round(card.getBoundingClientRect().top);
+    const transcriptBottom = Math.round(scroller.getBoundingClientRect().bottom);
     return {
-        messageTops: [...document.querySelectorAll('[data-testid="assistant-text-section"]')]
-            .map((section) => Math.round(section.getBoundingClientRect().top)),
+        messageTops: sections.map(
+            (section) => Math.round(section.getBoundingClientRect().top)),
+        lastMessageBottom: Math.round(
+            sections.at(-1).getBoundingClientRect().bottom),
         composerHeight: Math.round(ta.getBoundingClientRect().height),
+        composerTop,
+        transcriptBottom,
+        overlap: transcriptBottom - composerTop,
+        formMarginTop: Math.round(
+            parseFloat(getComputedStyle(form).marginTop) || 0),
         distanceFromBottom: Math.round(
             scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop),
-        viewport: [scroller.clientHeight, scroller.scrollHeight, Math.round(scroller.scrollTop)],
+        viewport: [
+            scroller.clientHeight,
+            scroller.scrollHeight,
+            Math.round(scroller.scrollTop),
+        ],
         railTicks: rail
             ? [...rail.querySelectorAll('button')]
                   .map((tick) => Math.round(tick.getBoundingClientRect().top))
@@ -65,11 +72,10 @@ _PROBE = """() => {
 def _settled_geometry(page: Page, timeout_s: float = 15.0) -> dict:
     """Read :data:`_PROBE` once two consecutive reads agree.
 
-    The layout settles through several passes — the composer's measurement, the
-    trailing spacer's ResizeObserver, then stick-to-bottom — and how long that
-    takes varies with CI load. Polling for a stable read beats sleeping a fixed
-    guess: it can't return mid-settle, and it doesn't pay a fixed cost once the
-    layout is already quiet.
+    The layout settles through several passes — the composer's measurement,
+    the trailing spacer's ResizeObserver, then stick-to-bottom — and how long
+    that takes varies with CI load. Polling for a stable read beats sleeping a
+    fixed guess.
 
     :param page: Playwright page on the chat surface.
     :param timeout_s: How long to keep polling before giving up.
@@ -87,11 +93,11 @@ def _settled_geometry(page: Page, timeout_s: float = 15.0) -> dict:
     raise AssertionError(f"layout never settled; last reading: {previous}")
 
 
-def test_composer_growth_does_not_shift_transcript(
+def test_composer_growth_reflows_transcript_without_covering_output(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Newlines, typing, and deletions all leave the transcript where it was."""
+    """Growth reflows the viewport; same-height edits remain stable."""
     base_url, session_id = seeded_session
     # Enough turns to overflow the viewport: the transcript has to be
     # scrollable for a scrollTop clamp to have anywhere to land, and each turn
@@ -111,34 +117,70 @@ def test_composer_growth_does_not_shift_transcript(
     composer = page.get_by_label("Message the agent")
     expect(composer).to_be_visible(timeout=30_000)
     composer.click()
-    # The baseline is the resting layout: the initial scroll-to-bottom and the
-    # trailing spacer's measurement have both landed.
     baseline = _settled_geometry(page)
-    assert baseline["distanceFromBottom"] <= 1, baseline
     assert baseline["railTicks"], baseline
 
-    def assert_transcript_idle(state: dict, label: str) -> None:
-        """Everything but the composer itself is byte-identical to baseline."""
-        for key in ("messageTops", "viewport", "railTicks"):
-            assert state[key] == baseline[key], (label, key, baseline[key], state[key])
+    def assert_clearance(state: dict, label: str) -> None:
+        """The transcript ends at the composer and remains bottom-locked."""
+        assert abs(state["overlap"]) <= 1, (label, state)
+        assert state["lastMessageBottom"] <= state["composerTop"] + 1, (
+            label,
+            state,
+        )
+        assert state["formMarginTop"] == 0, (label, state)
         assert state["distanceFromBottom"] <= 1, (label, state)
+
+    assert_clearance(baseline, "baseline")
 
     # Grow: three Shift+Enter newlines, one line taller each.
     for _ in range(3):
         composer.press("Shift+Enter")
     grown = _settled_geometry(page)
     assert grown["composerHeight"] > baseline["composerHeight"], grown
-    assert_transcript_idle(grown, "after newlines")
+    growth = grown["composerHeight"] - baseline["composerHeight"]
+    viewport_shrink = baseline["viewport"][0] - grown["viewport"][0]
+    assert abs(viewport_shrink - growth) <= 1, (baseline, grown)
+    assert_clearance(grown, "after newlines")
 
-    # Type into the now-multi-line composer: the height doesn't change, but the
-    # hook re-measures — and used to clamp the transcript on every keystroke.
+    # Typing at the same height still re-measures the textarea. The wrapper pin
+    # must prevent that temporary collapse from moving the transcript.
     composer.type("hello", delay=30)
-    assert_transcript_idle(_settled_geometry(page), "after typing")
+    typed = _settled_geometry(page)
+    for key in (
+        "messageTops",
+        "composerHeight",
+        "composerTop",
+        "transcriptBottom",
+        "viewport",
+        "railTicks",
+    ):
+        assert typed[key] == grown[key], (
+            "after typing",
+            key,
+            grown[key],
+            typed[key],
+        )
+    assert_clearance(typed, "after typing")
 
-    # Shrink back: deleting the newlines returns the composer to one row and
-    # still leaves the transcript untouched.
+    # Shrink back: deleting the newlines restores the resting geometry.
     for _ in range(len("hello") + 3):
         composer.press("Backspace")
     shrunk = _settled_geometry(page)
-    assert shrunk["composerHeight"] == baseline["composerHeight"], (baseline, shrunk)
-    assert_transcript_idle(shrunk, "after deleting")
+    assert shrunk["composerHeight"] == baseline["composerHeight"], (
+        baseline,
+        shrunk,
+    )
+    for key in (
+        "messageTops",
+        "composerTop",
+        "transcriptBottom",
+        "viewport",
+        "railTicks",
+    ):
+        assert shrunk[key] == baseline[key], (
+            "after deleting",
+            key,
+            baseline[key],
+            shrunk[key],
+        )
+    assert_clearance(shrunk, "after deleting")

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -115,57 +115,79 @@ def _scroll_to_distance_from_bottom(page: Page, distance: int) -> dict:
     )
 
 
-def _scroll_with_pointer_momentum(
-    page: Page,
-    pointer_distance: int,
-    settled_distance: int,
-) -> dict:
-    """Release a touch pointer, then deliver its trailing momentum scroll."""
-    return page.evaluate(
-        """async ({ pointerDistance, settledDistance }) => {
-            const form = document.querySelector(
-                'textarea[aria-label="Message the agent"]'
-            ).closest('form');
-            const scroller = form.parentElement.querySelector('[role="log"] > div');
-            const setDistance = (distance) => {
-                scroller.scrollTop =
-                    scroller.scrollHeight - scroller.clientHeight - distance;
-                scroller.dispatchEvent(new Event('scroll'));
-            };
-            const distance = () => Math.round(
-                scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
-            );
-
-            scroller.dispatchEvent(new PointerEvent('pointerdown', {
-                bubbles: true,
-                buttons: 1,
-                isPrimary: true,
-                pointerId: 1,
-                pointerType: 'touch',
-            }));
-            setDistance(pointerDistance);
-            await new Promise((resolve) => setTimeout(resolve, 20));
-            const whilePressed = distance();
-
-            window.dispatchEvent(new PointerEvent('pointerup', {
-                bubbles: true,
-                isPrimary: true,
-                pointerId: 1,
-                pointerType: 'touch',
-            }));
-            setDistance(settledDistance);
-            await new Promise((resolve) => setTimeout(resolve, 20));
-
-            return {
-                whilePressed,
-                afterRelease: distance(),
-            };
-        }""",
-        {
-            "pointerDistance": pointer_distance,
-            "settledDistance": settled_distance,
-        },
-    )
+def _scroll_with_native_touch(page: Page) -> dict:
+    """Scroll through Chromium's native touch-panning path."""
+    session = page.context.new_cdp_session(page)
+    try:
+        session.send(
+            "Emulation.setTouchEmulationEnabled",
+            {"enabled": True, "maxTouchPoints": 1},
+        )
+        target = page.evaluate(
+            """() => {
+                const form = document.querySelector(
+                    'textarea[aria-label="Message the agent"]'
+                ).closest('form');
+                const scroller = form.parentElement.querySelector('[role="log"] > div');
+                const rect = scroller.getBoundingClientRect();
+                const events = [];
+                const record = (event) => events.push(event.type);
+                for (const type of ['pointerdown', 'pointermove', 'pointercancel']) {
+                    window.addEventListener(type, record, { capture: true });
+                }
+                scroller.addEventListener('scroll', record);
+                scroller.addEventListener('scrollend', record);
+                window.__nativeTouchProbe = { events, scroller };
+                return {
+                    x: Math.round(rect.left + rect.width / 2),
+                    y: Math.round(rect.top + Math.min(rect.height * 0.35, 220)),
+                    initialScrollTop: Math.round(scroller.scrollTop),
+                };
+            }"""
+        )
+        point = {
+            "x": target["x"],
+            "y": target["y"],
+            "id": 1,
+            "radiusX": 2,
+            "radiusY": 2,
+            "force": 1,
+        }
+        session.send(
+            "Input.dispatchTouchEvent",
+            {"type": "touchStart", "touchPoints": [point]},
+        )
+        for offset in (35, 75, 120, 170, 225, 280):
+            session.send(
+                "Input.dispatchTouchEvent",
+                {
+                    "type": "touchMove",
+                    "touchPoints": [{**point, "y": point["y"] + offset}],
+                },
+            )
+            page.wait_for_timeout(16)
+        session.send(
+            "Input.dispatchTouchEvent",
+            {"type": "touchEnd", "touchPoints": []},
+        )
+        page.wait_for_timeout(600)
+        return page.evaluate(
+            """initialScrollTop => {
+                const { events, scroller } = window.__nativeTouchProbe;
+                return {
+                    events,
+                    initialScrollTop,
+                    settledScrollTop: Math.round(scroller.scrollTop),
+                    settledDistance: Math.round(
+                        scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+                    ),
+                };
+            }""",
+            target["initialScrollTop"],
+        )
+    finally:
+        session.send("Emulation.setTouchEmulationEnabled", {"enabled": False})
+        session.detach()
 
 
 def _click_scroll_to_bottom(page: Page) -> None:
@@ -205,14 +227,14 @@ def _append_streamed_output(page: Page, height: int) -> dict:
     )
 
 
-def _append_output_while_growing_composer(
+def _append_output_during_composer_reflow(
     page: Page,
     initial_height: int,
-    restoring_height: int,
+    followup_height: int,
 ) -> dict:
-    """Grow output and composer together, then append again during restore."""
+    """Grow output and composer together, then append again while layout settles."""
     return page.evaluate(
-        """async ({ initialHeight, restoringHeight }) => {
+        """async ({ initialHeight, followupHeight }) => {
             const textarea = document.querySelector(
                 'textarea[aria-label="Message the agent"]'
             );
@@ -243,18 +265,17 @@ def _append_output_while_growing_composer(
             valueSetter.call(textarea, `${textarea.value}\n\n\n`);
             textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
 
-            // The first frame delivers the combined content/container resize
-            // and schedules restoration. The second runs while that restore is
-            // active, before its clear frame has completed.
+            // Let the combined content/container resize begin settling, then
+            // append another chunk before the layout has gone idle.
             await new Promise((resolve) => requestAnimationFrame(resolve));
             await new Promise((resolve) => requestAnimationFrame(resolve));
-            appendProbe(restoringHeight, 'during-restore-output-probe');
+            appendProbe(followupHeight, 'during-reflow-output-probe');
 
-            return { before, afterDuringRestore: geometry() };
+            return { before, afterDuringReflow: geometry() };
         }""",
         {
             "initialHeight": initial_height,
-            "restoringHeight": restoring_height,
+            "followupHeight": followup_height,
         },
     )
 
@@ -295,6 +316,25 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         )
         assert state["formMarginTop"] == 0, (label, state)
         assert state["distanceFromBottom"] <= 1, (label, state)
+
+    def assert_reader_anchor(before: dict, after: dict, label: str) -> None:
+        """Composer reflow must not move the transcript under an escaped reader."""
+        assert abs(after["viewport"][2] - before["viewport"][2]) <= 1, (
+            label,
+            before,
+            after,
+        )
+        assert len(after["messageTops"]) == len(before["messageTops"]), (
+            label,
+            before,
+            after,
+        )
+        assert all(
+            abs(after_top - before_top) <= 1
+            for before_top, after_top in zip(
+                before["messageTops"], after["messageTops"], strict=True
+            )
+        ), (label, before, after)
 
     assert_clearance(baseline, "baseline")
 
@@ -351,9 +391,50 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         )
     assert_clearance(shrunk, "after deleting")
 
+    # Chromium touch panning cancels pointer delivery before its native scroll
+    # events. Browser anchoring, not application pointer state, must preserve the
+    # settled transcript position when the composer later grows.
+    browser = page.context.browser
+    assert browser is not None
+    touch_context = browser.new_context(
+        viewport={"width": 500, "height": 713},
+        has_touch=True,
+    )
+    try:
+        touch_page = touch_context.new_page()
+        touch_page.goto(f"{base_url}/c/{session_id}")
+        expect(touch_page.locator(_TEXT_SECTION)).to_have_count(6, timeout=30_000)
+        touch_composer = touch_page.get_by_label("Message the agent")
+        expect(touch_composer).to_be_visible(timeout=30_000)
+        touch_composer.click()
+        touch_baseline = _settled_geometry(touch_page)
+        assert_clearance(touch_baseline, "native touch baseline")
+
+        touch = _scroll_with_native_touch(touch_page)
+        assert touch["settledDistance"] > 100, touch
+        assert touch["settledScrollTop"] < touch["initialScrollTop"], touch
+        assert "pointercancel" in touch["events"], touch
+        assert "scroll" in touch["events"], touch
+        assert touch["events"].index("pointercancel") < touch["events"].index("scroll"), touch
+        assert "scrollend" in touch["events"], touch
+        touch_settled = _settled_geometry(touch_page)
+        assert abs(touch_settled["distanceFromBottom"] - touch["settledDistance"]) <= 1, (
+            touch,
+            touch_settled,
+        )
+        expect(touch_composer).to_be_focused()
+
+        touch_composer.press("Shift+Enter")
+        touch_grown = _settled_geometry(touch_page)
+        assert_reader_anchor(touch_settled, touch_grown, "native touch composer growth")
+        assert abs(touch_grown["overlap"]) <= 1, touch_grown
+        expect(touch_composer).to_be_focused()
+    finally:
+        touch_context.close()
+
     # Escape bottom lock, then let output stream below the reader without
-    # moving the scroll container. Composer growth must preserve the real
-    # post-stream distance, not the distance cached before content grew.
+    # moving the scroll container. Native anchoring must keep the visible
+    # transcript stable when later composer growth shrinks the viewport.
     _scroll_to_distance_from_bottom(page, 180)
     escaped = _settled_geometry(page)
     assert abs(escaped["distanceFromBottom"] - 180) <= 1, escaped
@@ -374,22 +455,10 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         composer.press("Shift+Enter")
     streamed_grown = _settled_geometry(page)
     assert abs(streamed_grown["overlap"]) <= 1, streamed_grown
-    assert abs(streamed_grown["distanceFromBottom"] - streamed["distanceFromBottom"]) <= 1, (
-        {
-            "before": {
-                "distance": streamed["distanceFromBottom"],
-                "viewport": streamed["viewport"],
-            },
-            "after": {
-                "distance": streamed_grown["distanceFromBottom"],
-                "viewport": streamed_grown["viewport"],
-            },
-        },
-    )
+    assert_reader_anchor(streamed, streamed_grown, "streamed composer growth")
 
-    # The first genuine user scroll after another content-height change must
-    # replace the reconciled distance instead of being mistaken for a synthetic
-    # content-resize scroll.
+    # A genuine reader scroll after more output must remain visually stable
+    # through the next composer reflow.
     for _ in range(3):
         composer.press("Backspace")
     _settled_geometry(page)
@@ -404,17 +473,11 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         composer.press("Shift+Enter")
     after_user_scroll_grown = _settled_geometry(page)
     assert abs(after_user_scroll_grown["overlap"]) <= 1, after_user_scroll_grown
-    assert (
-        abs(
-            after_user_scroll_grown["distanceFromBottom"] - after_user_scroll["distanceFromBottom"]
-        )
-        <= 1
-    ), (after_user_scroll, after_user_scroll_grown)
+    assert_reader_anchor(after_user_scroll, after_user_scroll_grown, "reader composer growth")
 
-    # Output and composer growth may land in one ResizeObserver delivery while
-    # a follow-up stream chunk arrives before restoration clears. Preserve the
-    # real distance across both deltas instead of consuming either as resize
-    # bookkeeping.
+    # Output and composer growth may land in one layout delivery while a
+    # follow-up stream chunk arrives before the reflow settles. Neither change
+    # may move the visible transcript under an escaped reader.
     for _ in range(3):
         composer.press("Backspace")
     _settled_geometry(page)
@@ -422,7 +485,7 @@ def test_composer_growth_reflows_transcript_without_covering_output(
     same_frame_escaped = _settled_geometry(page)
     assert abs(same_frame_escaped["distanceFromBottom"] - 180) <= 1, same_frame_escaped
 
-    combined = _append_output_while_growing_composer(page, 240, 90)
+    combined = _append_output_during_composer_reflow(page, 240, 90)
     same_frame_grown = _settled_geometry(page)
     total_added_height = same_frame_grown["viewport"][1] - combined["before"]["scrollHeight"]
     assert total_added_height > 0, (combined, same_frame_grown)
@@ -431,19 +494,13 @@ def test_composer_growth_reflows_transcript_without_covering_output(
         same_frame_grown,
     )
     assert page.locator('[data-testid="same-frame-output-probe"]').count() == 1
-    assert page.locator('[data-testid="during-restore-output-probe"]').count() == 1
-    expected_same_frame_distance = same_frame_escaped["distanceFromBottom"] + total_added_height
-    assert abs(same_frame_grown["distanceFromBottom"] - expected_same_frame_distance) <= 1, (
-        same_frame_escaped,
-        combined,
-        same_frame_grown,
-    )
+    assert page.locator('[data-testid="during-reflow-output-probe"]').count() == 1
+    assert_reader_anchor(same_frame_escaped, same_frame_grown, "same-frame reflow")
     assert abs(same_frame_grown["overlap"]) <= 1, same_frame_grown
     expect(composer).to_be_focused()
 
-    # A legitimate library re-lock must replace the local escaped-distance
-    # shadow. The next composer resize must keep the transcript at the bottom
-    # instead of restoring the stale reader distance from before the click.
+    # The library's scroll control owns re-locking. The bottom bridge must keep
+    # that lock through the next composer resize and subsequent streamed output.
     composer.fill("")
     _settled_geometry(page)
     _scroll_to_distance_from_bottom(page, 400)
@@ -465,9 +522,8 @@ def test_composer_growth_reflows_transcript_without_covering_output(
     button_following_output = _settled_geometry(page)
     assert button_following_output["distanceFromBottom"] <= 1, button_following_output
 
-    # Sending a multiline message uses ScrollToBottomOnSend while clearing the
-    # draft shrinks the composer. A subsequent draft growth must not resurrect
-    # the stale escaped distance or disable bottom-follow during the active turn.
+    # Sending a multiline message re-locks through ScrollToBottomOnSend while
+    # clearing the draft shrinks the composer. Later growth must keep following.
     composer.fill("")
     _settled_geometry(page)
     _scroll_to_distance_from_bottom(page, 320)
@@ -484,26 +540,4 @@ def test_composer_growth_reflows_transcript_without_covering_output(
     send_relocked_grown = _settled_geometry(page)
     assert send_relocked_grown["distanceFromBottom"] <= 1, send_relocked_grown
     assert abs(send_relocked_grown["overlap"]) <= 1, send_relocked_grown
-    expect(composer).to_be_focused()
-
-    # A released touch gesture keeps scrolling through momentum. Every trailing
-    # scroll remains user-driven, so the final settled distance must replace the
-    # finger-down distance before a later composer resize restores anything.
-    page.set_viewport_size({"width": 500, "height": 713})
-    composer.fill("")
-    composer.focus()
-    _settled_geometry(page)
-    momentum = _scroll_with_pointer_momentum(page, 500, 650)
-    assert abs(momentum["whilePressed"] - 500) <= 1, momentum
-    assert abs(momentum["afterRelease"] - 650) <= 1, momentum
-    momentum_settled = _settled_geometry(page)
-    assert abs(momentum_settled["distanceFromBottom"] - 650) <= 1, momentum_settled
-
-    composer.press("Shift+Enter")
-    momentum_grown = _settled_geometry(page)
-    assert abs(momentum_grown["distanceFromBottom"] - 650) <= 1, (
-        momentum_settled,
-        momentum_grown,
-    )
-    assert abs(momentum_grown["overlap"]) <= 1, momentum_grown
     expect(composer).to_be_focused()

--- a/web/src/components/UserMessageNav.tsx
+++ b/web/src/components/UserMessageNav.tsx
@@ -29,9 +29,7 @@ export function UserMessageNav({
     <TooltipProvider>
       <div
         className={cn(
-          // bottom clears the composer's growth (0 elsewhere), which overlaps
-          // the bottom of the transcript it's anchored to.
-          "pointer-events-none absolute right-4 bottom-[calc(1rem+var(--composer-growth,0px))] flex flex-col gap-1",
+          "pointer-events-none absolute right-4 bottom-4 flex flex-col gap-1",
           className,
         )}
       >

--- a/web/src/components/ai-elements/conversation.tsx
+++ b/web/src/components/ai-elements/conversation.tsx
@@ -108,10 +108,7 @@ export const ConversationScrollButton = ({
     !isAtBottom && (
       <Button
         className={cn(
-          // Offset by the composer's growth (0 elsewhere): a grown composer
-          // overlaps the bottom of this scroll area, and the button has to
-          // stay above its card.
-          "absolute bottom-[calc(1rem+var(--composer-growth,0px))] left-[50%] translate-x-[-50%] rounded-full",
+          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
           // Keep the fill OPAQUE on hover. The outline variant's hover (bg-muted)
           // is a translucent black wash (--muted is #0000000f), so over the chat
           // content behind it the button reads as transparent on hover. Hover

--- a/web/src/hooks/useAutoGrowTextarea.test.tsx
+++ b/web/src/hooks/useAutoGrowTextarea.test.tsx
@@ -136,9 +136,8 @@ describe("useAutoGrowTextarea", () => {
   });
 
   it("reports how far past one row the box has grown", () => {
-    // The in-session composer subtracts this from its own top margin, keeping
-    // the extra rows out of the flex column so the transcript's scroll
-    // viewport — and the scrollbar and turn rail drawn from it — hold still.
+    // Callers use this to react to the textarea's capped growth without
+    // remeasuring its content independently.
     const growth: number[] = [];
     const { getByTestId } = render(<Harness value="x" onGrowth={(px) => growth.push(px)} />);
     const ta = getByTestId("ta") as HTMLTextAreaElement;

--- a/web/src/hooks/useAutoGrowTextarea.ts
+++ b/web/src/hooks/useAutoGrowTextarea.ts
@@ -68,10 +68,8 @@ function measureTextarea(
  * covering the case where ``scrollHeight`` reads 0 on mount (e.g. mid
  * client-side route swap, before layout settles).
  *
- * ``onGrowth`` reports how much taller than its resting height the box now
- * is, so a caller can keep that growth out of the surrounding layout — see
- * the in-session composer, which floats the extra rows over the transcript
- * rather than shrinking it.
+ * ``onGrowth`` reports how much taller than its resting height the box now is
+ * for callers that need to coordinate nearby controls with the resized input.
  */
 export function useAutoGrowTextarea(
   ref: RefObject<HTMLTextAreaElement | null>,

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -112,6 +112,42 @@ function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
+describe("Composer growth layout", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps multiline growth in layout instead of offsetting the form over the transcript", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    const form = ta.closest("form");
+    expect(form).not.toBeNull();
+
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, "getComputedStyle").mockImplementation((element, pseudoElt) => {
+      if (element === ta) {
+        return {
+          lineHeight: "20px",
+          paddingTop: "0px",
+          paddingBottom: "0px",
+          minHeight: "0px",
+        } as CSSStyleDeclaration;
+      }
+      return originalGetComputedStyle(element, pseudoElt);
+    });
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => 220,
+    });
+
+    fireEvent.change(ta, { target: { value: "one\ntwo\nthree\nfour" } });
+
+    expect(ta.style.height).toBe("200px");
+    expect(form?.style.marginTop).toBe("");
+  });
+});
+
 describe("Composer Claude goal control", () => {
   afterEach(() => {
     cleanup();

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -83,6 +83,8 @@ describe("KeepBottomOnViewportResize", () => {
     stickContext.scrollRef.current = null;
     stickContext.contentRef.current = null;
     stickContext.isAtBottom = false;
+    stickContext.state.isAtBottom = false;
+    stickContext.state.escapedFromLock = true;
     stickContext.scrollToBottom.mockReset();
 
     class StubResizeObserver {
@@ -117,6 +119,8 @@ describe("KeepBottomOnViewportResize", () => {
     stickContext.scrollRef.current = null;
     stickContext.contentRef.current = null;
     stickContext.isAtBottom = false;
+    stickContext.state.isAtBottom = false;
+    stickContext.state.escapedFromLock = true;
   });
 
   function flushFrames() {
@@ -127,8 +131,8 @@ describe("KeepBottomOnViewportResize", () => {
     });
   }
 
-  function makeScrollRoot() {
-    const metrics = { scrollTop: 800, scrollHeight: 2000, clientHeight: 700 };
+  function makeScrollRoot(scrollTop = 1300) {
+    const metrics = { scrollTop, scrollHeight: 2000, clientHeight: 700 };
     const scrollRoot = document.createElement("div");
     setScrollMetrics(scrollRoot, metrics);
     stickContext.scrollRef.current = scrollRoot;
@@ -138,6 +142,8 @@ describe("KeepBottomOnViewportResize", () => {
   it("keeps a bottom-locked transcript pinned after its viewport shrinks", () => {
     const { metrics } = makeScrollRoot();
     stickContext.isAtBottom = true;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
     render(<KeepBottomOnViewportResize />);
 
     metrics.clientHeight = 650;
@@ -152,7 +158,7 @@ describe("KeepBottomOnViewportResize", () => {
   });
 
   it("leaves an escaped reader anchored by the browser", () => {
-    const { metrics } = makeScrollRoot();
+    const { metrics } = makeScrollRoot(800);
     render(<KeepBottomOnViewportResize />);
 
     metrics.clientHeight = 650;
@@ -161,6 +167,43 @@ describe("KeepBottomOnViewportResize", () => {
     expect(stickContext.scrollToBottom).not.toHaveBeenCalled();
     expect(frames.size).toBe(0);
     expect(metrics.scrollTop).toBe(800);
+  });
+
+  it("ignores the public near-bottom alias when the live lock is escaped", () => {
+    const { metrics } = makeScrollRoot(1250);
+    stickContext.isAtBottom = true;
+    stickContext.state.isAtBottom = false;
+    stickContext.state.escapedFromLock = true;
+    render(<KeepBottomOnViewportResize />);
+
+    metrics.clientHeight = 650;
+    act(() => resize?.());
+
+    expect(stickContext.scrollToBottom).not.toHaveBeenCalled();
+    expect(frames.size).toBe(0);
+    expect(metrics.scrollTop).toBe(1250);
+  });
+
+  it("keeps a user escape after a same-resize library reclassification", () => {
+    const { metrics, scrollRoot } = makeScrollRoot();
+    stickContext.isAtBottom = true;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    render(<KeepBottomOnViewportResize />);
+
+    metrics.scrollTop = 1250;
+    stickContext.state.isAtBottom = false;
+    stickContext.state.escapedFromLock = true;
+    fireEvent.scroll(scrollRoot);
+
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    metrics.clientHeight = 650;
+    act(() => resize?.());
+
+    expect(stickContext.scrollToBottom).not.toHaveBeenCalled();
+    expect(frames.size).toBe(0);
+    expect(metrics.scrollTop).toBe(1250);
   });
 
   it("ignores content-only resize notifications", () => {
@@ -178,6 +221,8 @@ describe("KeepBottomOnViewportResize", () => {
   it("disconnects the observer and cancels a queued follow-up frame", () => {
     const { metrics } = makeScrollRoot();
     stickContext.isAtBottom = true;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
     const { unmount } = render(<KeepBottomOnViewportResize />);
 
     metrics.clientHeight = 650;

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -3,10 +3,18 @@ import { Profiler, useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserMessageBlock } from "@/lib/blocks";
 import { useChatStore } from "@/store/chatStore";
-import { HistoryAutoLoader, JumpToTopButton, LatestTurnSpacer } from "./ChatPage";
+import {
+  HistoryAutoLoader,
+  JumpToTopButton,
+  LatestTurnSpacer,
+  PreserveScrollDistanceOnResize,
+} from "./ChatPage";
 
 const stickContext = vi.hoisted(() => ({
   scrollRef: { current: null as HTMLElement | null },
+  contentRef: { current: null as HTMLElement | null },
+  state: { isAtBottom: false, escapedFromLock: true },
+  stopScroll: undefined as (() => void) | undefined,
 }));
 
 vi.mock("use-stick-to-bottom", () => ({
@@ -58,6 +66,153 @@ function setScrollMetrics(
     get: () => metrics.clientHeight ?? 0,
   });
 }
+
+describe("PreserveScrollDistanceOnResize", () => {
+  let resize: (() => void) | null;
+  let disconnectSpy = vi.fn<() => void>();
+  let nextFrameId: number;
+  let frames: Map<number, FrameRequestCallback>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resize = null;
+    disconnectSpy.mockClear();
+    nextFrameId = 1;
+    frames = new Map();
+    stickContext.scrollRef.current = null;
+    stickContext.contentRef.current = null;
+    stickContext.state.isAtBottom = false;
+    stickContext.state.escapedFromLock = true;
+    stickContext.stopScroll = vi.fn();
+
+    class StubResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resize = () => callback([], this as unknown as ResizeObserver);
+      }
+      observe() {}
+      disconnect() {
+        disconnectSpy();
+      }
+    }
+    vi.stubGlobal("ResizeObserver", StubResizeObserver);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = nextFrameId++;
+        frames.set(id, callback);
+        return id;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => {
+        frames.delete(id);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    stickContext.scrollRef.current = null;
+    stickContext.contentRef.current = null;
+    stickContext.stopScroll = undefined;
+  });
+
+  function flushRestore() {
+    act(() => {
+      for (let pass = 0; pass < 5 && frames.size > 0; pass += 1) {
+        const callbacks = [...frames.values()];
+        frames.clear();
+        for (const callback of callbacks) callback(performance.now());
+        vi.advanceTimersByTime(3);
+      }
+    });
+  }
+
+  function makeScrollRoot() {
+    const metrics = { scrollTop: 800, scrollHeight: 2000, clientHeight: 700 };
+    const scrollRoot = document.createElement("div");
+    setScrollMetrics(scrollRoot, metrics);
+    stickContext.scrollRef.current = scrollRoot;
+    return { metrics, scrollRoot };
+  }
+
+  it("preserves post-release momentum through scrollend and cancels an active restore", () => {
+    const { metrics, scrollRoot } = makeScrollRoot();
+    render(<PreserveScrollDistanceOnResize />);
+
+    fireEvent.pointerDown(scrollRoot);
+    fireEvent.scroll(scrollRoot);
+    act(() => vi.advanceTimersByTime(2));
+    fireEvent.pointerUp(window);
+
+    metrics.clientHeight = 650;
+    act(() => resize?.());
+    expect(frames.size).toBe(1);
+
+    metrics.scrollTop = 700;
+    fireEvent.scroll(scrollRoot);
+    act(() => vi.advanceTimersByTime(2));
+    expect(cancelAnimationFrame).toHaveBeenCalled();
+    expect(frames.size).toBe(0);
+
+    fireEvent(scrollRoot, new Event("scrollend"));
+    act(() => vi.advanceTimersByTime(22));
+
+    metrics.clientHeight = 600;
+    act(() => resize?.());
+    flushRestore();
+
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(650);
+    expect(stickContext.state.escapedFromLock).toBe(true);
+    expect(stickContext.state.isAtBottom).toBe(false);
+  });
+
+  it("keeps momentum active until the last-scroll debounce when scrollend is unavailable", () => {
+    const { metrics, scrollRoot } = makeScrollRoot();
+    render(<PreserveScrollDistanceOnResize />);
+
+    fireEvent.pointerDown(scrollRoot);
+    fireEvent.scroll(scrollRoot);
+    act(() => vi.advanceTimersByTime(2));
+    fireEvent.pointerUp(window);
+
+    metrics.scrollTop = 700;
+    fireEvent.scroll(scrollRoot);
+    act(() => vi.advanceTimersByTime(142));
+
+    metrics.scrollTop = 650;
+    fireEvent.scroll(scrollRoot);
+    act(() => vi.advanceTimersByTime(152));
+
+    metrics.clientHeight = 600;
+    act(() => resize?.());
+    flushRestore();
+
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(650);
+  });
+
+  it("cleans up observer, pointer intent, timers, and queued restore frames", () => {
+    const { metrics, scrollRoot } = makeScrollRoot();
+    const { unmount } = render(<PreserveScrollDistanceOnResize />);
+
+    fireEvent.pointerDown(scrollRoot);
+    fireEvent.pointerUp(window);
+    metrics.clientHeight = 650;
+    act(() => resize?.());
+    expect(frames.size).toBe(1);
+
+    unmount();
+
+    expect(disconnectSpy).toHaveBeenCalledOnce();
+    expect(cancelAnimationFrame).toHaveBeenCalled();
+    expect(frames.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
 
 describe("HistoryAutoLoader", () => {
   beforeEach(() => {

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -6,13 +6,15 @@ import { useChatStore } from "@/store/chatStore";
 import {
   HistoryAutoLoader,
   JumpToTopButton,
+  KeepBottomOnViewportResize,
   LatestTurnSpacer,
-  PreserveScrollDistanceOnResize,
 } from "./ChatPage";
 
 const stickContext = vi.hoisted(() => ({
   scrollRef: { current: null as HTMLElement | null },
   contentRef: { current: null as HTMLElement | null },
+  isAtBottom: false,
+  scrollToBottom: vi.fn(),
   state: { isAtBottom: false, escapedFromLock: true },
   stopScroll: undefined as (() => void) | undefined,
 }));
@@ -67,23 +69,21 @@ function setScrollMetrics(
   });
 }
 
-describe("PreserveScrollDistanceOnResize", () => {
+describe("KeepBottomOnViewportResize", () => {
   let resize: (() => void) | null;
   let disconnectSpy = vi.fn<() => void>();
   let nextFrameId: number;
   let frames: Map<number, FrameRequestCallback>;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     resize = null;
     disconnectSpy.mockClear();
     nextFrameId = 1;
     frames = new Map();
     stickContext.scrollRef.current = null;
     stickContext.contentRef.current = null;
-    stickContext.state.isAtBottom = false;
-    stickContext.state.escapedFromLock = true;
-    stickContext.stopScroll = vi.fn();
+    stickContext.isAtBottom = false;
+    stickContext.scrollToBottom.mockReset();
 
     class StubResizeObserver {
       constructor(callback: ResizeObserverCallback) {
@@ -113,22 +113,17 @@ describe("PreserveScrollDistanceOnResize", () => {
 
   afterEach(() => {
     cleanup();
-    vi.clearAllTimers();
     vi.unstubAllGlobals();
-    vi.useRealTimers();
     stickContext.scrollRef.current = null;
     stickContext.contentRef.current = null;
-    stickContext.stopScroll = undefined;
+    stickContext.isAtBottom = false;
   });
 
-  function flushRestore() {
+  function flushFrames() {
     act(() => {
-      for (let pass = 0; pass < 5 && frames.size > 0; pass += 1) {
-        const callbacks = [...frames.values()];
-        frames.clear();
-        for (const callback of callbacks) callback(performance.now());
-        vi.advanceTimersByTime(3);
-      }
+      const callbacks = [...frames.values()];
+      frames.clear();
+      for (const callback of callbacks) callback(performance.now());
     });
   }
 
@@ -140,67 +135,51 @@ describe("PreserveScrollDistanceOnResize", () => {
     return { metrics, scrollRoot };
   }
 
-  it("preserves post-release momentum through scrollend and cancels an active restore", () => {
-    const { metrics, scrollRoot } = makeScrollRoot();
-    render(<PreserveScrollDistanceOnResize />);
-
-    fireEvent.pointerDown(scrollRoot);
-    fireEvent.scroll(scrollRoot);
-    act(() => vi.advanceTimersByTime(2));
-    fireEvent.pointerUp(window);
+  it("keeps a bottom-locked transcript pinned after its viewport shrinks", () => {
+    const { metrics } = makeScrollRoot();
+    stickContext.isAtBottom = true;
+    render(<KeepBottomOnViewportResize />);
 
     metrics.clientHeight = 650;
     act(() => resize?.());
+
+    expect(stickContext.scrollToBottom).toHaveBeenCalledOnce();
+    expect(stickContext.scrollToBottom).toHaveBeenCalledWith("instant");
     expect(frames.size).toBe(1);
 
-    metrics.scrollTop = 700;
-    fireEvent.scroll(scrollRoot);
-    act(() => vi.advanceTimersByTime(2));
-    expect(cancelAnimationFrame).toHaveBeenCalled();
+    flushFrames();
+    expect(stickContext.scrollToBottom).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves an escaped reader anchored by the browser", () => {
+    const { metrics } = makeScrollRoot();
+    render(<KeepBottomOnViewportResize />);
+
+    metrics.clientHeight = 650;
+    act(() => resize?.());
+
+    expect(stickContext.scrollToBottom).not.toHaveBeenCalled();
     expect(frames.size).toBe(0);
-
-    fireEvent(scrollRoot, new Event("scrollend"));
-    act(() => vi.advanceTimersByTime(22));
-
-    metrics.clientHeight = 600;
-    act(() => resize?.());
-    flushRestore();
-
-    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(650);
-    expect(stickContext.state.escapedFromLock).toBe(true);
-    expect(stickContext.state.isAtBottom).toBe(false);
+    expect(metrics.scrollTop).toBe(800);
   });
 
-  it("keeps momentum active until the last-scroll debounce when scrollend is unavailable", () => {
-    const { metrics, scrollRoot } = makeScrollRoot();
-    render(<PreserveScrollDistanceOnResize />);
+  it("ignores content-only resize notifications", () => {
+    const { metrics } = makeScrollRoot();
+    stickContext.isAtBottom = true;
+    render(<KeepBottomOnViewportResize />);
 
-    fireEvent.pointerDown(scrollRoot);
-    fireEvent.scroll(scrollRoot);
-    act(() => vi.advanceTimersByTime(2));
-    fireEvent.pointerUp(window);
-
-    metrics.scrollTop = 700;
-    fireEvent.scroll(scrollRoot);
-    act(() => vi.advanceTimersByTime(142));
-
-    metrics.scrollTop = 650;
-    fireEvent.scroll(scrollRoot);
-    act(() => vi.advanceTimersByTime(152));
-
-    metrics.clientHeight = 600;
+    metrics.scrollHeight = 2200;
     act(() => resize?.());
-    flushRestore();
 
-    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(650);
+    expect(stickContext.scrollToBottom).not.toHaveBeenCalled();
+    expect(frames.size).toBe(0);
   });
 
-  it("cleans up observer, pointer intent, timers, and queued restore frames", () => {
-    const { metrics, scrollRoot } = makeScrollRoot();
-    const { unmount } = render(<PreserveScrollDistanceOnResize />);
+  it("disconnects the observer and cancels a queued follow-up frame", () => {
+    const { metrics } = makeScrollRoot();
+    stickContext.isAtBottom = true;
+    const { unmount } = render(<KeepBottomOnViewportResize />);
 
-    fireEvent.pointerDown(scrollRoot);
-    fireEvent.pointerUp(window);
     metrics.clientHeight = 650;
     act(() => resize?.());
     expect(frames.size).toBe(1);
@@ -210,7 +189,6 @@ describe("PreserveScrollDistanceOnResize", () => {
     expect(disconnectSpy).toHaveBeenCalledOnce();
     expect(cancelAnimationFrame).toHaveBeenCalled();
     expect(frames.size).toBe(0);
-    expect(vi.getTimerCount()).toBe(0);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2375,111 +2375,208 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
  * `scrollTop = scrollHeight - clientHeight - distance`. We also observe the
  * transcript content: output can keep growing while an escaped reader's
  * `scrollTop` stays still, so that growth must increase the stored distance
- * before a later composer resize restores it. An explicit restore target
- * distinguishes our own scroll from the next genuine user scroll.
+ * before a later composer resize restores it. The boundary before the trailing
+ * spacer distinguishes output growth from viewport-only layout changes, while
+ * explicit input intent distinguishes genuine reader scrolling from synthetic
+ * clamp and restore events.
  */
 function PreserveScrollDistanceOnResize() {
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
     contentRef?: React.RefObject<HTMLElement>;
     scrollRef?: React.RefObject<HTMLElement>;
+    stopScroll?: () => void;
   };
   const contentRef = ctx.contentRef;
   const scrollRef = ctx.scrollRef;
   const state = ctx.state;
+  const stopScroll = ctx.stopScroll;
 
   useEffect(() => {
     const el = scrollRef?.current;
     if (!el) return;
+    const content = (contentRef?.current ?? el.firstElementChild) as HTMLElement | null;
+    const spacer = content?.lastElementChild as HTMLElement | null;
 
     const measure = () => el.scrollHeight - el.clientHeight - el.scrollTop;
-    let distance = state.escapedFromLock ? Math.max(0, measure()) : 1;
+    const measureContentExtent = () =>
+      content && spacer
+        ? spacer.getBoundingClientRect().top - content.getBoundingClientRect().top
+        : el.scrollHeight;
+    let escaped = state.escapedFromLock;
+    let distance = escaped ? Math.max(0, measure()) : 1;
     let prevSH = el.scrollHeight;
     let prevCH = el.clientHeight;
+    let prevContentExtent = measureContentExtent();
     let restoring = false;
     let restoreFrame: number | null = null;
     let clearRestoreFrame: number | null = null;
+    let clearRestoreTimer: number | null = null;
     let restorePasses = 0;
     let scrollTimer: number | null = null;
+    let userIntentTimer: number | null = null;
+    let userScrollIntent = false;
+    let pointerScrolling = false;
 
-    const reconcileContentHeight = (scrollHeight: number) => {
+    const reconcileContentHeight = (scrollHeight: number, clientHeight: number) => {
       const delta = scrollHeight - prevSH;
-      if (delta === 0) return;
-      distance = state.escapedFromLock ? Math.max(0, distance + delta) : 1;
+      const contentExtent = measureContentExtent();
+      const contentChanged = Math.abs(contentExtent - prevContentExtent) >= 1;
+      const viewportResizeActive = restoring || clientHeight !== prevCH;
+      if (delta !== 0 && (!viewportResizeActive || contentChanged)) {
+        distance = escaped ? Math.max(0, distance + delta) : 1;
+      }
       prevSH = scrollHeight;
+      prevContentExtent = contentExtent;
+    };
+
+    const preserveEscapedState = () => {
+      if (!escaped) return;
+      stopScroll?.();
+      state.escapedFromLock = true;
+      state.isAtBottom = false;
     };
 
     const applyRestore = () => {
       restoreFrame = null;
       const scrollHeight = el.scrollHeight;
       const clientHeight = el.clientHeight;
+      reconcileContentHeight(scrollHeight, clientHeight);
+      preserveEscapedState();
       const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
       el.scrollTop = Math.max(0, Math.min(maxScrollTop, maxScrollTop - distance));
-      prevSH = el.scrollHeight;
       prevCH = el.clientHeight;
       clearRestoreFrame = requestAnimationFrame(() => {
         clearRestoreFrame = null;
-        if (Math.abs(Math.max(0, measure()) - distance) > 1 && restorePasses < 3) {
-          restorePasses += 1;
-          restoreFrame = requestAnimationFrame(applyRestore);
-          return;
-        }
-        restoring = false;
-        restorePasses = 0;
+        clearRestoreTimer = window.setTimeout(() => {
+          clearRestoreTimer = null;
+          if (Math.abs(Math.max(0, measure()) - distance) > 1 && restorePasses < 3) {
+            restorePasses += 1;
+            restoreFrame = requestAnimationFrame(applyRestore);
+            return;
+          }
+          restoring = false;
+          restorePasses = 0;
+        }, 2);
       });
     };
 
     const scheduleRestore = () => {
-      if (!restoring) restorePasses = 0;
-      restoring = true;
-      if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
-      if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
+      preserveEscapedState();
+      if (!restoring) {
+        restorePasses = 0;
+        restoring = true;
+      }
+      if (clearRestoreFrame !== null) {
+        cancelAnimationFrame(clearRestoreFrame);
+        clearRestoreFrame = null;
+      }
+      if (clearRestoreTimer !== null) {
+        window.clearTimeout(clearRestoreTimer);
+        clearRestoreTimer = null;
+      }
+      if (restoreFrame !== null) return;
       restoreFrame = requestAnimationFrame(applyRestore);
+    };
+
+    const cancelRestore = () => {
+      if (restoreFrame !== null) {
+        cancelAnimationFrame(restoreFrame);
+        restoreFrame = null;
+      }
+      if (clearRestoreFrame !== null) {
+        cancelAnimationFrame(clearRestoreFrame);
+        clearRestoreFrame = null;
+      }
+      if (clearRestoreTimer !== null) {
+        window.clearTimeout(clearRestoreTimer);
+        clearRestoreTimer = null;
+      }
+      restoring = false;
+      restorePasses = 0;
+    };
+
+    const markUserScrollIntent = () => {
+      userScrollIntent = true;
+      if (userIntentTimer !== null) window.clearTimeout(userIntentTimer);
+      userIntentTimer = window.setTimeout(() => {
+        userIntentTimer = null;
+        userScrollIntent = false;
+      }, 150);
+    };
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) {
+        markUserScrollIntent();
+      }
+    };
+
+    const onPointerDown = () => {
+      pointerScrolling = true;
+    };
+
+    const onPointerUp = () => {
+      pointerScrolling = false;
     };
 
     const onScroll = () => {
       if (scrollTimer !== null) window.clearTimeout(scrollTimer);
-      // The library updates `escapedFromLock` one millisecond after its scroll
-      // listener runs. Read its stable mutable state after that classification
-      // so scrollbar drags and the first post-stream user scroll are genuine,
-      // while its own bottom-lock scrolls remain synthetic here.
+      // Explicit wheel/key/pointer intent distinguishes genuine reader movement
+      // from the library's own clamp and bottom-lock scrolls.
       scrollTimer = window.setTimeout(() => {
         scrollTimer = null;
-        if (restoring) return;
+        const userInitiated = userScrollIntent || pointerScrolling;
+        userScrollIntent = false;
+        if (userIntentTimer !== null) {
+          window.clearTimeout(userIntentTimer);
+          userIntentTimer = null;
+        }
         const sh = el.scrollHeight;
         const ch = el.clientHeight;
-        if (ch !== prevCH) {
-          scheduleRestore();
+        reconcileContentHeight(sh, ch);
+        if (!userInitiated) {
+          if (ch !== prevCH) scheduleRestore();
           return;
         }
-        distance = state.escapedFromLock ? Math.max(0, measure()) : 1;
-        prevSH = sh;
+        if (restoring) cancelRestore();
+        const measuredDistance = Math.max(0, measure());
+        escaped = measuredDistance > 1;
+        distance = escaped ? measuredDistance : 1;
+        if (escaped) stopScroll?.();
+        state.escapedFromLock = escaped;
+        state.isAtBottom = !escaped;
         prevCH = ch;
       }, 2);
     };
 
     const observer = new ResizeObserver(() => {
-      const sh = el.scrollHeight;
       const ch = el.clientHeight;
-      if (restoring) {
-        scheduleRestore();
-        return;
-      }
+      reconcileContentHeight(el.scrollHeight, ch);
       if (ch !== prevCH) scheduleRestore();
-      else reconcileContentHeight(sh);
     });
 
     el.addEventListener("scroll", onScroll, { passive: true });
+    el.addEventListener("wheel", markUserScrollIntent, { passive: true });
+    el.addEventListener("keydown", onKeyDown);
+    el.addEventListener("pointerdown", onPointerDown, { passive: true });
+    window.addEventListener("pointerup", onPointerUp, { passive: true });
+    window.addEventListener("pointercancel", onPointerUp, { passive: true });
     observer.observe(el);
-    const content = contentRef?.current ?? el.firstElementChild;
     if (content) observer.observe(content);
     return () => {
       el.removeEventListener("scroll", onScroll);
+      el.removeEventListener("wheel", markUserScrollIntent);
+      el.removeEventListener("keydown", onKeyDown);
+      el.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
       observer.disconnect();
       if (scrollTimer !== null) window.clearTimeout(scrollTimer);
+      if (userIntentTimer !== null) window.clearTimeout(userIntentTimer);
       if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
       if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
+      if (clearRestoreTimer !== null) window.clearTimeout(clearRestoreTimer);
     };
-  }, [contentRef, scrollRef, state]);
+  }, [contentRef, scrollRef, state, stopScroll]);
 
   return null;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2366,19 +2366,24 @@ export function KeepBottomOnViewportResize() {
     scrollRef?: React.RefObject<HTMLElement>;
   };
   const scrollRef = ctx.scrollRef;
-  const isAtBottom = ctx.isAtBottom;
+  const state = ctx.state;
   const scrollToBottom = ctx.scrollToBottom;
 
   useEffect(() => {
     const el = scrollRef?.current;
     if (!el || typeof ResizeObserver === "undefined") return;
+    const isPhysicallyAtBottom = () => el.scrollHeight - el.clientHeight - el.scrollTop <= 1;
+    let wasBottomLocked = state.isAtBottom && !state.escapedFromLock && isPhysicallyAtBottom();
     let clientHeight = el.clientHeight;
     let frame: number | null = null;
+    const onScroll = () => {
+      wasBottomLocked = isPhysicallyAtBottom();
+    };
     const observer = new ResizeObserver(() => {
       const nextHeight = el.clientHeight;
       if (nextHeight === clientHeight) return;
       clientHeight = nextHeight;
-      if (!isAtBottom) return;
+      if (!wasBottomLocked) return;
       scrollToBottom("instant");
       if (frame !== null) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
@@ -2386,12 +2391,14 @@ export function KeepBottomOnViewportResize() {
         scrollToBottom("instant");
       });
     });
+    el.addEventListener("scroll", onScroll, { passive: true });
     observer.observe(el);
     return () => {
+      el.removeEventListener("scroll", onScroll);
       observer.disconnect();
       if (frame !== null) cancelAnimationFrame(frame);
     };
-  }, [isAtBottom, scrollRef, scrollToBottom]);
+  }, [scrollRef, scrollToBottom, state]);
 
   return null;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2429,7 +2429,16 @@ function PreserveScrollDistanceOnResize() {
       prevContentExtent = contentExtent;
     };
 
+    const syncBottomLock = () => {
+      const measuredDistance = Math.max(0, measure());
+      if (!state.isAtBottom && measuredDistance > 1) return false;
+      escaped = false;
+      distance = 1;
+      return true;
+    };
+
     const preserveEscapedState = () => {
+      if (syncBottomLock()) return;
       if (!escaped) return;
       stopScroll?.();
       state.escapedFromLock = true;
@@ -2534,6 +2543,7 @@ function PreserveScrollDistanceOnResize() {
         const ch = el.clientHeight;
         reconcileContentHeight(sh, ch);
         if (!userInitiated) {
+          if (syncBottomLock() && restoring) cancelRestore();
           if (ch !== prevCH) scheduleRestore();
           return;
         }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2372,56 +2372,114 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
  *
  * So we watch the scroll container itself with a `ResizeObserver` and, on any
  * size change, hold the scroll position relative to the bottom constant:
- * `scrollTop = scrollHeight - clientHeight - distance`. `distance` is tracked
- * from genuine user scrolls only — scrolls that coincide with a dimension change
- * (the resize's own clamp, or our restore) are ignored so they can't corrupt it.
- * At the bottom (distance 0) you stay at the bottom; scrolled up reading
- * history, you keep seeing the same messages. New messages still go through the
- * library (content resize doesn't change the container's box). Stateless across
- * any number of keyboard cycles.
+ * `scrollTop = scrollHeight - clientHeight - distance`. We also observe the
+ * transcript content: output can keep growing while an escaped reader's
+ * `scrollTop` stays still, so that growth must increase the stored distance
+ * before a later composer resize restores it. An explicit restore target
+ * distinguishes our own scroll from the next genuine user scroll.
  */
 function PreserveScrollDistanceOnResize() {
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    contentRef?: React.RefObject<HTMLElement>;
     scrollRef?: React.RefObject<HTMLElement>;
   };
+  const contentRef = ctx.contentRef;
   const scrollRef = ctx.scrollRef;
+  const state = ctx.state;
 
   useEffect(() => {
     const el = scrollRef?.current;
     if (!el) return;
 
     const measure = () => el.scrollHeight - el.clientHeight - el.scrollTop;
-    let distance = Math.max(0, measure());
+    let distance = state.escapedFromLock ? Math.max(0, measure()) : 1;
     let prevSH = el.scrollHeight;
     let prevCH = el.clientHeight;
+    let restoring = false;
+    let restoreFrame: number | null = null;
+    let clearRestoreFrame: number | null = null;
+    let restorePasses = 0;
+    let scrollTimer: number | null = null;
+
+    const reconcileContentHeight = (scrollHeight: number) => {
+      const delta = scrollHeight - prevSH;
+      if (delta === 0) return;
+      distance = state.escapedFromLock ? Math.max(0, distance + delta) : 1;
+      prevSH = scrollHeight;
+    };
+
+    const applyRestore = () => {
+      restoreFrame = null;
+      const scrollHeight = el.scrollHeight;
+      const clientHeight = el.clientHeight;
+      const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+      el.scrollTop = Math.max(0, Math.min(maxScrollTop, maxScrollTop - distance));
+      prevSH = el.scrollHeight;
+      prevCH = el.clientHeight;
+      clearRestoreFrame = requestAnimationFrame(() => {
+        clearRestoreFrame = null;
+        if (Math.abs(Math.max(0, measure()) - distance) > 1 && restorePasses < 3) {
+          restorePasses += 1;
+          restoreFrame = requestAnimationFrame(applyRestore);
+          return;
+        }
+        restoring = false;
+        restorePasses = 0;
+      });
+    };
+
+    const scheduleRestore = () => {
+      if (!restoring) restorePasses = 0;
+      restoring = true;
+      if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
+      if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
+      restoreFrame = requestAnimationFrame(applyRestore);
+    };
 
     const onScroll = () => {
-      const sh = el.scrollHeight;
-      const ch = el.clientHeight;
-      // A scroll that lands on the same frame as a size change is resize-induced
-      // (the browser's clamp, or our own restore below) — not the user. Skip it
-      // so it can't overwrite the distance we're trying to preserve.
-      if (sh !== prevSH || ch !== prevCH) {
+      if (scrollTimer !== null) window.clearTimeout(scrollTimer);
+      // The library updates `escapedFromLock` one millisecond after its scroll
+      // listener runs. Read its stable mutable state after that classification
+      // so scrollbar drags and the first post-stream user scroll are genuine,
+      // while its own bottom-lock scrolls remain synthetic here.
+      scrollTimer = window.setTimeout(() => {
+        scrollTimer = null;
+        if (restoring) return;
+        const sh = el.scrollHeight;
+        const ch = el.clientHeight;
+        if (ch !== prevCH) {
+          scheduleRestore();
+          return;
+        }
+        distance = state.escapedFromLock ? Math.max(0, measure()) : 1;
         prevSH = sh;
         prevCH = ch;
-        return;
-      }
-      distance = Math.max(0, measure());
+      }, 2);
     };
 
     const observer = new ResizeObserver(() => {
-      el.scrollTop = el.scrollHeight - el.clientHeight - distance;
-      prevSH = el.scrollHeight;
-      prevCH = el.clientHeight;
+      const sh = el.scrollHeight;
+      const ch = el.clientHeight;
+      if (restoring) {
+        scheduleRestore();
+        return;
+      }
+      if (ch !== prevCH) scheduleRestore();
+      else reconcileContentHeight(sh);
     });
 
     el.addEventListener("scroll", onScroll, { passive: true });
     observer.observe(el);
+    const content = contentRef?.current ?? el.firstElementChild;
+    if (content) observer.observe(content);
     return () => {
       el.removeEventListener("scroll", onScroll);
       observer.disconnect();
+      if (scrollTimer !== null) window.clearTimeout(scrollTimer);
+      if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
+      if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
     };
-  }, [scrollRef]);
+  }, [contentRef, scrollRef, state]);
 
   return null;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1825,15 +1825,6 @@ function MainAgentSurface({
     conversationRef.current = el;
     setContainerEl(el);
   }, []);
-  // How far the composer has grown past its resting height. The composer keeps
-  // that growth out of the flex column, so the wrapper's box never moves —
-  // this only lifts the overlays pinned to its bottom edge (the scroll-to-
-  // bottom button, the Working… tab, the message nav) clear of the taller
-  // card. Written straight to the DOM: a re-render per line of typing would
-  // re-render the whole transcript for a purely visual offset.
-  const publishComposerGrowth = useCallback((px: number) => {
-    conversationRef.current?.style.setProperty("--composer-growth", `${px}px`);
-  }, []);
   const [terminalSurfaceEl, setTerminalSurfaceEl] = useState<HTMLElement | null>(null);
   // True only while the chat/terminal surface is the frontmost thing on screen.
   // Drives both native overlays so neither floats over an opened drawer.
@@ -2210,7 +2201,6 @@ function MainAgentSurface({
             subagentRoutingEligible={subagentRoutingEligible}
             subAgentLabel={subAgentLabel}
             wrapperLabel={wrapperLabel}
-            onGrowthChange={publishComposerGrowth}
           />
 
           {/* Chat/Terminal toggle for terminal-first sessions, reconnect-or-
@@ -2315,9 +2305,7 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
       aria-live="polite"
       data-testid="working-indicator-pin"
       className={cn(
-        // bottom tracks --composer-growth so the tab keeps meeting the card's
-        // top edge while the composer is grown (it overlaps this wrapper).
-        "pointer-events-none absolute inset-x-0 bottom-[var(--composer-growth,0px)] z-20 transition-opacity duration-200",
+        "pointer-events-none absolute inset-x-0 bottom-0 z-20 transition-opacity duration-200",
         visible ? "opacity-100" : "opacity-0",
       )}
     >
@@ -2374,16 +2362,13 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
 
 /**
  * Preserves the transcript's distance-from-bottom whenever its scroll container
- * resizes on the iOS shell — so the content you're looking at stays put while
- * the soft keyboard opens/closes (and while the composer grows on focus).
+ * resizes — so the content you're looking at stays put while the composer grows
+ * or, on the iOS shell, while the soft keyboard opens and closes.
  *
- * Two things resize the container, and neither is handled by `use-stick-to-
- * bottom` (which only re-anchors on *content* resize): the keyboard, via
- * `useIOSViewportLock` shrinking the app-shell; and the composer growing taller
- * when focused (its send row / status line), which steals flex height from the
- * transcript a couple of lines at a time — *without* firing a visualViewport
- * resize. Watching only visualViewport missed the composer growth, which is why
- * the transcript crept up ~2 lines on focus.
+ * Neither resize is handled by `use-stick-to-bottom`, which only re-anchors on
+ * *content* resize. The composer steals flex height from the transcript on every
+ * platform; the iOS keyboard also shrinks the app shell through
+ * `useIOSViewportLock` without changing the transcript content.
  *
  * So we watch the scroll container itself with a `ResizeObserver` and, on any
  * size change, hold the scroll position relative to the bottom constant:
@@ -2402,7 +2387,6 @@ function PreserveScrollDistanceOnResize() {
   const scrollRef = ctx.scrollRef;
 
   useEffect(() => {
-    if (!isIOSShell()) return;
     const el = scrollRef?.current;
     if (!el) return;
 
@@ -4062,13 +4046,6 @@ interface ComposerProps {
    * keep using ``modelPickerKind`` / ``isNativeWrapper``.
    */
   wrapperLabel?: string | null;
-  /**
-   * Reports how many pixels taller than its resting height the composer has
-   * grown. The composer keeps that growth out of the column's flex layout
-   * (see the negative top margin below); the transcript uses the number to
-   * lift its bottom-anchored overlays clear of the taller card.
-   */
-  onGrowthChange?: (px: number) => void;
 }
 
 /**
@@ -4475,7 +4452,6 @@ export function Composer({
   subagentRoutingEligible = false,
   subAgentLabel = null,
   wrapperLabel = null,
-  onGrowthChange,
 }: ComposerProps) {
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<File[]>([]);
@@ -4511,7 +4487,6 @@ export function Composer({
   // dropdown instead of sending (see submit()).
   const [pickerOpenNonce, setPickerOpenNonce] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Declared after textareaRef so dictation can place the caret after the
   // text it inserts (and insert at the caret rather than the draft's end).
@@ -5004,20 +4979,9 @@ export function Composer({
   };
 
   // Auto-grow the textarea from 1 row up to 10 rows, then let it scroll.
-  // The extra rows float over the transcript instead of shrinking it: a
-  // negative top margin holds the form's margin box at its resting height, so
-  // the transcript's scroll viewport — and with it the scrollbar's travel and
-  // the turn rail's centering — stays exactly where it was. Only the taller
-  // card overlaps, and it's opaque across the message column.
-  const applyGrowth = useCallback(
-    (px: number) => {
-      const form = formRef.current;
-      if (form) form.style.marginTop = px > 0 ? `${-px}px` : "";
-      onGrowthChange?.(px);
-    },
-    [onGrowthChange],
-  );
-  useAutoGrowTextarea(textareaRef, value, 10, applyGrowth);
+  // Growth stays in the flex column so the transcript viewport ends where the
+  // composer begins instead of letting the card cover visible output.
+  useAutoGrowTextarea(textareaRef, value, 10);
 
   // Scope recall to the active conversation so ArrowUp surfaces only this
   // chat's prompts, not the last thing typed in any other chat.
@@ -5307,12 +5271,9 @@ export function Composer({
 
   return (
     <form
-      ref={formRef}
       onSubmit={handleSubmit}
       className={cn(
-        // relative: the grown card overlaps the transcript above it, and a
-        // positioned box paints over that in-flow sibling.
-        "chat-composer-form relative px-4 md:px-6",
+        "chat-composer-form px-4 md:px-6",
         isTerminalFirst ? "terminal-first-composer-form pb-1.5" : "pb-3",
       )}
     >

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2414,8 +2414,11 @@ function PreserveScrollDistanceOnResize() {
     let restorePasses = 0;
     let scrollTimer: number | null = null;
     let userIntentTimer: number | null = null;
+    let pointerScrollEndTimer: number | null = null;
     let userScrollIntent = false;
     let pointerScrolling = false;
+    let pointerReleased = false;
+    let pointerScrollObserved = false;
 
     const reconcileContentHeight = (scrollHeight: number, clientHeight: number) => {
       const delta = scrollHeight - prevSH;
@@ -2519,15 +2522,50 @@ function PreserveScrollDistanceOnResize() {
       }
     };
 
+    const clearPointerScrollIntent = () => {
+      if (pointerScrollEndTimer !== null) {
+        window.clearTimeout(pointerScrollEndTimer);
+        pointerScrollEndTimer = null;
+      }
+      pointerScrolling = false;
+      pointerReleased = false;
+      pointerScrollObserved = false;
+    };
+
+    const schedulePointerScrollEnd = (delay = 150) => {
+      if (!pointerScrolling || !pointerReleased) return;
+      if (pointerScrollEndTimer !== null) window.clearTimeout(pointerScrollEndTimer);
+      pointerScrollEndTimer = window.setTimeout(clearPointerScrollIntent, delay);
+    };
+
     const onPointerDown = () => {
+      if (pointerScrollEndTimer !== null) {
+        window.clearTimeout(pointerScrollEndTimer);
+        pointerScrollEndTimer = null;
+      }
       pointerScrolling = true;
+      pointerReleased = false;
+      pointerScrollObserved = false;
     };
 
     const onPointerUp = () => {
-      pointerScrolling = false;
+      if (!pointerScrolling) return;
+      if (!pointerScrollObserved) {
+        clearPointerScrollIntent();
+        return;
+      }
+      pointerReleased = true;
+      schedulePointerScrollEnd();
+    };
+
+    const onScrollEnd = () => {
+      // Let the debounced final scroll adopt its distance before ending intent.
+      schedulePointerScrollEnd(20);
     };
 
     const onScroll = () => {
+      if (pointerScrolling && !pointerReleased) pointerScrollObserved = true;
+      if (pointerReleased) schedulePointerScrollEnd();
       if (scrollTimer !== null) window.clearTimeout(scrollTimer);
       // Explicit wheel/key/pointer intent distinguishes genuine reader movement
       // from the library's own clamp and bottom-lock scrolls.
@@ -2568,6 +2606,7 @@ function PreserveScrollDistanceOnResize() {
     el.addEventListener("wheel", markUserScrollIntent, { passive: true });
     el.addEventListener("keydown", onKeyDown);
     el.addEventListener("pointerdown", onPointerDown, { passive: true });
+    el.addEventListener("scrollend", onScrollEnd, { passive: true });
     window.addEventListener("pointerup", onPointerUp, { passive: true });
     window.addEventListener("pointercancel", onPointerUp, { passive: true });
     observer.observe(el);
@@ -2577,11 +2616,13 @@ function PreserveScrollDistanceOnResize() {
       el.removeEventListener("wheel", markUserScrollIntent);
       el.removeEventListener("keydown", onKeyDown);
       el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("scrollend", onScrollEnd);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerUp);
       observer.disconnect();
       if (scrollTimer !== null) window.clearTimeout(scrollTimer);
       if (userIntentTimer !== null) window.clearTimeout(userIntentTimer);
+      if (pointerScrollEndTimer !== null) window.clearTimeout(pointerScrollEndTimer);
       if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
       if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
       if (clearRestoreTimer !== null) window.clearTimeout(clearRestoreTimer);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2022,7 +2022,7 @@ function MainAgentSurface({
               >
                 {/* Scroll helpers — must live inside StickToBottom to access context. */}
                 <ScrollToBottomOnSend nonce={sendScrollNonce} />
-                <PreserveScrollDistanceOnResize />
+                <KeepBottomOnViewportResize />
                 <ConversationScrollRefBridge onScroller={setScroller} />
                 <HistoryAutoLoader scrollElement={scroller?.el ?? null} />
                 {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
@@ -2360,274 +2360,38 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
   return null;
 }
 
-/**
- * Preserves the transcript's distance-from-bottom whenever its scroll container
- * resizes — so the content you're looking at stays put while the composer grows
- * or, on the iOS shell, while the soft keyboard opens and closes.
- *
- * Neither resize is handled by `use-stick-to-bottom`, which only re-anchors on
- * *content* resize. The composer steals flex height from the transcript on every
- * platform; the iOS keyboard also shrinks the app shell through
- * `useIOSViewportLock` without changing the transcript content.
- *
- * So we watch the scroll container itself with a `ResizeObserver` and, on any
- * size change, hold the scroll position relative to the bottom constant:
- * `scrollTop = scrollHeight - clientHeight - distance`. We also observe the
- * transcript content: output can keep growing while an escaped reader's
- * `scrollTop` stays still, so that growth must increase the stored distance
- * before a later composer resize restores it. The boundary before the trailing
- * spacer distinguishes output growth from viewport-only layout changes, while
- * explicit input intent distinguishes genuine reader scrolling from synthetic
- * clamp and restore events.
- */
-export function PreserveScrollDistanceOnResize() {
+/** Keep bottom-locked readers pinned when the composer changes viewport height. */
+export function KeepBottomOnViewportResize() {
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
-    contentRef?: React.RefObject<HTMLElement>;
     scrollRef?: React.RefObject<HTMLElement>;
-    stopScroll?: () => void;
   };
-  const contentRef = ctx.contentRef;
   const scrollRef = ctx.scrollRef;
-  const state = ctx.state;
-  const stopScroll = ctx.stopScroll;
+  const isAtBottom = ctx.isAtBottom;
+  const scrollToBottom = ctx.scrollToBottom;
 
   useEffect(() => {
     const el = scrollRef?.current;
-    if (!el) return;
-    const content = (contentRef?.current ?? el.firstElementChild) as HTMLElement | null;
-    const spacer = content?.lastElementChild as HTMLElement | null;
-
-    const measure = () => el.scrollHeight - el.clientHeight - el.scrollTop;
-    const measureContentExtent = () =>
-      content && spacer
-        ? spacer.getBoundingClientRect().top - content.getBoundingClientRect().top
-        : el.scrollHeight;
-    let escaped = state.escapedFromLock;
-    let distance = escaped ? Math.max(0, measure()) : 1;
-    let prevSH = el.scrollHeight;
-    let prevCH = el.clientHeight;
-    let prevContentExtent = measureContentExtent();
-    let restoring = false;
-    let restoreFrame: number | null = null;
-    let clearRestoreFrame: number | null = null;
-    let clearRestoreTimer: number | null = null;
-    let restorePasses = 0;
-    let scrollTimer: number | null = null;
-    let userIntentTimer: number | null = null;
-    let pointerScrollEndTimer: number | null = null;
-    let userScrollIntent = false;
-    let pointerScrolling = false;
-    let pointerReleased = false;
-    let pointerScrollObserved = false;
-
-    const reconcileContentHeight = (scrollHeight: number, clientHeight: number) => {
-      const delta = scrollHeight - prevSH;
-      const contentExtent = measureContentExtent();
-      const contentChanged = Math.abs(contentExtent - prevContentExtent) >= 1;
-      const viewportResizeActive = restoring || clientHeight !== prevCH;
-      if (delta !== 0 && (!viewportResizeActive || contentChanged)) {
-        distance = escaped ? Math.max(0, distance + delta) : 1;
-      }
-      prevSH = scrollHeight;
-      prevContentExtent = contentExtent;
-    };
-
-    const syncBottomLock = () => {
-      const measuredDistance = Math.max(0, measure());
-      if (!state.isAtBottom && measuredDistance > 1) return false;
-      escaped = false;
-      distance = 1;
-      return true;
-    };
-
-    const preserveEscapedState = () => {
-      if (syncBottomLock()) return;
-      if (!escaped) return;
-      stopScroll?.();
-      state.escapedFromLock = true;
-      state.isAtBottom = false;
-    };
-
-    const applyRestore = () => {
-      restoreFrame = null;
-      const scrollHeight = el.scrollHeight;
-      const clientHeight = el.clientHeight;
-      reconcileContentHeight(scrollHeight, clientHeight);
-      preserveEscapedState();
-      const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
-      el.scrollTop = Math.max(0, Math.min(maxScrollTop, maxScrollTop - distance));
-      prevCH = el.clientHeight;
-      clearRestoreFrame = requestAnimationFrame(() => {
-        clearRestoreFrame = null;
-        clearRestoreTimer = window.setTimeout(() => {
-          clearRestoreTimer = null;
-          if (Math.abs(Math.max(0, measure()) - distance) > 1 && restorePasses < 3) {
-            restorePasses += 1;
-            restoreFrame = requestAnimationFrame(applyRestore);
-            return;
-          }
-          restoring = false;
-          restorePasses = 0;
-        }, 2);
-      });
-    };
-
-    const scheduleRestore = () => {
-      preserveEscapedState();
-      if (!restoring) {
-        restorePasses = 0;
-        restoring = true;
-      }
-      if (clearRestoreFrame !== null) {
-        cancelAnimationFrame(clearRestoreFrame);
-        clearRestoreFrame = null;
-      }
-      if (clearRestoreTimer !== null) {
-        window.clearTimeout(clearRestoreTimer);
-        clearRestoreTimer = null;
-      }
-      if (restoreFrame !== null) return;
-      restoreFrame = requestAnimationFrame(applyRestore);
-    };
-
-    const cancelRestore = () => {
-      if (restoreFrame !== null) {
-        cancelAnimationFrame(restoreFrame);
-        restoreFrame = null;
-      }
-      if (clearRestoreFrame !== null) {
-        cancelAnimationFrame(clearRestoreFrame);
-        clearRestoreFrame = null;
-      }
-      if (clearRestoreTimer !== null) {
-        window.clearTimeout(clearRestoreTimer);
-        clearRestoreTimer = null;
-      }
-      restoring = false;
-      restorePasses = 0;
-    };
-
-    const markUserScrollIntent = () => {
-      userScrollIntent = true;
-      if (userIntentTimer !== null) window.clearTimeout(userIntentTimer);
-      userIntentTimer = window.setTimeout(() => {
-        userIntentTimer = null;
-        userScrollIntent = false;
-      }, 150);
-    };
-
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) {
-        markUserScrollIntent();
-      }
-    };
-
-    const clearPointerScrollIntent = () => {
-      if (pointerScrollEndTimer !== null) {
-        window.clearTimeout(pointerScrollEndTimer);
-        pointerScrollEndTimer = null;
-      }
-      pointerScrolling = false;
-      pointerReleased = false;
-      pointerScrollObserved = false;
-    };
-
-    const schedulePointerScrollEnd = (delay = 150) => {
-      if (!pointerScrolling || !pointerReleased) return;
-      if (pointerScrollEndTimer !== null) window.clearTimeout(pointerScrollEndTimer);
-      pointerScrollEndTimer = window.setTimeout(clearPointerScrollIntent, delay);
-    };
-
-    const onPointerDown = () => {
-      if (pointerScrollEndTimer !== null) {
-        window.clearTimeout(pointerScrollEndTimer);
-        pointerScrollEndTimer = null;
-      }
-      pointerScrolling = true;
-      pointerReleased = false;
-      pointerScrollObserved = false;
-    };
-
-    const onPointerUp = () => {
-      if (!pointerScrolling) return;
-      if (!pointerScrollObserved) {
-        clearPointerScrollIntent();
-        return;
-      }
-      pointerReleased = true;
-      schedulePointerScrollEnd();
-    };
-
-    const onScrollEnd = () => {
-      // Let the debounced final scroll adopt its distance before ending intent.
-      schedulePointerScrollEnd(20);
-    };
-
-    const onScroll = () => {
-      if (pointerScrolling && !pointerReleased) pointerScrollObserved = true;
-      if (pointerReleased) schedulePointerScrollEnd();
-      if (scrollTimer !== null) window.clearTimeout(scrollTimer);
-      // Explicit wheel/key/pointer intent distinguishes genuine reader movement
-      // from the library's own clamp and bottom-lock scrolls.
-      scrollTimer = window.setTimeout(() => {
-        scrollTimer = null;
-        const userInitiated = userScrollIntent || pointerScrolling;
-        userScrollIntent = false;
-        if (userIntentTimer !== null) {
-          window.clearTimeout(userIntentTimer);
-          userIntentTimer = null;
-        }
-        const sh = el.scrollHeight;
-        const ch = el.clientHeight;
-        reconcileContentHeight(sh, ch);
-        if (!userInitiated) {
-          if (syncBottomLock() && restoring) cancelRestore();
-          if (ch !== prevCH) scheduleRestore();
-          return;
-        }
-        if (restoring) cancelRestore();
-        const measuredDistance = Math.max(0, measure());
-        escaped = measuredDistance > 1;
-        distance = escaped ? measuredDistance : 1;
-        if (escaped) stopScroll?.();
-        state.escapedFromLock = escaped;
-        state.isAtBottom = !escaped;
-        prevCH = ch;
-      }, 2);
-    };
-
+    if (!el || typeof ResizeObserver === "undefined") return;
+    let clientHeight = el.clientHeight;
+    let frame: number | null = null;
     const observer = new ResizeObserver(() => {
-      const ch = el.clientHeight;
-      reconcileContentHeight(el.scrollHeight, ch);
-      if (ch !== prevCH) scheduleRestore();
+      const nextHeight = el.clientHeight;
+      if (nextHeight === clientHeight) return;
+      clientHeight = nextHeight;
+      if (!isAtBottom) return;
+      scrollToBottom("instant");
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        scrollToBottom("instant");
+      });
     });
-
-    el.addEventListener("scroll", onScroll, { passive: true });
-    el.addEventListener("wheel", markUserScrollIntent, { passive: true });
-    el.addEventListener("keydown", onKeyDown);
-    el.addEventListener("pointerdown", onPointerDown, { passive: true });
-    el.addEventListener("scrollend", onScrollEnd, { passive: true });
-    window.addEventListener("pointerup", onPointerUp, { passive: true });
-    window.addEventListener("pointercancel", onPointerUp, { passive: true });
     observer.observe(el);
-    if (content) observer.observe(content);
     return () => {
-      el.removeEventListener("scroll", onScroll);
-      el.removeEventListener("wheel", markUserScrollIntent);
-      el.removeEventListener("keydown", onKeyDown);
-      el.removeEventListener("pointerdown", onPointerDown);
-      el.removeEventListener("scrollend", onScrollEnd);
-      window.removeEventListener("pointerup", onPointerUp);
-      window.removeEventListener("pointercancel", onPointerUp);
       observer.disconnect();
-      if (scrollTimer !== null) window.clearTimeout(scrollTimer);
-      if (userIntentTimer !== null) window.clearTimeout(userIntentTimer);
-      if (pointerScrollEndTimer !== null) window.clearTimeout(pointerScrollEndTimer);
-      if (restoreFrame !== null) cancelAnimationFrame(restoreFrame);
-      if (clearRestoreFrame !== null) cancelAnimationFrame(clearRestoreFrame);
-      if (clearRestoreTimer !== null) window.clearTimeout(clearRestoreTimer);
+      if (frame !== null) cancelAnimationFrame(frame);
     };
-  }, [contentRef, scrollRef, state, stopScroll]);
+  }, [isAtBottom, scrollRef, scrollToBottom]);
 
   return null;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2380,7 +2380,7 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
  * explicit input intent distinguishes genuine reader scrolling from synthetic
  * clamp and restore events.
  */
-function PreserveScrollDistanceOnResize() {
+export function PreserveScrollDistanceOnResize() {
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
     contentRef?: React.RefObject<HTMLElement>;
     scrollRef?: React.RefObject<HTMLElement>;


### PR DESCRIPTION
## Related issue

[OMNI-2901: Composer covers viewport](https://linear.app/omnigent/issue/OMNI-2901/composer-covers-viewport)

## Summary

- Keep the growing composer in normal flex flow so multiline prompts shrink the transcript viewport instead of covering chat output.
- Remove the accumulated custom scroll-distance, pointer/momentum, manual-restore, and duplicated lock-state machine. Native browser anchoring preserves escaped readers; `use-stick-to-bottom` owns bottom following and explicit button/send re-locks.
- Keep one small viewport-resize bridge for genuinely bottom-locked readers. It records exact pre-resize bottom lock from live library state plus physical geometry, rather than the public `isAtBottom` alias that also reports true within 70px.
- Add focused unit and real Chromium coverage for the final 50px near-bottom regression while retaining same-frame streaming, restore-window output, button/send re-lock, native touch, focus, and zero-overlap coverage.

**ELI5:** CSS does the layout job: the composer takes more room and the transcript takes less. The browser keeps a scrolled-up reader looking at the same content, while the existing chat-scroll library keeps bottom-following readers at the bottom. The app only remembers whether the reader was *actually* at the bottom before the composer changed height.

```text
Before: [ transcript ---------------- ]
                              [ composer overlaps ↑ ]

After:  [ transcript -------- ]
        [ composer in flow --- ]
```

## Test Plan

- `npm exec vitest -- run src/pages/ChatPage.historyLoad.test.tsx`
  - 35 focused tests passed.
  - Final RED: public `isAtBottom=true` while live state was unlocked/escaped incorrectly called `scrollToBottom("instant")`; same-resize library reclassification also exposed the stale decision.
  - GREEN: exact pre-resize physical bottom lock pins only true bottom readers; escaped readers never invoke the bridge; observer/listener/frame cleanup remains covered.
- `.venv/bin/pytest -q tests/e2e_ui/chat/test_composer_growth_transcript_stability.py -s`
  - 1 focused Chromium regression passed.
  - Final trusted-wheel RED: a genuine escaped reader settled `51px` from bottom, then composer growth snapped it to `1px` with a `92px` `scrollTop` jump.
  - GREEN: the 50px reader keeps `scrollTop` and visible message tops stable within 1px, overlap stays `0px`, and textarea focus remains.
  - The same regression retains bottom follow, sequential streaming, output and composer growth in one frame, output during reflow settling, scroll-button re-lock, multiline-send re-lock, appended bottom follow, and native touch `pointercancel → scroll → scrollend` coverage.
- Focused static gates passed:
  - Prettier and Oxlint on changed frontend files.
  - `npm run type-check`.
  - Ruff format/check on the changed Python regression.
  - Production Vite build during the focused Chromium regression.
  - `.venv/bin/pre-commit run --files web/src/pages/ChatPage.tsx web/src/pages/ChatPage.historyLoad.test.tsx tests/e2e_ui/chat/test_composer_growth_transcript_stability.py`.
- Verified the real three-process stack on the mandated ports: server health returned `{"status":"ok"}`, the host registered, and the feature Vite frontend returned HTTP 200 at `http://localhost:5173`.
- SP2K browser verification:
  - Standard light/dark: genuine 50px upward escape preserved `scrollTop 2075→2075` and all visible message tops exactly; overlap `0px`; focus retained.
  - Narrow `500×713`, light/dark: `scrollTop 1011→1011`, visible message-top deltas `[0, 0]`, overlap `0px`, focus retained, transcript scrollable.
  - Short `1000×433`, light/dark: `scrollTop 1182.5→1182.5`, visible message-top deltas `[0, 0]`, overlap `0px`, focus retained, transcript scrollable.
- Exhaustive unit, integration, and E2E suites were intentionally not run locally; GitHub CI owns the full matrix.

## Demo

### Before (main)

Exact unfixed base `c4dd03c47c9c24a3067bc2eea127e1d832b49049`, `1200×800`, light theme. The transcript bottom remains at `675px` while the expanded composer top moves to `488px`, so the composer covers `187px` of the transcript and hides final output.

![Before main: 187px transcript overlap](https://raw.githubusercontent.com/zhengwin/omnigent/OMNI-2901-evidence/tmp-evidence/omni-2901/before-main-annotated.png)

### After (this PR)

The transcript and composer meet with `0px` overlap because both remain in normal flex layout; final output stays visible above the composer.

![After PR: zero overlap](https://raw.githubusercontent.com/zhengwin/omnigent/OMNI-2901-evidence/tmp-evidence/omni-2901/after-pr-annotated.png)

### Native-anchor refactor

The live-stack recording demonstrates growing-composer reflow, output clearance, bottom follow, escaped-reader stability, focus retention, and light/dark behavior without custom pointer or momentum restoration.

[Native-anchor browser video](https://raw.githubusercontent.com/zhengwin/omnigent/OMNI-2901-evidence/tmp-evidence/omni-2901/native-anchor-round5.webm)

### Final 50px near-bottom regression

The public library alias treats readers within 70px as near-bottom. Before the final fix, trusted Chromium input reproduced `51px → 1px` with a `92px` jump. At head `cc0aea0714cbef75547339486b3f7b45ce3accec`, the exact pre-resize lock predicate preserves scroll and visible message coordinates at standard, narrow, and short viewports while maintaining `0px` overlap and focus.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The final architecture keeps CSS flex flow and native browser anchoring as the source of truth. `use-stick-to-bottom` continues to own streaming follow and explicit button/send re-locks. `KeepBottomOnViewportResize` adds only one pre-resize boolean: it initializes from the library's actual live lock state plus exact physical bottom, updates from physical bottom on scroll, and requests the library's public instant bottom scroll only when that boolean was true.

This avoids the public near-bottom alias that caused the final `51px → 1px` snap, while also avoiding any return to custom distance math, manual `scrollTop` restoration, momentum timers, pointer state, or retry loops. Focused automation covers bridge lifecycle, cleanup, 50px escaped-reader stability, same-frame and restore-window output, button/send re-locks, appended bottom follow, native touch, focus, and output clearance. Manual SP2K checks cover light/dark standard, narrow, and short layouts with exact DOM geometry.

Full repository suites remain CI-only by explicit workflow choice.

## Changelog

Chat output stays visible above a growing composer; bottom-following readers remain pinned while readers who scroll up—even just 50px—keep the same visible content.