### PR TITLE
fix(web): migrate useResizableColumn to pointer events with keyboard resize (touch P0)

### DIFF
--- a/tests/e2e_ui/shells/test_terminals_column_resize.py
+++ b/tests/e2e_ui/shells/test_terminals_column_resize.py
@@ -1,0 +1,167 @@
+"""E2E: resizing the terminals-panel list column by pointer and keyboard.
+
+The full-screen Shells panel (``TerminalsPanel``) splits into a terminal
+list column and an xterm pane on desktop, divided by a draggable handle
+(``useResizableColumn``). The handle is a pointer-events separator: it
+captures the pointer on pointerdown (so drags keep tracking off the thin
+strip), carries ``touch-action: none`` plus an invisible widened hit
+target for touch, and is a focusable ARIA separator resizable with
+ArrowLeft/ArrowRight under the same 100–480px clamps as dragging.
+
+The panel's only UI entry point is the mobile Shells drawer (desktop
+opens shells as rail tabs instead), while the column split needs a
+desktop viewport — so the test opens the panel at a phone viewport and
+then widens the window, which is also a real tablet-rotation scenario
+the handle must survive.
+
+Terminals are launched over REST (the same runner path as
+``sys_terminal_launch``) so no LLM turn is involved and the flow is
+deterministic.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+from playwright.sync_api import Page, ViewportSize, expect
+
+# Below Tailwind's ``md`` (768px) so the FAB/mobile drawer renders.
+_MOBILE_VIEWPORT: ViewportSize = {"width": 390, "height": 844}
+# Comfortably above ``md`` so the panel splits into list + xterm columns.
+_DESKTOP_VIEWPORT: ViewportSize = {"width": 1400, "height": 900}
+
+# useResizableColumn defaults: initial 176, clamps [100, 480], 20px/keypress.
+_DEFAULT_WIDTH = 176
+_KEY_STEP = 20
+_DRAG_TARGET_WIDTH = 256
+
+
+def _launch_terminal(base_url: str, session_id: str, session_key: str) -> None:
+    """Launch an agent-declared ``zsh`` terminal via REST (no LLM turn)."""
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/resources/terminals",
+        json={"terminal": "zsh", "session_key": session_key},
+        timeout=60.0,
+    )
+    resp.raise_for_status()
+
+
+def _open_terminals_panel_on_desktop(page: Page, base_url: str, session_id: str) -> None:
+    """Open the full-screen Shells panel, then widen to a desktop viewport.
+
+    Mobile flow (FAB → Shells drawer → tap the ``main`` shell row) is the
+    panel's entry point; the subsequent viewport widening flips the panel
+    into its desktop list/xterm split where the column handle renders.
+    """
+    page.set_viewport_size(_MOBILE_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    page.get_by_role("button", name="Open session menu").click()
+    # Accessible name includes the shell-count badge (e.g. "Shells 2").
+    shells_entry = page.get_by_role("menuitem", name=re.compile(r"^Shells\b"))
+    expect(shells_entry).to_be_visible(timeout=10_000)
+    shells_entry.click()
+
+    drawer = page.get_by_test_id("shells-panel-drawer")
+    expect(drawer).to_have_attribute("data-state", "open")
+    row = drawer.get_by_role("button").filter(has_text="main").filter(has_text="zsh")
+    expect(row.first).to_be_visible(timeout=30_000)
+    row.first.click()
+
+    panel = page.get_by_test_id("terminals-panel")
+    expect(panel).to_have_attribute("data-state", "open")
+
+    page.set_viewport_size(_DESKTOP_VIEWPORT)
+
+
+def _separator(page: Page):
+    """The column-resize handle, scoped to the terminals panel."""
+    return page.get_by_test_id("terminals-panel").get_by_role(
+        "separator", name="Resize terminal list"
+    )
+
+
+def _list_panel_width(page: Page) -> float:
+    """Measured width of the terminal-list column (the handle's next sibling)."""
+    return _separator(page).evaluate("el => el.nextElementSibling.getBoundingClientRect().width")
+
+
+def test_terminals_column_resizes_by_pointer_and_keyboard(
+    page: Page,
+    terminal_session: tuple[str, str],
+) -> None:
+    """Drag, keyboard-resize, and row-tap isolation of the list column.
+
+    One flow (panel setup is the expensive part): drag the handle to a new
+    width and verify it sticks after release, step it with arrow keys on
+    the focused separator, and confirm interactions with adjacent list
+    rows — tapping a row, wheel-scrolling over the list — never resize.
+    """
+    base_url, session_id = terminal_session
+    # Two shells so the negative row-tap check can select a non-active row
+    # (tapping the active row toggles the xterm closed, hiding the handle).
+    _launch_terminal(base_url, session_id, "main")
+    _launch_terminal(base_url, session_id, "aux")
+
+    _open_terminals_panel_on_desktop(page, base_url, session_id)
+
+    handle = _separator(page)
+    expect(handle).to_be_visible(timeout=30_000)
+
+    # Touch affordance: competing gestures must not pan/zoom during a drag.
+    assert handle.evaluate("el => getComputedStyle(el).touchAction") == "none"
+    expect(handle).to_have_attribute("aria-valuenow", str(_DEFAULT_WIDTH))
+    assert abs(_list_panel_width(page) - _DEFAULT_WIDTH) < 2
+
+    # --- Pointer drag: press on the handle, pull right, release. The width
+    # follows the pointer (measured from the split row's left edge) and the
+    # new width persists after the pointer lifts. hover() first: the panel
+    # slides in (translate transition), and hover's actionability check waits
+    # for the handle's position to stabilize before we read its box.
+    handle.hover()
+    box = handle.bounding_box()
+    assert box is not None, "resize handle should have a bounding box"
+    container_left = handle.evaluate("el => el.parentElement.getBoundingClientRect().left")
+    start_y = box["y"] + box["height"] / 2
+    page.mouse.move(box["x"] + box["width"] / 2, start_y)
+    page.mouse.down()
+    page.mouse.move(container_left + _DRAG_TARGET_WIDTH, start_y, steps=8)
+    page.mouse.up()
+
+    expect(handle).to_have_attribute("aria-valuenow", str(_DRAG_TARGET_WIDTH))
+    assert abs(_list_panel_width(page) - _DRAG_TARGET_WIDTH) < 2
+
+    # Persists after release: pointer movement without a pressed button
+    # must not keep resizing (the drag really ended on pointerup).
+    page.mouse.move(container_left + 400, start_y)
+    expect(handle).to_have_attribute("aria-valuenow", str(_DRAG_TARGET_WIDTH))
+
+    # --- Keyboard: the handle is a focusable separator; arrow keys step the
+    # width by 20px under the same clamps as dragging.
+    handle.focus()
+    page.keyboard.press("ArrowLeft")
+    expect(handle).to_have_attribute("aria-valuenow", str(_DRAG_TARGET_WIDTH - _KEY_STEP))
+    page.keyboard.press("ArrowRight")
+    page.keyboard.press("ArrowRight")
+    keyboard_width = _DRAG_TARGET_WIDTH + _KEY_STEP
+    expect(handle).to_have_attribute("aria-valuenow", str(keyboard_width))
+    assert abs(_list_panel_width(page) - keyboard_width) < 2
+
+    # --- Negative: interacting with the list next to the handle must not
+    # resize. Tapping the ``aux`` row (its center, well clear of the handle's
+    # invisible hit pad at the column boundary) selects that shell...
+    panel = page.get_by_test_id("terminals-panel")
+    aux_row = panel.get_by_role("button").filter(has_text="aux").filter(has_text="zsh")
+    expect(aux_row.first).to_be_visible()
+    aux_row.first.click()
+    expect(aux_row.first).to_have_class(re.compile("bg-accent"))  # now active
+
+    # ...and a wheel scroll over the list is plain scrolling, not a resize.
+    row_box = aux_row.first.bounding_box()
+    assert row_box is not None
+    page.mouse.move(row_box["x"] + row_box["width"] / 2, row_box["y"] + 5)
+    page.mouse.wheel(0, 120)
+
+    expect(handle).to_have_attribute("aria-valuenow", str(keyboard_width))
+    assert abs(_list_panel_width(page) - keyboard_width) < 2

--- a/tests/e2e_ui/shells/test_terminals_column_resize.py
+++ b/tests/e2e_ui/shells/test_terminals_column_resize.py
@@ -22,6 +22,7 @@ deterministic.
 from __future__ import annotations
 
 import re
+import time
 
 import httpx
 from playwright.sync_api import Page, ViewportSize, expect
@@ -48,6 +49,44 @@ def _launch_terminal(base_url: str, session_id: str, session_key: str) -> None:
     resp.raise_for_status()
 
 
+def _force_chat_first(base_url: str, session_id: str, timeout_s: float = 15.0) -> None:
+    """Pin the session to the chat-first presentation before the page loads.
+
+    When the runner starts hosting an SDK session it auto-creates an
+    embedded Omnigent REPL terminal and stamps ``omnigent.ui: terminal``
+    on the session. A session carrying that label renders terminal-first:
+    tapping a shell row opens the shell in the MAIN view and the
+    full-screen ``TerminalsPanel`` (the surface with the resizable column
+    split under test) never mounts — so whether this test's entry path
+    works depends on a race between the runner's stamp and the page load.
+    Wait briefly for the one-time stamp (the terminal launches already
+    forced the runner's session init, which runs the REPL ensure + stamp
+    inline, so it lands within seconds when it lands at all), then delete
+    the label (empty value clears it; the runner never re-stamps — the
+    REPL-terminal ensure is guarded) so the entry path is
+    deterministically chat-first.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/labels", timeout=10.0)
+        resp.raise_for_status()
+        if resp.json().get("labels", {}).get("omnigent.ui") == "terminal":
+            break
+        time.sleep(0.5)
+    # Delete regardless: if the stamp never landed (REPL creation failed,
+    # a logged warning path that also never retries), the label is simply
+    # absent and the delete is a no-op — either way chat-first from here.
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.ui": ""}},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/labels", timeout=10.0)
+    resp.raise_for_status()
+    assert resp.json().get("labels", {}).get("omnigent.ui") != "terminal"
+
+
 def _open_terminals_panel_on_desktop(page: Page, base_url: str, session_id: str) -> None:
     """Open the full-screen Shells panel, then widen to a desktop viewport.
 
@@ -58,7 +97,9 @@ def _open_terminals_panel_on_desktop(page: Page, base_url: str, session_id: str)
     page.set_viewport_size(_MOBILE_VIEWPORT)
     page.goto(f"{base_url}/c/{session_id}")
 
-    page.get_by_role("button", name="Open session menu").click()
+    fab = page.get_by_role("button", name="Open session menu")
+    expect(fab).to_be_visible(timeout=15_000)
+    fab.click()
     # Accessible name includes the shell-count badge (e.g. "Shells 2").
     shells_entry = page.get_by_role("menuitem", name=re.compile(r"^Shells\b"))
     expect(shells_entry).to_be_visible(timeout=10_000)
@@ -104,6 +145,7 @@ def test_terminals_column_resizes_by_pointer_and_keyboard(
     # (tapping the active row toggles the xterm closed, hiding the handle).
     _launch_terminal(base_url, session_id, "main")
     _launch_terminal(base_url, session_id, "aux")
+    _force_chat_first(base_url, session_id)
 
     _open_terminals_panel_on_desktop(page, base_url, session_id)
 

--- a/tests/e2e_ui/shells/test_terminals_column_resize.py
+++ b/tests/e2e_ui/shells/test_terminals_column_resize.py
@@ -34,6 +34,7 @@ _DESKTOP_VIEWPORT: ViewportSize = {"width": 1400, "height": 900}
 # useResizableColumn defaults: initial 176, clamps [100, 480], 20px/keypress.
 _DEFAULT_WIDTH = 176
 _KEY_STEP = 20
+_MAX_WIDTH = 480
 _DRAG_TARGET_WIDTH = 256
 
 
@@ -148,6 +149,16 @@ def test_terminals_column_resizes_by_pointer_and_keyboard(
     expect(handle).to_have_attribute("aria-valuenow", str(keyboard_width))
     assert abs(_list_panel_width(page) - keyboard_width) < 2
 
+    # Clamp: enough presses to overshoot maxWidth (480) pin the width there;
+    # one more press must not push past it.
+    for _ in range((_MAX_WIDTH - keyboard_width) // _KEY_STEP + 2):
+        page.keyboard.press("ArrowRight")
+    expect(handle).to_have_attribute("aria-valuenow", str(_MAX_WIDTH))
+    page.keyboard.press("ArrowRight")
+    expect(handle).to_have_attribute("aria-valuenow", str(_MAX_WIDTH))
+    assert abs(_list_panel_width(page) - _MAX_WIDTH) < 2
+    keyboard_width = _MAX_WIDTH
+
     # --- Negative: interacting with the list next to the handle must not
     # resize. Tapping the ``aux`` row (its center, well clear of the handle's
     # invisible hit pad at the column boundary) selects that shell...
@@ -155,7 +166,9 @@ def test_terminals_column_resizes_by_pointer_and_keyboard(
     aux_row = panel.get_by_role("button").filter(has_text="aux").filter(has_text="zsh")
     expect(aux_row.first).to_be_visible()
     aux_row.first.click()
-    expect(aux_row.first).to_have_class(re.compile("bg-accent"))  # now active
+    # Anchored: the inactive row carries hover:bg-accent/60, which a bare
+    # "bg-accent" substring would also match.
+    expect(aux_row.first).to_have_class(re.compile(r"(?:^|\s)bg-accent(?:\s|$)"))
 
     # ...and a wheel scroll over the list is plain scrolling, not a resize.
     row_box = aux_row.first.bounding_box()

--- a/web/src/hooks/useResizableColumn.test.tsx
+++ b/web/src/hooks/useResizableColumn.test.tsx
@@ -113,6 +113,55 @@ describe("useResizableColumn pointer dragging", () => {
     expect(document.body.style.cursor).toBe("");
     expect(document.body.style.userSelect).toBe("");
   });
+
+  it("ends the drag via the document fallback when the handle element is gone", () => {
+    const { result } = renderColumn(0);
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(5)));
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    // If the handle unmounts mid-drag (breakpoint flip, terminal exit) its
+    // React handlers never fire — the document-level pointerup fallback must
+    // still end the drag instead of wedging body styles + activePointerId.
+    act(() => {
+      const up = new Event("pointerup");
+      Object.defineProperty(up, "pointerId", { value: 5 });
+      document.dispatchEvent(up);
+    });
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // The drag state is fully released: a fresh pointer can start a new drag.
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(6)));
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(6, 200)));
+    expect(result.current.width).toBe(200);
+    act(() => result.current.handleProps.onPointerUp(pointerEvent(6)));
+  });
+
+  it("stays idle when pointer capture fails", () => {
+    const { result } = renderColumn(0);
+    const failing = pointerEvent(
+      9,
+      0,
+      vi.fn(() => {
+        throw new DOMException("InvalidPointerId");
+      }),
+    );
+
+    act(() => result.current.handleProps.onPointerDown(failing));
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // No drag was armed by the failed capture...
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(9, 300)));
+    expect(result.current.width).toBe(176);
+
+    // ...and a later pointer can still start one.
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(10)));
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(10, 300)));
+    expect(result.current.width).toBe(300);
+    act(() => result.current.handleProps.onPointerUp(pointerEvent(10)));
+  });
 });
 
 describe("useResizableColumn keyboard resizing", () => {
@@ -163,18 +212,35 @@ describe("useResizableColumn keyboard resizing", () => {
 });
 
 describe("useResizableColumn touch affordances", () => {
-  it("disables touch-action and widens the hit target to >=44px without repainting it", () => {
+  // The painted strip the consumer renders is 4px wide (`w-1`); the hit box
+  // is that strip plus the invisible padding on each side.
+  const PAINTED = 4;
+
+  it("disables touch-action and keeps a >=24px hit target on fine pointers", () => {
+    // jsdom's matchMedia never matches "(pointer: coarse)" → fine-pointer pad.
     const { result } = renderColumn(0);
     const style = result.current.handleProps.style;
 
     expect(style.touchAction).toBe("none");
+    expect(style.paddingLeft + PAINTED + style.paddingRight).toBeGreaterThanOrEqual(24);
 
-    // Symmetric padding gives a >=44px hit box; matching negative margins keep
-    // the layout box in place and background-clip keeps the padding unpainted.
-    expect(style.paddingLeft + style.paddingRight).toBeGreaterThanOrEqual(44);
-    expect(style.marginLeft).toBe(-style.paddingLeft);
-    expect(style.marginRight).toBe(-style.paddingRight);
+    // The negative margin anchors the painted strip's right edge to the
+    // consumer-provided `left` boundary; background-clip keeps the pad
+    // unpainted so the visual weight stays a 4px line.
+    expect(style.marginLeft).toBe(-(style.paddingLeft + PAINTED));
     expect(style.backgroundClip).toBe("content-box");
     expect(style.boxSizing).toBe("content-box");
+  });
+
+  it("widens the hit target to >=44px on coarse pointers", () => {
+    const spy = vi.spyOn(window, "matchMedia").mockReturnValue({ matches: true } as MediaQueryList);
+    const { result } = renderColumn(0);
+    const style = result.current.handleProps.style;
+    spy.mockRestore();
+
+    expect(style.paddingLeft + PAINTED + style.paddingRight).toBeGreaterThanOrEqual(44);
+    // Pad biased toward the terminal pane so the list rows' trailing status
+    // badges keep more of their tappable area.
+    expect(style.paddingRight).toBeGreaterThan(style.paddingLeft);
   });
 });

--- a/web/src/hooks/useResizableColumn.test.tsx
+++ b/web/src/hooks/useResizableColumn.test.tsx
@@ -6,10 +6,13 @@ function pointerEvent(
   pointerId: number,
   clientX = 0,
   setPointerCapture = vi.fn(),
+  { button = 0, pointerType = "touch" } = {},
 ): React.PointerEvent & { setPointerCapture: ReturnType<typeof vi.fn> } {
   return {
     pointerId,
     clientX,
+    button,
+    pointerType,
     preventDefault: vi.fn(),
     currentTarget: { setPointerCapture },
     setPointerCapture,
@@ -137,6 +140,26 @@ describe("useResizableColumn pointer dragging", () => {
     expect(result.current.width).toBe(200);
     act(() => result.current.handleProps.onPointerUp(pointerEvent(6)));
   });
+
+  it.each(["mouse", "pen"] as const)(
+    "ignores a secondary-button (%s) pointerdown entirely",
+    (pointerType) => {
+      const { result } = renderColumn(0);
+
+      // Right-click / pen barrel button (button 2) must not arm a drag,
+      // capture the pointer, or flip body styles.
+      const down = pointerEvent(11, 0, vi.fn(), { button: 2, pointerType });
+      act(() => result.current.handleProps.onPointerDown(down));
+      expect(down.setPointerCapture).not.toHaveBeenCalled();
+      expect(down.preventDefault).not.toHaveBeenCalled();
+      expect(document.body.style.cursor).toBe("");
+      expect(document.body.style.userSelect).toBe("");
+
+      // No activePointerId was published: moves from that pointer are inert.
+      act(() => result.current.handleProps.onPointerMove(pointerEvent(11, 300)));
+      expect(result.current.width).toBe(176);
+    },
+  );
 
   it("stays idle when pointer capture fails", () => {
     const { result } = renderColumn(0);

--- a/web/src/hooks/useResizableColumn.test.tsx
+++ b/web/src/hooks/useResizableColumn.test.tsx
@@ -2,8 +2,6 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useResizableColumn } from "./useResizableColumn";
 
-type Handle = ReturnType<typeof useResizableColumn>["handleProps"];
-
 function pointerEvent(
   pointerId: number,
   clientX = 0,
@@ -19,8 +17,9 @@ function pointerEvent(
 }
 
 function keyEvent(key: string) {
-  const preventDefault = vi.fn();
-  return { event: { key, preventDefault } as unknown as React.KeyboardEvent, preventDefault };
+  return { key, preventDefault: vi.fn() } as unknown as React.KeyboardEvent & {
+    preventDefault: ReturnType<typeof vi.fn>;
+  };
 }
 
 /** Render the hook with a container anchored at the given viewport left edge. */
@@ -85,24 +84,24 @@ describe("useResizableColumn pointer dragging", () => {
     expect(result.current.width).toBe(300);
   });
 
-  it.each([
-    ["onPointerCancel", (h: Handle) => h.onPointerCancel],
-    ["onLostPointerCapture", (h: Handle) => h.onLostPointerCapture],
-  ])("aborts cleanly on %s, keeping the last applied width", (_name, pick) => {
-    const { result } = renderColumn(0);
+  it.each(["onPointerCancel", "onLostPointerCapture"] as const)(
+    "aborts cleanly on %s, keeping the last applied width",
+    (name) => {
+      const { result } = renderColumn(0);
 
-    act(() => result.current.handleProps.onPointerDown(pointerEvent(3)));
-    act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 250)));
-    expect(result.current.width).toBe(250);
+      act(() => result.current.handleProps.onPointerDown(pointerEvent(3)));
+      act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 250)));
+      expect(result.current.width).toBe(250);
 
-    act(() => pick(result.current.handleProps)(pointerEvent(3)));
-    expect(document.body.style.cursor).toBe("");
-    expect(document.body.style.userSelect).toBe("");
+      act(() => result.current.handleProps[name](pointerEvent(3)));
+      expect(document.body.style.cursor).toBe("");
+      expect(document.body.style.userSelect).toBe("");
 
-    // The aborted pointer is dead: further moves must not resize.
-    act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 400)));
-    expect(result.current.width).toBe(250);
-  });
+      // The aborted pointer is dead: further moves must not resize.
+      act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 400)));
+      expect(result.current.width).toBe(250);
+    },
+  );
 
   it("resets body cursor/selection when unmounted mid-drag", () => {
     const { result, unmount } = renderColumn(0);
@@ -121,28 +120,28 @@ describe("useResizableColumn keyboard resizing", () => {
     const { result } = renderColumn(0);
 
     const right = keyEvent("ArrowRight");
-    act(() => result.current.handleProps.onKeyDown(right.event));
+    act(() => result.current.handleProps.onKeyDown(right));
     expect(result.current.width).toBe(196);
     expect(right.preventDefault).toHaveBeenCalled();
 
-    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft").event));
+    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft")));
     expect(result.current.width).toBe(176);
 
     // Repeated ArrowLeft stops at minWidth (100).
     for (let i = 0; i < 10; i++) {
-      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft").event));
+      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft")));
     }
     expect(result.current.width).toBe(100);
 
     // Repeated ArrowRight stops at maxWidth (480).
     for (let i = 0; i < 30; i++) {
-      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight").event));
+      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight")));
     }
     expect(result.current.width).toBe(480);
 
     // Unrelated keys neither resize nor swallow the event.
     const other = keyEvent("Enter");
-    act(() => result.current.handleProps.onKeyDown(other.event));
+    act(() => result.current.handleProps.onKeyDown(other));
     expect(result.current.width).toBe(480);
     expect(other.preventDefault).not.toHaveBeenCalled();
   });
@@ -158,7 +157,7 @@ describe("useResizableColumn keyboard resizing", () => {
     expect(props["aria-valuemin"]).toBe(100);
     expect(props["aria-valuemax"]).toBe(480);
 
-    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight").event));
+    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight")));
     expect(result.current.handleProps["aria-valuenow"]).toBe(196);
   });
 });

--- a/web/src/hooks/useResizableColumn.test.tsx
+++ b/web/src/hooks/useResizableColumn.test.tsx
@@ -1,0 +1,181 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useResizableColumn } from "./useResizableColumn";
+
+type Handle = ReturnType<typeof useResizableColumn>["handleProps"];
+
+function pointerEvent(
+  pointerId: number,
+  clientX = 0,
+  setPointerCapture = vi.fn(),
+): React.PointerEvent & { setPointerCapture: ReturnType<typeof vi.fn> } {
+  return {
+    pointerId,
+    clientX,
+    preventDefault: vi.fn(),
+    currentTarget: { setPointerCapture },
+    setPointerCapture,
+  } as unknown as React.PointerEvent & { setPointerCapture: ReturnType<typeof vi.fn> };
+}
+
+function keyEvent(key: string) {
+  const preventDefault = vi.fn();
+  return { event: { key, preventDefault } as unknown as React.KeyboardEvent, preventDefault };
+}
+
+/** Render the hook with a container anchored at the given viewport left edge. */
+function renderColumn(containerLeft = 0) {
+  const rendered = renderHook(() => useResizableColumn());
+  rendered.result.current.containerRef.current = {
+    getBoundingClientRect: () => ({ left: containerLeft }),
+  } as HTMLElement;
+  return rendered;
+}
+
+afterEach(() => {
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
+});
+
+describe("useResizableColumn pointer dragging", () => {
+  it("captures the pointer on pointerdown and tracks moves on the captured element", () => {
+    const { result } = renderColumn(100);
+    const down = pointerEvent(7);
+
+    act(() => result.current.handleProps.onPointerDown(down));
+    expect(down.setPointerCapture).toHaveBeenCalledWith(7);
+    expect(document.body.style.cursor).toBe("col-resize");
+    expect(document.body.style.userSelect).toBe("none");
+
+    // Width follows the pointer, measured from the container's left edge.
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(7, 400)));
+    expect(result.current.width).toBe(300);
+
+    // Drag clamps to [minWidth, maxWidth] (defaults 100..480).
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(7, 100)));
+    expect(result.current.width).toBe(100);
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(7, 5000)));
+    expect(result.current.width).toBe(480);
+
+    act(() => result.current.handleProps.onPointerUp(pointerEvent(7)));
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // Moves after release no longer resize.
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(7, 350)));
+    expect(result.current.width).toBe(480);
+  });
+
+  it("ignores a second concurrent pointer (first pointer wins)", () => {
+    const { result } = renderColumn(0);
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(1)));
+
+    // A second finger going down mid-drag must not capture or steal the drag.
+    const second = pointerEvent(2);
+    act(() => result.current.handleProps.onPointerDown(second));
+    expect(second.setPointerCapture).not.toHaveBeenCalled();
+
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(2, 999)));
+    expect(result.current.width).toBe(176);
+
+    // The second pointer lifting must not end the first pointer's drag.
+    act(() => result.current.handleProps.onPointerUp(pointerEvent(2)));
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(1, 300)));
+    expect(result.current.width).toBe(300);
+  });
+
+  it.each([
+    ["onPointerCancel", (h: Handle) => h.onPointerCancel],
+    ["onLostPointerCapture", (h: Handle) => h.onLostPointerCapture],
+  ])("aborts cleanly on %s, keeping the last applied width", (_name, pick) => {
+    const { result } = renderColumn(0);
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(3)));
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 250)));
+    expect(result.current.width).toBe(250);
+
+    act(() => pick(result.current.handleProps)(pointerEvent(3)));
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // The aborted pointer is dead: further moves must not resize.
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(3, 400)));
+    expect(result.current.width).toBe(250);
+  });
+
+  it("resets body cursor/selection when unmounted mid-drag", () => {
+    const { result, unmount } = renderColumn(0);
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(4)));
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    unmount();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+});
+
+describe("useResizableColumn keyboard resizing", () => {
+  it("resizes with arrow keys using the same clamps as dragging", () => {
+    const { result } = renderColumn(0);
+
+    const right = keyEvent("ArrowRight");
+    act(() => result.current.handleProps.onKeyDown(right.event));
+    expect(result.current.width).toBe(196);
+    expect(right.preventDefault).toHaveBeenCalled();
+
+    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft").event));
+    expect(result.current.width).toBe(176);
+
+    // Repeated ArrowLeft stops at minWidth (100).
+    for (let i = 0; i < 10; i++) {
+      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowLeft").event));
+    }
+    expect(result.current.width).toBe(100);
+
+    // Repeated ArrowRight stops at maxWidth (480).
+    for (let i = 0; i < 30; i++) {
+      act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight").event));
+    }
+    expect(result.current.width).toBe(480);
+
+    // Unrelated keys neither resize nor swallow the event.
+    const other = keyEvent("Enter");
+    act(() => result.current.handleProps.onKeyDown(other.event));
+    expect(result.current.width).toBe(480);
+    expect(other.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("exposes a focusable separator with value semantics that track the width", () => {
+    const { result } = renderColumn(0);
+    const props = result.current.handleProps;
+
+    expect(props.role).toBe("separator");
+    expect(props.tabIndex).toBe(0);
+    expect(props["aria-orientation"]).toBe("vertical");
+    expect(props["aria-valuenow"]).toBe(176);
+    expect(props["aria-valuemin"]).toBe(100);
+    expect(props["aria-valuemax"]).toBe(480);
+
+    act(() => result.current.handleProps.onKeyDown(keyEvent("ArrowRight").event));
+    expect(result.current.handleProps["aria-valuenow"]).toBe(196);
+  });
+});
+
+describe("useResizableColumn touch affordances", () => {
+  it("disables touch-action and widens the hit target to >=44px without repainting it", () => {
+    const { result } = renderColumn(0);
+    const style = result.current.handleProps.style;
+
+    expect(style.touchAction).toBe("none");
+
+    // Symmetric padding gives a >=44px hit box; matching negative margins keep
+    // the layout box in place and background-clip keeps the padding unpainted.
+    expect(style.paddingLeft + style.paddingRight).toBeGreaterThanOrEqual(44);
+    expect(style.marginLeft).toBe(-style.paddingLeft);
+    expect(style.marginRight).toBe(-style.paddingRight);
+    expect(style.backgroundClip).toBe("content-box");
+    expect(style.boxSizing).toBe("content-box");
+  });
+});

--- a/web/src/hooks/useResizableColumn.ts
+++ b/web/src/hooks/useResizableColumn.ts
@@ -1,11 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const KEYBOARD_STEP_PX = 20;
-// Padding on each side of the visual handle so the touch/pen hit target is at
-// least 44px wide without changing the handle's painted width (the matching
-// negative margins keep the layout box where it was, and background-clip:
-// content-box keeps hover/active backgrounds off the padded area).
-const HIT_TARGET_PAD_PX = 22;
+// Width of the painted separator strip (the consumer's `w-1` element).
+const PAINTED_WIDTH_PX = 4;
+
+// Invisible hit-target padding around the painted strip. The handle sits over
+// the boundary between the terminal list and the xterm pane, so the pad is
+// biased toward the terminal side: list rows end with a status badge flush
+// against the boundary (taps there must select the row), while the xterm's
+// leftmost pixels are rarely interactive. Coarse pointers get a 44px total
+// target; fine pointers get the 24px minimum so the pad steals less hover
+// area from the row badges.
+const COARSE_PAD = { left: 12, right: 28 }; // 12 + 4 + 28 = 44px
+const FINE_PAD = { left: 6, right: 14 }; // 6 + 4 + 14 = 24px
+
+function hitTargetPad() {
+  const coarse =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches;
+  return coarse ? COARSE_PAD : FINE_PAD;
+}
 
 export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth = 480) {
   const [width, setWidth] = useState(defaultWidth);
@@ -13,6 +28,9 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
   // second concurrent pointer is ignored until the first drag ends.
   const activePointerId = useRef<number | null>(null);
   const containerRef = useRef<HTMLElement | null>(null);
+  // Removes the document-level fallback listeners for the active drag.
+  const removeDocListeners = useRef<(() => void) | null>(null);
+  const pad = useRef(hitTargetPad()).current;
 
   const clamp = useCallback(
     (w: number) => Math.max(minWidth, Math.min(maxWidth, w)),
@@ -22,20 +40,43 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
   const endDrag = useCallback(() => {
     if (activePointerId.current === null) return;
     activePointerId.current = null;
+    removeDocListeners.current?.();
+    removeDocListeners.current = null;
     document.body.style.cursor = "";
     document.body.style.userSelect = "";
   }, []);
 
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
-    if (activePointerId.current !== null) return;
-    e.preventDefault();
-    activePointerId.current = e.pointerId;
-    // Capture so moves keep arriving when the pointer leaves the handle (or
-    // crosses an iframe), and so no other gesture consumer sees the stream.
-    e.currentTarget.setPointerCapture(e.pointerId);
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (activePointerId.current !== null) return;
+      e.preventDefault();
+      // Capture so moves keep arriving when the pointer leaves the handle (or
+      // crosses an iframe), and so no other gesture consumer sees the stream.
+      // Capture first: if it throws (pointer already gone), stay idle rather
+      // than publishing a drag that can never receive its end events.
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        return;
+      }
+      activePointerId.current = e.pointerId;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      // Document-level fallback: if the handle element unmounts mid-drag
+      // (breakpoint flip, active terminal exits) its React handlers never
+      // fire, which would leave the drag armed and body styles stuck.
+      const onDocEnd = (ev: PointerEvent) => {
+        if (ev.pointerId === activePointerId.current) endDrag();
+      };
+      document.addEventListener("pointerup", onDocEnd);
+      document.addEventListener("pointercancel", onDocEnd);
+      removeDocListeners.current = () => {
+        document.removeEventListener("pointerup", onDocEnd);
+        document.removeEventListener("pointercancel", onDocEnd);
+      };
+    },
+    [endDrag],
+  );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -71,8 +112,7 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
     [clamp],
   );
 
-  // Reset body cursor/selection if the component unmounts mid-drag (the
-  // element's capture is released implicitly when it leaves the DOM).
+  // Reset body cursor/selection if the hook itself unmounts mid-drag.
   useEffect(() => endDrag, [endDrag]);
 
   return {
@@ -80,7 +120,14 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
     width,
     /** Attach to the flex-row container to anchor drag calculations. */
     containerRef,
-    /** Spread onto the resize handle element at the right edge of the left column. */
+    /**
+     * Spread onto the resize handle. Render the handle as a direct child of
+     * the (overflow-hidden, relative) split row — NOT inside the scrollable
+     * list panel, where the invisible pad would be clipped and add horizontal
+     * overflow — absolutely positioned with `left: width`. The negative
+     * margin then aligns the painted strip's right edge to the boundary,
+     * with the invisible pad straddling it.
+     */
     handleProps: {
       onPointerDown,
       onPointerMove,
@@ -98,10 +145,9 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
       style: {
         touchAction: "none",
         boxSizing: "content-box",
-        paddingLeft: HIT_TARGET_PAD_PX,
-        paddingRight: HIT_TARGET_PAD_PX,
-        marginLeft: -HIT_TARGET_PAD_PX,
-        marginRight: -HIT_TARGET_PAD_PX,
+        paddingLeft: pad.left,
+        paddingRight: pad.right,
+        marginLeft: -(pad.left + PAINTED_WIDTH_PX),
         backgroundClip: "content-box",
       } as const,
     },

--- a/web/src/hooks/useResizableColumn.ts
+++ b/web/src/hooks/useResizableColumn.ts
@@ -1,45 +1,83 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const KEYBOARD_STEP_PX = 20;
+// Padding on each side of the visual handle so the touch/pen hit target is at
+// least 44px wide without changing the handle's painted width (the matching
+// negative margins keep the layout box where it was, and background-clip:
+// content-box keeps hover/active backgrounds off the padded area).
+const HIT_TARGET_PAD_PX = 22;
+
 export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth = 480) {
   const [width, setWidth] = useState(defaultWidth);
-  const dragging = useRef(false);
+  // Pointer id of the active drag; null when idle. First pointer wins — a
+  // second concurrent pointer is ignored until the first drag ends.
+  const activePointerId = useRef<number | null>(null);
   const containerRef = useRef<HTMLElement | null>(null);
   const minRef = useRef(minWidth);
   const maxRef = useRef(maxWidth);
   minRef.current = minWidth;
   maxRef.current = maxWidth;
 
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
+  const clamp = useCallback(
+    (w: number) => Math.max(minRef.current, Math.min(maxRef.current, w)),
+    [],
+  );
+
+  const endDrag = useCallback(() => {
+    if (activePointerId.current === null) return;
+    activePointerId.current = null;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (activePointerId.current !== null) return;
     e.preventDefault();
-    dragging.current = true;
+    activePointerId.current = e.pointerId;
+    // Capture so moves keep arriving when the pointer leaves the handle (or
+    // crosses an iframe), and so no other gesture consumer sees the stream.
+    e.currentTarget.setPointerCapture(e.pointerId);
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, []);
 
-  useEffect(() => {
-    function onMouseMove(e: MouseEvent) {
-      if (!dragging.current || !containerRef.current) return;
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== activePointerId.current || !containerRef.current) return;
       const left = containerRef.current.getBoundingClientRect().left;
-      setWidth(Math.max(minRef.current, Math.min(maxRef.current, e.clientX - left)));
-    }
-    function onMouseUp() {
-      if (!dragging.current) return;
-      dragging.current = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    }
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
-    return () => {
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
-      if (dragging.current) {
-        dragging.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
+      setWidth(clamp(e.clientX - left));
+    },
+    [clamp],
+  );
+
+  // pointerup ends the drag; pointercancel and capture loss abort it cleanly,
+  // keeping the last applied width (never a half-state).
+  const onPointerEnd = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== activePointerId.current) return;
+      endDrag();
+    },
+    [endDrag],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Vertical separator between columns: ArrowRight widens the left
+      // column, ArrowLeft narrows it, with the same clamps as dragging.
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        setWidth((w) => clamp(w + KEYBOARD_STEP_PX));
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        setWidth((w) => clamp(w - KEYBOARD_STEP_PX));
       }
-    };
-  }, []);
+    },
+    [clamp],
+  );
+
+  // Reset body cursor/selection if the component unmounts mid-drag (the
+  // element's capture is released implicitly when it leaves the DOM).
+  useEffect(() => endDrag, [endDrag]);
 
   return {
     /** Pixel width for the left column (apply as inline style). */
@@ -48,10 +86,28 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
     containerRef,
     /** Spread onto the resize handle element at the right edge of the left column. */
     handleProps: {
-      onMouseDown,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: onPointerEnd,
+      onPointerCancel: onPointerEnd,
+      onLostPointerCapture: onPointerEnd,
+      onKeyDown,
       role: "separator" as const,
+      tabIndex: 0,
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize terminal list",
+      "aria-valuenow": width,
+      "aria-valuemin": minWidth,
+      "aria-valuemax": maxWidth,
+      style: {
+        touchAction: "none",
+        boxSizing: "content-box",
+        paddingLeft: HIT_TARGET_PAD_PX,
+        paddingRight: HIT_TARGET_PAD_PX,
+        marginLeft: -HIT_TARGET_PAD_PX,
+        marginRight: -HIT_TARGET_PAD_PX,
+        backgroundClip: "content-box",
+      } as const,
     },
   };
 }

--- a/web/src/hooks/useResizableColumn.ts
+++ b/web/src/hooks/useResizableColumn.ts
@@ -13,14 +13,10 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
   // second concurrent pointer is ignored until the first drag ends.
   const activePointerId = useRef<number | null>(null);
   const containerRef = useRef<HTMLElement | null>(null);
-  const minRef = useRef(minWidth);
-  const maxRef = useRef(maxWidth);
-  minRef.current = minWidth;
-  maxRef.current = maxWidth;
 
   const clamp = useCallback(
-    (w: number) => Math.max(minRef.current, Math.min(maxRef.current, w)),
-    [],
+    (w: number) => Math.max(minWidth, Math.min(maxWidth, w)),
+    [minWidth, maxWidth],
   );
 
   const endDrag = useCallback(() => {

--- a/web/src/hooks/useResizableColumn.ts
+++ b/web/src/hooks/useResizableColumn.ts
@@ -48,6 +48,9 @@ export function useResizableColumn(defaultWidth = 176, minWidth = 100, maxWidth 
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
+      // Only the primary button starts a drag — right-click / pen barrel
+      // button must not capture the pointer or flip body styles.
+      if (e.button !== 0) return;
       if (activePointerId.current !== null) return;
       e.preventDefault();
       // Capture so moves keep arriving when the pointer leaves the handle (or

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -239,3 +239,66 @@ describe("TerminalsPanel navigation", () => {
     );
   });
 });
+
+describe("TerminalsPanel column resize handle", () => {
+  // jsdom has no layout engine, so these tests assert the structural
+  // invariants that produce the desired geometry in a real browser: the
+  // handle must live OUTSIDE the vertically scrolling list panel (a pad
+  // inside it gets clipped and makes the list pannable horizontally) and
+  // sit on the column boundary via `left: <list width>`.
+  function getHandle() {
+    return screen.getByRole("separator", { name: /resize terminal list/i });
+  }
+
+  function getListPanel() {
+    // The list panel is the scrollable element containing the row buttons.
+    const row = screen.getByRole("button", { name: /main/i });
+    const panel = row.parentElement as HTMLElement;
+    expect(panel.className).toContain("overflow-y-auto");
+    return panel;
+  }
+
+  it("renders the handle at the boundary, outside the scrollable list panel", () => {
+    renderPanel({ initialTerminalKey: "terminal:terminal_main" });
+
+    const handle = getHandle();
+    const listPanel = getListPanel();
+
+    // Sibling of the list panel inside the overflow-hidden split row — never
+    // a descendant of the scroll container that would clip its hit pad.
+    expect(listPanel.contains(handle)).toBe(false);
+    expect(handle.parentElement).toBe(listPanel.parentElement);
+
+    // Anchored on the column boundary with the drag/touch affordances live.
+    expect(handle.style.left).toBe("176px");
+    expect(handle.style.touchAction).toBe("none");
+    expect(handle.style.paddingLeft).not.toBe("");
+  });
+
+  it("keeps terminal rows selectable outside the handle pad", () => {
+    renderPanel({ initialTerminalKey: "terminal:terminal_main" });
+
+    // Tapping the body of another row (well clear of the boundary pad) must
+    // still switch the active terminal.
+    fireEvent.click(screen.getByRole("button", { name: /worker/i }));
+    act(() => {
+      vi.advanceTimersByTime(200); // past the layout-settle mount deferral
+    });
+    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+      "data-terminal-id",
+      "terminal_worker",
+    );
+  });
+
+  it("adds no horizontally overflowing content to the list panel", () => {
+    renderPanel({ initialTerminalKey: "terminal:terminal_main" });
+
+    // The only element wider than the column (the invisible hit pad) must not
+    // be inside the list panel; everything the panel contains is w-full rows.
+    const listPanel = getListPanel();
+    for (const child of Array.from(listPanel.children)) {
+      expect((child as HTMLElement).style.paddingLeft).toBe("");
+      expect(child.getAttribute("role")).not.toBe("separator");
+    }
+  });
+});

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -191,8 +191,20 @@ export function TerminalsPanel({
           Desktop: flex-row — list on left, xterm on right. */}
       <div
         ref={splitRef as React.RefObject<HTMLDivElement>}
-        className="flex min-h-0 flex-1 flex-col md:flex-row overflow-hidden"
+        className="relative flex min-h-0 flex-1 flex-col md:flex-row overflow-hidden"
       >
+        {/* Column resize handle — desktop only. Sibling of the list panel
+            (not inside it): the list scrolls vertically, which would clip
+            the handle's invisible hit pad and make the list pannable
+            horizontally. Positioned on the column boundary; the pad
+            straddles it while the painted strip stays 4px. */}
+        {activeTerminal && isDesktop && (
+          <div
+            {...columnHandleProps}
+            style={{ ...columnHandleProps.style, left: listWidth }}
+            className="absolute inset-y-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          />
+        )}
         {/* List panel */}
         <div
           className={cn(
@@ -202,13 +214,6 @@ export function TerminalsPanel({
           // Width only meaningful on desktop (horizontal split).
           style={activeTerminal && isDesktop ? { width: listWidth } : undefined}
         >
-          {/* Column resize handle — desktop only */}
-          {activeTerminal && isDesktop && (
-            <div
-              {...columnHandleProps}
-              className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
-            />
-          )}
           {terminals.map((t) => {
             const key = terminalTabKey(t);
             const isActive = key === activeKey;


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The terminal list column resizer (`useResizableColumn`) only listened for mouse events, so touch and stylus users could not resize the split at all. This migrates the drag path to pointer events per TR-6/7/9 of the touch interaction spec: capture-first `setPointerCapture` on pointerdown (a capture failure leaves the hook idle), move/up handled on the captured element, clean abort on `pointercancel` AND `lostpointercapture` (last applied width, never a half-state), first-pointer-wins, and document-level pointerup/pointercancel fallbacks so a handle that unmounts mid-drag (breakpoint flip, terminal exit) can never wedge body cursor/selection.
- The handle now renders as a sibling of the list panel inside the overflow-hidden split row, absolutely positioned on the column boundary — not inside the `overflow-y-auto` list, where its invisible hit pad would be clipped and add horizontal pannability. The pad is coarse-pointer-aware (44px total on touch/stylus, 24px minimum on fine pointers per TR-7) and biased toward the terminal pane so the list rows' trailing status badges keep their tappable area; the painted strip stays 4px. `touch-action: none` blocks competing gesture consumers during a drag (TR-9).
- TR-8: this was the one resize hook without a keyboard path — the handle is now a focusable separator (`role=separator`, `tabIndex=0`, `aria-orientation`, `aria-valuenow/min/max`) resizable with ArrowLeft/ArrowRight under the same min/max clamps as dragging.

ELI5: the thin divider between the terminal list and the terminal used to understand only a mouse. Now it understands fingers, pens, and the keyboard too — and it grew an invisible grab zone (44px on touchscreens) centered on the boundary so it's easy to hit, while still looking like the same thin line and never blocking the list's rows or scrolling.

```
before: handle inside overflow-y-auto list ─► pad clipped + list pans sideways
after:  split row (overflow-hidden, relative)
          ├ handle (absolute, left: listWidth, pad straddles boundary)
          ├ list panel (scrolls vertically, no wide children)
          └ xterm pane
        pointerdown ─► setPointerCapture (try/catch) ─► move/up on handle
          ├ pointercancel / lostpointercapture ─► clean abort
          └ document pointerup/cancel fallback ─► no wedged drag on unmount
        keyboard: focus separator ─► ArrowLeft/ArrowRight (same clamps)
```

## Test Plan

- `web/src/hooks/useResizableColumn.test.tsx` (11 tests): pointer capture on pointerdown, width tracking + min/max clamps, first-pointer-wins, clean abort on `pointercancel`/`lostpointercapture`, mid-drag unmount cleanup, document-fallback drag end when the handle element is gone (next drag still works), idle-on-capture-failure, arrow-key resize with clamps + `preventDefault`, separator ARIA semantics, and fine (≥24px) / coarse (≥44px, terminal-biased) hit-target affordances.
- `web/src/shell/TerminalsPanel.test.tsx` (+3 tests): the handle renders outside the scrollable list panel as its sibling at `left: listWidth` with `touch-action: none`; terminal rows stay selectable; no wide/padded children inside the list panel.
- Mutation checks: with the migration reverted, all hook tests fail; with the relocation + lifecycle fixes reverted, the 6 new tests fail while the regression guards still pass.
- New `tests/e2e_ui/shells/test_terminals_column_resize.py`: real-browser flow — opens the Shells panel via its mobile-drawer entry point, widens to a desktop viewport, drags the column handle (width tracks the pointer and persists after release), arrow-key resizes the focused separator under the same clamps, and asserts negative isolation (adjacent row taps still select; wheel scroll over the list never resizes). Terminals launched over REST, no LLM turn.
- `tsc -b` clean; `pre-commit` (prettier, oxlint, web type check) clean; full `TerminalsPanel.test.tsx` suite green.

## Demo

Terminals-column seam touch-drag validated live on [Android tablet](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/gap-tablet-column.mp4) — the terminal-list seam tracks through its clamp and persists at 255px after release; an adjacent terminal tap/scroll does not trigger a resize.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior is covered by the hook + component unit tests above; no manual-only claims.

## Changelog

The terminal list divider can now be resized by touch, stylus, and keyboard (arrow keys on the focused separator), with a larger touch hit target that no longer interferes with list scrolling.

---
This pull request and its description were written by Isaac.

