### PR TITLE
fix(host): keep capability probes out of tunnel handshake

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3051,7 +3051,8 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
     spawned = _spawn_host_daemon_process(
-        args=args, env=_build_host_daemon_env(server_url=server_url)
+        args=args,
+        env=_build_host_daemon_env(server_url=server_url),
     )
     if spawned is None:
         return False
@@ -7871,6 +7872,9 @@ def _prompt_stop_local_server() -> None:
 # server URL, missing credentials) leaves nothing on the terminal, so we wait
 # this long and surface its log instead of falsely reporting success.
 _BACKGROUND_HOST_GRACE_S = 2.0
+# A detached process isn't ready merely because its PID survived. Wait until
+# the server confirms the host row and live tunnel are online.
+_BACKGROUND_HOST_REGISTRATION_GRACE_S = 30.0
 
 
 def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
@@ -7883,16 +7887,48 @@ def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
     deadline = time.time() + _BACKGROUND_HOST_GRACE_S
     while True:
         if not _pid_alive(record.pid):
-            from omnigent._runner_startup import format_runner_log_tail
-
-            log_path = Path(record.log_path) if record.log_path else None
             raise click.ClickException(
                 "The host daemon exited immediately after starting."
-                f"{format_runner_log_tail(log_path)}"
+                f"{_background_host_log_detail(record.log_path)}"
             )
         if time.time() >= deadline:
             return
         time.sleep(0.1)
+
+
+def _background_host_log_detail(log_path: str | None) -> str:
+    """Return the host log path and a short failure tail."""
+    if log_path is None:
+        return ""
+    path = Path(log_path)
+    detail = f"\nHost log: {path}"
+    try:
+        tail = path.read_bytes()[-4096:].decode("utf-8", errors="replace").strip()
+    except OSError:
+        return detail
+    if tail:
+        detail += "\n--- host log tail ---\n" + "\n".join(tail.splitlines()[-12:])
+    return detail
+
+
+def _confirm_background_host_registered(record: _HostDaemonRecord) -> None:
+    """Wait until the detached daemon completes server registration."""
+    deadline = time.monotonic() + _BACKGROUND_HOST_REGISTRATION_GRACE_S
+    while True:
+        if not _pid_alive(record.pid):
+            raise click.ClickException(
+                "The host daemon exited before registering with the server."
+                f"{_background_host_log_detail(record.log_path)}"
+            )
+        if _daemon_host_online(record, timeout_s=1.0):
+            return
+        if time.monotonic() >= deadline:
+            raise click.ClickException(
+                "The host daemon started but did not register with the server "
+                f"within {_BACKGROUND_HOST_REGISTRATION_GRACE_S:.0f}s."
+                f"{_background_host_log_detail(record.log_path)}"
+            )
+        time.sleep(0.2)
 
 
 def _run_background_host(
@@ -7922,7 +7958,7 @@ def _run_background_host(
     :param non_interactive: When ``True``, never launch the browser login —
         fail with the ``omnigent login`` hint instead.
     :raises click.ClickException: If the daemon cannot be spawned, exits
-        immediately after starting, or (local mode) never serves its local
+        immediately, fails to register, or (local mode) never serves its local
         Omnigent server.
     """
     if server:
@@ -7932,30 +7968,40 @@ def _run_background_host(
     _ensure_host_daemon(server or None)
     record = _find_daemon_record(target)
     if record is None:
-        # No record for this target: either the live local-mode daemon already
-        # serves the requested URL, or the spawn itself failed.
+        # A local daemon may already own the requested URL under its local
+        # registry key. It is reusable only after its host is online too.
         if _local_daemon_serves_target(target, server or None):
-            click.echo(f"The local host daemon already serves {target}.")
-            return
+            local_record = _find_daemon_record(_LOCAL_DAEMON_MARKER)
+            if local_record is not None:
+                _confirm_background_host_registered(local_record)
+                click.echo(f"The local host daemon already serves {target}.")
+                return
         raise click.ClickException(
             "Could not spawn the background host daemon. See ~/.omnigent/logs/host/ for details."
         )
-    if previous is not None and previous.pid == record.pid:
-        headline = _cli_style("Host daemon already running", fg="yellow", bold=True)
-    else:
-        _confirm_background_host_alive(record)
-        headline = _cli_style("Started the host daemon in the background", fg="green", bold=True)
+    reused = previous is not None and previous.pid == record.pid
+    try:
+        if not reused:
+            _confirm_background_host_alive(record)
+        if record.mode == "local":
+            # The status probe needs the daemon-owned server's loopback URL.
+            server_url = _discover_local_server_url()
+            _update_daemon_resolved_server_url(target, server_url)
+            record = _find_daemon_record(target) or record
+        else:
+            server_url = target
+        _confirm_background_host_registered(record)
+    except click.ClickException:
+        if not reused:
+            with contextlib.suppress(click.ClickException):
+                _terminate_daemon(record, force=True)
+        raise
+    headline = _cli_style(
+        "Host daemon already running" if reused else "Started the host daemon in the background",
+        fg="yellow" if reused else "green",
+        bold=True,
+    )
     click.echo(f"{headline} (pid {record.pid}).")
-    if record.mode == "local":
-        # A local-mode daemon owns the local Omnigent server, so this command is
-        # the whole "start everything" step — wait for that server and report
-        # its URL, otherwise the Web UI is unreachable without a follow-up
-        # `omnigent server status`. Resolved after the headline above so a cold
-        # start isn't a silent terminal.
-        server_url = _discover_local_server_url()
-        _update_daemon_resolved_server_url(target, server_url)
-    else:
-        server_url = target
     _echo_host_field("server", _cli_style(server_url, fg="cyan"))
     if record.log_path is not None:
         _echo_host_field("log", _display_path(Path(record.log_path)))

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -35,6 +35,7 @@ from omnigent.host import HOST_FATAL_EXIT_CODE
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     WORKSPACE_MISSING_ERROR_CODE,
+    HostConnectionErrorFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -339,6 +340,9 @@ _LOOPBACK_REFUSED_FATAL_ATTEMPTS = 30
 # endpoint that accepts and never speaks is functionally down.
 _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 
+# Capability discovery is advisory and must not delay the host channel forever.
+_HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
+
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
 # user, so its environment holds the user's personal secrets (API keys,
@@ -597,8 +601,8 @@ _LOGIN_REDIRECT_FATAL_ATTEMPTS = 3
 class HostConnectError(Exception):
     """A non-retryable failure while opening the host tunnel.
 
-    Raised when the WebSocket upgrade fails in a way that reconnecting
-    can never fix — the Databricks Apps proxy bounced the connection to
+    Raised when connection setup or the server reports a failure that
+    reconnecting cannot fix — the Databricks Apps proxy bounced the connection to
     a login page (wrong/absent workspace credentials), the server
     returned a permanent ``4xx`` (unauthenticated, unauthorized, or a
     build that predates the host API), or a loopback server refused a
@@ -781,6 +785,10 @@ class _RunnerHandle:
     log_path: Path
 
 
+class HostRetryableConnectionError(Exception):
+    """Server-reported channel failure that should use reconnect backoff."""
+
+
 class HostProcess:
     """Manages the host daemon lifecycle.
 
@@ -818,6 +826,12 @@ class HostProcess:
         # server — where the same failures retry forever instead of killing a
         # host with running sessions.
         self._ever_connected = False
+        # Capability discovery belongs to daemon initialization, not the
+        # connection handshake. Reconnects reuse this snapshot while the live
+        # refresh task keeps it current.
+        self._configured_harnesses: dict[str, HarnessAvailability] | None = None
+        self._gateway_inference: dict[str, bool] | None = None
+        self._capabilities_initialized = False
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
         # Consecutive 401/403 upgrade rejections on an already-connected host;
@@ -2518,6 +2532,67 @@ class HostProcess:
             ],
         )
 
+    async def _probe_configured_harnesses(
+        self,
+        *,
+        startup: bool,
+    ) -> dict[str, HarnessAvailability] | None:
+        """Collect harness readiness without letting a probe break the channel."""
+        try:
+            return await asyncio.to_thread(configured_harness_map)
+        except Exception as exc:
+            _logger.exception("Host harness readiness probe failed")
+            if startup:
+                print(
+                    "⚠ Could not inspect installed harnesses; the host will "
+                    f"connect with harness readiness unknown: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            return None
+
+    async def _probe_gateway_inference(self, *, startup: bool) -> dict[str, bool] | None:
+        """Collect gateway metadata without letting a probe break the channel."""
+        try:
+            return await asyncio.to_thread(gateway_inference_map)
+        except Exception as exc:
+            _logger.exception("Host gateway-inference probe failed")
+            if startup:
+                print(
+                    "⚠ Could not inspect gateway inference; the host will "
+                    f"connect with gateway backing unknown: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            return None
+
+    async def _initialize_capabilities(self) -> None:
+        """Build the initial capability snapshot once, before any handshake."""
+        if self._capabilities_initialized:
+            return
+        try:
+            configured, gateway = await asyncio.wait_for(
+                asyncio.gather(
+                    self._probe_configured_harnesses(startup=True),
+                    self._probe_gateway_inference(startup=True),
+                ),
+                timeout=_HOST_CAPABILITY_INIT_TIMEOUT_S,
+            )
+        except TimeoutError:
+            configured = gateway = None
+            _logger.error(
+                "Host capability discovery exceeded %.0fs; continuing with unknown metadata",
+                _HOST_CAPABILITY_INIT_TIMEOUT_S,
+            )
+            print(
+                "⚠ Host capability discovery timed out; connecting with readiness unknown.",
+                file=sys.stderr,
+                flush=True,
+            )
+        self._configured_harnesses = configured
+        self._gateway_inference = gateway
+        self._capabilities_initialized = True
+
     async def run(self) -> None:
         """Run the host process with reconnection.
 
@@ -2530,6 +2605,11 @@ class HostProcess:
             authorization / outdated server, or a loopback server that
             kept refusing connections (the local server is gone).
         """
+        # Capability probes may shell out or inspect local config, so perform
+        # them once during daemon initialization. They are advisory: a broken
+        # harness is reported as unknown and must not prevent registration.
+        await self._initialize_capabilities()
+
         # Reap orphaned harness/tool grandchildren that reparent here when a
         # runner dies (this host is PID 1 in a container, or a subreaper
         # otherwise). Without this they pile up as <defunct> zombies and can
@@ -2858,20 +2938,7 @@ class HostProcess:
         return None
 
     async def _serve_frames(self, ws: websockets.asyncio.client.ClientConnection) -> None:
-        """Announce readiness, then service host frames until disconnect.
-
-        Sends the ``host.hello`` frame, prints the success banner, then
-        loops dispatching launch/stop/stat/list_dir/worktree requests and
-        answering runner pings until the connection closes. Harness-readiness
-        updates run in a separate task (:meth:`_harness_readiness_loop`) so a
-        slow probe can never stall this receive loop.
-
-        :param ws: The open tunnel connection returned by the websockets
-            client.
-        :returns: None. Returns when the receive loop is broken.
-        :raises Exception: On WebSocket disconnect or error — propagated
-            to the reconnect loop in :meth:`run`.
-        """
+        """Send the cached host hello, then service frames until disconnect."""
         _tel_opt_out = False
         try:
             from omnigent.telemetry.client import is_disabled as _tel_disabled
@@ -2887,32 +2954,27 @@ class HostProcess:
                 _tel_install_id = _get_install_id()
         except Exception:  # noqa: BLE001
             pass
-        configured_harnesses = await asyncio.to_thread(configured_harness_map)
-        gateway_inference = await asyncio.to_thread(gateway_inference_map)
         hello = HostHelloFrame(
             version=VERSION,
             frame_protocol_version=1,
             name=self._identity.name,
             runners=self._alive_runner_ids(),
-            # Off the event loop: probes PATH and reads local config.
-            # The loop below refreshes changes; launch remains authoritative.
-            configured_harnesses=configured_harnesses,
-            gateway_inference=gateway_inference,
+            configured_harnesses=self._configured_harnesses,
+            gateway_inference=self._gateway_inference,
             telemetry_opt_out=_tel_opt_out,
             installation_id=_tel_install_id,
         )
-        await ws.send(encode_host_frame(hello))
+        try:
+            encoded_hello = encode_host_frame(hello)
+        except Exception as exc:
+            raise HostConnectError(f"Could not encode host.hello: {exc}") from exc
+        await ws.send(encoded_hello)
         self._ws = ws
-        # Flush exit reports that raced a disconnect: a runner that died
-        # while the tunnel was down would otherwise never be reported and
-        # the waiting client would poll to its timeout.
+        # Reports raised while disconnected must wait until registration; the
+        # server cannot route them before this connection owns the host.
         for runner_id, error in list(self._unreported_exits.items()):
             del self._unreported_exits[runner_id]
             await self._report_runner_exit(runner_id, error)
-        # ``print`` (not ``_logger.warning``) so the user always sees the
-        # success line after the noisy ``databricks.sdk`` warnings —
-        # otherwise the terminal goes silent after auth and there's no
-        # signal the WS handshake actually completed.
         print(
             f"✓ Connected as {self._identity.name!r} "
             f"({self._identity.host_id}), {len(hello.runners)} live runner(s). "
@@ -2920,23 +2982,19 @@ class HostProcess:
             flush=True,
         )
 
-        # Readiness refresh runs in its own task, never on this receive loop:
-        # a harness probe that blocks (a hung CLI ``--version`` / ``auth
-        # status``) must not delay ``ws.recv()`` or the inline keepalive pong
-        # the server's watchdog counts as liveness, or it closes the tunnel
-        # with ``4003 ping timeout``.
-        readiness_task = asyncio.create_task(
-            self._harness_readiness_loop(ws, configured_harnesses)
-        )
+        readiness_task = asyncio.create_task(self._harness_readiness_loop(ws))
         try:
             while True:
                 raw = await ws.recv()
-                # Any inbound frame proves the server end is alive — the
-                # reconnect loop's silent-connect streak keys off this.
                 self._conn_frame_received = True
                 if isinstance(raw, str):
-                    # Each frame is handled on its own task so a slow handler
-                    # (a model-options CLI exec, a long git walk) can't
+                    # Connection-control frames decide whether this receive
+                    # loop exits or reconnects, so handle them inline. Ordinary
+                    # request frames run concurrently below; exceptions raised
+                    # on those detached tasks are intentionally contained.
+                    self._raise_connection_error_from_raw(raw)
+                    # Each request frame is handled on its own task so a slow
+                    # handler (a model-options CLI exec, a long git walk) can't
                     # head-of-line block the frames behind it — measured
                     # 0.3-1.3s of added session-create latency when a launch
                     # or stat queued behind one. Responses correlate by
@@ -2952,58 +3010,65 @@ class HostProcess:
     async def _harness_readiness_loop(
         self,
         ws: websockets.asyncio.client.ClientConnection,
-        initial: dict[str, HarnessAvailability],
     ) -> None:
-        """
-        Push harness-readiness updates on a timer, off the receive loop.
-
-        Runs as its own task so a slow readiness probe (a harness CLI whose
-        ``--version`` / ``auth status`` subprocess hangs) can never delay
-        ``ws.recv()`` or the inline keepalive pong — the cause of spurious
-        ``4003 ping timeout`` disconnects. Recomputes the map on the quick
-        cadence gated by a cheap "did an unavailable harness just become ready"
-        check and on the full cadence unconditionally, sending a
-        :class:`HostHarnessReadinessFrame` only when the map changes.
-
-        :param ws: The open tunnel connection used to send update frames.
-        :param initial: The readiness map already reported in ``host.hello``;
-            the baseline the first update diffs against.
-        :returns: None. Runs until cancelled when the connection ends.
-        """
-        configured = initial
-        # Gateway-backing baseline, recomputed with readiness: a flip alone
-        # (same binaries, new credentials) must reach the server without a
-        # reconnect.
-        gateway = await asyncio.to_thread(gateway_inference_map)
+        """Refresh advisory capabilities without endangering the tunnel."""
+        configured = self._configured_harnesses
+        gateway = self._gateway_inference
         loop = asyncio.get_running_loop()
         next_quick = loop.time() + HARNESS_READINESS_REFRESH_INTERVAL_S
         next_full = loop.time() + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
         while True:
             await asyncio.sleep(max(0.0, min(next_quick, next_full) - loop.time()))
             now = loop.time()
-            refresh_full = now >= next_full
+            refresh_full = configured is None or now >= next_full
             if now >= next_quick:
                 next_quick = now + HARNESS_READINESS_REFRESH_INTERVAL_S
-                if not refresh_full:
-                    refresh_full = await asyncio.to_thread(
-                        _unavailable_harness_became_ready, configured
-                    )
+                if not refresh_full and configured is not None:
+                    try:
+                        refresh_full = await asyncio.to_thread(
+                            _unavailable_harness_became_ready, configured
+                        )
+                    except Exception:
+                        _logger.exception("Host harness quick readiness probe failed")
             if not refresh_full:
                 continue
-            latest = await asyncio.to_thread(configured_harness_map)
-            latest_gateway = await asyncio.to_thread(gateway_inference_map)
+
+            latest = await self._probe_configured_harnesses(startup=False)
+            latest_gateway = await self._probe_gateway_inference(startup=False)
             next_full = now + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
-            if latest != configured or latest_gateway != gateway:
+            new_configured = latest if latest is not None else configured
+            new_gateway = latest_gateway if latest_gateway is not None else gateway
+            if new_configured is None:
+                continue
+            if new_configured != configured or new_gateway != gateway:
                 await ws.send(
                     encode_host_frame(
                         HostHarnessReadinessFrame(
-                            configured_harnesses=latest,
-                            gateway_inference=latest_gateway,
+                            configured_harnesses=new_configured,
+                            gateway_inference=new_gateway,
                         )
                     )
                 )
-                configured = latest
-                gateway = latest_gateway
+                configured = new_configured
+                gateway = new_gateway
+                self._configured_harnesses = configured
+                self._gateway_inference = gateway
+
+    def _raise_connection_error(self, frame: HostConnectionErrorFrame) -> None:
+        """Raise the lifecycle exception requested by a server error frame."""
+        message = f"Host connection failed during {frame.stage}: {frame.error}"
+        if frame.retryable:
+            raise HostRetryableConnectionError(message)
+        raise HostConnectError(message)
+
+    def _raise_connection_error_from_raw(self, raw: str) -> None:
+        """Handle connection-level frames before request-task dispatch."""
+        try:
+            frame = decode_host_frame(raw)
+        except ValueError:
+            return
+        if isinstance(frame, HostConnectionErrorFrame):
+            self._raise_connection_error(frame)
 
     def _start_frame_task(self, ws: websockets.asyncio.client.ClientConnection, raw: str) -> None:
         """Handle one inbound frame on its own task, off the receive loop.
@@ -3094,6 +3159,10 @@ class HostProcess:
             ignored.
         :returns: None.
         """
+        if isinstance(frame, HostConnectionErrorFrame):
+            # Defensive for direct callers; production handles this inline in
+            # _serve_frames so detached request tasks cannot swallow it.
+            self._raise_connection_error(frame)
         if isinstance(frame, HostLaunchRunnerFrame):
             # Frames run on concurrent tasks, but launch/stop must keep their
             # arrival order relative to each other (a stop for a session must

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -43,6 +43,7 @@ class HostFrameKind(str, Enum):
     """All host frame kinds; the value is the JSON wire string."""
 
     HELLO = "host.hello"
+    CONNECTION_ERROR = "host.connection_error"
     HARNESS_READINESS = "host.harness_readiness"
     LAUNCH_RUNNER = "host.launch_runner"
     LAUNCH_RUNNER_RESULT = "host.launch_runner_result"
@@ -94,7 +95,7 @@ class HostHelloFrame:
         machine, e.g. ``{"claude-sdk": True, "codex": False}``
         (see ``omnigent.onboarding.harness_readiness``). Keys
         cover every accepted harness spelling. ``None`` means
-        unknown (an older host that doesn't report it) — never
+        unknown (an older host, or a startup probe that failed) — never
         treat ``None`` as "nothing is configured". Changes arrive in
         :class:`HostHarnessReadinessFrame`; launch-time checks remain
         authoritative.
@@ -102,8 +103,8 @@ class HostHelloFrame:
         launch on this host resolves AI-Gateway-backed inference, e.g.
         ``{"claude-native": True, "codex": False}`` (see
         ``omnigent.gateway_inference``). A family that could not be evaluated
-        is omitted. ``None`` means unknown (an older host that doesn't report
-        it) — never treat it as "nothing is gateway-backed".
+        is omitted. ``None`` means unknown (an older host, or a startup probe
+        that failed) — never treat it as "nothing is gateway-backed".
     """
 
     version: str
@@ -114,6 +115,20 @@ class HostHelloFrame:
     gateway_inference: dict[str, bool] | None = None
     telemetry_opt_out: bool = False
     installation_id: str | None = None
+
+
+@dataclass
+class HostConnectionErrorFrame:
+    """Server-side channel failure sent before the WebSocket closes.
+
+    :param stage: Connection stage that failed, e.g. ``"registration"``.
+    :param error: Exception message from the server.
+    :param retryable: Whether reconnecting may recover.
+    """
+
+    stage: str
+    error: str
+    retryable: bool
 
 
 @dataclass
@@ -851,6 +866,7 @@ class HostModelOptionsResultFrame:
 
 HostFrame = (
     HostHelloFrame
+    | HostConnectionErrorFrame
     | HostHarnessReadinessFrame
     | HostLaunchRunnerFrame
     | HostLaunchRunnerResultFrame
@@ -932,6 +948,15 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "gateway_inference": frame.gateway_inference,
                 "telemetry_opt_out": frame.telemetry_opt_out,
                 "installation_id": frame.installation_id,
+            }
+        )
+    if isinstance(frame, HostConnectionErrorFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.CONNECTION_ERROR.value,
+                "stage": frame.stage,
+                "error": frame.error,
+                "retryable": frame.retryable,
             }
         )
     if isinstance(frame, HostHarnessReadinessFrame):
@@ -1295,6 +1320,12 @@ def _decode_known_host_frame(
     match kind:
         case HostFrameKind.HELLO:
             return _decode_host_hello(msg)
+        case HostFrameKind.CONNECTION_ERROR:
+            return HostConnectionErrorFrame(
+                stage=_required_str(msg, "stage"),
+                error=_required_str(msg, "error"),
+                retryable=_required_bool(msg, "retryable"),
+            )
         case HostFrameKind.HARNESS_READINESS:
             return _decode_harness_readiness(msg)
         case HostFrameKind.LAUNCH_RUNNER:

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.host.frames import (
+    HostConnectionErrorFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeResultFrame,
     HostDetectCredentialsResultFrame,
@@ -45,6 +46,7 @@ from omnigent.host.frames import (
     HostStopRunnerResultFrame,
     HostStoreSecretResultFrame,
     decode_host_frame,
+    encode_host_frame,
 )
 from omnigent.host.identity import MANAGED_HOST_TOKEN_HEADER
 from omnigent.runner.transports.ws_tunnel.frames import (
@@ -228,25 +230,30 @@ def create_host_tunnel_router(
 
         await ws.accept()
         conn: HostConnection | None = None
+        host_persisted = False
+        stage = "hello"
         try:
             raw = await ws.receive_text()
             frame = decode_host_frame(raw)
             if not isinstance(frame, HostHelloFrame):
-                await ws.close(code=4001, reason="expected host.hello frame")
+                error = "expected host.hello frame"
+                await _send_connection_error(ws, stage="hello", error=error)
+                await ws.close(code=4001, reason=error)
                 return
 
+            stage = "protocol"
             remote_major = frame.frame_protocol_version
             if remote_major != SUPPORTED_FRAME_PROTOCOL_MAJOR:
-                await ws.close(
-                    code=4002,
-                    reason=(
-                        f"frame_protocol_version mismatch: "
-                        f"server supports {SUPPORTED_FRAME_PROTOCOL_MAJOR}, "
-                        f"host sent {remote_major}"
-                    ),
+                error = (
+                    f"frame_protocol_version mismatch: "
+                    f"server supports {SUPPORTED_FRAME_PROTOCOL_MAJOR}, "
+                    f"host sent {remote_major}"
                 )
+                await _send_connection_error(ws, stage="protocol", error=error)
+                await ws.close(code=4002, reason=error)
                 return
 
+            stage = "registration"
             await asyncio.to_thread(
                 host_store.upsert_on_connect,
                 host_id=host_id,
@@ -255,7 +262,9 @@ def create_host_tunnel_router(
                 allow_host_id_reown=allow_host_id_reown,
                 configured_harnesses=frame.configured_harnesses,
             )
+            host_persisted = True
 
+            stage = "registry"
             conn = host_registry.register(
                 host_id,
                 ws,
@@ -266,6 +275,7 @@ def create_host_tunnel_router(
             # started learns the host's gateway backing here, so a server
             # restart converges as soon as each host reconnects.
             host_registry.record_gateway_inference(host_id, frame.gateway_inference)
+            stage = "connected"
             _logger.info(
                 "Host %s connected (version=%s, name=%s, runners=%s)",
                 host_id,
@@ -362,14 +372,45 @@ def create_host_tunnel_router(
                             "on_host_disconnect callback failed for %s",
                             host_id,
                         )
-        except Exception:
+        except Exception as exc:
             _logger.exception("Host tunnel error for %s", host_id)
-            # Same guard as above: don't touch a host we never registered.
+            retryable = stage in {"registration", "registry", "connected"}
+            await _send_connection_error(
+                ws,
+                stage=stage,
+                error=str(exc),
+                retryable=retryable,
+            )
+            with contextlib.suppress(Exception):
+                await ws.close(code=4005, reason="host connection failed")
             if conn is not None:
                 if host_registry.deregister(host_id, conn=conn):
                     await asyncio.to_thread(host_store.set_offline, host_id)
+            elif host_persisted:
+                await asyncio.to_thread(host_store.set_offline, host_id)
 
     return router
+
+
+async def _send_connection_error(
+    ws: WebSocket,
+    *,
+    stage: str,
+    error: str,
+    retryable: bool = False,
+) -> None:
+    """Best-effort error report while the accepted WebSocket is writable."""
+    message = error or "unknown server error"
+    with contextlib.suppress(Exception):
+        await ws.send_text(
+            encode_host_frame(
+                HostConnectionErrorFrame(
+                    stage=stage,
+                    error=message,
+                    retryable=retryable,
+                )
+            )
+        )
 
 
 async def _refuse_upgrade(ws: WebSocket, *, status: int, reason: str) -> None:

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -680,6 +680,7 @@ def _patch_background_host_spawn(
     # only slows the test down.
     monkeypatch.setattr("omnigent.cli._BACKGROUND_HOST_GRACE_S", 0.0)
     monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: checked == pid)
+    monkeypatch.setattr("omnigent.cli._daemon_host_online", lambda record, **kwargs: True)
     # Local mode waits for the server the daemon owns; no real server here.
     monkeypatch.setattr("omnigent.cli._discover_local_server_url", lambda: "http://127.0.0.1:6767")
     log_path = tmp_path / "host-test.log"
@@ -726,6 +727,36 @@ def test_host_background_spawns_detached_daemon(
     # its URL is reported too (the Web UI is otherwise unreachable).
     assert spawned_args and "--local" in spawned_args[0]
     assert "server: http://127.0.0.1:6767" in result.output
+
+
+def test_host_background_fails_when_daemon_never_registers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live PID without a registered channel must not be reported as started."""
+    _spawned, log_path = _patch_background_host_spawn(monkeypatch, tmp_path)
+    log_path.write_text("Host registration failed: database unavailable\n")
+    monkeypatch.setattr("omnigent.cli._daemon_host_online", lambda record, **kwargs: False)
+    monkeypatch.setattr("omnigent.cli._BACKGROUND_HOST_REGISTRATION_GRACE_S", 0.0)
+    monkeypatch.setattr(
+        "omnigent.cli._ensure_databricks_server_auth", lambda *args, **kwargs: None
+    )
+    terminated: list[int] = []
+    monkeypatch.setattr(
+        "omnigent.cli._terminate_daemon",
+        lambda record, *, force: terminated.append(record.pid),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["host", "--background", "--server", "https://example.databricksapps.com"],
+    )
+
+    assert result.exit_code != 0
+    assert "did not register with the server" in result.output
+    assert "database unavailable" in result.output
+    assert "Started the host daemon" not in result.output
+    assert terminated == [4242]
 
 
 def test_host_background_does_not_block(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -22,12 +22,14 @@ from omnigent.host import HOST_FATAL_EXIT_CODE
 from omnigent.host.connect import (
     HostConnectError,
     HostProcess,
+    HostRetryableConnectionError,
     _build_runner_env,
     _RunnerHandle,
     run_host_process,
 )
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HostConnectionErrorFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostDetectCredentialsFrame,
@@ -980,12 +982,22 @@ class _FakeTunnel:
         self.sent.append(data)
 
     async def recv(self) -> str:
-        """Simulate an immediate disconnect.
-
-        :returns: Never returns.
-        :raises ConnectionError: Always — ends the serve loop.
-        """
+        """Simulate an immediate disconnect after hello."""
         raise ConnectionError("test disconnect")
+
+
+class _ConnectionErrorTunnel:
+    """Tunnel that returns one server connection error after host.hello."""
+
+    def __init__(self, frame: HostConnectionErrorFrame) -> None:
+        self.frame = frame
+        self.sent: list[str] = []
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        return encode_host_frame(self.frame)
 
 
 class _RecordingWS:
@@ -1040,9 +1052,11 @@ async def test_live_host_refreshes_harness_readiness_without_reconnect(
         0.01,
     )
     host = _make_host_process()
+    host._configured_harnesses = {"pi": False}
+    host._gateway_inference = {"codex": True}
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws, {"pi": False}))
+    task = asyncio.create_task(host._harness_readiness_loop(ws))
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1070,9 +1084,11 @@ async def test_live_host_full_refresh_detects_auth_completion(
         0.01,
     )
     host = _make_host_process()
+    host._configured_harnesses = {"codex": "needs-auth"}
+    host._gateway_inference = {"codex": True}
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws, {"codex": "needs-auth"}))
+    task = asyncio.create_task(host._harness_readiness_loop(ws))
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1102,9 +1118,11 @@ async def test_live_host_does_not_repeat_unchanged_readiness(
         0.01,
     )
     host = _make_host_process()
+    host._configured_harnesses = {"codex": "needs-auth"}
+    host._gateway_inference = {"codex": True}
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws, {"codex": "needs-auth"}))
+    task = asyncio.create_task(host._harness_readiness_loop(ws))
     try:
         # Let at least two full refreshes recompute-and-compare before stopping.
         for _ in range(400):
@@ -1137,9 +1155,11 @@ async def test_live_host_repushes_when_only_gateway_inference_changes(
         0.01,
     )
     host = _make_host_process()
+    host._configured_harnesses = {"codex": True}
+    host._gateway_inference = {"codex": False}
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws, {"codex": True}))
+    task = asyncio.create_task(host._harness_readiness_loop(ws))
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1423,6 +1443,57 @@ async def test_unreported_exit_flushes_after_reconnect(
     # The queue drained — a retained entry would re-send on every
     # reconnect forever.
     assert host._unreported_exits == {}
+
+
+async def test_capability_probe_timeout_does_not_block_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A hung startup probe degrades to unknown metadata after its deadline."""
+    host = _make_host_process()
+    never = asyncio.Event()
+
+    async def _blocked(*, startup: bool) -> None:
+        del startup
+        await never.wait()
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _blocked)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _blocked)
+    monkeypatch.setattr("omnigent.host.connect._HOST_CAPABILITY_INIT_TIMEOUT_S", 0.01)
+
+    await host._initialize_capabilities()
+
+    assert host._configured_harnesses is None
+    assert host._gateway_inference is None
+    assert "capability discovery timed out" in capsys.readouterr().err
+
+
+async def test_capability_probe_failure_does_not_block_registration(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Optional startup discovery fails visibly but hello still reaches the server."""
+
+    def _denied() -> dict[str, bool]:
+        raise PermissionError(13, "Permission denied", "/usr/local/bin/codex")
+
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _denied)
+    monkeypatch.setattr(
+        "omnigent.host.connect.gateway_inference_map",
+        lambda: {"codex": False},
+    )
+    host = _make_host_process()
+    await host._initialize_capabilities()
+    tunnel = _FakeTunnel()
+
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type]
+
+    hello = decode_host_frame(tunnel.sent[0])
+    assert isinstance(hello, HostHelloFrame)
+    assert hello.configured_harnesses is None
+    assert hello.gateway_inference == {"codex": False}
+    assert "Permission denied: '/usr/local/bin/codex'" in capsys.readouterr().err
 
 
 async def test_hello_advertises_installed_version() -> None:
@@ -3165,10 +3236,7 @@ class _DroppedTunnel:
     """
 
     def __init__(self, frames_before_drop: int = 0) -> None:
-        """Store the inbound-frame script.
-
-        :param frames_before_drop: Frames to serve before dropping.
-        """
+        """Store the inbound-frame script."""
         self._frames_left = frames_before_drop
 
     async def send(self, data: str | bytes) -> None:
@@ -3179,11 +3247,7 @@ class _DroppedTunnel:
         """
 
     async def recv(self) -> str:
-        """Serve scripted frames, then fail like an abrupt close.
-
-        :returns: An undecodable frame while any are scripted.
-        :raises ConnectionClosedError: Once the script is exhausted.
-        """
+        """Serve scripted frames, then drop."""
         if self._frames_left > 0:
             self._frames_left -= 1
             return "not-a-decodable-frame"
@@ -4053,20 +4117,12 @@ async def test_silent_connect_streak_escalates_and_slows_reconnects(
     caplog: pytest.LogCaptureFixture,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Accepted-but-silent connections escalate past a bounded streak.
-
-    An endpoint that accepts the upgrade and never sends a frame used to
-    classify every drop as a benign ingress recycle and hammer it at the
-    prompt cadence forever (observed: ~6s cycles for 7 hours, silently).
-    Past the streak the host must log ONE error, warn the terminal once,
-    and drop to normal backoff.
-    """
+    """Repeated accepted-but-silent connections escalate to slow backoff."""
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
     monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
     monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
-    # Five accepted-silent connections (threshold 3), then stop.
     spy = _ConnectSpy([None, None, None, None, None, asyncio.CancelledError()])
     _patch_connect(monkeypatch, spy)
     host = _host()
@@ -4074,14 +4130,13 @@ async def test_silent_connect_streak_escalates_and_slows_reconnects(
     with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
         await host.run()
 
-    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert len(errors) == 1, "must escalate exactly once per episode"
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
     assert "3 consecutive connections but never responded" in errors[0].message
-    # The terminal notice reached stderr exactly once.
     assert capsys.readouterr().err.count("never responded") == 1
-    # Cadence flip: below the threshold the drops ride the recycle fast
-    # path; at/after it they must not.
-    reconnects = [r.message for r in caplog.records if "Reconnecting in" in r.message]
+    reconnects = [
+        record.message for record in caplog.records if "Reconnecting in" in record.message
+    ]
     assert len(reconnects) == 5
     assert "(recycle — prompt reconnect)" in reconnects[1]
     assert "(recycle — prompt reconnect)" not in reconnects[-1]
@@ -4091,18 +4146,12 @@ async def test_inbound_frame_resets_silent_connect_streak(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """One received frame proves the endpoint alive and resets the streak.
-
-    Only CONSECUTIVE silent connections may escalate — a healthy
-    connection in between (any inbound frame, even one the dispatcher
-    ignores) restarts the count, so ordinary recycles never trip it.
-    """
+    """Any inbound frame resets consecutive silent-connection accounting."""
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
     monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
     monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
-    # 2 silent, one frame-serving (resets), 2 silent: never 3 in a row.
     spy = _ConnectSpy([None, None, 1, None, None, asyncio.CancelledError()])
     _patch_connect(monkeypatch, spy)
     host = _host()
@@ -4111,7 +4160,70 @@ async def test_inbound_frame_resets_silent_connect_streak(
         await host.run()
 
     assert host._silent_connect_streak == 2
-    assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert not [record for record in caplog.records if record.levelno == logging.ERROR]
+
+
+async def test_connection_error_frame_fails_loudly_on_live_receive_path() -> None:
+    """A non-retryable server error escapes the live receive loop."""
+    host = _host()
+    tunnel = _ConnectionErrorTunnel(
+        HostConnectionErrorFrame(
+            stage="registration",
+            error="database unavailable",
+            retryable=False,
+        )
+    )
+
+    with pytest.raises(HostConnectError, match="registration: database unavailable"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type]
+
+    assert len(tunnel.sent) == 1
+    assert isinstance(decode_host_frame(tunnel.sent[0]), HostHelloFrame)
+    assert host._frame_tasks == set()
+
+
+async def test_retryable_connection_error_escapes_live_receive_path() -> None:
+    """A retryable server error reaches the reconnect loop's exception class."""
+    host = _host()
+    tunnel = _ConnectionErrorTunnel(
+        HostConnectionErrorFrame(
+            stage="registration",
+            error="database restarting",
+            retryable=True,
+        )
+    )
+
+    with pytest.raises(HostRetryableConnectionError, match="registration: database restarting"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type]
+
+    assert host._frame_tasks == set()
+
+
+async def test_capabilities_are_initialized_once_across_reconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnect handshakes reuse startup metadata instead of rerunning probes."""
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    calls = {"readiness": 0, "gateway": 0}
+
+    def _readiness() -> dict[str, bool]:
+        calls["readiness"] += 1
+        return {"pi": True}
+
+    def _gateway() -> dict[str, bool]:
+        calls["gateway"] += 1
+        return {"codex": True}
+
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _readiness)
+    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", _gateway)
+    spy = _ConnectSpy([None, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    await host.run()
+
+    assert spy.call_count == 3
+    assert calls == {"readiness": 1, "gateway": 1}
 
 
 class _FakeZygote:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -8,6 +8,7 @@ import pytest
 
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HostConnectionErrorFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -257,6 +258,17 @@ def test_hello_frame_configured_harnesses_round_trip() -> None:
     # Exact map equality: both the True and the False must survive —
     # False is the actionable "warn the user" value.
     assert decoded.configured_harnesses == {"claude-sdk": True, "codex": "needs-auth"}
+
+
+def test_connection_error_frame_round_trip() -> None:
+    """Connection errors preserve the server stage and exception message."""
+    original = HostConnectionErrorFrame(
+        stage="registration",
+        error="[Errno 13] Permission denied",
+        retryable=False,
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert decoded == original
 
 
 def test_harness_readiness_frame_round_trip() -> None:

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -13,9 +13,11 @@ from sqlalchemy.orm import Session
 from omnigent.db.db_models import SqlHost
 from omnigent.db.utils import get_or_create_engine, now_epoch
 from omnigent.host.frames import (
+    HostConnectionErrorFrame,
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
+    decode_host_frame,
     encode_host_frame,
 )
 from omnigent.server.auth import AuthProvider
@@ -305,6 +307,63 @@ async def test_host_tunnel_upserts_db_on_connect(
     assert host.status == "online"
 
 
+async def test_host_tunnel_reports_registration_failure(
+    host_app: tuple[FastAPI, HostRegistry, HostStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-registration server exception closes with an actionable stage."""
+    app, registry, store = host_app
+
+    def _fail_upsert(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(store, "upsert_on_connect", _fail_upsert)
+    comm = await _connect_route(app, _TUNNEL_PATH)
+    await comm.send_input(
+        {"type": "websocket.receive", "text": _make_hello()},
+    )
+
+    sent = await comm.receive_output(timeout=1.0)
+    assert sent["type"] == "websocket.send"
+    error = decode_host_frame(sent["text"])
+    assert error == HostConnectionErrorFrame(
+        stage="registration",
+        error="database unavailable",
+        retryable=True,
+    )
+    close = await comm.receive_output(timeout=1.0)
+    assert close["type"] == "websocket.close"
+    assert close["code"] == 4005
+    assert registry.get(_HOST_ID) is None
+
+
+async def test_registry_failure_marks_persisted_host_offline(
+    host_app: tuple[FastAPI, HostRegistry, HostStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure after the upsert must not leave a ghost-online host row."""
+    app, registry, store = host_app
+
+    def _fail_register(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(registry, "register", _fail_register)
+    comm = await _connect_route(app, _TUNNEL_PATH)
+    await comm.send_input({"type": "websocket.receive", "text": _make_hello()})
+
+    sent = await comm.receive_output(timeout=1.0)
+    error = decode_host_frame(sent["text"])
+    assert error == HostConnectionErrorFrame(
+        stage="registry",
+        error="registry unavailable",
+        retryable=True,
+    )
+    await _wait_offline(store, _HOST_ID)
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.status == "offline"
+
+
 async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
     db_uri: str,
 ) -> None:
@@ -413,6 +472,12 @@ async def test_host_tunnel_rejects_bad_protocol_version(
         {"type": "websocket.receive", "text": bad_hello},
     )
 
+    sent = await comm.receive_output(timeout=1.0)
+    assert sent["type"] == "websocket.send"
+    error = decode_host_frame(sent["text"])
+    assert isinstance(error, HostConnectionErrorFrame)
+    assert error.stage == "protocol"
+    assert "frame_protocol_version mismatch" in error.error
     close = await comm.receive_output(timeout=1.0)
     assert close["type"] == "websocket.close"
     assert close.get("code") == 4002
@@ -442,6 +507,14 @@ async def test_host_tunnel_rejects_non_hello_first_frame(
         {"type": "websocket.receive", "text": result_frame},
     )
 
+    sent = await comm.receive_output(timeout=1.0)
+    assert sent["type"] == "websocket.send"
+    error = decode_host_frame(sent["text"])
+    assert error == HostConnectionErrorFrame(
+        stage="hello",
+        error="expected host.hello frame",
+        retryable=False,
+    )
     close = await comm.receive_output(timeout=1.0)
     assert close["type"] == "websocket.close"
     assert close.get("code") == 4001


### PR DESCRIPTION
## Related issue

Closes [OMNI-2964](https://linear.app/omnigent/issue/OMNI-2964/fix-host-tunnel-connection-issue-when-it-fails-to-detect-hanress)

## Summary

- Move harness and gateway capability discovery out of reconnect handshakes, bound startup discovery, and degrade probe failures to visible warnings with unknown metadata.
- Add a backward-compatible `host.connection_error` frame so accepted tunnels can surface server-side setup failures with their stage and retryability.
- Make background startup wait for the existing server-side host status before reporting success and retain reconnect regression coverage.

ELI5: checking which agent CLIs are installed is optional setup information. A broken CLI should not prevent the host from introducing itself to the server, so the host now connects with that information marked unknown and refreshes it later.

```text
host startup ── capability probe ──┬─ success → cached metadata
                                  └─ failure/timeout → warning + unknown
                                                    │
                                                    ▼
WebSocket upgrade → host.hello → connected receive loop
                                      ▲
server setup failure → host.connection_error
```

## Test Plan

- `uv run pytest tests/host/test_frames.py tests/server/integration/test_host_tunnel_route.py tests/host/test_connect.py tests/host/test_cli_host.py -q`
- `uv run pytest tests/host/test_connect.py::test_silent_connect_streak_escalates_and_slows_reconnects tests/host/test_connect.py::test_inbound_frame_resets_silent_connect_streak -q`
- `uv run ruff check` on all changed Python and test files.
- `uv run pyrefly check omnigent/host/connect.py omnigent/host/frames.py omnigent/server/routes/host_tunnel.py omnigent/cli.py`

## Demo

N/A — backend/CLI reliability change with no visual UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises capability exceptions and timeouts, server error propagation, background registration checks, retryability, and silent reconnect backoff.

## Changelog

`omnigent host` now stays connected when optional harness detection fails and surfaces server-side tunnel setup errors.
