### PR TITLE
fix(web): migrate comments-panel resize to pointer events for touch

### DIFF
--- a/tests/e2e_ui/comments/test_comments_panel_resize.py
+++ b/tests/e2e_ui/comments/test_comments_panel_resize.py
@@ -1,0 +1,245 @@
+"""E2E: resizing the CommentsPanel via its divider gutter.
+
+The comments panel is resized by dragging the slim divider gutter that sits
+between the code/diff viewer and the panel (``role=separator`` labelled
+"Resize comments panel"). The interaction is pointer-event driven (touch,
+pen, and mouse share the same handlers), the chosen width persists across a
+reload, and the gutter's invisible hit slivers are capped so pointer input
+on the viewer beside the gutter must never start a resize.
+
+Covered here:
+
+  1. Dragging the gutter leftward widens the panel to track the pointer
+     (width = panel right edge − pointer x).
+  2. The dragged width survives a full page reload (persisted preference).
+  3. NEGATIVE: a press-and-drag over the viewer, left of the gutter's capped
+     hit sliver, does not resize the panel.
+
+If this goes red, the likely regression is in ``useResizableCommentsPanel``
+(pointer capture / clamp / persistence) or in CommentsPanel's divider-gutter
+markup (the gutter must stay a flex sibling between viewer and panel).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_FILE_PATH = "resize_target.md"
+
+# Anchor paragraph for the seeded comment; appears exactly once so the stored
+# offsets unambiguously match the file content.
+_ANCHOR_TEXT = "Resize gutter anchor paragraph."
+
+_FILE_CONTENT = f"""\
+# Comments Resize Test
+
+{_ANCHOR_TEXT}
+
+Closing paragraph with filler text.
+"""
+
+_COMMENT_BODY = "Comment pinning the panel open for the resize test."
+
+# Wide desktop viewport: the FileViewer rail must have enough row space that
+# a leftward drag can widen the panel without hitting the dynamic clamp
+# (which reserves 240px for the viewer beside the gutter).
+_DESKTOP_VIEWPORT = {"width": 1728, "height": 1080}
+
+# Preferred leftward drag distance; shrunk at runtime if the viewer has less
+# spare room than this above its 240px minimum.
+_DRAG_PX = 100
+
+# The viewer's clamp-protected minimum width (MIN_VIEWER_PX in
+# useResizableCommentsPanel.ts) plus slack, so the capped drag never lands in
+# clamp territory and the tracking assertion stays exact.
+_VIEWER_MIN_PX = 240
+_CLAMP_SLACK_PX = 20
+
+# Pixel tolerance for width assertions (sub-pixel layout rounding).
+_TOLERANCE = 3.0
+
+# The gutter's invisible hit sliver may overhang the viewer by at most this
+# many px (VIEWER_SLIVER_PX in useResizableCommentsPanel.ts). The negative
+# probe presses just left of this budget, measured from the VIEWER's right
+# edge — never from the gutter's own box, which a hit-region regression
+# would move (dragging the probe along with it and masking the leak).
+_VIEWER_SLIVER_BUDGET_PX = 10
+
+# Safety margin between the budget line and the probe press point, absorbing
+# sub-pixel layout rounding while staying close enough to catch a sliver
+# that grows even a few px past its cap.
+_PROBE_MARGIN_PX = 4
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def commented_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed a markdown file plus one open comment via REST.
+
+    The ``?comment={id}`` deep link then opens the file with the comments
+    panel already visible — no in-browser selection dance needed.
+
+    :param seeded_session: Base fixture providing a runner-bound
+        ``(base_url, session_id)`` pair.
+    :returns: ``(base_url, session_id, comment_id)``.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_FILE_PATH}"
+    )
+    httpx.put(
+        file_url,
+        json={"content": _FILE_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    ).raise_for_status()
+
+    start = _FILE_CONTENT.find(_ANCHOR_TEXT)
+    assert start != -1, "fixture bug: anchor text missing from file content"
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/comments",
+        json={
+            "path": _FILE_PATH,
+            "body": _COMMENT_BODY,
+            "start_index": start,
+            "end_index": start + len(_ANCHOR_TEXT),
+            "anchor_content": _ANCHOR_TEXT,
+        },
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, resp.json()["id"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_panel(page: Page, base_url: str, session_id: str, comment_id: str) -> Locator:
+    """Deep-link into the file with the comments panel open; return the gutter.
+
+    :returns: The divider-gutter separator locator, ready to drag.
+    """
+    page.goto(f"{base_url}/c/{session_id}?file={_FILE_PATH}&comment={comment_id}")
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible(timeout=30_000)
+    expect(file_viewer).to_contain_text(_COMMENT_BODY, timeout=15_000)
+
+    separator = file_viewer.get_by_role("separator", name="Resize comments panel")
+    expect(separator).to_be_visible()
+    return separator
+
+
+def _panel_width(separator: Locator) -> float:
+    """Measure the panel root (the gutter's next sibling) rendered width."""
+    return separator.evaluate("el => el.nextElementSibling.getBoundingClientRect().width")
+
+
+def _panel_right(separator: Locator) -> float:
+    """Measure the panel root's right edge (fixed during a drag)."""
+    return separator.evaluate("el => el.nextElementSibling.getBoundingClientRect().right")
+
+
+def _viewer_width(separator: Locator) -> float:
+    """Measure the code/diff viewer's rendered width (the gutter's preceding sibling)."""
+    return separator.evaluate("el => el.previousElementSibling.getBoundingClientRect().width")
+
+
+def _viewer_right(separator: Locator) -> float:
+    """Measure the code/diff viewer's right edge (the gutter's preceding sibling).
+
+    The negative probe anchors here: the viewer's own box marks the seam the
+    layout owns, independent of how far the gutter's hit sliver actually
+    reaches — so a hit-region regression cannot move the probe with it.
+    """
+    return separator.evaluate("el => el.previousElementSibling.getBoundingClientRect().right")
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_gutter_drag_resizes_panel_and_persists(
+    page: Page,
+    commented_session: tuple[str, str, str],
+) -> None:
+    """Drag the divider gutter, verify the width tracks, persists, and is scoped."""
+    base_url, session_id, comment_id = commented_session
+    page.set_viewport_size(_DESKTOP_VIEWPORT)
+    separator = _open_panel(page, base_url, session_id, comment_id)
+
+    box = separator.bounding_box()
+    assert box is not None, "separator has no layout box"
+    start_x = box["x"] + box["width"] / 2
+    y = box["y"] + box["height"] / 2
+    panel_right = _panel_right(separator)
+    initial_width = _panel_width(separator)
+
+    # Keep the drag inside the un-clamped window: the hook stops widening the
+    # panel once the viewer would drop below its 240px minimum, so cap the
+    # distance by the viewer's spare room to keep the tracking check exact.
+    spare = _viewer_width(separator) - _VIEWER_MIN_PX - _CLAMP_SLACK_PX
+    drag_px = min(_DRAG_PX, spare)
+    assert drag_px >= 40, (
+        f"viewer too narrow ({_viewer_width(separator)}px) to exercise an "
+        f"un-clamped drag at {_DESKTOP_VIEWPORT['width']}px viewport"
+    )
+
+    # 1. Drag leftward: the hook derives width from the panel's right edge and
+    #    the pointer position, so the final width must track the release point.
+    end_x = start_x - drag_px
+    page.mouse.move(start_x, y)
+    page.mouse.down()
+    page.mouse.move(end_x, y, steps=8)
+    page.mouse.up()
+
+    dragged_width = _panel_width(separator)
+    expected = panel_right - end_x
+    assert abs(dragged_width - expected) <= _TOLERANCE, (
+        f"panel width {dragged_width} does not track the pointer release at "
+        f"{end_x} (expected ~{expected}, started at {initial_width})"
+    )
+
+    # 2. The released width is a persisted preference: it must survive a full
+    #    reload (fresh React tree, width restored from storage).
+    page.reload()
+    separator = _open_panel(page, base_url, session_id, comment_id)
+    reloaded_width = _panel_width(separator)
+    assert abs(reloaded_width - dragged_width) <= _TOLERANCE, (
+        f"panel width {reloaded_width} after reload lost the dragged width {dragged_width}"
+    )
+
+    # 3. NEGATIVE: press-and-drag over the viewer, just left of the gutter's
+    #    sliver budget, must not resize — the viewer keeps its own pointer
+    #    stream (text selection / scrollbar). The probe is anchored to the
+    #    VIEWER's right edge plus the fixed budget, NOT to the separator's own
+    #    box: a regression that widens the hit sliver would shift that box and
+    #    carry a box-relative probe out of harm's way, hiding the leak.
+    outside_x = _viewer_right(separator) - _VIEWER_SLIVER_BUDGET_PX - _PROBE_MARGIN_PX
+    page.mouse.move(outside_x, y)
+    page.mouse.down()
+    page.mouse.move(outside_x - 80, y, steps=5)
+    page.mouse.up()
+
+    final_width = _panel_width(separator)
+    assert abs(final_width - reloaded_width) <= _TOLERANCE, (
+        f"a drag starting {_PROBE_MARGIN_PX}px outside the {_VIEWER_SLIVER_BUDGET_PX}px "
+        f"viewer-side sliver budget resized the panel "
+        f"({reloaded_width} -> {final_width}); the hit sliver leaked over the viewer"
+    )

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPanelSizePreference } from "@/lib/panelSizePreferences";
 import {
   resetCommentsWidthStoreForTesting,
@@ -10,6 +10,44 @@ const originalInnerWidth = window.innerWidth;
 
 function setInnerWidth(px: number): void {
   Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: px });
+}
+
+// jsdom has no pointer capture, so tests drive the returned handlers directly
+// with a stub handle element that tracks capture state.
+function makeHandleTarget() {
+  const captured = new Set<number>();
+  return {
+    setPointerCapture: vi.fn((id: number) => captured.add(id)),
+    releasePointerCapture: vi.fn((id: number) => captured.delete(id)),
+    hasPointerCapture: (id: number) => captured.has(id),
+  };
+}
+
+type HandleTarget = ReturnType<typeof makeHandleTarget>;
+
+function pointerEvent(
+  target: HandleTarget,
+  overrides: Partial<{ pointerId: number; pointerType: string; button: number; clientX: number }>,
+): React.PointerEvent {
+  return {
+    pointerId: 1,
+    pointerType: "touch",
+    button: 0,
+    clientX: 0,
+    preventDefault: () => {},
+    currentTarget: target,
+    ...overrides,
+  } as unknown as React.PointerEvent;
+}
+
+/** Panel root whose right edge sits at x=1000 inside a 2000px-wide row. */
+function attachContainer(ref: React.MutableRefObject<HTMLDivElement | null>): void {
+  const parent = document.createElement("div");
+  const panel = document.createElement("div");
+  parent.appendChild(panel);
+  vi.spyOn(parent, "getBoundingClientRect").mockReturnValue({ width: 2000 } as DOMRect);
+  vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({ right: 1000 } as DOMRect);
+  ref.current = panel;
 }
 
 beforeEach(() => {
@@ -48,6 +86,132 @@ describe("useResizableCommentsPanel persistence", () => {
   });
 });
 
+describe("useResizableCommentsPanel pointer drag", () => {
+  it("captures the pointer on pointerdown and resizes from pointermove", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 7 })));
+    // Capture keeps the drag alive when the pointer leaves the 1px handle.
+    expect(target.setPointerCapture).toHaveBeenCalledWith(7);
+
+    // Panel right edge is at 1000, so a move to x=700 means a 300px width.
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 7, clientX: 700 }),
+      ),
+    );
+    expect(result.current.width).toBe(300);
+
+    // Live moves must not persist; only the release does.
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBeNull();
+    act(() =>
+      result.current.handleProps.onPointerUp(pointerEvent(target, { pointerId: 7, clientX: 700 })),
+    );
+    expect(target.releasePointerCapture).toHaveBeenCalledWith(7);
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBe(300);
+    unmount();
+  });
+
+  it("ignores a second concurrent pointer — first pointer wins", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 1 })));
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 2 })));
+    // A second finger neither captures nor steals the drag.
+    expect(target.setPointerCapture).toHaveBeenCalledTimes(1);
+
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 2, clientX: 500 }),
+      ),
+    );
+    expect(result.current.width).toBe(240);
+
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 1, clientX: 700 }),
+      ),
+    );
+    expect(result.current.width).toBe(300);
+    unmount();
+  });
+
+  it("does not start a drag from a secondary mouse button", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() =>
+      result.current.handleProps.onPointerDown(
+        pointerEvent(target, { pointerType: "mouse", button: 2 }),
+      ),
+    );
+    expect(target.setPointerCapture).not.toHaveBeenCalled();
+
+    act(() => result.current.handleProps.onPointerMove(pointerEvent(target, { clientX: 700 })));
+    expect(result.current.width).toBe(240);
+    unmount();
+  });
+
+  it.each([
+    ["pointercancel", "onPointerCancel"],
+    ["lostpointercapture", "onLostPointerCapture"],
+  ] as const)("aborts cleanly at the last applied width on %s", (_name, handler) => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 3 })));
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 3, clientX: 700 }),
+      ),
+    );
+    act(() => result.current.handleProps[handler](pointerEvent(target, { pointerId: 3 })));
+
+    // Never a half-state: width settles, body styles restore, drag is over so
+    // later moves from the same pointer are inert.
+    expect(result.current.width).toBe(300);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 3, clientX: 500 }),
+      ),
+    );
+    expect(result.current.width).toBe(300);
+    unmount();
+  });
+});
+
+describe("useResizableCommentsPanel touch affordances", () => {
+  it("declares touch-action none and a >=44px invisible hit target", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+
+    // No scroll/swipe may start from the handle during a potential drag.
+    expect(result.current.handleProps.style.touchAction).toBe("none");
+
+    // The 1px visual handle carries an invisible child widened for touch/pen.
+    const hit = result.current.handleProps.children;
+    expect(hit.props["aria-hidden"]).toBe(true);
+    expect(hit.props.style.width).toBeGreaterThanOrEqual(44);
+    expect(hit.props.style.touchAction).toBe("none");
+    unmount();
+  });
+
+  it("keeps the separator contract the consumer's markup relies on", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    expect(result.current.handleProps.role).toBe("separator");
+    expect(result.current.handleProps["aria-label"]).toBe("Resize comments panel");
+    expect(result.current.handleProps.tabIndex).toBe(0);
+    unmount();
+  });
+});
+
 describe("useResizableCommentsPanel drag overlay", () => {
   const overlaySelector = () =>
     [...document.body.children].find(
@@ -55,33 +219,34 @@ describe("useResizableCommentsPanel drag overlay", () => {
         c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
     ) ?? null;
 
-  it("mounts a full-window overlay during a drag so mouseup isn't lost to the preview iframe", () => {
-    // The divider sits between the HTML-preview iframe and this panel. Without
-    // an overlay, dragging over the frame routes mousemove/mouseup into it and
-    // the parent never sees the release, so the drag sticks to the cursor.
+  it("shields iframes with a full-window overlay for the duration of the drag", () => {
+    // The divider sits beside the HTML-preview iframe. If capture is lost,
+    // the overlay keeps the pointer stream in the parent document so the
+    // release is never swallowed by the frame.
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    const target = makeHandleTarget();
     expect(overlaySelector()).toBeNull();
 
-    act(() =>
-      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
-    );
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, {})));
     const overlay = overlaySelector();
     expect(overlay).not.toBeNull();
     expect(overlay?.style.cursor).toBe("col-resize");
 
-    act(() => window.dispatchEvent(new MouseEvent("mouseup")));
+    act(() => result.current.handleProps.onPointerUp(pointerEvent(target, {})));
     expect(overlaySelector()).toBeNull();
     unmount();
   });
 
-  it("removes the overlay if unmounted mid-drag", () => {
+  it("removes the overlay and restores body styles if unmounted mid-drag", () => {
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
-    act(() =>
-      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
-    );
+    const target = makeHandleTarget();
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, {})));
     expect(overlaySelector()).not.toBeNull();
+    expect(document.body.style.cursor).toBe("col-resize");
 
     unmount();
     expect(overlaySelector()).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
   });
 });

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -81,13 +81,16 @@ const overlaySelector = () =>
       c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
   ) ?? null;
 
-/** Panel root whose right edge sits at x=1000 inside a 2000px-wide row. */
-function attachContainer(ref: React.MutableRefObject<HTMLDivElement | null>): void {
+/** Panel root inside the split row; defaults to right edge x=1000, row 2000px. */
+function attachContainer(
+  ref: React.MutableRefObject<HTMLDivElement | null>,
+  { parentWidth = 2000, panelRight = 1000 } = {},
+): void {
   const parent = document.createElement("div");
   const panel = document.createElement("div");
   parent.appendChild(panel);
-  vi.spyOn(parent, "getBoundingClientRect").mockReturnValue({ width: 2000 } as DOMRect);
-  vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({ right: 1000 } as DOMRect);
+  vi.spyOn(parent, "getBoundingClientRect").mockReturnValue({ width: parentWidth } as DOMRect);
+  vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({ right: panelRight } as DOMRect);
   ref.current = panel;
 }
 
@@ -179,6 +182,32 @@ describe("useResizableCommentsPanel pointer drag", () => {
       ),
     );
     expect(result.current.width).toBe(300);
+    unmount();
+  });
+
+  it("leaves at least 240px for the viewer at maximum width with the gutter present", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    // Full row is [viewer, gutter, panel]: a 500px row with the panel's right
+    // edge flush at x=500, so every pixel the panel takes comes out of the
+    // viewer+gutter budget.
+    attachContainer(result.current.containerRef, { parentWidth: 500, panelRight: 500 });
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 6 })));
+    // Drag all the way left — the clamp, not the pointer, decides the max.
+    act(() =>
+      result.current.handleProps.onPointerMove(pointerEvent(target, { pointerId: 6, clientX: 0 })),
+    );
+
+    // The dynamic max must budget the gutter's footprint (always the coarse
+    // 8px) on top of the viewer's 240px minimum: 500 − 240 − 8 = 252.
+    const width = result.current.width as number;
+    expect(width).toBe(252);
+    expect(500 - width - 8).toBeGreaterThanOrEqual(240);
+
+    act(() =>
+      result.current.handleProps.onPointerUp(pointerEvent(target, { pointerId: 6, clientX: 0 })),
+    );
     unmount();
   });
 

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -174,8 +174,10 @@ describe("useResizableCommentsPanel pointer drag", () => {
     act(() => result.current.handleProps[handler](pointerEvent(target, { pointerId: 3 })));
 
     // Never a half-state: width settles, body styles restore, drag is over so
-    // later moves from the same pointer are inert.
+    // later moves from the same pointer are inert. An abort is not a choice —
+    // the last applied width stays on screen but is never persisted.
     expect(result.current.width).toBe(300);
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBeNull();
     expect(document.body.style.cursor).toBe("");
     expect(document.body.style.userSelect).toBe("");
     act(() =>
@@ -191,15 +193,23 @@ describe("useResizableCommentsPanel pointer drag", () => {
 describe("useResizableCommentsPanel touch affordances", () => {
   it("declares touch-action none and a >=44px invisible hit target", () => {
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    const { style } = result.current.handleProps;
 
     // No scroll/swipe may start from the handle during a potential drag.
-    expect(result.current.handleProps.style.touchAction).toBe("none");
+    expect(style.touchAction).toBe("none");
 
-    // The 1px visual handle carries an invisible child widened for touch/pen.
-    const hit = result.current.handleProps.children;
-    expect(hit.props["aria-hidden"]).toBe(true);
-    expect(hit.props.style.width).toBeGreaterThanOrEqual(44);
-    expect(hit.props.style.touchAction).toBe("none");
+    // Invisible padding widens the ~1px visual handle to >=44px; negative
+    // margins cancel its footprint and content-box keeps backgrounds off it.
+    const pad = Number(style.paddingLeft);
+    expect(pad).toBe(Number(style.paddingRight));
+    expect(pad * 2 + 4).toBeGreaterThanOrEqual(44);
+    expect(Number(style.marginLeft)).toBe(-pad);
+    expect(Number(style.marginRight)).toBe(-pad);
+    expect(style.boxSizing).toBe("content-box");
+    expect(style.backgroundClip).toBe("content-box");
+
+    // The affordance is pure style — nothing is rendered into the handle.
+    expect("children" in result.current.handleProps).toBe(false);
     unmount();
   });
 

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -337,7 +337,24 @@ describe("useResizableCommentsPanel pointer drag", () => {
 });
 
 describe("useResizableCommentsPanel touch affordances", () => {
-  it("declares touch-action none and an invisible asymmetric hit target", () => {
+  // The handle is a divider gutter: a real flex child whose layout footprint
+  // is the gutter width (4px painted strip + padding + the cancelling
+  // negative margins) and whose hit box overhangs each neighbor by only a
+  // capped sliver. Derived from the returned style:
+  const gutterGeometry = (style: React.CSSProperties) => {
+    const padLeft = Number(style.paddingLeft);
+    const padRight = Number(style.paddingRight);
+    const marginLeft = Number(style.marginLeft);
+    const marginRight = Number(style.marginRight);
+    return {
+      hitTotal: 4 + padLeft + padRight,
+      footprint: 4 + padLeft + padRight + marginLeft + marginRight,
+      viewerOverhang: -marginLeft,
+      inwardOverhang: -marginRight,
+    };
+  };
+
+  it("declares touch-action none and a capped-sliver gutter hit target", () => {
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
     const { style } = result.current.handleProps;
 
@@ -345,16 +362,15 @@ describe("useResizableCommentsPanel touch affordances", () => {
     expect(style.touchAction).toBe("none");
 
     // Fine pointer (the matchMedia stub reports no coarse pointer): >=24px
-    // total, weighted toward the viewer side where nothing interactive sits.
-    const viewerPad = Number(style.paddingLeft);
-    const inwardPad = Number(style.paddingRight);
-    expect(viewerPad + 4 + inwardPad).toBeGreaterThanOrEqual(24);
-    expect(viewerPad).toBeGreaterThan(inwardPad);
+    // hit total in a 6px-wide gutter. The slivers are capped so a classic
+    // viewer scrollbar and the panel's content keep their pointer streams.
+    const g = gutterGeometry(style);
+    expect(g.hitTotal).toBeGreaterThanOrEqual(24);
+    expect(g.footprint).toBe(6);
+    expect(g.viewerOverhang).toBeLessThanOrEqual(10);
+    expect(g.inwardOverhang).toBeLessThanOrEqual(8);
 
-    // Negative margins cancel the pads' footprint and content-box keeps
-    // hover/active backgrounds off them — the visible strip is unchanged.
-    expect(Number(style.marginLeft)).toBe(-viewerPad);
-    expect(Number(style.marginRight)).toBe(-inwardPad);
+    // Content-box keeps hover/active backgrounds on the 4px painted strip.
     expect(style.boxSizing).toBe("content-box");
     expect(style.backgroundClip).toBe("content-box");
 
@@ -363,20 +379,17 @@ describe("useResizableCommentsPanel touch affordances", () => {
     unmount();
   });
 
-  it("widens the hit target to >=44px total on coarse-pointer devices", () => {
+  it("widens the gutter and hit target on coarse-pointer devices", () => {
     mockMatchMedia({ "(pointer: coarse)": true });
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
-    const { style } = result.current.handleProps;
 
-    const viewerPad = Number(style.paddingLeft);
-    const inwardPad = Number(style.paddingRight);
-    expect(viewerPad + 4 + inwardPad).toBeGreaterThanOrEqual(44);
-    // The natural grab side (over the viewer) must be >=24px on its own; the
-    // inward pad stays small so header/tab/card taps aren't stolen.
-    expect(viewerPad).toBeGreaterThanOrEqual(24);
-    expect(inwardPad).toBeLessThanOrEqual(8);
-    expect(Number(style.marginLeft)).toBe(-viewerPad);
-    expect(Number(style.marginRight)).toBe(-inwardPad);
+    // Coarse: 8px gutter, 26px hit total — TR-7's 24px floor with the same
+    // sliver caps (the preferred 44px would need a visually wide gutter).
+    const g = gutterGeometry(result.current.handleProps.style);
+    expect(g.hitTotal).toBe(26);
+    expect(g.footprint).toBe(8);
+    expect(g.viewerOverhang).toBeLessThanOrEqual(10);
+    expect(g.inwardOverhang).toBeLessThanOrEqual(8);
     unmount();
   });
 

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -40,6 +40,47 @@ function pointerEvent(
   } as unknown as React.PointerEvent;
 }
 
+const originalMatchMedia = window.matchMedia;
+
+type MediaListener = (e: MediaQueryListEvent) => void;
+
+/** Controllable matchMedia mock: per-query matches plus a change-event firer. */
+function mockMatchMedia(matches: Record<string, boolean> = {}) {
+  const listeners = new Map<string, Set<MediaListener>>();
+  window.matchMedia = ((query: string) => ({
+    matches: matches[query] ?? false,
+    media: query,
+    onchange: null,
+    addEventListener: (_: string, cb: MediaListener) => {
+      if (!listeners.has(query)) listeners.set(query, new Set());
+      listeners.get(query)?.add(cb);
+    },
+    removeEventListener: (_: string, cb: MediaListener) => listeners.get(query)?.delete(cb),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+  return {
+    fire(query: string, value: boolean) {
+      for (const cb of listeners.get(query) ?? new Set<MediaListener>()) {
+        cb({ matches: value } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+/** jsdom has no PointerEvent constructor; a plain Event with pointerId works
+ * for the hook's document-level fallback listeners. */
+function docPointerEvent(type: string, pointerId: number): Event {
+  return Object.assign(new Event(type), { pointerId });
+}
+
+const overlaySelector = () =>
+  [...document.body.children].find(
+    (c): c is HTMLElement =>
+      c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
+  ) ?? null;
+
 /** Panel root whose right edge sits at x=1000 inside a 2000px-wide row. */
 function attachContainer(ref: React.MutableRefObject<HTMLDivElement | null>): void {
   const parent = document.createElement("div");
@@ -58,6 +99,7 @@ afterEach(() => {
   localStorage.clear();
   resetCommentsWidthStoreForTesting();
   setInnerWidth(originalInnerWidth);
+  window.matchMedia = originalMatchMedia;
 });
 
 describe("useResizableCommentsPanel persistence", () => {
@@ -140,6 +182,110 @@ describe("useResizableCommentsPanel pointer drag", () => {
     unmount();
   });
 
+  it("ends the drag from the document fallback when capture delivery fails", () => {
+    // A browser can drop capture without firing the handle's own pointerup
+    // (tab switch, node detach). The document-level fallback still ends the
+    // drag — a release, so it persists — and the max-z overlay comes down.
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 5 })));
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 5, clientX: 700 }),
+      ),
+    );
+    act(() => void document.dispatchEvent(docPointerEvent("pointerup", 5)));
+
+    expect(overlaySelector()).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBe(300);
+    unmount();
+  });
+
+  it("aborts without persisting from the document pointercancel fallback", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 5 })));
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 5, clientX: 700 }),
+      ),
+    );
+    act(() => void document.dispatchEvent(docPointerEvent("pointercancel", 5)));
+
+    expect(overlaySelector()).toBeNull();
+    expect(result.current.width).toBe(300);
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBeNull();
+    unmount();
+  });
+
+  it("aborts the drag when the layout flips below the md breakpoint", () => {
+    // Flipping to mobile unmounts the handle, so its up/cancel can never
+    // arrive; the drag must end (unpersisted) or the overlay would wedge.
+    const mm = mockMatchMedia();
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 4 })));
+    expect(overlaySelector()).not.toBeNull();
+
+    act(() => mm.fire("(min-width: 768px)", false));
+    expect(result.current.isDesktop).toBe(false);
+    expect(overlaySelector()).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBeNull();
+    unmount();
+  });
+
+  it("stays fully idle when pointer capture throws", () => {
+    // If capture fails, publishing drag state anyway would leave a stale
+    // activePointerId that a later reused pointerId could match — ending
+    // (and persisting) a drag that never started.
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+    target.setPointerCapture.mockImplementation(() => {
+      throw new Error("InvalidPointerId");
+    });
+
+    act(() => result.current.handleProps.onPointerDown(pointerEvent(target, { pointerId: 9 })));
+    expect(overlaySelector()).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+
+    act(() =>
+      result.current.handleProps.onPointerMove(
+        pointerEvent(target, { pointerId: 9, clientX: 700 }),
+      ),
+    );
+    expect(result.current.width).toBe(240);
+
+    act(() => void document.dispatchEvent(docPointerEvent("pointerup", 9)));
+    expect(readPanelSizePreference("commentsPanelWidthPx")).toBeNull();
+    unmount();
+  });
+
+  it("does not start a drag from a pen barrel button", () => {
+    // A pen barrel press dispatches pointerType "pen" with button 2; only
+    // the primary button/tip (button 0) may start a drag.
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    attachContainer(result.current.containerRef);
+    const target = makeHandleTarget();
+
+    act(() =>
+      result.current.handleProps.onPointerDown(
+        pointerEvent(target, { pointerType: "pen", button: 2 }),
+      ),
+    );
+    expect(target.setPointerCapture).not.toHaveBeenCalled();
+    expect(overlaySelector()).toBeNull();
+    unmount();
+  });
+
   it("does not start a drag from a secondary mouse button", () => {
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
     attachContainer(result.current.containerRef);
@@ -191,25 +337,63 @@ describe("useResizableCommentsPanel pointer drag", () => {
 });
 
 describe("useResizableCommentsPanel touch affordances", () => {
-  it("declares touch-action none and a >=44px invisible hit target", () => {
+  it("declares touch-action none and an invisible asymmetric hit target", () => {
     const { result, unmount } = renderHook(() => useResizableCommentsPanel());
     const { style } = result.current.handleProps;
 
     // No scroll/swipe may start from the handle during a potential drag.
     expect(style.touchAction).toBe("none");
 
-    // Invisible padding widens the ~1px visual handle to >=44px; negative
-    // margins cancel its footprint and content-box keeps backgrounds off it.
-    const pad = Number(style.paddingLeft);
-    expect(pad).toBe(Number(style.paddingRight));
-    expect(pad * 2 + 4).toBeGreaterThanOrEqual(44);
-    expect(Number(style.marginLeft)).toBe(-pad);
-    expect(Number(style.marginRight)).toBe(-pad);
+    // Fine pointer (the matchMedia stub reports no coarse pointer): >=24px
+    // total, weighted toward the viewer side where nothing interactive sits.
+    const viewerPad = Number(style.paddingLeft);
+    const inwardPad = Number(style.paddingRight);
+    expect(viewerPad + 4 + inwardPad).toBeGreaterThanOrEqual(24);
+    expect(viewerPad).toBeGreaterThan(inwardPad);
+
+    // Negative margins cancel the pads' footprint and content-box keeps
+    // hover/active backgrounds off them — the visible strip is unchanged.
+    expect(Number(style.marginLeft)).toBe(-viewerPad);
+    expect(Number(style.marginRight)).toBe(-inwardPad);
     expect(style.boxSizing).toBe("content-box");
     expect(style.backgroundClip).toBe("content-box");
 
     // The affordance is pure style — nothing is rendered into the handle.
     expect("children" in result.current.handleProps).toBe(false);
+    unmount();
+  });
+
+  it("widens the hit target to >=44px total on coarse-pointer devices", () => {
+    mockMatchMedia({ "(pointer: coarse)": true });
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    const { style } = result.current.handleProps;
+
+    const viewerPad = Number(style.paddingLeft);
+    const inwardPad = Number(style.paddingRight);
+    expect(viewerPad + 4 + inwardPad).toBeGreaterThanOrEqual(44);
+    // The natural grab side (over the viewer) must be >=24px on its own; the
+    // inward pad stays small so header/tab/card taps aren't stolen.
+    expect(viewerPad).toBeGreaterThanOrEqual(24);
+    expect(inwardPad).toBeLessThanOrEqual(8);
+    expect(Number(style.marginLeft)).toBe(-viewerPad);
+    expect(Number(style.marginRight)).toBe(-inwardPad);
+    unmount();
+  });
+
+  it("exposes the width to assistive tech via aria value attributes", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    expect(result.current.handleProps["aria-valuenow"]).toBe(240);
+    expect(result.current.handleProps["aria-valuemin"]).toBe(200);
+    expect(result.current.handleProps["aria-valuemax"]).toBe(640);
+
+    // The value tracks live resizes.
+    act(() => {
+      result.current.handleProps.onKeyDown({
+        key: "ArrowLeft",
+        preventDefault: () => {},
+      } as React.KeyboardEvent);
+    });
+    expect(result.current.handleProps["aria-valuenow"]).toBe(260);
     unmount();
   });
 
@@ -223,12 +407,6 @@ describe("useResizableCommentsPanel touch affordances", () => {
 });
 
 describe("useResizableCommentsPanel drag overlay", () => {
-  const overlaySelector = () =>
-    [...document.body.children].find(
-      (c): c is HTMLElement =>
-        c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
-    ) ?? null;
-
   it("shields iframes with a full-window overlay for the duration of the drag", () => {
     // The divider sits beside the HTML-preview iframe. If capture is lost,
     // the overlay keeps the pointer stream in the parent document so the

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -180,10 +180,16 @@ export function useResizableCommentsPanel() {
 
   // Clamp a candidate width to [MIN, dynamic max], leaving MIN_VIEWER_PX for
   // the sibling code/diff viewer so the panel can't swallow the whole row.
+  // The divider gutter is a third flex child in the row, so its footprint
+  // comes out of the budget too — always the coarse 8px, so a pointer-type
+  // flip mid-session can never shrink the viewer below its minimum.
   const clampWidth = useCallback((candidate: number): number => {
     const parent = containerRef.current?.parentElement;
     const parentWidth = parent?.getBoundingClientRect().width ?? window.innerWidth;
-    const max = Math.max(MIN_WIDTH_PX, Math.min(MAX_WIDTH_PX, parentWidth - MIN_VIEWER_PX));
+    const max = Math.max(
+      MIN_WIDTH_PX,
+      Math.min(MAX_WIDTH_PX, parentWidth - MIN_VIEWER_PX - GUTTER_COARSE_PX),
+    );
     return Math.max(MIN_WIDTH_PX, Math.min(candidate, max));
   }, []);
 

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -24,9 +24,15 @@ const MAX_WIDTH_PX = 640;
 const MIN_VIEWER_PX = 240;
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
-/** Invisible padding on each side of the 1px visual handle, widening the hit
- * target for touch/pen without changing its visual weight. */
-const HANDLE_HIT_PAD_PX = 20;
+// Invisible hit padding around the ~1px visual handle. Asymmetric on purpose:
+// the natural grab side is the viewer side (the handle sits on the panel's
+// LEFT edge), where the pad only overlaps inert code-viewer margin — while the
+// inward pad lies over the panel's own header/tabs/cards, so it must stay
+// small enough not to steal their taps or vertical-scroll starts.
+const COARSE_VIEWER_PAD_PX = 32; // 32 + 4 paint + 8 = 44px total for fingers
+const COARSE_INWARD_PAD_PX = 8;
+const FINE_VIEWER_PAD_PX = 16; // 16 + 4 paint + 4 = 24px total for mouse/pen
+const FINE_INWARD_PAD_PX = 4;
 
 // ---------------------------------------------------------------------------
 // Module-level width store (shared across panel remounts within a session)
@@ -105,6 +111,9 @@ export function useResizableCommentsPanel() {
   const activePointerId = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  // Removes the document-level pointerup/pointercancel fallbacks installed
+  // for the active drag; null when idle.
+  const removeDocFallbacks = useRef<(() => void) | null>(null);
 
   // While dragging, a transparent full-window overlay sits above the panel so
   // the pointer stream keeps reaching the parent document even if capture is
@@ -135,6 +144,20 @@ export function useResizableCommentsPanel() {
     return () => mql.removeEventListener("change", handler);
   }, []);
 
+  // Coarse pointers (fingers) get the full 44px hit box; fine pointers
+  // (mouse, trackpad, pen tip) can acquire a 24px one.
+  const [isCoarse, setIsCoarse] = useState(
+    () => typeof window !== "undefined" && !!window.matchMedia?.("(pointer: coarse)").matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia?.("(pointer: coarse)");
+    if (!mql) return;
+    const handler = (e: MediaQueryListEvent) => setIsCoarse(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
   // Clamp a candidate width to [MIN, dynamic max], leaving MIN_VIEWER_PX for
   // the sibling code/diff viewer so the panel can't swallow the whole row.
   const clampWidth = useCallback((candidate: number): number => {
@@ -153,6 +176,8 @@ export function useResizableCommentsPanel() {
     (persist: boolean) => {
       if (activePointerId.current === null) return;
       activePointerId.current = null;
+      removeDocFallbacks.current?.();
+      removeDocFallbacks.current = null;
       removeDragOverlay();
       if (persist) persistStoredWidth();
       document.body.style.cursor = "";
@@ -163,19 +188,42 @@ export function useResizableCommentsPanel() {
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
-      // First pointer wins; a right/middle mouse press doesn't start a drag.
+      // First pointer wins; only the primary button/tip starts a drag. (A pen
+      // barrel button reports pointerType "pen" with button 2, so the guard
+      // must not be mouse-only; touch and pen tip are always button 0.)
       if (activePointerId.current !== null) return;
-      if (e.pointerType === "mouse" && e.button !== 0) return;
+      if (e.button !== 0) return;
+      // Capture BEFORE publishing any drag state: if capture throws (pointer
+      // already gone, detached node), staying fully idle avoids a stale
+      // activePointerId that a later reused pointerId could match — which
+      // would spuriously end (and persist) a drag that never started.
+      try {
+        e.currentTarget.setPointerCapture?.(e.pointerId); // jsdom lacks capture
+      } catch {
+        return;
+      }
       e.preventDefault();
       activePointerId.current = e.pointerId;
-      // Capture routes every move/up to the handle even when the pointer
-      // leaves it mid-drag. Optional-chained: jsdom lacks pointer capture.
-      e.currentTarget.setPointerCapture?.(e.pointerId);
+      // Document-level fallbacks: if the browser drops capture without
+      // delivering the handle's up/cancel, the drag still ends here so the
+      // max-z overlay can never outlive it.
+      const onDocPointerUp = (ev: PointerEvent) => {
+        if (ev.pointerId === activePointerId.current) endDrag(true);
+      };
+      const onDocPointerCancel = (ev: PointerEvent) => {
+        if (ev.pointerId === activePointerId.current) endDrag(false);
+      };
+      document.addEventListener("pointerup", onDocPointerUp);
+      document.addEventListener("pointercancel", onDocPointerCancel);
+      removeDocFallbacks.current = () => {
+        document.removeEventListener("pointerup", onDocPointerUp);
+        document.removeEventListener("pointercancel", onDocPointerCancel);
+      };
       addDragOverlay();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
-    [addDragOverlay],
+    [addDragOverlay, endDrag],
   );
 
   const onPointerMove = useCallback(
@@ -228,6 +276,12 @@ export function useResizableCommentsPanel() {
   // Unmount mid-drag: abort (no persist) and clean up body/overlay state.
   useEffect(() => () => endDrag(false), [endDrag]);
 
+  // The layout flipping to mobile mid-drag unmounts the handle, so its
+  // up/cancel can never arrive — abort so the overlay doesn't outlive the drag.
+  useEffect(() => {
+    if (!isDesktop) endDrag(false);
+  }, [isDesktop, endDrag]);
+
   // Re-clamp the stored width when the viewport resizes so a width chosen on
   // a wider layout doesn't crowd out the viewer after the window shrinks.
   useEffect(() => {
@@ -261,19 +315,23 @@ export function useResizableCommentsPanel() {
       role: "separator" as const,
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize comments panel",
+      "aria-valuenow": width,
+      "aria-valuemin": MIN_WIDTH_PX,
+      "aria-valuemax": MAX_WIDTH_PX,
       tabIndex: 0,
       // The handle owns its touches outright (no scroll/selection may start
       // from it), and invisible padding widens the too-thin visual handle
-      // into a touch-acquirable hit target. Negative margins cancel the
+      // into an acquirable hit target — weighted toward the viewer side,
+      // where it overlaps nothing interactive. Negative margins cancel the
       // padding's footprint and content-box keeps hover/active backgrounds
       // painting only the visible sliver, so the visual weight is unchanged.
       style: {
         touchAction: "none",
         boxSizing: "content-box",
-        paddingLeft: HANDLE_HIT_PAD_PX,
-        paddingRight: HANDLE_HIT_PAD_PX,
-        marginLeft: -HANDLE_HIT_PAD_PX,
-        marginRight: -HANDLE_HIT_PAD_PX,
+        paddingLeft: isCoarse ? COARSE_VIEWER_PAD_PX : FINE_VIEWER_PAD_PX,
+        paddingRight: isCoarse ? COARSE_INWARD_PAD_PX : FINE_INWARD_PAD_PX,
+        marginLeft: isCoarse ? -COARSE_VIEWER_PAD_PX : -FINE_VIEWER_PAD_PX,
+        marginRight: isCoarse ? -COARSE_INWARD_PAD_PX : -FINE_INWARD_PAD_PX,
         backgroundClip: "content-box",
       } as React.CSSProperties,
     },

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -14,7 +14,14 @@
 // file is opened, matching the other panel-resize hooks. Explicit user
 // resizes are also persisted so a full page reload restores the width.
 
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { readPanelSizePreference, writePanelSizePreference } from "@/lib/panelSizePreferences";
 
 const DEFAULT_WIDTH_PX = 240; // matches the previous fixed `md:w-60`
@@ -24,6 +31,8 @@ const MAX_WIDTH_PX = 640;
 const MIN_VIEWER_PX = 240;
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
+/** Invisible touch hit target centered on the 1px visual handle. */
+const HIT_TARGET_PX = 44;
 
 // ---------------------------------------------------------------------------
 // Module-level width store (shared across panel remounts within a session)
@@ -97,14 +106,16 @@ export function resetCommentsWidthStoreForTesting(): void {
 export function useResizableCommentsPanel() {
   const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const width = Math.max(MIN_WIDTH_PX, Math.min(raw ?? DEFAULT_WIDTH_PX, MAX_WIDTH_PX));
-  const dragging = useRef(false);
+  // Pointer id of the active drag; null when idle. A second concurrent
+  // pointer (e.g. another finger) is ignored — first pointer wins.
+  const activePointerId = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
 
   // While dragging, a transparent full-window overlay sits above the panel so
-  // the pointer stream keeps reaching the parent document. Without it, dragging
-  // over a cross-origin/sandboxed iframe (e.g. the HTML preview) routes mousemove
-  // /mouseup into the frame, the parent never sees mouseup, and the drag sticks.
+  // the pointer stream keeps reaching the parent document even if capture is
+  // lost. Without it, dragging over a cross-origin/sandboxed iframe (e.g. the
+  // HTML preview) routes moves into the frame and the drag sticks.
   const addDragOverlay = useCallback(() => {
     if (overlayRef.current || typeof document === "undefined") return;
     const el = document.createElement("div");
@@ -139,15 +150,66 @@ export function useResizableCommentsPanel() {
     return Math.max(MIN_WIDTH_PX, Math.min(candidate, max));
   }, []);
 
-  const onMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  // Ends the drag at the last applied width (never a half-state): clears the
+  // active pointer, drops the overlay, persists once, and restores the body
+  // cursor/selection. Idempotent so pointerup + the lostpointercapture it
+  // triggers don't double-run.
+  const endDrag = useCallback(() => {
+    if (activePointerId.current === null) return;
+    activePointerId.current = null;
+    removeDragOverlay();
+    persistStoredWidth();
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, [removeDragOverlay]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // First pointer wins; a right/middle mouse press doesn't start a drag.
+      if (activePointerId.current !== null) return;
+      if (e.pointerType === "mouse" && e.button !== 0) return;
       e.preventDefault();
-      dragging.current = true;
+      activePointerId.current = e.pointerId;
+      // Capture routes every move/up to the handle even when the pointer
+      // leaves it mid-drag. Optional-chained: jsdom lacks pointer capture.
+      e.currentTarget.setPointerCapture?.(e.pointerId);
       addDragOverlay();
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
     [addDragOverlay],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== activePointerId.current || !containerRef.current) return;
+      const right = containerRef.current.getBoundingClientRect().right;
+      // Update the live width only; persist once on release to avoid a
+      // synchronous localStorage write per move.
+      setStoredWidth(clampWidth(right - e.clientX));
+    },
+    [clampWidth],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== activePointerId.current) return;
+      if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+      endDrag();
+    },
+    [endDrag],
+  );
+
+  // pointercancel (e.g. the browser reclaims the touch) and capture loss
+  // both abort cleanly to the last applied width.
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== activePointerId.current) return;
+      endDrag();
+    },
+    [endDrag],
   );
 
   // Keyboard resize: left/right arrows widen/narrow by 20px.
@@ -165,35 +227,8 @@ export function useResizableCommentsPanel() {
     [clampWidth],
   );
 
-  useEffect(() => {
-    function onMouseMove(e: MouseEvent) {
-      if (!dragging.current || !containerRef.current) return;
-      const right = containerRef.current.getBoundingClientRect().right;
-      // Update the live width only; persist once on release to avoid a
-      // synchronous localStorage write per mousemove.
-      setStoredWidth(clampWidth(right - e.clientX));
-    }
-    function onMouseUp() {
-      if (!dragging.current) return;
-      dragging.current = false;
-      removeDragOverlay();
-      persistStoredWidth();
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    }
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
-    return () => {
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
-      if (dragging.current) {
-        dragging.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-      removeDragOverlay();
-    };
-  }, [clampWidth, removeDragOverlay]);
+  // Unmount mid-drag: abort and clean up body/overlay state.
+  useEffect(() => endDrag, [endDrag]);
 
   // Re-clamp the stored width when the viewport resizes so a width chosen on
   // a wider layout doesn't crowd out the viewer after the window shrinks.
@@ -219,12 +254,35 @@ export function useResizableCommentsPanel() {
     isDesktop,
     /** Props to spread onto the resize handle element. */
     handleProps: {
-      onMouseDown,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onLostPointerCapture: onPointerCancel,
       onKeyDown,
       role: "separator" as const,
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize comments panel",
       tabIndex: 0,
+      // The handle owns its touches outright — no scroll/selection may start
+      // from it while a drag is possible.
+      style: { touchAction: "none" } as React.CSSProperties,
+      // Invisible widened hit target: the visual handle is 1px, far too thin
+      // to acquire by touch or pen. Rendered as the handle's child so events
+      // from it hit the handlers above without changing the visual weight.
+      children: createElement("span", {
+        "aria-hidden": true,
+        style: {
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          left: "50%",
+          width: HIT_TARGET_PX,
+          transform: "translateX(-50%)",
+          touchAction: "none",
+          cursor: "col-resize",
+        } as React.CSSProperties,
+      }),
     },
   };
 }

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -14,14 +14,7 @@
 // file is opened, matching the other panel-resize hooks. Explicit user
 // resizes are also persisted so a full page reload restores the width.
 
-import {
-  createElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { readPanelSizePreference, writePanelSizePreference } from "@/lib/panelSizePreferences";
 
 const DEFAULT_WIDTH_PX = 240; // matches the previous fixed `md:w-60`
@@ -31,8 +24,9 @@ const MAX_WIDTH_PX = 640;
 const MIN_VIEWER_PX = 240;
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
-/** Invisible touch hit target centered on the 1px visual handle. */
-const HIT_TARGET_PX = 44;
+/** Invisible padding on each side of the 1px visual handle, widening the hit
+ * target for touch/pen without changing its visual weight. */
+const HANDLE_HIT_PAD_PX = 20;
 
 // ---------------------------------------------------------------------------
 // Module-level width store (shared across panel remounts within a session)
@@ -151,17 +145,21 @@ export function useResizableCommentsPanel() {
   }, []);
 
   // Ends the drag at the last applied width (never a half-state): clears the
-  // active pointer, drops the overlay, persists once, and restores the body
-  // cursor/selection. Idempotent so pointerup + the lostpointercapture it
-  // triggers don't double-run.
-  const endDrag = useCallback(() => {
-    if (activePointerId.current === null) return;
-    activePointerId.current = null;
-    removeDragOverlay();
-    persistStoredWidth();
-    document.body.style.cursor = "";
-    document.body.style.userSelect = "";
-  }, [removeDragOverlay]);
+  // active pointer, drops the overlay, and restores the body cursor/selection.
+  // Only a deliberate release persists; aborts (cancel, capture loss, unmount)
+  // keep the width on screen but don't write storage. Idempotent so pointerup
+  // + the lostpointercapture it triggers don't double-run.
+  const endDrag = useCallback(
+    (persist: boolean) => {
+      if (activePointerId.current === null) return;
+      activePointerId.current = null;
+      removeDragOverlay();
+      if (persist) persistStoredWidth();
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    },
+    [removeDragOverlay],
+  );
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -197,17 +195,17 @@ export function useResizableCommentsPanel() {
       if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
-      endDrag();
+      endDrag(true);
     },
     [endDrag],
   );
 
   // pointercancel (e.g. the browser reclaims the touch) and capture loss
-  // both abort cleanly to the last applied width.
+  // both abort cleanly to the last applied width, without persisting it.
   const onPointerCancel = useCallback(
     (e: React.PointerEvent) => {
       if (e.pointerId !== activePointerId.current) return;
-      endDrag();
+      endDrag(false);
     },
     [endDrag],
   );
@@ -227,8 +225,8 @@ export function useResizableCommentsPanel() {
     [clampWidth],
   );
 
-  // Unmount mid-drag: abort and clean up body/overlay state.
-  useEffect(() => endDrag, [endDrag]);
+  // Unmount mid-drag: abort (no persist) and clean up body/overlay state.
+  useEffect(() => () => endDrag(false), [endDrag]);
 
   // Re-clamp the stored width when the viewport resizes so a width chosen on
   // a wider layout doesn't crowd out the viewer after the window shrinks.
@@ -264,25 +262,20 @@ export function useResizableCommentsPanel() {
       "aria-orientation": "vertical" as const,
       "aria-label": "Resize comments panel",
       tabIndex: 0,
-      // The handle owns its touches outright — no scroll/selection may start
-      // from it while a drag is possible.
-      style: { touchAction: "none" } as React.CSSProperties,
-      // Invisible widened hit target: the visual handle is 1px, far too thin
-      // to acquire by touch or pen. Rendered as the handle's child so events
-      // from it hit the handlers above without changing the visual weight.
-      children: createElement("span", {
-        "aria-hidden": true,
-        style: {
-          position: "absolute",
-          top: 0,
-          bottom: 0,
-          left: "50%",
-          width: HIT_TARGET_PX,
-          transform: "translateX(-50%)",
-          touchAction: "none",
-          cursor: "col-resize",
-        } as React.CSSProperties,
-      }),
+      // The handle owns its touches outright (no scroll/selection may start
+      // from it), and invisible padding widens the too-thin visual handle
+      // into a touch-acquirable hit target. Negative margins cancel the
+      // padding's footprint and content-box keeps hover/active backgrounds
+      // painting only the visible sliver, so the visual weight is unchanged.
+      style: {
+        touchAction: "none",
+        boxSizing: "content-box",
+        paddingLeft: HANDLE_HIT_PAD_PX,
+        paddingRight: HANDLE_HIT_PAD_PX,
+        marginLeft: -HANDLE_HIT_PAD_PX,
+        marginRight: -HANDLE_HIT_PAD_PX,
+        backgroundClip: "content-box",
+      } as React.CSSProperties,
     },
   };
 }

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -24,15 +24,35 @@ const MAX_WIDTH_PX = 640;
 const MIN_VIEWER_PX = 240;
 /** Tailwind `md` breakpoint — must track the value in tailwind.config. */
 const MD_BREAKPOINT = 768;
-// Invisible hit padding around the ~1px visual handle. Asymmetric on purpose:
-// the natural grab side is the viewer side (the handle sits on the panel's
-// LEFT edge), where the pad only overlaps inert code-viewer margin — while the
-// inward pad lies over the panel's own header/tabs/cards, so it must stay
-// small enough not to steal their taps or vertical-scroll starts.
-const COARSE_VIEWER_PAD_PX = 32; // 32 + 4 paint + 8 = 44px total for fingers
-const COARSE_INWARD_PAD_PX = 8;
-const FINE_VIEWER_PAD_PX = 16; // 16 + 4 paint + 4 = 24px total for mouse/pen
-const FINE_INWARD_PAD_PX = 4;
+// The handle is a dedicated divider gutter between the viewer and the panel —
+// a real flex child outside both scroll containers, so its hit area overlays
+// almost no content. The painted strip (`w-1`) sits centered in the gutter;
+// invisible padding fills the rest and overhangs each side by a small sliver
+// via negative margins. The slivers are capped so the viewer's scrollbar and
+// the panel's header/tabs/cards keep their taps and scroll starts — which
+// also caps the hit total at 26px coarse / 24px fine (TR-7's 24px floor; the
+// preferred 44px would need a visually wide gutter the layout doesn't permit).
+const PAINTED_STRIP_PX = 4; // must match the handle's `w-1` class
+const GUTTER_COARSE_PX = 8;
+const GUTTER_FINE_PX = 6;
+const VIEWER_SLIVER_PX = 10; // ≤10: a 14px viewer scrollbar keeps 4px + its own gutter
+const INWARD_SLIVER_PX = 8; // ≤8: stays within the panel's 12px content gutter
+
+/** Inline style for the divider-gutter handle: layout footprint = gutter
+ * width, hit box = gutter + both slivers, paint = the centered `w-1` strip. */
+function gutterStyle(isCoarse: boolean): React.CSSProperties {
+  const gutter = isCoarse ? GUTTER_COARSE_PX : GUTTER_FINE_PX;
+  const inset = (gutter - PAINTED_STRIP_PX) / 2;
+  return {
+    touchAction: "none",
+    boxSizing: "content-box",
+    paddingLeft: VIEWER_SLIVER_PX + inset,
+    paddingRight: INWARD_SLIVER_PX + inset,
+    marginLeft: -VIEWER_SLIVER_PX,
+    marginRight: -INWARD_SLIVER_PX,
+    backgroundClip: "content-box",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Module-level width store (shared across panel remounts within a session)
@@ -304,7 +324,12 @@ export function useResizableCommentsPanel() {
     containerRef,
     /** Whether the resize handle should render (desktop only). */
     isDesktop,
-    /** Props to spread onto the resize handle element. */
+    /**
+     * Props to spread onto the divider-gutter handle. Render it as the
+     * panel's PRECEDING SIBLING in the split row (a `w-1 shrink-0` flex
+     * child), never inside either scroll container — the pads would be
+     * clipped and would steal the neighbors' pointer streams.
+     */
     handleProps: {
       onPointerDown,
       onPointerMove,
@@ -319,21 +344,13 @@ export function useResizableCommentsPanel() {
       "aria-valuemin": MIN_WIDTH_PX,
       "aria-valuemax": MAX_WIDTH_PX,
       tabIndex: 0,
-      // The handle owns its touches outright (no scroll/selection may start
-      // from it), and invisible padding widens the too-thin visual handle
-      // into an acquirable hit target — weighted toward the viewer side,
-      // where it overlaps nothing interactive. Negative margins cancel the
-      // padding's footprint and content-box keeps hover/active backgrounds
-      // painting only the visible sliver, so the visual weight is unchanged.
-      style: {
-        touchAction: "none",
-        boxSizing: "content-box",
-        paddingLeft: isCoarse ? COARSE_VIEWER_PAD_PX : FINE_VIEWER_PAD_PX,
-        paddingRight: isCoarse ? COARSE_INWARD_PAD_PX : FINE_INWARD_PAD_PX,
-        marginLeft: isCoarse ? -COARSE_VIEWER_PAD_PX : -FINE_VIEWER_PAD_PX,
-        marginRight: isCoarse ? -COARSE_INWARD_PAD_PX : -FINE_INWARD_PAD_PX,
-        backgroundClip: "content-box",
-      } as React.CSSProperties,
+      // The gutter owns its touches outright (no scroll/selection may start
+      // from it). With content-box sizing the `w-1` class is the painted
+      // strip; padding centers it in the gutter and adds the overhang
+      // slivers, whose footprint the negative margins cancel — so the
+      // element occupies exactly the gutter width and the hover/active
+      // background (content-box clipped) never widens visually.
+      style: gutterStyle(isCoarse),
     },
   };
 }

--- a/web/src/shell/CommentsPanel.test.tsx
+++ b/web/src/shell/CommentsPanel.test.tsx
@@ -511,3 +511,58 @@ describe("CommentsPanel active-comment reveal", () => {
     expect(screen.getByText("Comment c2")).toBeInTheDocument();
   });
 });
+
+// ── Resize handle geometry ────────────────────────────────────────────────────
+
+describe("CommentsPanel resize handle geometry", () => {
+  const getSeparator = () => screen.getByRole("separator", { name: "Resize comments panel" });
+  const dragOverlayPresent = () =>
+    [...document.body.children].some(
+      (c) => c instanceof HTMLElement && c.style.zIndex === "2147483647",
+    );
+
+  it("leaves the handle's viewer-side hit pad unclipped by the panel root", () => {
+    const { container } = renderPanel([makeComment("c1")], []);
+    const root = container.firstElementChild as HTMLElement;
+    const separator = getSeparator();
+
+    // The root must not clip: the hit pad extends past the panel's left edge
+    // over the viewer — the natural grab side. Clipping lives on an inner
+    // content wrapper that does NOT contain the handle.
+    expect(root.className).not.toMatch(/overflow-hidden/);
+    const wrapper = root.querySelector(":scope > .overflow-hidden");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.contains(separator)).toBe(false);
+
+    // The negative margin pushes the pad's footprint over the viewer side.
+    expect(separator.style.marginLeft).toBe(`-${separator.style.paddingLeft}`);
+  });
+
+  it("keeps taps and scrolls on the panel content out of the handle", () => {
+    renderPanel([makeComment("c1")], [makeComment("c2", "addressed")]);
+
+    // The inward pad stays small so it only overlaps the header/list gutter,
+    // never the tappable content.
+    expect(parseFloat(getSeparator().style.paddingRight)).toBeLessThanOrEqual(8);
+
+    // Pressing and tapping a tab must interact with the tab, not the handle:
+    // no drag overlay appears and the tab actually switches.
+    const addressedTab = screen.getByRole("button", { name: /addressed/i });
+    fireEvent.pointerDown(addressedTab);
+    expect(dragOverlayPresent()).toBe(false);
+    fireEvent.click(addressedTab);
+    expect(screen.getByText("Comment c2")).toBeInTheDocument();
+  });
+
+  it("keeps the visible handle strip unchanged by the hit padding", () => {
+    renderPanel([], []);
+    const separator = getSeparator();
+
+    // 1px-ish painted strip: the pads are invisible (content-box background)
+    // and their footprint is cancelled by the matching negative margins.
+    expect(separator.className).toMatch(/\bw-1\b/);
+    expect(separator.style.boxSizing).toBe("content-box");
+    expect(separator.style.backgroundClip).toBe("content-box");
+    expect(separator.style.marginRight).toBe(`-${separator.style.paddingRight}`);
+  });
+});

--- a/web/src/shell/CommentsPanel.test.tsx
+++ b/web/src/shell/CommentsPanel.test.tsx
@@ -414,10 +414,10 @@ describe("CommentsPanel resize affordance", () => {
   it("renders a resize handle and applies an inline width on desktop", () => {
     renderPanel([makeComment("c1")], []);
 
-    // The separator is the drag handle; its parent is the panel root, which
+    // The separator is the divider gutter preceding the panel root, which
     // gets an explicit pixel width (default 240px) so it can be dragged wider.
     const handle = screen.getByRole("separator", { name: "Resize comments panel" });
-    expect((handle.parentElement as HTMLElement).style.width).toBe("240px");
+    expect((handle.nextElementSibling as HTMLElement).style.width).toBe("240px");
   });
 
   it("omits the handle and inline width on a narrow (mobile) viewport", () => {
@@ -514,36 +514,43 @@ describe("CommentsPanel active-comment reveal", () => {
 
 // ── Resize handle geometry ────────────────────────────────────────────────────
 
-describe("CommentsPanel resize handle geometry", () => {
+describe("CommentsPanel resize divider gutter", () => {
+  // jsdom has no layout engine, so these tests pin the structural invariants
+  // that produce the geometry in a real browser: the gutter must be a flex
+  // sibling BEFORE the panel root (i.e. between the viewer and the panel in
+  // FileViewer's row) and outside every scroll/clip container, with its hit
+  // overhang capped on both sides.
   const getSeparator = () => screen.getByRole("separator", { name: "Resize comments panel" });
   const dragOverlayPresent = () =>
     [...document.body.children].some(
       (c) => c instanceof HTMLElement && c.style.zIndex === "2147483647",
     );
 
-  it("leaves the handle's viewer-side hit pad unclipped by the panel root", () => {
+  it("renders the gutter between the viewer and the panel, outside both scroll containers", () => {
     const { container } = renderPanel([makeComment("c1")], []);
-    const root = container.firstElementChild as HTMLElement;
     const separator = getSeparator();
 
-    // The root must not clip: the hit pad extends past the panel's left edge
-    // over the viewer — the natural grab side. Clipping lives on an inner
-    // content wrapper that does NOT contain the handle.
-    expect(root.className).not.toMatch(/overflow-hidden/);
-    const wrapper = root.querySelector(":scope > .overflow-hidden");
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.contains(separator)).toBe(false);
+    // First child of the split row slot, immediately followed by the panel
+    // root — so in FileViewer's flex row it sits between viewer and panel.
+    expect(container.firstElementChild).toBe(separator);
+    const panelRoot = separator.nextElementSibling as HTMLElement;
+    expect(panelRoot).not.toBeNull();
+    expect(panelRoot.contains(separator)).toBe(false);
 
-    // The negative margin pushes the pad's footprint over the viewer side.
-    expect(separator.style.marginLeft).toBe(`-${separator.style.paddingLeft}`);
+    // The panel root clips its own content again; the gutter must sit outside
+    // every clipping/scrolling ancestor or its hit slivers would be cut off.
+    expect(panelRoot.className).toMatch(/overflow-hidden/);
+    expect(separator.closest(".overflow-hidden, .overflow-y-auto")).toBeNull();
   });
 
-  it("keeps taps and scrolls on the panel content out of the handle", () => {
+  it("caps the hit overhang over the viewer and the panel content", () => {
     renderPanel([makeComment("c1")], [makeComment("c2", "addressed")]);
+    const style = getSeparator().style;
 
-    // The inward pad stays small so it only overlaps the header/list gutter,
-    // never the tappable content.
-    expect(parseFloat(getSeparator().style.paddingRight)).toBeLessThanOrEqual(8);
+    // Slivers: ≤10px over the viewer (a 14px scrollbar keeps its majority),
+    // ≤8px inward (within the panel's 12px content gutter).
+    expect(-parseFloat(style.marginLeft)).toBeLessThanOrEqual(10);
+    expect(-parseFloat(style.marginRight)).toBeLessThanOrEqual(8);
 
     // Pressing and tapping a tab must interact with the tab, not the handle:
     // no drag overlay appears and the tab actually switches.
@@ -554,15 +561,23 @@ describe("CommentsPanel resize handle geometry", () => {
     expect(screen.getByText("Comment c2")).toBeInTheDocument();
   });
 
-  it("keeps the visible handle strip unchanged by the hit padding", () => {
+  it("keeps the painted strip slim inside the gutter's layout footprint", () => {
     renderPanel([], []);
     const separator = getSeparator();
+    const style = separator.style;
 
-    // 1px-ish painted strip: the pads are invisible (content-box background)
-    // and their footprint is cancelled by the matching negative margins.
+    // 4px painted strip (w-1, content-box background); the layout footprint
+    // is the slim gutter itself — padding minus the cancelling margins.
     expect(separator.className).toMatch(/\bw-1\b/);
-    expect(separator.style.boxSizing).toBe("content-box");
-    expect(separator.style.backgroundClip).toBe("content-box");
-    expect(separator.style.marginRight).toBe(`-${separator.style.paddingRight}`);
+    expect(style.boxSizing).toBe("content-box");
+    expect(style.backgroundClip).toBe("content-box");
+    const footprint =
+      4 +
+      parseFloat(style.paddingLeft) +
+      parseFloat(style.paddingRight) +
+      parseFloat(style.marginLeft) +
+      parseFloat(style.marginRight);
+    expect(footprint).toBeLessThanOrEqual(8);
+    expect(footprint).toBeGreaterThan(0);
   });
 });

--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -147,22 +147,24 @@ export function CommentsPanel({
   }, [activeSelection, tab]);
 
   return (
-    <div
-      ref={containerRef}
-      style={isDesktop && width != null ? { width } : undefined}
-      className="relative flex shrink-0 flex-col border-border w-full h-64 border-t md:h-auto md:border-t-0 md:border-l"
-    >
-      {/* Resize handle — desktop only (mobile stacks the panel full-width below) */}
+    <>
+      {/* Divider gutter owning the resize interaction — desktop only (mobile
+          stacks the panel full-width below). A real flex child BETWEEN the
+          viewer and the panel, outside both scroll containers, so its
+          invisible hit slivers overhang each neighbor by only a few px
+          instead of sitting over the viewer's scrollbar or the panel's
+          header/tabs/cards. */}
       {isDesktop && (
         <div
           {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          className="relative z-10 w-1 shrink-0 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
         />
       )}
-      {/* Content wrapper carries the clipping so the handle's invisible hit
-          padding can extend past the panel's left edge over the viewer (the
-          natural grab side); the FileViewer row still bounds everything. */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        ref={containerRef}
+        style={isDesktop && width != null ? { width } : undefined}
+        className="relative flex shrink-0 flex-col overflow-hidden border-border w-full h-64 border-t md:h-auto md:border-t-0 md:border-l"
+      >
         {/* Header — fixed height so layout doesn't shift when button is hidden */}
         <div className="flex h-11 shrink-0 items-center justify-between px-3 border-b border-border">
           <span className="text-sm font-semibold">Comments</span>
@@ -318,7 +320,7 @@ export function CommentsPanel({
           )}
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -150,7 +150,7 @@ export function CommentsPanel({
     <div
       ref={containerRef}
       style={isDesktop && width != null ? { width } : undefined}
-      className="relative flex shrink-0 flex-col overflow-hidden border-border w-full h-64 border-t md:h-auto md:border-t-0 md:border-l"
+      className="relative flex shrink-0 flex-col border-border w-full h-64 border-t md:h-auto md:border-t-0 md:border-l"
     >
       {/* Resize handle — desktop only (mobile stacks the panel full-width below) */}
       {isDesktop && (
@@ -159,118 +159,147 @@ export function CommentsPanel({
           className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
         />
       )}
-      {/* Header — fixed height so layout doesn't shift when button is hidden */}
-      <div className="flex h-11 shrink-0 items-center justify-between px-3 border-b border-border">
-        <span className="text-sm font-semibold">Comments</span>
-        {tab === "open" && (
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            className="rounded-full px-3 gap-1.5"
-            disabled={!canAddress || comments.length === 0 || addressPending}
-            onClick={onAddressAll}
-          >
-            <WandSparklesIcon className="size-3.5" />
-            Address All
-          </Button>
-        )}
-      </div>
-
-      {/* Tabs */}
-      <div className="flex shrink-0 border-b border-border">
-        {TABS.map((t) => {
-          const count = t === "open" ? comments.length : addressedComments.length;
-          return (
-            <button
-              key={t}
+      {/* Content wrapper carries the clipping so the handle's invisible hit
+          padding can extend past the panel's left edge over the viewer (the
+          natural grab side); the FileViewer row still bounds everything. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Header — fixed height so layout doesn't shift when button is hidden */}
+        <div className="flex h-11 shrink-0 items-center justify-between px-3 border-b border-border">
+          <span className="text-sm font-semibold">Comments</span>
+          {tab === "open" && (
+            <Button
               type="button"
-              className={cn(
-                "flex-1 py-1.5 text-sm font-medium capitalize transition-colors cursor-pointer",
-                tab === t
-                  ? "border-b-2 border-primary text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setTab(t)}
+              variant="outline"
+              size="xs"
+              className="rounded-full px-3 gap-1.5"
+              disabled={!canAddress || comments.length === 0 || addressPending}
+              onClick={onAddressAll}
             >
-              {t === "open" ? "Open" : "Addressed"}
-              {count > 0 && (
-                <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] tabular-nums">
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      {!canEdit && (
-        <div className="shrink-0 border-b border-border px-3 py-2 text-sm text-muted-foreground">
-          You have read-only access to this session.
+              <WandSparklesIcon className="size-3.5" />
+              Address All
+            </Button>
+          )}
         </div>
-      )}
 
-      <div className="flex-1 overflow-y-auto">
-        {/* Input section — shown when text is selected with no existing comment at same range and user can edit */}
-        {tab === "open" &&
-          activeSelection != null &&
-          !comments.some(
-            (c) =>
-              c.start_index === activeSelection.start_index &&
-              c.end_index === activeSelection.end_index,
-          ) &&
-          (canEdit ? (
-            <div className="space-y-2 border-b border-border px-3 py-2">
-              {activeSelection.anchor_content && (
-                <div className="truncate rounded bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
-                  <span className="text-foreground/60">Selection: </span>
-                  {displayAnchorContent(activeSelection.anchor_content).split("\n")[0]}
-                </div>
-              )}
-              <textarea
-                ref={addCommentTextareaRef}
-                className="w-full resize-none rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground"
-                rows={3}
-                placeholder="Add a comment…"
-                value={body}
-                onChange={(e) => {
-                  setBody(e.target.value);
-                  if (pendingBodyRef) pendingBodyRef.current = e.target.value;
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey && body.trim()) {
-                    e.preventDefault();
+        {/* Tabs */}
+        <div className="flex shrink-0 border-b border-border">
+          {TABS.map((t) => {
+            const count = t === "open" ? comments.length : addressedComments.length;
+            return (
+              <button
+                key={t}
+                type="button"
+                className={cn(
+                  "flex-1 py-1.5 text-sm font-medium capitalize transition-colors cursor-pointer",
+                  tab === t
+                    ? "border-b-2 border-primary text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setTab(t)}
+              >
+                {t === "open" ? "Open" : "Addressed"}
+                {count > 0 && (
+                  <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] tabular-nums">
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {!canEdit && (
+          <div className="shrink-0 border-b border-border px-3 py-2 text-sm text-muted-foreground">
+            You have read-only access to this session.
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto">
+          {/* Input section — shown when text is selected with no existing comment at same range and user can edit */}
+          {tab === "open" &&
+            activeSelection != null &&
+            !comments.some(
+              (c) =>
+                c.start_index === activeSelection.start_index &&
+                c.end_index === activeSelection.end_index,
+            ) &&
+            (canEdit ? (
+              <div className="space-y-2 border-b border-border px-3 py-2">
+                {activeSelection.anchor_content && (
+                  <div className="truncate rounded bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
+                    <span className="text-foreground/60">Selection: </span>
+                    {displayAnchorContent(activeSelection.anchor_content).split("\n")[0]}
+                  </div>
+                )}
+                <textarea
+                  ref={addCommentTextareaRef}
+                  className="w-full resize-none rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground"
+                  rows={3}
+                  placeholder="Add a comment…"
+                  value={body}
+                  onChange={(e) => {
+                    setBody(e.target.value);
+                    if (pendingBodyRef) pendingBodyRef.current = e.target.value;
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey && body.trim()) {
+                      e.preventDefault();
+                      onAddComment(body.trim());
+                      setBody("");
+                      if (pendingBodyRef) pendingBodyRef.current = "";
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  size="xs"
+                  className="w-full"
+                  disabled={!body.trim()}
+                  onClick={() => {
                     onAddComment(body.trim());
                     setBody("");
                     if (pendingBodyRef) pendingBodyRef.current = "";
-                  }
-                }}
-              />
-              <Button
-                type="button"
-                size="xs"
-                className="w-full"
-                disabled={!body.trim()}
-                onClick={() => {
-                  onAddComment(body.trim());
-                  setBody("");
-                  if (pendingBodyRef) pendingBodyRef.current = "";
-                }}
-              >
-                Add Comment
-              </Button>
-            </div>
-          ) : null)}
+                  }}
+                >
+                  Add Comment
+                </Button>
+              </div>
+            ) : null)}
 
-        {/* Comment list */}
-        {tab === "open" ? (
-          comments.length === 0 ? (
+          {/* Comment list */}
+          {tab === "open" ? (
+            comments.length === 0 ? (
+              <div className="flex items-center justify-center p-8 text-sm text-muted-foreground">
+                No open comments.
+              </div>
+            ) : (
+              <div className="space-y-2 p-3">
+                {comments.map((c) => {
+                  const isSelected =
+                    activeSelection?.start_index === c.start_index &&
+                    activeSelection?.end_index === c.end_index;
+                  return (
+                    <CommentCard
+                      key={c.id}
+                      comment={c}
+                      isSelected={isSelected}
+                      cardRef={isSelected ? selectedCardRef : undefined}
+                      onClick={() => onClickComment(c)}
+                      onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
+                      onEdit={canModify(c) ? (newBody) => onEditComment(c.id, newBody) : undefined}
+                      onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
+                    />
+                  );
+                })}
+              </div>
+            )
+          ) : addressedComments.length === 0 ? (
             <div className="flex items-center justify-center p-8 text-sm text-muted-foreground">
-              No open comments.
+              No addressed comments.
             </div>
           ) : (
             <div className="space-y-2 p-3">
-              {comments.map((c) => {
+              {addressedComments.map((c) => {
                 const isSelected =
                   activeSelection?.start_index === c.start_index &&
                   activeSelection?.end_index === c.end_index;
@@ -280,38 +309,14 @@ export function CommentsPanel({
                     comment={c}
                     isSelected={isSelected}
                     cardRef={isSelected ? selectedCardRef : undefined}
-                    onClick={() => onClickComment(c)}
                     onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
-                    onEdit={canModify(c) ? (newBody) => onEditComment(c.id, newBody) : undefined}
                     onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
                   />
                 );
               })}
             </div>
-          )
-        ) : addressedComments.length === 0 ? (
-          <div className="flex items-center justify-center p-8 text-sm text-muted-foreground">
-            No addressed comments.
-          </div>
-        ) : (
-          <div className="space-y-2 p-3">
-            {addressedComments.map((c) => {
-              const isSelected =
-                activeSelection?.start_index === c.start_index &&
-                activeSelection?.end_index === c.end_index;
-              return (
-                <CommentCard
-                  key={c.id}
-                  comment={c}
-                  isSelected={isSelected}
-                  cardRef={isSelected ? selectedCardRef : undefined}
-                  onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
-                  onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
-                />
-              );
-            })}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Related issue

<!-- Part of the touch-interaction workstream (spec TR-6/7/9); no standalone issue. -->

Closes #

## Summary

- The CommentsPanel resize handle only listened to `mousedown` + window `mousemove`/`mouseup`, so it could not be dragged with a finger or stylus at all.
- Migrated `useResizableCommentsPanel` to pointer events with `setPointerCapture` taken before any drag state is published (a capture throw stays fully idle): move/up are handled on the captured handle, `pointercancel`/`lostpointercapture` abort cleanly at the last applied width **without persisting it** (only a deliberate release writes storage), document-level pointerup/pointercancel fallbacks and an `isDesktop`-flip abort guarantee the max-z iframe-shield overlay never outlives a drag, a second concurrent pointer is ignored (first pointer wins), and only the primary button/tip starts a drag (a pen barrel button is pen/button:2).
- The handle is now a **dedicated divider gutter**: a slim real flex child between the viewer and the panel (the panel's preceding sibling), outside both scroll containers, with the 4px painted strip centered in it — the same boundary-element pattern as the sibling column-resize PR. Earlier revisions widened the handle with pads over content, which clipped against the panel's `overflow-hidden` and then sat over the viewer's scrollbar; the gutter retires that approach.
- Gutter geometry: 8px coarse / 6px fine layout footprint (`matchMedia("(pointer: coarse)")`, live-updating); hit slivers overhang ≤10px over the viewer (a 14px scrollbar keeps its majority, VS-Code-sash style) and ≤8px inward (within the panel's 12px content gutter) → **26px coarse / 24px fine hit totals**. That satisfies TR-7's 24px floor; the preferred 44px is not reachable at this seam without a visually wide gutter, given the sliver caps.
- The separator keeps its `role`/`aria-label` contract and gains `aria-valuenow/min/max` (live during drag) plus the existing arrow-key resize. Width semantics and persistence are unchanged (width still anchors to the panel's right edge); the only layout shift is the gutter's own 6–8px.

ELI5: the thin drag bar next to the comments panel used to understand only a mouse. Now it lives on its own slim divider strip between the code and the comments, understands fingers and pens, holds onto whichever pointer grabbed it first until it lets go, and quietly extends a few invisible pixels onto each neighbor so it's easy to grab without stealing their scrollbars or taps.

```
FileViewer row (flex, overflow-hidden)
┌───────────────────────────┬──┬──────────────────┐
│ code / diff viewer        │gu│  CommentsPanel   │
│ (overflow-y-auto)         │tt│ (overflow-hidden)│
│                     ≤10px→│er│←≤8px             │
│              hit slivers  │▐ │  (4px painted    │
└───────────────────────────┴──┴───strip)─────────┘
gutter = the separator: handleProps, pointer capture,
keyboard, ARIA; outside both scroll containers
```

## Test Plan

- `./node_modules/.bin/vitest run src/hooks/useResizableCommentsPanel.test.tsx src/shell/CommentsPanel.test.tsx` — 41/41 pass: pointer capture + drag math, capture-throw idling, first-pointer-wins, secondary-button and pen-barrel rejection, no-persist aborts on `pointercancel`/`lostpointercapture`, document-fallback drag end, `isDesktop`-flip abort, unmount cleanup, overlay lifecycle, coarse/fine gutter geometry, ARIA values, and mounted structural tests (gutter rendered between viewer and panel outside both scroll containers, overhang caps, painted strip unchanged, content taps not stolen).
- Mutation checks at each revision: new tests shown red with the fix reverted (latest: 5 structural/geometry tests fail against the pre-gutter sources; earlier rounds: 8 pointer tests and both no-persist abort tests red against the mouse/persisting implementations).
- Full web unit suite: 5727 passed; the only failures (3 in `NewChatDialog.test.tsx`) reproduce with this PR's changes stashed — pre-existing and unrelated.
- `tsc -b` clean; pre-commit (prettier, oxlint, web type check, ruff) clean.
- `uv run --frozen --group test pytest tests/e2e_ui/comments/test_comments_panel_resize.py -o addopts=""` — **1 passed**: real-browser (Playwright/Chromium) coverage of the resize flow — pointer-drag the gutter and assert the panel width tracks the release point, reload and assert the width persisted, and a negative probe pressing-and-dragging over the viewer just outside the gutter's 10px hit-sliver budget asserting no resize. Mutation check: with the hook + CommentsPanel reverted to `origin/main` and the SPA rebuilt, the test fails (the old markup has no gutter sibling); restored → green. (Local note: run with the ambient `OMNIGENT_RUNNER_*` env stripped when invoking from inside an omnigent session, or the fixture's spawned runner inherits delegated-auth wiring and never comes online.)
- jsdom has no layout engine, so the mounted unit tests pin the structural invariants that produce the geometry; the e2e_ui test and the live validation videos below provide the real hit-test proof.

## Demo


Comments seam touch-drag validated live — [foldable](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/gap-foldable-comments.mp4), [tablet](https://raw.githubusercontent.com/btli/omnigent/demo-assets/touch-validation-final/gap-tablet-richer.mp4) — tracked, clamped, persisted; seam gutter does not capture viewer scrollbar or adjacent taps.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests drive the pointer handlers directly (jsdom has no real pointer capture or layout engine) and pin the divider-gutter structure in mounted CommentsPanel tests; `tests/e2e_ui/comments/test_comments_panel_resize.py` covers the real-browser drag/persist/negative-hit flow end to end.

## Changelog

The comments panel can now be resized by touch and stylus via a slim divider gutter between the code and the panel

This pull request and its description were written by Isaac.


