### PR TITLE
feat(desktop): build macOS app for Intel + Apple Silicon

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -88,8 +88,20 @@
       "gatekeeperAssess": false,
       "notarize": false,
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "publish": [
         {


### PR DESCRIPTION
## Related issue

Closes #842

## Summary

Makes the macOS desktop build emit **both Intel (x64) and Apple Silicon (arm64)** installers instead of only the build host's architecture.

- `web/electron/package.json`: `build.mac.target` gains `arch: ["x64", "arm64"]` for both `dmg` and `zip`. `mac.artifactName` already templates `${arch}`, so the two arches never collide (`Omnigent-<ver>-x64.dmg` / `-arm64.dmg`, `-x64-mac.zip` / `-arm64-mac.zip`). Previously, with no `arch` key, `electron-builder --mac` produced only the host runner's arch.

This is config only — no runtime code changes. `electron-builder` reads `mac.target` identically whether invoked by CI or by the manual dev-Mac release build (`pnpm run build:mac:release`), so the signed release path now produces an Intel binary too.

## Test Plan

The identical `mac.target` config was exercised end-to-end on a GitHub-hosted macOS runner — run https://github.com/omnigent-ai/omnigent/actions/runs/31752513238 — which produced **both** arches from a single `electron-builder --mac` invocation:

```
• building  target=DMG        arch=arm64  +  arch=x64
• building  target=macOS zip  arch=arm64  +  arch=x64
• building block map (both arches) + latest-mac.yml
```

(That run used a temporary CI workflow that has since been removed; the artifact this PR changes — `mac.target` — is what was validated, and it is read the same way by the manual dev-Mac release build.)

Remaining human check: on a real Intel Mac, mount the `x64` `.dmg` and confirm it launches.

## Demo

N/A — build-config change (produces installers; no runtime UI change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by building the same `mac.target` config on a macOS runner (run linked above): one `electron-builder --mac` invocation produced both x64 and arm64 dmg/zip + a single `latest-mac.yml`. No unit-testable surface — this is electron-builder packaging config.

## Changelog

macOS desktop app now ships an Intel (x64) build alongside Apple Silicon.

This pull request and its description were written by Isaac.
