### PR TITLE
Migrate panel resize to pointer events

### DIFF
--- a/tests/e2e_ui/files/test_workspace_panel_resize.py
+++ b/tests/e2e_ui/files/test_workspace_panel_resize.py
@@ -1,0 +1,47 @@
+"""E2E coverage for the workspace push-panel resize seam."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def _open_execution_logs_panel(page: Page) -> None:
+    expect(page.get_by_test_id("execution-logs-card")).to_be_visible(timeout=30_000)
+    page.get_by_test_id("execution-log-row-main").click()
+    expect(page.get_by_test_id("execution-logs-panel")).to_be_visible()
+
+
+def test_workspace_panel_pointer_resize_persists_without_annexing_chat(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Resize the workspace panel while adjacent chat input stays inert."""
+    base_url, session_id = seeded_session
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{base_url}/c/{session_id}?debug=1")
+    _open_execution_logs_panel(page)
+
+    panel = page.get_by_test_id("execution-logs-panel")
+    handle = page.get_by_role("separator", name="Resize panel")
+    initial_width = panel.bounding_box()["width"]
+    handle_box = handle.bounding_box()
+
+    page.mouse.move(handle_box["x"] + handle_box["width"] / 2, handle_box["y"] + 100)
+    page.mouse.down()
+    page.mouse.move(handle_box["x"] - 80, handle_box["y"] + 100, steps=4)
+    page.mouse.up()
+
+    resized_width = panel.bounding_box()["width"]
+    assert resized_width >= initial_width + 70
+
+    chat = page.locator("main").first
+    chat_box = chat.bounding_box()
+    page.mouse.move(chat_box["x"] + chat_box["width"] / 2, chat_box["y"] + 200)
+    page.mouse.wheel(0, 200)
+    page.mouse.click(chat_box["x"] + chat_box["width"] / 2, chat_box["y"] + 200)
+    expect(panel).to_have_js_property("offsetWidth", round(resized_width))
+
+    page.reload()
+    _open_execution_logs_panel(page)
+    persisted_width = page.get_by_test_id("execution-logs-panel").bounding_box()["width"]
+    assert abs(persisted_width - resized_width) <= 1

--- a/tests/e2e_ui/files/test_workspace_panel_resize.py
+++ b/tests/e2e_ui/files/test_workspace_panel_resize.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
+_FINE_GUTTER_PX = 10
+
 
 def _open_execution_logs_panel(page: Page) -> None:
     expect(page.get_by_test_id("execution-logs-card")).to_be_visible(timeout=30_000)
@@ -35,7 +37,7 @@ def test_workspace_panel_pointer_resize_persists_without_annexing_chat(
     assert resized_width >= initial_width + 70
 
     panel_box = panel.bounding_box()
-    probe_x = panel_box["x"] - 8
+    probe_x = panel_box["x"] - _FINE_GUTTER_PX - 8
     probe_y = panel_box["y"] + panel_box["height"] / 2
     assert panel.evaluate(
         """(panel, point) => {
@@ -51,7 +53,7 @@ def test_workspace_panel_pointer_resize_persists_without_annexing_chat(
             return true;
         }""",
         {"x": probe_x, "y": probe_y},
-    )
+    ), "chat-side probe landed on the panel resize handle"
     page.mouse.move(probe_x, probe_y)
     page.mouse.down()
     page.mouse.move(probe_x - 12, probe_y, steps=2)

--- a/tests/e2e_ui/files/test_workspace_panel_resize.py
+++ b/tests/e2e_ui/files/test_workspace_panel_resize.py
@@ -34,12 +34,30 @@ def test_workspace_panel_pointer_resize_persists_without_annexing_chat(
     resized_width = panel.bounding_box()["width"]
     assert resized_width >= initial_width + 70
 
-    chat = page.locator("main").first
-    chat_box = chat.bounding_box()
-    page.mouse.move(chat_box["x"] + chat_box["width"] / 2, chat_box["y"] + 200)
-    page.mouse.wheel(0, 200)
-    page.mouse.click(chat_box["x"] + chat_box["width"] / 2, chat_box["y"] + 200)
-    expect(panel).to_have_js_property("offsetWidth", round(resized_width))
+    panel_box = panel.bounding_box()
+    probe_x = panel_box["x"] - 8
+    probe_y = panel_box["y"] + panel_box["height"] / 2
+    assert panel.evaluate(
+        """(panel, point) => {
+            const target = document.elementFromPoint(point.x, point.y);
+            if (!target || panel.contains(target) || target.closest('[role="separator"]')) {
+                return false;
+            }
+            target.addEventListener(
+                'pointerdown',
+                () => document.documentElement.dataset.resizeProbeReceived = 'true',
+                { once: true },
+            );
+            return true;
+        }""",
+        {"x": probe_x, "y": probe_y},
+    )
+    page.mouse.move(probe_x, probe_y)
+    page.mouse.down()
+    page.mouse.move(probe_x - 12, probe_y, steps=2)
+    page.mouse.up()
+    expect(page.locator("html")).to_have_attribute("data-resize-probe-received", "true")
+    assert abs(panel.bounding_box()["width"] - resized_width) <= 1
 
     page.reload()
     _open_execution_logs_panel(page)

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -1,7 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPanelSizePreference } from "@/lib/panelSizePreferences";
-import { resetSharedWidthStoreForTesting, useResizablePanel } from "./useResizablePanel";
+import {
+  HANDLE_HIT_PAD_PX,
+  resetSharedWidthStoreForTesting,
+  useResizablePanel,
+} from "./useResizablePanel";
 
 const originalInnerWidth = window.innerWidth;
 
@@ -19,29 +23,30 @@ function createPointerHandle() {
   return { element, setPointerCapture, releasePointerCapture };
 }
 
-function dispatchPointer(
+function pointerEvent(
   element: HTMLElement,
-  type: string,
-  { pointerId, clientX = 0 }: { pointerId: number; clientX?: number },
-): void {
-  const event = new Event(type, { bubbles: true });
-  Object.defineProperties(event, {
-    pointerId: { value: pointerId },
-    clientX: { value: clientX },
-  });
-  element.dispatchEvent(event);
-}
-
-function startPointerDrag(
-  onPointerDown: React.PointerEventHandler<HTMLElement>,
-  element: HTMLElement,
-  pointerId: number,
-): void {
-  onPointerDown({
+  {
+    pointerId,
+    clientX = 0,
+    pointerType = "touch",
+    button = 0,
+    preventDefault = () => {},
+  }: {
+    pointerId: number;
+    clientX?: number;
+    pointerType?: string;
+    button?: number;
+    preventDefault?: () => void;
+  },
+): React.PointerEvent<HTMLElement> {
+  return {
     currentTarget: element,
     pointerId,
-    preventDefault: () => {},
-  } as React.PointerEvent<HTMLElement>);
+    clientX,
+    pointerType,
+    button,
+    preventDefault,
+  } as React.PointerEvent<HTMLElement>;
 }
 
 beforeEach(() => {
@@ -114,13 +119,15 @@ describe("useResizablePanel persistence", () => {
     const handle = createPointerHandle();
 
     act(() => {
-      startPointerDrag(result.current.handleProps.onPointerDown, handle.element, 7);
+      result.current.handleProps.onPointerDown(pointerEvent(handle.element, { pointerId: 7 }));
     });
     expect(handle.setPointerCapture).toHaveBeenCalledWith(7);
 
     act(() => {
       // 2000px viewport, cursor at 1200 → width = innerWidth - clientX = 800.
-      dispatchPointer(handle.element, "pointermove", { pointerId: 7, clientX: 1200 });
+      result.current.handleProps.onPointerMove(
+        pointerEvent(handle.element, { pointerId: 7, clientX: 1200 }),
+      );
     });
 
     // Live width tracks the drag, but nothing is written to storage mid-drag —
@@ -129,7 +136,7 @@ describe("useResizablePanel persistence", () => {
     expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
 
     act(() => {
-      dispatchPointer(handle.element, "pointerup", { pointerId: 7 });
+      result.current.handleProps.onPointerUp(pointerEvent(handle.element, { pointerId: 7 }));
     });
 
     // Release snapshots the final width exactly once.
@@ -137,21 +144,25 @@ describe("useResizablePanel persistence", () => {
     expect(handle.releasePointerCapture).toHaveBeenCalledWith(7);
   });
 
-  it.each(["pointercancel", "lostpointercapture"])(
-    "aborts cleanly on %s without persisting",
-    (abortEvent) => {
+  it.each(["onPointerCancel", "onLostPointerCapture"] as const)(
+    "aborts cleanly via %s without persisting",
+    (abortHandler) => {
       const { result } = renderHook(() => useResizablePanel(true));
       const handle = createPointerHandle();
 
       act(() => {
-        startPointerDrag(result.current.handleProps.onPointerDown, handle.element, 11);
-        dispatchPointer(handle.element, "pointermove", { pointerId: 11, clientX: 1200 });
+        result.current.handleProps.onPointerDown(pointerEvent(handle.element, { pointerId: 11 }));
+        result.current.handleProps.onPointerMove(
+          pointerEvent(handle.element, { pointerId: 11, clientX: 1200 }),
+        );
       });
       expect(result.current.panelWidth).toBe(800);
 
       act(() => {
-        dispatchPointer(handle.element, abortEvent, { pointerId: 11 });
-        dispatchPointer(handle.element, "pointermove", { pointerId: 11, clientX: 1400 });
+        result.current.handleProps[abortHandler](pointerEvent(handle.element, { pointerId: 11 }));
+        result.current.handleProps.onPointerMove(
+          pointerEvent(handle.element, { pointerId: 11, clientX: 1400 }),
+        );
       });
 
       expect(result.current.panelWidth).toBe(800);
@@ -167,9 +178,13 @@ describe("useResizablePanel persistence", () => {
     const secondHandle = createPointerHandle();
 
     act(() => {
-      startPointerDrag(result.current.handleProps.onPointerDown, firstHandle.element, 1);
-      startPointerDrag(result.current.handleProps.onPointerDown, secondHandle.element, 2);
-      dispatchPointer(secondHandle.element, "pointermove", { pointerId: 2, clientX: 1400 });
+      result.current.handleProps.onPointerDown(pointerEvent(firstHandle.element, { pointerId: 1 }));
+      result.current.handleProps.onPointerDown(
+        pointerEvent(secondHandle.element, { pointerId: 2 }),
+      );
+      result.current.handleProps.onPointerMove(
+        pointerEvent(secondHandle.element, { pointerId: 2, clientX: 1400 }),
+      );
     });
 
     expect(firstHandle.setPointerCapture).toHaveBeenCalledWith(1);
@@ -177,9 +192,35 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.panelWidth).toBe(1000);
 
     act(() => {
-      dispatchPointer(firstHandle.element, "pointermove", { pointerId: 1, clientX: 1200 });
+      result.current.handleProps.onPointerMove(
+        pointerEvent(firstHandle.element, { pointerId: 1, clientX: 1200 }),
+      );
     });
     expect(result.current.panelWidth).toBe(800);
+  });
+
+  it("ignores secondary mouse buttons", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+    const handle = createPointerHandle();
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleProps.onPointerDown(
+        pointerEvent(handle.element, {
+          pointerId: 3,
+          pointerType: "mouse",
+          button: 2,
+          preventDefault,
+        }),
+      );
+      result.current.handleProps.onPointerMove(
+        pointerEvent(handle.element, { pointerId: 3, clientX: 1200 }),
+      );
+    });
+
+    expect(handle.setPointerCapture).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(result.current.panelWidth).toBe(1000);
   });
 
   it("returns touch-action and a 44px cross-axis hit target", () => {
@@ -188,8 +229,8 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.handleProps.style).toMatchObject({
       touchAction: "none",
       boxSizing: "content-box",
-      paddingInline: 20,
-      marginInline: -20,
+      paddingInline: HANDLE_HIT_PAD_PX,
+      marginInline: -HANDLE_HIT_PAD_PX,
       backgroundClip: "content-box",
     });
   });

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPanelSizePreference } from "@/lib/panelSizePreferences";
 import { resetSharedWidthStoreForTesting, useResizablePanel } from "./useResizablePanel";
 
@@ -7,6 +7,41 @@ const originalInnerWidth = window.innerWidth;
 
 function setInnerWidth(px: number): void {
   Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: px });
+}
+
+function createPointerHandle() {
+  const element = document.createElement("div");
+  const capturedPointers = new Set<number>();
+  const setPointerCapture = vi.fn((pointerId: number) => capturedPointers.add(pointerId));
+  const releasePointerCapture = vi.fn((pointerId: number) => capturedPointers.delete(pointerId));
+  const hasPointerCapture = vi.fn((pointerId: number) => capturedPointers.has(pointerId));
+  Object.assign(element, { setPointerCapture, releasePointerCapture, hasPointerCapture });
+  return { element, setPointerCapture, releasePointerCapture };
+}
+
+function dispatchPointer(
+  element: HTMLElement,
+  type: string,
+  { pointerId, clientX = 0 }: { pointerId: number; clientX?: number },
+): void {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    clientX: { value: clientX },
+  });
+  element.dispatchEvent(event);
+}
+
+function startPointerDrag(
+  onPointerDown: React.PointerEventHandler<HTMLElement>,
+  element: HTMLElement,
+  pointerId: number,
+): void {
+  onPointerDown({
+    currentTarget: element,
+    pointerId,
+    preventDefault: () => {},
+  } as React.PointerEvent<HTMLElement>);
 }
 
 beforeEach(() => {
@@ -74,30 +109,89 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.panelWidth).toBe(980);
   });
 
-  it("updates live width during a drag but only persists on release", () => {
+  it("captures the pointer and persists the final width on release", () => {
     const { result } = renderHook(() => useResizablePanel(true));
+    const handle = createPointerHandle();
 
     act(() => {
-      result.current.handleProps.onMouseDown({
-        preventDefault: () => {},
-      } as React.MouseEvent);
+      startPointerDrag(result.current.handleProps.onPointerDown, handle.element, 7);
     });
+    expect(handle.setPointerCapture).toHaveBeenCalledWith(7);
+
     act(() => {
       // 2000px viewport, cursor at 1200 → width = innerWidth - clientX = 800.
-      window.dispatchEvent(new MouseEvent("mousemove", { clientX: 1200 }));
+      dispatchPointer(handle.element, "pointermove", { pointerId: 7, clientX: 1200 });
     });
 
     // Live width tracks the drag, but nothing is written to storage mid-drag —
-    // persisting per mousemove would fire a synchronous setItem on every frame.
+    // persisting per pointermove would fire a synchronous setItem on every frame.
     expect(result.current.panelWidth).toBe(800);
     expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
 
     act(() => {
-      window.dispatchEvent(new MouseEvent("mouseup"));
+      dispatchPointer(handle.element, "pointerup", { pointerId: 7 });
     });
 
     // Release snapshots the final width exactly once.
     expect(readPanelSizePreference("pushPanelWidthPx")).toBe(800);
+    expect(handle.releasePointerCapture).toHaveBeenCalledWith(7);
+  });
+
+  it.each(["pointercancel", "lostpointercapture"])(
+    "aborts cleanly on %s without persisting",
+    (abortEvent) => {
+      const { result } = renderHook(() => useResizablePanel(true));
+      const handle = createPointerHandle();
+
+      act(() => {
+        startPointerDrag(result.current.handleProps.onPointerDown, handle.element, 11);
+        dispatchPointer(handle.element, "pointermove", { pointerId: 11, clientX: 1200 });
+      });
+      expect(result.current.panelWidth).toBe(800);
+
+      act(() => {
+        dispatchPointer(handle.element, abortEvent, { pointerId: 11 });
+        dispatchPointer(handle.element, "pointermove", { pointerId: 11, clientX: 1400 });
+      });
+
+      expect(result.current.panelWidth).toBe(800);
+      expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
+      expect(document.body.style.cursor).toBe("");
+      expect(document.body.style.userSelect).toBe("");
+    },
+  );
+
+  it("ignores additional pointers until the active drag ends", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+    const firstHandle = createPointerHandle();
+    const secondHandle = createPointerHandle();
+
+    act(() => {
+      startPointerDrag(result.current.handleProps.onPointerDown, firstHandle.element, 1);
+      startPointerDrag(result.current.handleProps.onPointerDown, secondHandle.element, 2);
+      dispatchPointer(secondHandle.element, "pointermove", { pointerId: 2, clientX: 1400 });
+    });
+
+    expect(firstHandle.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(secondHandle.setPointerCapture).not.toHaveBeenCalled();
+    expect(result.current.panelWidth).toBe(1000);
+
+    act(() => {
+      dispatchPointer(firstHandle.element, "pointermove", { pointerId: 1, clientX: 1200 });
+    });
+    expect(result.current.panelWidth).toBe(800);
+  });
+
+  it("returns touch-action and a 44px cross-axis hit target", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+
+    expect(result.current.handleProps.style).toMatchObject({
+      touchAction: "none",
+      boxSizing: "content-box",
+      paddingInline: 20,
+      marginInline: -20,
+      backgroundClip: "content-box",
+    });
   });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -353,6 +353,9 @@ describe("useResizablePanel persistence", () => {
       backgroundClip: "content-box",
     });
     expect(4 + Number(style.paddingInlineStart) + Number(style.paddingInlineEnd)).toBe(target);
+    // The transcript scrollbar thumb occupies the 6–12px band from this seam;
+    // keep the handle out of that band so touch-scroll starts remain available.
+    expect(-Number(style.marginInlineStart)).toBeLessThanOrEqual(6);
     expect(
       4 +
         Number(style.paddingInlineStart) +
@@ -365,12 +368,12 @@ describe("useResizablePanel persistence", () => {
   it("updates the gutter when primary pointer coarseness changes", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(11);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(7);
 
     act(() => setCoarseMatch(true));
 
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(12);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(8);
   });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -342,17 +342,15 @@ describe("useResizablePanel persistence", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     const style = result.current.handleProps.style;
     const inset = (gutter - 4) / 2;
-    const totalPadding = HANDLE_OUTWARD_SLIVER_PX + HANDLE_INWARD_SLIVER_PX + 2 * inset;
 
     expect(style).toMatchObject({
       touchAction: "none",
       boxSizing: "content-box",
-      paddingInlineStart: gutter,
-      paddingInlineEnd: totalPadding - gutter,
+      paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
+      paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
       marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
       marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
       backgroundClip: "content-box",
-      clipPath: `inset(0 0 0 ${gutter}px)`,
     });
     expect(4 + Number(style.paddingInlineStart) + Number(style.paddingInlineEnd)).toBe(target);
     // The transcript scrollbar thumb occupies the 6–12px band from this seam;
@@ -373,12 +371,12 @@ describe("useResizablePanel persistence", () => {
   it("updates the gutter when primary pointer coarseness changes", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(10);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(9);
 
     act(() => setCoarseMatch(true));
 
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(12);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(10);
   });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -49,6 +49,12 @@ function pointerEvent(
   } as React.PointerEvent<HTMLElement>;
 }
 
+function dispatchDocumentPointer(type: "pointerup" | "pointercancel", pointerId: number): void {
+  const event = new Event(type);
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  document.dispatchEvent(event);
+}
+
 beforeEach(() => {
   setInnerWidth(2000);
 });
@@ -144,6 +150,35 @@ describe("useResizablePanel persistence", () => {
     expect(handle.releasePointerCapture).toHaveBeenCalledWith(7);
   });
 
+  it("stays idle when pointer capture throws", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+    const failedHandle = createPointerHandle();
+    const nextHandle = createPointerHandle();
+    failedHandle.setPointerCapture.mockImplementation(() => {
+      throw new Error("capture failed");
+    });
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleProps.onPointerDown(
+        pointerEvent(failedHandle.element, { pointerId: 8, preventDefault }),
+      );
+      result.current.handleProps.onPointerMove(
+        pointerEvent(failedHandle.element, { pointerId: 8, clientX: 1200 }),
+      );
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(result.current.panelWidth).toBe(1000);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    act(() => {
+      result.current.handleProps.onPointerDown(pointerEvent(nextHandle.element, { pointerId: 9 }));
+    });
+    expect(nextHandle.setPointerCapture).toHaveBeenCalledWith(9);
+  });
+
   it.each(["onPointerCancel", "onLostPointerCapture"] as const)(
     "aborts cleanly via %s without persisting",
     (abortHandler) => {
@@ -199,7 +234,54 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.panelWidth).toBe(800);
   });
 
-  it("ignores secondary mouse buttons", () => {
+  it("recovers when the handle unmounts mid-drag", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+    const removedHandle = createPointerHandle();
+    const nextHandle = createPointerHandle();
+    document.body.appendChild(removedHandle.element);
+
+    act(() => {
+      result.current.handleProps.onPointerDown(
+        pointerEvent(removedHandle.element, { pointerId: 4 }),
+      );
+      result.current.handleProps.onPointerMove(
+        pointerEvent(removedHandle.element, { pointerId: 4, clientX: 1200 }),
+      );
+      removedHandle.element.remove();
+      dispatchDocumentPointer("pointercancel", 4);
+    });
+
+    expect(result.current.panelWidth).toBe(800);
+    expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    act(() => {
+      result.current.handleProps.onPointerDown(pointerEvent(nextHandle.element, { pointerId: 5 }));
+    });
+    expect(nextHandle.setPointerCapture).toHaveBeenCalledWith(5);
+  });
+
+  it("aborts when the desktop/open gate flips during a drag", () => {
+    const { result, rerender } = renderHook(({ open }) => useResizablePanel(open), {
+      initialProps: { open: true },
+    });
+    const handle = createPointerHandle();
+
+    act(() => {
+      result.current.handleProps.onPointerDown(pointerEvent(handle.element, { pointerId: 6 }));
+      result.current.handleProps.onPointerMove(
+        pointerEvent(handle.element, { pointerId: 6, clientX: 1200 }),
+      );
+    });
+    rerender({ open: false });
+
+    expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("ignores non-primary pen buttons", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     const handle = createPointerHandle();
     const preventDefault = vi.fn();
@@ -208,7 +290,7 @@ describe("useResizablePanel persistence", () => {
       result.current.handleProps.onPointerDown(
         pointerEvent(handle.element, {
           pointerId: 3,
-          pointerType: "mouse",
+          pointerType: "pen",
           button: 2,
           preventDefault,
         }),

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -356,6 +356,9 @@ describe("useResizablePanel persistence", () => {
     // The transcript scrollbar thumb occupies the 6–12px band from this seam;
     // keep the handle out of that band so touch-scroll starts remain available.
     expect(-Number(style.marginInlineStart)).toBeLessThanOrEqual(6);
+    // FilesPanel's toolbar uses px-2 (8px); do not annex beyond that gutter
+    // into its search control or other panel-side interactive content.
+    expect(-Number(style.marginInlineEnd)).toBeLessThanOrEqual(8);
     expect(
       4 +
         Number(style.paddingInlineStart) +
@@ -368,12 +371,12 @@ describe("useResizablePanel persistence", () => {
   it("updates the gutter when primary pointer coarseness changes", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(7);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(9);
 
     act(() => setCoarseMatch(true));
 
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(8);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(10);
   });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -342,15 +342,17 @@ describe("useResizablePanel persistence", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     const style = result.current.handleProps.style;
     const inset = (gutter - 4) / 2;
+    const totalPadding = HANDLE_OUTWARD_SLIVER_PX + HANDLE_INWARD_SLIVER_PX + 2 * inset;
 
     expect(style).toMatchObject({
       touchAction: "none",
       boxSizing: "content-box",
-      paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
-      paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
+      paddingInlineStart: gutter,
+      paddingInlineEnd: totalPadding - gutter,
       marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
       marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
       backgroundClip: "content-box",
+      clipPath: `inset(0 0 0 ${gutter}px)`,
     });
     expect(4 + Number(style.paddingInlineStart) + Number(style.paddingInlineEnd)).toBe(target);
     // The transcript scrollbar thumb occupies the 6–12px band from this seam;
@@ -371,12 +373,12 @@ describe("useResizablePanel persistence", () => {
   it("updates the gutter when primary pointer coarseness changes", () => {
     const { result } = renderHook(() => useResizablePanel(true));
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(9);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(10);
 
     act(() => setCoarseMatch(true));
 
     expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
-    expect(result.current.handleProps.style.paddingInlineStart).toBe(10);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(12);
   });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -1,16 +1,44 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPanelSizePreference } from "@/lib/panelSizePreferences";
 import {
+  HANDLE_FINE_HIT_PAD_PX,
   HANDLE_HIT_PAD_PX,
   resetSharedWidthStoreForTesting,
   useResizablePanel,
 } from "./useResizablePanel";
 
 const originalInnerWidth = window.innerWidth;
+const originalMatchMedia = window.matchMedia;
+let desktopMatches = true;
+let coarsePointer = false;
+const desktopChangeListeners = new Set<(event: MediaQueryListEvent) => void>();
 
 function setInnerWidth(px: number): void {
   Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: px });
+}
+
+function installMatchMedia(): void {
+  window.matchMedia = vi.fn((query: string) => ({
+    matches: query === "(pointer: coarse)" ? coarsePointer : desktopMatches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+      if (query.includes("min-width")) desktopChangeListeners.add(listener);
+    },
+    removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+      desktopChangeListeners.delete(listener);
+    },
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+}
+
+function setDesktopMatch(matches: boolean): void {
+  desktopMatches = matches;
+  const event = { matches } as MediaQueryListEvent;
+  for (const listener of desktopChangeListeners) listener(event);
 }
 
 function createPointerHandle() {
@@ -49,20 +77,20 @@ function pointerEvent(
   } as React.PointerEvent<HTMLElement>;
 }
 
-function dispatchDocumentPointer(type: "pointerup" | "pointercancel", pointerId: number): void {
-  const event = new Event(type);
-  Object.defineProperty(event, "pointerId", { value: pointerId });
-  document.dispatchEvent(event);
-}
-
 beforeEach(() => {
   setInnerWidth(2000);
+  desktopMatches = true;
+  coarsePointer = false;
+  desktopChangeListeners.clear();
+  installMatchMedia();
 });
 
 afterEach(() => {
   localStorage.clear();
   resetSharedWidthStoreForTesting();
   setInnerWidth(originalInnerWidth);
+  window.matchMedia = originalMatchMedia;
+  desktopChangeListeners.clear();
 });
 
 describe("useResizablePanel persistence", () => {
@@ -234,38 +262,25 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.panelWidth).toBe(800);
   });
 
-  it("recovers when the handle unmounts mid-drag", () => {
-    const { result } = renderHook(() => useResizablePanel(true));
-    const removedHandle = createPointerHandle();
-    const nextHandle = createPointerHandle();
-    document.body.appendChild(removedHandle.element);
+  it("aborts without persisting when the hook unmounts mid-drag", () => {
+    const { result, unmount } = renderHook(() => useResizablePanel(true));
+    const handle = createPointerHandle();
 
     act(() => {
-      result.current.handleProps.onPointerDown(
-        pointerEvent(removedHandle.element, { pointerId: 4 }),
-      );
+      result.current.handleProps.onPointerDown(pointerEvent(handle.element, { pointerId: 4 }));
       result.current.handleProps.onPointerMove(
-        pointerEvent(removedHandle.element, { pointerId: 4, clientX: 1200 }),
+        pointerEvent(handle.element, { pointerId: 4, clientX: 1200 }),
       );
-      removedHandle.element.remove();
-      dispatchDocumentPointer("pointercancel", 4);
+      unmount();
     });
 
-    expect(result.current.panelWidth).toBe(800);
     expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
     expect(document.body.style.cursor).toBe("");
     expect(document.body.style.userSelect).toBe("");
-
-    act(() => {
-      result.current.handleProps.onPointerDown(pointerEvent(nextHandle.element, { pointerId: 5 }));
-    });
-    expect(nextHandle.setPointerCapture).toHaveBeenCalledWith(5);
   });
 
-  it("aborts when the desktop/open gate flips during a drag", () => {
-    const { result, rerender } = renderHook(({ open }) => useResizablePanel(open), {
-      initialProps: { open: true },
-    });
+  it("aborts when the desktop media query flips during a drag", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
     const handle = createPointerHandle();
 
     act(() => {
@@ -274,8 +289,9 @@ describe("useResizablePanel persistence", () => {
         pointerEvent(handle.element, { pointerId: 6, clientX: 1200 }),
       );
     });
-    rerender({ open: false });
+    act(() => setDesktopMatch(false));
 
+    expect(result.current.isDesktop).toBe(false);
     expect(readPanelSizePreference("pushPanelWidthPx")).toBeNull();
     expect(document.body.style.cursor).toBe("");
     expect(document.body.style.userSelect).toBe("");
@@ -305,17 +321,51 @@ describe("useResizablePanel persistence", () => {
     expect(result.current.panelWidth).toBe(1000);
   });
 
-  it("returns touch-action and a 44px cross-axis hit target", () => {
+  it.each([
+    ["fine", false, HANDLE_FINE_HIT_PAD_PX, 24],
+    ["coarse", true, HANDLE_HIT_PAD_PX, 44],
+  ] as const)("returns a centered zero-footprint %s hit target", (_, coarse, pad, target) => {
+    coarsePointer = coarse;
     const { result } = renderHook(() => useResizablePanel(true));
+    const style = result.current.handleProps.style;
 
-    expect(result.current.handleProps.style).toMatchObject({
+    expect(style).toMatchObject({
       touchAction: "none",
       boxSizing: "content-box",
-      paddingInline: HANDLE_HIT_PAD_PX,
-      marginInline: -HANDLE_HIT_PAD_PX,
+      paddingInline: pad,
+      marginInline: -(pad + 2),
       backgroundClip: "content-box",
     });
+    expect(4 + 2 * Number(style.paddingInline)).toBe(target);
+    expect(4 + 2 * Number(style.paddingInline) + 2 * Number(style.marginInline)).toBe(0);
   });
+
+  it.each(["FilesPanelDrawer", "FileViewer", "ExecutionLogsPanel", "TerminalsPanel"])(
+    "keeps the %s boundary handle outside the clipping panel",
+    (consumer) => {
+      const { result } = renderHook(() => useResizablePanel(true));
+      render(
+        <div className="flex" data-testid={`${consumer}-row`}>
+          <div
+            {...result.current.handleProps}
+            className="relative z-10 w-1 shrink-0 self-stretch"
+          />
+          <aside className="overflow-hidden" data-testid={`${consumer}-panel`} />
+        </div>,
+      );
+
+      const panel = screen.getByTestId(`${consumer}-panel`);
+      const handle = screen.getByRole("separator", { name: "Resize panel" });
+      expect(handle.nextElementSibling).toBe(panel);
+      expect(panel.contains(handle)).toBe(false);
+      expect(handle.closest("aside, .overflow-auto, .overflow-hidden")).toBeNull();
+      expect(handle.className).toMatch(/\bw-1\b/);
+      expect(handle.style.backgroundClip).toBe("content-box");
+      expect(
+        4 + 2 * parseFloat(handle.style.paddingInline) + 2 * parseFloat(handle.style.marginInline),
+      ).toBe(0);
+    },
+  );
 
   it("notifies multiple mounted subscribers from the shared width store", () => {
     const first = renderHook(() => useResizablePanel(true));

--- a/web/src/hooks/useResizablePanel.test.tsx
+++ b/web/src/hooks/useResizablePanel.test.tsx
@@ -1,9 +1,11 @@
-import { act, render, renderHook, screen } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPanelSizePreference } from "@/lib/panelSizePreferences";
 import {
-  HANDLE_FINE_HIT_PAD_PX,
-  HANDLE_HIT_PAD_PX,
+  HANDLE_COARSE_GUTTER_PX,
+  HANDLE_FINE_GUTTER_PX,
+  HANDLE_INWARD_SLIVER_PX,
+  HANDLE_OUTWARD_SLIVER_PX,
   resetSharedWidthStoreForTesting,
   useResizablePanel,
 } from "./useResizablePanel";
@@ -13,6 +15,7 @@ const originalMatchMedia = window.matchMedia;
 let desktopMatches = true;
 let coarsePointer = false;
 const desktopChangeListeners = new Set<(event: MediaQueryListEvent) => void>();
+const coarseChangeListeners = new Set<(event: MediaQueryListEvent) => void>();
 
 function setInnerWidth(px: number): void {
   Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: px });
@@ -26,13 +29,21 @@ function installMatchMedia(): void {
     addListener: () => {},
     removeListener: () => {},
     addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
-      if (query.includes("min-width")) desktopChangeListeners.add(listener);
+      if (query === "(pointer: coarse)") coarseChangeListeners.add(listener);
+      else if (query.includes("min-width")) desktopChangeListeners.add(listener);
     },
     removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
-      desktopChangeListeners.delete(listener);
+      if (query === "(pointer: coarse)") coarseChangeListeners.delete(listener);
+      else desktopChangeListeners.delete(listener);
     },
     dispatchEvent: () => false,
   })) as typeof window.matchMedia;
+}
+
+function setCoarseMatch(matches: boolean): void {
+  coarsePointer = matches;
+  const event = { matches } as MediaQueryListEvent;
+  for (const listener of coarseChangeListeners) listener(event);
 }
 
 function setDesktopMatch(matches: boolean): void {
@@ -82,6 +93,7 @@ beforeEach(() => {
   desktopMatches = true;
   coarsePointer = false;
   desktopChangeListeners.clear();
+  coarseChangeListeners.clear();
   installMatchMedia();
 });
 
@@ -91,6 +103,7 @@ afterEach(() => {
   setInnerWidth(originalInnerWidth);
   window.matchMedia = originalMatchMedia;
   desktopChangeListeners.clear();
+  coarseChangeListeners.clear();
 });
 
 describe("useResizablePanel persistence", () => {
@@ -322,50 +335,43 @@ describe("useResizablePanel persistence", () => {
   });
 
   it.each([
-    ["fine", false, HANDLE_FINE_HIT_PAD_PX, 24],
-    ["coarse", true, HANDLE_HIT_PAD_PX, 44],
-  ] as const)("returns a centered zero-footprint %s hit target", (_, coarse, pad, target) => {
+    ["fine", false, HANDLE_FINE_GUTTER_PX, 24],
+    ["coarse", true, HANDLE_COARSE_GUTTER_PX, 26],
+  ] as const)("returns the budgeted %s seam gutter", (_, coarse, gutter, target) => {
     coarsePointer = coarse;
     const { result } = renderHook(() => useResizablePanel(true));
     const style = result.current.handleProps.style;
+    const inset = (gutter - 4) / 2;
 
     expect(style).toMatchObject({
       touchAction: "none",
       boxSizing: "content-box",
-      paddingInline: pad,
-      marginInline: -(pad + 2),
+      paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
+      paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
+      marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
+      marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
       backgroundClip: "content-box",
     });
-    expect(4 + 2 * Number(style.paddingInline)).toBe(target);
-    expect(4 + 2 * Number(style.paddingInline) + 2 * Number(style.marginInline)).toBe(0);
+    expect(4 + Number(style.paddingInlineStart) + Number(style.paddingInlineEnd)).toBe(target);
+    expect(
+      4 +
+        Number(style.paddingInlineStart) +
+        Number(style.paddingInlineEnd) +
+        Number(style.marginInlineStart) +
+        Number(style.marginInlineEnd),
+    ).toBe(gutter);
   });
 
-  it.each(["FilesPanelDrawer", "FileViewer", "ExecutionLogsPanel", "TerminalsPanel"])(
-    "keeps the %s boundary handle outside the clipping panel",
-    (consumer) => {
-      const { result } = renderHook(() => useResizablePanel(true));
-      render(
-        <div className="flex" data-testid={`${consumer}-row`}>
-          <div
-            {...result.current.handleProps}
-            className="relative z-10 w-1 shrink-0 self-stretch"
-          />
-          <aside className="overflow-hidden" data-testid={`${consumer}-panel`} />
-        </div>,
-      );
+  it("updates the gutter when primary pointer coarseness changes", () => {
+    const { result } = renderHook(() => useResizablePanel(true));
+    expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(11);
 
-      const panel = screen.getByTestId(`${consumer}-panel`);
-      const handle = screen.getByRole("separator", { name: "Resize panel" });
-      expect(handle.nextElementSibling).toBe(panel);
-      expect(panel.contains(handle)).toBe(false);
-      expect(handle.closest("aside, .overflow-auto, .overflow-hidden")).toBeNull();
-      expect(handle.className).toMatch(/\bw-1\b/);
-      expect(handle.style.backgroundClip).toBe("content-box");
-      expect(
-        4 + 2 * parseFloat(handle.style.paddingInline) + 2 * parseFloat(handle.style.marginInline),
-      ).toBe(0);
-    },
-  );
+    act(() => setCoarseMatch(true));
+
+    expect(result.current.handleProps.style.marginInlineStart).toBe(-HANDLE_OUTWARD_SLIVER_PX);
+    expect(result.current.handleProps.style.paddingInlineStart).toBe(12);
+  });
 
   it("notifies multiple mounted subscribers from the shared width store", () => {
     const first = renderHook(() => useResizablePanel(true));

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -7,9 +7,9 @@ const MAX_WIDTH_RATIO = 0.8; // 80% of viewport
 const MD_BREAKPOINT = 768;
 const PAINTED_HANDLE_WIDTH_PX = 4;
 export const HANDLE_OUTWARD_SLIVER_PX = 6;
-export const HANDLE_INWARD_SLIVER_PX = 12;
-export const HANDLE_COARSE_GUTTER_PX = 8;
-export const HANDLE_FINE_GUTTER_PX = 6;
+export const HANDLE_INWARD_SLIVER_PX = 8;
+export const HANDLE_COARSE_GUTTER_PX = 12;
+export const HANDLE_FINE_GUTTER_PX = 10;
 
 function handleGutterStyle(isCoarse: boolean): React.CSSProperties {
   const gutter = isCoarse ? HANDLE_COARSE_GUTTER_PX : HANDLE_FINE_GUTTER_PX;

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -5,6 +5,8 @@ const MIN_WIDTH_PX = 320;
 const MAX_WIDTH_RATIO = 0.8; // 80% of viewport
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
+/** Padding that expands the visual 4px handle to a 44px hit target. */
+export const HANDLE_HIT_PAD_PX = 20;
 
 /** Clamp a width value to the allowed range for the current viewport. */
 function clampWidth(w: number, minPx = MIN_WIDTH_PX): number {
@@ -99,11 +101,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     getSharedWidthSnapshot,
     getSharedWidthServerSnapshot,
   );
-  const activePointerRef = useRef<{
-    element: HTMLElement;
-    pointerId: number;
-    cleanup: () => void;
-  } | null>(null);
+  const activePointerId = useRef<number | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
@@ -166,16 +164,11 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     overlayRef.current = null;
   }, []);
 
-  const finishDrag = useCallback(
-    (pointerId: number, persist: boolean) => {
-      const activePointer = activePointerRef.current;
-      if (activePointer === null || pointerId !== activePointer.pointerId) return;
-      activePointerRef.current = null;
-      activePointer.cleanup();
+  const endDrag = useCallback(
+    (persist: boolean) => {
+      if (activePointerId.current === null) return;
+      activePointerId.current = null;
       if (persist) persistSharedWidth();
-      if (activePointer.element.hasPointerCapture(activePointer.pointerId)) {
-        activePointer.element.releasePointerCapture(activePointer.pointerId);
-      }
       removeDragOverlay();
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -186,35 +179,42 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLElement>) => {
       if (!open || !isDesktop) return;
-      if (activePointerRef.current !== null) return;
+      if (activePointerId.current !== null) return;
+      if (e.pointerType === "mouse" && e.button !== 0) return;
       e.preventDefault();
-      const element = e.currentTarget;
-      const pointerId = e.pointerId;
-      const onPointerMove = (event: PointerEvent) => {
-        if (event.pointerId !== pointerId) return;
-        // Update the live width only; persisting on every move would fire a
-        // synchronous localStorage write per pointermove. Snapshot once on release.
-        setSharedWidth(clampWidth(window.innerWidth - event.clientX, minWidthRef.current));
-      };
-      const onPointerUp = (event: PointerEvent) => finishDrag(event.pointerId, true);
-      const onPointerAbort = (event: PointerEvent) => finishDrag(event.pointerId, false);
-      const cleanup = () => {
-        element.removeEventListener("pointermove", onPointerMove);
-        element.removeEventListener("pointerup", onPointerUp);
-        element.removeEventListener("pointercancel", onPointerAbort);
-        element.removeEventListener("lostpointercapture", onPointerAbort);
-      };
-      activePointerRef.current = { element, pointerId, cleanup };
-      element.addEventListener("pointermove", onPointerMove);
-      element.addEventListener("pointerup", onPointerUp);
-      element.addEventListener("pointercancel", onPointerAbort);
-      element.addEventListener("lostpointercapture", onPointerAbort);
-      element.setPointerCapture(pointerId);
+      activePointerId.current = e.pointerId;
+      e.currentTarget.setPointerCapture?.(e.pointerId);
       addDragOverlay();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
-    [addDragOverlay, finishDrag, open, isDesktop],
+    [addDragOverlay, open, isDesktop],
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (e.pointerId !== activePointerId.current) return;
+    // Update the live width only; persist once on pointerup to avoid a
+    // synchronous localStorage write per pointermove.
+    setSharedWidth(clampWidth(window.innerWidth - e.clientX, minWidthRef.current));
+  }, []);
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (e.pointerId !== activePointerId.current) return;
+      endDrag(true);
+      if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+    },
+    [endDrag],
+  );
+
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (e.pointerId !== activePointerId.current) return;
+      endDrag(false);
+    },
+    [endDrag],
   );
 
   // Keyboard resize: left/right arrow keys adjust width by 20px.
@@ -239,21 +239,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     [open, isDesktop, resolvedWidth],
   );
 
-  useEffect(() => {
-    return () => {
-      const activePointer = activePointerRef.current;
-      if (activePointer !== null) {
-        activePointerRef.current = null;
-        activePointer.cleanup();
-        if (activePointer.element.hasPointerCapture(activePointer.pointerId)) {
-          activePointer.element.releasePointerCapture(activePointer.pointerId);
-        }
-        removeDragOverlay();
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-    };
-  }, [removeDragOverlay]);
+  useEffect(() => () => endDrag(false), [endDrag]);
 
   // On mobile the panel is a fixed full-screen overlay — no inline width.
   const panelWidth = isDesktop ? (open ? resolvedWidth : 0) : undefined;
@@ -264,12 +250,16 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     /** Props to spread onto the resize handle element. */
     handleProps: {
       onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onLostPointerCapture: onPointerCancel,
       onKeyDown,
       style: {
         touchAction: "none",
         boxSizing: "content-box" as const,
-        paddingInline: 20,
-        marginInline: -20,
+        paddingInline: HANDLE_HIT_PAD_PX,
+        marginInline: -HANDLE_HIT_PAD_PX,
         backgroundClip: "content-box",
       },
       role: "separator" as const,

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -14,16 +14,14 @@ export const HANDLE_FINE_GUTTER_PX = 10;
 function handleGutterStyle(isCoarse: boolean): React.CSSProperties {
   const gutter = isCoarse ? HANDLE_COARSE_GUTTER_PX : HANDLE_FINE_GUTTER_PX;
   const inset = (gutter - PAINTED_HANDLE_WIDTH_PX) / 2;
-  const totalPadding = HANDLE_OUTWARD_SLIVER_PX + HANDLE_INWARD_SLIVER_PX + 2 * inset;
   return {
     touchAction: "none",
     boxSizing: "content-box",
-    paddingInlineStart: gutter,
-    paddingInlineEnd: totalPadding - gutter,
+    paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
+    paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
     marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
     marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
     backgroundClip: "content-box",
-    clipPath: `inset(0 0 0 ${gutter}px)`,
   };
 }
 

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -102,6 +102,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     getSharedWidthServerSnapshot,
   );
   const activePointerId = useRef<number | null>(null);
+  const documentFallbackCleanupRef = useRef<(() => void) | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
@@ -168,6 +169,8 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     (persist: boolean) => {
       if (activePointerId.current === null) return;
       activePointerId.current = null;
+      documentFallbackCleanupRef.current?.();
+      documentFallbackCleanupRef.current = null;
       if (persist) persistSharedWidth();
       removeDragOverlay();
       document.body.style.cursor = "";
@@ -180,15 +183,31 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     (e: React.PointerEvent<HTMLElement>) => {
       if (!open || !isDesktop) return;
       if (activePointerId.current !== null) return;
-      if (e.pointerType === "mouse" && e.button !== 0) return;
+      if (e.button !== 0) return;
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        return;
+      }
       e.preventDefault();
       activePointerId.current = e.pointerId;
-      e.currentTarget.setPointerCapture?.(e.pointerId);
+      const onDocumentPointerUp = (event: PointerEvent) => {
+        if (event.pointerId === activePointerId.current) endDrag(true);
+      };
+      const onDocumentPointerCancel = (event: PointerEvent) => {
+        if (event.pointerId === activePointerId.current) endDrag(false);
+      };
+      document.addEventListener("pointerup", onDocumentPointerUp);
+      document.addEventListener("pointercancel", onDocumentPointerCancel);
+      documentFallbackCleanupRef.current = () => {
+        document.removeEventListener("pointerup", onDocumentPointerUp);
+        document.removeEventListener("pointercancel", onDocumentPointerCancel);
+      };
       addDragOverlay();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
-    [addDragOverlay, open, isDesktop],
+    [addDragOverlay, endDrag, open, isDesktop],
   );
 
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
@@ -240,6 +259,10 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   );
 
   useEffect(() => () => endDrag(false), [endDrag]);
+
+  useEffect(() => {
+    if (!open || !isDesktop) endDrag(false);
+  }, [endDrag, isDesktop, open]);
 
   // On mobile the panel is a fixed full-screen overlay — no inline width.
   const panelWidth = isDesktop ? (open ? resolvedWidth : 0) : undefined;

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -6,17 +6,23 @@ const MAX_WIDTH_RATIO = 0.8; // 80% of viewport
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
 const PAINTED_HANDLE_WIDTH_PX = 4;
-/** Per-side padding for the preferred 44px coarse-pointer hit target. */
-export const HANDLE_HIT_PAD_PX = 20;
-/** Per-side padding for the 24px fine-pointer hit target. */
-export const HANDLE_FINE_HIT_PAD_PX = 10;
+export const HANDLE_OUTWARD_SLIVER_PX = 10;
+export const HANDLE_INWARD_SLIVER_PX = 8;
+export const HANDLE_COARSE_GUTTER_PX = 8;
+export const HANDLE_FINE_GUTTER_PX = 6;
 
-function handleHitPad(): number {
-  const isCoarse =
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(pointer: coarse)").matches;
-  return isCoarse ? HANDLE_HIT_PAD_PX : HANDLE_FINE_HIT_PAD_PX;
+function handleGutterStyle(isCoarse: boolean): React.CSSProperties {
+  const gutter = isCoarse ? HANDLE_COARSE_GUTTER_PX : HANDLE_FINE_GUTTER_PX;
+  const inset = (gutter - PAINTED_HANDLE_WIDTH_PX) / 2;
+  return {
+    touchAction: "none",
+    boxSizing: "content-box",
+    paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
+    paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
+    marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
+    marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
+    backgroundClip: "content-box",
+  };
 }
 
 /** Clamp a width value to the allowed range for the current viewport. */
@@ -115,7 +121,6 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   const activePointerId = useRef<number | null>(null);
   const documentFallbackCleanupRef = useRef<(() => void) | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
-  const hitPad = useRef(handleHitPad()).current;
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
 
@@ -127,6 +132,18 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   useEffect(() => {
     const mql = window.matchMedia(`(min-width: ${MD_BREAKPOINT}px)`);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  const [isCoarse, setIsCoarse] = useState(
+    () => typeof window !== "undefined" && !!window.matchMedia?.("(pointer: coarse)").matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia?.("(pointer: coarse)");
+    if (!mql) return;
+    const handler = (e: MediaQueryListEvent) => setIsCoarse(e.matches);
     mql.addEventListener("change", handler);
     return () => mql.removeEventListener("change", handler);
   }, []);
@@ -290,13 +307,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
       onPointerCancel,
       onLostPointerCapture: onPointerCancel,
       onKeyDown,
-      style: {
-        touchAction: "none",
-        boxSizing: "content-box" as const,
-        paddingInline: hitPad,
-        marginInline: -(hitPad + PAINTED_HANDLE_WIDTH_PX / 2),
-        backgroundClip: "content-box",
-      },
+      style: handleGutterStyle(isCoarse),
       role: "separator" as const,
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize panel",

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -6,8 +6,8 @@ const MAX_WIDTH_RATIO = 0.8; // 80% of viewport
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
 const PAINTED_HANDLE_WIDTH_PX = 4;
-export const HANDLE_OUTWARD_SLIVER_PX = 10;
-export const HANDLE_INWARD_SLIVER_PX = 8;
+export const HANDLE_OUTWARD_SLIVER_PX = 6;
+export const HANDLE_INWARD_SLIVER_PX = 12;
 export const HANDLE_COARSE_GUTTER_PX = 8;
 export const HANDLE_FINE_GUTTER_PX = 6;
 

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -79,7 +79,7 @@ export function resetSharedWidthStoreForTesting(): void {
 }
 
 /**
- * Hook for making a right-side panel resizable via mouse drag on its left edge.
+ * Hook for making a right-side panel resizable via pointer drag on its left edge.
  *
  * On desktop (`≥ md`) the panel width is controlled via an inline style
  * driven by drag state. On mobile (`< md`) the panel is a full-screen
@@ -99,7 +99,12 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     getSharedWidthSnapshot,
     getSharedWidthServerSnapshot,
   );
-  const dragging = useRef(false);
+  const activePointerRef = useRef<{
+    element: HTMLElement;
+    pointerId: number;
+    cleanup: () => void;
+  } | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
 
@@ -147,15 +152,69 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     minWidthPx,
   );
 
-  const onMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const addDragOverlay = useCallback(() => {
+    if (overlayRef.current || typeof document === "undefined") return;
+    const element = document.createElement("div");
+    element.style.cssText =
+      "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;background:transparent;";
+    document.body.appendChild(element);
+    overlayRef.current = element;
+  }, []);
+
+  const removeDragOverlay = useCallback(() => {
+    overlayRef.current?.remove();
+    overlayRef.current = null;
+  }, []);
+
+  const finishDrag = useCallback(
+    (pointerId: number, persist: boolean) => {
+      const activePointer = activePointerRef.current;
+      if (activePointer === null || pointerId !== activePointer.pointerId) return;
+      activePointerRef.current = null;
+      activePointer.cleanup();
+      if (persist) persistSharedWidth();
+      if (activePointer.element.hasPointerCapture(activePointer.pointerId)) {
+        activePointer.element.releasePointerCapture(activePointer.pointerId);
+      }
+      removeDragOverlay();
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    },
+    [removeDragOverlay],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
       if (!open || !isDesktop) return;
+      if (activePointerRef.current !== null) return;
       e.preventDefault();
-      dragging.current = true;
+      const element = e.currentTarget;
+      const pointerId = e.pointerId;
+      const onPointerMove = (event: PointerEvent) => {
+        if (event.pointerId !== pointerId) return;
+        // Update the live width only; persisting on every move would fire a
+        // synchronous localStorage write per pointermove. Snapshot once on release.
+        setSharedWidth(clampWidth(window.innerWidth - event.clientX, minWidthRef.current));
+      };
+      const onPointerUp = (event: PointerEvent) => finishDrag(event.pointerId, true);
+      const onPointerAbort = (event: PointerEvent) => finishDrag(event.pointerId, false);
+      const cleanup = () => {
+        element.removeEventListener("pointermove", onPointerMove);
+        element.removeEventListener("pointerup", onPointerUp);
+        element.removeEventListener("pointercancel", onPointerAbort);
+        element.removeEventListener("lostpointercapture", onPointerAbort);
+      };
+      activePointerRef.current = { element, pointerId, cleanup };
+      element.addEventListener("pointermove", onPointerMove);
+      element.addEventListener("pointerup", onPointerUp);
+      element.addEventListener("pointercancel", onPointerAbort);
+      element.addEventListener("lostpointercapture", onPointerAbort);
+      element.setPointerCapture(pointerId);
+      addDragOverlay();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
-    [open, isDesktop],
+    [addDragOverlay, finishDrag, open, isDesktop],
   );
 
   // Keyboard resize: left/right arrow keys adjust width by 20px.
@@ -181,35 +240,20 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   );
 
   useEffect(() => {
-    function onMouseMove(e: MouseEvent) {
-      if (!dragging.current) return;
-      // Update the live width only; persisting on every move would fire a
-      // synchronous localStorage write per mousemove. We snapshot once on release.
-      setSharedWidth(clampWidth(window.innerWidth - e.clientX, minWidthRef.current));
-    }
-
-    function onMouseUp() {
-      if (!dragging.current) return;
-      dragging.current = false;
-      persistSharedWidth();
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    }
-
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
     return () => {
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
-      // Reset body styles if unmounted mid-drag (e.g. panel closed
-      // via Escape while dragging).
-      if (dragging.current) {
-        dragging.current = false;
+      const activePointer = activePointerRef.current;
+      if (activePointer !== null) {
+        activePointerRef.current = null;
+        activePointer.cleanup();
+        if (activePointer.element.hasPointerCapture(activePointer.pointerId)) {
+          activePointer.element.releasePointerCapture(activePointer.pointerId);
+        }
+        removeDragOverlay();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }
     };
-  }, []);
+  }, [removeDragOverlay]);
 
   // On mobile the panel is a fixed full-screen overlay — no inline width.
   const panelWidth = isDesktop ? (open ? resolvedWidth : 0) : undefined;
@@ -219,8 +263,15 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
     panelWidth,
     /** Props to spread onto the resize handle element. */
     handleProps: {
-      onMouseDown,
+      onPointerDown,
       onKeyDown,
+      style: {
+        touchAction: "none",
+        boxSizing: "content-box" as const,
+        paddingInline: 20,
+        marginInline: -20,
+        backgroundClip: "content-box",
+      },
       role: "separator" as const,
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize panel",

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -5,8 +5,19 @@ const MIN_WIDTH_PX = 320;
 const MAX_WIDTH_RATIO = 0.8; // 80% of viewport
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
-/** Padding that expands the visual 4px handle to a 44px hit target. */
+const PAINTED_HANDLE_WIDTH_PX = 4;
+/** Per-side padding for the preferred 44px coarse-pointer hit target. */
 export const HANDLE_HIT_PAD_PX = 20;
+/** Per-side padding for the 24px fine-pointer hit target. */
+export const HANDLE_FINE_HIT_PAD_PX = 10;
+
+function handleHitPad(): number {
+  const isCoarse =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches;
+  return isCoarse ? HANDLE_HIT_PAD_PX : HANDLE_FINE_HIT_PAD_PX;
+}
 
 /** Clamp a width value to the allowed range for the current viewport. */
 function clampWidth(w: number, minPx = MIN_WIDTH_PX): number {
@@ -104,6 +115,7 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
   const activePointerId = useRef<number | null>(null);
   const documentFallbackCleanupRef = useRef<(() => void) | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const hitPad = useRef(handleHitPad()).current;
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
 
@@ -281,8 +293,8 @@ export function useResizablePanel(open: boolean, defaultWidthVw = 50, minWidthPx
       style: {
         touchAction: "none",
         boxSizing: "content-box" as const,
-        paddingInline: HANDLE_HIT_PAD_PX,
-        marginInline: -HANDLE_HIT_PAD_PX,
+        paddingInline: hitPad,
+        marginInline: -(hitPad + PAINTED_HANDLE_WIDTH_PX / 2),
         backgroundClip: "content-box",
       },
       role: "separator" as const,

--- a/web/src/hooks/useResizablePanel.ts
+++ b/web/src/hooks/useResizablePanel.ts
@@ -14,14 +14,16 @@ export const HANDLE_FINE_GUTTER_PX = 10;
 function handleGutterStyle(isCoarse: boolean): React.CSSProperties {
   const gutter = isCoarse ? HANDLE_COARSE_GUTTER_PX : HANDLE_FINE_GUTTER_PX;
   const inset = (gutter - PAINTED_HANDLE_WIDTH_PX) / 2;
+  const totalPadding = HANDLE_OUTWARD_SLIVER_PX + HANDLE_INWARD_SLIVER_PX + 2 * inset;
   return {
     touchAction: "none",
     boxSizing: "content-box",
-    paddingInlineStart: HANDLE_OUTWARD_SLIVER_PX + inset,
-    paddingInlineEnd: HANDLE_INWARD_SLIVER_PX + inset,
+    paddingInlineStart: gutter,
+    paddingInlineEnd: totalPadding - gutter,
     marginInlineStart: -HANDLE_OUTWARD_SLIVER_PX,
     marginInlineEnd: -HANDLE_INWARD_SLIVER_PX,
     backgroundClip: "content-box",
+    clipPath: `inset(0 0 0 ${gutter}px)`,
   };
 }
 

--- a/web/src/shell/ExecutionLogsPanel.test.tsx
+++ b/web/src/shell/ExecutionLogsPanel.test.tsx
@@ -25,6 +25,7 @@ const h = vi.hoisted(() => ({
     fetchNextPage: () => {},
   },
   sessionStatus: "idle" as string,
+  isDesktop: false,
 }));
 
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => {
@@ -39,7 +40,15 @@ vi.mock("@/hooks/useSessionItems", () => ({
 }));
 
 vi.mock("@/hooks/useResizablePanel", () => ({
-  useResizablePanel: () => ({ panelWidth: 400, handleProps: { tabIndex: 0 }, isDesktop: false }),
+  useResizablePanel: () => ({
+    panelWidth: 400,
+    handleProps: {
+      role: "separator" as const,
+      "aria-label": "Resize panel",
+      tabIndex: 0,
+    },
+    isDesktop: h.isDesktop,
+  }),
 }));
 
 vi.mock("@/store/chatStore", () => ({
@@ -92,6 +101,7 @@ beforeEach(() => {
     fetchNextPage: () => {},
   };
   h.sessionStatus = "idle";
+  h.isDesktop = false;
 });
 
 afterEach(() => {
@@ -99,6 +109,18 @@ afterEach(() => {
 });
 
 describe("ExecutionLogsPanel open/close gating", () => {
+  it("renders the resize handle as the panel's unclipped boundary sibling", () => {
+    h.isDesktop = true;
+    renderPanel({ open: true });
+    const handle = screen.getByRole("separator", { name: "Resize panel" });
+    const panel = screen.getByTestId("execution-logs-panel");
+
+    expect(handle.nextElementSibling).toBe(panel);
+    expect(panel.contains(handle)).toBe(false);
+    expect(handle.closest(".overflow-hidden, .overflow-auto, .overflow-y-auto")).toBeNull();
+    expect(handle.className).toMatch(/\bz-10\b/);
+  });
+
   it("reflects open state via data-state and shows the active entry", () => {
     // WHY: when open the panel exposes data-state=open and renders the selector
     // for the main entry; the empty-content branch must not be taken.

--- a/web/src/shell/ExecutionLogsPanel.tsx
+++ b/web/src/shell/ExecutionLogsPanel.tsx
@@ -133,104 +133,106 @@ export function ExecutionLogsPanel({
   const [view, setView] = useState<"items" | "sse">("items");
 
   return (
-    <aside
-      ref={ref}
-      data-testid="execution-logs-panel"
-      data-state={open ? "open" : "closed"}
-      style={{ width: panelWidth }}
-      className={cn(
-        "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
-        "fixed inset-0 z-50 shadow-lg",
-        open ? "translate-x-0" : "translate-x-full",
-        "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
-        open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
-      )}
-      aria-hidden={!open}
-      data-collapsed={!open || undefined}
-    >
-      {isDesktop && (
+    <>
+      {isDesktop && open && (
         <div
           {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          className="relative z-10 w-1 shrink-0 self-stretch cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
         />
       )}
-      <header className="flex shrink-0 items-center justify-between border-border border-b px-4 py-3">
-        <h2 className="font-medium text-ui">Execution logs</h2>
-        <Button type="button" variant="ghost" size="icon-sm" aria-label="Close" onClick={onClose}>
-          <XIcon className="size-4" />
-        </Button>
-      </header>
+      <aside
+        ref={ref}
+        data-testid="execution-logs-panel"
+        data-state={open ? "open" : "closed"}
+        style={{ width: panelWidth }}
+        className={cn(
+          "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
+          "fixed inset-0 z-50 shadow-lg",
+          open ? "translate-x-0" : "translate-x-full",
+          "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
+          open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
+        )}
+        aria-hidden={!open}
+        data-collapsed={!open || undefined}
+      >
+        <header className="flex shrink-0 items-center justify-between border-border border-b px-4 py-3">
+          <h2 className="font-medium text-ui">Execution logs</h2>
+          <Button type="button" variant="ghost" size="icon-sm" aria-label="Close" onClick={onClose}>
+            <XIcon className="size-4" />
+          </Button>
+        </header>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
-        {!open || !activeEntry ? (
-          <div className="flex-1" />
-        ) : (
-          <>
-            <div className="flex items-center gap-2">
-              <Select value={activeEntry.key} onValueChange={setActiveKey}>
-                {/* The trigger already has `w-fit` by default. We add
+        <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+          {!open || !activeEntry ? (
+            <div className="flex-1" />
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <Select value={activeEntry.key} onValueChange={setActiveKey}>
+                  {/* The trigger already has `w-fit` by default. We add
                     `self-start` so the flex column doesn't stretch it
                     across the panel's cross-axis — without this, the
                     trigger fills the full panel width regardless of
                     content. */}
-                <SelectTrigger className="self-start">
-                  <SelectValue>
-                    <span className="inline-flex items-center gap-2">
-                      <activeEntry.icon className="size-3.5 shrink-0 text-muted-foreground" />
-                      {activeEntry.label}
-                    </span>
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {entries.map((e) => (
-                    <SelectItem key={e.key} value={e.key}>
+                  <SelectTrigger className="self-start">
+                    <SelectValue>
                       <span className="inline-flex items-center gap-2">
-                        <e.icon className="size-3.5 shrink-0 text-muted-foreground" />
-                        {e.label}
+                        <activeEntry.icon className="size-3.5 shrink-0 text-muted-foreground" />
+                        {activeEntry.label}
                       </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {/* View toggle: conv items vs raw SSE events */}
-              <div className="ml-auto flex rounded-md border border-border text-sm">
-                <button
-                  type="button"
-                  className={cn(
-                    "px-2 py-1 rounded-l-md",
-                    view === "items"
-                      ? "bg-muted font-medium"
-                      : "text-muted-foreground hover:bg-muted/50",
-                  )}
-                  onClick={() => setView("items")}
-                >
-                  Items
-                </button>
-                <button
-                  type="button"
-                  className={cn(
-                    "px-2 py-1 rounded-r-md border-l border-border",
-                    view === "sse"
-                      ? "bg-muted font-medium"
-                      : "text-muted-foreground hover:bg-muted/50",
-                  )}
-                  onClick={() => setView("sse")}
-                >
-                  SSE
-                </button>
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {entries.map((e) => (
+                      <SelectItem key={e.key} value={e.key}>
+                        <span className="inline-flex items-center gap-2">
+                          <e.icon className="size-3.5 shrink-0 text-muted-foreground" />
+                          {e.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {/* View toggle: conv items vs raw SSE events */}
+                <div className="ml-auto flex rounded-md border border-border text-sm">
+                  <button
+                    type="button"
+                    className={cn(
+                      "px-2 py-1 rounded-l-md",
+                      view === "items"
+                        ? "bg-muted font-medium"
+                        : "text-muted-foreground hover:bg-muted/50",
+                    )}
+                    onClick={() => setView("items")}
+                  >
+                    Items
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(
+                      "px-2 py-1 rounded-r-md border-l border-border",
+                      view === "sse"
+                        ? "bg-muted font-medium"
+                        : "text-muted-foreground hover:bg-muted/50",
+                    )}
+                    onClick={() => setView("sse")}
+                  >
+                    SSE
+                  </button>
+                </div>
               </div>
-            </div>
-            {view === "items" ? (
-              /* Remount the items list when the session changes so the
+              {view === "items" ? (
+                /* Remount the items list when the session changes so the
                  expand/collapse state resets between selections. */
-              <SessionItemsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
-            ) : (
-              <SseEventsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
-            )}
-          </>
-        )}
-      </div>
-    </aside>
+                <SessionItemsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
+              ) : (
+                <SseEventsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
+              )}
+            </>
+          )}
+        </div>
+      </aside>
+    </>
   );
 }
 

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -303,6 +303,20 @@ function clearIOSViewport(): void {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+describe("FileViewer resize handle geometry", () => {
+  it("renders the handle as the panel's unclipped boundary sibling", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    renderViewer({ open: true });
+    const handle = screen.getByRole("separator", { name: "Resize panel" });
+    const panel = screen.getByTestId("file-viewer");
+
+    expect(handle.nextElementSibling).toBe(panel);
+    expect(panel.contains(handle)).toBe(false);
+    expect(handle.closest(".overflow-hidden, .overflow-auto, .overflow-y-auto")).toBeNull();
+    expect(handle.className).toMatch(/\bz-10\b/);
+  });
+});
+
 // The mobile viewer is a `fixed inset-0` overlay that the iOS shell-lock (which
 // only resizes flow content inside .app-shell) can't lift above the soft
 // keyboard. It pads its own bottom by the keyboard inset so the comments panel

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -1528,30 +1528,31 @@ function FileViewerBody({
   }
 
   return (
-    <aside
-      data-testid="file-viewer"
-      style={{ width: panelWidth, paddingBottom: keyboardInset || undefined }}
-      className={cn(
-        "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
-        // Mobile (default): fixed full-screen overlay, slide via translate-x.
-        "fixed inset-0 z-50 shadow-lg",
-        open ? "translate-x-0" : "translate-x-full",
-        // Desktop: static flex sibling; inline width from resize hook.
-        "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
-        open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
-      )}
-      aria-hidden={!open}
-      data-collapsed={!open || undefined}
-      inert={!open}
-    >
-      {/* Resize handle — desktop only (mobile is full-screen overlay) */}
-      {isDesktop && (
+    <>
+      {isDesktop && open && (
         <div
           {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          className="relative z-10 w-1 shrink-0 self-stretch cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
         />
       )}
-      {open && innerContent}
-    </aside>
+      <aside
+        data-testid="file-viewer"
+        style={{ width: panelWidth, paddingBottom: keyboardInset || undefined }}
+        className={cn(
+          "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
+          // Mobile (default): fixed full-screen overlay, slide via translate-x.
+          "fixed inset-0 z-50 shadow-lg",
+          open ? "translate-x-0" : "translate-x-full",
+          // Desktop: static flex sibling; inline width from resize hook.
+          "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
+          open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
+        )}
+        aria-hidden={!open}
+        data-collapsed={!open || undefined}
+        inert={!open}
+      >
+        {open && innerContent}
+      </aside>
+    </>
   );
 }

--- a/web/src/shell/FilesPanelDrawer.test.tsx
+++ b/web/src/shell/FilesPanelDrawer.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FilesPanelDrawer } from "./FilesPanelDrawer";
+
+vi.mock("@/hooks/useResizablePanel", () => ({
+  useResizablePanel: () => ({
+    panelWidth: 400,
+    handleProps: {
+      role: "separator" as const,
+      "aria-label": "Resize panel",
+      tabIndex: 0,
+    },
+    isDesktop: true,
+  }),
+}));
+
+vi.mock("./FilesPanel", () => ({
+  FilesPanel: () => <div data-testid="files-panel-content" />,
+}));
+
+describe("FilesPanelDrawer resize handle geometry", () => {
+  it("renders the handle as the panel's unclipped boundary sibling", () => {
+    render(
+      <FilesPanelDrawer
+        open
+        onClose={vi.fn()}
+        onFileSelect={vi.fn()}
+        flatView={false}
+        showHidden={false}
+        onShowHiddenChange={vi.fn()}
+        sort="recent"
+        onSortChange={vi.fn()}
+      />,
+    );
+    const handle = screen.getByRole("separator", { name: "Resize panel" });
+    const panel = screen.getByTestId("files-panel-drawer");
+
+    expect(handle.nextElementSibling).toBe(panel);
+    expect(panel.contains(handle)).toBe(false);
+    expect(handle.closest(".overflow-hidden, .overflow-auto, .overflow-y-auto")).toBeNull();
+    expect(handle.className).toMatch(/\bz-10\b/);
+  });
+});

--- a/web/src/shell/FilesPanelDrawer.tsx
+++ b/web/src/shell/FilesPanelDrawer.tsx
@@ -81,42 +81,44 @@ export function FilesPanelDrawer({
   }, [open]);
 
   return (
-    <aside
-      ref={ref}
-      data-testid="files-panel-drawer"
-      data-state={open ? "open" : "closed"}
-      style={{ width: panelWidth }}
-      className={cn(
-        "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
-        "fixed inset-0 z-50 shadow-lg",
-        open ? "translate-x-0" : "translate-x-full",
-        "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
-        open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
-      )}
-      aria-hidden={!open}
-      data-collapsed={!open || undefined}
-    >
-      {isDesktop && (
+    <>
+      {isDesktop && open && (
         <div
           {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          className="relative z-10 w-1 shrink-0 self-stretch cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
         />
       )}
-      {/* FilesPanel switches to its full-screen layout when `onClose`
+      <aside
+        ref={ref}
+        data-testid="files-panel-drawer"
+        data-state={open ? "open" : "closed"}
+        style={{ width: panelWidth }}
+        className={cn(
+          "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
+          "fixed inset-0 z-50 shadow-lg",
+          open ? "translate-x-0" : "translate-x-full",
+          "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0 md:shrink-0",
+          open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
+        )}
+        aria-hidden={!open}
+        data-collapsed={!open || undefined}
+      >
+        {/* FilesPanel switches to its full-screen layout when `onClose`
           is set: it owns the header (title + X close button) and
           fills the parent's height. Mount it only while open so the
           folder tree initializes from the latest inline-panel state. */}
-      {open && (
-        <FilesPanel
-          onFileSelect={onFileSelect}
-          flatView={flatView}
-          showHidden={showHidden}
-          onShowHiddenChange={onShowHiddenChange}
-          sort={sort}
-          onSortChange={onSortChange}
-          onClose={onClose}
-        />
-      )}
-    </aside>
+        {open && (
+          <FilesPanel
+            onFileSelect={onFileSelect}
+            flatView={flatView}
+            showHidden={showHidden}
+            onShowHiddenChange={onShowHiddenChange}
+            sort={sort}
+            onSortChange={onSortChange}
+            onClose={onClose}
+          />
+        )}
+      </aside>
+    </>
   );
 }

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -106,6 +106,19 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("TerminalsPanel resize handle geometry", () => {
+  it("renders the handle as the panel's unclipped boundary sibling", () => {
+    renderPanel();
+    const handle = screen.getByRole("separator", { name: "Resize panel" });
+    const panel = screen.getByTestId("terminals-panel");
+
+    expect(handle.nextElementSibling).toBe(panel);
+    expect(panel.contains(handle)).toBe(false);
+    expect(handle.closest(".overflow-hidden, .overflow-auto, .overflow-y-auto")).toBeNull();
+    expect(handle.className).toMatch(/\bz-10\b/);
+  });
+});
+
 describe("TerminalsPanel navigation", () => {
   it("opens to the list view with all terminals visible and no terminal mounted", () => {
     renderPanel();

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -146,116 +146,122 @@ export function TerminalsPanel({
   }, [open]);
 
   return (
-    <aside
-      ref={ref}
-      data-testid="terminals-panel"
-      data-state={open ? "open" : "closed"}
-      data-expanded={expanded}
-      data-fluid={fluid}
-      style={panelStyle}
-      className={cn(
-        "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
-        "fixed inset-0 z-50 shadow-lg",
-        open ? "translate-x-0" : "translate-x-full",
-        "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0",
-        fluid ? "md:flex-1" : "md:shrink-0",
-        open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
-      )}
-      aria-hidden={!open}
-      data-collapsed={!open || undefined}
-    >
-      {/* Resize handle — desktop only. Suppressed in fluid mode. */}
-      {isDesktop && !fluid && (
+    <>
+      {isDesktop && open && !fluid && (
         <div
           {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          className="relative z-10 w-1 shrink-0 self-stretch cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
         />
       )}
+      <aside
+        ref={ref}
+        data-testid="terminals-panel"
+        data-state={open ? "open" : "closed"}
+        data-expanded={expanded}
+        data-fluid={fluid}
+        style={panelStyle}
+        className={cn(
+          "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
+          "fixed inset-0 z-50 shadow-lg",
+          open ? "translate-x-0" : "translate-x-full",
+          "md:relative md:inset-auto md:z-auto md:shadow-none md:translate-x-0",
+          fluid ? "md:flex-1" : "md:shrink-0",
+          open ? "md:border-border md:border-l" : "md:w-0 md:border-l-0",
+        )}
+        aria-hidden={!open}
+        data-collapsed={!open || undefined}
+      >
+        <header className="flex shrink-0 items-center justify-between border-border border-b px-4 py-2">
+          <h2 className="font-medium text-ui">Shells</h2>
+          <div className="flex items-center gap-1">
+            {/* Renders only when the agent's spec declares terminals. */}
+            <NewTerminalButton
+              conversationId={conversationId}
+              onCreated={(key) => setActiveKey(key)}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close"
+              onClick={onClose}
+            >
+              <XIcon className="size-4" />
+            </Button>
+          </div>
+        </header>
 
-      <header className="flex shrink-0 items-center justify-between border-border border-b px-4 py-2">
-        <h2 className="font-medium text-ui">Shells</h2>
-        <div className="flex items-center gap-1">
-          {/* Renders only when the agent's spec declares terminals. */}
-          <NewTerminalButton
-            conversationId={conversationId}
-            onCreated={(key) => setActiveKey(key)}
-          />
-          <Button type="button" variant="ghost" size="icon-sm" aria-label="Close" onClick={onClose}>
-            <XIcon className="size-4" />
-          </Button>
-        </div>
-      </header>
-
-      {/* Split content.
+        {/* Split content.
           Mobile: flex-col — list on top, xterm below.
           Desktop: flex-row — list on left, xterm on right. */}
-      <div
-        ref={splitRef as React.RefObject<HTMLDivElement>}
-        className="flex min-h-0 flex-1 flex-col md:flex-row overflow-hidden"
-      >
-        {/* List panel */}
         <div
-          className={cn(
-            "relative flex shrink-0 flex-col overflow-y-auto py-1",
-            activeTerminal ? "border-b border-border md:border-b-0 md:border-r" : "flex-1",
-          )}
-          // Width only meaningful on desktop (horizontal split).
-          style={activeTerminal && isDesktop ? { width: listWidth } : undefined}
+          ref={splitRef as React.RefObject<HTMLDivElement>}
+          className="flex min-h-0 flex-1 flex-col md:flex-row overflow-hidden"
         >
-          {/* Column resize handle — desktop only */}
-          {activeTerminal && isDesktop && (
-            <div
-              {...columnHandleProps}
-              className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
-            />
-          )}
-          {terminals.map((t) => {
-            const key = terminalTabKey(t);
-            const isActive = key === activeKey;
-            return (
-              <button
-                key={key}
-                type="button"
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-1.5 text-left",
-                  isActive ? "bg-accent" : "hover:bg-accent/60",
-                )}
-                onClick={() => setActiveKey(isActive ? null : key)}
-              >
-                <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                {t.session && <span className="shrink-0 text-sm font-medium">{t.session}</span>}
-                <span className="truncate text-sm text-muted-foreground/70">{t.name}</span>
-                <span className="flex-1" />
-                <TerminalStatusBadge status={getStatus(t)} />
-              </button>
-            );
-          })}
-        </div>
-
-        {/* xterm — only rendered when a terminal is selected */}
-        <div className={cn("min-h-0 min-w-0 flex-1", !activeTerminal && "hidden")}>
-          {expanded && activeTerminal ? (
-            // Scope the key to the session: agent terminals share a fixed id
-            // across same-shape sessions (e.g. `terminal_claude_main`), so id
-            // alone reuses the xterm mount and shows stale scrollback.
-            <div key={`${conversationId}:${activeTerminal.id}`} className="flex h-full flex-col">
-              <TerminalView
-                sessionId={conversationId}
-                terminalId={activeTerminal.id}
-                readOnly={readOnly}
-                transport={activeTerminal.transport}
-                directAttachUrl={activeTerminal.directAttachUrl}
-                onStateChange={(state) => {
-                  setTerminalConnectionState(activeTerminal.id, state);
-                }}
-                onActivity={() => markTerminalActive(activeTerminal.id)}
+          {/* List panel */}
+          <div
+            className={cn(
+              "relative flex shrink-0 flex-col overflow-y-auto py-1",
+              activeTerminal ? "border-b border-border md:border-b-0 md:border-r" : "flex-1",
+            )}
+            // Width only meaningful on desktop (horizontal split).
+            style={activeTerminal && isDesktop ? { width: listWidth } : undefined}
+          >
+            {/* Column resize handle — desktop only */}
+            {activeTerminal && isDesktop && (
+              <div
+                {...columnHandleProps}
+                className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
               />
-            </div>
-          ) : (
-            <div className="flex-1" />
-          )}
+            )}
+            {terminals.map((t) => {
+              const key = terminalTabKey(t);
+              const isActive = key === activeKey;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-left",
+                    isActive ? "bg-accent" : "hover:bg-accent/60",
+                  )}
+                  onClick={() => setActiveKey(isActive ? null : key)}
+                >
+                  <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  {t.session && <span className="shrink-0 text-sm font-medium">{t.session}</span>}
+                  <span className="truncate text-sm text-muted-foreground/70">{t.name}</span>
+                  <span className="flex-1" />
+                  <TerminalStatusBadge status={getStatus(t)} />
+                </button>
+              );
+            })}
+          </div>
+
+          {/* xterm — only rendered when a terminal is selected */}
+          <div className={cn("min-h-0 min-w-0 flex-1", !activeTerminal && "hidden")}>
+            {expanded && activeTerminal ? (
+              // Scope the key to the session: agent terminals share a fixed id
+              // across same-shape sessions (e.g. `terminal_claude_main`), so id
+              // alone reuses the xterm mount and shows stale scrollback.
+              <div key={`${conversationId}:${activeTerminal.id}`} className="flex h-full flex-col">
+                <TerminalView
+                  sessionId={conversationId}
+                  terminalId={activeTerminal.id}
+                  readOnly={readOnly}
+                  transport={activeTerminal.transport}
+                  directAttachUrl={activeTerminal.directAttachUrl}
+                  onStateChange={(state) => {
+                    setTerminalConnectionState(activeTerminal.id, state);
+                  }}
+                  onActivity={() => markTerminalActive(activeTerminal.id)}
+                />
+              </div>
+            ) : (
+              <div className="flex-1" />
+            )}
+          </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
Part of #4790

## Related issue

N/A — implements TR-6, TR-7, and TR-9 from the touch interaction specification.

## Summary

- Migrates `useResizablePanel` from window-level mouse events to captured pointer events so mouse, touch, and pen resize the shared right-side panels.
- Aborts cleanly on pointer cancellation, capture loss, and unmount; ignores concurrent pointers; preserves keyboard resizing, width persistence, desktop gating, and iframe shielding.
- Returns `touch-action: none` plus an invisible 44px cross-axis hit target entirely through `handleProps`, without consumer changes.

**ELI5:** The resize strip now holds onto the first finger or stylus that grabs it, keeps receiving movement even when the pointer crosses other content, and lets go safely if the browser cancels the gesture.

```text
pointerdown -> capture first pointer -> pointermove updates width
                                 |-> pointerup persists width
                                 |-> cancel/capture loss cleans up
second pointer -----------------------> ignored
```

## Test Plan

- `npx -y -p node@22 -p pnpm@11.15.1 -c 'node --version && pnpm --version && pnpm install --frozen-lockfile'`
- `cd web && npx -y -p node@22 -c './node_modules/.bin/vitest run src/hooks/useResizablePanel.test.tsx && ./node_modules/.bin/tsc -b'`
- Mutation check: restored the old mouse-only hook while retaining the new tests; 5 tests failed for pointer capture, pointer cancellation, capture loss, first-pointer-wins, and touch affordances. Restoring the implementation returned the suite to 8/8 passing.
- Staged pre-commit hooks passed, including web Prettier, oxlint, and TypeScript type check. The all-files run passed every hook except `pyrefly`, which discovered zero Python files because this worktree lives under the parent repo's ignored `.worktrees` directory.

## Demo


Workspace-panel seam touch-drag validated live on [foldable](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/android-foldable.mp4) and [tablet](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/android-tablet.mp4) — smooth tracking, clamps, persistence; adjacent content scroll unaffected.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused hook tests cover pointer capture and release, cancellation, capture loss, concurrent pointer arbitration, persistence timing, and returned touch affordances.

## Changelog

Resize right-side panels with touch or a stylus using a larger, easier-to-grab handle.
