### PR TITLE
fix(web): archive sessions optimistically in the sidebar

### DIFF
--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1323,10 +1323,30 @@ describe("useStopSession invalidation", () => {
 });
 
 describe("useBulkArchiveConversations", () => {
+  function archivedResponse(id: string, updated_at: number) {
+    return mockResponse({
+      id,
+      object: "conversation",
+      title: id,
+      created_at: 0,
+      updated_at,
+      archived: true,
+      labels: {},
+    });
+  }
+
   function renderBulkArchiveHook() {
     const queryClient = new QueryClient({
       defaultOptions: { mutations: { retry: false } },
     });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([
+        conversation({ id: "conv_a" }),
+        conversation({ id: "conv_b" }),
+        conversation({ id: "conv_keep" }),
+      ]),
+    );
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
@@ -1334,30 +1354,12 @@ describe("useBulkArchiveConversations", () => {
     return { queryClient, invalidateSpy, rendered };
   }
 
-  it("PATCHes each session and invalidates the list on success", async () => {
+  it("PATCHes each session and overlays the archive in place, never invalidating the list", async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        mockResponse({
-          id: "conv_a",
-          object: "conversation",
-          title: "A",
-          created_at: 0,
-          updated_at: 10,
-          labels: {},
-        }),
-      )
-      .mockResolvedValueOnce(
-        mockResponse({
-          id: "conv_b",
-          object: "conversation",
-          title: "B",
-          created_at: 0,
-          updated_at: 11,
-          labels: {},
-        }),
-      );
+      .mockResolvedValueOnce(archivedResponse("conv_a", 10))
+      .mockResolvedValueOnce(archivedResponse("conv_b", 11));
 
-    const { invalidateSpy, rendered } = renderBulkArchiveHook();
+    const { queryClient, invalidateSpy, rendered } = renderBulkArchiveHook();
     rendered.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: true });
     await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
 
@@ -1366,24 +1368,32 @@ describe("useBulkArchiveConversations", () => {
       expect(init.method).toBe("PATCH");
       expect(JSON.parse(init.body as string)).toEqual({ archived: true });
     }
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+
+    // The optimistic overlay already spliced the archived rows out of the
+    // non-archived list and recomputed its page cursors, so the selection
+    // leaves the sidebar without waiting on the network.
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_keep"]);
+    expect(data!.pages[0].first_id).toBe("conv_keep");
+    expect(data!.pages[0].last_id).toBe("conv_keep");
+
+    // Like the single-row hook, the conversations lists are never
+    // invalidated: an immediate refetch races the server's async search
+    // reindex and can resurrect the just-archived rows. Only the DB-direct
+    // project lists refresh (archiving a project's last live member
+    // empties its folder).
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["archived-project-names"] });
   });
 
-  it("throws with failed ids when some archives fail", async () => {
+  it("keeps the overlay for succeeded rows when some archives fail", async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        mockResponse({
-          id: "conv_a",
-          object: "conversation",
-          title: "A",
-          created_at: 0,
-          updated_at: 10,
-          labels: {},
-        }),
-      )
+      .mockResolvedValueOnce(archivedResponse("conv_a", 10))
       .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
 
-    const { rendered } = renderBulkArchiveHook();
+    const { queryClient, rendered } = renderBulkArchiveHook();
     rendered.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: true });
     await waitFor(() => expect(rendered.result.current.isError).toBe(true));
 
@@ -1391,9 +1401,16 @@ describe("useBulkArchiveConversations", () => {
     expect(rendered.result.current.error).toMatchObject({
       message: "Failed to archive 1 of 2 conversations",
       failed: ["conv_b"],
-      succeeded: [],
+      succeeded: ["conv_a"],
       total: 2,
     });
+
+    // The wholesale rollback restores every row, then the overlay is
+    // re-applied to just the succeeded ones — their PATCHes landed
+    // server-side, so conv_a stays archived out of the list while the
+    // failed conv_b returns.
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_b", "conv_keep"]);
   });
 });
 
@@ -1998,34 +2015,181 @@ describe("useMoveToProject", () => {
 });
 
 describe("useArchiveConversation", () => {
-  it("PATCHes archived and invalidates both the conversations and projects queries", async () => {
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({
-        id: "conv_a",
-        object: "conversation",
-        title: "A",
-        created_at: 0,
-        updated_at: 10,
-        labels: { omni_project: "Sprint 42" },
-      }),
-    );
+  const ARCHIVE_RESPONSE = {
+    id: "conv_a",
+    object: "conversation",
+    title: "A",
+    created_at: 0,
+    updated_at: 10,
+    archived: true,
+    labels: { omni_project: "Sprint 42" },
+  };
+
+  function seedArchiveCaches() {
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    // Every cache the row renders from: the non-archived sidebar variant,
+    // the includeArchived variant, its project folder, the pinned sibling
+    // cache, and the pinned-row backfill.
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_keep" })]),
+    );
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_keep" })]),
+    );
+    queryClient.setQueryData(
+      ["project-sessions", "Sprint 42"],
+      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_sibling" })]),
+    );
+    queryClient.setQueryData(["conversation-backfill", "conv_a"], conversation({ id: "conv_a" }));
+    queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, {
+      conversations: [conversation({ id: "conv_a" }), conversation({ id: "conv_pin_other" })],
+      filterHonored: true,
+    });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
+    return { queryClient, invalidateSpy, wrapper };
+  }
+
+  function expectArchiveOverlay(queryClient: QueryClient) {
+    // Non-archived list + folder: the row is spliced out (cursors
+    // recomputed) so the sidebar row disappears on the next frame.
+    const base = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(base!.pages[0].data.map((c) => c.id)).toEqual(["conv_keep"]);
+    expect(base!.pages[0].first_id).toBe("conv_keep");
+    const folder = queryClient.getQueryData<ConversationsInfiniteData>([
+      "project-sessions",
+      "Sprint 42",
+    ]);
+    expect(folder!.pages[0].data.map((c) => c.id)).toEqual(["conv_sibling"]);
+    // includeArchived list: the row stays (the archived view must still
+    // find it) but flagged, so the sidebar's client-side `archived !==
+    // true` filter peels it out of the visible sections.
+    const withArchived = queryClient.getQueryData<ConversationsInfiniteData>([
+      "conversations",
+      "",
+      true,
+    ]);
+    expect(withArchived!.pages[0].data.find((c) => c.id === "conv_a")!.archived).toBe(true);
+    // The pinned sibling cache holds its own row copies; the flag flip is
+    // what drops an archived pinned session from the Pinned section...
+    const pinned = queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
+    expect(pinned!.conversations.find((c) => c.id === "conv_a")!.archived).toBe(true);
+    // ...and the still-fresh backfill can't resurrect the pre-flip row.
+    expect(
+      queryClient.getQueryData<Conversation>(["conversation-backfill", "conv_a"])!.archived,
+    ).toBe(true);
+  }
+
+  it("overlays the archive before the server responds, then refreshes only DB-direct lists", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const { queryClient, invalidateSpy, wrapper } = seedArchiveCaches();
     const { result } = renderHook(() => useArchiveConversation(), { wrapper });
 
     result.current.mutate({ id: "conv_a", archived: true });
+
+    // The overlay lands from onMutate — before the PATCH resolves. This is
+    // what makes the sidebar row vanish on click instead of after the
+    // network round-trip.
+    await waitFor(() => {
+      const base = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+      ]);
+      expect(base!.pages[0].data.map((c) => c.id)).toEqual(["conv_keep"]);
+    });
+    expectArchiveOverlay(queryClient);
+
+    resolveFetch(mockResponse(ARCHIVE_RESPONSE));
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_a");
     expect(init.method).toBe("PATCH");
     expect(JSON.parse(init.body as string)).toEqual({ archived: true });
-    // Projects must refresh too: archiving the last live member of a project
-    // removes its folder; unarchiving restores it.
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+
+    // The conversations lists are patched by the overlay and converge via
+    // the session-updates stream — invalidating them here would race the
+    // server's async search reindex and resurrect the row. Only the
+    // DB-direct project lists refresh: archiving the last live member of
+    // a project removes its folder.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["archived-project-names"] });
+    // Nothing reverts the overlay after success.
+    expectArchiveOverlay(queryClient);
+  });
+
+  it("restores every cache when the PATCH fails", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    const { queryClient, wrapper } = seedArchiveCaches();
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+    // The restored row carries no failure state of its own (it unmounted
+    // when the overlay dropped it), so the toast is the only signal the
+    // user gets that the archive didn't land.
+    const toasts: string[] = [];
+    window.addEventListener("omnigent:toast", (e) => {
+      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
+    });
+
+    result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(toasts).toEqual(["Couldn't archive the session — it's back in the sidebar."]);
+
+    // Wholesale rollback: the row is back in the non-archived list and its
+    // folder, and unflagged everywhere else — the pre-click state.
+    const base = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(base!.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_keep"]);
+    const folder = queryClient.getQueryData<ConversationsInfiniteData>([
+      "project-sessions",
+      "Sprint 42",
+    ]);
+    expect(folder!.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_sibling"]);
+    const withArchived = queryClient.getQueryData<ConversationsInfiniteData>([
+      "conversations",
+      "",
+      true,
+    ]);
+    expect(withArchived!.pages[0].data.find((c) => c.id === "conv_a")!.archived).toBeFalsy();
+    const pinned = queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY);
+    expect(pinned!.conversations.find((c) => c.id === "conv_a")!.archived).toBeFalsy();
+    expect(
+      queryClient.getQueryData<Conversation>(["conversation-backfill", "conv_a"])!.archived,
+    ).toBeFalsy();
+  });
+
+  it("flips the flag back on unarchive so the row re-enters the sidebar", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ ...ARCHIVE_RESPONSE, archived: false }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    // Unarchive starts from the archived view's world: the row lives in
+    // the includeArchived cache, flagged.
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: true })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    result.current.mutate({ id: "conv_a", archived: false });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The includeArchived cache flips in place — the sidebar renders from
+    // it filtered by `archived !== true`, so the row re-enters instantly.
+    // Lists the row isn't cached in (folders, searches) converge via the
+    // session-updates stream; the overlay can't sort it in locally.
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", true]);
+    expect(data!.pages[0].data.find((c) => c.id === "conv_a")!.archived).toBe(false);
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1,7 +1,8 @@
 // TanStack Query wrapper around `GET /v1/sessions`, plus mutation
-// hooks for `PATCH /v1/sessions/{id}` (rename) and
-// `DELETE /v1/sessions/{id}`. Rename and delete are optimistic and patch
-// the cached lists in place (see `useRenameConversation` /
+// hooks for `PATCH /v1/sessions/{id}` (rename, archive) and
+// `DELETE /v1/sessions/{id}`. Rename, archive, and delete are
+// optimistic and patch the cached lists in place (see
+// `useRenameConversation` / `useArchiveConversation` /
 // `useStopAndDeleteConversation` — a refetch would race the server's
 // async search reindex); the remaining mutations invalidate the
 // conversations list on success so the sidebar reflects the change.
@@ -636,12 +637,148 @@ export function useRenameConversation() {
 }
 
 /**
+ * Caches an archive overlay touches, snapshotted so a failed PATCH can
+ * restore them wholesale (the overlay drops rows from pages, which a
+ * field-level revert couldn't undo — the row's old page position is
+ * lost). Mirrors the move-to-project rollback shape.
+ */
+interface ArchivedOverlaySnapshot {
+  conversations: [readonly unknown[], ConversationsInfiniteData | undefined][];
+  projectSessions: [readonly unknown[], ConversationsInfiniteData | undefined][];
+  pinned: PinnedConversationsResult | undefined;
+  backfills: [id: string, data: Conversation | null | undefined][];
+}
+
+function snapshotArchivedOverlay(
+  queryClient: QueryClient,
+  ids: readonly string[],
+): ArchivedOverlaySnapshot {
+  return {
+    conversations: queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["conversations"],
+    }),
+    projectSessions: queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["project-sessions"],
+    }),
+    pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
+    backfills: ids.map((id) => [
+      id,
+      queryClient.getQueryData<Conversation | null>(["conversation-backfill", id]),
+    ]),
+  };
+}
+
+function restoreArchivedOverlay(queryClient: QueryClient, snapshot: ArchivedOverlaySnapshot) {
+  for (const [key, data] of [...snapshot.conversations, ...snapshot.projectSessions]) {
+    if (data !== undefined) queryClient.setQueryData(key, data);
+  }
+  if (snapshot.pinned !== undefined) {
+    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, snapshot.pinned);
+  }
+  for (const [id, data] of snapshot.backfills) {
+    if (data !== undefined) queryClient.setQueryData(["conversation-backfill", id], data);
+  }
+}
+
+/**
+ * Flip the archived flag on every cached copy of the given rows.
+ *
+ * Archiving drops the row from the non-archived lists (search variants
+ * and project folders — via `removeIdsFromPages` so page cursors stay
+ * paginatable) and flips the flag in the includeArchived lists, where
+ * the sidebar's client-side filter peels the row out of the visible
+ * sections on the next frame. Unarchiving only flips the flag: a row
+ * returning to a list it isn't cached in (a folder, a matching search)
+ * can't be placed in the server's sort order locally, so the
+ * session-updates stream's refetch converges those.
+ */
+function overlayArchivedFlag(
+  queryClient: QueryClient,
+  ids: ReadonlySet<string>,
+  archived: boolean,
+) {
+  const itemsById = new Map<string, SessionListWireItem>(
+    [...ids].map((id) => [id, { id, archived }]),
+  );
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    const filters = filtersFromConversationQueryKey(key);
+    if (archived && !filters.includeArchived) {
+      const { data: next, removed } = removeIdsFromPages(data, ids);
+      if (removed) queryClient.setQueryData(key, next);
+      continue;
+    }
+    const { data: next } = mergeItemsIntoPages(
+      data,
+      itemsById,
+      filters,
+      // activeId only gates `needsRefetch`, which is unused here — the
+      // stream's own invalidation reconciles list membership.
+      undefined,
+    );
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["project-sessions"],
+  })) {
+    // Folder lists are non-archived — an archived row can't stay. On
+    // unarchive the row isn't cached here (it was archived out), but
+    // merge defensively in case a stale copy lingers.
+    if (archived) {
+      const { data: next, removed } = removeIdsFromPages(data, ids);
+      if (removed) queryClient.setQueryData(key, next);
+    } else {
+      const { data: next } = mergeItemsIntoPages(
+        data,
+        itemsById,
+        PROJECT_FOLDER_FILTERS,
+        undefined,
+      );
+      if (next !== data) queryClient.setQueryData(key, next);
+    }
+  }
+  // The Pinned section reads a sibling cache holding its own row copies,
+  // so an archived pinned session keeps rendering there unless the flag
+  // flips here too (the sidebar's archived filter then drops it).
+  queryClient.setQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY, (old) =>
+    old
+      ? {
+          ...old,
+          conversations: old.conversations.map((c) => (ids.has(c.id) ? { ...c, archived } : c)),
+        }
+      : old,
+  );
+  // The pinned-row backfill (staleTime 60s) feeds rows outside the
+  // paginated window; left stale it would re-enter the sidebar pre-flip.
+  for (const id of ids) {
+    queryClient.setQueryData<Conversation | null>(["conversation-backfill", id], (old) =>
+      old ? { ...old, archived } : old,
+    );
+  }
+}
+
+/**
  * Archive / unarchive a conversation via `PATCH /v1/sessions/{id}`.
  *
- * Invalidates the conversations list on success so the row moves
- * into (or out of) the sidebar's "Archived" section. Mirrors the
- * rename hook's `markConversationSeen` anchoring: the PATCH bumps
- * server `updated_at`, and without this the unseen tracker would
+ * Optimistic: `onMutate` overlays the new archived flag into every
+ * cached list (`overlayArchivedFlag`), so the row leaves the sidebar on
+ * the next frame rather than after the PATCH + list-refetch
+ * round-trips; `onError` restores the pre-mutation caches wholesale and
+ * toasts the failure (the overlay unmounted the row that could show it).
+ *
+ * Overlaying in place instead of invalidating is deliberate — the same
+ * reindex-lag race `useRenameConversation` documents: `GET /v1/sessions`
+ * may list from a search index that lags the write, so an immediate
+ * refetch can resurrect the just-archived row. Membership converges via
+ * the `WS /v1/sessions/updates` stream (an archived-flip frame schedules
+ * the provider's own refetch) and the low-rate reconciliation polls;
+ * only the DB-direct project lists are invalidated here. The server
+ * stops the runner itself on archive (`_best_effort_stop`), so callers
+ * fire this directly — no client-side stop first.
+ *
+ * Mirrors the rename hook's `markConversationSeen` anchoring: the PATCH
+ * bumps server `updated_at`, and without this the unseen tracker would
  * flag the user's own archive action as new activity.
  */
 export function useArchiveConversation() {
@@ -649,16 +786,38 @@ export function useArchiveConversation() {
   return useMutation({
     mutationFn: ({ id, archived }: { id: string; archived: boolean }) =>
       archiveConversation(id, archived),
+    onMutate: async ({ id, archived }) => {
+      // Cancel in-flight list refetches (the reconcile poll or a
+      // WS-triggered fetch) so a response that started before the
+      // overlay can't resolve after it and snap the row back.
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ["conversations"] }),
+        queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
+      ]);
+      const previous = snapshotArchivedOverlay(queryClient, [id]);
+      overlayArchivedFlag(queryClient, new Set([id]), archived);
+      return previous;
+    },
+    onError: (_err, { archived }, previous) => {
+      if (previous) restoreArchivedOverlay(queryClient, previous);
+      // The row is back in the list but nothing else marks it as failed
+      // (the row unmounted when the overlay dropped it, taking any in-row
+      // error state with it), so the toast is the only failure signal.
+      showToast(
+        archived
+          ? "Couldn't archive the session — it's back in the sidebar."
+          : "Couldn't unarchive the session — it's back in the archived list.",
+      );
+    },
     onSuccess: (updated) => {
       markConversationSeen(updated.id, updated.updated_at);
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      // Archiving/unarchiving the last (or first) non-archived member of a
-      // project removes/restores it from the server's project list, and adds
-      // or drops it from that project folder's own paginated list.
+      // Archiving/unarchiving the last (or first) non-archived member of
+      // a project removes/restores it from the server's project list.
+      // /v1/sessions/projects reads the DB directly (no search-index
+      // lag), so this refetch can't resurrect the row.
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
-      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
-      // Archive membership just changed, so the archived-view picker's option
-      // set may have gained/lost a project.
+      // Archive membership just changed, so the archived-view picker's
+      // option set may have gained/lost a project.
       void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
     },
   });
@@ -918,36 +1077,63 @@ export function useStopSession() {
 /**
  * Archive multiple conversations in parallel via `PATCH /v1/sessions/{id}`.
  *
- * Each session is archived independently — individual failures don't
- * block the rest. The conversations list is invalidated once on
- * completion so the sidebar refreshes. Returns an array of session IDs
- * that failed.
+ * Optimistic like `useArchiveConversation`: every row's archived flag
+ * flips in the caches on mutate, so the selection leaves the sidebar
+ * immediately. Each session is archived independently — individual
+ * failures don't block the rest, and on partial failure only the failed
+ * rows' caches roll back: the succeeded PATCHes did land server-side,
+ * so those rows keep the overlay.
  */
 export function useBulkArchiveConversations() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ ids, archived }: { ids: string[]; archived: boolean }) => {
       const results = await Promise.allSettled(ids.map((id) => archiveConversation(id, archived)));
+      const succeeded: string[] = [];
       const failed: string[] = [];
       for (let i = 0; i < results.length; i++) {
-        if (results[i].status === "rejected") failed.push(ids[i]);
-        else
+        if (results[i].status === "rejected") {
+          failed.push(ids[i]);
+        } else {
+          succeeded.push(ids[i]);
           markConversationSeen(
             ids[i],
             (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at,
           );
+        }
       }
       if (failed.length > 0) {
-        throw new BulkConversationMutationError("archive", { failed, total: ids.length });
+        throw new BulkConversationMutationError("archive", {
+          failed,
+          succeeded,
+          total: ids.length,
+        });
       }
       return results
         .filter((r): r is PromiseFulfilledResult<Conversation> => r.status === "fulfilled")
         .map((r) => r.value);
     },
+    onMutate: async ({ ids, archived }) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ["conversations"] }),
+        queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
+      ]);
+      const previous = snapshotArchivedOverlay(queryClient, ids);
+      overlayArchivedFlag(queryClient, new Set(ids), archived);
+      return previous;
+    },
+    onError: (error, { archived }, previous) => {
+      if (!previous) return;
+      restoreArchivedOverlay(queryClient, previous);
+      if (error instanceof BulkConversationMutationError && error.succeeded.length > 0) {
+        overlayArchivedFlag(queryClient, new Set(error.succeeded), archived);
+      }
+    },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      // See useArchiveConversation: the conversations lists converge via
+      // the overlay + session-updates stream; only DB-direct project
+      // lists are safe to refetch immediately.
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
-      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
       void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
     },
   });

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -285,7 +285,7 @@ export function mergeItemsIntoPages(
  */
 export function removeIdsFromPages(
   data: ConversationsInfiniteData | undefined,
-  ids: Set<string>,
+  ids: ReadonlySet<string>,
 ): { data: ConversationsInfiniteData | undefined; removed: boolean } {
   if (!data || ids.size === 0) return { data, removed: false };
   let changed = false;

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -1,23 +1,21 @@
-// Tests for the archive flow in the sidebar. Contract: archiving sends ONLY
-// the archive PATCH (`archived: true`). The "Archiving…" status row stays up
-// until the row LEAVES the sidebar — on success it's held (the row unmounts
-// when the list refetch drops the archived row, taking the spinner with it),
-// and only an error clears it to restore the interactive row for retry.
-// Clearing on settle would flash the row back to its clickable form a
-// round-trip before it actually leaves. The runner stop is the server's job
-// once the flag commits — a client stop would race the server's against the
-// same runner, and it would also put the runner's stop timeouts in front of
-// the flag flip. The kebab's user-facing "Stop session" action is a separate
-// affordance covered by Sidebar.stop.test.tsx. Unarchiving flips the flag
-// back with no status row. See ConversationRow.runArchive in Sidebar.tsx.
+// Tests for the archive flow in the sidebar. Contract: clicking Archive
+// fires `useArchiveConversation` immediately — no client-side stop first
+// (the server stops the runner itself on archive) and no "Archiving…"
+// status row, because the mutation is optimistic: the hook's cache overlay
+// drops the row from the sidebar on the next frame (covered by the hook
+// tests in useConversations.test.ts; here the hook is mocked, so the row
+// stays). That unmount also means nothing can wait on a mutate-level
+// callback — the toast pointing at the session's new home and the
+// navigate-away run synchronously at click time, while the failure toast
+// lives in the hook. See ConversationRow.runArchive in Sidebar.tsx.
 //
 // Archived sessions are no longer listed in the sidebar (they moved to the
 // Settings page), so unarchiving is covered by SettingsPage.test.tsx; this
 // file exercises the archive path from a row's kebab.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -122,16 +120,18 @@ function renderSidebar() {
   );
 }
 
-/** Open the row's action dropdown and click the archive/unarchive item. */
-function clickArchive() {
+/** Open the row's action dropdown and click the archive item. */
+function clickArchive(row?: HTMLElement) {
+  const scope = row ? within(row) : screen;
   // Radix DropdownMenu opens on pointerdown, not click.
-  fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+  fireEvent.pointerDown(scope.getByTestId("conversation-actions"), { button: 0 });
   fireEvent.click(screen.getByTestId("archive-conversation"));
 }
 
 beforeEach(() => {
   mocks.archive.mutate.mockReset();
   mocks.stop.mutate.mockReset();
+  mockConversations([CONV]);
 });
 
 afterEach(() => {
@@ -139,36 +139,40 @@ afterEach(() => {
 });
 
 describe("archive flow", () => {
-  it("archives with a single PATCH and no client-side stop", () => {
-    mockConversations([CONV]);
+  it("fires the archive mutation immediately — no client-side stop first", () => {
     renderSidebar();
     clickArchive();
 
     expect(mocks.archive.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.archive.mutate).toHaveBeenCalledWith(
-      { id: "conv_1", archived: true },
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        // Only an error restores the interactive row; success intentionally
-        // leaves the spinner up until the row unmounts (see the "keeps the
-        // 'Archiving…' row up after the archive succeeds" case below).
-        onError: expect.any(Function),
-      }),
-    );
-    // The server owns the stop. A client stop here would race it against
-    // the same runner and put its timeouts in front of the flag flip.
+    // Exactly one argument — no mutate-level callbacks. The hook's overlay
+    // unmounts this row on the next frame, and callbacks on an unmounted
+    // observer never fire, so everything lives in the hook or runs
+    // synchronously at click time (like confirmDelete).
+    expect(mocks.archive.mutate).toHaveBeenCalledWith({ id: "conv_1", archived: true });
+    // The server stops the runner itself once the archived flag commits,
+    // so the client must not gate the archive on a stop round-trip — that
+    // serialization was what made archiving feel slow.
     expect(mocks.stop.mutate).not.toHaveBeenCalled();
   });
 
-  it("toasts a pointer to Settings once the archive succeeds", () => {
-    mockConversations([CONV]);
+  it("shows no 'Archiving…' status row — the optimistic overlay removes the row", () => {
     renderSidebar();
     clickArchive();
 
-    // Drive the archive to its success callback.
-    const archiveArgs = mocks.archive.mutate.mock.calls[0];
-    act(() => (archiveArgs[1] as { onSuccess: () => void }).onSuccess());
+    // With the hook mocked the row stays rendered, but the old in-flight
+    // status row is gone for good: the real hook's cache overlay is what
+    // takes the row out of the list now.
+    expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
+  });
 
+  it("toasts a pointer to the session's new home at click time", () => {
+    renderSidebar();
+    clickArchive();
+
+    // The mutate stub never resolves, so the toast can't be waiting on the
+    // server: the row leaves the sidebar immediately and the user needs to
+    // know where it went.
     const toast = screen.getByTestId("toast");
     expect(within(toast).getByText(/View archived sessions in/)).toBeInTheDocument();
     expect(within(toast).getByRole("link", { name: "Settings" })).toHaveAttribute(
@@ -176,62 +180,68 @@ describe("archive flow", () => {
       "/settings/archived",
     );
   });
+});
 
-  // Unarchive moved out of the sidebar: archived sessions no longer render
-  // here (they're on the Settings page), so the "Unarchive" affordance is
-  // covered by SettingsPage.test.tsx instead.
+// --- Active-session redirect on archive -------------------------------
+//
+// The row leaves the sidebar the moment Archive is clicked, so the
+// redirect runs then too: if the user is viewing the session being
+// archived, the chat surface would otherwise sit on a session that just
+// left their list. Archiving any other row must leave them where they
+// are. Mirrors the delete flow's redirect tests.
 
-  it("shows an 'Archiving…' status row while the archive is in flight", () => {
-    // The archive mock never settles (vi.fn() stub), so the row stays in
-    // its in-flight state — the window the user sees. Without the indicator
-    // the row would look idle while the archive ran.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
+const CONV_OTHER: Conversation = { ...CONV, id: "conv_2", title: "Other Session" };
 
-    const row = screen.getByTestId("conversation-archiving");
-    expect(within(row).getByText("Archiving…")).toBeInTheDocument();
-    // The interactive link is replaced by the status row, so the session
-    // can't be re-opened or re-archived mid-flight.
-    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname}</div>;
+}
+
+/** Render the sidebar inside a router started at `path`, with a probe. */
+function renderSidebarRouted(path: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const tree = (
+    <>
+      <Sidebar open={true} onClose={vi.fn()} />
+      <LocationProbe />
+    </>
+  );
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route path="/" element={tree} />
+            <Route path="/c/:conversationId" element={tree} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("active-session redirect on archive", () => {
+  it("redirects to / when the archived conversation is the active one", () => {
+    mockConversations([CONV, CONV_OTHER]);
+    renderSidebarRouted("/c/conv_1");
+    expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_1");
+
+    clickArchive(screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement);
+
+    // Viewing conv_1 when it was archived → bounce to / immediately. The
+    // mutate stub never resolves, proving the redirect doesn't wait on it.
+    expect(screen.getByTestId("loc")).toHaveTextContent("/");
   });
 
-  it("keeps the 'Archiving…' row up after the archive succeeds", () => {
-    // On success the spinner must NOT be cleared: the row leaves the sidebar
-    // only when the ['conversations'] refetch drops the archived row (which
-    // unmounts this row and its spinner together). Clearing on success would
-    // flash the row back to its plain, clickable form for the round-trip until
-    // the refetch lands — the exact regression this guards. Here the mocked
-    // list still contains the row (no refetch modeled), so firing onSuccess
-    // must leave the status row in place.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
+  it("does NOT redirect when archiving a row the user isn't viewing", () => {
+    mockConversations([CONV, CONV_OTHER]);
+    renderSidebarRouted("/c/conv_2");
+    expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_2");
 
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
+    clickArchive(screen.getByRole("link", { name: /My Session/ }).closest("li") as HTMLElement);
 
-    const archiveOnSuccess = mocks.archive.mutate.mock.calls[0][1].onSuccess as () => void;
-    act(() => archiveOnSuccess());
-
-    // Still archiving, still no interactive link — the row hasn't left yet.
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /My Session/ })).not.toBeInTheDocument();
-  });
-
-  it("restores the interactive row when the archive errors", () => {
-    // The only escape hatch from the status row: a failed archive clears the
-    // flag so the user gets the clickable row back to retry. Success has no
-    // such clear (see above) — the row instead leaves via the refetch.
-    mockConversations([CONV]);
-    renderSidebar();
-    clickArchive();
-
-    expect(screen.getByTestId("conversation-archiving")).toBeInTheDocument();
-
-    const archiveOnError = mocks.archive.mutate.mock.calls[0][1].onError as () => void;
-    act(() => archiveOnError());
-
-    expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
+    // conv_2 is untouched, so the user stays in the chat they're reading —
+    // a redirect here would yank them out of an unrelated session.
+    expect(screen.getByTestId("loc")).toHaveTextContent("/c/conv_2");
   });
 });

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -3,7 +3,7 @@
 // closes the dialog, and leaves the row alone — the mutation itself
 // splices the row out of the cached lists on the next frame (see
 // `useStopAndDeleteConversation`), so the sidebar never shows an
-// in-flight status row for a delete the way it does for an archive.
+// in-flight status row for a delete — archive works the same way.
 // See ConversationRow.confirmDelete in Sidebar.tsx.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3077,10 +3077,6 @@ function ConversationRow({
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [leaveOpen, setLeaveOpen] = useState(false);
-  // True while an archive is in flight. Drives the "Archiving…" status
-  // row — without it the row shows nothing while the archive completes.
-  // Delete needs no counterpart: it drops its row optimistically.
-  const [isArchiving, setIsArchiving] = useState(false);
   const gitBranch = conversation.git_branch ?? null;
   // Every row action gates on ownership alone — the sidebar carries no
   // effective-permission level, so rename/share/move/drag are owner-only and
@@ -3252,21 +3248,6 @@ function ConversationRow({
     );
   }
 
-  // Archiving is a single PATCH (see runArchive); show a status row for the
-  // span instead of leaving the row looking idle. The spinner stays up until
-  // the row itself leaves the sidebar: on success the list refetches and this
-  // row unmounts (dropped from the default view), which removes the spinner
-  // with it — it is deliberately NOT cleared on PATCH-settle, or it would
-  // vanish a round-trip before the row does. On failure the flag clears and
-  // the interactive row returns so the user can retry.
-  if (isArchiving) {
-    return (
-      <li>
-        <ArchivingRow label={label} />
-      </li>
-    );
-  }
-
   function confirmDelete() {
     // Fire-and-forget: close the dialog and drop the row immediately so the
     // user isn't blocked on the (potentially slow) DELETE — server-side
@@ -3284,39 +3265,17 @@ function ConversationRow({
 
   function runArchive() {
     const nextArchived = !isArchived;
-    // Unarchiving is a quick flag flip — no status row.
-    if (!nextArchived) {
-      archive.mutate({ id: conversation.id, archived: false });
-      return;
+    // Fire-and-forget, like confirmDelete: the hook drops the row from the
+    // cached lists optimistically, which unmounts this component, so the
+    // navigate and toast run before mutate — a mutate-level callback would
+    // never fire. On failure the hook rolls the row back and toasts why.
+    if (nextArchived) {
+      // Archiving the session being viewed? Leave now, and point the user
+      // at its new home — it no longer shows in the sidebar list.
+      if (isActive) navigate("/", { replace: true });
+      showArchivedToast();
     }
-    // Archiving sends only the PATCH: the server stops the session (and
-    // tears down a host-spawned runner) in the background once the flag is
-    // committed. Sending a client stop too would race that one against the
-    // same runner, and the loser gets a 503 from the already-killed pane.
-    //
-    // "Archiving…" must stay up until the row actually LEAVES the sidebar,
-    // not merely until the PATCH resolves. The PATCH success only kicks off
-    // an async `["conversations"]` refetch (see useArchiveConversation); the
-    // row drops out a round-trip later, once that refetch lands and the
-    // archived row is filtered out of the rendered list. Clearing the
-    // spinner on settle (the old behavior) reopened that gap: the row flashed
-    // back to its plain, clickable form — spinner gone — while the session
-    // was still listed. So we DON'T clear it on success: this row unmounts
-    // when the refetch removes it, which tears the spinner down with it.
-    // Only an error clears the flag, restoring the interactive row for retry.
-    setIsArchiving(true);
-    archive.mutate(
-      { id: conversation.id, archived: true },
-      {
-        // Point the user at where the session went — it's no longer in
-        // the sidebar list, so surface its new home in Settings.
-        onSuccess: () => {
-          if (isActive) navigate("/", { replace: true });
-          showArchivedToast();
-        },
-        onError: () => setIsArchiving(false),
-      },
-    );
+    archive.mutate({ id: conversation.id, archived: nextArchived });
   }
 
   function confirmLeave() {
@@ -3829,30 +3788,6 @@ function PinnedProjectFlyoutContent({
         </p>
       )}
     </HoverCardContent>
-  );
-}
-
-/**
- * In-flight status row shown while a session is being archived (the
- * archive PATCH in ConversationRow.runArchive). Delete has no
- * counterpart: it removes its row optimistically, so there is nothing
- * left to show progress on. Archive failures fall back to the
- * interactive row rather than a persistent error state, so there's no
- * retry/dismiss affordance here.
- */
-function ArchivingRow({ label }: { label: string }) {
-  return (
-    <div
-      className={cn(SIDEBAR_ROW, "flex w-full items-center text-muted-foreground opacity-70")}
-      data-testid="conversation-archiving"
-      aria-live="polite"
-    >
-      <Loader2Icon className="size-3.5 shrink-0 animate-spin" aria-hidden />
-      <span className="min-w-0 flex-1 truncate" title={label}>
-        {label}
-      </span>
-      <span className="shrink-0 text-sm">Archiving…</span>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Related issue

N/A — no tracking issue.

## Summary

Archiving a session from the sidebar used to run **stop → PATCH → refetch the whole list** before the row disappeared, so the UI felt stuck for seconds after every click. This makes archive/unarchive optimistic, mirroring the existing optimistic-delete pattern:

- `useArchiveConversation` now applies a TanStack Query cache overlay in `onMutate`: the row is dropped from the sidebar/folder lists (or its `archived` flag flips, for unarchive) on the next frame — no client-side stop first; the server stops the runner itself once the `archived` flag commits. Page cursors are recomputed via `removeIdsFromPages` so infinite scroll keeps working, and on success we deliberately do **not** invalidate the list queries (avoids the search-reindex resurrection race).
- The optimistic drop unmounts the row, and TanStack Query v5 mutate-level callbacks are listener-gated (they never fire after unmount — verified in `@tanstack/query-core` 5.101.2), so the navigate-away and the "View archived sessions in Settings" toast run **synchronously at click time** in `ConversationRow`, and the failure path lives in the hook-level `onError`: restore every touched cache wholesale and toast, since the restored row carries no error state of its own.
- The old `"Archiving…"` status row and the `isArchiving` state are gone — the row simply isn't there while the mutation is in flight, same as delete.

**ELI5:** archiving used to mail a letter to the server and wait for the reply before taking the book off the shelf; now we take the book off the shelf the moment you ask, and only put it back (with a note explaining why) if the server says no.

```
Before:  click ──► POST stop ──► PATCH archived ──► refetch list ──► row finally gone
                     (seconds of nothing happening)

After:   click ──► row gone from cache (next frame) + toast + navigate-away
                   └──► PATCH archived ──► ok: invalidate sidebar counts only
                                          └─ fail: restore caches + toast "it's back"
```

## Test Plan

- `vitest run src/shell/Sidebar.archive.test.tsx src/shell/Sidebar.delete.test.tsx src/hooks/useConversations.test.ts src/lib/sessionListCache.test.ts` — 114/114 pass. New coverage: archive fires immediately with no client-side stop and no mutate-level callbacks; no `"Archiving…"` row; click-time toast pointing at `/settings/archived`; redirect to `/` when archiving the session being viewed (and no redirect for other rows); hook-level rollback of every cache plus the direction-aware failure toast on PATCH error.
- Full web suite: `vitest run` — 284 files, 5715 tests pass.
- `tsc -b`, `oxlint --deny-warnings`, and `pre-commit run` on all changed files — clean.

## Demo

Behaviour change, before → after:

- **Before:** click *Archive* → row shows "Archiving…" and stays in the sidebar until stop + PATCH + refetch complete (seconds).
- **After:** click *Archive* → the row leaves the sidebar immediately, a toast offers a link to *Settings → Archived sessions*, and viewing that session bounces you to `/` at click time. On failure the row reappears with a toast explaining the archive didn't land.

(Screen recording not attachable from this headless environment; the exact sequence above is asserted by the new tests.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified via the automated tests listed above (new unit/component tests plus the full web suite, typecheck, lint, and pre-commit hooks); no manual browser run was performed from this environment.

## Changelog

Archiving a session now removes it from the sidebar instantly instead of waiting for a server round-trip

This pull request and its description were written by Isaac.
