### PR TITLE
fix(server): only fail a session when a runner drop interrupts a turn

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2538,7 +2538,7 @@ async def _mark_runner_sessions_offline_impl(
         # turn edges), falling back to the row for a session whose live state
         # was published before a restart.
         live = _session_status_cache.get(conv.id, conv.live_status)
-        interrupted = live in ("running", "waiting")
+        interrupted = live in _MID_TURN_STATUSES
         dead_on_arrival = fail_idle_top_level and conv.kind != "sub_agent"
         if not interrupted and not dead_on_arrival:
             continue
@@ -5554,6 +5554,12 @@ async def _dispatch_session_event_to_runner_impl(
 RUNNER_DISCONNECT_GRACE_S: float = 10.0
 # Delay between relay stream reconnect attempts inside the grace window.
 _RELAY_RETRY_INTERVAL_S: float = 0.5
+# Session statuses that mean a turn was in flight. A runner going away
+# only interrupts work in one of these states; from any other state the
+# departure is a benign disconnect, carried by liveness rather than a
+# failure. ``waiting`` counts because the turn's background work (shells,
+# sub-agents) outlives the turn and dies with the runner.
+_MID_TURN_STATUSES = ("running", "waiting")
 
 
 class _RelayTransportLost(Exception):
@@ -5569,6 +5575,31 @@ class _RelayTransportLost(Exception):
         self.intentional = intentional
 
 
+async def _runner_drop_interrupted_turn(
+    session_id: str,
+    conversation_store: ConversationStore,
+) -> bool:
+    """
+    Report whether a departing runner caught this session mid-turn.
+
+    Prefers the relay-fed cache — the replica holding the runner's tunnel
+    saw the turn edges — and falls back to the row for a session whose live
+    state was published before a restart, so a deploy mid-turn does not
+    downgrade a real interruption to a benign one.
+
+    :param session_id: Session/conversation identifier,
+        e.g. ``"conv_abc123"``.
+    :param conversation_store: Store used to read the durable live status.
+    :returns: ``True`` when a turn was in flight
+        (:data:`_MID_TURN_STATUSES`).
+    """
+    cached = _session_status_cache.get(session_id)
+    if cached is not None:
+        return cached in _MID_TURN_STATUSES
+    conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+    return conv is not None and conv.live_status in _MID_TURN_STATUSES
+
+
 async def _relay_runner_stream(
     session_id: str,
     runner_client: httpx.AsyncClient,
@@ -5581,9 +5612,14 @@ async def _relay_runner_stream(
     Transport drops from ingress recycles and sleep-wake reconnects
     re-register the runner within :data:`RUNNER_DISCONNECT_GRACE_S`, so a
     lost stream retries inside that window instead of failing the
-    session. The ``failed`` status (with durable ``runner_disconnected``
-    labels) publishes only when the runner stays gone past the grace; an
-    intentional Stop still exits quietly at once.
+    session. An intentional Stop exits quietly at once.
+
+    Past the grace the runner is genuinely gone, and only a session it
+    caught mid-turn (:func:`_runner_drop_interrupted_turn`) gets the
+    ``failed`` status and durable ``runner_disconnected`` labels — the same
+    rule :func:`_mark_runner_sessions_offline_impl` applies to the runner's
+    other sessions. An idle session had no work to interrupt, so it stays
+    idle and the disconnect surfaces through liveness instead.
 
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
@@ -5638,6 +5674,20 @@ async def _relay_runner_stream(
                     session_id,
                     None,
                     conversation_store,
+                )
+            elif not await _runner_drop_interrupted_turn(session_id, conversation_store):
+                # The runner went away while this session sat idle (host
+                # asleep, host restart, `omnigent host` stopped). Nothing was
+                # interrupted, so there is no error to report: publishing one
+                # lit a red "connection to the host dropped" banner over a
+                # session that had simply finished its last turn. The absence
+                # is already carried by liveness (``clear_runner_liveness``),
+                # which drives the reconnect affordance. Stay silent — no
+                # status edge, and no clearing of labels either, so a genuine
+                # earlier failure keeps its error.
+                _logger.info(
+                    "Relay: runner gone for idle session=%s; no failure to report",
+                    session_id,
                 )
             else:
                 # Publish a failed status so the client's SSE stream sees a

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5587,17 +5587,34 @@ async def _runner_drop_interrupted_turn(
     state was published before a restart, so a deploy mid-turn does not
     downgrade a real interruption to a benign one.
 
+    An unreadable or missing row leaves the question open, and this runs
+    inside the disconnect handler: answering "not mid-turn" there would
+    both swallow the failure and let the error escape the handler, killing
+    the relay without publishing anything — the silent truncation the
+    failed status exists to prevent. So an indeterminate answer reports the
+    drop, as the ungated relay always did.
+
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
     :param conversation_store: Store used to read the durable live status.
     :returns: ``True`` when a turn was in flight
-        (:data:`_MID_TURN_STATUSES`).
+        (:data:`_MID_TURN_STATUSES`) or the state is indeterminate.
     """
     cached = _session_status_cache.get(session_id)
     if cached is not None:
         return cached in _MID_TURN_STATUSES
-    conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
-    return conv is not None and conv.live_status in _MID_TURN_STATUSES
+    try:
+        conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+    except Exception:  # noqa: BLE001 — an unreadable row must not kill the relay
+        _logger.warning(
+            "Relay: live-status read failed for session=%s; reporting the drop",
+            session_id,
+            exc_info=True,
+        )
+        return True
+    if conv is None:
+        return True
+    return conv.live_status in _MID_TURN_STATUSES
 
 
 async def _relay_runner_stream(

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -1520,10 +1520,17 @@ async def test_on_runner_disconnect_spares_idle_sessions_and_labels_interrupted_
         await communicator.send_input({"type": "websocket.disconnect", "code": 1006})
 
         async def _hook_ran() -> None:
-            while sessions_module._session_status_cache.get(running_id) != "failed":
+            # The hook publishes the status first and persists the labels on
+            # a later await, so wait for the labels — the end state asserted
+            # below — instead of the status flip that precedes them.
+            while True:
+                conv = store.get_conversation(running_id)
+                if conv is not None and sessions_module._last_task_error_from_labels(conv.labels):
+                    return
                 await asyncio.sleep(0.01)
 
         await asyncio.wait_for(_hook_ran(), timeout=5.0)
+        assert sessions_module._session_status_cache.get(running_id) == "failed"
 
         # The interrupted turn is failed AND carries the cause, so the client
         # renders a recoverable "Disconnected" and recovery can clear it.

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -426,7 +426,7 @@ async def test_relay_publishes_failed_status_on_tunnel_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A tunnel close mid-stream publishes ``session.status`` "failed".
+    A tunnel close mid-TURN publishes ``session.status`` "failed".
 
     Regression test for #1114: before the fix the relay swallowed the
     ``ConnectionError`` and exited silently, leaving the client's SSE
@@ -444,6 +444,10 @@ async def test_relay_publishes_failed_status_on_tunnel_close(
     gate = asyncio.Event()
     fake_runner = _TunnelCloseRunnerClient(gate)
     session_id = "03048a276e8a91fab748c87a77d638bf"
+    # A turn is in flight — the state #1114 is about. Only an interrupted
+    # turn is failed by the drop; an idle session stays quiet (see
+    # test_relay_stays_quiet_when_runner_leaves_an_idle_session).
+    sessions_module._session_status_cache[session_id] = "running"
 
     collector = None
     try:
@@ -478,6 +482,7 @@ async def test_relay_publishes_failed_status_on_tunnel_close(
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
                 await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
 
 
@@ -492,19 +497,24 @@ class _RecordingLabelStore:
     persisted disconnect code, so both are implemented here.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, live_status: str = "idle") -> None:
         self.labels: dict[str, dict[str, str]] = {}
+        self.live_status = live_status
 
     def set_labels(self, conversation_id: str, updates: dict[str, str]) -> None:
         self.labels.setdefault(conversation_id, {}).update(updates)
 
     def get_conversation(self, conversation_id: str) -> Any:
-        """Return a conversation-shaped object exposing ``.labels``.
+        """Return a conversation-shaped object exposing the read fields.
 
-        Only ``.labels`` is read by the recovery guard, so a lightweight
-        namespace over the recorded labels is enough.
+        ``.labels`` is read by the recovery guard and ``.live_status`` by
+        the mid-turn check when the in-memory status cache is cold, so a
+        lightweight namespace over both is enough.
         """
-        return SimpleNamespace(labels=dict(self.labels.get(conversation_id, {})))
+        return SimpleNamespace(
+            labels=dict(self.labels.get(conversation_id, {})),
+            live_status=self.live_status,
+        )
 
 
 @pytest.mark.asyncio
@@ -512,7 +522,7 @@ async def test_relay_persists_disconnect_error_labels_on_tunnel_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A tunnel close persists the ``runner_disconnected`` cause as labels.
+    A tunnel close mid-turn persists the ``runner_disconnected`` cause as labels.
 
     Option B: a runner that merely disconnected must be distinguishable
     from a genuine task failure. The relay-fed status cache only carries a
@@ -534,6 +544,8 @@ async def test_relay_persists_disconnect_error_labels_on_tunnel_close(
     fake_runner = _TunnelCloseRunnerClient(gate)
     store = _RecordingLabelStore()
     session_id = "82fe36b7ca1bfb567bfbcce4eaa487a1"
+    # Only an interrupted turn is failed by the drop, so put one in flight.
+    sessions_module._session_status_cache[session_id] = "running"
 
     try:
         handle = await sessions_module._ensure_runner_relay_ready(
@@ -571,6 +583,7 @@ async def test_relay_persists_disconnect_error_labels_on_tunnel_close(
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
                 await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
 
 
@@ -603,6 +616,9 @@ async def test_runner_recovery_clears_persisted_disconnect_error_labels(
     fake_runner = _TunnelCloseRunnerClient(gate)
     store = _RecordingLabelStore()
     session_id = "51af098ee822b1a024acb911f3cdf297"
+    # A turn in flight, so the drop below is a genuine interruption and the
+    # relay persists the labels this test then asserts recovery clears.
+    sessions_module._session_status_cache[session_id] = "running"
 
     try:
         # Disconnect first: the relay persists the runner_disconnected
@@ -850,6 +866,139 @@ async def test_relay_running_edge_clears_stale_intentional_stop_marker(
         sessions_module._intentional_stop_sessions.discard(session_id)
         if collector is not None:
             await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_relay_stays_quiet_when_runner_leaves_an_idle_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A runner leaving an idle session is not an error.
+
+    A host going away (asleep, restarted, ``omnigent host`` stopped) drops
+    the tunnel of every session bound to it, including ones that finished
+    their last turn hours ago. The relay used to fail all of them, so those
+    sessions rendered a red "The connection to the host dropped
+    unexpectedly" banner over a transcript where nothing had been
+    interrupted. Scripts a completed turn (``running`` then ``idle``) before
+    the drop and asserts the relay publishes no failure and persists no
+    error labels — the disconnect surfaces through liveness instead.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.RUNNER_DISCONNECT_GRACE_S",
+        0.0,
+    )
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    frames = [
+        'data: {"type": "session.status", "status": "running"}\n\n',
+        'data: {"type": "session.status", "status": "idle"}\n\n',
+    ]
+    fake_runner = _ScriptedThenDropRunnerClient(frames, gate)
+    store = _RecordingLabelStore()
+    session_id = "1e2d3c4b5a69788796a5b4c3d2e1f0a9"
+
+    collector = None
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_idle_disconnect",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        collector = await start_session_stream_collector(session_id)
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        statuses = []
+        while not collector.queue.empty():
+            statuses.append(await collector.queue.get())
+        assert [e.get("status") for e in statuses if e.get("type") == "session.status"] == [
+            "running",
+            "idle",
+        ], f"expected only the scripted turn edges, saw {statuses}"
+
+        # The session stays idle: no failed edge for the sidebar badge, and
+        # no durable labels for the snapshot to project as a last_task_error
+        # (which is what synthesizes the transcript's error block on reload).
+        assert sessions_module._session_status_cache.get(session_id) == "idle"
+        assert sessions_module._last_task_error_from_labels(store.labels[session_id]) is None
+    finally:
+        gate.set()
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_relay_fails_mid_turn_session_from_the_row_when_the_cache_is_cold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A cold status cache falls back to the row, so a restart keeps the failure.
+
+    The in-memory status cache is per-replica and empty after a restart, but
+    the relay is re-established for sessions that were mid-turn when the
+    server went down (a deploy). Reading only the cache would classify that
+    session as idle and swallow a real interruption, leaving the turn hung
+    with no error. The durable ``live_status`` on the row is the fallback,
+    matching ``_mark_runner_sessions_offline_impl``.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.RUNNER_DISCONNECT_GRACE_S",
+        0.0,
+    )
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    # No status frames: the relay never caches an edge, exactly as after a
+    # restart. The row carries the mid-turn state instead.
+    fake_runner = _ScriptedThenDropRunnerClient([], gate)
+    store = _RecordingLabelStore(live_status="running")
+    session_id = "0f9e8d7c6b5a49382716253445362718"
+
+    try:
+        assert sessions_module._session_status_cache.get(session_id) is None
+
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_cold_cache",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        assert sessions_module._session_status_cache.get(session_id) == "failed"
+        persisted = sessions_module._last_task_error_from_labels(store.labels[session_id])
+        assert persisted is not None
+        assert persisted["code"] == "runner_disconnected"
+    finally:
+        gate.set()
         handle = sessions_module._runner_relay_tasks.get(session_id)
         if handle is not None and not handle.task.done():
             handle.task.cancel()

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -745,8 +745,8 @@ class _ScriptedThenDropStreamResponse:
 
     :param frames: Ready-to-send ``data: ...`` frames yielded in order
         before the tunnel drop.
-    :param gate: Event the test sets once subscribed, gating the drop so
-        the collector observes every scripted frame first.
+    :param gate: Event the test sets once subscribed, gating the frames and
+        the drop so the collector observes every scripted frame.
     """
 
     def __init__(self, frames: list[str], gate: asyncio.Event) -> None:
@@ -765,10 +765,14 @@ class _ScriptedThenDropStreamResponse:
         del exc_type, exc, traceback
 
     async def aiter_text(self) -> AsyncIterator[str]:
+        # The heartbeat comes first so the caller's readiness wait resolves,
+        # then everything else waits for the gate: a frame yielded before the
+        # test subscribes would be published to nobody, making assertions on
+        # the relayed events scheduler-dependent.
         yield 'data: {"type": "session.heartbeat"}\n\n'
+        await self._gate.wait()
         for frame in self._frames:
             yield frame
-        await self._gate.wait()
         raise ConnectionError("tunnel closed before request completed")
 
 
@@ -923,9 +927,12 @@ async def test_relay_stays_quiet_when_runner_leaves_an_idle_session(
         gate.set()
         await asyncio.wait_for(handle.task, timeout=2.0)
 
-        statuses = []
-        while not collector.queue.empty():
-            statuses.append(await collector.queue.get())
+        # Wait for each edge rather than draining a snapshot: the quiet path
+        # publishes nothing and awaits nothing, so the relay task can finish
+        # before the collector's pump is ever scheduled.
+        statuses: list[dict[str, Any]] = []
+        while len([e for e in statuses if e.get("type") == "session.status"]) < 2:
+            statuses.append(await asyncio.wait_for(collector.queue.get(), timeout=2.0))
         assert [e.get("status") for e in statuses if e.get("type") == "session.status"] == [
             "running",
             "idle",
@@ -934,6 +941,8 @@ async def test_relay_stays_quiet_when_runner_leaves_an_idle_session(
         # The session stays idle: no failed edge for the sidebar badge, and
         # no durable labels for the snapshot to project as a last_task_error
         # (which is what synthesizes the transcript's error block on reload).
+        # The cache is written only by ``_publish_status``, so ``idle`` here
+        # also proves no failure edge followed the scripted ones.
         assert sessions_module._session_status_cache.get(session_id) == "idle"
         assert sessions_module._last_task_error_from_labels(store.labels[session_id]) is None
     finally:
@@ -993,6 +1002,70 @@ async def test_relay_fails_mid_turn_session_from_the_row_when_the_cache_is_cold(
         gate.set()
         await asyncio.wait_for(handle.task, timeout=2.0)
 
+        assert sessions_module._session_status_cache.get(session_id) == "failed"
+        persisted = sessions_module._last_task_error_from_labels(store.labels[session_id])
+        assert persisted is not None
+        assert persisted["code"] == "runner_disconnected"
+    finally:
+        gate.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+async def test_relay_reports_the_drop_when_the_live_status_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An unreadable row reports the drop instead of killing the relay.
+
+    The cold-cache fallback reads the row from inside the disconnect
+    handler. A store error there must not escape: an exception thrown out of
+    that handler ends the relay task before either branch publishes,
+    truncating the client's stream with no error event — exactly what the
+    ``failed`` status exists to prevent. An indeterminate answer therefore
+    reports the drop, as the ungated relay always did.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.RUNNER_DISCONNECT_GRACE_S",
+        0.0,
+    )
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _ScriptedThenDropRunnerClient([], gate)
+    store = _RecordingLabelStore()
+    monkeypatch.setattr(
+        store,
+        "get_conversation",
+        lambda conversation_id: (_ for _ in ()).throw(RuntimeError("db blip")),
+    )
+    session_id = "abcdef0123456789abcdef0123456789"
+
+    try:
+        assert sessions_module._session_status_cache.get(session_id) is None
+
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_unreadable_row",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        # The relay survived the store error and still reported the cause.
+        assert handle.task.exception() is None
         assert sessions_module._session_status_cache.get(session_id) == "failed"
         persisted = sessions_module._last_task_error_from_labels(store.labels[session_id])
         assert persisted is not None


### PR DESCRIPTION
## Related issue

Part of #1528 (§b — "server keeps idle disconnect from failing the session"). Not
a full close: the umbrella also covers the idle-exit sentinel, host-side benign
exit suppression, and calm rendering in the web Subagents panel.

Overlaps the older, stale #2645, which fixed the same two publish paths before
`sessions.py` was decomposed. Differences noted at the bottom.

## Summary

A session that had **finished** its last turn rendered a red **"The connection to
the host dropped unexpectedly. / Runner disconnected unexpectedly."** banner in the
transcript whenever the host went away — asleep, restarted, or `omnigent host`
stopped. Nothing had been interrupted.

Two server paths react to a runner tunnel dropping, and they disagreed:

- `_mark_runner_sessions_offline_impl` already failed only sessions whose live
  status was `running` / `waiting` — that gate exists because a runner drop used to
  paint the whole Agents rail red for sub-agents that had *completed successfully*.
- `_relay_runner_stream` failed the session on **any** tunnel close. Its stream
  stays subscribed while the session is idle (the runner heartbeats every 15s), so
  every idle bound session published `failed` plus durable `runner_disconnected`
  labels once the 10s reconnect grace expired.

Both paths now share one predicate, `_MID_TURN_STATUSES`. An idle drop publishes
nothing **and clears nothing**, so a genuine earlier failure keeps its error. The
resolution falls back to the durable `live_status` on the row when the per-replica
status cache is cold, so a deploy mid-turn doesn't downgrade a real interruption to
a benign one.

Nothing is lost by the silence: `useSessionLiveness` derives the disconnect
independently from `runner_online` / `host_online`, never from session status, so
the session still gets its calm "Host is offline" / "Agent disconnected" reconnect
affordance.

**ELI5:** The work had already finished. Then the machine running it went to sleep.
The server noticed the helper vanish and stamped the finished job "failed", so the
chat grew a red error box about work that had succeeded. Now the server checks
whether a turn was actually in flight before blaming the disconnect.

```text
                       ┌─ turn in flight (running/waiting) ─→ failed + runner_disconnected
host goes away ─→ 10s grace ─┤                                     (unchanged: #1114 stays fixed)
                       └─ idle ─────────────────────────────→ silent; liveness shows
                                                              "Host is offline" + reconnect

Before:  last turn OK ─→ host sleeps ─→ red "connection to the host dropped" banner
After:   last turn OK ─→ host sleeps ─→ stays idle, reconnect affordance only
```

## Test Plan

Unit / integration:

```bash
uv run pytest tests/server/routes/test_sessions_runner_relay.py \
              tests/server/test_session_live_state.py \
              tests/server/integration/test_sessions_tunnel_three_layer.py
```

- **New** `test_relay_stays_quiet_when_runner_leaves_an_idle_session` — scripts a
  completed turn (`running` → `idle`), drops the tunnel, asserts no `failed` edge
  and no persisted error labels. Verified non-vacuous: with the gate disabled it
  fails with `['running','idle','failed'] == ['running','idle']`.
- **New** `test_relay_fails_mid_turn_session_from_the_row_when_the_cache_is_cold` —
  cold cache + `live_status="running"` row still fails with `runner_disconnected`
  (the restart-mid-turn case).
- **Updated** the three existing relay-disconnect tests to seed the mid-turn
  precondition explicitly (`_session_status_cache = "running"`). They previously
  dropped the tunnel with an *empty* cache, so they'd have silently started
  exercising the new quiet path; the #1114 mid-turn assertion is what they were
  written for, and it's now stated rather than implied.
- **Fixed a pre-existing race** in
  `test_on_runner_disconnect_spares_idle_sessions_and_labels_interrupted_ones`: it
  waited on the status flip, which `_mark_runner_sessions_offline_impl` publishes
  *before* the labels the test then asserts. Reproduced at HEAD without this change
  (1 failure in 5 full-file runs); now waits on the labels. 6/6 green after.

Manual, on a host-backed session:

1. Let a turn finish (session idle, no spinner), then `Ctrl-C` the `omnigent host`
   process or sleep the laptop. Past the 10s grace: **no red banner**; the
   "Agent disconnected" / "Host is offline" reconnect UI appears instead. Reload —
   still clean, since the labels the snapshot projects were never written.
2. Contrast, which must still error: send a message so a turn is running, then kill
   the host mid-turn. The red banner still appears and survives a reload.
3. Bring the host back and reconnect — a mid-turn failure clears via
   `_publish_runner_recovered_status`, as before.

Also ran the repo pre-commit hooks over the changed files (`ruff format`,
`ruff check`, secret scan, and the custom hooks all pass).

## Demo

N/A — server-side change, no frontend code touched. The user-visible effect is the
*absence* of the banner; see the before/after in the Summary diagram.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two behaviours are worth a reviewer's eye:

1. **Native mid-turn lull.** For native harnesses the PTY-activity watcher can
   publish a bare `idle` during a lull inside a turn. A host death in exactly that
   window is now silent where it previously errored. The "Working…" spinner reads
   `sessionStatus` 1:1 and is already off in that state, so the old banner
   contradicted what was on screen — and `_mark_runner_sessions_offline_impl`
   already skipped that same session today.
2. **Dispatch window.** The `running` edge comes from the runner's own SSE, not
   from dispatch, so a tunnel that drops within milliseconds of dispatch *and*
   stays down for the full 10s grace leaves the cache at the previous `idle`. This
   window is not new — #2645 shares it, since the cached status there is also
   `idle` — and closing it needs a server-published dispatch edge, which is out of
   scope here.

## Relationship to #2645

Same diagnosis, arrived at from the UI side (a red banner on an idle host-backed
session) rather than the bwrap `--as-pid-1` one-shot case. Three differences:

- **Rebased on the decomposition.** #2645 patches `server/routes/sessions.py` and
  `server/app.py`, which have since been split into
  `server/routes/_sessions/orchestration.py`; the app-level gate it adds already
  landed there as `_mark_runner_sessions_offline_impl`. This PR only has to fix the
  remaining relay path.
- **One shared predicate** instead of two independent status checks, so the two
  paths can't drift apart again.
- **Durable fallback.** #2645 reads only the in-memory cache and fails on a cold
  one. That's backwards for the restart case: the cache is empty after a deploy
  while the row still says `running`, so the mid-turn signal lives on the row.
  Covered by the new cold-cache test.

Happy to close this in favour of a rebased #2645 if @rsclafani would rather carry
it — the delta above is the part worth keeping either way.

## Changelog

A host going to sleep or restarting no longer shows a "connection to the host
dropped" error on sessions that had already finished their work.
