### PR TITLE
test(antigravity): wait for quiescence poll progress

### DIFF
--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -4826,10 +4826,14 @@ async def test_the_quiescence_recheck_backs_off_after_agy_vetoes_a_close(
     """
     polls = 0
     idle_checks = 0
+    reached_target = asyncio.Event()
+    loop = asyncio.get_running_loop()
 
     def _steps(_port: int, _cascade: str) -> list[dict[str, Any]]:
         nonlocal polls
         polls += 1
+        if polls == 30:
+            loop.call_soon_threadsafe(reached_target.set)
         return [_load("user_input")]  # turn open, never another step
 
     def _still_running(_port: int) -> dict[str, Any]:
@@ -4854,13 +4858,12 @@ async def test_the_quiescence_recheck_backs_off_after_agy_vetoes_a_close(
                 child_session_id="conv_child_a",
             )
         )
-        deadline = 0
-        while polls < 30 and deadline < 10_000:
-            deadline += 1
-            await asyncio.sleep(0)
-        mirror.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await mirror
+        try:
+            await asyncio.wait_for(reached_target.wait(), timeout=_MIRROR_HANG_GUARD_S)
+        finally:
+            mirror.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await mirror
 
     assert polls >= 30, f"the mirror should have kept polling a vetoed child; got {polls}"
     # Windows of 2, 4, 8, 16 reach poll 30 in four checks; a flat window would


### PR DESCRIPTION
## Related issue

N/A — test-only reliability fix.

## Summary

- Prevent the quiescence backoff regression test from exhausting an event-loop iteration budget while its polls are still completing in worker threads.
- Signal the async test when the target poll count is reached and always cancel its mirror task during cleanup.

## Test Plan

- `uv run pytest tests/test_antigravity_native_reader.py::test_the_quiescence_recheck_backs_off_after_agy_vetoes_a_close -q`
- `uv run ruff check tests/test_antigravity_native_reader.py`
- Repository pre-commit hooks passed during commit.

## Demo

N/A — non-visual test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated unit test exercises the existing quiescence recheck backoff behavior with deterministic cross-thread synchronization.
