### PR TITLE
feat(web): single input-capability hook + canonical md breakpoint (touch TR-1..4)

### DIFF
--- a/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeBridgeScript.kt
@@ -158,7 +158,12 @@ object NativeBridgeScript {
                 // (overlays) Back should dismiss; at md+ they dock as persistent
                 // rails (md:relative md:translate-x-0, still data-state="open")
                 // that Back must NOT close. Modal dialogs dismiss at any width.
-                const narrow = window.innerWidth < 768;
+                // The web layer owns the breakpoint (web/src/lib/breakpoints.ts)
+                // and publishes it as __omnigentIsMobileViewport; the inline
+                // check is a fallback for older web builds without the signal.
+                const narrow = typeof window.__omnigentIsMobileViewport === "function"
+                  ? !!window.__omnigentIsMobileViewport()
+                  : window.innerWidth < 768;
                 // 1. Conversations sidebar (a drawer only when narrow; closed =
                 // data-collapsed).
                 if (narrow) {

--- a/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OmnigentWebViewClientTest.kt
@@ -79,6 +79,20 @@ class OmnigentWebViewClientTest {
     }
 
     @Test
+    fun `back handler consumes the web layer's breakpoint signal`() {
+        // The web layer owns the md breakpoint (web/src/lib/breakpoints.ts) and
+        // publishes __omnigentIsMobileViewport; the back handler must consult it
+        // rather than re-derive the drawer/rail boundary from its own literal.
+        val backHandler =
+            NativeBridgeScript.source
+                .substringAfter("__omnigentNativeHandleBack")
+        assertTrue(backHandler.contains("window.__omnigentIsMobileViewport === \"function\""))
+        assertTrue(backHandler.contains("window.__omnigentIsMobileViewport()"))
+        // The inline width check survives only as the older-web-build fallback.
+        assertTrue(backHandler.contains(": window.innerWidth < 768"))
+    }
+
+    @Test
     fun `off-origin page finish injects nothing`() {
         val webView = RecordingWebView(ApplicationProvider.getApplicationContext())
         val client = client(shouldInjectBridgeAtPageReady = true)

--- a/web/src/hooks/useInputCapabilities.test.tsx
+++ b/web/src/hooks/useInputCapabilities.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useInputCapabilities } from "./useInputCapabilities";
+
+// Controllable matchMedia: per-query matches plus manually fired change
+// events, so the hook's reactivity can be exercised (a convertible flipping
+// modes, a mouse attaching).
+function installMatchMedia(state: Record<string, boolean>) {
+  const listeners = new Map<string, Set<() => void>>();
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      get matches() {
+        return state[query] ?? false;
+      },
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: (_: string, cb: () => void) => {
+        if (!listeners.has(query)) listeners.set(query, new Set());
+        listeners.get(query)!.add(cb);
+      },
+      removeEventListener: (_: string, cb: () => void) => {
+        listeners.get(query)?.delete(cb);
+      },
+      dispatchEvent: () => false,
+    })),
+  });
+  return {
+    set(query: string, matches: boolean) {
+      state[query] = matches;
+      for (const cb of listeners.get(query) ?? []) cb();
+    },
+  };
+}
+
+function setMaxTouchPoints(value: number) {
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  setMaxTouchPoints(0);
+});
+
+describe("useInputCapabilities", () => {
+  it("reports a mouse desktop when no query matches", () => {
+    installMatchMedia({});
+    const { result } = renderHook(() => useInputCapabilities());
+    expect(result.current).toEqual({
+      coarsePrimary: false,
+      anyCoarse: false,
+      hoverPrimary: false,
+      hasTouch: false,
+    });
+  });
+
+  it("reads each capability from its media query and maxTouchPoints", () => {
+    installMatchMedia({
+      "(pointer: coarse)": true,
+      "(any-pointer: coarse)": true,
+      "(hover: hover)": false,
+    });
+    setMaxTouchPoints(5);
+    const { result } = renderHook(() => useInputCapabilities());
+    expect(result.current).toEqual({
+      coarsePrimary: true,
+      anyCoarse: true,
+      hoverPrimary: false,
+      hasTouch: true,
+    });
+  });
+
+  it("keeps viewport-independent axes independent: a fine-primary touch laptop", () => {
+    // any-pointer coarse (touchscreen present) with a fine hovering primary
+    // (trackpad) — TR-2's touch-laptop shape must be representable.
+    installMatchMedia({
+      "(any-pointer: coarse)": true,
+      "(hover: hover)": true,
+    });
+    setMaxTouchPoints(10);
+    const { result } = renderHook(() => useInputCapabilities());
+    expect(result.current).toEqual({
+      coarsePrimary: false,
+      anyCoarse: true,
+      hoverPrimary: true,
+      hasTouch: true,
+    });
+  });
+
+  it("updates live when a media query flips (convertible mode change)", () => {
+    const media = installMatchMedia({ "(hover: hover)": true });
+    const { result } = renderHook(() => useInputCapabilities());
+    expect(result.current.coarsePrimary).toBe(false);
+    expect(result.current.hoverPrimary).toBe(true);
+
+    act(() => {
+      media.set("(pointer: coarse)", true);
+      media.set("(hover: hover)", false);
+    });
+    expect(result.current.coarsePrimary).toBe(true);
+    expect(result.current.hoverPrimary).toBe(false);
+  });
+
+  it("returns a referentially stable snapshot while values are unchanged", () => {
+    installMatchMedia({ "(hover: hover)": true });
+    const { result, rerender } = renderHook(() => useInputCapabilities());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/web/src/hooks/useInputCapabilities.test.tsx
+++ b/web/src/hooks/useInputCapabilities.test.tsx
@@ -16,9 +16,6 @@ function installMatchMedia(state: Record<string, boolean>) {
         return state[query] ?? false;
       },
       media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
       addEventListener: (_: string, cb: () => void) => {
         if (!listeners.has(query)) listeners.set(query, new Set());
         listeners.get(query)!.add(cb);
@@ -26,7 +23,6 @@ function installMatchMedia(state: Record<string, boolean>) {
       removeEventListener: (_: string, cb: () => void) => {
         listeners.get(query)?.delete(cb);
       },
-      dispatchEvent: () => false,
     })),
   });
   return {

--- a/web/src/hooks/useInputCapabilities.ts
+++ b/web/src/hooks/useInputCapabilities.ts
@@ -9,6 +9,8 @@
 
 import { useSyncExternalStore } from "react";
 
+import { subscribeMatchMedia } from "@/lib/breakpoints";
+
 export interface InputCapabilities {
   /** Primary pointer is coarse — `(pointer: coarse)`. */
   coarsePrimary: boolean;
@@ -42,7 +44,7 @@ function read(): InputCapabilities {
     coarsePrimary: coarse,
     anyCoarse,
     hoverPrimary: hover,
-    hasTouch: typeof navigator !== "undefined" && navigator.maxTouchPoints > 0,
+    hasTouch: navigator.maxTouchPoints > 0,
   };
 }
 
@@ -64,12 +66,7 @@ function getSnapshot(): InputCapabilities {
 }
 
 function subscribe(callback: () => void): () => void {
-  if (typeof window === "undefined" || !window.matchMedia) return () => {};
-  const lists = CAPABILITY_QUERIES.map((q) => window.matchMedia(q));
-  for (const mql of lists) mql.addEventListener("change", callback);
-  return () => {
-    for (const mql of lists) mql.removeEventListener("change", callback);
-  };
+  return subscribeMatchMedia(CAPABILITY_QUERIES, callback);
 }
 
 /**

--- a/web/src/hooks/useInputCapabilities.ts
+++ b/web/src/hooks/useInputCapabilities.ts
@@ -1,0 +1,82 @@
+// Single source of truth for pointer/input capability.
+//
+// Capability gates AFFORDANCES and defaults only (hit-target sizing,
+// persistent vs hover-revealed controls, swipe hints) — never per-event
+// handling. Gesture recognition must instead branch on the active sequence's
+// `PointerEvent.pointerType`, so a touch on a fine-primary laptop still gets
+// gesture semantics regardless of what these queries report. Viewport width
+// is an independent LAYOUT axis — see `@/lib/breakpoints`.
+
+import { useSyncExternalStore } from "react";
+
+export interface InputCapabilities {
+  /** Primary pointer is coarse — `(pointer: coarse)`. */
+  coarsePrimary: boolean;
+  /** ANY attached pointer is coarse — `(any-pointer: coarse)`. */
+  anyCoarse: boolean;
+  /** Primary pointer can hover — `(hover: hover)`. */
+  hoverPrimary: boolean;
+  /** A touch digitizer is present — `navigator.maxTouchPoints > 0`. */
+  hasTouch: boolean;
+}
+
+const CAPABILITY_QUERIES = [
+  "(pointer: coarse)",
+  "(any-pointer: coarse)",
+  "(hover: hover)",
+] as const;
+
+// SSR / no-matchMedia fallback: assume a hovering fine pointer (mouse
+// desktop), matching the shell's historical desktop-first defaults.
+const SERVER_SNAPSHOT: InputCapabilities = {
+  coarsePrimary: false,
+  anyCoarse: false,
+  hoverPrimary: true,
+  hasTouch: false,
+};
+
+function read(): InputCapabilities {
+  if (typeof window === "undefined" || !window.matchMedia) return SERVER_SNAPSHOT;
+  const [coarse, anyCoarse, hover] = CAPABILITY_QUERIES.map((q) => window.matchMedia(q).matches);
+  return {
+    coarsePrimary: coarse,
+    anyCoarse,
+    hoverPrimary: hover,
+    hasTouch: typeof navigator !== "undefined" && navigator.maxTouchPoints > 0,
+  };
+}
+
+// useSyncExternalStore requires a referentially stable snapshot while values
+// are unchanged; re-reading is cheap, so compare and keep the old object.
+let cached: InputCapabilities = SERVER_SNAPSHOT;
+
+function getSnapshot(): InputCapabilities {
+  const next = read();
+  if (
+    next.coarsePrimary !== cached.coarsePrimary ||
+    next.anyCoarse !== cached.anyCoarse ||
+    next.hoverPrimary !== cached.hoverPrimary ||
+    next.hasTouch !== cached.hasTouch
+  ) {
+    cached = next;
+  }
+  return cached;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const lists = CAPABILITY_QUERIES.map((q) => window.matchMedia(q));
+  for (const mql of lists) mql.addEventListener("change", callback);
+  return () => {
+    for (const mql of lists) mql.removeEventListener("change", callback);
+  };
+}
+
+/**
+ * Reactive input-capability snapshot. Updates live when a convertible flips
+ * modes or a mouse attaches/detaches (matchMedia change events). SSR-safe:
+ * the server snapshot assumes a mouse desktop.
+ */
+export function useInputCapabilities(): InputCapabilities {
+  return useSyncExternalStore(subscribe, getSnapshot, () => SERVER_SNAPSHOT);
+}

--- a/web/src/hooks/useInputCapabilities.ts
+++ b/web/src/hooks/useInputCapabilities.ts
@@ -18,7 +18,11 @@ export interface InputCapabilities {
   anyCoarse: boolean;
   /** Primary pointer can hover — `(hover: hover)`. */
   hoverPrimary: boolean;
-  /** A touch digitizer is present — `navigator.maxTouchPoints > 0`. */
+  /**
+   * A touch digitizer is present — `navigator.maxTouchPoints > 0`. Re-read
+   * only when a capability media query fires; a digitizer change that flips
+   * no query is not observed (accepted point-in-time limitation).
+   */
   hasTouch: boolean;
 }
 

--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -8,22 +8,15 @@
 
 import { useSyncExternalStore } from "react";
 
-import { maxWidthQuery } from "@/lib/breakpoints";
-
-// Mirror Tailwind's `max-md` variant exactly so this hook stays in lockstep
-// with the `max-md:` / `md:` classes already used across the shell.
-const MOBILE_QUERY = maxWidthQuery();
+import { MD_MAX_WIDTH_QUERY, subscribeMatchMedia } from "@/lib/breakpoints";
 
 function subscribe(callback: () => void): () => void {
-  if (typeof window === "undefined" || !window.matchMedia) return () => {};
-  const mql = window.matchMedia(MOBILE_QUERY);
-  mql.addEventListener("change", callback);
-  return () => mql.removeEventListener("change", callback);
+  return subscribeMatchMedia([MD_MAX_WIDTH_QUERY], callback);
 }
 
 function getSnapshot(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia(MOBILE_QUERY).matches;
+  return window.matchMedia(MD_MAX_WIDTH_QUERY).matches;
 }
 
 /**

--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -8,9 +8,11 @@
 
 import { useSyncExternalStore } from "react";
 
+import { maxWidthQuery } from "@/lib/breakpoints";
+
 // Mirror Tailwind's `max-md` variant exactly so this hook stays in lockstep
 // with the `max-md:` / `md:` classes already used across the shell.
-const MOBILE_QUERY = "(max-width: 767.98px)";
+const MOBILE_QUERY = maxWidthQuery();
 
 function subscribe(callback: () => void): () => void {
   if (typeof window === "undefined" || !window.matchMedia) return () => {};

--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -8,15 +8,16 @@
 
 import { useSyncExternalStore } from "react";
 
-import { MD_MAX_WIDTH_QUERY, subscribeMatchMedia } from "@/lib/breakpoints";
+import { MD_MAX_WIDTH_QUERY, isMobileViewport, subscribeMatchMedia } from "@/lib/breakpoints";
 
 function subscribe(callback: () => void): () => void {
   return subscribeMatchMedia([MD_MAX_WIDTH_QUERY], callback);
 }
 
+// One canonical predicate: the snapshot IS the imperative helper, so the
+// reactive and point-in-time answers can never diverge.
 function getSnapshot(): boolean {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia(MD_MAX_WIDTH_QUERY).matches;
+  return isMobileViewport();
 }
 
 /**

--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -3,15 +3,15 @@
 // The shell's responsive layout pivots on Tailwind's `md` breakpoint
 // (`min-width: 768px`), used both as CSS classes (`md:` / `max-md:`) and as
 // the JS threshold in AppShell's `initialSidebarOpen`. This hook exposes the
-// `max-md` side of that line to component logic that can't be expressed in
+// mobile side of that line to component logic that can't be expressed in
 // CSS alone (e.g. swapping a hover flyout for an in-place page on touch).
 
 import { useSyncExternalStore } from "react";
 
-import { MD_MAX_WIDTH_QUERY, isMobileViewport, subscribeMatchMedia } from "@/lib/breakpoints";
+import { MD_MIN_WIDTH_QUERY, isMobileViewport, subscribeMatchMedia } from "@/lib/breakpoints";
 
 function subscribe(callback: () => void): () => void {
-  return subscribeMatchMedia([MD_MAX_WIDTH_QUERY], callback);
+  return subscribeMatchMedia([MD_MIN_WIDTH_QUERY], callback);
 }
 
 // One canonical predicate: the snapshot IS the imperative helper, so the

--- a/web/src/lib/breakpoints.test.ts
+++ b/web/src/lib/breakpoints.test.ts
@@ -2,35 +2,26 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
-import {
-  MD_BREAKPOINT_PX,
-  MD_MAX_WIDTH_QUERY,
-  MD_MIN_WIDTH_QUERY,
-  isMobileViewport,
-} from "./breakpoints";
+import { MD_BREAKPOINT_PX, MD_MIN_WIDTH_QUERY, isMobileViewport } from "./breakpoints";
 
-function stubMatchMedia(matchesFor: (query: string) => boolean) {
+// Evaluate min-/max-width queries against a simulated viewport width, so
+// boundary behavior at fractional widths can be exercised.
+function stubViewportWidth(width: number) {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     configurable: true,
     value: vi.fn((query: string) => ({
-      matches: matchesFor(query),
+      matches: (() => {
+        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        if (min) return width >= parseFloat(min[1]);
+        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        if (max) return width <= parseFloat(max[1]);
+        return false;
+      })(),
       media: query,
       addEventListener: () => {},
       removeEventListener: () => {},
     })),
-  });
-}
-
-// Evaluate this module's min-/max-width queries against a simulated viewport
-// width, so boundary behavior at fractional widths can be exercised.
-function stubViewportWidth(width: number) {
-  stubMatchMedia((query) => {
-    const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
-    if (min) return width >= parseFloat(min[1]);
-    const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
-    if (max) return width <= parseFloat(max[1]);
-    return false;
   });
 }
 
@@ -41,10 +32,8 @@ afterEach(() => {
 describe("breakpoints", () => {
   it("encodes Tailwind's md breakpoint exactly once", () => {
     expect(MD_BREAKPOINT_PX).toBe(768);
-    // md: variant (inclusive lower bound).
+    // md: variant (inclusive lower bound) — the one canonical query.
     expect(MD_MIN_WIDTH_QUERY).toBe("(min-width: 768px)");
-    // max-md: variant (exclusive upper bound, 768 - 0.02).
-    expect(MD_MAX_WIDTH_QUERY).toBe("(max-width: 767.98px)");
   });
 
   it("isMobileViewport is true below md and false at md+", () => {
@@ -56,14 +45,15 @@ describe("breakpoints", () => {
   });
 
   // The hook, the imperative helper, and the native-shell signal must give
-  // the SAME answer at every width — including the fractional sliver
-  // (767.98, 768) where a max-width:767.98 and a !min-width:768 encoding
-  // would disagree. Canonical predicate: the max-md query.
+  // the SAME answer at every width. The pole is "mobile unless provably
+  // md+": in the fractional sliver (767.98, 768) — reachable under browser
+  // zoom — Tailwind's md: overrides don't apply, the page renders its mobile
+  // base styles, and the predicate must say mobile too.
   it.each([
     [767, true],
     [767.5, true],
     [767.98, true],
-    [767.99, false],
+    [767.99, true],
     [768, false],
   ])("hook, helper, and published signal agree at %spx", (width, mobile) => {
     stubViewportWidth(width);

--- a/web/src/lib/breakpoints.test.ts
+++ b/web/src/lib/breakpoints.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { MD_BREAKPOINT_PX, isMobileViewport, maxWidthQuery, minWidthQuery } from "./breakpoints";
+
+function stubMatchMedia(matchesFor: (query: string) => boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: matchesFor(query),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("breakpoints", () => {
+  it("encodes Tailwind's md breakpoint exactly once", () => {
+    expect(MD_BREAKPOINT_PX).toBe(768);
+    // md: variant (inclusive lower bound).
+    expect(minWidthQuery()).toBe("(min-width: 768px)");
+    // max-md: variant (exclusive upper bound, 768 - 0.02).
+    expect(maxWidthQuery()).toBe("(max-width: 767.98px)");
+  });
+
+  it("builds queries for arbitrary breakpoints", () => {
+    expect(minWidthQuery(1024)).toBe("(min-width: 1024px)");
+    expect(maxWidthQuery(1024)).toBe("(max-width: 1023.98px)");
+  });
+
+  it("isMobileViewport is true below md and false at md+", () => {
+    stubMatchMedia((q) => q === minWidthQuery());
+    expect(isMobileViewport()).toBe(false);
+
+    stubMatchMedia(() => false);
+    expect(isMobileViewport()).toBe(true);
+  });
+
+  it("publishes the signal native shells consume for their back handler", () => {
+    // eslint-disable-next-line no-underscore-dangle -- bridge-global naming
+    expect(window.__omnigentIsMobileViewport).toBe(isMobileViewport);
+  });
+});

--- a/web/src/lib/breakpoints.test.ts
+++ b/web/src/lib/breakpoints.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 
-import { MD_BREAKPOINT_PX, isMobileViewport, maxWidthQuery, minWidthQuery } from "./breakpoints";
+import {
+  MD_BREAKPOINT_PX,
+  MD_MAX_WIDTH_QUERY,
+  MD_MIN_WIDTH_QUERY,
+  isMobileViewport,
+} from "./breakpoints";
 
 function stubMatchMedia(matchesFor: (query: string) => boolean) {
   Object.defineProperty(window, "matchMedia", {
@@ -9,12 +14,8 @@ function stubMatchMedia(matchesFor: (query: string) => boolean) {
     value: vi.fn((query: string) => ({
       matches: matchesFor(query),
       media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
       addEventListener: () => {},
       removeEventListener: () => {},
-      dispatchEvent: () => false,
     })),
   });
 }
@@ -27,18 +28,13 @@ describe("breakpoints", () => {
   it("encodes Tailwind's md breakpoint exactly once", () => {
     expect(MD_BREAKPOINT_PX).toBe(768);
     // md: variant (inclusive lower bound).
-    expect(minWidthQuery()).toBe("(min-width: 768px)");
+    expect(MD_MIN_WIDTH_QUERY).toBe("(min-width: 768px)");
     // max-md: variant (exclusive upper bound, 768 - 0.02).
-    expect(maxWidthQuery()).toBe("(max-width: 767.98px)");
-  });
-
-  it("builds queries for arbitrary breakpoints", () => {
-    expect(minWidthQuery(1024)).toBe("(min-width: 1024px)");
-    expect(maxWidthQuery(1024)).toBe("(max-width: 1023.98px)");
+    expect(MD_MAX_WIDTH_QUERY).toBe("(max-width: 767.98px)");
   });
 
   it("isMobileViewport is true below md and false at md+", () => {
-    stubMatchMedia((q) => q === minWidthQuery());
+    stubMatchMedia((q) => q === MD_MIN_WIDTH_QUERY);
     expect(isMobileViewport()).toBe(false);
 
     stubMatchMedia(() => false);

--- a/web/src/lib/breakpoints.test.ts
+++ b/web/src/lib/breakpoints.test.ts
@@ -1,5 +1,7 @@
+import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import {
   MD_BREAKPOINT_PX,
   MD_MAX_WIDTH_QUERY,
@@ -20,6 +22,18 @@ function stubMatchMedia(matchesFor: (query: string) => boolean) {
   });
 }
 
+// Evaluate this module's min-/max-width queries against a simulated viewport
+// width, so boundary behavior at fractional widths can be exercised.
+function stubViewportWidth(width: number) {
+  stubMatchMedia((query) => {
+    const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+    if (min) return width >= parseFloat(min[1]);
+    const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+    if (max) return width <= parseFloat(max[1]);
+    return false;
+  });
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -34,11 +48,30 @@ describe("breakpoints", () => {
   });
 
   it("isMobileViewport is true below md and false at md+", () => {
-    stubMatchMedia((q) => q === MD_MIN_WIDTH_QUERY);
+    stubViewportWidth(MD_BREAKPOINT_PX);
     expect(isMobileViewport()).toBe(false);
 
-    stubMatchMedia(() => false);
+    stubViewportWidth(MD_BREAKPOINT_PX - 1);
     expect(isMobileViewport()).toBe(true);
+  });
+
+  // The hook, the imperative helper, and the native-shell signal must give
+  // the SAME answer at every width — including the fractional sliver
+  // (767.98, 768) where a max-width:767.98 and a !min-width:768 encoding
+  // would disagree. Canonical predicate: the max-md query.
+  it.each([
+    [767, true],
+    [767.5, true],
+    [767.98, true],
+    [767.99, false],
+    [768, false],
+  ])("hook, helper, and published signal agree at %spx", (width, mobile) => {
+    stubViewportWidth(width);
+    expect(isMobileViewport()).toBe(mobile);
+    // eslint-disable-next-line no-underscore-dangle -- bridge-global naming
+    expect(window.__omnigentIsMobileViewport?.()).toBe(mobile);
+    const { result } = renderHook(() => useIsMobileViewport());
+    expect(result.current).toBe(mobile);
   });
 
   it("publishes the signal native shells consume for their back handler", () => {

--- a/web/src/lib/breakpoints.test.ts
+++ b/web/src/lib/breakpoints.test.ts
@@ -12,9 +12,9 @@ function stubViewportWidth(width: number) {
     configurable: true,
     value: vi.fn((query: string) => ({
       matches: (() => {
-        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        const min = query.match(/^\(min-width: ([\d.]+)px\)$/);
         if (min) return width >= parseFloat(min[1]);
-        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        const max = query.match(/^\(max-width: ([\d.]+)px\)$/);
         if (max) return width <= parseFloat(max[1]);
         return false;
       })(),

--- a/web/src/lib/breakpoints.ts
+++ b/web/src/lib/breakpoints.ts
@@ -35,12 +35,14 @@ export function subscribeMatchMedia(queries: readonly string[], callback: () => 
 /**
  * True on mobile viewports (below the `md` breakpoint). Non-reactive
  * point-in-time check for event handlers; components that must re-render on
- * breakpoint crossings use `useIsMobileViewport` instead. SSR-safe (returns
- * false when window is undefined).
+ * breakpoint crossings use `useIsMobileViewport` instead — both evaluate the
+ * SAME `MD_MAX_WIDTH_QUERY`, so they can never disagree, even at fractional
+ * widths inside the (767.98, 768) sliver where max-md and min-width:768 both
+ * fail to match. SSR-safe (returns false when window is undefined).
  */
 export function isMobileViewport(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
-  return !window.matchMedia(MD_MIN_WIDTH_QUERY).matches;
+  return window.matchMedia(MD_MAX_WIDTH_QUERY).matches;
 }
 
 declare global {

--- a/web/src/lib/breakpoints.ts
+++ b/web/src/lib/breakpoints.ts
@@ -10,16 +10,26 @@
 export const MD_BREAKPOINT_PX = 768;
 
 /** `(min-width: …)` media query — matches Tailwind's `md:` variant. */
-export function minWidthQuery(px: number = MD_BREAKPOINT_PX): string {
-  return `(min-width: ${px}px)`;
-}
+export const MD_MIN_WIDTH_QUERY = `(min-width: ${MD_BREAKPOINT_PX}px)`;
 
 /**
  * `(max-width: …)` media query — matches Tailwind's `max-md:` variant, whose
  * upper bound is exclusive (768 - 0.02 = 767.98px).
  */
-export function maxWidthQuery(px: number = MD_BREAKPOINT_PX): string {
-  return `(max-width: ${px - 0.02}px)`;
+export const MD_MAX_WIDTH_QUERY = `(max-width: ${MD_BREAKPOINT_PX - 0.02}px)`;
+
+/**
+ * Subscribe to change events on a set of media queries. SSR-safe (no-op
+ * teardown when matchMedia is unavailable). Returns the unsubscribe function
+ * expected by `useSyncExternalStore` subscribe callbacks.
+ */
+export function subscribeMatchMedia(queries: readonly string[], callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const lists = queries.map((q) => window.matchMedia(q));
+  for (const mql of lists) mql.addEventListener("change", callback);
+  return () => {
+    for (const mql of lists) mql.removeEventListener("change", callback);
+  };
 }
 
 /**
@@ -30,7 +40,7 @@ export function maxWidthQuery(px: number = MD_BREAKPOINT_PX): string {
  */
 export function isMobileViewport(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
-  return !window.matchMedia(minWidthQuery()).matches;
+  return !window.matchMedia(MD_MIN_WIDTH_QUERY).matches;
 }
 
 declare global {

--- a/web/src/lib/breakpoints.ts
+++ b/web/src/lib/breakpoints.ts
@@ -6,17 +6,19 @@
 // variants (767px / 767.98px / 768) can't drift apart. Viewport width is a
 // LAYOUT concern only — input capability (touch, hover) is a separate axis,
 // exposed by `useInputCapabilities`.
+//
+// Pole choice: the layout predicate is "mobile unless provably md+", i.e.
+// `!(min-width: 768px)`. Tailwind's `md:` overrides are what produce the
+// desktop layout, and they apply only at >= 768px — at fractional widths in
+// (767.98, 768) (reachable under browser zoom) neither `md:` nor `max-md:`
+// matches, so the page renders its mobile base styles. A max-md-based
+// predicate would call that sliver "desktop" and disagree with what's on
+// screen; deliberately none exists here.
 
 export const MD_BREAKPOINT_PX = 768;
 
 /** `(min-width: …)` media query — matches Tailwind's `md:` variant. */
 export const MD_MIN_WIDTH_QUERY = `(min-width: ${MD_BREAKPOINT_PX}px)`;
-
-/**
- * `(max-width: …)` media query — matches Tailwind's `max-md:` variant, whose
- * upper bound is exclusive (768 - 0.02 = 767.98px).
- */
-export const MD_MAX_WIDTH_QUERY = `(max-width: ${MD_BREAKPOINT_PX - 0.02}px)`;
 
 /**
  * Subscribe to change events on a set of media queries. SSR-safe (no-op
@@ -33,16 +35,15 @@ export function subscribeMatchMedia(queries: readonly string[], callback: () => 
 }
 
 /**
- * True on mobile viewports (below the `md` breakpoint). Non-reactive
- * point-in-time check for event handlers; components that must re-render on
- * breakpoint crossings use `useIsMobileViewport` instead — both evaluate the
- * SAME `MD_MAX_WIDTH_QUERY`, so they can never disagree, even at fractional
- * widths inside the (767.98, 768) sliver where max-md and min-width:768 both
- * fail to match. SSR-safe (returns false when window is undefined).
+ * True on mobile-layout viewports: anything not provably at `md`+ (see the
+ * module comment on the pole choice). Non-reactive point-in-time check for
+ * event handlers; components that must re-render on breakpoint crossings use
+ * `useIsMobileViewport` instead — its snapshot IS this function, so the two
+ * can never disagree. SSR-safe (returns false when window is undefined).
  */
 export function isMobileViewport(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia(MD_MAX_WIDTH_QUERY).matches;
+  return !window.matchMedia(MD_MIN_WIDTH_QUERY).matches;
 }
 
 declare global {

--- a/web/src/lib/breakpoints.ts
+++ b/web/src/lib/breakpoints.ts
@@ -1,0 +1,49 @@
+// Canonical encoding of the shell's `md` layout breakpoint.
+//
+// Tailwind's `md` breakpoint (768px) is the shell's single mobile/desktop
+// layout pivot, used both by CSS (`md:` / `max-md:` classes) and by JS call
+// sites. Every JS encoding of that line derives from this module so the
+// variants (767px / 767.98px / 768) can't drift apart. Viewport width is a
+// LAYOUT concern only — input capability (touch, hover) is a separate axis,
+// exposed by `useInputCapabilities`.
+
+export const MD_BREAKPOINT_PX = 768;
+
+/** `(min-width: …)` media query — matches Tailwind's `md:` variant. */
+export function minWidthQuery(px: number = MD_BREAKPOINT_PX): string {
+  return `(min-width: ${px}px)`;
+}
+
+/**
+ * `(max-width: …)` media query — matches Tailwind's `max-md:` variant, whose
+ * upper bound is exclusive (768 - 0.02 = 767.98px).
+ */
+export function maxWidthQuery(px: number = MD_BREAKPOINT_PX): string {
+  return `(max-width: ${px - 0.02}px)`;
+}
+
+/**
+ * True on mobile viewports (below the `md` breakpoint). Non-reactive
+ * point-in-time check for event handlers; components that must re-render on
+ * breakpoint crossings use `useIsMobileViewport` instead. SSR-safe (returns
+ * false when window is undefined).
+ */
+export function isMobileViewport(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return !window.matchMedia(minWidthQuery()).matches;
+}
+
+declare global {
+  interface Window {
+    /** Layout signal consumed by native shells (see publication below). */
+    __omnigentIsMobileViewport?: () => boolean;
+  }
+}
+
+// Native shells (e.g. the Android back handler in NativeBridgeScript.kt)
+// consume the web layer's breakpoint signal instead of re-deriving it from
+// their own copy of the literal.
+if (typeof window !== "undefined") {
+  // eslint-disable-next-line no-underscore-dangle -- bridge-global naming
+  window.__omnigentIsMobileViewport = isMobileViewport;
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -121,9 +121,9 @@ function stubViewportWidth(width: number) {
     configurable: true,
     value: (query: string) => ({
       matches: (() => {
-        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        const min = query.match(/^\(min-width: ([\d.]+)px\)$/);
         if (min) return width >= parseFloat(min[1]);
-        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        const max = query.match(/^\(max-width: ([\d.]+)px\)$/);
         if (max) return width <= parseFloat(max[1]);
         return false;
       })(),

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -112,6 +112,35 @@ function renderWithTooltips(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
+// Evaluate min-/max-width media queries against a simulated viewport width,
+// so each test runs at an explicit real-browser width instead of inheriting
+// the global test-setup mock (which answers false to every query).
+function stubViewportWidth(width: number) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: (() => {
+        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        if (min) return width >= parseFloat(min[1]);
+        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        if (max) return width <= parseFloat(max[1]);
+        return false;
+      })(),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+// These suites assert desktop composer behavior (mount autofocus,
+// Enter-sends, hover affordances); tests that need a mobile width re-pin it
+// themselves.
+beforeEach(() => {
+  stubViewportWidth(1280);
+});
+
 describe("Composer Claude goal control", () => {
   afterEach(() => {
     cleanup();
@@ -1459,29 +1488,13 @@ describe("Composer reply-quote focus", () => {
     expect(document.activeElement).toBe(ta);
   });
 
-  // The mobile boundary is the canonical md query (max-width: 767.98px), not
-  // the historical bespoke 767px — 767.5px sits between the two, so this test
-  // pins the migrated boundary: suppression must apply there.
+  // The mobile boundary is the canonical layout predicate (not provably at
+  // md+), not the historical bespoke 767px — 767.5px sits between the two,
+  // so this test pins the migrated boundary: suppression must apply there.
   it("suppresses mount autofocus at 767.5px (below the canonical md boundary)", () => {
-    const original = window.matchMedia;
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      configurable: true,
-      value: (query: string) => ({
-        // Simulate a 767.5px-wide viewport: only (max-width: 767.98px)
-        // matches; (min-width: 768px) and friends do not.
-        matches: query === "(max-width: 767.98px)",
-        media: query,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-      }),
-    });
-    try {
-      render(<Composer {...composerProps()} />);
-      expect(document.activeElement).not.toBe(textarea());
-    } finally {
-      window.matchMedia = original;
-    }
+    stubViewportWidth(767.5);
+    render(<Composer {...composerProps()} />);
+    expect(document.activeElement).not.toBe(textarea());
   });
 
   it("does not steal focus when a quote is removed", () => {

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1459,6 +1459,31 @@ describe("Composer reply-quote focus", () => {
     expect(document.activeElement).toBe(ta);
   });
 
+  // The mobile boundary is the canonical md query (max-width: 767.98px), not
+  // the historical bespoke 767px — 767.5px sits between the two, so this test
+  // pins the migrated boundary: suppression must apply there.
+  it("suppresses mount autofocus at 767.5px (below the canonical md boundary)", () => {
+    const original = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        // Simulate a 767.5px-wide viewport: only (max-width: 767.98px)
+        // matches; (min-width: 768px) and friends do not.
+        matches: query === "(max-width: 767.98px)",
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
+    try {
+      render(<Composer {...composerProps()} />);
+      expect(document.activeElement).not.toBe(textarea());
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
   it("does not steal focus when a quote is removed", () => {
     // Removing a chip (the X button) shrinks the count — the effect only
     // fires when the count grows, so focus must stay put.

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -200,6 +200,34 @@ describe("mentionMarkerFor", () => {
   });
 });
 
+// Evaluate min-/max-width media queries against a simulated viewport width,
+// so each test runs at an explicit real-browser width instead of inheriting
+// the global test-setup mock (which answers false to every query).
+function stubViewportWidth(width: number) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: (() => {
+        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        if (min) return width >= parseFloat(min[1]);
+        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        if (max) return width <= parseFloat(max[1]);
+        return false;
+      })(),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+// Pin a desktop width for every test: the mention browser's keyboard
+// behavior (Enter acts on the highlighted row) is gated off on mobile.
+beforeEach(() => {
+  stubViewportWidth(1280);
+});
+
 describe("Composer @-file-mention browser (native sessions)", () => {
   // Each test gets a fresh conversation id and a cleared draft store: the
   // module-scoped ``sessionDrafts`` map (persisted to localStorage) is keyed by

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -209,9 +209,9 @@ function stubViewportWidth(width: number) {
     configurable: true,
     value: (query: string) => ({
       matches: (() => {
-        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        const min = query.match(/^\(min-width: ([\d.]+)px\)$/);
         if (min) return width >= parseFloat(min[1]);
-        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        const max = query.match(/^\(max-width: ([\d.]+)px\)$/);
         if (max) return width <= parseFloat(max[1]);
         return false;
       })(),

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4628,6 +4628,9 @@ export function Composer({
   // On mobile, programmatic focus immediately summons the software keyboard.
   // Keep desktop's fast-type affordance, but let mobile users explicitly tap
   // the composer when switching back from Terminal or changing sessions.
+  // "Mobile" is deliberately the canonical md query (max-width: 767.98px),
+  // so the keyboard-suppression boundary tracks the shell's layout pivot
+  // rather than a bespoke 767px threshold.
   const isMobile = useIsMobileViewport();
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4628,9 +4628,9 @@ export function Composer({
   // On mobile, programmatic focus immediately summons the software keyboard.
   // Keep desktop's fast-type affordance, but let mobile users explicitly tap
   // the composer when switching back from Terminal or changing sessions.
-  // "Mobile" is deliberately the canonical md query (max-width: 767.98px),
-  // so the keyboard-suppression boundary tracks the shell's layout pivot
-  // rather than a bespoke 767px threshold.
+  // "Mobile" is deliberately the canonical layout predicate (not provably
+  // at md+), so the keyboard-suppression boundary tracks the shell's layout
+  // pivot rather than a bespoke 767px threshold.
   const isMobile = useIsMobileViewport();
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4628,17 +4628,9 @@ export function Composer({
   // On mobile, programmatic focus immediately summons the software keyboard.
   // Keep desktop's fast-type affordance, but let mobile users explicitly tap
   // the composer when switching back from Terminal or changing sessions.
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches,
-  );
+  const isMobile = useIsMobileViewport();
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
 
   useEffect(() => {
     const restored = conversationId ? sessionDrafts.get(conversationId) : undefined;

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -483,9 +483,9 @@ function stubViewportWidth(width: number) {
     configurable: true,
     value: (query: string) => ({
       matches: (() => {
-        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        const min = query.match(/^\(min-width: ([\d.]+)px\)$/);
         if (min) return width >= parseFloat(min[1]);
-        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        const max = query.match(/^\(max-width: ([\d.]+)px\)$/);
         if (max) return width <= parseFloat(max[1]);
         return false;
       })(),

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -474,7 +474,33 @@ function withWindowOrigin(origin: string, run: () => void) {
   }
 }
 
+// Evaluate min-/max-width media queries against a simulated viewport width,
+// so each test runs at an explicit real-browser width instead of inheriting
+// the global test-setup mock (which answers false to every query).
+function stubViewportWidth(width: number) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: (() => {
+        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        if (min) return width >= parseFloat(min[1]);
+        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        if (max) return width <= parseFloat(max[1]);
+        return false;
+      })(),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
 beforeEach(() => {
+  // Default to a mobile width: these suites were written against a sidebar
+  // that starts closed. Tests that need desktop semantics (hover peek)
+  // re-pin a desktop width themselves.
+  stubViewportWidth(375);
   useConvMock.mockReset();
   useTerminalsMock.mockReset();
   useTerminalsMock.mockReturnValue({
@@ -1258,8 +1284,13 @@ describe("Workspace rail maximize", () => {
     // armed from INSIDE it. Armed from the title-bar trigger (outside), a pointer
     // that never crosses the card leaves it with no pointerenter and therefore no
     // pointerleave, so the card used to sit open indefinitely.
+    // Hover peek is a desktop affordance; at a desktop width the sidebar
+    // starts open, so collapse it first to expose the peek trigger.
+    stubViewportWidth(1280);
     mockConversations([{ id: "conv_abc", permission_level: null }]);
     renderShell("/c/conv_abc");
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
 
     fireEvent.pointerEnter(screen.getByRole("button", { name: /open sidebar/i }));
     await waitFor(() => expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "true"));
@@ -1274,8 +1305,13 @@ describe("Workspace rail maximize", () => {
   it("keeps peeking while the pointer is over the card itself", async () => {
     // The other half: dismissal must not be so eager that moving onto the card —
     // the entire point of peeking — closes it.
+    // Same desktop setup as above: collapse the open-by-default sidebar to
+    // expose the peek trigger.
+    stubViewportWidth(1280);
     mockConversations([{ id: "conv_abc", permission_level: null }]);
     renderShell("/c/conv_abc");
+    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
 
     fireEvent.pointerEnter(screen.getByRole("button", { name: /open sidebar/i }));
     await waitFor(() => expect(screen.getByTestId("sidebar")).toHaveAttribute("data-peek", "true"));

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -80,7 +80,7 @@ import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
-import { isMobileViewport } from "@/lib/breakpoints";
+import { MD_MIN_WIDTH_QUERY, isMobileViewport } from "@/lib/breakpoints";
 import { Sidebar } from "./Sidebar";
 import { SidebarHeaderActions } from "./SidebarHeaderActions";
 import { useSettingsRoute } from "./settingsNav";
@@ -1894,11 +1894,13 @@ export function AppShell() {
 
 /**
  * Initial sidebar open state — open on desktop, closed on mobile. SSR-
- * safe (returns false when window is undefined). The threshold (`md`)
- * matches Tailwind's default 768px, used in the Sidebar's responsive
- * classes.
+ * safe (returns false when window is undefined). Deliberately probes the
+ * DESKTOP side (`min-width`) rather than negating `isMobileViewport()`:
+ * the sidebar should default open only when the viewport is provably at
+ * `md`+, so ambiguous environments (the fractional sliver, jsdom) start
+ * closed.
  */
 function initialSidebarOpen(): boolean {
   if (typeof window === "undefined") return false;
-  return !isMobileViewport();
+  return window.matchMedia(MD_MIN_WIDTH_QUERY).matches;
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -80,7 +80,7 @@ import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
-import { MD_MIN_WIDTH_QUERY, isMobileViewport } from "@/lib/breakpoints";
+import { isMobileViewport } from "@/lib/breakpoints";
 import { Sidebar } from "./Sidebar";
 import { SidebarHeaderActions } from "./SidebarHeaderActions";
 import { useSettingsRoute } from "./settingsNav";
@@ -1893,14 +1893,11 @@ export function AppShell() {
 }
 
 /**
- * Initial sidebar open state — open on desktop, closed on mobile. SSR-
- * safe (returns false when window is undefined). Deliberately probes the
- * DESKTOP side (`min-width`) rather than negating `isMobileViewport()`:
- * the sidebar should default open only when the viewport is provably at
- * `md`+, so ambiguous environments (the fractional sliver, jsdom) start
- * closed.
+ * Initial sidebar open state — open on desktop, closed on mobile, per the
+ * one canonical layout predicate ("mobile unless provably md+"). SSR-safe
+ * (returns false when window is undefined).
  */
 function initialSidebarOpen(): boolean {
   if (typeof window === "undefined") return false;
-  return window.matchMedia(MD_MIN_WIDTH_QUERY).matches;
+  return !isMobileViewport();
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -80,7 +80,8 @@ import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
-import { isMobileViewport, Sidebar } from "./Sidebar";
+import { isMobileViewport } from "@/lib/breakpoints";
+import { Sidebar } from "./Sidebar";
 import { SidebarHeaderActions } from "./SidebarHeaderActions";
 import { useSettingsRoute } from "./settingsNav";
 import { SubagentsPanel } from "./SubagentsPanel";
@@ -1899,5 +1900,5 @@ export function AppShell() {
  */
 function initialSidebarOpen(): boolean {
   if (typeof window === "undefined") return false;
-  return window.matchMedia("(min-width: 768px)").matches;
+  return !isMobileViewport();
 }

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -1385,27 +1385,43 @@ describe("Sidebar project sections", () => {
   });
 
   it("closes the mobile overlay when the project pencil is tapped", () => {
-    // jsdom's matchMedia mock reports non-desktop, so isMobileViewport() is
-    // true: a plain pencil tap must close the full-screen sidebar overlay,
-    // otherwise the pre-filed new-session page is left hidden behind it.
+    // Pin a mobile-width viewport (the canonical max-md query matches) so
+    // isMobileViewport() is true: a plain pencil tap must close the
+    // full-screen sidebar overlay, otherwise the pre-filed new-session page
+    // is left hidden behind it.
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: query === "(max-width: 767.98px)",
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
     ]);
     const onClose = vi.fn();
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    render(
-      <QueryClientProvider client={qc}>
-        <TooltipProvider>
-          <MemoryRouter initialEntries={["/"]}>
-            <Sidebar open onClose={onClose} />
-          </MemoryRouter>
-        </TooltipProvider>
-      </QueryClientProvider>,
-    );
+    try {
+      render(
+        <QueryClientProvider client={qc}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={["/"]}>
+              <Sidebar open onClose={onClose} />
+            </MemoryRouter>
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
 
-    fireEvent.click(screen.getByTestId("project-new-session").closest("a")!);
-    expect(onClose).toHaveBeenCalled();
+      fireEvent.click(screen.getByTestId("project-new-session").closest("a")!);
+      expect(onClose).toHaveBeenCalled();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it("starts a project folder collapsed with its rows hidden", () => {

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -254,7 +254,33 @@ function closeProjectsMenu() {
   fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
 }
 
+// Evaluate min-/max-width media queries against a simulated viewport width,
+// so each test runs at an explicit real-browser width instead of inheriting
+// the global test-setup mock (which answers false to every query).
+function stubViewportWidth(width: number) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: (() => {
+        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        if (min) return width >= parseFloat(min[1]);
+        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        if (max) return width <= parseFloat(max[1]);
+        return false;
+      })(),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
 beforeEach(() => {
+  // Default to a desktop width: these suites assert hover affordances
+  // (session tooltips, project flyouts) that are gated off on mobile. Tests
+  // that need a mobile width re-pin it themselves.
+  stubViewportWidth(1280);
   useConvMock.mockReset();
   useHostsMock.mockReset();
   useHostsMock.mockReturnValue({ data: [] });
@@ -1385,43 +1411,28 @@ describe("Sidebar project sections", () => {
   });
 
   it("closes the mobile overlay when the project pencil is tapped", () => {
-    // Pin a mobile-width viewport (the canonical max-md query matches) so
-    // isMobileViewport() is true: a plain pencil tap must close the
-    // full-screen sidebar overlay, otherwise the pre-filed new-session page
-    // is left hidden behind it.
-    const originalMatchMedia = window.matchMedia;
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      configurable: true,
-      value: (query: string) => ({
-        matches: query === "(max-width: 767.98px)",
-        media: query,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-      }),
-    });
+    // At a phone width isMobileViewport() is true: a plain pencil tap must
+    // close the full-screen sidebar overlay, otherwise the pre-filed
+    // new-session page is left hidden behind it.
+    stubViewportWidth(375);
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
     ]);
     const onClose = vi.fn();
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    try {
-      render(
-        <QueryClientProvider client={qc}>
-          <TooltipProvider>
-            <MemoryRouter initialEntries={["/"]}>
-              <Sidebar open onClose={onClose} />
-            </MemoryRouter>
-          </TooltipProvider>
-        </QueryClientProvider>,
-      );
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/"]}>
+            <Sidebar open onClose={onClose} />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
 
-      fireEvent.click(screen.getByTestId("project-new-session").closest("a")!);
-      expect(onClose).toHaveBeenCalled();
-    } finally {
-      window.matchMedia = originalMatchMedia;
-    }
+    fireEvent.click(screen.getByTestId("project-new-session").closest("a")!);
+    expect(onClose).toHaveBeenCalled();
   });
 
   it("starts a project folder collapsed with its rows hidden", () => {

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -263,9 +263,9 @@ function stubViewportWidth(width: number) {
     configurable: true,
     value: (query: string) => ({
       matches: (() => {
-        const min = /^\(min-width: ([\d.]+)px\)$/.exec(query);
+        const min = query.match(/^\(min-width: ([\d.]+)px\)$/);
         if (min) return width >= parseFloat(min[1]);
-        const max = /^\(max-width: ([\d.]+)px\)$/.exec(query);
+        const max = query.match(/^\(max-width: ([\d.]+)px\)$/);
         if (max) return width <= parseFloat(max[1]);
         return false;
       })(),

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -127,6 +127,7 @@ import {
 } from "@/hooks/useConversations";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { isMobileViewport } from "@/lib/breakpoints";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode, sandboxOptionLabel } from "@/lib/capabilities";
 import { relativeTime } from "@/lib/relativeTime";
@@ -4611,20 +4612,6 @@ function BulkActionBar({
       </Dialog>
     </>
   );
-}
-
-/**
- * Returns true on mobile viewports (below the `md` breakpoint of
- * 768px). Used to gate the auto-close-on-navigation behavior — on
- * mobile the sidebar is a full-screen overlay so dismissing on action
- * is what reveals the destination; on desktop the sidebar pushes content
- * aside and staying open is more useful.
- *
- * SSR-safe (returns false when window is undefined).
- */
-export function isMobileViewport(): boolean {
-  if (typeof window === "undefined") return false;
-  return !window.matchMedia("(min-width: 768px)").matches;
 }
 
 // Default collapse state: every section (Pinned / Projects / Chats / Shared)


### PR DESCRIPTION
Part of #4790

## Related issue

Closes #

## Summary

Foundation phase (TR-1..4) of the touch-interaction spec: give the web app one source of truth for pointer capability and one canonical encoding of the `md` layout breakpoint, keeping the two axes independent.

- **`useInputCapabilities`** (new hook) — single shared input-capability primitive: `(pointer: coarse)`, `(any-pointer: coarse)`, `(hover: hover)` plus `navigator.maxTouchPoints`. SSR-safe and reactive to `matchMedia` changes (convertible flipping modes, mouse attach/detach). Per TR-2 it gates affordances only — gesture recognition will bind to `PointerEvent.pointerType`, never these queries.
- **`@/lib/breakpoints`** (new module) — one exported `MD_BREAKPOINT_PX` constant + `minWidthQuery`/`maxWidthQuery` builders, and the shared `isMobileViewport()` helper. The five drifting md encodings now derive from it: `useIsMobileViewport` (`767.98px`), ChatPage's composer `matchMedia` (`767px`), AppShell's `initialSidebarOpen` (`min-width: 768px`), Sidebar's local `isMobileViewport()` helper (moved into the module), and the Android back handler.
- **Android (TR-4)** — the breakpoints module publishes `window.__omnigentIsMobileViewport`; `NativeBridgeScript`'s back handler consults that signal instead of re-deriving `innerWidth < 768` (the inline check survives only as a fallback for older web builds without the signal).

Zero behavior change on mouse desktops: every call site keeps its exact former query semantics (767.98px is `768 - 0.02`, Tailwind's own `max-md` encoding).

```
        layout axis                          input axis
  ┌──────────────────────┐          ┌──────────────────────────┐
  │  lib/breakpoints.ts  │          │ useInputCapabilities.ts  │
  │  MD_BREAKPOINT_PX    │          │ coarsePrimary / anyCoarse│
  │  min/maxWidthQuery   │          │ hoverPrimary / hasTouch  │
  │  isMobileViewport()  │          └──────────────────────────┘
  └──────────┬───────────┘            (affordances only; gestures
     ┌───────┼──────────┬─────────┐    bind to pointerType)
     ▼       ▼          ▼         ▼
 useIsMobile AppShell  Sidebar  window.__omnigentIsMobileViewport
 Viewport    ChatPage           ▲ consumed by Android back handler
```

## Test Plan

- `npx pnpm install --frozen-lockfile` at repo root.
- New unit tests: `web/src/lib/breakpoints.test.ts` (canonical encoding, query builders, `isMobileViewport`, native-signal publication) and `web/src/hooks/useInputCapabilities.test.tsx` (per-query mapping, `maxTouchPoints`, touch-laptop shape, live matchMedia reactivity, referentially stable snapshots) — 9 tests.
- Touched-suite regression run: `Sidebar.test.tsx`, `AppShell.test.tsx`, `ChatPage.test.ts`, `ChatPage.composer.test.tsx` + new tests — 500 passed. `tsc -b` clean.
- Android: `:app:testDebugUnitTest --tests OmnigentWebViewClientTest` — 20 passed, including a new test asserting the back handler consumes `__omnigentIsMobileViewport` rather than a second literal.
- Mutation checks: with the implementation reverted (tests kept), the new web test files fail (2 failed) and the new Kotlin test fails (`20 tests completed, 1 failed`); green with the fix restored.
- `pre-commit` clean (prettier, oxlint, tsc, ktlint).

## Demo


Breakpoint/capability behavior across all four form factors: [Android phone](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/android-phone.mp4) (below-md mobile layout), [foldable unfolded](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/android-foldable.mp4) + [tablet](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/android-tablet.mp4) (>=md coarse-pointer regime: desktop rails with working touch), [iPhone](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/ios-phone.mp4).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New hooks/modules are covered by dedicated unit tests; the rewired call sites (ChatPage composer, AppShell sidebar default, Sidebar auto-close) are covered by their existing suites, which all pass unchanged — the consolidation preserves each site's former query semantics.

## Changelog

Groundwork for touch support: one shared input-capability hook and a single canonical `md` breakpoint across web and the Android shell.

This pull request and its description were written by Isaac.
