### PR TITLE
fix(omnidev): forward custom Vite port with pnpm

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -50,7 +50,7 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 |---|---|---|
 | server | `uv run omnigent --log-to-stderr server --host 127.0.0.1 --port <p> --database-uri … --artifact-location …` | Waited on via `GET /health`. |
 | host   | `uv run omnigent --log-to-stderr host --server http://127.0.0.1:<p>` | Started once the server is healthy. |
-| vite   | `pnpm run dev -- --host <host> --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
+| vite   | `pnpm run dev --host <host> --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
 
 Before Vite starts (and on a manual Vite restart), omnidev runs `pnpm install`
 in `web/` when needed — `node_modules/` is missing, or `package.json` /

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -120,7 +120,7 @@ impl ProcSpec {
         }
     }
 
-    /// `pnpm run dev -- --host <host> --port <p> --strictPort`, from `web/`.
+    /// `pnpm run dev --host <host> --port <p> --strictPort`, from `web/`.
     /// `OMNIGENT_URL` (in the pod env) points Vite's proxy at this pod's backend.
     pub fn vite(pod: &Pod) -> ProcSpec {
         if let Some(profile) = &pod.profile {
@@ -128,10 +128,10 @@ impl ProcSpec {
         }
         ProcSpec {
             program: "pnpm".into(),
+            // pnpm forwards script arguments directly; `--` would make Vite ignore the flags.
             args: vec![
                 "run".into(),
                 "dev".into(),
-                "--".into(),
                 "--host".into(),
                 pod.vite_host.clone(),
                 "--port".into(),
@@ -151,7 +151,7 @@ mod tests {
     use crate::profile::{ProcessProfile, Profile};
 
     #[test]
-    fn vite_uses_configured_bind_host_but_backend_url_stays_loopback() {
+    fn vite_forwards_configured_host_and_port_but_backend_url_stays_loopback() {
         let repo = tempdir();
         let pod_dir = tempdir();
         let pod = Pod::create(
@@ -167,8 +167,18 @@ mod tests {
         .unwrap();
 
         let vite = ProcSpec::vite(&pod);
-        let host_flag = vite.args.iter().position(|arg| arg == "--host").unwrap();
-        assert_eq!(vite.args[host_flag + 1], "0.0.0.0");
+        assert_eq!(
+            vite.args,
+            [
+                "run",
+                "dev",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "19292",
+                "--strictPort",
+            ]
+        );
         assert_eq!(pod.server_url(), "http://127.0.0.1:19191");
     }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Fix omnidev's Vite command after the pnpm migration: pnpm forwards script arguments directly, so the retained npm-style `--` caused Vite to ignore the configured host, port, and strict-port flag.
- Remove the separator, assert the complete forwarded argument list in the unit test, and correct the omnidev documentation.

## Test Plan

- `cargo test --manifest-path dev/omnidev/Cargo.toml process::tests::vite_forwards_configured_host_and_port_but_backend_url_stays_loopback`
- `cargo fmt --manifest-path dev/omnidev/Cargo.toml -- --check`
- `git diff --check`
- Manually ran `pnpm run dev --host 127.0.0.1 --port 43220 --strictPort` from `web/` and confirmed Vite bound to port 43220.

## Demo

N/A — this fixes local development process arguments and has no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test now verifies pnpm receives the configured Vite host and port without an npm-style separator. A direct pnpm/Vite run confirmed the corrected command binds to the requested port.

## Changelog

`omnidev --vite-port` once again starts the frontend on the requested port.
