### PR TITLE
Add native Polly review integration

### DIFF
--- a/docs/OMNIGENT_BOT_SETUP.md
+++ b/docs/OMNIGENT_BOT_SETUP.md
@@ -178,6 +178,15 @@ token and posts the review **as `omnigent-ci[bot]`**:
 > **trusted default branch** and fetches the PR diff via the API; PR-authored
 > code is never executed, and the minted token is scoped to the post step only.
 
+### Moving an existing webhook to native Polly Review
+
+Canary `omni integration polly` on one test repository first. Confirm an
+accepted job resumes after a daemon restart, replay the same delivery to prove
+it does not post twice, and push a newer PR head to prove the older job is
+superseded. For cutover, drain and stop the old webhook service before changing
+the GitHub App's single webhook URL to `/webhooks/github`. Keep the stopped old
+service and its data only for rollback; never run both consumers concurrently.
+
 ---
 
 ## Quick reference

--- a/docs/superpowers/plans/2026-08-13-native-polly-review.md
+++ b/docs/superpowers/plans/2026-08-13-native-polly-review.md
@@ -1,0 +1,70 @@
+# Native Polly Review Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-08-13-polly-review-integration-design.md`
+
+## Global Constraints
+
+- Reuse Omnigent's device grant, secret store, `IntegrationDaemon`, session/file APIs, and CLI conventions.
+- Add no runtime dependency; SQLite is stdlib.
+- Use TDD for every behavior change.
+- Keep the integration in Omnigent core under `omnigent/integrations/polly`.
+- Never expose GitHub or Omnigent credentials to reviewer sessions.
+- Do not commit, push, deploy, or change external services without explicit authorization.
+
+## Task 1: OIDC scoped device authorization
+
+**Files:** `omnigent/server/routes/device_auth.py`, `omnigent/server/app.py`, `tests/server/test_device_auth.py`
+
+1. Replace the OIDC rejection test with a failing router/flow test proving an OIDC-authenticated browser identity can approve a device grant.
+2. Verify the test fails because the router and app mount reject OIDC.
+3. Generalize the existing router guard and identity lookup to Accounts plus OIDC without changing token scope, refresh, revocation, or header-mode rejection.
+4. Mount the device router when either supported auth mode is active and device auth is enabled.
+5. Run `uv run pytest tests/server/test_device_auth.py` and the affected server app tests.
+
+## Task 2: Built-in safe review agent
+
+**Files:** built-in agent bundle and server seeding tests identified from the current Polly seeding pattern.
+
+1. Add failing tests for an idempotently seeded `polly-review` agent containing exactly `claude_review` and `codex_review`.
+2. Assert both workers have fixed harnesses, no spawn, no skills, no OS environment, and no shell/write tools.
+3. Add the smallest bundle and reuse the existing content-aware seed helper.
+4. Run the focused bundle/server tests.
+
+## Task 3: Durable native integration runtime
+
+**Files:** `omnigent/integrations/polly/*` plus focused tests under `tests/integrations/polly/`.
+
+Build in red/green slices:
+
+1. Webhook HMAC verification, event/action filtering, draft/fork skips, and delivery deduplication.
+2. SQLite schema and job transitions: pending, running, retry_wait, published, failed, superseded; recover running jobs at startup.
+3. GitHub App JWT, installation-token cache/refresh, repository installation resolution, diff fetch, review lookup by hidden marker, one review publish, and living status comment update.
+4. Omnigent client using scoped access/refresh tokens: create parent and exact reviewer child sessions, upload/copy one diff file, start turns, poll durable results, and interrupt the surviving child if its peer fails.
+5. Strict Review-ID-scoped output extraction and deterministic merge: blockers union, worst verdict, labeled summaries, path/line dedupe with higher priority, resolved-ID intersection, still-open union, and invalid anchors moved to the body.
+6. Worker orchestration: current-head checks before and after review, one fresh reviewer pair per durable job attempt, bounded idempotent transport retry, crash recovery, supersession, and marker-based exactly-once publication recovery.
+7. End-to-end test with fake GitHub and Omnigent proving two child outputs create one GitHub review.
+
+Run focused tests after every slice, then the complete Polly integration suite.
+
+## Task 4: CLI setup, onboarding, and cutover support
+
+**Files:** `omnigent/cli.py`, Polly integration CLI/runtime modules, and CLI tests.
+
+1. Add failing CLI tests for setup, foreground/background, status, stop, logs, doctor, and retry.
+2. Reuse `IntegrationDaemon("polly", ...)` for lifecycle behavior.
+3. Implement non-secret config under the Omnigent data directory and store the GitHub private key, webhook secret, and Omnigent refresh token through the existing secret store.
+4. Implement GitHub App manifest onboarding with CSRF state and one-time code exchange, plus existing-App import using a private-key file and hidden webhook-secret prompt.
+5. Make setup select and validate the `polly-review` agent, one online host with ready Claude and Codex harnesses, and a dedicated empty absolute workspace.
+6. Implement `doctor` as read-only checks and `retry` as a failed-job reset.
+7. Add migration guidance to the existing integration documentation: canary, restart recovery, delivery replay, head supersession, drain old service, change one webhook URL, and preserve the old service only for rollback.
+8. Run focused CLI tests, `pre-commit run --all-files`, and the full relevant Python suite.
+
+## Acceptance
+
+- A valid webhook is durably acknowledged before review work starts.
+- Two child sessions are visible in Omnigent and exactly one review appears on GitHub.
+- Replaying a delivery or losing a GitHub POST response never creates a duplicate review.
+- Restarting the daemon resumes accepted work.
+- A newer head prevents an older review from publishing.
+- Setup and logs never expose stored secrets.
+- Accounts behavior remains unchanged; OIDC works; header/proxy remains rejected.

--- a/docs/superpowers/specs/2026-08-13-polly-review-integration-design.md
+++ b/docs/superpowers/specs/2026-08-13-polly-review-integration-design.md
@@ -1,0 +1,63 @@
+# Polly Review Integration Design
+
+## Goal
+
+Make Polly Review a first-class Omnigent integration that an operator can connect to their own GitHub App and Omnigent deployment without Kainotomic-specific infrastructure.
+
+## Contract
+
+- Accept only GitHub `pull_request` webhooks for opened, reopened, synchronize, and ready-for-review actions.
+- Skip drafts and forks.
+- Run exactly two deterministic reviewers: Claude and Codex.
+- Give both reviewers the same uploaded diff without cloning or shell access.
+- Strictly validate Review-ID-scoped JSON and merge the two results deterministically.
+- Publish exactly one GitHub review per repository, pull request, and head SHA.
+- Persist accepted deliveries and jobs so restarts and webhook redelivery do not lose or duplicate reviews.
+
+## Security
+
+- Operators own and install their GitHub App.
+- The App requests only Pull requests: write and the pull_request event; Metadata read is implicit.
+- Omnigent access uses the existing scoped device grant under Accounts or OIDC. Header/proxy auth remains unsupported.
+- Secrets use Omnigent's existing keychain/owner-only fallback store. No PATs, cookie secrets, or administrator JWT minting.
+- Reviewers have no spawn, skills, OS environment, shell, repository checkout, GitHub credentials, or write tools.
+- Reviews run from a dedicated empty workspace, never `/`, a home directory, or `/root`.
+
+## Runtime
+
+`omni integration polly` reuses `IntegrationDaemon` and runs a single worker backed by stdlib SQLite in WAL mode. Webhook receipt validates and persists before returning HTTP 202. Interrupted running jobs return to pending at startup. A newer PR head supersedes older pending work.
+
+The worker uploads the capped UTF-8 diff once per durable job attempt, creates one direct Claude and Codex child-session pair, polls both, and then merges their strict outputs. A failed pair consumes that durable attempt; the next scheduled attempt creates one fresh pair. Before publication it rechecks the PR head. A hidden deterministic marker in the review body lets retries recover an uncertain GitHub POST without creating a duplicate.
+
+## CLI
+
+```text
+omni integration polly setup --server URL --public-url HTTPS_URL
+omni integration polly [--background]
+omni integration polly status
+omni integration polly stop
+omni integration polly logs [-f]
+omni integration polly doctor
+omni integration polly retry JOB_ID
+```
+
+Setup supports GitHub's App manifest flow and import of an existing App. `doctor` validates Omnigent authentication, the bundled agent, host harness readiness, the dedicated workspace, App installation, selected repositories, and webhook reachability without starting a review.
+
+## Deliberate Limits
+
+- Pull requests only; no push or standalone commit reviews.
+- One daemon per configuration; no multi-replica coordination.
+- Diff-only review; no repository checkout.
+- No smart routing; Claude-plus-Codex fanout is fixed.
+- Existing Node webhook state is not migrated. Cutover drains and stops it before changing the App webhook URL.
+
+## Migration and rollback
+
+Canary the native integration with a test repository first. Verify restart recovery by
+stopping it after a delivery is accepted, restarting it, and confirming the job resumes;
+then replay that delivery and confirm no second review appears. Push a newer PR head while
+an older review is running and confirm the older job is superseded before publication.
+
+For production cutover, drain and stop the old service, then change the GitHub App's single
+webhook URL to the native Polly `/webhooks/github` endpoint. Keep the stopped old service and
+its data only as a rollback target; never run both consumers against the same App webhook.

--- a/examples/polly_review/agents/claude_review/config.yaml
+++ b/examples/polly_review/agents/claude_review/config.yaml
@@ -1,0 +1,16 @@
+spec_version: 1
+name: claude_review
+description: Tool-free Claude reviewer for an uploaded pull-request diff.
+spawn: false
+async: false
+skills: none
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+    tool_free: true
+
+prompt: |
+  Review only the supplied diff. Do not request repository access or take
+  actions. Return only JSON matching the schema in the task.

--- a/examples/polly_review/agents/codex_review/config.yaml
+++ b/examples/polly_review/agents/codex_review/config.yaml
@@ -1,0 +1,19 @@
+spec_version: 1
+name: codex_review
+description: Tool-free Codex reviewer for an uploaded pull-request diff.
+spawn: false
+async: false
+skills: none
+
+executor:
+  type: omnigent
+  config:
+    harness: codex
+    tool_free: true
+    disable_native_tools: true
+    enable_web_search: false
+    minimal_config: true
+
+prompt: |
+  Review only the supplied diff. Do not request repository access or take
+  actions. Return only JSON matching the schema in the task.

--- a/examples/polly_review/config.yaml
+++ b/examples/polly_review/config.yaml
@@ -1,0 +1,20 @@
+spec_version: 1
+name: polly-review
+description: Fixed, tool-free Claude and Codex reviewers for Polly Review.
+spawn: false
+async: false
+skills: none
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  This agent contains Polly Review's fixed reviewers. The integration invokes
+  the reviewers directly.
+
+tools:
+  agents:
+    - claude_review
+    - codex_review

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -68,6 +68,7 @@ from omnigent.host.local_server import (
 )
 from omnigent.inner import _proc, ui
 from omnigent.integration_daemon import IntegrationDaemon
+from omnigent.integrations.polly.cli import register_polly_command as _register_polly_command
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
 from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
@@ -9511,6 +9512,7 @@ def integration(ctx: click.Context) -> None:
     \b
     Available integrations:
       slack   The @omnigent Slack socket-mode bot.
+      polly   Native pull-request reviews from Claude and Codex.
 
     Run ``omni integration slack`` to start the Slack bot in the foreground,
     or ``omni integration slack --background`` to run it in the background.
@@ -9655,6 +9657,9 @@ def slack_logs(follow: bool) -> None:
         raise click.ClickException(
             f"`tail` not available to follow the log. Log file: {log_path}"
         ) from exc
+
+
+_register_polly_command(integration)
 
 
 @cli.group("config", cls=_ConfigGroup)

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1381,6 +1381,7 @@ class ClaudeSDKExecutor(Executor):
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
         api_key_helper: str | None = None,
+        tool_free: bool = False,
     ) -> None:
         """Create a ClaudeSDKExecutor.
 
@@ -1480,6 +1481,7 @@ class ClaudeSDKExecutor(Executor):
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter
+        self._tool_free = tool_free
         # Write the bundle's plugin manifest now (idempotent) so that
         # ``--plugin-dir <bundle>`` produces clean
         # ``<agent-name>:<skill-name>`` labels in Claude's skill
@@ -1569,7 +1571,7 @@ class ClaudeSDKExecutor(Executor):
                     "~/.databrickscfg profile."
                 )
             self._extra_env.update(gateway_env)
-        self._extra_env[_CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV] = "true"
+        self._extra_env[_CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV] = "false" if tool_free else "true"
 
         # Retry policy → Anthropic SDK env vars passed to the Claude
         # CLI subprocess. ``ANTHROPIC_MAX_RETRIES`` and
@@ -2202,7 +2204,9 @@ class ClaudeSDKExecutor(Executor):
             return
 
         # Build MCP tools from Omnigent tool schemas
-        mcp_tools = _build_mcp_tools(tools, self._tool_executor) if tools else []
+        mcp_tools = (
+            _build_mcp_tools(tools, self._tool_executor) if tools and not self._tool_free else []
+        )
 
         # Create MCP server config for Omnigent tools. The SDK's
         # ``McpServerConfig`` union is opaque to us — we pass through
@@ -2236,7 +2240,7 @@ class ClaudeSDKExecutor(Executor):
         # When ``allowed_tools`` is empty the SDK omits ``--allowedTools``
         # entirely, letting Claude's normal permission flow apply.
         allowed_tools: list[str] = []
-        if self._permission_mode in ("auto", "bypassPermissions"):
+        if not self._tool_free and self._permission_mode in ("auto", "bypassPermissions"):
             # Allow all Omnigent MCP tools (no per-call human gate needed)
             for schema in tools:
                 raw_tname = schema.get("name")
@@ -2314,13 +2318,16 @@ class ClaudeSDKExecutor(Executor):
         # MCP tools (declared via ``os_env`` in the spec), not the
         # SDK's native Bash/Read/Edit/Write. Keep Skill and ToolSearch in
         # the base set so MCP definitions can be discovered on demand.
-        base_tools: list[str] = ["Skill", "ToolSearch"]
+        base_tools: list[str] = [] if self._tool_free else ["Skill", "ToolSearch"]
         # Translate the spec's host-skill filter into the SDK
         # options. Falls back to ``"all"`` semantics when the
         # field is malformed (the parser already validates, so
         # this is belt-and-suspenders).
-        resolved = _resolve_skills_option(self._skills_filter) or _ResolvedSkills(
-            skills="all", setting_sources=None
+        resolved = (
+            _ResolvedSkills(skills=[], setting_sources=[])
+            if self._tool_free
+            else _resolve_skills_option(self._skills_filter)
+            or _ResolvedSkills(skills="all", setting_sources=None)
         )
         # Bundle skills are exposed via the SDK's plugin mechanism.
         # The bundle's ``<bundle>/skills/<dir>/SKILL.md`` files are
@@ -2330,7 +2337,7 @@ class ClaudeSDKExecutor(Executor):
         # ``name`` (and thus the skill-listing prefix) comes from
         # the manifest written at construction time.
         bundle_plugins: list[Any] = []  # type: ignore[explicit-any]  # SdkPluginConfig is a TypedDict — typed Any here to keep the import lazy
-        if self._bundle_dir is not None:
+        if self._bundle_dir is not None and not self._tool_free:
             bundle_plugins.append({"type": "local", "path": str(self._bundle_dir)})
         options_kwargs: dict[str, Any] = {  # type: ignore[explicit-any]  # ClaudeAgentOptions accepts mixed-typed kwargs (str / list / dict / callable / etc.)
             "tools": base_tools,

--- a/omnigent/inner/claude_sdk_harness.py
+++ b/omnigent/inner/claude_sdk_harness.py
@@ -112,6 +112,7 @@ _ENV_PERMISSION_MODE = "HARNESS_CLAUDE_SDK_PERMISSION_MODE"
 _ENV_OS_ENV = "HARNESS_CLAUDE_SDK_OS_ENV"
 _ENV_RETRY_POLICY = "HARNESS_CLAUDE_SDK_RETRY_POLICY"
 _ENV_SKILLS_FILTER = "HARNESS_CLAUDE_SDK_SKILLS_FILTER"
+_ENV_TOOL_FREE = "HARNESS_CLAUDE_SDK_TOOL_FREE"
 _ENV_BUNDLE_DIR = "HARNESS_CLAUDE_SDK_BUNDLE_DIR"
 _ENV_AGENT_NAME = "HARNESS_CLAUDE_SDK_AGENT_NAME"
 _ENV_GATEWAY_BASE_URL = "HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"
@@ -296,6 +297,7 @@ def _build_claude_sdk_executor() -> Executor:
         agent_name=agent_name,
         skills_filter=_resolve_skills_filter(),
         api_key_helper=os.environ.get(_ENV_API_KEY_HELPER) or None,
+        tool_free=os.environ.get(_ENV_TOOL_FREE, "").strip().lower() in ("1", "true", "yes"),
     )
 
 

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -828,7 +828,7 @@ def _populate_codex_home_config(
             # its timeout. auth.json alone cannot supply these provider tables.
             source_config = tomlkit.parse(source_file.read_text())
             minimal_document = tomlkit.document()
-            for key in ("model_provider", "model_providers", "profiles"):
+            for key in ("model_provider", "model_providers", "profile", "profiles"):
                 if key in source_config:
                     minimal_document[key] = source_config[key]
             dest_path.write_text(tomlkit.dumps(minimal_document))
@@ -1238,6 +1238,7 @@ _CODEX_OMNIGENT_LAUNCH_ENV_VARS: tuple[str, ...] = (
     CODEX_ROUTER_DIR_ENV_VAR,
     CODEX_ROUTER_SESSION_ID_ENV_VAR,
     CODEX_EXTENDED_CATALOG_ENV_VAR,
+    _CODEX_MINIMAL_CONFIG_ENV,
 )
 
 
@@ -2056,8 +2057,13 @@ class _CodexAppServerSession:
         if self._started:
             return
         self._loop = asyncio.get_running_loop()
+        minimal_config = self._env.get(_CODEX_MINIMAL_CONFIG_ENV, "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+        }
         codex_home_root = Path(tempfile.gettempdir())
-        if self._cwd and self._cwd != "/":
+        if not minimal_config and self._cwd and self._cwd != "/":
             try:
                 codex_home_root = Path(self._cwd) / ".codex-tmp"
                 codex_home_root.mkdir(parents=True, exist_ok=True)
@@ -2094,7 +2100,7 @@ class _CodexAppServerSession:
         # hooks instead of being symlinked in untouched. Only an auto-harness
         # Smart Routing session gets that endpoint, so a plain or pinned session
         # keeps the symlink — and with it mid-session edits to the user's file.
-        router_bridge_dir = codex_router_bridge_dir(self._env)
+        router_bridge_dir = None if minimal_config else codex_router_bridge_dir(self._env)
         if router_bridge_dir is not None:
             # Probed only on the routing path so a plain session never pays the
             # subprocess. A CLI too old for the spawn gate drops the hooks and
@@ -2112,6 +2118,7 @@ class _CodexAppServerSession:
             _populate_codex_home_config,
             self._codex_home_dir,
             config_source,
+            minimal_config=minimal_config,
             inject_hooks=router_bridge_dir is not None,
             extend_model_catalog=codex_extended_catalog_requested(self._env),
         )
@@ -2345,11 +2352,25 @@ class _CodexAppServerSession:
             }
             if system_prompt:
                 params["developerInstructions"] = system_prompt
+            features: CodexParams = {}
             if tools:
                 params["dynamicTools"] = _dynamic_tool_specs(tools)
-                features: CodexParams = {"unified_exec": False}
-                if self._disable_native_tools:
-                    features["shell_tool"] = False
+                features["unified_exec"] = False
+            if self._disable_native_tools:
+                features.update(
+                    {
+                        "unified_exec": False,
+                        "shell_tool": False,
+                        "apps": False,
+                        "browser_use": False,
+                        "computer_use": False,
+                        "image_generation": False,
+                        "multi_agent": False,
+                        "tool_search": False,
+                        "view_image": False,
+                    }
+                )
+            if features:
                 params["config"] = {"features": features}
             response = await self._request("thread/start", params)
             thread = response.get("result", {}).get("thread", {})

--- a/omnigent/integration_daemon.py
+++ b/omnigent/integration_daemon.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import secrets
 import signal
 import subprocess
 import time
@@ -20,6 +21,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from omnigent.inner import _proc
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock.
+    fcntl = None  # type: ignore[assignment]
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +40,7 @@ class DaemonRecord:
     pid: int
     log_path: str
     started_at: int
+    identity: str | None = None
 
 
 class IntegrationDaemon:
@@ -48,6 +55,13 @@ class IntegrationDaemon:
     def __init__(self, name: str, state_dir: Path) -> None:
         self.name = name
         self._record_path = state_dir / "integrations" / f"{name}.json"
+        self._owner_path = state_dir / "integrations" / f"{name}.lock"
+        self._reclaim_path = state_dir / "integrations" / f"{name}.lock.reclaim"
+        env_name = "".join(character if character.isalnum() else "_" for character in name)
+        self._owner_fd_env = f"OMNIGENT_{env_name.upper()}_DAEMON_OWNER_FD"
+        self._owner_token_env = f"OMNIGENT_{env_name.upper()}_DAEMON_OWNER_TOKEN"
+        self._owner_fd: int | None = None
+        self._owner_token: str | None = None
 
     # ── Record persistence ────────────────────────────────────────
 
@@ -65,22 +79,173 @@ class IntegrationDaemon:
             started_at = int(raw["started_at"])
         except (KeyError, TypeError, ValueError):
             return None
-        return DaemonRecord(pid=pid, log_path=log_path, started_at=started_at)
+        identity = raw.get("identity")
+        if identity is not None and not isinstance(identity, str):
+            return None
+        return DaemonRecord(pid=pid, log_path=log_path, started_at=started_at, identity=identity)
 
     def _write_record(self, record: DaemonRecord) -> None:
         self._record_path.parent.mkdir(parents=True, exist_ok=True)
-        self._record_path.write_text(
-            json.dumps(
-                {
-                    "pid": record.pid,
-                    "log_path": record.log_path,
-                    "started_at": record.started_at,
-                }
-            )
-        )
+        payload: dict[str, int | str] = {
+            "pid": record.pid,
+            "log_path": record.log_path,
+            "started_at": record.started_at,
+        }
+        if record.identity is not None:
+            payload["identity"] = record.identity
+        self._record_path.write_text(json.dumps(payload))
 
     def _clear_record(self) -> None:
         self._record_path.unlink(missing_ok=True)
+
+    def _owner(self) -> tuple[int, str] | None:
+        try:
+            raw = json.loads(self._owner_path.read_text())
+            token = raw["token"]
+            if not isinstance(token, str) or not token:
+                return None
+            return int(raw["pid"]), token
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return None
+
+    def _write_owner(self, fd: int, pid: int, token: str) -> None:
+        payload = json.dumps({"pid": pid, "token": token}).encode()
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.ftruncate(fd, 0)
+        os.write(fd, payload)
+        os.fsync(fd)
+
+    def _acquire_owner(self) -> None:
+        if self._owner_fd is not None or self._owner_token is not None:
+            return
+        self._owner_path.parent.mkdir(parents=True, exist_ok=True)
+        pid = os.getpid()
+        token = os.environ.pop(self._owner_token_env, None) or secrets.token_urlsafe(24)
+        if fcntl is not None:
+            inherited = os.environ.pop(self._owner_fd_env, None)
+            if inherited is not None:
+                try:
+                    fd = int(inherited)
+                    if os.fstat(fd).st_ino != self._owner_path.stat().st_ino:
+                        raise OSError("owner fd does not match lock file")
+                except (OSError, ValueError) as exc:
+                    raise RuntimeError(f"invalid {self.name} daemon ownership handoff") from exc
+                os.set_inheritable(fd, False)
+                self._owner_fd = fd
+                self._write_owner(fd, pid, token)
+                return
+            fd = os.open(self._owner_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                os.close(fd)
+                owner = self._owner()
+                suffix = f" (pid {owner[0]})" if owner else ""
+                raise RuntimeError(f"{self.name} daemon already running{suffix}") from exc
+            self._owner_fd = fd
+            self._write_owner(fd, pid, token)
+            return
+
+        for _ in range(3):  # pragma: no cover - Windows fallback.
+            try:
+                fd = os.open(self._owner_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError as exc:
+                owner = self._owner()
+                if owner and owner[1] == token:
+                    self._owner_path.write_text(json.dumps({"pid": pid, "token": token}))
+                    self._owner_token = token
+                    return
+                if owner and self._pid_alive(owner[0]):
+                    raise RuntimeError(
+                        f"{self.name} daemon already running (pid {owner[0]})"
+                    ) from exc
+                try:
+                    guard_fd = os.open(
+                        self._reclaim_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600
+                    )
+                except FileExistsError as guard_exc:
+                    raise RuntimeError(f"{self.name} daemon ownership is being reclaimed") from (
+                        guard_exc
+                    )
+                try:
+                    with os.fdopen(guard_fd, "w") as handle:
+                        json.dump({"pid": pid, "token": token}, handle)
+                    owner = self._owner()
+                    if owner and self._pid_alive(owner[0]):
+                        raise RuntimeError(
+                            f"{self.name} daemon already running (pid {owner[0]})"
+                        ) from exc
+                    self._owner_path.unlink(missing_ok=True)
+                finally:
+                    self._reclaim_path.unlink(missing_ok=True)
+                continue
+            with os.fdopen(fd, "w") as handle:
+                json.dump({"pid": pid, "token": token}, handle)
+            self._owner_token = token
+            return
+        raise RuntimeError(f"could not claim {self.name} daemon ownership")
+
+    def _release_owner(self, *, force: bool = False) -> None:
+        if self._owner_fd is not None:
+            fd, self._owner_fd = self._owner_fd, None
+            self._owner_path.unlink(missing_ok=True)
+            if fcntl is not None:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            return
+        if fcntl is not None:
+            cleanup_fd: int | None = None
+            try:
+                cleanup_fd = os.open(self._owner_path, os.O_CREAT | os.O_RDWR, 0o600)
+                fcntl.flock(cleanup_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                if cleanup_fd is not None:
+                    with contextlib.suppress(OSError):
+                        os.close(cleanup_fd)
+                return
+            assert cleanup_fd is not None
+            self._owner_path.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                fcntl.flock(cleanup_fd, fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                os.close(cleanup_fd)
+            return
+        owner = self._owner()
+        if force or (owner and owner == (os.getpid(), self._owner_token)):
+            self._owner_path.unlink(missing_ok=True)
+        self._owner_token = None
+
+    def acquire_current(self, log_path: str | Path) -> DaemonRecord:
+        """Claim daemon ownership for this process or accept its pre-spawn record."""
+        current = self.running_record()
+        pid = os.getpid()
+        if current is not None:
+            if current.pid != pid:
+                raise RuntimeError(f"{self.name} daemon already running (pid {current.pid})")
+        self._acquire_owner()
+        if current is not None:
+            return current
+        record = DaemonRecord(
+            pid=pid,
+            log_path=str(log_path),
+            started_at=int(time.time()),
+            identity=self._pid_identity(pid),
+        )
+        try:
+            self._write_record(record)
+        except BaseException:
+            self._release_owner()
+            raise
+        return record
+
+    def release_current(self) -> None:
+        """Release ownership only when this process owns the daemon record."""
+        record = self.read_record()
+        if record is not None and record.pid == os.getpid():
+            self._clear_record()
+            self._release_owner()
 
     # ── Liveness ──────────────────────────────────────────────────
 
@@ -89,6 +254,8 @@ class IntegrationDaemon:
         """Whether *pid* names a live process (best-effort, POSIX/Windows)."""
         if pid <= 0:
             return False
+        if os.name == "nt":
+            return IntegrationDaemon._pid_identity(pid) is not None
         try:
             os.kill(pid, 0)
         except ProcessLookupError:
@@ -99,6 +266,88 @@ class IntegrationDaemon:
         except OSError:
             return False
         return True
+
+    @staticmethod
+    def _pid_identity(pid: int) -> str | None:
+        if os.name != "nt":
+            return None
+        try:  # pragma: no cover - exercised on Windows.
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            filetime = ctypes.POINTER(wintypes.FILETIME)
+            kernel32.GetProcessTimes.argtypes = [
+                wintypes.HANDLE,
+                filetime,
+                filetime,
+                filetime,
+                filetime,
+            ]
+            kernel32.GetProcessTimes.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+            kernel32.CloseHandle.restype = wintypes.BOOL
+            handle = kernel32.OpenProcess(0x1000, False, pid)
+            if not handle:
+                return None
+            try:
+                created = wintypes.FILETIME()
+                exited = wintypes.FILETIME()
+                kernel = wintypes.FILETIME()
+                user = wintypes.FILETIME()
+                if not kernel32.GetProcessTimes(
+                    handle,
+                    ctypes.byref(created),
+                    ctypes.byref(exited),
+                    ctypes.byref(kernel),
+                    ctypes.byref(user),
+                ):
+                    return None
+                return str((created.dwHighDateTime << 32) | created.dwLowDateTime)
+            finally:
+                kernel32.CloseHandle(handle)
+        except (AttributeError, OSError):
+            return None
+
+    def _owner_lock_held(self) -> bool:
+        if fcntl is None:
+            return False
+        try:
+            fd = os.open(self._owner_path, os.O_RDWR)
+        except OSError:
+            return False
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+            except OSError:
+                return False
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+        finally:
+            os.close(fd)
+
+    def _record_has_held_owner(self, record: DaemonRecord) -> bool:
+        if fcntl is None:
+            owner = self._owner()
+            return bool(
+                owner
+                and owner[0] == record.pid
+                and record.identity
+                and record.identity == self._pid_identity(record.pid)
+            )
+        for _ in range(3):
+            owner = self._owner()
+            held = self._owner_lock_held()
+            if owner is not None and owner[0] == record.pid and held:
+                return True
+            if not held:
+                return False
+            time.sleep(0.01)
+        return False
 
     def running_record(self) -> DaemonRecord | None:
         """Return the record only if its process is actually alive.
@@ -127,6 +376,8 @@ class IntegrationDaemon:
         while True:
             if not self._pid_alive(record.pid):
                 self._clear_record()
+                return False
+            if not self._record_has_held_owner(record):
                 return False
             if time.time() >= deadline:
                 return True
@@ -159,6 +410,11 @@ class IntegrationDaemon:
             ``.env`` file) so the daemon doesn't inherit the arbitrary
             directory ``omni`` was launched from.
         """
+        current = self.running_record()
+        if current is not None:
+            raise RuntimeError(f"{self.name} daemon already running (pid {current.pid})")
+        self._acquire_owner()
+
         from omnigent.process_logging import (
             PROCESS_LOG_FILE_ENV_VAR,
             child_logging_popen_kwargs,
@@ -167,10 +423,22 @@ class IntegrationDaemon:
 
         log_path, log_fh = open_process_log_file(self.name)
         env = {**env, PROCESS_LOG_FILE_ENV_VAR: str(log_path)}
+        if self._owner_fd is not None:
+            os.set_inheritable(self._owner_fd, True)
+            env[self._owner_fd_env] = str(self._owner_fd)
+            owner = self._owner()
+            if owner is not None:
+                env[self._owner_token_env] = owner[1]
+        elif self._owner_token is not None:  # pragma: no cover - Windows fallback.
+            env[self._owner_token_env] = self._owner_token
         # Detached: own session/process group (spawn_kwargs), stdin closed,
         # stdout+stderr to the log file. Mirrors the host daemon spawn.
         try:
             with child_logging_popen_kwargs(env) as logging_kwargs:
+                if self._owner_fd is not None:
+                    logging_kwargs["pass_fds"] = tuple(
+                        {*logging_kwargs.get("pass_fds", ()), self._owner_fd}
+                    )
                 proc = subprocess.Popen(
                     argv,
                     env=env,
@@ -181,9 +449,26 @@ class IntegrationDaemon:
                     **_proc.spawn_kwargs(),
                     **logging_kwargs,
                 )
+        except BaseException:
+            self._release_owner()
+            raise
         finally:
             log_fh.close()
-        record = DaemonRecord(pid=proc.pid, log_path=str(log_path), started_at=int(time.time()))
+        record = DaemonRecord(
+            pid=proc.pid,
+            log_path=str(log_path),
+            started_at=int(time.time()),
+            identity=self._pid_identity(proc.pid),
+        )
+        if self._owner_fd is not None:
+            fd, self._owner_fd = self._owner_fd, None
+            try:
+                self._write_owner(fd, proc.pid, env[self._owner_token_env])
+            finally:
+                os.close(fd)
+        elif self._owner_token is not None:  # pragma: no cover - Windows fallback.
+            self._owner_path.write_text(json.dumps({"pid": proc.pid, "token": self._owner_token}))
+            self._owner_token = None
         self._write_record(record)
         return record
 
@@ -199,15 +484,20 @@ class IntegrationDaemon:
         if record is None:
             self._clear_record()
             return None
+        if not self._record_has_held_owner(record):
+            raise RuntimeError(
+                f"{self.name} daemon ownership cannot be verified; refusing to signal"
+            )
         self._signal(record.pid, signal.SIGTERM)
         deadline = time.time() + grace_seconds
         while time.time() < deadline:
             if not self._pid_alive(record.pid):
                 break
             time.sleep(0.1)
-        if self._pid_alive(record.pid):
+        if self._pid_alive(record.pid) and self._record_has_held_owner(record):
             self._signal(record.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         self._clear_record()
+        self._release_owner(force=True)
         return record
 
     @staticmethod

--- a/omnigent/integrations/__init__.py
+++ b/omnigent/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""First-party external integrations."""

--- a/omnigent/integrations/polly/__init__.py
+++ b/omnigent/integrations/polly/__init__.py
@@ -1,0 +1,7 @@
+"""Durable Polly pull-request review runtime."""
+
+from omnigent.integrations.polly.store import Job, PollyStore
+from omnigent.integrations.polly.webhook import create_webhook_app
+from omnigent.integrations.polly.worker import PollyWorker
+
+__all__ = ["Job", "PollyStore", "PollyWorker", "create_webhook_app"]

--- a/omnigent/integrations/polly/cli.py
+++ b/omnigent/integrations/polly/cli.py
@@ -1,0 +1,726 @@
+from __future__ import annotations
+
+import html
+import json
+import os
+import secrets as stdlib_secrets
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from dataclasses import asdict, dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from typing import cast
+from urllib.parse import parse_qs, quote, urlparse
+
+import click
+import httpx
+
+from omnigent.host.local_server import _local_data_dir
+from omnigent.integration_daemon import IntegrationDaemon
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.onboarding import secrets as secret_store
+
+GITHUB_PRIVATE_KEY_SECRET = "polly-github-private-key"
+WEBHOOK_SECRET_SECRET = "polly-github-webhook-secret"
+OMNIGENT_ACCESS_TOKEN_SECRET = "polly-omnigent-access-token"
+OMNIGENT_REFRESH_TOKEN_SECRET = "polly-omnigent-refresh-token"
+OMNIGENT_DEVICE_CLIENT_SECRET = "polly-omnigent-device-client-secret"
+_DEVICE_CLIENT_SECRET_HEADER = "X-Omnigent-Client-Secret"
+_GITHUB_API = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class PollyConfig:
+    server_url: str
+    public_url: str
+    listen_host: str
+    listen_port: int
+    workspace: str
+    agent_id: str
+    host_id: str
+    github_app_id: str
+    github_app_slug: str
+    repositories: tuple[str, ...]
+
+
+def integration_dir() -> Path:
+    return _local_data_dir() / "integrations" / "polly"
+
+
+def config_path() -> Path:
+    return integration_dir() / "config.json"
+
+
+def database_path() -> Path:
+    return integration_dir() / "polly.sqlite3"
+
+
+def save_config(config: PollyConfig) -> None:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(config), indent=2, sort_keys=True) + "\n")
+
+
+def load_config() -> PollyConfig:
+    try:
+        raw = json.loads(config_path().read_text())
+        raw["repositories"] = tuple(raw["repositories"])
+        return PollyConfig(**raw)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise click.ClickException(
+            "Polly is not configured. Run `omni integration polly setup`."
+        ) from exc
+
+
+def _validate_origin(value: str, label: str, *, allow_loopback_http: bool) -> str:
+    parsed = urlparse(value)
+    loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+    try:
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{label} URL must be a valid origin") from exc
+    if (
+        not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(f"{label} URL must be an origin without credentials, path, or query")
+    if parsed.scheme != "https" and not (
+        allow_loopback_http and parsed.scheme == "http" and loopback
+    ):
+        raise ValueError(f"{label} URL must use HTTPS")
+    return value[:-1] if parsed.path == "/" else value
+
+
+def validate_public_url(value: str, *, allow_loopback_http: bool = False) -> str:
+    return _validate_origin(value, "public", allow_loopback_http=allow_loopback_http)
+
+
+def validate_server_url(value: str) -> str:
+    return _validate_origin(value, "server", allow_loopback_http=True)
+
+
+def validate_port(value: int) -> int:
+    if not 1 <= value <= 65535:
+        raise ValueError("listener port must be between 1 and 65535")
+    return value
+
+
+def validate_workspace(value: str) -> str:
+    raw_parts = value.split("/")
+    path = PurePosixPath(value)
+    parts = path.parts[1:]
+    direct_home = len(parts) == 2 and parts[0] in {"home", "Users"}
+    if (
+        not path.is_absolute()
+        or "." in raw_parts
+        or ".." in raw_parts
+        or not parts
+        or parts == ("root",)
+        or direct_home
+    ):
+        raise ValueError(
+            "workspace must be an absolute dedicated directory, not a filesystem root or home"
+        )
+    return str(path)
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"} if access_token else {}
+
+
+def acquire_device_tokens(
+    server_url: str,
+    *,
+    device_client_secret: str = "",
+    client: httpx.Client | None = None,
+) -> tuple[str, str]:
+    own_client = client is None
+    client = client or httpx.Client(base_url=server_url, timeout=15)
+    try:
+        headers = (
+            {_DEVICE_CLIENT_SECRET_HEADER: device_client_secret} if device_client_secret else {}
+        )
+        response = client.post(
+            "/oauth/device/authorize", json={"client_id": "polly"}, headers=headers
+        )
+        if response.status_code == 404:
+            raise click.ClickException(
+                "The server does not offer scoped device grants. Accounts or OIDC with "
+                "OMNIGENT_DEVICE_GRANT_ENABLED=1 is required; header/proxy auth is unsupported."
+            )
+        response.raise_for_status()
+        grant = response.json()
+        click.echo(f"Authorize Polly in your browser: {grant['verification_uri_complete']}")
+        webbrowser.open(str(grant["verification_uri_complete"]))
+        deadline = time.monotonic() + int(grant.get("expires_in", 600))
+        interval = max(1, int(grant.get("interval", 5)))
+        while time.monotonic() < deadline:
+            token = client.post(
+                "/oauth/token",
+                headers=headers,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code": grant["device_code"],
+                },
+            )
+            if token.status_code == 200:
+                payload = token.json()
+                access = payload.get("access_token") if isinstance(payload, dict) else None
+                refresh = payload.get("refresh_token") if isinstance(payload, dict) else None
+                if not isinstance(access, str) or not isinstance(refresh, str):
+                    raise click.ClickException("Device authorization returned invalid tokens.")
+                access, refresh = access.strip(), refresh.strip()
+                if not access or not refresh:
+                    raise click.ClickException("Device authorization returned invalid tokens.")
+                return access, refresh
+            error = (
+                token.json().get("error")
+                if token.headers.get("content-type", "").startswith("application/json")
+                else None
+            )
+            if error == "slow_down":
+                interval += 5
+            elif error != "authorization_pending":
+                token.raise_for_status()
+            time.sleep(interval)
+        raise click.ClickException("Device authorization expired before approval.")
+    finally:
+        if own_client:
+            client.close()
+
+
+def exchange_manifest_code(
+    callback_url: str, *, expected_state: str, client: httpx.Client | None = None
+) -> dict[str, object]:
+    query = parse_qs(urlparse(callback_url).query)
+    if query.get("state") != [expected_state]:
+        raise ValueError("GitHub App manifest callback state did not match")
+    code = query.get("code", [""])[0]
+    if not code:
+        raise ValueError("GitHub App manifest callback carried no code")
+    own_client = client is None
+    client = client or httpx.Client(base_url=_GITHUB_API, timeout=30)
+    try:
+        response = client.post(f"{_GITHUB_API}/app-manifests/{quote(code, safe='')}/conversions")
+        response.raise_for_status()
+        payload = response.json()
+    finally:
+        if own_client:
+            client.close()
+    required = ("id", "slug", "pem", "webhook_secret")
+    if not isinstance(payload, dict) or any(not payload.get(key) for key in required):
+        raise ValueError("GitHub manifest conversion response was incomplete")
+    return cast(dict[str, object], payload)
+
+
+def _manifest_registration_url(organization: str | None) -> str:
+    if organization is None:
+        return "https://github.com/settings/apps/new"
+    organization = organization.strip()
+    if not organization or "/" in organization:
+        raise click.ClickException("GitHub organization must be one account name.")
+    return f"https://github.com/organizations/{quote(organization, safe='')}/settings/apps/new"
+
+
+def _manifest_flow(public_url: str, organization: str | None = None) -> dict[str, object]:
+    state = stdlib_secrets.token_urlsafe(24)
+    callback: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                callback.append(f"http://127.0.0.1{self.path}")
+                body = b"GitHub App created. Return to the terminal."
+            else:
+                manifest = {
+                    "name": "Omnigent Polly Review",
+                    "url": public_url,
+                    "redirect_url": f"http://127.0.0.1:{server.server_port}/callback?state={state}",
+                    "hook_attributes": {"url": f"{public_url}/webhooks/github", "active": True},
+                    "public": False,
+                    "default_permissions": {"pull_requests": "write"},
+                    "default_events": ["pull_request"],
+                }
+                body = (
+                    '<form id="f" method="post" action="'
+                    f'{_manifest_registration_url(organization)}">'
+                    '<input type="hidden" name="manifest" value="'
+                    f'{html.escape(json.dumps(manifest), quote=True)}">'
+                    '<button type="submit">Create GitHub App</button></form>'
+                ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: ARG002
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/"
+        click.echo(f"Create the least-privilege GitHub App in your browser: {url}")
+        webbrowser.open(url)
+        deadline = time.monotonic() + 600
+        while not callback and time.monotonic() < deadline:
+            time.sleep(0.1)
+        if not callback:
+            raise click.ClickException("Timed out waiting for the GitHub App manifest callback.")
+        return exchange_manifest_code(callback[0], expected_state=state)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _validate_server_selection(
+    server_url: str, access_token: str, workspace: str, host_selector: str | None
+) -> tuple[str, str]:
+    headers = _auth_headers(access_token)
+    with httpx.Client(base_url=server_url, headers=headers, timeout=30) as client:
+        agents = client.get("/v1/agents", params={"limit": 1000})
+        agents.raise_for_status()
+        matches = [
+            item for item in agents.json().get("data", []) if item.get("name") == "polly-review"
+        ]
+        if len(matches) != 1:
+            raise click.ClickException(
+                "The bundled `polly-review` agent is not available exactly once."
+            )
+        hosts = client.get("/v1/hosts")
+        hosts.raise_for_status()
+        ready = [
+            host
+            for host in hosts.json().get("hosts", [])
+            if host.get("status") == "online"
+            and host.get("configured_harnesses", {}).get("claude-sdk") is True
+            and host.get("configured_harnesses", {}).get("codex") is True
+        ]
+        if host_selector is not None:
+            selected = [
+                host
+                for host in ready
+                if host.get("host_id") == host_selector or host.get("name") == host_selector
+            ]
+            if len(selected) != 1:
+                available = (
+                    ", ".join(
+                        f"{host.get('name') or '<unnamed>'} ({host.get('host_id')})"
+                        for host in ready
+                    )
+                    or "none"
+                )
+                raise click.ClickException(
+                    f"--host {host_selector!r} did not identify one ready host. "
+                    f"Ready hosts: {available}."
+                )
+        elif len(ready) == 1:
+            selected = ready
+        elif not ready:
+            raise click.ClickException("No online host reports claude-sdk=True and codex=True.")
+        else:
+            available = ", ".join(
+                f"{host.get('name') or '<unnamed>'} ({host.get('host_id')})" for host in ready
+            )
+            raise click.ClickException(
+                f"Multiple ready hosts found; select one with --host ID_OR_NAME: {available}."
+            )
+        host_id = str(selected[0]["host_id"])
+        path = quote(workspace.lstrip("/"), safe="/")
+        listing = client.get(f"/v1/hosts/{quote(host_id, safe='')}/filesystem/{path}")
+        if listing.status_code == 404:
+            raise click.ClickException(
+                f"Workspace does not exist on host {host_id}. Create {workspace} there, "
+                "leave it empty, and rerun setup."
+            )
+        listing.raise_for_status()
+        if listing.json().get("data") != []:
+            raise click.ClickException(f"Workspace {workspace} must already exist and be empty.")
+        return str(matches[0]["id"]), host_id
+
+
+def _github_app_jwt(app_id: str, private_key: str) -> str:
+    import jwt
+
+    now = int(time.time())
+    return jwt.encode(
+        {"iat": now - 60, "exp": now + 540, "iss": app_id}, private_key, algorithm="RS256"
+    )
+
+
+def _validate_existing_app(app_id: str, app_slug: str, private_key: str) -> None:
+    token = _github_app_jwt(app_id, private_key)
+    with httpx.Client(
+        base_url=_GITHUB_API, headers={"Authorization": f"Bearer {token}"}
+    ) as client:
+        response = client.get("/app")
+        response.raise_for_status()
+        app = response.json()
+    if app.get("slug") != app_slug:
+        raise click.ClickException("GitHub App slug does not match the supplied App ID/key.")
+    permissions = app.get("permissions", {})
+    if permissions.get("pull_requests") != "write" or set(permissions) - {
+        "pull_requests",
+        "metadata",
+    }:
+        raise click.ClickException("GitHub App permissions must be only Pull requests: write.")
+    if set(app.get("events", [])) != {"pull_request"}:
+        raise click.ClickException("GitHub App events must be only pull_request.")
+
+
+def _validate_repository_installations(
+    app_id: str, private_key: str, repositories: tuple[str, ...]
+) -> None:
+    token = _github_app_jwt(app_id, private_key)
+    with httpx.Client(
+        base_url=_GITHUB_API, headers={"Authorization": f"Bearer {token}"}, timeout=30
+    ) as client:
+        for repository in repositories:
+            owner, repo = repository.split("/", 1)
+            response = client.get(
+                f"/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/installation"
+            )
+            if response.status_code == 404:
+                raise click.ClickException(
+                    f"GitHub App is not installed on selected repository {repository}."
+                )
+            response.raise_for_status()
+
+
+def _run_setup(
+    *,
+    server: str,
+    public_url: str,
+    listen_host: str,
+    listen_port: int,
+    workspace: str,
+    host: str | None,
+    app_id: str | None,
+    app_slug: str | None,
+    private_key_file: Path | None,
+    repositories: tuple[str, ...],
+    allow_loopback_http: bool,
+    device_client_secret_file: Path | None = None,
+    github_organization: str | None = None,
+) -> PollyConfig:
+    server = validate_server_url(server)
+    public_url = validate_public_url(public_url, allow_loopback_http=allow_loopback_http)
+    listen_port = validate_port(listen_port)
+    workspace = validate_workspace(workspace)
+    device_client_secret = os.environ.get("OMNIGENT_DEVICE_CLIENT_SECRET", "").strip()
+    if device_client_secret_file is not None:
+        try:
+            device_client_secret = device_client_secret_file.read_text().strip()
+        except OSError as exc:
+            raise click.ClickException(f"Could not read device client secret file: {exc}") from exc
+        if not device_client_secret:
+            raise click.ClickException("Device client secret file is empty.")
+    importing = any(value is not None for value in (app_id, app_slug, private_key_file))
+    private_key = ""
+    webhook_secret = ""
+    if importing:
+        if app_id is None or app_slug is None or private_key_file is None:
+            raise click.ClickException(
+                "Existing-App import requires --app-id, --app-slug, and --private-key-file."
+            )
+        try:
+            private_key = private_key_file.read_text()
+        except OSError as exc:
+            raise click.ClickException(f"Could not read private key file: {exc}") from exc
+        if not private_key.strip():
+            raise click.ClickException("GitHub private key must not be empty.")
+    access_token, refresh_token = acquire_device_tokens(
+        server, device_client_secret=device_client_secret
+    )
+    agent_id, host_id = _validate_server_selection(server, access_token, workspace, host)
+
+    if importing:
+        webhook_secret = click.prompt("GitHub webhook secret", hide_input=True)
+        if not webhook_secret.strip():
+            raise click.ClickException("GitHub webhook secret must not be empty.")
+        _validate_existing_app(str(app_id), str(app_slug), private_key)
+    else:
+        app = _manifest_flow(public_url, github_organization)
+        app_id, app_slug = str(app["id"]), str(app["slug"])
+        private_key, webhook_secret = str(app["pem"]), str(app["webhook_secret"])
+        if not private_key.strip() or not webhook_secret.strip():
+            raise click.ClickException("GitHub App returned an empty required credential.")
+        install_url = f"https://github.com/apps/{quote(app_slug, safe='')}/installations/new"
+        click.echo(f"Install the GitHub App on the repositories to review: {install_url}")
+        webbrowser.open(install_url)
+
+    selected = repositories or tuple(
+        part.strip()
+        for part in click.prompt("Installed repositories (owner/name, comma-separated)").split(",")
+        if part.strip()
+    )
+    if not selected or any(repo.count("/") != 1 for repo in selected):
+        raise click.ClickException("Select at least one installed repository as owner/name.")
+    _validate_repository_installations(str(app_id), private_key, selected)
+
+    config = PollyConfig(
+        server_url=server.rstrip("/"),
+        public_url=public_url,
+        listen_host=listen_host,
+        listen_port=listen_port,
+        workspace=workspace,
+        agent_id=agent_id,
+        host_id=host_id,
+        github_app_id=str(app_id),
+        github_app_slug=str(app_slug),
+        repositories=selected,
+    )
+    secret_store.store_secret(GITHUB_PRIVATE_KEY_SECRET, private_key)
+    secret_store.store_secret(WEBHOOK_SECRET_SECRET, webhook_secret)
+    secret_store.store_secret(OMNIGENT_ACCESS_TOKEN_SECRET, access_token)
+    secret_store.store_secret(OMNIGENT_REFRESH_TOKEN_SECRET, refresh_token)
+    secret_store.store_secret(OMNIGENT_DEVICE_CLIENT_SECRET, device_client_secret)
+    save_config(config)
+    click.echo(f"Polly configured. GitHub webhook: {public_url}/webhooks/github")
+    return config
+
+
+def _daemon() -> IntegrationDaemon:
+    return IntegrationDaemon("polly", _local_data_dir())
+
+
+def _runtime_argv() -> list[str]:
+    return [sys.executable, "-m", "omnigent.integrations.polly.runtime"]
+
+
+def _start_background() -> None:
+    load_config()
+    daemon = _daemon()
+    current = daemon.running_record()
+    if current:
+        click.echo(f"Polly already running (pid {current.pid}).")
+        return
+    record = daemon.start(_runtime_argv(), os.environ.copy())
+    if not daemon.confirm_alive(record, grace_seconds=2):
+        tail = daemon.read_log_tail()
+        raise click.ClickException("Polly exited immediately." + (f"\n{tail}" if tail else ""))
+    click.echo(f"Started Polly in the background (pid {record.pid}).")
+
+
+def run_doctor() -> dict[str, bool]:
+    checks = dict.fromkeys(
+        (
+            "config",
+            "secrets",
+            "access token",
+            "agent",
+            "host",
+            "harness readiness",
+            "workspace",
+            "GitHub App",
+            "installation repositories",
+            "public health",
+        ),
+        False,
+    )
+    try:
+        config = load_config()
+        checks["config"] = True
+        private_key = secret_store.load_secret(GITHUB_PRIVATE_KEY_SECRET)
+        webhook = secret_store.load_secret(WEBHOOK_SECRET_SECRET)
+        refresh = secret_store.load_secret(OMNIGENT_REFRESH_TOKEN_SECRET)
+        access = secret_store.load_secret(OMNIGENT_ACCESS_TOKEN_SECRET)
+        checks["secrets"] = all(
+            isinstance(value, str) and bool(value.strip())
+            for value in (private_key, webhook, refresh, access)
+        )
+        if not checks["secrets"]:
+            return checks
+        assert isinstance(access, str)
+        headers = _auth_headers(access)
+        with httpx.Client(base_url=config.server_url, headers=headers, timeout=15) as client:
+            agent_response = client.get("/v1/agents", params={"limit": 1000})
+            agent_response.raise_for_status()
+            checks["access token"] = True
+            agents = agent_response.json().get("data", [])
+            checks["agent"] = any(
+                a.get("id") == config.agent_id and a.get("name") == "polly-review" for a in agents
+            )
+            hosts = client.get("/v1/hosts").json().get("hosts", [])
+            host = next((h for h in hosts if h.get("host_id") == config.host_id), None)
+            checks["host"] = bool(host and host.get("status") == "online")
+            readiness = host.get("configured_harnesses", {}) if host else {}
+            checks["harness readiness"] = (
+                readiness.get("claude-sdk") is True and readiness.get("codex") is True
+            )
+            path = quote(config.workspace.lstrip("/"), safe="/")
+            listing = client.get(f"/v1/hosts/{quote(config.host_id, safe='')}/filesystem/{path}")
+            checks["workspace"] = listing.status_code == 200 and listing.json().get("data") == []
+        if private_key:
+            _validate_existing_app(config.github_app_id, config.github_app_slug, private_key)
+            checks["GitHub App"] = True
+            import asyncio
+
+            from omnigent.integrations.polly.github import GitHubAppClient
+
+            async def repositories_installed() -> bool:
+                async with httpx.AsyncClient(base_url=_GITHUB_API, timeout=15) as github_http:
+                    github = GitHubAppClient(
+                        config.github_app_id,
+                        private_key,
+                        github_http,
+                        app_slug=config.github_app_slug,
+                    )
+                    for repository in config.repositories:
+                        owner, repo = repository.split("/", 1)
+                        await github.installation_for(owner, repo)
+                return True
+
+            checks["installation repositories"] = asyncio.run(repositories_installed())
+        with httpx.Client(timeout=15) as client:
+            response = client.get(f"{config.public_url}/health")
+            checks["public health"] = (
+                response.status_code == 200 and response.json().get("status") == "ok"
+            )
+    except (click.ClickException, httpx.HTTPError, KeyError, TypeError, ValueError):
+        pass
+    return checks
+
+
+def register_polly_command(integration: click.Group) -> None:
+    @integration.group("polly", invoke_without_command=True)
+    @click.option("--background", is_flag=True)
+    @click.pass_context
+    def polly(ctx: click.Context, background: bool) -> None:
+        """Run and manage native Polly pull-request reviews."""
+        if ctx.invoked_subcommand is not None:
+            return
+        if background:
+            _start_background()
+            return
+        load_config()
+        current = _daemon().running_record()
+        if current:
+            raise click.ClickException(f"Polly is already running (pid {current.pid}).")
+        result = subprocess.run(_runtime_argv(), env=os.environ.copy(), check=False)
+        raise SystemExit(result.returncode)
+
+    @polly.command("status")
+    def status() -> None:
+        record = _daemon().running_record()
+        click.echo(f"Polly: running (pid {record.pid})." if record else "Polly: not running.")
+
+    @polly.command("stop")
+    def stop() -> None:
+        record = _daemon().stop()
+        click.echo(f"Stopped Polly (pid {record.pid})." if record else "Polly: not running.")
+
+    @polly.command("logs")
+    @click.option("-f", "--follow", is_flag=True)
+    def logs(follow: bool) -> None:
+        record = _daemon().read_record()
+        if not record:
+            click.echo("No Polly daemon has been started yet.")
+            return
+        if follow:
+            subprocess.run(["tail", "-f", record.log_path], check=False)
+        else:
+            click.echo(record.log_path)
+
+    @polly.command("setup")
+    @click.option("--server", required=True)
+    @click.option("--public-url", required=True)
+    @click.option("--listen-host", default="127.0.0.1", show_default=True)
+    @click.option("--listen-port", default=8788, type=int, show_default=True)
+    @click.option("--workspace", required=True)
+    @click.option("--host")
+    @click.option("--app-id")
+    @click.option("--app-slug")
+    @click.option("--private-key-file", type=click.Path(path_type=Path))
+    @click.option("--device-client-secret-file", type=click.Path(path_type=Path))
+    @click.option("--github-organization")
+    @click.option("--repository", "repositories", multiple=True)
+    @click.option("--allow-loopback-http", is_flag=True, hidden=True)
+    def setup(
+        server: str,
+        public_url: str,
+        listen_host: str,
+        listen_port: int,
+        workspace: str,
+        host: str | None,
+        app_id: str | None,
+        app_slug: str | None,
+        private_key_file: Path | None,
+        device_client_secret_file: Path | None,
+        github_organization: str | None,
+        repositories: tuple[str, ...],
+        allow_loopback_http: bool,
+    ) -> None:
+        if _daemon().running_record():
+            raise click.ClickException("Stop the running Polly daemon before setup.")
+        try:
+            _run_setup(
+                server=server,
+                public_url=public_url,
+                listen_host=listen_host,
+                listen_port=listen_port,
+                workspace=workspace,
+                host=host,
+                app_id=app_id,
+                app_slug=app_slug,
+                private_key_file=private_key_file,
+                device_client_secret_file=device_client_secret_file,
+                github_organization=github_organization,
+                repositories=repositories,
+                allow_loopback_http=allow_loopback_http,
+            )
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    @polly.command("doctor")
+    def doctor() -> None:
+        checks = run_doctor()
+        for name, passed in checks.items():
+            click.echo(f"{name}: {'OK' if passed else 'FAIL'}")
+        if not all(checks.values()):
+            raise click.ClickException("Polly doctor found problems.")
+
+    @polly.command("retry")
+    @click.argument("job_id", type=int)
+    def retry(job_id: int) -> None:
+        store = PollyStore(database_path())
+        try:
+            store.get_job(job_id)
+        except KeyError as exc:
+            raise click.ClickException(f"Polly job {job_id} does not exist.") from exc
+        if not store.reset_failed(job_id):
+            raise click.ClickException(f"Polly job {job_id} is not failed.")
+        click.echo(f"Polly job {job_id} queued for retry.")
+
+    @polly.command("jobs")
+    def jobs() -> None:
+        for job in PollyStore(database_path()).list_jobs():
+            error = job.error or "-"
+            for name in (
+                GITHUB_PRIVATE_KEY_SECRET,
+                WEBHOOK_SECRET_SECRET,
+                OMNIGENT_ACCESS_TOKEN_SECRET,
+                OMNIGENT_REFRESH_TOKEN_SECRET,
+                OMNIGENT_DEVICE_CLIENT_SECRET,
+            ):
+                secret = secret_store.load_secret(name)
+                if secret and secret.strip():
+                    error = error.replace(secret, "[redacted]")
+                    error = error.replace(" ".join(secret.split()), "[redacted]")
+            error = " ".join(error.split())[:200]
+            click.echo(
+                f"{job.id}\t{job.owner}/{job.repo}\t#{job.pr_number}\t{job.head_sha}\t"
+                f"{job.state}\t{error}"
+            )

--- a/omnigent/integrations/polly/github.py
+++ b/omnigent/integrations/polly/github.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, TypeAlias, cast
+
+import httpx
+import jwt
+
+JsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # GitHub JSON boundary
+PrivateKey: TypeAlias = Any  # type: ignore[explicit-any]  # PyJWT accepts crypto key objects
+RequestKwargs: TypeAlias = Any  # type: ignore[explicit-any]  # forwarded to httpx
+MAX_DIFF_BYTES = 400_000
+_TRUNCATED = "\n\n[Diff truncated at 400,000 UTF-8 bytes. Review only the content provided.]\n"
+
+
+class GitHubAppClient:
+    def __init__(
+        self,
+        app_id: str,
+        private_key: str | bytes | PrivateKey,
+        http: httpx.AsyncClient,
+        *,
+        app_slug: str,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.app_id = app_id
+        self.private_key = private_key
+        self.http = http
+        self.bot_login = f"{app_slug}[bot]"
+        self.clock = clock
+        self._installations: dict[tuple[str, str], int] = {}
+        self._tokens: dict[int, tuple[str, float]] = {}
+
+    def app_jwt(self) -> str:
+        issued = int(self.clock()) - 60
+        return jwt.encode(
+            {"iat": issued, "exp": issued + 540, "iss": self.app_id},
+            self.private_key,
+            algorithm="RS256",
+        )
+
+    async def installation_for(self, owner: str, repo: str) -> int:
+        key = (owner, repo)
+        if key in self._installations:
+            return self._installations[key]
+        response = await self.http.get(
+            f"/repos/{owner}/{repo}/installation",
+            headers=self._app_headers(),
+        )
+        response.raise_for_status()
+        installation_id = int(response.json()["id"])
+        self._installations[key] = installation_id
+        return installation_id
+
+    def prime_installation(self, owner: str, repo: str, installation_id: int) -> None:
+        self._installations[(owner, repo)] = installation_id
+
+    async def installation_token(self, owner: str, repo: str) -> str:
+        installation_id = await self.installation_for(owner, repo)
+        return await self._installation_token(installation_id)
+
+    async def _installation_token(self, installation_id: int) -> str:
+        cached = self._tokens.get(installation_id)
+        if cached and cached[1] - self.clock() > 300:
+            return cached[0]
+        response = await self.http.post(
+            f"/app/installations/{installation_id}/access_tokens",
+            headers=self._app_headers(),
+        )
+        response.raise_for_status()
+        payload = response.json()
+        expires = payload.get("expires_at")
+        try:
+            parsed_expiry = datetime.fromisoformat(expires.replace("Z", "+00:00")).timestamp()
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            parsed_expiry = self.clock() + 3600
+        token = payload["token"]
+        if not isinstance(token, str) or not token:
+            raise ValueError("GitHub installation token response carried no token")
+        self._tokens[installation_id] = (token, parsed_expiry)
+        return token
+
+    async def get_pull(self, owner: str, repo: str, number: int) -> JsonObject:
+        result = await self._json("GET", f"/repos/{owner}/{repo}/pulls/{number}", owner, repo)
+        if not isinstance(result, dict):
+            raise ValueError("GitHub pull response was not an object")
+        return cast(JsonObject, result)
+
+    async def get_diff(self, owner: str, repo: str, number: int) -> str:
+        response = await self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{number}",
+            owner,
+            repo,
+            headers={"Accept": "application/vnd.github.diff"},
+        )
+        raw = response.content
+        if len(raw) <= MAX_DIFF_BYTES:
+            return raw.decode("utf-8")
+        notice = _TRUNCATED.encode()
+        prefix = raw[: MAX_DIFF_BYTES - len(notice)].decode("utf-8", errors="ignore")
+        return prefix + _TRUNCATED
+
+    async def find_review(
+        self, owner: str, repo: str, number: int, marker: str
+    ) -> JsonObject | None:
+        page = 1
+        while True:
+            reviews = await self._json(
+                "GET",
+                f"/repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100&page={page}",
+                owner,
+                repo,
+            )
+            if not isinstance(reviews, list):
+                raise ValueError("GitHub review list was not an array")
+            found = next(
+                (review for review in reviews if self._owned_marker(review, marker)),
+                None,
+            )
+            if found or len(reviews) < 100:
+                return found
+            page += 1
+
+    async def publish_review_once(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        head_sha: str,
+        body: str,
+        comments: list[JsonObject],
+    ) -> JsonObject:
+        marker = body.split("\n", 1)[0]
+        existing = await self.find_review(owner, repo, number, marker)
+        if existing:
+            return existing
+        payload = {
+            "event": "COMMENT",
+            "commit_id": head_sha,
+            "body": body,
+            "comments": [
+                {
+                    "path": comment["path"],
+                    "line": comment["line"],
+                    "side": "RIGHT",
+                    "body": f"**{comment['priority']} · {comment['title']}**\n\n{comment['body']}",
+                }
+                for comment in comments
+            ],
+        }
+        result = await self._json(
+            "POST", f"/repos/{owner}/{repo}/pulls/{number}/reviews", owner, repo, json=payload
+        )
+        if not isinstance(result, dict):
+            raise ValueError("GitHub review response was not an object")
+        return result
+
+    async def upsert_status_comment(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        body: str,
+        cached_id: int | None = None,
+    ) -> int:
+        if cached_id is not None:
+            response = await self._request(
+                "PATCH",
+                f"/repos/{owner}/{repo}/issues/comments/{cached_id}",
+                owner,
+                repo,
+                json={"body": body},
+                allowed={404},
+            )
+            if response.status_code != 404:
+                return cached_id
+        marker = body.split("\n", 1)[0]
+        found = None
+        page = 1
+        while True:
+            comments = await self._json(
+                "GET",
+                f"/repos/{owner}/{repo}/issues/{number}/comments?per_page=100&page={page}",
+                owner,
+                repo,
+            )
+            if not isinstance(comments, list):
+                raise ValueError("GitHub comment list was not an array")
+            found = next(
+                (comment for comment in comments if self._owned_marker(comment, marker)),
+                None,
+            )
+            if found or len(comments) < 100:
+                break
+            page += 1
+        if found:
+            await self._json(
+                "PATCH",
+                f"/repos/{owner}/{repo}/issues/comments/{found['id']}",
+                owner,
+                repo,
+                json={"body": body},
+            )
+            return int(found["id"])
+        created = await self._json(
+            "POST",
+            f"/repos/{owner}/{repo}/issues/{number}/comments",
+            owner,
+            repo,
+            json={"body": body},
+        )
+        if not isinstance(created, dict):
+            raise ValueError("GitHub comment response was not an object")
+        return int(created["id"])
+
+    def _app_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.app_jwt()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        owner: str,
+        repo: str,
+        *,
+        allowed: set[int] | None = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: RequestKwargs,
+    ) -> httpx.Response:
+        installation_id = await self.installation_for(owner, repo)
+        token = await self._installation_token(installation_id)
+        request_headers = self._base_headers(f"Bearer {token}")
+        request_headers.update(headers or {})
+        response = await self.http.request(method, path, headers=request_headers, **kwargs)
+        if response.status_code == 401:
+            self._tokens.pop(installation_id, None)
+            token = await self._installation_token(installation_id)
+            request_headers["Authorization"] = f"Bearer {token}"
+            response = await self.http.request(method, path, headers=request_headers, **kwargs)
+        if response.status_code not in (allowed or set()):
+            response.raise_for_status()
+        return response
+
+    async def _json(
+        self, method: str, path: str, owner: str, repo: str, **kwargs: RequestKwargs
+    ) -> object:
+        return cast(object, (await self._request(method, path, owner, repo, **kwargs)).json())
+
+    @staticmethod
+    def _base_headers(authorization: str) -> dict[str, str]:
+        return {
+            "Authorization": authorization,
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _owned_marker(self, item: object, marker: str) -> bool:
+        if not isinstance(item, dict):
+            return False
+        body = item.get("body")
+        user = item.get("user")
+        return (
+            isinstance(body, str)
+            and body.splitlines()[:1] == [marker]
+            and isinstance(user, dict)
+            and user.get("login") == self.bot_login
+        )

--- a/omnigent/integrations/polly/omnigent.py
+++ b/omnigent/integrations/polly/omnigent.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias, cast
+
+import httpx
+
+from omnigent.integrations.polly.review import (
+    ReviewValidationError,
+    extract_review,
+    review_schema,
+)
+
+REVIEWERS = ("claude_review", "codex_review")
+JsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # REST/model JSON boundary
+RequestKwargs: TypeAlias = Any  # type: ignore[explicit-any]  # forwarded to httpx
+
+
+class ReviewerFailure(RuntimeError):
+    pass
+
+
+class OmnigentClient:
+    def __init__(
+        self,
+        http: httpx.AsyncClient,
+        *,
+        access_token: str,
+        refresh_token: str,
+        device_client_secret: str = "",
+        agent_id: str,
+        host_id: str,
+        workspace: str,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        save_tokens: Callable[[str, str], object | Awaitable[object]] | None = None,
+        poll_interval: float = 1,
+        max_polls: int = 600,
+    ) -> None:
+        self.http = http
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.device_client_secret = device_client_secret
+        self.agent_id = agent_id
+        self.host_id = host_id
+        self.workspace = workspace
+        self.sleep = sleep
+        self.save_tokens = save_tokens
+        self.poll_interval = poll_interval
+        self.max_polls = max_polls
+        self._refresh_lock = asyncio.Lock()
+
+    async def review_pair(self, diff: str, review_id: str) -> dict[str, JsonObject]:
+        started: list[str] = []
+        tasks: list[asyncio.Task[JsonObject]] = []
+        children: dict[str, str] = {}
+        try:
+            parent = await self._json(
+                "POST",
+                "/v1/sessions",
+                json={
+                    "agent_id": self.agent_id,
+                    "title": f"Polly review {review_id}",
+                    "host_id": self.host_id,
+                    "workspace": self.workspace,
+                    "subagent_routing_override": "off",
+                },
+            )
+            parent_id = self._id(parent, "parent session")
+            started.append(parent_id)
+            uploaded = await self._json(
+                "POST",
+                f"/v1/sessions/{parent_id}/resources/files",
+                files={"file": ("review.diff", diff.encode(), "text/plain")},
+            )
+            parent_file_id = self._id(uploaded, "uploaded diff")
+            await self._wait_parent_ready(parent_id)
+            schema = json.dumps(review_schema(review_id), separators=(",", ":"))
+
+            for reviewer in REVIEWERS:
+                child = await self._json(
+                    "POST",
+                    "/v1/sessions",
+                    json={
+                        "agent_id": self.agent_id,
+                        "parent_session_id": parent_id,
+                        "sub_agent_name": reviewer,
+                        "title": f"{reviewer}:{review_id}",
+                        "subagent_routing_override": "off",
+                    },
+                )
+                child_id = self._id(child, f"{reviewer} child session")
+                started.append(child_id)
+                copied = await self._json(
+                    "POST",
+                    f"/v1/sessions/{child_id}/resources/files:copy",
+                    json={"source_session_id": parent_id, "file_ids": [parent_file_id]},
+                )
+                try:
+                    child_file_id = copied["mapping"][parent_file_id]["new_id"]
+                except (KeyError, TypeError) as exc:
+                    raise ReviewerFailure(f"{reviewer} diff copy returned no file id") from exc
+                await self._request(
+                    "POST",
+                    f"/v1/sessions/{child_id}/events",
+                    json={
+                        "type": "message",
+                        "data": {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": (
+                                        f"Review the attached diff. Review-ID: {review_id}. "
+                                        "Return only one JSON object matching this exact schema: "
+                                        f"{schema}"
+                                    ),
+                                },
+                                {
+                                    "type": "input_file",
+                                    "file_id": child_file_id,
+                                    "filename": "review.diff",
+                                },
+                            ],
+                        },
+                    },
+                )
+                children[reviewer] = child_id
+
+            tasks = [
+                asyncio.create_task(self._poll(children[reviewer], review_id))
+                for reviewer in REVIEWERS
+            ]
+            results = await asyncio.gather(*tasks)
+            return dict(zip(REVIEWERS, results, strict=True))
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.gather(
+                *(self.interrupt(session_id) for session_id in started),
+                return_exceptions=True,
+            )
+            raise
+
+    async def interrupt(self, session_id: str) -> None:
+        try:
+            await self._request(
+                "POST", f"/v1/sessions/{session_id}/events", json={"type": "interrupt"}
+            )
+        except httpx.HTTPError:
+            return
+
+    async def _poll(self, session_id: str, review_id: str) -> JsonObject:
+        observed_active = False
+        for _ in range(self.max_polls):
+            snapshot = await self._json("GET", f"/v1/sessions/{session_id}")
+            status = snapshot.get("status")
+            if status in {"failed", "error", "cancelled"}:
+                raise ReviewerFailure(f"reviewer session {session_id} {status}")
+            if status in {"running", "waiting"}:
+                observed_active = True
+            if status in {"idle", "completed"}:
+                text = self._assistant_text(snapshot)
+                if text is not None:
+                    try:
+                        return extract_review(text, review_id)
+                    except ReviewValidationError as exc:
+                        raise ReviewerFailure(str(exc)) from exc
+                if status == "completed" or observed_active:
+                    raise ReviewerFailure(
+                        f"reviewer session {session_id} completed without output"
+                    )
+            await self.sleep(self.poll_interval)
+        raise ReviewerFailure(f"reviewer session {session_id} did not finish")
+
+    async def _wait_parent_ready(self, session_id: str) -> None:
+        for _ in range(self.max_polls):
+            snapshot = await self._json("GET", f"/v1/sessions/{session_id}")
+            if snapshot.get("runner_online") is True and snapshot.get("runner_id"):
+                return
+            if snapshot.get("status") == "failed":
+                raise ReviewerFailure("parent session runner failed to start")
+            await self.sleep(self.poll_interval)
+        raise ReviewerFailure("parent session runner did not become ready")
+
+    async def _request(self, method: str, path: str, **kwargs: RequestKwargs) -> httpx.Response:
+        token = self.access_token
+        response = await self.http.request(
+            method, path, headers={"Authorization": f"Bearer {token}"}, **kwargs
+        )
+        if response.status_code == 401:
+            await self._refresh(token)
+            response = await self.http.request(
+                method,
+                path,
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                **kwargs,
+            )
+        response.raise_for_status()
+        return response
+
+    async def _refresh(self, failed_token: str) -> None:
+        async with self._refresh_lock:
+            if self.access_token != failed_token:
+                return
+            response = await self.http.post(
+                "/oauth/token",
+                headers=(
+                    {"X-Omnigent-Client-Secret": self.device_client_secret}
+                    if self.device_client_secret
+                    else {}
+                ),
+                data={"grant_type": "refresh_token", "refresh_token": self.refresh_token},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            self.access_token = payload["access_token"]
+            self.refresh_token = payload["refresh_token"]
+            if self.save_tokens:
+                saved = self.save_tokens(self.access_token, self.refresh_token)
+                if inspect.isawaitable(saved):
+                    await saved
+
+    async def _json(self, method: str, path: str, **kwargs: RequestKwargs) -> JsonObject:
+        payload = cast(object, (await self._request(method, path, **kwargs)).json())
+        if not isinstance(payload, dict):
+            raise ReviewerFailure(f"{path} returned a non-object response")
+        return cast(JsonObject, payload)
+
+    @staticmethod
+    def _id(payload: object, label: str) -> str:
+        value = payload.get("id") if isinstance(payload, dict) else None
+        if not isinstance(value, str) or not value:
+            raise ReviewerFailure(f"{label} returned no id")
+        return value
+
+    @staticmethod
+    def _assistant_text(snapshot: JsonObject) -> str | None:
+        items = snapshot.get("items") or snapshot.get("history") or []
+        texts: list[str] = []
+        for item in items:
+            data = item.get("data", item) if isinstance(item, dict) else {}
+            if data.get("role") != "assistant":
+                continue
+            content = data.get("content", [])
+            if isinstance(content, str):
+                texts.append(content)
+                continue
+            parts: list[str] = []
+            for part in content if isinstance(content, list) else []:
+                if isinstance(part, dict) and part.get("type") in {"output_text", "text"}:
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            if parts:
+                texts.append("".join(parts))
+        return texts[-1] if texts else None

--- a/omnigent/integrations/polly/review.py
+++ b/omnigent/integrations/polly/review.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any, TypeAlias
+
+JsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # model JSON boundary
+
+VERDICTS = ("Sound", "Mostly sound", "Unclear", "Risky", "Needs changes")
+PRIORITIES = ("High", "Medium", "Low")
+_REQUIRED = {"review_id", "summary", "approach_verdict", "has_blocking_issues", "inline_comments"}
+_OPTIONAL = {
+    "status_update",
+    "resolved_previous_findings",
+    "still_open_previous_findings",
+    "workspace_status",
+}
+_COMMENT_KEYS = {"path", "line", "priority", "title", "body"}
+_HUNK = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_NON_WHITESPACE = r"\S"
+_PATH_PATTERN = r"^(?!/|\./|\.\./|a/|b/)(?=.*\S)[^\r\n]+$"
+_VALID_PATH = re.compile(_PATH_PATTERN)
+
+
+class ReviewValidationError(ValueError):
+    pass
+
+
+def review_schema(review_id: str) -> JsonObject:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": sorted(_REQUIRED),
+        "properties": {
+            "review_id": {"type": "string", "const": review_id},
+            "summary": {"type": "string", "minLength": 1, "pattern": _NON_WHITESPACE},
+            "approach_verdict": {"type": "string", "enum": list(VERDICTS)},
+            "has_blocking_issues": {"type": "boolean"},
+            "status_update": {"type": "string"},
+            "resolved_previous_findings": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
+            "still_open_previous_findings": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
+            "workspace_status": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "checked_out_sha": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+            },
+            "inline_comments": {
+                "type": "array",
+                "maxItems": 5,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": sorted(_COMMENT_KEYS),
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": _PATH_PATTERN,
+                        },
+                        "line": {"type": "integer", "minimum": 1},
+                        "priority": {"type": "string", "enum": list(PRIORITIES)},
+                        "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": _NON_WHITESPACE,
+                        },
+                        "body": {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": _NON_WHITESPACE,
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+def extract_review(text: str, review_id: str) -> JsonObject:
+    try:
+        raw = json.loads(text)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ReviewValidationError("review must be one JSON object") from exc
+    if not isinstance(raw, dict):
+        raise ReviewValidationError("review must be a JSON object")
+    unknown = set(raw) - _REQUIRED - _OPTIONAL
+    missing = _REQUIRED - set(raw)
+    if unknown:
+        raise ReviewValidationError(f"unexpected review fields: {sorted(unknown)}")
+    if missing:
+        raise ReviewValidationError(f"missing review fields: {sorted(missing)}")
+    if raw["review_id"] != review_id:
+        raise ReviewValidationError("Review-ID does not match")
+    if not isinstance(raw["summary"], str) or not raw["summary"].strip():
+        raise ReviewValidationError("summary must be non-empty")
+    if raw["approach_verdict"] not in VERDICTS:
+        raise ReviewValidationError("invalid approach verdict")
+    if not isinstance(raw["has_blocking_issues"], bool):
+        raise ReviewValidationError("has_blocking_issues must be boolean")
+    if not isinstance(raw["inline_comments"], list) or len(raw["inline_comments"]) > 5:
+        raise ReviewValidationError("inline_comments must contain at most five entries")
+    for comment in raw["inline_comments"]:
+        _validate_comment(comment)
+    for field in ("resolved_previous_findings", "still_open_previous_findings"):
+        value = raw.get(field, [])
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) and item for item in value
+        ):
+            raise ReviewValidationError(f"{field} must be a string list")
+    status = raw.get("status_update")
+    if status is not None and not isinstance(status, str):
+        raise ReviewValidationError("status_update must be a string")
+    workspace = raw.get("workspace_status")
+    if workspace is not None:
+        if not isinstance(workspace, dict) or set(workspace) - {"checked_out_sha", "note"}:
+            raise ReviewValidationError("workspace_status fields are invalid")
+        if not all(isinstance(value, str) for value in workspace.values()):
+            raise ReviewValidationError("workspace_status values must be strings")
+    return raw
+
+
+def _validate_comment(comment: object) -> None:
+    if not isinstance(comment, dict) or set(comment) != _COMMENT_KEYS:
+        raise ReviewValidationError("inline comment fields are invalid")
+    path = comment["path"]
+    if not isinstance(path, str) or _VALID_PATH.fullmatch(path) is None:
+        raise ReviewValidationError("inline comment path must be repository-relative")
+    if (
+        not isinstance(comment["line"], int)
+        or isinstance(comment["line"], bool)
+        or comment["line"] < 1
+    ):
+        raise ReviewValidationError("inline comment line must be positive")
+    if comment["priority"] not in PRIORITIES:
+        raise ReviewValidationError("invalid inline comment priority")
+    if not all(
+        isinstance(comment[field], str) and comment[field].strip() for field in ("title", "body")
+    ):
+        raise ReviewValidationError("inline comment title and body are required")
+
+
+def merge_reviews(reviews: Mapping[str, JsonObject], diff: str) -> JsonObject:
+    if set(reviews) != {"claude_review", "codex_review"}:
+        raise ReviewValidationError("exactly claude_review and codex_review are required")
+    ordered = [("Claude", reviews["claude_review"]), ("Codex", reviews["codex_review"])]
+    anchors = _diff_anchors(diff)
+    comments: dict[tuple[str, int], JsonObject] = {}
+    demoted: dict[tuple[str, int], JsonObject] = {}
+    rank = {priority: index for index, priority in enumerate(PRIORITIES)}
+    for _, review in ordered:
+        for comment in review["inline_comments"]:
+            key = (comment["path"], comment["line"])
+            if key not in anchors:
+                previous = demoted.get(key)
+                if previous is None or rank[comment["priority"]] < rank[previous["priority"]]:
+                    demoted[key] = comment
+                continue
+            previous = comments.get(key)
+            if previous is None or rank[comment["priority"]] < rank[previous["priority"]]:
+                comments[key] = comment
+
+    summaries = [f"## {label}\n{review['summary'].strip()}" for label, review in ordered]
+    if demoted:
+        summaries.append(
+            "## Findings without a valid diff anchor\n"
+            + "\n".join(
+                f"- **{item['priority']} · {item['title']}** "
+                f"`{item['path']}:{item['line']}` — {item['body']}"
+                for item in sorted(
+                    demoted.values(),
+                    key=lambda item: (rank[item["priority"]], item["path"], item["line"]),
+                )
+            )
+        )
+    resolved = set(ordered[0][1].get("resolved_previous_findings", []))
+    resolved.intersection_update(ordered[1][1].get("resolved_previous_findings", []))
+    still_open = list(
+        dict.fromkeys(
+            item
+            for _, review in ordered
+            for item in review.get("still_open_previous_findings", [])
+        )
+    )
+    return {
+        "summary": "\n\n".join(summaries),
+        "approach_verdict": max(
+            (review["approach_verdict"] for _, review in ordered), key=VERDICTS.index
+        ),
+        "has_blocking_issues": any(review["has_blocking_issues"] for _, review in ordered),
+        "status_update": " ".join(
+            value.strip()
+            for _, review in ordered
+            if isinstance((value := review.get("status_update")), str) and value.strip()
+        ),
+        "resolved_previous_findings": sorted(resolved),
+        "still_open_previous_findings": still_open,
+        "blocking_findings": sorted(
+            (
+                item
+                for item in (*comments.values(), *demoted.values())
+                if item["priority"] == "High"
+            ),
+            key=lambda item: (item["path"], item["line"]),
+        ),
+        "inline_comments": sorted(
+            comments.values(),
+            key=lambda item: (rank[item["priority"]], item["path"], item["line"]),
+        )[:5],
+    }
+
+
+def _diff_anchors(diff: str) -> set[tuple[str, int]]:
+    anchors: set[tuple[str, int]] = set()
+    path: str | None = None
+    new_line = 0
+    old_remaining = 0
+    new_remaining = 0
+    for line in diff.splitlines():
+        if old_remaining or new_remaining:
+            if line.startswith("\\"):
+                continue
+            marker = line[:1]
+            if marker == "+":
+                anchors.add((path, new_line))  # type: ignore[arg-type]
+                new_line += 1
+                new_remaining -= 1
+                continue
+            if marker == "-":
+                old_remaining -= 1
+                continue
+            if marker == " " or not line:
+                anchors.add((path, new_line))  # type: ignore[arg-type]
+                new_line += 1
+                old_remaining -= 1
+                new_remaining -= 1
+                continue
+            old_remaining = new_remaining = 0
+        if line.startswith("+++ "):
+            raw = line[4:].split("\t", 1)[0]
+            path = None if raw == "/dev/null" else raw.removeprefix("b/")
+            continue
+        match = _HUNK.match(line)
+        if match and path:
+            old_remaining = int(match.group(1) or 1)
+            new_line = int(match.group(2))
+            new_remaining = int(match.group(3) or 1)
+    return anchors

--- a/omnigent/integrations/polly/runtime.py
+++ b/omnigent/integrations/polly/runtime.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import httpx
+import uvicorn
+from fastapi import FastAPI
+
+from omnigent.integration_daemon import IntegrationDaemon
+from omnigent.integrations.polly.cli import (
+    GITHUB_PRIVATE_KEY_SECRET,
+    OMNIGENT_ACCESS_TOKEN_SECRET,
+    OMNIGENT_DEVICE_CLIENT_SECRET,
+    OMNIGENT_REFRESH_TOKEN_SECRET,
+    WEBHOOK_SECRET_SECRET,
+    PollyConfig,
+    database_path,
+    integration_dir,
+    load_config,
+)
+from omnigent.integrations.polly.github import GitHubAppClient
+from omnigent.integrations.polly.omnigent import OmnigentClient
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.integrations.polly.webhook import create_webhook_app
+from omnigent.integrations.polly.worker import PollyWorker
+from omnigent.onboarding import secrets as secret_store
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PollyRuntime:
+    app: FastAPI
+    github_http: httpx.AsyncClient
+    omnigent_http: httpx.AsyncClient
+    started: asyncio.Event
+
+
+def build_runtime(
+    *,
+    config: PollyConfig,
+    private_key: str,
+    webhook_secret: str,
+    refresh_token: str,
+    access_token: str = "",
+    device_client_secret: str = "",
+    store: PollyStore | None = None,
+    daemon: IntegrationDaemon | None = None,
+    worker: PollyWorker | None = None,
+    idle_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> PollyRuntime:
+    store = store or PollyStore(database_path())
+    daemon = daemon or IntegrationDaemon("polly", integration_dir().parents[1])
+    github_http = httpx.AsyncClient(base_url="https://api.github.com", timeout=30)
+    omnigent_http = httpx.AsyncClient(base_url=config.server_url, timeout=30)
+    github = GitHubAppClient(
+        config.github_app_id,
+        private_key,
+        github_http,
+        app_slug=config.github_app_slug,
+    )
+
+    def save_tokens(access: str, refresh: str) -> None:
+        secret_store.store_secret(OMNIGENT_REFRESH_TOKEN_SECRET, refresh)
+        secret_store.store_secret(OMNIGENT_ACCESS_TOKEN_SECRET, access)
+
+    omnigent = OmnigentClient(
+        omnigent_http,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        device_client_secret=device_client_secret,
+        agent_id=config.agent_id,
+        host_id=config.host_id,
+        workspace=config.workspace,
+        save_tokens=save_tokens,
+    )
+    worker = worker or PollyWorker(store, github, omnigent)
+    started = asyncio.Event()
+    stop = asyncio.Event()
+    task: asyncio.Task[None] | None = None
+
+    def worker_ready() -> bool:
+        return task is not None and not task.done()
+
+    app = create_webhook_app(
+        store, webhook_secret, repositories=config.repositories, ready=worker_ready
+    )
+
+    async def work() -> None:
+        while not stop.is_set():
+            try:
+                did_work = await worker.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Polly worker iteration failed")
+                await idle_sleep(0.5)
+                continue
+            if not did_work:
+                await idle_sleep(0.5)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        nonlocal task
+        daemon.acquire_current(integration_dir() / "polly.log")
+        store.recover_running()
+        task = asyncio.create_task(work())
+        started.set()
+        try:
+            yield
+        finally:
+            stop.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            await github_http.aclose()
+            await omnigent_http.aclose()
+            daemon.release_current()
+
+    app.router.lifespan_context = lifespan
+    return PollyRuntime(
+        app=app,
+        github_http=github_http,
+        omnigent_http=omnigent_http,
+        started=started,
+    )
+
+
+def _required_secret(name: str) -> str:
+    value = secret_store.load_secret(name)
+    if not value or not value.strip():
+        raise RuntimeError(f"missing Polly secret slot: {name}")
+    return value
+
+
+def _optional_secret(name: str) -> str:
+    return secret_store.load_secret(name) or ""
+
+
+def main() -> None:
+    config = load_config()
+    runtime = build_runtime(
+        config=config,
+        private_key=_required_secret(GITHUB_PRIVATE_KEY_SECRET),
+        webhook_secret=_required_secret(WEBHOOK_SECRET_SECRET),
+        refresh_token=_required_secret(OMNIGENT_REFRESH_TOKEN_SECRET),
+        access_token=_optional_secret(OMNIGENT_ACCESS_TOKEN_SECRET),
+        device_client_secret=_optional_secret(OMNIGENT_DEVICE_CLIENT_SECRET),
+    )
+    uvicorn.run(runtime.app, host=config.listen_host, port=config.listen_port)
+
+
+if __name__ == "__main__":
+    main()

--- a/omnigent/integrations/polly/store.py
+++ b/omnigent/integrations/polly/store.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeAlias
+
+JsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # persisted JSON
+
+STATES = {"pending", "running", "retry_wait", "published", "failed", "superseded"}
+
+
+@dataclass(frozen=True)
+class Job:
+    id: int
+    owner: str
+    repo: str
+    pr_number: int
+    head_sha: str
+    installation_id: int
+    review_id: str
+    state: str
+    attempts: int
+    next_attempt_at: float | None
+    status_comment_id: int | None
+    outputs: JsonObject | None
+    error: str | None
+
+
+class PollyStore:
+    def __init__(self, path: str | Path, *, clock: Callable[[], float] = time.time) -> None:
+        self.path = Path(path)
+        self.clock = clock
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as db:
+            db.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS deliveries (
+                    id TEXT PRIMARY KEY,
+                    received_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    owner TEXT NOT NULL,
+                    repo TEXT NOT NULL,
+                    pr_number INTEGER NOT NULL,
+                    head_sha TEXT NOT NULL,
+                    installation_id INTEGER NOT NULL,
+                    review_id TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (
+                        state IN (
+                            'pending','running','retry_wait','published','failed','superseded'
+                        )
+                    ),
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at REAL,
+                    status_comment_id INTEGER,
+                    outputs_json TEXT,
+                    error TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    UNIQUE(owner, repo, pr_number, head_sha)
+                );
+                CREATE INDEX IF NOT EXISTS jobs_claimable
+                    ON jobs(state, created_at, id);
+                """
+            )
+            columns = {row[1] for row in db.execute("PRAGMA table_info(jobs)")}
+            if "next_attempt_at" not in columns:
+                db.execute("ALTER TABLE jobs ADD COLUMN next_attempt_at REAL")
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path, timeout=30)
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA busy_timeout=30000")
+        return db
+
+    def accept(
+        self,
+        delivery_id: str,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        head_sha: str,
+        installation_id: int,
+    ) -> str:
+        now = self.clock()
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            delivery = db.execute(
+                "INSERT OR IGNORE INTO deliveries(id, received_at) VALUES (?, ?)",
+                (delivery_id, now),
+            )
+            if delivery.rowcount == 0:
+                db.commit()
+                return "duplicate"
+            job = db.execute(
+                """
+                INSERT OR IGNORE INTO jobs(
+                    owner, repo, pr_number, head_sha, installation_id, review_id,
+                    state, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                """,
+                (
+                    owner,
+                    repo,
+                    pr_number,
+                    head_sha,
+                    installation_id,
+                    secrets.token_hex(8),
+                    now,
+                    now,
+                ),
+            )
+            revived = db.execute(
+                """
+                UPDATE jobs SET state = 'pending', next_attempt_at = NULL, updated_at = ?
+                WHERE owner = ? AND repo = ? AND pr_number = ? AND head_sha = ?
+                  AND state = 'superseded'
+                """,
+                (now, owner, repo, pr_number, head_sha),
+            )
+            if job.rowcount or revived.rowcount:
+                db.execute(
+                    """
+                    UPDATE jobs SET state = 'superseded', updated_at = ?
+                    WHERE owner = ? AND repo = ? AND pr_number = ? AND head_sha != ?
+                      AND state IN ('pending', 'retry_wait')
+                    """,
+                    (now, owner, repo, pr_number, head_sha),
+                )
+            db.commit()
+            return "accepted" if job.rowcount else "duplicate"
+
+    def supersede_and_enqueue_current_head(self, job: Job, head_sha: str | None) -> None:
+        now = self.clock()
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            if head_sha is not None:
+                db.execute(
+                    """
+                    INSERT OR IGNORE INTO jobs(
+                        owner, repo, pr_number, head_sha, installation_id, review_id,
+                        state, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                    """,
+                    (
+                        job.owner,
+                        job.repo,
+                        job.pr_number,
+                        head_sha,
+                        job.installation_id,
+                        secrets.token_hex(8),
+                        now,
+                        now,
+                    ),
+                )
+                db.execute(
+                    """
+                    UPDATE jobs SET state = 'pending', next_attempt_at = NULL, updated_at = ?
+                    WHERE owner = ? AND repo = ? AND pr_number = ? AND head_sha = ?
+                      AND state = 'superseded'
+                    """,
+                    (now, job.owner, job.repo, job.pr_number, head_sha),
+                )
+            db.execute(
+                """
+                UPDATE jobs SET state = 'superseded', next_attempt_at = NULL, updated_at = ?
+                WHERE id = ? AND state = 'running'
+                """,
+                (now, job.id),
+            )
+            db.commit()
+
+    def recover_running(self) -> int:
+        with self._connect() as db:
+            result = db.execute(
+                """
+                UPDATE jobs SET state = 'pending', next_attempt_at = NULL, updated_at = ?
+                WHERE state = 'running'
+                """,
+                (self.clock(),),
+            )
+            return result.rowcount
+
+    def claim_next(self) -> Job | None:
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            row = db.execute(
+                """
+                SELECT * FROM jobs
+                WHERE state = 'pending'
+                   OR (state = 'retry_wait' AND next_attempt_at <= ?)
+                ORDER BY created_at, id LIMIT 1
+                """,
+                (self.clock(),),
+            ).fetchone()
+            if row is None:
+                db.commit()
+                return None
+            db.execute(
+                """
+                UPDATE jobs SET state = 'running', attempts = attempts + 1,
+                    next_attempt_at = NULL, updated_at = ?
+                WHERE id = ?
+                """,
+                (self.clock(), row["id"]),
+            )
+            claimed = db.execute("SELECT * FROM jobs WHERE id = ?", (row["id"],)).fetchone()
+            if claimed is None:
+                raise AssertionError("claimed job disappeared")
+            db.commit()
+        return self._job(claimed)
+
+    def set_state(self, job_id: int, state: str, *, error: str | None = None) -> None:
+        if state not in STATES:
+            raise ValueError(f"unknown job state: {state}")
+        with self._connect() as db:
+            db.execute(
+                """
+                UPDATE jobs SET state = ?, error = ?, next_attempt_at = NULL, updated_at = ?
+                WHERE id = ?
+                """,
+                (state, error, self.clock(), job_id),
+            )
+
+    def schedule_retry(self, job_id: int, *, delay: float, error: str) -> None:
+        with self._connect() as db:
+            db.execute(
+                """
+                UPDATE jobs SET state = 'retry_wait', error = ?,
+                    next_attempt_at = ?, updated_at = ?
+                WHERE id = ? AND state = 'running'
+                """,
+                (error, self.clock() + delay, self.clock(), job_id),
+            )
+
+    def save_outputs(self, job_id: int, outputs: JsonObject) -> None:
+        with self._connect() as db:
+            db.execute(
+                "UPDATE jobs SET outputs_json = ?, updated_at = ? WHERE id = ?",
+                (json.dumps(outputs, sort_keys=True), self.clock(), job_id),
+            )
+
+    def set_status_comment(self, job_id: int, comment_id: int | None) -> None:
+        with self._connect() as db:
+            db.execute(
+                "UPDATE jobs SET status_comment_id = ?, updated_at = ? WHERE id = ?",
+                (comment_id, self.clock(), job_id),
+            )
+
+    def reset_failed(self, job_id: int) -> bool:
+        with self._connect() as db:
+            result = db.execute(
+                """
+                UPDATE jobs SET state = 'pending', attempts = 0, error = NULL,
+                    next_attempt_at = NULL, updated_at = ?
+                WHERE id = ? AND state = 'failed'
+                """,
+                (self.clock(), job_id),
+            )
+            return result.rowcount == 1
+
+    def get_job(self, job_id: int) -> Job:
+        with self._connect() as db:
+            row = db.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        if row is None:
+            raise KeyError(job_id)
+        return self._job(row)
+
+    def list_jobs(self) -> list[Job]:
+        with self._connect() as db:
+            rows = db.execute("SELECT * FROM jobs ORDER BY id").fetchall()
+        return [self._job(row) for row in rows]
+
+    @staticmethod
+    def _job(row: sqlite3.Row) -> Job:
+        return Job(
+            id=row["id"],
+            owner=row["owner"],
+            repo=row["repo"],
+            pr_number=row["pr_number"],
+            head_sha=row["head_sha"],
+            installation_id=row["installation_id"],
+            review_id=row["review_id"],
+            state=row["state"],
+            attempts=row["attempts"],
+            next_attempt_at=row["next_attempt_at"],
+            status_comment_id=row["status_comment_id"],
+            outputs=json.loads(row["outputs_json"]) if row["outputs_json"] else None,
+            error=row["error"],
+        )

--- a/omnigent/integrations/polly/webhook.py
+++ b/omnigent/integrations/polly/webhook.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Callable
+
+from fastapi import FastAPI, HTTPException, Request
+
+from omnigent.integrations.polly.store import PollyStore
+
+_ACTIONS = {"opened", "reopened", "synchronize", "ready_for_review"}
+
+
+def create_webhook_app(
+    store: PollyStore,
+    webhook_secret: str,
+    *,
+    max_body_bytes: int = 1_048_576,
+    repositories: tuple[str, ...] | None = None,
+    ready: Callable[[], bool] | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    secret = webhook_secret.encode()
+    allowed_repositories = (
+        {repository.casefold() for repository in repositories}
+        if repositories is not None
+        else None
+    )
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        if ready is not None and not ready():
+            raise HTTPException(503, "Polly worker unavailable")
+        return {"status": "ok"}
+
+    @app.post("/webhooks/github", status_code=202)
+    async def github_webhook(request: Request) -> dict[str, str]:
+        body = bytearray()
+        async for chunk in request.stream():
+            if len(chunk) > max_body_bytes - len(body):
+                raise HTTPException(413, "webhook body too large")
+            body.extend(chunk)
+
+        supplied = request.headers.get("X-Hub-Signature-256", "")
+        expected = "sha256=" + hmac.new(secret, bytes(body), hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(supplied, expected):
+            raise HTTPException(401, "invalid webhook signature")
+
+        event = request.headers.get("X-GitHub-Event")
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HTTPException(400, "invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise HTTPException(400, "webhook payload must be an object")
+
+        if event != "pull_request" or payload.get("action") not in _ACTIONS:
+            return {"status": "skipped"}
+        pull = payload.get("pull_request")
+        if not isinstance(pull, dict):
+            raise HTTPException(400, "incomplete pull request payload")
+        head = pull.get("head")
+        base = pull.get("base")
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise HTTPException(400, "incomplete pull request payload")
+        head_repo = head.get("repo")
+        base_repo = base.get("repo")
+        if not isinstance(head_repo, dict) or not isinstance(base_repo, dict):
+            raise HTTPException(400, "incomplete pull request payload")
+        if pull.get("draft") or head_repo.get("full_name") != base_repo.get("full_name"):
+            return {"status": "skipped"}
+
+        delivery = request.headers.get("X-GitHub-Delivery", "").strip()
+        repo = payload.get("repository")
+        installation = payload.get("installation")
+        if not isinstance(repo, dict) or not isinstance(installation, dict):
+            raise HTTPException(400, "incomplete pull request payload")
+        try:
+            owner = repo["owner"]["login"]
+            name = repo["name"]
+            number = int(pull["number"])
+            head_sha = pull["head"]["sha"]
+            installation_id = int(installation["id"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise HTTPException(400, "incomplete pull request payload") from exc
+        if not delivery or not all(
+            isinstance(value, str) and value for value in (owner, name, head_sha)
+        ):
+            raise HTTPException(400, "incomplete pull request payload")
+        if (
+            allowed_repositories is not None
+            and f"{owner}/{name}".casefold() not in allowed_repositories
+        ):
+            return {"status": "skipped"}
+
+        return {"status": store.accept(delivery, owner, name, number, head_sha, installation_id)}
+
+    return app

--- a/omnigent/integrations/polly/worker.py
+++ b/omnigent/integrations/polly/worker.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias, TypeVar
+
+import httpx
+
+from omnigent.integrations.polly.omnigent import ReviewerFailure
+from omnigent.integrations.polly.review import merge_reviews
+from omnigent.integrations.polly.store import Job, PollyStore
+
+_T = TypeVar("_T")
+JsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # client JSON boundary
+_RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
+
+
+def _is_retryable_transport_error(exc: Exception) -> bool:
+    return isinstance(exc, httpx.TransportError) or (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code in _RETRYABLE_HTTP_STATUSES
+    )
+
+
+class PollyWorker:
+    def __init__(  # type: ignore[explicit-any]  # structural external clients
+        self,
+        store: PollyStore,
+        github: Any,
+        omnigent: Any,
+        *,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        transport_attempts: int = 3,
+        max_job_attempts: int = 3,
+        retry_delays: tuple[float, ...] = (5, 30),
+    ) -> None:
+        self.store = store
+        self.github = github
+        self.omnigent = omnigent
+        self.sleep = sleep
+        self.transport_attempts = transport_attempts
+        self.max_job_attempts = max_job_attempts
+        self.retry_delays = retry_delays
+        if max_job_attempts < 1 or len(retry_delays) < max_job_attempts - 1:
+            raise ValueError("retry_delays must cover every retryable job attempt")
+
+    async def run_once(self) -> bool:
+        job = self.store.claim_next()
+        if job is None:
+            return False
+        try:
+            await self._run(job)
+        except (ReviewerFailure, httpx.TransportError, httpx.HTTPStatusError) as exc:
+            retryable = isinstance(exc, ReviewerFailure) or _is_retryable_transport_error(exc)
+            if not retryable or job.attempts >= self.max_job_attempts:
+                self.store.set_state(job.id, "failed", error=str(exc))
+            else:
+                self.store.schedule_retry(
+                    job.id,
+                    delay=self.retry_delays[job.attempts - 1],
+                    error=str(exc),
+                )
+        except Exception as exc:  # noqa: BLE001
+            self.store.set_state(job.id, "failed", error=str(exc))
+        return True
+
+    async def _run(self, job: Job) -> None:
+        marker = self._review_marker(job)
+        existing = await self._transport(
+            lambda: self.github.find_review(job.owner, job.repo, job.pr_number, marker)
+        )
+        pull = await self._transport(
+            lambda: self.github.get_pull(job.owner, job.repo, job.pr_number)
+        )
+        head_sha = self._head(pull)
+        if head_sha != job.head_sha:
+            self.store.supersede_and_enqueue_current_head(job, head_sha)
+            return
+        if existing:
+            await self._update_status(job, "Review published.")
+            self.store.set_state(job.id, "published")
+            return
+        diff = await self._transport(
+            lambda: self.github.get_diff(job.owner, job.repo, job.pr_number)
+        )
+
+        if job.outputs is None:
+            outputs = await self.omnigent.review_pair(diff, job.review_id)
+            self.store.save_outputs(job.id, outputs)
+        else:
+            outputs = job.outputs
+
+        pull = await self._transport(
+            lambda: self.github.get_pull(job.owner, job.repo, job.pr_number)
+        )
+        head_sha = self._head(pull)
+        if head_sha != job.head_sha:
+            self.store.supersede_and_enqueue_current_head(job, head_sha)
+            return
+
+        merged = merge_reviews(outputs, diff)
+        body = self._review_body(marker, merged)
+        await self._transport(
+            lambda: self.github.publish_review_once(
+                job.owner,
+                job.repo,
+                job.pr_number,
+                job.head_sha,
+                body,
+                merged["inline_comments"],
+            )
+        )
+        await self._update_status(job, merged["status_update"] or "Review published.")
+        self.store.set_state(job.id, "published")
+
+    async def _update_status(self, job: Job, message: str) -> None:
+        body = f"{self._status_marker(job)}\n{message}"
+        comment_id = await self._transport(
+            lambda: self.github.upsert_status_comment(
+                job.owner,
+                job.repo,
+                job.pr_number,
+                body,
+                job.status_comment_id,
+            )
+        )
+        self.store.set_status_comment(job.id, comment_id)
+
+    async def _transport(self, operation: Callable[[], Awaitable[_T]]) -> _T:
+        for attempt in range(self.transport_attempts):
+            try:
+                return await operation()
+            except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+                if (
+                    not _is_retryable_transport_error(exc)
+                    or attempt + 1 == self.transport_attempts
+                ):
+                    raise
+                await self.sleep(2**attempt)
+        raise AssertionError("unreachable")
+
+    @staticmethod
+    def _head(pull: JsonObject) -> str:
+        head = pull.get("head")
+        sha = head.get("sha") if isinstance(head, dict) else None
+        if not isinstance(sha, str) or not sha:
+            raise ValueError("GitHub pull response is missing a valid head SHA")
+        return sha
+
+    @staticmethod
+    def _review_marker(job: Job) -> str:
+        return f"<!-- polly-review:{job.owner}/{job.repo}#{job.pr_number}:{job.head_sha} -->"
+
+    @staticmethod
+    def _status_marker(job: Job) -> str:
+        return f"<!-- polly-status:{job.owner}/{job.repo}#{job.pr_number} -->"
+
+    @staticmethod
+    def _review_body(marker: str, merged: JsonObject) -> str:
+        blockers = [
+            f"- `{item['path']}:{item['line']}` **{item['title']}** — {item['body']}"
+            for item in merged["blocking_findings"]
+        ]
+        if merged["has_blocking_issues"] and not blockers:
+            blockers = ["- Reviewers reported blocking issues; see summaries above."]
+
+        def section(title: str, values: list[str]) -> str:
+            return f"## {title}\n" + ("\n".join(f"- {value}" for value in values) or "- None.")
+
+        return "\n\n".join(
+            [
+                f"{marker}\n**Disposition:** "
+                + ("BLOCKING" if merged["has_blocking_issues"] else "NON-BLOCKING"),
+                merged["summary"],
+                f"**Approach:** {merged['approach_verdict']}",
+                "## Blockers\n" + ("\n".join(blockers) or "- None."),
+                section("Resolved previous findings", merged["resolved_previous_findings"]),
+                section("Still-open previous findings", merged["still_open_previous_findings"]),
+            ]
+        )

--- a/omnigent/resources/examples/polly_review
+++ b/omnigent/resources/examples/polly_review
@@ -1,0 +1,1 @@
+../../../examples/polly_review

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5843,7 +5843,7 @@ def create_runner_app(
                     )
             _session_tool_schemas[conv] = all_tools
 
-        if cached_spec and cached_spec.mcp_servers:
+        if cached_spec and cached_spec.mcp_servers and not cached_spec.tool_free:
             from omnigent.runner.mcp_manager import compute_spec_hash
 
             _mcp_hash = compute_spec_hash(list(cached_spec.mcp_servers))
@@ -5876,7 +5876,11 @@ def create_runner_app(
                     )
 
         _spec_tools = _session_tool_schemas.get(conv) or []
-        _client_tools = cast(list[_JsonObject], msg_body.get("tools") or [])
+        _client_tools = (
+            []
+            if cached_spec is not None and cached_spec.tool_free
+            else cast(list[_JsonObject], msg_body.get("tools") or [])
+        )
         merged_tools = _merge_request_client_tools(_spec_tools, _client_tools)
         if merged_tools:
             harness_body["tools"] = merged_tools
@@ -6154,7 +6158,11 @@ def create_runner_app(
                         _turn_spec_entry = _resolved_turn_spec
             _turn_spec_resolved = True
             _turn_mcp = ProxyMcpManager(conv_id, server_client)
-            if _eager_spec_error is None and _turn_spec is not None:
+            if (
+                _eager_spec_error is None
+                and _turn_spec is not None
+                and not cast(AgentSpec, _turn_spec).tool_free
+            ):
                 try:
                     _mcp = await _turn_mcp.schemas_for(cast(AgentSpec, _turn_spec))
                     _mcp_schemas = _mcp.schemas
@@ -6232,7 +6240,15 @@ def create_runner_app(
                 return
 
             event_body = _wrap_as_message_event(body)
-            _inject_mcp_schemas(event_body, _mcp_schemas)
+            event_spec = (
+                _unwrap_resolved_spec((await _resolve_turn_spec_lazy())[0])
+                if event_body.get("tools") or _mcp_schemas
+                else None
+            )
+            if event_spec is not None and event_spec.tool_free:
+                event_body.pop("tools", None)
+            else:
+                _inject_mcp_schemas(event_body, _mcp_schemas)
             _response_id: str | None = None
             try:
                 async with client.stream(

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -98,6 +98,18 @@ _DIR_MODE = 0o700
 # umask configurations that would otherwise loosen it.
 _SOCKET_MODE = 0o600
 
+_SAFETY_ENV_SUFFIXES = (
+    "_BUNDLE_DIR",
+    "_CWD",
+    "_DISABLE_NATIVE_TOOLS",
+    "_ENABLE_WEB_SEARCH",
+    "_MINIMAL_CONFIG",
+    "_OS_ENV",
+    "_PERMISSION_MODE",
+    "_SKILLS_FILTER",
+    "_TOOL_FREE",
+)
+
 # Default idle-reaper window: a subprocess that has not been
 # touched (via ``get_client`` or an AP→harness HTTP call updating
 # ``last_used_at``) for this many seconds is killed and unregistered.
@@ -470,12 +482,14 @@ class _SubprocessEntry:
         endpoint: _HarnessEndpoint,
         harness: str,
         model: str | None = None,
+        safety_fingerprint: tuple[tuple[str, str], ...] = (),
     ) -> None:
         self.process = process
         self.client = client
         self.endpoint = endpoint
         self.harness = harness
         self.model = model
+        self.safety_fingerprint = safety_fingerprint
         self.last_used_at: float = 0.0
 
 
@@ -493,6 +507,21 @@ def _model_env_key(harness: str) -> str:
         ``"claude-sdk"`` or ``"HARNESS_CODEX_MODEL"`` for ``"codex"``.
     """
     return f"HARNESS_{harness.upper().replace('-', '_')}_MODEL"
+
+
+def _safety_env_fingerprint(
+    harness: str,
+    env: dict[str, str] | None,
+) -> tuple[tuple[str, str], ...]:
+    """Return stable, process-fixed safety config from a harness spawn env."""
+    prefix = f"HARNESS_{harness.upper().replace('-', '_')}_"
+    return tuple(
+        sorted(
+            (key, value)
+            for key, value in (env or {}).items()
+            if key.startswith(prefix) and key.endswith(_SAFETY_ENV_SUFFIXES)
+        )
+    )
 
 
 def _build_harness_spawn_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -694,8 +723,8 @@ class HarnessProcessManager:
         runner subprocess of the right harness type, waits for the
         Unix socket to appear, and constructs an
         :class:`httpx.AsyncClient` over it. Subsequent calls
-        return the cached client (``env`` is ignored on cache
-        hits — config is fixed at first-spawn time).
+        return the cached client unless its process-fixed model or
+        safety configuration changed.
 
         Crash detection: if the previously-spawned subprocess has
         exited (``returncode is not None``), the entry is dropped
@@ -800,6 +829,20 @@ class HarnessProcessManager:
                 await self._close_entry(entry)
                 entry = None
                 respawn_reason = "harness_respawn_agent_switch"
+            if entry is not None:
+                requested_safety = (
+                    _safety_env_fingerprint(harness, env) if env is not None else None
+                )
+                if requested_safety is not None and requested_safety != entry.safety_fingerprint:
+                    _logger.info(
+                        "harness %s for conversation %s: safety config changed; respawning",
+                        harness,
+                        conversation_id,
+                    )
+                    replaced_response_id = self._in_flight_response_ids.get(conversation_id)
+                    await self._close_entry(entry)
+                    entry = None
+                    respawn_reason = "harness_respawn_config_switch"
             if entry is not None:
                 # The model is baked into the subprocess env at spawn time;
                 # a later turn requesting a different model (e.g. after the
@@ -1254,6 +1297,7 @@ class HarnessProcessManager:
                 # triggers a respawn in ``get_client`` — the model is a fixed
                 # process env var, not re-read per turn.
                 model=(env or {}).get(_model_env_key(harness)),
+                safety_fingerprint=_safety_env_fingerprint(harness, env),
             )
         except BaseException:
             # From spawn onward the process must have exactly one owner:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1171,6 +1171,8 @@ def _build_claude_sdk_spawn_env(
         :meth:`HarnessProcessManager.get_client(env=...)`.
     """
     env: dict[str, str] = {}
+    if spec.tool_free:
+        env["HARNESS_CLAUDE_SDK_TOOL_FREE"] = "1"
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_CLAUDE_SDK_MODEL"] = model
@@ -1296,17 +1298,8 @@ def _build_codex_spawn_env(
     Maps spec.executor fields → the ``HARNESS_CODEX_*`` env vars
     defined in ``omnigent/inner/codex_harness.py``. Mirrors
     :func:`_build_claude_sdk_spawn_env` — same per-spawn env-var
-    pattern from §Step 5a. The codex-specific env vars
-    (``HARNESS_CODEX_PATH``, ``HARNESS_CODEX_ENABLE_WEB_SEARCH``,
-    ``HARNESS_CODEX_DISABLE_NATIVE_TOOLS``) are not threaded
-    through here in v1: the legacy
-    :func:`omnigent.inner.executor_factory.create_executor`
-    path doesn't surface them either, so AP-side parity is
-    preserved by leaving them at the inner executor's defaults.
-    Operators who want non-default values set those env vars
-    on the Omnigent server directly (they propagate to the subprocess
-    through normal env inheritance — the wrap's per-spawn
-    overrides only override, they don't filter).
+    pattern from §Step 5a. Per-agent native-tool and web-search
+    switches are forwarded to the isolated harness process.
 
     :param spec: The agent spec.
     :param workdir: The bundle's on-disk path (extracted by the
@@ -1321,6 +1314,18 @@ def _build_codex_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_CODEX_MODEL"] = model
+    if "disable_native_tools" in spec.executor.config:
+        env["HARNESS_CODEX_DISABLE_NATIVE_TOOLS"] = (
+            "1" if _config_flag_is_true(spec.executor.config["disable_native_tools"]) else "0"
+        )
+    if "enable_web_search" in spec.executor.config:
+        env["HARNESS_CODEX_ENABLE_WEB_SEARCH"] = (
+            "1" if _config_flag_is_true(spec.executor.config["enable_web_search"]) else "0"
+        )
+    if "minimal_config" in spec.executor.config:
+        env["HARNESS_CODEX_MINIMAL_CONFIG"] = (
+            "1" if _config_flag_is_true(spec.executor.config["minimal_config"]) else "0"
+        )
 
     # Generic-provider branch (slotted ahead of the legacy-profile /
     # databricks-prefix path): a ProviderAuth on the spec, or — when the spec

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -165,9 +165,10 @@ WELL_KNOWN_MANIFEST_VERSION = 1
 _WEB_UI_GZIP_MINIMUM_SIZE = 1024
 _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
+_POLLY_REVIEW_AGENT_NAME = "polly-review"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
 _SESSION_PATH_RE = re.compile(r"/v1/sessions/([^/]+)")
-# polly's and debby's multi-file bundles are packaged under
+# The shipped multi-file example bundles are packaged under
 # omnigent.resources.examples (see pyproject package-data), so they resolve
 # in both a repo checkout and an installed wheel. The presence check in each
 # seeder is a safety net.
@@ -175,6 +176,9 @@ _SESSION_PATH_RE = re.compile(r"/v1/sessions/([^/]+)")
 # Windows checkout (where Git leaves it as a stub text file); a no-op elsewhere.
 _DEBBY_BUNDLE_SOURCE = resolve_repo_symlink(Path(_examples_resources.__file__).parent / "debby")
 _POLLY_BUNDLE_SOURCE = resolve_repo_symlink(Path(_examples_resources.__file__).parent / "polly")
+_POLLY_REVIEW_BUNDLE_SOURCE = resolve_repo_symlink(
+    Path(_examples_resources.__file__).parent / "polly_review"
+)
 
 
 class _FastAPICallNext(Protocol):
@@ -479,6 +483,7 @@ def _ensure_default_agents(
     _ensure_default_native_agents(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_polly_review_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
 
 
@@ -735,6 +740,39 @@ def _ensure_default_polly_agent(
         agent_cache,
         name=_POLLY_AGENT_NAME,
         bundle_bytes=_build_polly_bundle(),
+    )
+
+
+def _build_polly_review_bundle() -> bytes:
+    """Build the packaged ``polly-review`` agent bundle."""
+    import tempfile
+
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bundle_dir = materialize_bundle(_POLLY_REVIEW_BUNDLE_SOURCE, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_polly_review_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """Register the packaged, fixed Polly Review agent when available."""
+    if not (_POLLY_REVIEW_BUNDLE_SOURCE / "config.yaml").is_file():
+        _logger.debug(
+            "polly-review bundle not found at %s; skipping seed",
+            _POLLY_REVIEW_BUNDLE_SOURCE,
+        )
+        return
+
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=_POLLY_REVIEW_AGENT_NAME,
+        bundle_bytes=_build_polly_review_bundle(),
     )
 
 
@@ -2559,17 +2597,17 @@ def create_app(
             )
 
         # Device Authorization Grant (RFC 8628): opt-in, default-off via
-        # OMNIGENT_DEVICE_GRANT_ENABLED, and accounts-mode only. OIDC delegates
-        # login to the IdP (cli-ticket flow), so it neither needs nor mounts
-        # these routes. Wires the revocation lookup into the auth provider so
+        # OMNIGENT_DEVICE_GRANT_ENABLED, under Accounts or full OIDC. Wires
+        # the revocation lookup into the auth provider so
         # revoking a grant immediately rejects its delegated access tokens.
         # See designs/DEVICE_AUTH.md.
         from omnigent.server.auth import env_var_is_truthy
+        from omnigent.server.routes.device_auth import unsupported_reason
 
         if (
             env_var_is_truthy("OMNIGENT_DEVICE_GRANT_ENABLED", default=False)
             and isinstance(auth_provider, UnifiedAuthProvider)
-            and auth_provider._source == "accounts"
+            and unsupported_reason(auth_provider) is None
             and permission_store is not None
         ):
             from omnigent.server.device_grant_store import DeviceGrantStore

--- a/omnigent/server/oidc.py
+++ b/omnigent/server/oidc.py
@@ -55,6 +55,8 @@ def mint_session_token(
     cookie_secret: bytes,
     ttl_seconds: int,
     provider: str,
+    *,
+    auth_time: int | None = None,
 ) -> str:
     """
     Mint a signed session JWT with a second-granularity lifetime.
@@ -71,15 +73,20 @@ def mint_session_token(
     :param ttl_seconds: Token lifetime in seconds.
     :param provider: Identity provider name, e.g. ``"google"`` or
         ``"accounts"``. Stored as an informational claim.
+    :param auth_time: When the user last proved their identity. Kept separate
+        from token issuance because an OIDC callback can silently reuse an IdP
+        session. Omitted when no fresh authentication was attested.
     :returns: An HS256-signed JWT string.
     """
     now = int(time.time())
-    payload = {
+    payload: dict[str, object] = {
         "sub": user_id,
         "iat": now,
         "exp": now + ttl_seconds,
         "provider": provider,
     }
+    if auth_time is not None:
+        payload["auth_time"] = auth_time
     return jwt.encode(payload, cookie_secret, algorithm="HS256")
 
 
@@ -88,6 +95,8 @@ def mint_session_cookie(
     cookie_secret: bytes,
     ttl_hours: int,
     provider: str,
+    *,
+    auth_time: int | None = None,
 ) -> str:
     """Mint a signed session cookie JWT.
 
@@ -97,9 +106,16 @@ def mint_session_cookie(
     :param ttl_hours: Session lifetime in hours.
     :param provider: Identity provider name, e.g. ``"google"``
         or ``"github"``. Stored as an informational claim.
+    :param auth_time: See :func:`mint_session_token`.
     :returns: An HS256-signed JWT string.
     """
-    return mint_session_token(user_id, cookie_secret, ttl_hours * 3600, provider)
+    return mint_session_token(
+        user_id,
+        cookie_secret,
+        ttl_hours * 3600,
+        provider,
+        auth_time=auth_time,
+    )
 
 
 def hmac_digest(token: str, secret: bytes) -> str:

--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -299,6 +299,7 @@ def create_accounts_auth_router(
             cookie_secret=config.cookie_secret,
             ttl_hours=config.session_ttl_hours,
             provider="accounts",
+            auth_time=now,
         )
 
         user = account_store.get_user(username)
@@ -446,6 +447,7 @@ def create_accounts_auth_router(
             cookie_secret=config.cookie_secret,
             ttl_hours=config.session_ttl_hours,
             provider="accounts",
+            auth_time=now,
         )
         resp = JSONResponse(
             status_code=200,
@@ -545,6 +547,7 @@ def create_accounts_auth_router(
             cookie_secret=config.cookie_secret,
             ttl_hours=config.session_ttl_hours,
             provider="accounts",
+            auth_time=now,
         )
         resp = JSONResponse(
             status_code=200,
@@ -631,6 +634,7 @@ def create_accounts_auth_router(
             cookie_secret=config.cookie_secret,
             ttl_hours=config.session_ttl_hours,
             provider="accounts",
+            auth_time=now,
         )
         resp = RedirectResponse(url="/", status_code=302)
         _set_session_cookie(

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -46,6 +46,9 @@ _AUTH_STATE_COOKIE_SECURE = "__Host-ap_auth_state"
 _AUTH_STATE_COOKIE_PLAIN = "ap_auth_state"
 _AUTH_STATE_TTL_SECONDS = 300  # 5 minutes
 _CLI_TICKET_TTL_SECONDS = 300  # 5 minutes
+# The signed state records a server timestamp while the IdP attests auth_time.
+# Permit only the existing bounded clock skew between them.
+_REAUTH_PROCESSING_ALLOWANCE_SECONDS = 120
 # How long an OIDC invite URL stays redeemable. Matches the accounts
 # provider's default invite window (72h) — long enough to share
 # out-of-band, short enough to bound exposure of an unused link.
@@ -163,6 +166,7 @@ def create_auth_router(
         # before the callback redeems it. Only meaningful when invites
         # are enabled; ignored otherwise.
         invite = request.query_params.get("invite") if _invites_enabled else None
+        reauth = request.query_params.get("reauth") == "1" and config.provider_type == "oidc"
 
         # Store state + code_verifier in a short-lived signed cookie.
         state_payload: dict[str, str | int] = {
@@ -175,6 +179,8 @@ def create_auth_router(
             state_payload["ticket"] = ticket
         if invite:
             state_payload["invite"] = invite
+        if reauth:
+            state_payload["reauth_at"] = int(time.time())
         state_jwt = jwt.encode(state_payload, config.cookie_secret, algorithm="HS256")
 
         # Build the authorization URL.
@@ -187,6 +193,9 @@ def create_auth_router(
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        if reauth:
+            params["prompt"] = "login"
+            params["max_age"] = "0"
         auth_url = config.authorization_endpoint + "?" + urlencode(params)
 
         response = RedirectResponse(url=auth_url, status_code=302)
@@ -264,6 +273,7 @@ def create_auth_router(
             "code_verifier": code_verifier,
         }
 
+        proven_at: int | None = None
         async with httpx.AsyncClient() as client:
             # GitHub requires Accept: application/json to get JSON
             # response from the token endpoint.
@@ -302,7 +312,15 @@ def create_auth_router(
                     access_token if isinstance(access_token, str) else "",
                 )
             else:
-                email = _resolve_oidc_email(token_json, config)
+                verified_claims = _verified_id_token_claims(token_json, config)
+                email = _resolve_oidc_email_from_verified_claims(verified_claims, config)
+                if state_payload.get("reauth_at") is not None:
+                    if not _idp_reauthenticated(verified_claims, state_payload.get("reauth_at")):
+                        return JSONResponse(
+                            status_code=403,
+                            content={"error": "Re-authentication was required but did not occur"},
+                        )
+                    proven_at = int(time.time())
 
         if not email:
             return JSONResponse(
@@ -359,6 +377,7 @@ def create_auth_router(
             cookie_secret=config.cookie_secret,
             ttl_hours=config.session_ttl_hours,
             provider=config.provider_type,
+            auth_time=proven_at,
         )
 
         # Check if this callback fulfills a CLI login ticket.
@@ -767,6 +786,42 @@ def _claim_is_verified_true(value: object) -> bool:
     return isinstance(value, str) and value.strip().lower() == "true"
 
 
+def _verified_id_token_claims(
+    token_json: dict[str, object],
+    config: OIDCConfig,
+) -> dict[str, object] | None:
+    """Validate an OIDC ID token and return only its verified claims."""
+    id_token = token_json.get("id_token")
+    if not isinstance(id_token, str) or not id_token:
+        return None
+    if config.jwks_uri is None:
+        _logger.warning("Rejecting id_token: OIDC configuration has no JWKS URI")
+        return None
+    try:
+        signing_key = jwt.PyJWKClient(config.jwks_uri).get_signing_key_from_jwt(id_token)
+        claims: dict[str, object] = jwt.decode(
+            id_token,
+            signing_key.key,
+            algorithms=["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"],
+            audience=config.client_id,
+            issuer=config.issuer,
+        )
+    except jwt.InvalidTokenError as exc:
+        _logger.warning("id_token validation failed: %s", exc)
+        return None
+    return claims
+
+
+def _idp_reauthenticated(verified_claims: dict[str, object] | None, reauth_at: object) -> bool:
+    """Return whether the IdP attests authentication after signed reauth demand."""
+    if verified_claims is None or not isinstance(reauth_at, int):
+        return False
+    auth_time = verified_claims.get("auth_time")
+    return isinstance(auth_time, int) and auth_time >= (
+        reauth_at - _REAUTH_PROCESSING_ALLOWANCE_SECONDS
+    )
+
+
 def _resolve_oidc_email(
     token_json: dict[str, object],
     config: OIDCConfig,
@@ -805,28 +860,21 @@ def _resolve_oidc_email(
         ``email_verified`` is not truthy (and verification is not
         skipped via config).
     """
-    id_token = token_json.get("id_token")
-    if not isinstance(id_token, str) or not id_token:
-        return None
-    if config.jwks_uri is None:
-        _logger.warning("Rejecting id_token: OIDC configuration has no JWKS URI")
+    return _resolve_oidc_email_from_verified_claims(
+        _verified_id_token_claims(token_json, config),
+        config,
+    )
+
+
+def _resolve_oidc_email_from_verified_claims(
+    verified_claims: dict[str, object] | None,
+    config: OIDCConfig,
+) -> str | None:
+    """Resolve an email from claims already verified by the OIDC boundary."""
+    if verified_claims is None:
         return None
 
-    try:
-        jwks_client = jwt.PyJWKClient(config.jwks_uri)
-        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
-        claims = jwt.decode(
-            id_token,
-            signing_key.key,
-            algorithms=["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"],
-            audience=config.client_id,
-            issuer=config.issuer,
-        )
-    except jwt.InvalidTokenError as exc:
-        _logger.warning("id_token validation failed: %s", exc)
-        return None
-
-    email = claims.get(config.email_claim)
+    email = verified_claims.get(config.email_claim)
     if not isinstance(email, str) or not email.strip():
         _logger.warning(
             "Rejecting id_token: %r claim is missing or not a non-empty string "
@@ -834,7 +882,7 @@ def _resolve_oidc_email(
             "IdPs that use a different claim for the email identity "
             "can set OMNIGENT_OIDC_EMAIL_CLAIM.",
             config.email_claim,
-            sorted(claims.keys()),
+            sorted(verified_claims.keys()),
         )
         return None
     email = email.strip()
@@ -867,7 +915,7 @@ def _resolve_oidc_email(
     # Absent/false ``email_verified`` is a hard reject — unless the
     # operator opted out (OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION) for
     # IdPs like Okta that omit the claim for directory-managed users.
-    if not _claim_is_verified_true(claims.get("email_verified")):
+    if not _claim_is_verified_true(verified_claims.get("email_verified")):
         if config.skip_email_verification:
             _logger.info(
                 "Accepting id_token email %r without email_verified "

--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -21,10 +21,10 @@ Endpoints (all mounted at the app root):
   returns delegated access + refresh tokens.
 - ``POST /oauth/revoke`` — revoke a grant (backs client logout).
 
-Mounted only in ``accounts`` auth mode (and only when
-``OMNIGENT_DEVICE_GRANT_ENABLED`` is set). OIDC deployments delegate login
-to the IdP via the cli-ticket flow (``/auth/cli-login``) and never use this
-grant; header mode has no server-mintable identity.
+Mounted in Accounts and full-OIDC auth modes when
+``OMNIGENT_DEVICE_GRANT_ENABLED`` is set. GitHub OAuth cannot attest a forced
+reauthentication, and header mode has no server-mintable identity, so neither
+can carry this grant.
 
 See ``designs/DEVICE_AUTH.md`` for the full design + threat model.
 
@@ -53,6 +53,7 @@ import logging
 import os
 import secrets
 import time
+from urllib.parse import quote
 
 import jwt
 from fastapi import APIRouter, HTTPException, Request
@@ -257,23 +258,41 @@ class _SlidingWindowRateLimiter:
         return True
 
 
+def unsupported_reason(auth_provider: UnifiedAuthProvider) -> str | None:
+    """Return why an auth provider cannot safely carry a device grant."""
+    if auth_provider._source not in ("accounts", "oidc"):
+        return f"{auth_provider._source!r} auth has no server-minted session to delegate from"
+    if auth_provider._source == "oidc":
+        config = auth_provider._oidc_config
+        if config is None:
+            return "oidc auth is selected but no OIDC config is present"
+        if config.provider_type != "oidc":
+            return (
+                f"{config.provider_type!r} is not full OIDC, so it cannot force and attest "
+                "reauthentication"
+            )
+    return None
+
+
 def create_device_auth_router(
     auth_provider: UnifiedAuthProvider,
     device_grant_store: DeviceGrantStore,
 ) -> APIRouter:
     """Build the ``/oauth/*`` device-grant router.
 
-    :param auth_provider: The active provider. Must be ``accounts`` mode;
-        its cookie config supplies the HMAC signing key and public base URL.
+    :param auth_provider: The active Accounts or full-OIDC provider.
     :param device_grant_store: Persistence for device grants.
     :returns: APIRouter to mount at the app root.
     """
-    if auth_provider._source != "accounts":
-        raise RuntimeError(
-            f"create_device_auth_router requires accounts auth (got {auth_provider._source!r})"
-        )
-    cookie_config = auth_provider._accounts_config
-    assert cookie_config is not None, "accounts mode must have an accounts config"
+    reason = unsupported_reason(auth_provider)
+    if reason is not None:
+        raise RuntimeError(f"create_device_auth_router cannot build: {reason}")
+    cookie_config = (
+        auth_provider._oidc_config
+        if auth_provider._source == "oidc"
+        else auth_provider._accounts_config
+    )
+    assert cookie_config is not None, f"{auth_provider._source} mode must have a cookie config"
     cookie_secret = cookie_config.cookie_secret
     base_url = cookie_config.base_url
     provider_name = auth_provider._source
@@ -389,28 +408,15 @@ def create_device_auth_router(
 
     # ── Browser consent page ──────────────────────────────────────
 
-    def _bounce_to_login(user_code: str, *, reauth: bool) -> RedirectResponse:
-        """302 to the login page, returning to this consent URL afterward.
-
-        ``reauth`` adds ``&reauth=1`` so the login page forces a fresh
-        password submit instead of auto-bouncing an already-signed-in user
-        (which would loop back here with the same stale session).
-        """
+    def _bounce_to_login(user_code: str) -> RedirectResponse:
+        """Force login, then return to this consent URL."""
         login_url = auth_provider.login_url or "/login"
         return_to = f"/oauth/device?user_code={user_code}" if user_code else "/oauth/device"
-        query = f"return_to={html.escape(return_to, quote=True)}"
-        if reauth:
-            query += "&reauth=1"
+        query = f"return_to={quote(return_to, safe='/')}&reauth=1"
         return RedirectResponse(url=f"{login_url}?{query}", status_code=302)
 
-    def _session_iat(request: Request) -> int | None:
-        """Return the ``iat`` (issue time) of the caller's session JWT.
-
-        Read from the session cookie (accounts mode mints a fresh ``iat``
-        on every ``/auth/login``, so this is effectively the last-login
-        time). ``None`` when absent/invalid. Used to enforce that consent
-        follows a login started FOR this device flow.
-        """
+    def _session_auth_time(request: Request) -> int | None:
+        """Return when the session owner last proved their identity."""
         token = request.cookies.get(cookie_config.session_cookie_name)
         if not token:
             return None
@@ -418,8 +424,8 @@ def create_device_auth_router(
             payload = jwt.decode(token, cookie_secret, algorithms=["HS256"])
         except jwt.InvalidTokenError:
             return None
-        iat = payload.get("iat")
-        return iat if isinstance(iat, int) else None
+        auth_time = payload.get("auth_time")
+        return auth_time if isinstance(auth_time, int) else None
 
     @router.get("/oauth/device")
     async def device_consent_page(request: Request) -> Response:
@@ -431,8 +437,8 @@ def create_device_auth_router(
         Omnigent identity being delegated and the requesting ``client_id``
         so any mismatch is visible before approval.
 
-        **Re-authentication:** consent requires a login performed AFTER this
-        device flow began (session ``iat`` ≥ the grant's ``created_at``). A
+        **Re-authentication:** consent requires proof performed AFTER this
+        device flow began (session ``auth_time`` ≥ the grant's ``created_at``). A
         pre-existing session — however recent — is bounced back through the
         login page with ``reauth=1``, so approving a device grant always
         costs a deliberate, fresh password entry. This closes the
@@ -443,7 +449,7 @@ def create_device_auth_router(
         user_id = auth_provider.get_user_id(request)
         user_code = (request.query_params.get("user_code") or "").strip()
         if user_id is None:
-            return _bounce_to_login(user_code, reauth=False)
+            return _bounce_to_login(user_code)
 
         if not user_code:
             return HTMLResponse(_consent_html(prompt_for_code=True), status_code=200)
@@ -456,13 +462,11 @@ def create_device_auth_router(
                 status_code=200,
             )
 
-        # Force a fresh login when the current session predates this grant:
-        # only a login started for THIS flow (iat ≥ the grant's created_at)
-        # may approve. Bounce with reauth=1 so the login page re-prompts
-        # rather than auto-returning the stale session (which would loop).
-        session_iat = _session_iat(request)
-        if session_iat is None or session_iat < grant.created_at:
-            return _bounce_to_login(user_code, reauth=True)
+        # Only a credential proven for this flow may approve it. Bounce with
+        # reauth=1 so the login path re-prompts instead of reusing a session.
+        session_auth_time = _session_auth_time(request)
+        if session_auth_time is None or session_auth_time < grant.created_at:
+            return _bounce_to_login(user_code)
 
         return HTMLResponse(
             _consent_html(
@@ -496,11 +500,9 @@ def create_device_auth_router(
                 status_code=200,
             )
 
-        # Re-auth gate, enforced here too (not just on the consent GET): a
-        # stale session must not approve by POSTing directly. Only a login
-        # started for THIS flow (session iat ≥ the grant's created_at) passes.
-        session_iat = _session_iat(request)
-        if session_iat is None or session_iat < grant.created_at:
+        # Enforce the proof on POST too so a direct request cannot bypass GET.
+        session_auth_time = _session_auth_time(request)
+        if session_auth_time is None or session_auth_time < grant.created_at:
             return HTMLResponse(
                 _consent_html(
                     error="Your session is too old to approve this login. "
@@ -647,9 +649,16 @@ def create_device_auth_router(
             max_lifetime_seconds=_GRANT_MAX_LIFETIME_SECONDS,
         )
         if rotated is None:
-            # Lost a concurrent rotation race, or the grant aged out between
-            # the check above and here — reject without revoking (this is not
-            # a reuse signal, so the grant must not be killed/oscillate).
+            # A CAS loser might have raced another holder of this same token.
+            # Recheck after the failed update: a now-previous digest is reuse
+            # and must revoke the winner's freshly-issued token. If it is not
+            # previous, this was an age-out/mismatch and must not revoke.
+            stale = device_grant_store.get_by_prev_refresh_hash(presented_hash)
+            if stale is not None and stale.id == grant.id:
+                device_grant_store.revoke(stale.id)
+                _logger.warning(
+                    "oauth/token: refresh reuse detected on grant %s — revoked", stale.id
+                )
             return _oauth_error("invalid_grant")
         if rotated.user_id is None:
             return _oauth_error("invalid_grant")

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -1567,3 +1567,9 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     spawn: bool = False
     agent_session_sharing: SharePolicy = SharePolicy.NONE
     source_rel_dir: str | None = field(default=None, compare=False)
+
+    @property
+    def tool_free(self) -> bool:
+        """Whether the harness and runner must expose no tools for this agent."""
+        value = self.executor.config.get("tool_free")
+        return value is True or (isinstance(value, str) and value.lower() == "true")

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -154,6 +154,8 @@ class ToolManager:
         # ``shutdown`` can close it cleanly. ``None`` when the spec
         # didn't declare ``os_env``.
         self._os_env: OSEnvironment | None = None
+        if spec.tool_free:
+            return
         self._register_skill_tools()
         self._register_builtin_tools()
         self._register_sub_agent_tools()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,7 +397,7 @@ include = ["omnigent*"]
 [tool.setuptools.package-data]
 "omnigent.db" = ["alembic.ini"]
 "omnigent.db.migrations" = ["script.py.mako"]
-"omnigent.resources.examples" = ["*.yaml", "*.sh", "debby/**/*", "polly/**/*"]
+"omnigent.resources.examples" = ["*.yaml", "*.sh", "debby/**/*", "polly/**/*", "polly_review/**/*"]
 "omnigent.resources.pi_native" = ["*.js"]
 "omnigent.resources.scripts" = ["*.sh"]
 # include UI assets in build, plus the static API-only landing page served

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class _GenerateBuildInfo(build_py):
     def _bundle_examples(self) -> None:
         """Copy bundled example agents into the wheel as real directories.
 
-        ``omnigent/resources/examples/{polly,debby}`` may exist as symlinks
+        ``omnigent/resources/examples/{polly,debby,polly_review}`` may exist as symlinks
         into the top-level ``examples/`` tree (or not at all) depending on
         the checkout, and setuptools' ``package-data`` never materializes
         symlinks into the built wheel — a directory symlink is not walked.
@@ -79,7 +79,7 @@ class _GenerateBuildInfo(build_py):
 
         root = Path(__file__).resolve().parent
         dest_root = Path(self.build_lib) / "omnigent" / "resources" / "examples"
-        for name in ("debby", "polly"):
+        for name in ("debby", "polly", "polly_review"):
             src = root / "examples" / name
             if not src.is_dir():
                 continue

--- a/tests/cli/test_integration_slack.py
+++ b/tests/cli/test_integration_slack.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
 
@@ -11,6 +15,201 @@ from click.testing import CliRunner
 
 from omnigent.cli import cli
 from omnigent.integration_daemon import DaemonRecord, IntegrationDaemon
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock ownership test")
+def test_stale_reused_pid_is_not_signaled_when_owner_lock_is_mismatched(tmp_path: Path) -> None:
+    import fcntl
+    import json
+    import os
+
+    daemon = IntegrationDaemon("slack", tmp_path)
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"], start_new_session=True
+    )
+    daemon._write_record(DaemonRecord(pid=process.pid, log_path="/tmp/x.log", started_at=1))
+    daemon._owner_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with daemon._owner_path.open("w+") as lock:
+            json.dump({"pid": os.getpid(), "token": "other-owner"}, lock)
+            lock.flush()
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+
+            current = daemon.running_record()
+            assert current is not None and current.pid == process.pid
+            saved = daemon.read_record()
+            assert saved is not None and saved.pid == process.pid
+            with pytest.raises(RuntimeError, match="cannot be verified"):
+                daemon.stop(grace_seconds=0)
+            assert process.poll() is None
+            assert json.loads(daemon._owner_path.read_text())["pid"] == os.getpid()
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock ownership test")
+def test_running_record_accepts_current_foreground_owner(tmp_path: Path) -> None:
+    daemon = IntegrationDaemon("slack", tmp_path)
+    record = daemon.acquire_current(tmp_path / "slack.log")
+    try:
+        assert daemon.running_record() == record
+    finally:
+        daemon.release_current()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock ownership test")
+def test_held_owner_lock_retries_transient_metadata_read(tmp_path: Path) -> None:
+    import fcntl
+    import json
+
+    daemon = IntegrationDaemon("slack", tmp_path)
+    record = DaemonRecord(pid=4242, log_path="/tmp/x.log", started_at=1)
+    daemon._write_record(record)
+    daemon._owner_path.parent.mkdir(parents=True, exist_ok=True)
+    with daemon._owner_path.open("w+") as lock:
+        json.dump({"pid": record.pid, "token": "owner"}, lock)
+        lock.flush()
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        owner = daemon._owner()
+        with (
+            mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+            mock.patch.object(daemon, "_owner", side_effect=[None, owner]),
+        ):
+            assert daemon.running_record() == record
+    assert daemon.read_record() == record
+
+
+def test_live_legacy_record_blocks_duplicate_start_and_refuses_stop(tmp_path: Path) -> None:
+    daemon = IntegrationDaemon("slack", tmp_path)
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"], start_new_session=True
+    )
+    record = DaemonRecord(pid=process.pid, log_path="/tmp/x.log", started_at=1)
+    daemon._write_record(record)
+    try:
+        assert daemon.running_record() == record
+        with mock.patch("omnigent.integration_daemon.subprocess.Popen") as popen:
+            with pytest.raises(RuntimeError, match="already running"):
+                daemon.start(["never-run"], {})
+        popen.assert_not_called()
+        with pytest.raises(RuntimeError, match="cannot be verified"):
+            daemon.stop(grace_seconds=0)
+        assert process.poll() is None
+        assert daemon.read_record() == record
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+
+def test_windows_owner_identity_allows_lifecycle_and_rejects_reuse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json
+
+    import omnigent.integration_daemon as daemon_module
+
+    daemon = IntegrationDaemon("slack", tmp_path)
+    record = DaemonRecord(pid=4242, log_path="/tmp/x.log", started_at=1, identity="birth")
+    daemon._write_record(record)
+    daemon._owner_path.parent.mkdir(parents=True, exist_ok=True)
+    daemon._owner_path.write_text(json.dumps({"pid": record.pid, "token": "owner"}))
+    monkeypatch.setattr(daemon_module, "fcntl", None)
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_pid_identity", return_value="birth"),
+        mock.patch.object(IntegrationDaemon, "_signal"),
+    ):
+        assert daemon.running_record() == record
+        assert daemon.confirm_alive(record, grace_seconds=0)
+        assert daemon.stop(grace_seconds=0) == record
+
+    daemon._write_record(record)
+    daemon._owner_path.write_text(json.dumps({"pid": record.pid, "token": "owner"}))
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_pid_identity", return_value="reused"),
+        mock.patch.object(IntegrationDaemon, "_signal") as signal_process,
+    ):
+        assert daemon.running_record() == record
+        with pytest.raises(RuntimeError, match="cannot be verified"):
+            daemon.stop(grace_seconds=0)
+    signal_process.assert_not_called()
+
+
+def test_windows_pid_identity_uses_full_win32_process_times_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+    from types import SimpleNamespace
+
+    import omnigent.integration_daemon as daemon_module
+
+    calls: dict[str, object] = {}
+
+    class Function:
+        def __init__(self, callback: object) -> None:
+            self.callback = callback
+            self.argtypes: object | None = None
+            self.restype: object | None = None
+
+        def __call__(self, *args: object) -> object:
+            return self.callback(*args)  # type: ignore[operator]
+
+    def open_process(access: object, inherit: object, pid: object) -> int:
+        calls["open"] = (access, inherit, pid)
+        return 1 << 40
+
+    def get_times(handle: object, *times: object) -> int:
+        calls["times"] = (handle, times)
+        created = ctypes.cast(times[0], ctypes.POINTER(wintypes.FILETIME)).contents
+        created.dwLowDateTime = 7
+        created.dwHighDateTime = 3
+        return 1
+
+    def close_handle(handle: object) -> int:
+        calls["close"] = handle
+        return 1
+
+    kernel32 = SimpleNamespace(
+        OpenProcess=Function(open_process),
+        GetProcessTimes=Function(get_times),
+        CloseHandle=Function(close_handle),
+    )
+    monkeypatch.setattr(daemon_module.os, "name", "nt")
+    monkeypatch.setattr(ctypes, "windll", SimpleNamespace(kernel32=kernel32), raising=False)
+
+    assert IntegrationDaemon._pid_identity(42) == str((3 << 32) | 7)
+    assert calls["open"] == (0x1000, False, 42)
+    assert calls["close"] == 1 << 40
+    handle, times = calls["times"]
+    assert handle == 1 << 40
+    assert len(times) == 4 and all(time is not None for time in times)
+    assert kernel32.OpenProcess.argtypes == [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    assert kernel32.OpenProcess.restype is wintypes.HANDLE
+    assert kernel32.GetProcessTimes.argtypes == [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    assert kernel32.GetProcessTimes.restype is wintypes.BOOL
+    assert kernel32.CloseHandle.argtypes == [wintypes.HANDLE]
+    assert kernel32.CloseHandle.restype is wintypes.BOOL
+
+
+def test_windows_pid_alive_never_uses_os_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    import omnigent.integration_daemon as daemon_module
+
+    monkeypatch.setattr(daemon_module.os, "name", "nt")
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_identity", return_value="birth"),
+        mock.patch.object(daemon_module.os, "kill") as kill,
+    ):
+        assert IntegrationDaemon._pid_alive(42)
+    kill.assert_not_called()
 
 
 @pytest.fixture
@@ -58,6 +257,7 @@ def test_stop_signals_and_clears(tmp_path: Path) -> None:
     alive = iter([True, False, False])
     with (
         mock.patch.object(IntegrationDaemon, "_pid_alive", side_effect=lambda _pid: next(alive)),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
         mock.patch.object(
             IntegrationDaemon, "_signal", side_effect=lambda pid, sig: calls.append(sig)
         ),
@@ -80,9 +280,67 @@ def test_confirm_alive_prunes_dead_record(tmp_path: Path) -> None:
     with mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=False):
         assert d.confirm_alive(record, grace_seconds=0.0) is False
     assert d.read_record() is None  # pruned
-    with mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True):
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
+    ):
         d._write_record(record)
         assert d.confirm_alive(record, grace_seconds=0.0) is True
+
+
+def test_concurrent_daemon_claims_have_exactly_one_owner(tmp_path: Path) -> None:
+    daemons = [IntegrationDaemon("polly", tmp_path), IntegrationDaemon("polly", tmp_path)]
+    barrier = threading.Barrier(2)
+
+    def synchronized_missing_record(_daemon: IntegrationDaemon) -> None:
+        barrier.wait()
+
+    def claim(daemon: IntegrationDaemon) -> bool:
+        try:
+            daemon.acquire_current(tmp_path / "polly.log")
+        except RuntimeError:
+            return False
+        return True
+
+    with mock.patch.object(IntegrationDaemon, "running_record", synchronized_missing_record):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            claimed = list(pool.map(claim, daemons))
+
+    assert sorted(claimed) == [False, True]
+    daemons[claimed.index(True)].release_current()
+
+
+def test_background_owner_lock_survives_spawn_handoff(tmp_path: Path) -> None:
+    ready = tmp_path / "ready"
+    script = """
+import sys
+import time
+from pathlib import Path
+from omnigent.integration_daemon import IntegrationDaemon
+
+daemon = IntegrationDaemon("polly", Path(sys.argv[1]))
+daemon.acquire_current(Path(sys.argv[1]) / "polly.log")
+Path(sys.argv[2]).write_text("ready")
+try:
+    time.sleep(30)
+finally:
+    daemon.release_current()
+"""
+    daemon = IntegrationDaemon("polly", tmp_path)
+    record = daemon.start([sys.executable, "-c", script, str(tmp_path), str(ready)], {})
+    try:
+        deadline = time.time() + 5
+        while not ready.exists() and time.time() < deadline:
+            time.sleep(0.05)
+        assert ready.exists()
+        assert daemon.running_record() == record
+
+        daemon._clear_record()
+        with pytest.raises(RuntimeError, match="already running"):
+            IntegrationDaemon("polly", tmp_path).acquire_current(tmp_path / "other.log")
+    finally:
+        daemon._write_record(record)
+        daemon.stop(grace_seconds=1)
 
 
 # ── CLI wiring ────────────────────────────────────────────────────
@@ -122,6 +380,7 @@ def test_slack_background_status_stop_lifecycle(data_dir: Path) -> None:
         # its own tests; short-circuit it here so the happy path doesn't wait
         # out the grace period.
         mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
         mock.patch.object(IntegrationDaemon, "confirm_alive", return_value=True),
     ):
         popen.return_value.pid = 9911
@@ -144,6 +403,7 @@ def test_slack_background_status_stop_lifecycle(data_dir: Path) -> None:
     # stop terminates and clears.
     with (
         mock.patch.object(IntegrationDaemon, "_pid_alive", side_effect=[True, False, False]),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
         mock.patch.object(IntegrationDaemon, "_signal"),
     ):
         stop = runner.invoke(cli, ["integration", "slack", "stop"])
@@ -207,6 +467,7 @@ def test_slack_foreground_refuses_when_daemon_running(data_dir: Path) -> None:
     with (
         mock.patch("omnigent.cli._slack_installed", return_value=True),
         mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
         mock.patch("omnigent.cli.subprocess.run") as run,
     ):
         result = runner.invoke(cli, ["integration", "slack"])

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1917,6 +1917,71 @@ class TestStreamEventStreaming(unittest.TestCase):
 
         _run(_t())
 
+    def test_tool_free_session_sends_no_dynamic_or_discovery_tools(self):
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        captured_options = {}
+
+        class _ResultMessage:
+            def __init__(self, session_id, result):
+                self.session_id = session_id
+                self.result = result
+
+        class _FakeSDK:
+            AssistantMessage = type("AssistantMessage", (), {})
+            UserMessage = type("UserMessage", (), {})
+            SystemMessage = type("SystemMessage", (), {})
+            ResultMessage = _ResultMessage
+            StreamEvent = type("StreamEvent", (), {})
+            ClaudeAgentOptions = type(
+                "ClaudeAgentOptions",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            )
+            messages = []
+
+            @staticmethod
+            def create_sdk_mcp_server(**kwargs):
+                raise AssertionError(f"tool-free request created MCP server: {kwargs}")
+
+            class ClaudeSDKClient:
+                def __init__(self, options):
+                    captured_options.update(options.__dict__)
+
+                async def connect(self):
+                    return None
+
+                async def query(self, prompt, session_id="default"):
+                    _FakeSDK.messages = [_ResultMessage(session_id, "done")]
+
+                async def receive_response(self):
+                    for message in _FakeSDK.messages:
+                        yield message
+
+                async def disconnect(self):
+                    return None
+
+        async def _t():
+            executor = ClaudeSDKExecutor(tool_free=True)
+            with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
+                events = [
+                    event
+                    async for event in executor.run_turn(
+                        [{"role": "user", "content": "hi", "session_id": "session-a"}],
+                        [{"name": "sleep", "description": "sleep", "parameters": {}}],
+                        "",
+                    )
+                ]
+
+            self.assertEqual(captured_options["tools"], [])
+            self.assertEqual(captured_options["allowed_tools"], [])
+            self.assertEqual(captured_options["mcp_servers"], {})
+            self.assertEqual(captured_options["skills"], [])
+            self.assertEqual(captured_options["setting_sources"], [])
+            self.assertIsInstance(events[-1], TurnComplete)
+
+        _run(_t())
+
     def test_session_send_tool_is_exposed_via_mcp(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
 

--- a/tests/inner/test_claude_sdk_harness.py
+++ b/tests/inner/test_claude_sdk_harness.py
@@ -79,6 +79,7 @@ def test_executor_factory_reads_env_vars(
     monkeypatch.setenv("HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH_INTERVAL_MS", "900000")
     monkeypatch.setenv("HARNESS_CLAUDE_SDK_CWD", "/tmp/test-cwd")
     monkeypatch.setenv("HARNESS_CLAUDE_SDK_PERMISSION_MODE", "acceptEdits")
+    monkeypatch.setenv("HARNESS_CLAUDE_SDK_TOOL_FREE", "1")
 
     captured: dict[str, Any] = {}
 
@@ -95,6 +96,7 @@ def test_executor_factory_reads_env_vars(
         base_url_override: str | None,
         gateway_auth_command: str | None,
         gateway_auth_refresh_interval_ms: str | None,
+        tool_free: bool,
         **_kwargs: Any,
     ) -> None:
         captured["cwd"] = cwd
@@ -107,6 +109,7 @@ def test_executor_factory_reads_env_vars(
         captured["base_url_override"] = base_url_override
         captured["gateway_auth_command"] = gateway_auth_command
         captured["gateway_auth_refresh_interval_ms"] = gateway_auth_refresh_interval_ms
+        captured["tool_free"] = tool_free
 
     with patch(
         "omnigent.inner.claude_sdk_harness.ClaudeSDKExecutor.__init__",
@@ -125,6 +128,7 @@ def test_executor_factory_reads_env_vars(
     assert captured["gateway_auth_refresh_interval_ms"] == "900000"
     assert captured["cwd"] == "/tmp/test-cwd"
     assert captured["permission_mode"] == "acceptEdits"
+    assert captured["tool_free"] is True
     # When ``HARNESS_CLAUDE_SDK_OS_ENV`` is unset (this test
     # doesn't set it), the wrap defaults to ``caller_process +
     # sandbox=none`` so the SDK exposes its native tools to the

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -38,6 +38,8 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.model_fallbacks import CODEX_DEFAULT_MODEL
+from omnigent.runtime.workflow import _build_codex_spawn_env
+from omnigent.spec.types import AgentSpec, ExecutorSpec
 
 
 def _run(coro):
@@ -956,6 +958,65 @@ class TestCodexExecutor(unittest.TestCase):
 
         _run(_t())
 
+    def test_app_server_disables_native_shell_without_dynamic_tools(self):
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+                disable_native_tools=True,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session._request = AsyncMock(
+                side_effect=[
+                    {"result": {"thread": {"id": "thread-1"}}},
+                    {"result": {"turn": {"id": "turn-1"}}},
+                ]
+            )
+
+            async def _inject_turn_completed() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "turn/completed",
+                        "params": {"turn": {"id": "turn-1"}},
+                    }
+                )
+
+            inject_task = asyncio.create_task(_inject_turn_completed())
+            _ = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "hi"}],
+                    tools=[],
+                    system_prompt="Be helpful.",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                )
+            ]
+            await inject_task
+
+            params = session._request.await_args_list[0].args[1]
+            self.assertEqual(
+                params["config"]["features"],
+                {
+                    "unified_exec": False,
+                    "shell_tool": False,
+                    "apps": False,
+                    "browser_use": False,
+                    "computer_use": False,
+                    "image_generation": False,
+                    "multi_agent": False,
+                    "tool_search": False,
+                    "view_image": False,
+                },
+            )
+
+        _run(_t())
+
     def test_close_uses_process_tree_termination(self):
         async def _t():
             session = _CodexAppServerSession(
@@ -1169,6 +1230,88 @@ class TestCodexExecutor(unittest.TestCase):
                     await session.close()
 
                 self.assertFalse(codex_home.exists())
+
+        _run(_t())
+
+    def test_minimal_config_reaches_session_and_keeps_workspace_empty(self):
+        """Reviewer spawn config survives executor filtering through session startup."""
+
+        async def _t():
+            recorded_home: Path | None = None
+
+            async def _failing_create_subprocess_exec(*args, **kwargs):
+                nonlocal recorded_home
+                recorded_home = Path(kwargs["env"]["CODEX_HOME"])
+                self.assertTrue((recorded_home / "auth.json").is_symlink())
+                self.assertFalse((recorded_home / "AGENTS.md").exists())
+                self.assertFalse((recorded_home / "hooks.json").exists())
+                self.assertFalse((recorded_home / "plugins").exists())
+                config_text = (recorded_home / "config.toml").read_text()
+                self.assertIn('model_provider = "reviewer"', config_text)
+                self.assertIn("[model_providers.reviewer]", config_text)
+                self.assertNotIn("mcp_servers", config_text)
+                raise RuntimeError("start failed")
+
+            with tempfile.TemporaryDirectory() as workspace:
+                with tempfile.TemporaryDirectory() as source:
+                    source_home = Path(source)
+                    (source_home / "auth.json").write_text('{"auth_mode": "chatgpt"}')
+                    (source_home / "AGENTS.md").write_text("ambient instructions")
+                    (source_home / "hooks.json").write_text('{"hooks": {}}')
+                    (source_home / "plugins" / "cache").mkdir(parents=True)
+                    (source_home / "config.toml").write_text(
+                        'model_provider = "reviewer"\n'
+                        '[model_providers.reviewer]\nbase_url = "https://example.test"\n'
+                        '[mcp_servers.ambient]\ncommand = "do-not-run"\n'
+                    )
+                    spec = AgentSpec(
+                        spec_version=1,
+                        name="codex-review",
+                        instructions="Review only the supplied diff.",
+                        executor=ExecutorSpec(
+                            type="omnigent",
+                            config={"harness": "codex", "minimal_config": True},
+                        ),
+                    )
+                    with (
+                        patch(
+                            "omnigent.runtime.workflow._resolve_provider_for_build",
+                            return_value=None,
+                        ),
+                        patch(
+                            "omnigent.runtime.workflow.codex_config_provider_dismissed",
+                            return_value=False,
+                        ),
+                        patch("omnigent.runtime.workflow._apply_harness_path_override"),
+                    ):
+                        spawn_env = _build_codex_spawn_env(spec)
+                    with patch.dict("os.environ", spawn_env, clear=True):
+                        executor = CodexExecutor(codex_path="/bin/echo")
+                    session = _CodexAppServerSession(
+                        codex_path="/bin/echo",
+                        cwd=workspace,
+                        env=executor._env,
+                        tool_executor=None,
+                    )
+                    session._request = AsyncMock(return_value={"result": {}})
+
+                    with (
+                        patch(
+                            "omnigent.inner.codex_executor._create_subprocess_exec",
+                            new=_failing_create_subprocess_exec,
+                        ),
+                        patch(
+                            "omnigent.inner.codex_executor._codex_home_config_source_from_env",
+                            return_value=source_home,
+                        ),
+                    ):
+                        with self.assertRaisesRegex(RuntimeError, "start failed"):
+                            await session.start()
+
+                    assert recorded_home is not None
+                    self.assertTrue(str(recorded_home).startswith(tempfile.gettempdir()))
+                    self.assertFalse(recorded_home.exists())
+                    self.assertEqual(list(Path(workspace).iterdir()), [])
 
         _run(_t())
 
@@ -2531,8 +2674,10 @@ def test_populate_codex_home_config_minimal_mode_keeps_only_provider_routing(
     (source / "auth.json").write_text('{"auth_mode": "chatgpt"}')
     (source / "AGENTS.md").write_text("global guidance")
     (source / "config.toml").write_text(
-        'model_provider = "Databricks"\n'
+        'model_provider = "unselected"\n'
+        'profile = "enterprise"\n'
         '[model_providers.Databricks]\nname = "Databricks"\nbase_url = "https://example"\n'
+        '[profiles.enterprise]\nmodel_provider = "Databricks"\n'
         "[plugins.example]\nenabled = true\n"
         '[mcp_servers.github]\nenabled = true\ncommand = "github-mcp"\n'
         '[marketplaces.example]\nsource = "https://example"\n'
@@ -2546,8 +2691,10 @@ def test_populate_codex_home_config_minimal_mode_keeps_only_provider_routing(
     assert (target / "auth.json").is_symlink()
     assert not (target / "AGENTS.md").exists()
     config_text = (target / "config.toml").read_text()
-    assert 'model_provider = "Databricks"' in config_text
+    assert 'model_provider = "unselected"' in config_text
+    assert 'profile = "enterprise"' in config_text
     assert "[model_providers.Databricks]" in config_text
+    assert "[profiles.enterprise]" in config_text
     assert "plugins" not in config_text
     assert "mcp_servers" not in config_text
     assert "marketplaces" not in config_text

--- a/tests/integrations/polly/test_cli.py
+++ b/tests/integrations/polly/test_cli.py
@@ -1,0 +1,742 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import click
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from omnigent.cli import cli
+from omnigent.integration_daemon import DaemonRecord, IntegrationDaemon
+from omnigent.integrations.polly.cli import (
+    GITHUB_PRIVATE_KEY_SECRET,
+    OMNIGENT_ACCESS_TOKEN_SECRET,
+    OMNIGENT_DEVICE_CLIENT_SECRET,
+    OMNIGENT_REFRESH_TOKEN_SECRET,
+    WEBHOOK_SECRET_SECRET,
+    PollyConfig,
+    _manifest_registration_url,
+    _run_setup,
+    _validate_repository_installations,
+    _validate_server_selection,
+    acquire_device_tokens,
+    exchange_manifest_code,
+    load_config,
+    run_doctor,
+    save_config,
+    validate_public_url,
+    validate_server_url,
+    validate_workspace,
+)
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.onboarding import secrets
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    return tmp_path
+
+
+def _config(root: Path) -> PollyConfig:
+    workspace = root / "workspace"
+    workspace.mkdir()
+    return PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+
+
+def test_config_is_non_secret_and_uses_stable_secret_slots(isolated: Path) -> None:
+    cfg = _config(isolated)
+    save_config(cfg)
+    secrets.store_secret(GITHUB_PRIVATE_KEY_SECRET, "PRIVATE-KEY")
+    secrets.store_secret(WEBHOOK_SECRET_SECRET, "WEBHOOK-SECRET")
+    secrets.store_secret(OMNIGENT_REFRESH_TOKEN_SECRET, "REFRESH-TOKEN")
+    secrets.store_secret(OMNIGENT_ACCESS_TOKEN_SECRET, "ACCESS-TOKEN")
+    secrets.store_secret(OMNIGENT_DEVICE_CLIENT_SECRET, "CLIENT-SECRET")
+
+    text = (isolated / "integrations" / "polly" / "config.json").read_text()
+
+    assert load_config() == cfg
+    assert "PRIVATE-KEY" not in text
+    assert "WEBHOOK-SECRET" not in text
+    assert "REFRESH-TOKEN" not in text
+    assert "ACCESS-TOKEN" not in text
+    assert "CLIENT-SECRET" not in text
+
+
+def test_device_authorization_sends_optional_client_secret_on_every_request() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/oauth/device/authorize":
+            return httpx.Response(
+                200,
+                json={
+                    "verification_uri_complete": "https://omni.test/device?code=ABCD",
+                    "device_code": "device",
+                    "expires_in": 60,
+                    "interval": 1,
+                },
+            )
+        return httpx.Response(200, json={"access_token": "access", "refresh_token": "refresh"})
+
+    with (
+        httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="https://omni.test"
+        ) as client,
+        mock.patch("omnigent.integrations.polly.cli.webbrowser.open"),
+    ):
+        tokens = acquire_device_tokens(
+            "https://omni.test", client=client, device_client_secret="client-secret"
+        )
+
+    assert tokens == ("access", "refresh")
+    assert len(requests) == 2
+    assert all(
+        request.headers["X-Omnigent-Client-Secret"] == "client-secret" for request in requests
+    )
+
+
+@pytest.mark.parametrize(
+    "status,payload",
+    [
+        (404, {}),
+        (200, {"access_token": "", "refresh_token": "refresh"}),
+        (200, {"access_token": "access", "refresh_token": "   "}),
+        (200, {"access_token": 1, "refresh_token": "refresh"}),
+        (200, {"access_token": "access"}),
+    ],
+)
+def test_device_authorization_rejects_unscoped_or_invalid_tokens(
+    status: int, payload: dict[str, object]
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/oauth/device/authorize":
+            if status == 404:
+                return httpx.Response(status, json=payload)
+            return httpx.Response(
+                200,
+                json={
+                    "verification_uri_complete": "https://omni.test/device?code=ABCD",
+                    "device_code": "device",
+                    "expires_in": 60,
+                    "interval": 1,
+                },
+            )
+        return httpx.Response(status, json=payload)
+
+    with (
+        httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://127.0.0.1:8000"
+        ) as client,
+        mock.patch("omnigent.integrations.polly.cli.webbrowser.open"),
+        pytest.raises(click.ClickException),
+    ):
+        acquire_device_tokens("http://127.0.0.1:8000", client=client)
+
+
+@pytest.mark.parametrize("url", ["http://example.com", "https://", "ftp://x.test"])
+def test_public_url_requires_https(url: str) -> None:
+    with pytest.raises(ValueError):
+        validate_public_url(url)
+
+
+def test_public_url_allows_loopback_http_only_when_explicit() -> None:
+    with pytest.raises(ValueError):
+        validate_public_url("http://127.0.0.1:8788")
+    assert validate_public_url("http://127.0.0.1:8788", allow_loopback_http=True) == (
+        "http://127.0.0.1:8788"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:password@example.com",
+        "https://example.com?token=secret",
+        "https://example.com#fragment",
+        "https://example.com:invalid",
+        "https://example.com//",
+    ],
+)
+def test_public_url_requires_a_strict_origin(url: str) -> None:
+    with pytest.raises(ValueError):
+        validate_public_url(url)
+
+
+def test_server_url_allows_https_or_loopback_http_only() -> None:
+    assert validate_server_url("https://omnigent.example.com/") == "https://omnigent.example.com"
+    assert validate_server_url("http://localhost:8000/") == "http://localhost:8000"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://omnigent.example.com",
+        "ftp://omnigent.example.com",
+        "https://",
+        "https://user:password@omnigent.example.com",
+        "https://omnigent.example.com/v1",
+        "https://omnigent.example.com?token=secret",
+        "https://omnigent.example.com#fragment",
+        "https://omnigent.example.com:invalid",
+    ],
+)
+def test_server_url_requires_a_secure_strict_origin(url: str) -> None:
+    with pytest.raises(ValueError):
+        validate_server_url(url)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "relative",
+        "/",
+        "/root",
+        "/root/",
+        "/root/.",
+        "/root/../root",
+        "/home/alice",
+        "/home/alice/",
+        "/home/alice/../alice",
+        "/Users/alice",
+        "/Users/alice/.",
+    ],
+)
+def test_workspace_rejects_non_dedicated_paths(path: str) -> None:
+    with pytest.raises(ValueError):
+        validate_workspace(path)
+
+
+def test_workspace_returns_a_canonical_absolute_path() -> None:
+    assert validate_workspace("/srv//polly/") == "/srv/polly"
+
+
+def test_manifest_exchange_checks_state_and_exchanges_code_once() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": 123,
+                "slug": "polly-test",
+                "pem": "PRIVATE-KEY",
+                "webhook_secret": "WEBHOOK-SECRET",
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = exchange_manifest_code(
+            "http://127.0.0.1/callback?state=expected&code=once",
+            expected_state="expected",
+            client=client,
+        )
+
+    assert result["slug"] == "polly-test"
+    assert requests[0].url.path == "/app-manifests/once/conversions"
+    with pytest.raises(ValueError, match="state"):
+        exchange_manifest_code(
+            "http://127.0.0.1/callback?state=wrong&code=once",
+            expected_state="expected",
+            client=mock.Mock(),
+        )
+
+
+def test_manifest_registration_can_target_an_organization() -> None:
+    assert _manifest_registration_url(None) == "https://github.com/settings/apps/new"
+    assert _manifest_registration_url("acme") == (
+        "https://github.com/organizations/acme/settings/apps/new"
+    )
+
+
+def test_server_selection_accepts_explicit_ready_host_and_lists_ambiguous_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/v1/agents":
+            return httpx.Response(
+                200, json={"data": [{"id": "ag_review", "name": "polly-review"}]}
+            )
+        if request.url.path == "/v1/hosts":
+            return httpx.Response(
+                200,
+                json={
+                    "hosts": [
+                        {
+                            "host_id": "host_1",
+                            "name": "laptop",
+                            "status": "online",
+                            "configured_harnesses": {"claude-sdk": True, "codex": True},
+                        },
+                        {
+                            "host_id": "host_2",
+                            "name": "server",
+                            "status": "online",
+                            "configured_harnesses": {"claude-sdk": True, "codex": True},
+                        },
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"data": []})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        "omnigent.integrations.polly.cli.httpx.Client",
+        lambda *args, **kwargs: real_client(
+            base_url=kwargs.get("base_url"),
+            headers=kwargs.get("headers"),
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+
+    assert _validate_server_selection("https://omni.test", "token", "/srv/polly", "server") == (
+        "ag_review",
+        "host_2",
+    )
+    assert requests[0].url.params["limit"] == "1000"
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _validate_server_selection("https://omni.test", "token", "/srv/polly", None)
+    message = str(exc_info.value)
+    assert "laptop (host_1)" in message
+    assert "server (host_2)" in message
+
+
+def test_setup_host_option_is_forwarded(isolated: Path) -> None:
+    with mock.patch("omnigent.integrations.polly.cli._run_setup") as run_setup:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "integration",
+                "polly",
+                "setup",
+                "--server",
+                "http://127.0.0.1:8000",
+                "--public-url",
+                "https://polly.example.com",
+                "--workspace",
+                str(isolated / "workspace"),
+                "--host",
+                "laptop",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert run_setup.call_args.kwargs["host"] == "laptop"
+
+
+def test_manifest_setup_opens_install_url_and_validates_selected_repositories(
+    isolated: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = isolated / "workspace"
+    workspace.mkdir()
+    app = {
+        "id": 123,
+        "slug": "polly-test",
+        "pem": "PRIVATE-KEY",
+        "webhook_secret": "WEBHOOK-SECRET",
+    }
+    with (
+        mock.patch(
+            "omnigent.integrations.polly.cli.acquire_device_tokens",
+            return_value=("access", "refresh"),
+        ),
+        mock.patch(
+            "omnigent.integrations.polly.cli._validate_server_selection",
+            return_value=("ag_review", "host_1"),
+        ),
+        mock.patch("omnigent.integrations.polly.cli._manifest_flow", return_value=app),
+        mock.patch(
+            "omnigent.integrations.polly.cli._validate_repository_installations"
+        ) as validate,
+        mock.patch("omnigent.integrations.polly.cli.webbrowser.open") as open_browser,
+        mock.patch("omnigent.integrations.polly.cli.secret_store.store_secret"),
+        mock.patch("omnigent.integrations.polly.cli.save_config"),
+    ):
+        _run_setup(
+            server="http://127.0.0.1:8000",
+            public_url="https://polly.example.com",
+            listen_host="127.0.0.1",
+            listen_port=8788,
+            workspace=str(workspace),
+            host=None,
+            app_id=None,
+            app_slug=None,
+            private_key_file=None,
+            repositories=("acme/widgets",),
+            allow_loopback_http=False,
+        )
+
+    install_url = "https://github.com/apps/polly-test/installations/new"
+    open_browser.assert_called_once_with(install_url)
+    assert install_url in capsys.readouterr().out
+    validate.assert_called_once_with("123", "PRIVATE-KEY", ("acme/widgets",))
+
+
+def test_existing_app_repository_validation_failure_writes_no_config_or_secrets(
+    isolated: Path,
+) -> None:
+    workspace = isolated / "workspace"
+    workspace.mkdir()
+    key = isolated / "app.pem"
+    key.write_text("PRIVATE-KEY")
+    with (
+        mock.patch(
+            "omnigent.integrations.polly.cli.acquire_device_tokens",
+            return_value=("access", "refresh"),
+        ),
+        mock.patch(
+            "omnigent.integrations.polly.cli._validate_server_selection",
+            return_value=("ag_review", "host_1"),
+        ),
+        mock.patch("omnigent.integrations.polly.cli._validate_existing_app"),
+        mock.patch("omnigent.integrations.polly.cli.click.prompt", return_value="WEBHOOK-SECRET"),
+        mock.patch(
+            "omnigent.integrations.polly.cli._validate_repository_installations",
+            side_effect=click.ClickException("not installed on acme/widgets"),
+        ),
+        mock.patch("omnigent.integrations.polly.cli.secret_store.store_secret") as store_secret,
+        mock.patch("omnigent.integrations.polly.cli.save_config") as save,
+    ):
+        with pytest.raises(click.ClickException, match="not installed"):
+            _run_setup(
+                server="http://127.0.0.1:8000",
+                public_url="https://polly.example.com",
+                listen_host="127.0.0.1",
+                listen_port=8788,
+                workspace=str(workspace),
+                host=None,
+                app_id="123",
+                app_slug="polly-test",
+                private_key_file=key,
+                repositories=("acme/widgets",),
+                allow_loopback_http=False,
+            )
+
+    store_secret.assert_not_called()
+    save.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "private_key,webhook_secret", [("   ", "WEBHOOK-SECRET"), ("PRIVATE-KEY", "  ")]
+)
+def test_existing_app_blank_required_input_writes_no_config_or_secrets(
+    isolated: Path, private_key: str, webhook_secret: str
+) -> None:
+    workspace = isolated / "workspace"
+    workspace.mkdir()
+    key = isolated / "app.pem"
+    key.write_text(private_key)
+    with (
+        mock.patch(
+            "omnigent.integrations.polly.cli.acquire_device_tokens",
+            return_value=("access", "refresh"),
+        ),
+        mock.patch(
+            "omnigent.integrations.polly.cli._validate_server_selection",
+            return_value=("ag_review", "host_1"),
+        ),
+        mock.patch("omnigent.integrations.polly.cli.click.prompt", return_value=webhook_secret),
+        mock.patch("omnigent.integrations.polly.cli._validate_existing_app") as validate_app,
+        mock.patch("omnigent.integrations.polly.cli.secret_store.store_secret") as store_secret,
+        mock.patch("omnigent.integrations.polly.cli.save_config") as save,
+    ):
+        with pytest.raises(click.ClickException, match="must not be empty"):
+            _run_setup(
+                server="http://127.0.0.1:8000",
+                public_url="https://polly.example.com",
+                listen_host="127.0.0.1",
+                listen_port=8788,
+                workspace=str(workspace),
+                host=None,
+                app_id="123",
+                app_slug="polly-test",
+                private_key_file=key,
+                repositories=("acme/widgets",),
+                allow_loopback_http=False,
+            )
+
+    validate_app.assert_not_called()
+    store_secret.assert_not_called()
+    save.assert_not_called()
+
+
+def test_repository_installation_validation_rejects_uninstalled_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    monkeypatch.setattr("jwt.encode", lambda *args, **kwargs: "app-jwt")
+    monkeypatch.setattr(
+        "omnigent.integrations.polly.cli.httpx.Client",
+        lambda *args, **kwargs: real_client(
+            base_url=kwargs.get("base_url"),
+            headers=kwargs.get("headers"),
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+
+    with pytest.raises(click.ClickException, match="acme/missing"):
+        _validate_repository_installations("123", "PRIVATE-KEY", ("acme/widgets", "acme/missing"))
+
+
+def test_cli_lifecycle_uses_polly_daemon(isolated: Path) -> None:
+    save_config(_config(isolated))
+    runner = CliRunner()
+    with (
+        mock.patch("omnigent.integration_daemon.subprocess.Popen") as popen,
+        mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
+        mock.patch.object(IntegrationDaemon, "confirm_alive", return_value=True),
+    ):
+        popen.return_value.pid = 9912
+        started = runner.invoke(cli, ["integration", "polly", "--background"])
+        assert started.exit_code == 0, started.output
+        assert popen.call_args.args[0][1:] == ["-m", "omnigent.integrations.polly.runtime"]
+        assert "9912" in runner.invoke(cli, ["integration", "polly", "status"]).output
+
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_alive", side_effect=[True, False, False]),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_signal"),
+    ):
+        stopped = runner.invoke(cli, ["integration", "polly", "stop"])
+    assert stopped.exit_code == 0
+    assert "Stopped" in stopped.output
+
+
+def test_cli_foreground_and_logs_follow(isolated: Path) -> None:
+    save_config(_config(isolated))
+    runner = CliRunner()
+    with mock.patch("omnigent.integrations.polly.cli.subprocess.run") as run:
+        run.return_value = mock.Mock(returncode=0)
+        result = runner.invoke(cli, ["integration", "polly"])
+    assert result.exit_code == 0, result.output
+    assert run.call_args.args[0][1:] == ["-m", "omnigent.integrations.polly.runtime"]
+
+    log = isolated / "polly.log"
+    log.write_text("safe log\n")
+    IntegrationDaemon("polly", isolated)._write_record(
+        DaemonRecord(pid=1, log_path=str(log), started_at=1)
+    )
+    with mock.patch("omnigent.integrations.polly.cli.subprocess.run") as run:
+        followed = runner.invoke(cli, ["integration", "polly", "logs", "-f"])
+    assert followed.exit_code == 0
+    assert run.call_args.args[0] == ["tail", "-f", str(log)]
+
+
+def test_retry_only_resets_failed_job(isolated: Path) -> None:
+    save_config(_config(isolated))
+    store = PollyStore(isolated / "integrations" / "polly" / "polly.sqlite3")
+    store.accept("d1", "acme", "widgets", 1, "head", 7)
+    job = store.list_jobs()[0]
+    runner = CliRunner()
+
+    refused = runner.invoke(cli, ["integration", "polly", "retry", str(job.id)])
+    assert refused.exit_code != 0
+    store.set_state(job.id, "failed", error="boom")
+    retried = runner.invoke(cli, ["integration", "polly", "retry", str(job.id)])
+
+    assert retried.exit_code == 0, retried.output
+    assert store.get_job(job.id).state == "pending"
+
+
+def test_jobs_lists_failed_id_without_secret_values(isolated: Path) -> None:
+    save_config(_config(isolated))
+    secrets.store_secret(OMNIGENT_ACCESS_TOKEN_SECRET, "ACCESS-TOKEN")
+    store = PollyStore(isolated / "integrations" / "polly" / "polly.sqlite3")
+    store.accept("d1", "acme", "widgets", 1, "head", 7)
+    job = store.list_jobs()[0]
+    store.set_state(job.id, "failed", error="GitHub request failed after retry: ACCESS-TOKEN")
+
+    result = CliRunner().invoke(cli, ["integration", "polly", "jobs"])
+
+    assert result.exit_code == 0, result.output
+    assert f"{job.id}" in result.output
+    assert "acme/widgets" in result.output
+    assert "#1" in result.output
+    assert "head" in result.output
+    assert "failed" in result.output
+    assert "GitHub request failed after retry: [redacted]" in result.output
+    assert "ACCESS-TOKEN" not in result.output
+
+
+def test_jobs_redacts_multiline_and_cutoff_secret_before_summary(isolated: Path) -> None:
+    save_config(_config(isolated))
+    multiline_secret = "MULTILINE-SECRET\nSECOND-LINE"
+    cutoff_secret = "CUTOFF-SECRET-MARKER"
+    secrets.store_secret(GITHUB_PRIVATE_KEY_SECRET, multiline_secret)
+    secrets.store_secret(WEBHOOK_SECRET_SECRET, cutoff_secret)
+    store = PollyStore(isolated / "integrations" / "polly" / "polly.sqlite3")
+    store.accept("d1", "acme", "widgets", 1, "head-1", 7)
+    store.accept("d2", "acme", "widgets", 2, "head-2", 7)
+    first, second = store.list_jobs()
+    store.set_state(first.id, "failed", error=f"request failed: {multiline_secret}")
+    store.set_state(second.id, "failed", error=("x" * 195) + cutoff_secret)
+
+    result = CliRunner().invoke(cli, ["integration", "polly", "jobs"])
+
+    assert result.exit_code == 0, result.output
+    assert "MULTILINE-SECRET" not in result.output
+    assert "SECOND-LINE" not in result.output
+    assert "MULTILINE-SECRET SECOND-LINE" not in result.output
+    assert "CUTOF" not in result.output
+
+
+def test_doctor_rejects_blank_required_secret_slots(isolated: Path) -> None:
+    save_config(_config(isolated))
+    for name in (
+        GITHUB_PRIVATE_KEY_SECRET,
+        WEBHOOK_SECRET_SECRET,
+        OMNIGENT_REFRESH_TOKEN_SECRET,
+        OMNIGENT_ACCESS_TOKEN_SECRET,
+    ):
+        secrets.store_secret(name, "   ")
+
+    checks = run_doctor()
+
+    assert checks["secrets"] is False
+    assert checks["access token"] is False
+
+
+def test_setup_refuses_running_daemon_before_reading_secrets(isolated: Path) -> None:
+    IntegrationDaemon("polly", isolated)._write_record(
+        DaemonRecord(pid=77, log_path=str(isolated / "log"), started_at=1)
+    )
+    with (
+        mock.patch.object(IntegrationDaemon, "_pid_alive", return_value=True),
+        mock.patch.object(IntegrationDaemon, "_record_has_held_owner", return_value=True),
+        mock.patch("omnigent.integrations.polly.cli._run_setup") as setup,
+    ):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "integration",
+                "polly",
+                "setup",
+                "--server",
+                "http://127.0.0.1:8000",
+                "--public-url",
+                "https://polly.example.com",
+                "--workspace",
+                str(isolated / "workspace"),
+            ],
+        )
+    assert result.exit_code != 0
+    assert "running" in result.output.lower()
+    setup.assert_not_called()
+
+
+def test_doctor_reports_each_read_only_check_without_secret_values(isolated: Path) -> None:
+    save_config(_config(isolated))
+    for name, value in (
+        (GITHUB_PRIVATE_KEY_SECRET, "PRIVATE-KEY"),
+        (WEBHOOK_SECRET_SECRET, "WEBHOOK-SECRET"),
+        (OMNIGENT_REFRESH_TOKEN_SECRET, "REFRESH-TOKEN"),
+        (OMNIGENT_ACCESS_TOKEN_SECRET, "ACCESS-TOKEN"),
+    ):
+        secrets.store_secret(name, value)
+    checks = {
+        "config": True,
+        "secrets": True,
+        "access token": True,
+        "agent": True,
+        "host": True,
+        "harness readiness": True,
+        "workspace": False,
+        "GitHub App": True,
+        "installation repositories": True,
+        "public health": True,
+    }
+    with mock.patch("omnigent.integrations.polly.cli.run_doctor", return_value=checks):
+        result = CliRunner().invoke(cli, ["integration", "polly", "doctor"])
+    assert result.exit_code != 0
+    assert "workspace: FAIL" in result.output
+    assert all(
+        value not in result.output
+        for value in ("PRIVATE-KEY", "WEBHOOK-SECRET", "REFRESH-TOKEN", "ACCESS-TOKEN")
+    )
+
+
+def test_doctor_does_not_rotate_or_write_credentials(isolated: Path) -> None:
+    config = _config(isolated)
+    save_config(config)
+    for name, value in (
+        (GITHUB_PRIVATE_KEY_SECRET, "PRIVATE-KEY"),
+        (WEBHOOK_SECRET_SECRET, "WEBHOOK-SECRET"),
+        (OMNIGENT_REFRESH_TOKEN_SECRET, "REFRESH-TOKEN"),
+        (OMNIGENT_ACCESS_TOKEN_SECRET, "ACCESS-TOKEN"),
+    ):
+        secrets.store_secret(name, value)
+
+    def response(url: str, payload: object) -> httpx.Response:
+        return httpx.Response(200, json=payload, request=httpx.Request("GET", url))
+
+    server_client = mock.MagicMock()
+    server_client.__enter__.return_value = server_client
+    server_client.__exit__.return_value = None
+    server_client.get.side_effect = [
+        response(
+            "https://omni.test/v1/agents",
+            {"data": [{"id": "ag_polly", "name": "polly-review"}]},
+        ),
+        response(
+            "https://omni.test/v1/hosts",
+            {
+                "hosts": [
+                    {
+                        "host_id": "host_1",
+                        "status": "online",
+                        "configured_harnesses": {"claude-sdk": True, "codex": True},
+                    }
+                ]
+            },
+        ),
+        response("https://omni.test/v1/filesystem", {"data": []}),
+    ]
+    public_client = mock.MagicMock()
+    public_client.__enter__.return_value = public_client
+    public_client.__exit__.return_value = None
+    public_client.get.return_value = response("https://polly.example.com/health", {"status": "ok"})
+
+    with (
+        mock.patch(
+            "omnigent.integrations.polly.cli.httpx.Client",
+            side_effect=[server_client, public_client],
+        ),
+        mock.patch("omnigent.integrations.polly.cli._validate_existing_app"),
+        mock.patch(
+            "omnigent.integrations.polly.github.GitHubAppClient.installation_for",
+            new=mock.AsyncMock(return_value=7),
+        ),
+        mock.patch("omnigent.integrations.polly.cli.secret_store.store_secret") as store,
+    ):
+        checks = run_doctor()
+
+    assert all(checks.values())
+    store.assert_not_called()

--- a/tests/integrations/polly/test_review_clients_worker.py
+++ b/tests/integrations/polly/test_review_clients_worker.py
@@ -1,0 +1,1131 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from omnigent.integrations.polly.github import GitHubAppClient
+from omnigent.integrations.polly.omnigent import OmnigentClient, ReviewerFailure
+from omnigent.integrations.polly.review import (
+    ReviewValidationError,
+    extract_review,
+    merge_reviews,
+    review_schema,
+)
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.integrations.polly.worker import PollyWorker
+
+
+def _review(review_id: str, *, verdict: str = "Sound", priority: str = "Low") -> dict[str, Any]:
+    return {
+        "review_id": review_id,
+        "summary": "Found one issue.",
+        "approach_verdict": verdict,
+        "has_blocking_issues": priority == "High",
+        "status_update": "Review complete.",
+        "resolved_previous_findings": ["fixed", "shared"],
+        "still_open_previous_findings": ["open"],
+        "inline_comments": [
+            {
+                "path": "app.py",
+                "line": 2,
+                "priority": priority,
+                "title": "Unsafe branch",
+                "body": "This branch can lose data.",
+            }
+        ],
+    }
+
+
+def test_strict_review_id_json_rejects_mismatch_and_extra_fields() -> None:
+    with pytest.raises(ReviewValidationError, match="Review-ID"):
+        extract_review(json.dumps(_review("wrong")), "expected")
+    extra = _review("expected") | {"unexpected": True}
+    with pytest.raises(ReviewValidationError, match="unexpected"):
+        extract_review(json.dumps(extra), "expected")
+    nested = _review("expected") | {"workspace_status": {"note": "ok", "secret": "leak"}}
+    with pytest.raises(ReviewValidationError, match="workspace_status"):
+        extract_review(json.dumps(nested), "expected")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("summary", "   \t"),
+        ("title", "\n\t"),
+        ("body", "   "),
+        ("path", "   "),
+        ("path", "/absolute.py"),
+        ("path", "./local.py"),
+        ("path", "../outside.py"),
+        ("path", "a/header.py"),
+        ("path", "b/header.py"),
+    ],
+)
+def test_prompt_schema_rejects_every_string_runtime_validation_rejects(
+    field: str, value: str
+) -> None:
+    schema = review_schema("rid")
+    if field == "summary":
+        field_schema = schema["properties"][field]
+    else:
+        field_schema = schema["properties"]["inline_comments"]["items"]["properties"][field]
+    pattern = field_schema.get("pattern")
+    schema_accepts = len(value) >= field_schema.get("minLength", 0) and (
+        pattern is None or re.search(pattern, value) is not None
+    )
+
+    review = _review("rid")
+    if field == "summary":
+        review[field] = value
+    else:
+        review["inline_comments"][0][field] = value
+    try:
+        extract_review(json.dumps(review), "rid")
+    except ReviewValidationError:
+        runtime_accepts = False
+    else:
+        runtime_accepts = True
+
+    assert schema_accepts is False
+    assert runtime_accepts is False
+
+
+def test_merge_is_deterministic_and_demotes_invalid_anchors() -> None:
+    claude = _review("rid", verdict="Mostly sound", priority="Low")
+    codex = _review("rid", verdict="Needs changes", priority="High")
+    codex["summary"] = "Found a blocker."
+    codex["resolved_previous_findings"] = ["shared", "other"]
+    codex["still_open_previous_findings"] = ["other-open"]
+    codex["inline_comments"].append(
+        {
+            "path": "missing.py",
+            "line": 99,
+            "priority": "Medium",
+            "title": "Unanchored",
+            "body": "Keep this finding in the body.",
+        }
+    )
+    claude["inline_comments"].append(
+        {
+            "path": "missing.py",
+            "line": 99,
+            "priority": "Low",
+            "title": "Duplicate unanchored",
+            "body": "This lower-priority duplicate must be dropped.",
+        }
+    )
+    diff = "\n".join(
+        [
+            "diff --git a/app.py b/app.py",
+            "--- a/app.py",
+            "+++ b/app.py",
+            "@@ -1,2 +1,2 @@",
+            " one",
+            "+two",
+            "-old",
+        ]
+    )
+
+    merged = merge_reviews({"claude_review": claude, "codex_review": codex}, diff)
+
+    assert merged["approach_verdict"] == "Needs changes"
+    assert merged["has_blocking_issues"] is True
+    assert merged["resolved_previous_findings"] == ["shared"]
+    assert merged["still_open_previous_findings"] == ["open", "other-open"]
+    assert merged["inline_comments"] == [codex["inline_comments"][0]]
+    assert "## Claude" in merged["summary"] and "## Codex" in merged["summary"]
+    assert "missing.py:99" in merged["summary"]
+    assert merged["summary"].count("missing.py:99") == 1
+    assert "**Medium · Unanchored**" in merged["summary"]
+
+
+@pytest.mark.asyncio
+async def test_github_app_auth_caches_token_and_publishes_review_once() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        path = request.url.path
+        if path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        if path == "/app/installations/7/access_tokens":
+            return httpx.Response(
+                201, json={"token": "install-token", "expires_at": "2030-01-01T00:00:00Z"}
+            )
+        if path == "/repos/acme/widgets/pulls/12/reviews" and request.method == "GET":
+            return httpx.Response(200, json=[])
+        if path == "/repos/acme/widgets/pulls/12/reviews":
+            return httpx.Response(200, json={"id": 99})
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    review_body = PollyWorker._review_body(
+        "<!-- polly-review:key -->",
+        {
+            "summary": "## Claude\nFound one issue.\n\n## Codex\nConfirmed it.",
+            "approach_verdict": "Needs changes",
+            "has_blocking_issues": True,
+            "blocking_findings": [
+                {
+                    "path": "app.py",
+                    "line": 2,
+                    "title": "Unsafe branch",
+                    "body": "This branch can lose data.",
+                }
+            ],
+            "resolved_previous_findings": ["fixed"],
+            "still_open_previous_findings": ["open"],
+        },
+    )
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://api.github.test") as http:
+        github = GitHubAppClient(
+            "123", key, http, app_slug="polly-review", clock=lambda: 1_700_000_000.0
+        )
+        first = await github.publish_review_once("acme", "widgets", 12, "head", review_body, [])
+        second = await github.installation_token("acme", "widgets")
+
+    assert first == {"id": 99}
+    assert second == "install-token"
+    assert (
+        Counter(request.url.path for request in requests)["/app/installations/7/access_tokens"]
+        == 1
+    )
+    app_claims = jwt.decode(
+        requests[0].headers["Authorization"].removeprefix("Bearer "),
+        options={"verify_signature": False},
+    )
+    assert app_claims == {"iat": 1_699_999_940, "exp": 1_700_000_480, "iss": "123"}
+    publish = requests[-1]
+    assert publish.headers["Authorization"] == "Bearer install-token"
+    assert json.loads(publish.content) == {
+        "event": "COMMENT",
+        "commit_id": "head",
+        "body": """<!-- polly-review:key -->
+**Disposition:** BLOCKING
+
+## Claude
+Found one issue.
+
+## Codex
+Confirmed it.
+
+**Approach:** Needs changes
+
+## Blockers
+- `app.py:2` **Unsafe branch** — This branch can lose data.
+
+## Resolved previous findings
+- fixed
+
+## Still-open previous findings
+- open""",
+        "comments": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_github_updates_status_comment_found_after_first_page() -> None:
+    writes: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        if request.url.path == "/app/installations/7/access_tokens":
+            return httpx.Response(
+                201,
+                json={"token": "install-token", "expires_at": "2030-01-01T00:00:00Z"},
+            )
+        if request.url.path == "/repos/acme/widgets/issues/12/comments":
+            if request.url.params["page"] == "1":
+                return httpx.Response(200, json=[{"id": i, "body": "other"} for i in range(100)])
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 123,
+                        "body": "<!-- polly-status:key -->\nold",
+                        "user": {"login": "polly-review[bot]"},
+                    }
+                ],
+            )
+        if request.url.path == "/repos/acme/widgets/issues/comments/123":
+            writes.append(request)
+            return httpx.Response(200, json={"id": 123})
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.test"
+    ) as http:
+        github = GitHubAppClient(
+            "123", key, http, app_slug="polly-review", clock=lambda: 1_700_000_000.0
+        )
+        comment_id = await github.upsert_status_comment(
+            "acme", "widgets", 12, "<!-- polly-status:key -->\nnew"
+        )
+
+    assert comment_id == 123
+    assert len(writes) == 1
+    assert json.loads(writes[0].content) == {"body": "<!-- polly-status:key -->\nnew"}
+
+
+@pytest.mark.asyncio
+async def test_github_marker_lookup_requires_exact_bot_and_paginates_to_short_page() -> None:
+    marker = "<!-- polly-review:key -->"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        if request.url.path == "/app/installations/7/access_tokens":
+            return httpx.Response(
+                201, json={"token": "token", "expires_at": "2030-01-01T00:00:00Z"}
+            )
+        if request.url.path == "/repos/acme/widgets/pulls/12/reviews":
+            page = int(request.url.params["page"])
+            if page <= 10:
+                batch = [{"id": page * 100 + i, "body": "other"} for i in range(100)]
+                if page == 1:
+                    batch[0] = {
+                        "id": 1,
+                        "body": f"prefix {marker}",
+                        "user": {"login": "polly-review[bot]"},
+                    }
+                    batch[1] = {
+                        "id": 2,
+                        "body": f"{marker}\nforged",
+                        "user": {"login": "attacker"},
+                    }
+                return httpx.Response(200, json=batch)
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 9999,
+                        "body": f"{marker}\nreal",
+                        "user": {"login": "polly-review[bot]"},
+                    }
+                ],
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.test"
+    ) as http:
+        github = GitHubAppClient(
+            "123", key, http, app_slug="polly-review", clock=lambda: 1_700_000_000.0
+        )
+        found = await github.find_review("acme", "widgets", 12, marker)
+
+    assert found is not None and found["id"] == 9999
+
+
+@pytest.mark.asyncio
+async def test_github_invalidates_installation_token_and_retries_once_on_401() -> None:
+    minted = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal minted
+        if request.url.path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        if request.url.path == "/app/installations/7/access_tokens":
+            minted += 1
+            return httpx.Response(
+                201,
+                json={"token": f"token-{minted}", "expires_at": "2030-01-01T00:00:00Z"},
+            )
+        if request.url.path == "/repos/acme/widgets/pulls/12":
+            if request.headers["Authorization"] == "Bearer token-1":
+                return httpx.Response(401)
+            return httpx.Response(200, json={"head": {"sha": "head"}})
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.test"
+    ) as http:
+        github = GitHubAppClient(
+            "123", key, http, app_slug="polly-review", clock=lambda: 1_700_000_000.0
+        )
+        pull = await github.get_pull("acme", "widgets", 12)
+
+    assert pull["head"] == {"sha": "head"}
+    assert minted == 2
+
+
+@pytest.mark.asyncio
+async def test_github_caps_diff_at_utf8_boundary_with_truncation_notice() -> None:
+    raw = ("a" * 399_950 + "€" * 100).encode()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/acme/widgets/installation":
+            return httpx.Response(200, json={"id": 7})
+        if request.url.path == "/app/installations/7/access_tokens":
+            return httpx.Response(
+                201, json={"token": "token", "expires_at": "2030-01-01T00:00:00Z"}
+            )
+        return httpx.Response(200, content=raw)
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.test"
+    ) as http:
+        github = GitHubAppClient(
+            "123", key, http, app_slug="polly-review", clock=lambda: 1_700_000_000.0
+        )
+        diff = await github.get_diff("acme", "widgets", 12)
+
+    assert len(diff.encode()) <= 400_000
+    assert "Diff truncated" in diff
+    diff.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_omnigent_refreshes_and_runs_exact_two_reviewers_with_one_upload() -> None:
+    calls: list[tuple[str, str, Any]] = []
+    parent_polls = 0
+    snapshots = {
+        "claude": _review("rid", verdict="Mostly sound"),
+        "codex": _review("rid", verdict="Sound"),
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal parent_polls
+        body: Any = None
+        if request.headers.get("Content-Type", "").startswith("application/json"):
+            body = json.loads(request.content)
+        calls.append((request.method, request.url.path, body))
+        if (
+            request.url.path == "/v1/sessions"
+            and request.headers.get("Authorization") == "Bearer expired"
+        ):
+            return httpx.Response(401)
+        if request.url.path == "/oauth/token":
+            assert request.headers["X-Omnigent-Client-Secret"] == "client-secret"
+            return httpx.Response(200, json={"access_token": "fresh", "refresh_token": "rotated"})
+        if request.url.path == "/v1/sessions" and body.get("parent_session_id") is None:
+            return httpx.Response(200, json={"id": "parent"})
+        if request.url.path == "/v1/sessions":
+            name = body["sub_agent_name"]
+            return httpx.Response(
+                200, json={"id": "claude" if name == "claude_review" else "codex"}
+            )
+        if request.url.path.endswith("/resources/files"):
+            return httpx.Response(200, json={"id": "parent-file"})
+        if request.url.path.endswith("/resources/files:copy"):
+            child = request.url.path.split("/")[3]
+            return httpx.Response(
+                200, json={"mapping": {"parent-file": {"new_id": f"{child}-file"}}}
+            )
+        if request.url.path.endswith("/events"):
+            return httpx.Response(204)
+        if request.url.path == "/v1/sessions/parent":
+            parent_polls += 1
+            return httpx.Response(
+                200,
+                json={
+                    "status": "idle",
+                    "runner_online": parent_polls > 1,
+                    "runner_id": "runner" if parent_polls > 1 else None,
+                    "items": [],
+                },
+            )
+        if request.url.path == "/v1/sessions/claude":
+            return httpx.Response(
+                200, json={"status": "idle", "items": [_assistant(snapshots["claude"])]}
+            )
+        if request.url.path == "/v1/sessions/codex":
+            return httpx.Response(
+                200, json={"status": "idle", "items": [_assistant(snapshots["codex"])]}
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://omni.test"
+    ) as http:
+        client = OmnigentClient(
+            http,
+            access_token="expired",
+            refresh_token="refresh",
+            device_client_secret="client-secret",
+            agent_id="polly-review",
+            host_id="host",
+            workspace="/tmp/polly",
+            sleep=lambda _: asyncio.sleep(0),
+        )
+        results = await client.review_pair("diff", "rid")
+
+    assert set(results) == {"claude_review", "codex_review"}
+    assert sum(path.endswith("/resources/files") for _, path, _ in calls) == 1
+    children = [
+        body
+        for method, path, body in calls
+        if method == "POST" and path == "/v1/sessions" and body and body.get("parent_session_id")
+    ]
+    assert [child["sub_agent_name"] for child in children] == ["claude_review", "codex_review"]
+    turns = [body for method, path, body in calls if method == "POST" and path.endswith("/events")]
+    assert all(turn["data"]["content"][1]["type"] == "input_file" for turn in turns)
+    prompts = [turn["data"]["content"][0]["text"] for turn in turns]
+    assert all('"additionalProperties":false' in prompt for prompt in prompts)
+    assert all(
+        '"enum":["Sound","Mostly sound","Unclear","Risky","Needs changes"]' in prompt
+        for prompt in prompts
+    )
+    assert all('"const":"rid"' in prompt for prompt in prompts)
+    first_child = next(
+        i
+        for i, call in enumerate(calls)
+        if call[:2] == ("POST", "/v1/sessions") and call[2].get("parent_session_id")
+    )
+    parent_gets = [i for i, call in enumerate(calls) if call[:2] == ("GET", "/v1/sessions/parent")]
+    assert len(parent_gets) == 2 and parent_gets[-1] < first_child
+    assert client.refresh_token == "rotated"
+
+
+@pytest.mark.asyncio
+async def test_omnigent_initial_idle_snapshot_waits_for_runner_cycle() -> None:
+    snapshots = iter(
+        [
+            {"status": "idle", "items": []},
+            {"status": "running", "items": []},
+            {"status": "idle", "items": [_assistant(_review("rid"))]},
+        ]
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sessions/child"
+        return httpx.Response(200, json=next(snapshots))
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://omni.test"
+    ) as http:
+        client = OmnigentClient(
+            http,
+            access_token="token",
+            refresh_token="refresh",
+            agent_id="polly-review",
+            host_id="host",
+            workspace="/tmp/polly",
+            sleep=lambda _: asyncio.sleep(0),
+        )
+        result = await client._poll("child", "rid")
+
+    assert result["review_id"] == "rid"
+
+
+@pytest.mark.asyncio
+async def test_omnigent_interrupts_started_child_when_later_setup_fails() -> None:
+    interrupts: list[str] = []
+    child_creates = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal child_creates
+        path = request.url.path
+        body = (
+            json.loads(request.content)
+            if request.headers.get("Content-Type", "").startswith("application/json")
+            else {}
+        )
+        if path == "/v1/sessions" and not body.get("parent_session_id"):
+            return httpx.Response(200, json={"id": "parent"})
+        if path == "/v1/sessions/parent/resources/files":
+            return httpx.Response(200, json={"id": "file"})
+        if path == "/v1/sessions/parent":
+            return httpx.Response(
+                200, json={"runner_online": True, "runner_id": "runner", "status": "idle"}
+            )
+        if path == "/v1/sessions":
+            child_creates += 1
+            return (
+                httpx.Response(200, json={"id": "claude"})
+                if child_creates == 1
+                else httpx.Response(500)
+            )
+        if path == "/v1/sessions/claude/resources/files:copy":
+            return httpx.Response(200, json={"mapping": {"file": {"new_id": "child-file"}}})
+        if path in {"/v1/sessions/parent/events", "/v1/sessions/claude/events"}:
+            if body.get("type") == "interrupt":
+                interrupts.append(path.split("/")[3])
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://omni.test"
+    ) as http:
+        client = OmnigentClient(
+            http,
+            access_token="token",
+            refresh_token="refresh",
+            agent_id="polly-review",
+            host_id="host",
+            workspace="/tmp/polly",
+            sleep=lambda _: asyncio.sleep(0),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.review_pair("diff", "rid")
+
+    assert sorted(interrupts) == ["claude", "parent"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed", [False, True], ids=["copy-http-failure", "copy-map"])
+async def test_omnigent_interrupts_parent_and_child_when_copy_setup_fails(
+    malformed: bool,
+) -> None:
+    interrupts: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = (
+            json.loads(request.content)
+            if request.headers.get("Content-Type", "").startswith("application/json")
+            else {}
+        )
+        if path == "/v1/sessions" and not body.get("parent_session_id"):
+            return httpx.Response(200, json={"id": "parent"})
+        if path == "/v1/sessions/parent/resources/files":
+            return httpx.Response(200, json={"id": "file"})
+        if path == "/v1/sessions/parent":
+            return httpx.Response(
+                200, json={"runner_online": True, "runner_id": "runner", "status": "idle"}
+            )
+        if path == "/v1/sessions":
+            return httpx.Response(200, json={"id": "claude"})
+        if path == "/v1/sessions/claude/resources/files:copy":
+            return httpx.Response(200, json={"mapping": {}}) if malformed else httpx.Response(500)
+        if path in {"/v1/sessions/parent/events", "/v1/sessions/claude/events"}:
+            if body.get("type") == "interrupt":
+                interrupts.append(path.split("/")[3])
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://omni.test"
+    ) as http:
+        client = OmnigentClient(
+            http,
+            access_token="token",
+            refresh_token="refresh",
+            agent_id="polly-review",
+            host_id="host",
+            workspace="/tmp/polly",
+            sleep=lambda _: asyncio.sleep(0),
+        )
+        with pytest.raises((httpx.HTTPStatusError, ReviewerFailure)):
+            await client.review_pair("diff", "rid")
+
+    assert sorted(interrupts) == ["claude", "parent"]
+
+
+@pytest.mark.asyncio
+async def test_omnigent_interrupts_both_started_children_when_polling_fails() -> None:
+    interrupts: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = (
+            json.loads(request.content)
+            if request.headers.get("Content-Type", "").startswith("application/json")
+            else {}
+        )
+        if path == "/v1/sessions" and not body.get("parent_session_id"):
+            return httpx.Response(200, json={"id": "parent"})
+        if path == "/v1/sessions/parent/resources/files":
+            return httpx.Response(200, json={"id": "file"})
+        if path == "/v1/sessions/parent":
+            return httpx.Response(
+                200, json={"runner_online": True, "runner_id": "runner", "status": "idle"}
+            )
+        if path == "/v1/sessions":
+            return httpx.Response(
+                200,
+                json={"id": "claude" if body["sub_agent_name"] == "claude_review" else "codex"},
+            )
+        if path.endswith("/resources/files:copy"):
+            child = path.split("/")[3]
+            return httpx.Response(200, json={"mapping": {"file": {"new_id": f"{child}-file"}}})
+        if path.endswith("/events"):
+            child = path.split("/")[3]
+            if body.get("type") == "interrupt":
+                interrupts.append(child)
+            return httpx.Response(204)
+        if path == "/v1/sessions/claude":
+            return httpx.Response(200, json={"status": "failed", "items": []})
+        if path == "/v1/sessions/codex":
+            return httpx.Response(200, json={"status": "running", "items": []})
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://omni.test"
+    ) as http:
+        client = OmnigentClient(
+            http,
+            access_token="token",
+            refresh_token="refresh",
+            agent_id="polly-review",
+            host_id="host",
+            workspace="/tmp/polly",
+            sleep=lambda _: asyncio.sleep(10),
+        )
+        with pytest.raises(ReviewerFailure):
+            await client.review_pair("diff", "rid")
+
+    assert sorted(interrupts) == ["claude", "codex", "parent"]
+
+
+def _assistant(review: dict[str, Any]) -> dict[str, Any]:
+    text = json.dumps(review)
+    middle = len(text) // 2
+    return {
+        "type": "message",
+        "data": {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": text[:middle]},
+                {"type": "output_text", "text": text[middle:]},
+            ],
+        },
+    }
+
+
+class FakeGitHub:
+    def __init__(self) -> None:
+        self.head = "head"
+        self.reviews: list[dict[str, Any]] = []
+        self.statuses: list[str] = []
+
+    async def get_pull(self, owner: str, repo: str, number: int) -> dict[str, Any]:
+        return {"head": {"sha": self.head}}
+
+    async def get_diff(self, owner: str, repo: str, number: int) -> str:
+        return "diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n+new"
+
+    async def find_review(
+        self, owner: str, repo: str, number: int, marker: str
+    ) -> dict[str, Any] | None:
+        return next((review for review in self.reviews if marker in review["body"]), None)
+
+    async def publish_review_once(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        head_sha: str,
+        body: str,
+        comments: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        existing = await self.find_review(owner, repo, number, body.split("\n", 1)[0])
+        if existing:
+            return existing
+        review = {"id": len(self.reviews) + 1, "body": body, "comments": comments}
+        self.reviews.append(review)
+        return review
+
+    async def upsert_status_comment(
+        self, owner: str, repo: str, number: int, body: str, cached_id: int | None = None
+    ) -> int:
+        self.statuses[:] = [body]
+        return 10
+
+
+class FakeOmnigent:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def review_pair(self, diff: str, review_id: str) -> dict[str, dict[str, Any]]:
+        self.calls += 1
+        return {
+            "claude_review": _review(review_id, verdict="Mostly sound"),
+            "codex_review": _review(review_id, verdict="Needs changes", priority="High"),
+        }
+
+
+@pytest.mark.asyncio
+async def test_worker_end_to_end_two_outputs_create_one_review(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = FakeGitHub()
+    omnigent = FakeOmnigent()
+    worker = PollyWorker(store, github, omnigent)
+
+    assert await worker.run_once() is True
+    assert len(github.reviews) == 1
+    assert omnigent.calls == 1
+    assert store.list_jobs()[0].state == "published"
+
+
+@pytest.mark.asyncio
+async def test_worker_publishes_complete_deterministic_review_body(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = FakeGitHub()
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once()
+
+    assert (
+        github.reviews[0]["body"]
+        == """<!-- polly-review:acme/widgets#12:head -->
+**Disposition:** BLOCKING
+
+## Claude
+Found one issue.
+
+## Codex
+Found one issue.
+
+## Findings without a valid diff anchor
+- **High · Unsafe branch** `app.py:2` — This branch can lose data.
+
+**Approach:** Needs changes
+
+## Blockers
+- `app.py:2` **Unsafe branch** — This branch can lose data.
+
+## Resolved previous findings
+- fixed
+- shared
+
+## Still-open previous findings
+- open"""
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_one_fresh_pair_per_durable_job_attempt(tmp_path: Path) -> None:
+    class FlakyOmnigent(FakeOmnigent):
+        async def review_pair(self, diff: str, review_id: str) -> dict[str, dict[str, Any]]:
+            self.calls += 1
+            if self.calls == 1:
+                raise ReviewerFailure("runner failed")
+            return {
+                "claude_review": _review(review_id, verdict="Mostly sound"),
+                "codex_review": _review(review_id, verdict="Needs changes", priority="High"),
+            }
+
+    now = [0.0]
+    database = tmp_path / "polly.db"
+    store = PollyStore(database, clock=lambda: now[0])
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = FakeGitHub()
+    omnigent = FlakyOmnigent()
+    worker = PollyWorker(store, github, omnigent, max_job_attempts=2, retry_delays=(5,))
+
+    assert await worker.run_once() is True
+    assert omnigent.calls == 1
+    assert store.list_jobs()[0].state == "retry_wait"
+    del worker, store
+    now[0] = 5
+    store = PollyStore(database, clock=lambda: now[0])
+    worker = PollyWorker(store, github, omnigent, max_job_attempts=2, retry_delays=(5,))
+    assert await worker.run_once() is True
+    assert omnigent.calls == 2
+    assert store.list_jobs()[0].state == "published"
+
+
+@pytest.mark.asyncio
+async def test_worker_does_not_transport_retry_review_pair(tmp_path: Path) -> None:
+    class OfflineOmnigent(FakeOmnigent):
+        async def review_pair(self, diff: str, review_id: str) -> dict[str, dict[str, Any]]:
+            self.calls += 1
+            raise httpx.ReadTimeout("review transport failed")
+
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    omnigent = OfflineOmnigent()
+
+    assert await PollyWorker(
+        store,
+        FakeGitHub(),
+        omnigent,
+        transport_attempts=3,
+        max_job_attempts=2,
+        retry_delays=(5,),
+    ).run_once()
+
+    assert omnigent.calls == 1
+    assert store.list_jobs()[0].state == "retry_wait"
+
+
+@pytest.mark.asyncio
+async def test_worker_transport_retries_are_due_and_finite(tmp_path: Path) -> None:
+    class OfflineGitHub(FakeGitHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def find_review(
+            self, owner: str, repo: str, number: int, marker: str
+        ) -> dict[str, Any] | None:
+            self.calls += 1
+            raise httpx.ReadTimeout("offline")
+
+    now = [0.0]
+    store = PollyStore(tmp_path / "polly.db", clock=lambda: now[0])
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = OfflineGitHub()
+    worker = PollyWorker(
+        store,
+        github,
+        FakeOmnigent(),
+        transport_attempts=1,
+        max_job_attempts=3,
+        retry_delays=(5, 10),
+    )
+
+    assert await worker.run_once() is True
+    assert store.list_jobs()[0].state == "retry_wait"
+    assert await worker.run_once() is False
+    now[0] = 5
+    assert await worker.run_once() is True
+    assert store.list_jobs()[0].state == "retry_wait"
+    now[0] = 15
+    assert await worker.run_once() is True
+
+    assert store.list_jobs()[0].state == "failed"
+    assert await worker.run_once() is False
+    assert github.calls == 3
+    assert store.reset_failed(store.list_jobs()[0].id) is True
+    assert store.list_jobs()[0].attempts == 0
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 503])
+@pytest.mark.asyncio
+async def test_worker_retryable_http_statuses_use_bounded_transport_and_job_retry(
+    tmp_path: Path, status_code: int
+) -> None:
+    class UnavailableGitHub(FakeGitHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def find_review(
+            self, owner: str, repo: str, number: int, marker: str
+        ) -> dict[str, Any] | None:
+            self.calls += 1
+            response = httpx.Response(
+                status_code,
+                request=httpx.Request("GET", "https://api.github.test/reviews"),
+            )
+            response.raise_for_status()
+            return None
+
+    now = [0.0]
+    store = PollyStore(tmp_path / "polly.db", clock=lambda: now[0])
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = UnavailableGitHub()
+    worker = PollyWorker(
+        store,
+        github,
+        FakeOmnigent(),
+        transport_attempts=2,
+        max_job_attempts=2,
+        retry_delays=(5,),
+        sleep=lambda _: asyncio.sleep(0),
+    )
+
+    assert await worker.run_once() is True
+    assert store.list_jobs()[0].state == "retry_wait"
+    assert github.calls == 2
+
+    now[0] = 5
+    assert await worker.run_once() is True
+    assert store.list_jobs()[0].state == "failed"
+    assert github.calls == 4
+
+
+@pytest.mark.asyncio
+async def test_worker_terminal_http_status_fails_without_retry(tmp_path: Path) -> None:
+    class MissingGitHub(FakeGitHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def find_review(
+            self, owner: str, repo: str, number: int, marker: str
+        ) -> dict[str, Any] | None:
+            self.calls += 1
+            response = httpx.Response(
+                404,
+                request=httpx.Request("GET", "https://api.github.test/reviews"),
+            )
+            response.raise_for_status()
+            return None
+
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = MissingGitHub()
+
+    assert await PollyWorker(store, github, FakeOmnigent(), transport_attempts=3).run_once()
+    assert store.list_jobs()[0].state == "failed"
+    assert github.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_crash_marker_replay_second_run_does_not_duplicate_review(
+    tmp_path: Path,
+) -> None:
+    class UncertainGitHub(FakeGitHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.outage = True
+
+        async def publish_review_once(
+            self,
+            owner: str,
+            repo: str,
+            number: int,
+            head_sha: str,
+            body: str,
+            comments: list[dict[str, Any]],
+        ) -> dict[str, Any]:
+            if not self.reviews:
+                self.reviews.append({"id": 1, "body": body, "comments": comments})
+            if self.outage:
+                raise httpx.ReadTimeout("response lost")
+            return self.reviews[0]
+
+    now = [0.0]
+    store = PollyStore(tmp_path / "polly.db", clock=lambda: now[0])
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = UncertainGitHub()
+    omnigent = FakeOmnigent()
+    worker = PollyWorker(
+        store,
+        github,
+        omnigent,
+        transport_attempts=1,
+        max_job_attempts=2,
+        retry_delays=(1,),
+    )
+
+    assert await worker.run_once() is True
+    assert store.list_jobs()[0].state == "retry_wait"
+    github.outage = False
+    now[0] = 1
+    assert await worker.run_once() is True
+
+    assert store.list_jobs()[0].state == "published"
+    assert len(github.reviews) == 1
+    assert omnigent.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_does_not_publish_when_head_changes_after_review(tmp_path: Path) -> None:
+    class MovingHeadGitHub(FakeGitHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.head_reads = 0
+
+        async def get_pull(self, owner: str, repo: str, number: int) -> dict[str, Any]:
+            self.head_reads += 1
+            return {"head": {"sha": "head" if self.head_reads == 1 else "new-head"}}
+
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+    github = MovingHeadGitHub()
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("head", "superseded"),
+        ("new-head", "pending"),
+    ]
+    assert github.reviews == []
+
+
+@pytest.mark.asyncio
+async def test_worker_marker_for_stale_head_restores_current_head(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("current", "acme", "widgets", 12, "current-head", 7)
+    store.accept("stale", "acme", "widgets", 12, "stale-head", 7)
+    github = FakeGitHub()
+    github.head = "current-head"
+    github.reviews.append(
+        {"id": 1, "body": "<!-- polly-review:acme/widgets#12:stale-head -->", "comments": []}
+    )
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("current-head", "pending"),
+        ("stale-head", "superseded"),
+    ]
+
+
+@pytest.mark.parametrize("pull", [{}, {"head": {}}, {"head": {"sha": None}}, {"head": {"sha": 7}}])
+@pytest.mark.asyncio
+async def test_worker_fails_malformed_current_head_without_superseding(
+    tmp_path: Path, pull: dict[str, Any]
+) -> None:
+    class MalformedHeadGitHub(FakeGitHub):
+        async def get_pull(self, owner: str, repo: str, number: int) -> dict[str, Any]:
+            return pull
+
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+
+    assert await PollyWorker(store, MalformedHeadGitHub(), FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [("head", "failed")]
+
+
+@pytest.mark.asyncio
+async def test_worker_restores_superseded_observed_current_head(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("current", "acme", "widgets", 12, "current-head", 7)
+    store.accept("stale", "acme", "widgets", 12, "stale-head", 7)
+    github = FakeGitHub()
+    github.head = "current-head"
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("current-head", "pending"),
+        ("stale-head", "superseded"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worker_creates_observed_current_head_missing_from_webhooks(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("stale", "acme", "widgets", 12, "stale-head", 7)
+    github = FakeGitHub()
+    github.head = "current-head"
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("stale-head", "superseded"),
+        ("current-head", "pending"),
+    ]
+
+
+@pytest.mark.parametrize("terminal_state", ["published", "failed"])
+@pytest.mark.asyncio
+async def test_worker_does_not_revive_terminal_observed_current_head(
+    tmp_path: Path, terminal_state: str
+) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("current", "acme", "widgets", 12, "current-head", 7)
+    current = store.list_jobs()[0]
+    store.set_state(current.id, terminal_state)
+    store.accept("stale", "acme", "widgets", 12, "stale-head", 7)
+    github = FakeGitHub()
+    github.head = "current-head"
+
+    assert await PollyWorker(store, github, FakeOmnigent()).run_once() is True
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("current-head", terminal_state),
+        ("stale-head", "superseded"),
+    ]

--- a/tests/integrations/polly/test_runtime.py
+++ b/tests/integrations/polly/test_runtime.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.integrations.polly.webhook import create_webhook_app
+
+
+def _payload(
+    *,
+    sha: str = "head-1",
+    draft: bool = False,
+    fork: bool = False,
+    repository: str = "acme/widgets",
+) -> bytes:
+    owner, name = repository.split("/", 1)
+    repo = {"full_name": repository, "owner": {"login": owner}, "name": name}
+    head_repo = {"full_name": f"other/{name}" if fork else repository}
+    return json.dumps(
+        {
+            "action": "opened",
+            "installation": {"id": 7},
+            "repository": repo,
+            "pull_request": {
+                "number": 12,
+                "draft": draft,
+                "head": {"sha": sha, "repo": head_repo},
+                "base": {"repo": repo},
+            },
+        }
+    ).encode()
+
+
+def _post(client: TestClient, body: bytes, *, delivery: str = "delivery-1") -> httpx.Response:
+    signature = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    return client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": delivery,
+            "X-Hub-Signature-256": signature,
+            "Content-Type": "application/json",
+        },
+    )
+
+
+def test_webhook_verifies_filters_and_durably_deduplicates(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    client = TestClient(create_webhook_app(store, "secret", max_body_bytes=1024))
+
+    assert client.get("/health").json() == {"status": "ok"}
+    accepted = _post(client, _payload())
+    duplicate = _post(client, _payload())
+
+    assert accepted.status_code == 202
+    assert accepted.json() == {"status": "accepted"}
+    assert duplicate.status_code == 202
+    assert duplicate.json() == {"status": "duplicate"}
+    jobs = store.list_jobs()
+    assert [(job.owner, job.repo, job.pr_number, job.head_sha, job.state) for job in jobs] == [
+        ("acme", "widgets", 12, "head-1", "pending")
+    ]
+
+
+def test_webhook_enforces_repository_allowlist_case_insensitively(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    client = TestClient(create_webhook_app(store, "secret", repositories=("ACME/WIDGETS",)))
+
+    allowed = _post(client, _payload(), delivery="allowed")
+    denied = _post(client, _payload(repository="acme/other"), delivery="denied")
+
+    assert allowed.json() == {"status": "accepted"}
+    assert denied.json() == {"status": "skipped"}
+    assert [(job.owner, job.repo) for job in store.list_jobs()] == [("acme", "widgets")]
+
+
+@pytest.mark.parametrize(
+    ("headers", "body", "status"),
+    [
+        ({"X-GitHub-Event": "pull_request", "X-GitHub-Delivery": "bad"}, _payload(), 401),
+        ({}, b"x" * 1025, 413),
+    ],
+)
+def test_webhook_rejects_bad_signature_and_oversized_raw_body(
+    tmp_path: Path, headers: dict[str, str], body: bytes, status: int
+) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    client = TestClient(create_webhook_app(store, "secret", max_body_bytes=1024))
+
+    response = client.post("/webhooks/github", content=body, headers=headers)
+
+    assert response.status_code == status
+    assert store.list_jobs() == []
+
+
+@pytest.mark.parametrize("body", [b"[]", b'{"action":"opened","pull_request":"bad"}'])
+def test_webhook_rejects_malformed_signed_payload(tmp_path: Path, body: bytes) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    client = TestClient(create_webhook_app(store, "secret"), raise_server_exceptions=False)
+
+    response = _post(client, body)
+
+    assert response.status_code == 400
+    assert store.list_jobs() == []
+
+
+@pytest.mark.parametrize(
+    ("event", "action", "draft", "fork"),
+    [
+        ("push", "opened", False, False),
+        ("pull_request", "closed", False, False),
+        ("pull_request", "opened", True, False),
+        ("pull_request", "opened", False, True),
+    ],
+)
+def test_webhook_skips_unsupported_or_unsafe_pull_requests(
+    tmp_path: Path, event: str, action: str, draft: bool, fork: bool
+) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    client = TestClient(create_webhook_app(store, "secret"))
+    body = json.loads(_payload(draft=draft, fork=fork))
+    body["action"] = action
+    raw = json.dumps(body).encode()
+    signature = "sha256=" + hmac.new(b"secret", raw, hashlib.sha256).hexdigest()
+
+    response = client.post(
+        "/webhooks/github",
+        content=raw,
+        headers={
+            "X-GitHub-Event": event,
+            "X-GitHub-Delivery": f"{event}-{action}-{draft}-{fork}",
+            "X-Hub-Signature-256": signature,
+        },
+    )
+
+    assert response.status_code == 202
+    assert response.json() == {"status": "skipped"}
+    assert store.list_jobs() == []
+
+
+def test_store_recovers_supersedes_and_only_resets_failed_jobs(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("d1", "acme", "widgets", 12, "old", 7)
+    old = store.claim_next()
+    assert old is not None and old.state == "running"
+
+    store.recover_running()
+    assert store.get_job(old.id).state == "pending"
+    store.accept("d2", "acme", "widgets", 12, "new", 7)
+    assert store.get_job(old.id).state == "superseded"
+
+    new = next(job for job in store.list_jobs() if job.head_sha == "new")
+    assert store.reset_failed(new.id) is False
+    store.set_state(new.id, "failed", error="model failed")
+    assert store.reset_failed(new.id) is True
+    assert store.get_job(new.id).state == "pending"
+
+
+def test_store_accept_revives_an_existing_superseded_head(tmp_path: Path) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("old", "acme", "widgets", 12, "old-head", 7)
+    store.accept("new", "acme", "widgets", 12, "new-head", 7)
+
+    assert store.accept("back-push", "acme", "widgets", 12, "old-head", 7) == "duplicate"
+
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("old-head", "pending"),
+        ("new-head", "superseded"),
+    ]
+
+
+@pytest.mark.parametrize("terminal_state", ["published", "failed"])
+def test_store_accept_does_not_revive_terminal_head(tmp_path: Path, terminal_state: str) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("first", "acme", "widgets", 12, "head", 7)
+    job = store.list_jobs()[0]
+    store.set_state(job.id, terminal_state)
+
+    assert store.accept("again", "acme", "widgets", 12, "head", 7) == "duplicate"
+    assert store.get_job(job.id).state == terminal_state
+
+
+@pytest.mark.parametrize("terminal_state", ["published", "failed"])
+def test_terminal_stale_delivery_does_not_supersede_current_pending_head(
+    tmp_path: Path, terminal_state: str
+) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("old", "acme", "widgets", 12, "old-head", 7)
+    old = store.list_jobs()[0]
+    store.set_state(old.id, terminal_state)
+    store.accept("current", "acme", "widgets", 12, "current-head", 7)
+
+    assert store.accept("delayed-old", "acme", "widgets", 12, "old-head", 7) == "duplicate"
+    assert [(job.head_sha, job.state) for job in store.list_jobs()] == [
+        ("old-head", terminal_state),
+        ("current-head", "pending"),
+    ]
+
+
+def test_claim_next_returns_claimed_job_without_second_store_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PollyStore(tmp_path / "polly.db")
+    store.accept("delivery", "acme", "widgets", 12, "head", 7)
+
+    def fail_second_read(_: int) -> None:
+        raise AssertionError("claim_next must return from its transaction")
+
+    monkeypatch.setattr(store, "get_job", fail_second_read)
+    claimed = store.claim_next()
+
+    assert claimed is not None
+    assert (claimed.state, claimed.attempts) == ("running", 1)
+
+
+def test_reopening_store_does_not_steal_live_job_and_explicit_recovery_resets_it(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "polly.db"
+    store = PollyStore(path)
+    store.accept("d1", "acme", "widgets", 12, "head", 7)
+    running = store.claim_next()
+    assert running is not None and running.state == "running"
+
+    reopened = PollyStore(path)
+
+    assert reopened.get_job(running.id).state == "running"
+    assert reopened.recover_running() == 1
+    assert reopened.get_job(running.id).state == "pending"
+
+
+def test_retry_wait_jobs_are_claimed_only_when_due_and_stop_at_attempt_ceiling(
+    tmp_path: Path,
+) -> None:
+    now = [100.0]
+    store = PollyStore(tmp_path / "polly.db", clock=lambda: now[0])
+    store.accept("d1", "acme", "widgets", 12, "head", 7)
+    first = store.claim_next()
+    assert first is not None
+    store.schedule_retry(first.id, delay=5, error="network")
+
+    assert store.claim_next() is None
+    now[0] = 105.0
+    second = store.claim_next()
+
+    assert second is not None
+    assert second.attempts == 2
+    assert second.next_attempt_at is None

--- a/tests/integrations/polly/test_runtime_entrypoint.py
+++ b/tests/integrations/polly/test_runtime_entrypoint.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from unittest import mock
+
+import httpx
+import pytest
+
+from omnigent.integrations.polly.cli import PollyConfig
+from omnigent.integrations.polly.runtime import _required_secret, build_runtime
+from omnigent.integrations.polly.store import PollyStore
+from omnigent.onboarding import secrets
+
+
+def test_runtime_required_secret_rejects_blank_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    secrets.store_secret("polly-github-webhook-secret", " \n")
+
+    with pytest.raises(RuntimeError, match="missing Polly secret slot"):
+        _required_secret("polly-github-webhook-secret")
+
+
+@pytest.mark.asyncio
+async def test_runtime_acquires_singleton_recovers_once_and_cleans_up(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+    store = mock.Mock()
+    store.recover_running.return_value = 1
+    daemon = mock.Mock()
+    worker = mock.Mock()
+    worker.run_once = mock.AsyncMock(side_effect=[False])
+
+    runtime = build_runtime(
+        config=config,
+        private_key="private",
+        webhook_secret="webhook",
+        refresh_token="refresh",
+        access_token="access",
+        store=store,
+        daemon=daemon,
+        worker=worker,
+        idle_sleep=mock.AsyncMock(),
+    )
+    async with runtime.app.router.lifespan_context(runtime.app):
+        await runtime.started.wait()
+
+    daemon.acquire_current.assert_called_once()
+    store.recover_running.assert_called_once_with()
+    daemon.release_current.assert_called_once()
+    await runtime.github_http.aclose()
+    await runtime.omnigent_http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_continues_after_one_worker_iteration_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+    progressed = asyncio.Event()
+    calls = 0
+
+    async def run_once() -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary store failure")
+        progressed.set()
+        return False
+
+    async def idle_sleep(_: float) -> None:
+        await asyncio.sleep(0)
+
+    worker = mock.Mock()
+    worker.run_once = run_once
+    runtime = build_runtime(
+        config=config,
+        private_key="private",
+        webhook_secret="webhook",
+        refresh_token="refresh",
+        daemon=mock.Mock(),
+        worker=worker,
+        idle_sleep=idle_sleep,
+    )
+
+    with caplog.at_level("ERROR"):
+        async with runtime.app.router.lifespan_context(runtime.app):
+            await asyncio.wait_for(progressed.wait(), timeout=1)
+
+    assert calls >= 2
+    assert "Polly worker iteration failed" in caplog.text
+    await runtime.github_http.aclose()
+    await runtime.omnigent_http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_health_is_unavailable_when_worker_task_stops(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+    started = asyncio.Event()
+
+    async def run_once() -> bool:
+        started.set()
+        raise asyncio.CancelledError
+
+    worker = mock.Mock()
+    worker.run_once = run_once
+    runtime = build_runtime(
+        config=config,
+        private_key="private",
+        webhook_secret="webhook",
+        refresh_token="refresh",
+        daemon=mock.Mock(),
+        worker=worker,
+    )
+
+    async with runtime.app.router.lifespan_context(runtime.app):
+        await started.wait()
+        await asyncio.sleep(0)
+        transport = httpx.ASGITransport(app=runtime.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+
+    assert response.status_code == 503
+    await runtime.github_http.aclose()
+    await runtime.omnigent_http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_persists_rotated_access_and_refresh_tokens(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+    worker = mock.Mock()
+    worker.run_once = mock.AsyncMock(return_value=False)
+    with (
+        mock.patch("omnigent.integrations.polly.runtime.OmnigentClient") as client,
+        mock.patch("omnigent.integrations.polly.runtime.secret_store.store_secret") as store,
+    ):
+        runtime = build_runtime(
+            config=config,
+            private_key="private",
+            webhook_secret="webhook",
+            refresh_token="refresh",
+            access_token="access",
+            device_client_secret="client-secret",
+            daemon=mock.Mock(),
+            worker=worker,
+            idle_sleep=mock.AsyncMock(),
+        )
+        client.call_args.kwargs["save_tokens"]("new-access", "new-refresh")
+
+    assert [call.args for call in store.call_args_list] == [
+        ("polly-omnigent-refresh-token", "new-refresh"),
+        ("polly-omnigent-access-token", "new-access"),
+    ]
+    await runtime.github_http.aclose()
+    await runtime.omnigent_http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_passes_configured_repository_allowlist_to_webhook(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = PollyConfig(
+        server_url="http://127.0.0.1:8000",
+        public_url="https://polly.example.com",
+        listen_host="127.0.0.1",
+        listen_port=8788,
+        workspace=str(workspace),
+        agent_id="ag_polly",
+        host_id="host_1",
+        github_app_id="123",
+        github_app_slug="polly-test",
+        repositories=("acme/widgets",),
+    )
+    store = PollyStore(tmp_path / "polly.sqlite3")
+    runtime = build_runtime(
+        config=config,
+        private_key="private",
+        webhook_secret="secret",
+        refresh_token="refresh",
+        store=store,
+        daemon=mock.Mock(),
+        worker=mock.Mock(),
+    )
+    payload = json.dumps(
+        {
+            "action": "opened",
+            "installation": {"id": 7},
+            "repository": {
+                "full_name": "acme/other",
+                "owner": {"login": "acme"},
+                "name": "other",
+            },
+            "pull_request": {
+                "number": 12,
+                "draft": False,
+                "head": {
+                    "sha": "head-1",
+                    "repo": {"full_name": "acme/other"},
+                },
+                "base": {"repo": {"full_name": "acme/other"}},
+            },
+        }
+    ).encode()
+    signature = "sha256=" + hmac.new(b"secret", payload, hashlib.sha256).hexdigest()
+    transport = httpx.ASGITransport(app=runtime.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/github",
+            content=payload,
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "delivery-1",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+    assert response.json() == {"status": "skipped"}
+    assert store.list_jobs() == []
+    await runtime.github_http.aclose()
+    await runtime.omnigent_http.aclose()

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -106,6 +106,58 @@ _TEST_HARNESS_NAME = "runner-test-default"
 _TEST_HARNESS_MODULE = "tests._fixtures.runner_test_harness"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("tool_free", "expects_tools"), [(True, False), (False, True)])
+async def test_runner_honors_tool_free_without_affecting_ordinary_agents(
+    tool_free: bool, expects_tools: bool
+) -> None:
+    harness = _RecoveryScriptedHarnessClient(
+        [
+            "event: response.created\n"
+            'data: {"type":"response.created","response":{"id":"r1"}}\n\n',
+            "event: response.completed\n"
+            'data: {"type":"response.completed","response":{"id":"r1"}}\n\n',
+        ]
+    )
+
+    async def resolve(_agent_id: str, _session_id: str | None = None) -> AgentSpec:
+        return AgentSpec(
+            spec_version=1,
+            executor=ExecutorSpec(
+                type="omnigent", config={"harness": "claude-sdk", "tool_free": tool_free}
+            ),
+        )
+
+    app = create_runner_app(
+        process_manager=_RecoveryFakeProcessManager(harness),  # type: ignore[arg-type]
+        spec_resolver=resolve,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _recovery_runner_client(app) as client:
+        response = await client.post(
+            "/v1/sessions/conv_tool_free/events",
+            params={"stream": "true"},
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_tool_free",
+                "content": [{"type": "input_text", "text": "review"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "injected_tool",
+                        "description": "must be dropped",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert len(harness.posted_bodies) == 1
+    assert ("tools" in harness.posted_bodies[0]) is expects_tools
+
+
 @pytest.fixture(autouse=True)
 def _assume_harness_clis_installed(monkeypatch: pytest.MonkeyPatch) -> None:
     """Neutralize the sub-agent dispatch CLI preflight for hermetic tests.

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -512,6 +512,60 @@ async def test_get_client_respawns_on_model_change(
         await manager.shutdown()
 
 
+@pytest.mark.parametrize(
+    ("config_key", "first_value", "safe_value"),
+    [
+        ("HARNESS_TEST_SKILLS_FILTER", '"all"', '"none"'),
+        ("HARNESS_TEST_DISABLE_NATIVE_TOOLS", "0", "1"),
+        ("HARNESS_TEST_ENABLE_WEB_SEARCH", "1", "0"),
+        ("HARNESS_TEST_MINIMAL_CONFIG", "0", "1"),
+        ("HARNESS_TEST_TOOL_FREE", "0", "1"),
+    ],
+)
+async def test_get_client_respawns_on_safety_config_change_only(
+    manager: HarnessProcessManager,
+    config_key: str,
+    first_value: str,
+    safe_value: str,
+) -> None:
+    """Same-harness agent switches replace stale safety config, not unrelated env."""
+    await manager.start()
+    try:
+        client_first = await manager.get_client(
+            "conv_safety_switch",
+            _TEST_HARNESS_NAME,
+            env={
+                config_key: first_value,
+                "HARNESS_TEST_CUSTOM": "first",
+            },
+        )
+        pid_first = (await client_first.get("/pid")).json()["pid"]
+
+        client_irrelevant = await manager.get_client(
+            "conv_safety_switch",
+            _TEST_HARNESS_NAME,
+            env={
+                config_key: first_value,
+                "HARNESS_TEST_CUSTOM": "second",
+            },
+        )
+        assert (await client_irrelevant.get("/pid")).json()["pid"] == pid_first
+
+        client_safe = await manager.get_client(
+            "conv_safety_switch",
+            _TEST_HARNESS_NAME,
+            env={
+                config_key: safe_value,
+                "HARNESS_TEST_CUSTOM": "third",
+            },
+        )
+        pid_safe = (await client_safe.get("/pid")).json()["pid"]
+        assert pid_safe != pid_first
+        assert (await client_safe.get(f"/env/{config_key}")).json() == {"value": safe_value}
+    finally:
+        await manager.shutdown()
+
+
 async def test_get_client_any_harness_sentinel_reuses_subprocess(
     manager: HarnessProcessManager,
 ) -> None:

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -69,6 +69,7 @@ def _clear_ambient_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DATABRICKS_TOKEN"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("omnigent.onboarding.harness_install._LOGIN_PROBE_CACHE", {})
     monkeypatch.setattr(
         "omnigent.runtime.workflow._resolve_catalog_default_model",
         lambda provider_name, family, *, context: _CATALOG_DEFAULTS[(provider_name, family)],
@@ -117,6 +118,7 @@ def _make_spec(
     use_responses: object | None = None,
     auth: ApiKeyAuth | DatabricksAuth | ProviderAuth | None = None,
     os_env: object | None = None,
+    executor_config: dict[str, object] | None = None,
 ) -> AgentSpec:
     """
     Build a minimal :class:`AgentSpec` for a given harness.
@@ -139,6 +141,8 @@ def _make_spec(
         config["profile"] = profile
     if use_responses is not None:
         config["use_responses"] = use_responses
+    if executor_config is not None:
+        config.update(executor_config)
     return AgentSpec(
         spec_version=1,
         name=f"test-{harness}",
@@ -322,6 +326,67 @@ def test_codex_uses_openai_global_default(config_home: Path) -> None:
     assert env["HARNESS_CODEX_MODEL"] == "gpt-default-model"
     # Codex defaults to the Responses wire API when the family omits wire_api.
     assert env["HARNESS_CODEX_WIRE_API"] == "responses"
+
+
+def test_codex_threads_native_tool_and_web_search_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-agent Codex safety switches reach the isolated harness process."""
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.codex_config_provider_dismissed", lambda _c: False
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow._apply_harness_path_override", lambda *_a: None)
+    spec = _make_spec(
+        harness="codex",
+        auth=ApiKeyAuth(api_key="sk-test"),
+        executor_config={"disable_native_tools": True, "enable_web_search": False},
+    )
+
+    env = _build_codex_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CODEX_DISABLE_NATIVE_TOOLS"] == "1"
+    assert env["HARNESS_CODEX_ENABLE_WEB_SEARCH"] == "0"
+
+
+def test_claude_threads_tool_free_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow._apply_harness_path_override", lambda *_a: None)
+    spec = _make_spec(
+        harness="claude-sdk",
+        auth=ApiKeyAuth(api_key="sk-test"),
+        executor_config={"tool_free": True},
+    )
+
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_TOOL_FREE"] == "1"
+
+
+def test_codex_threads_minimal_config_for_isolated_reviewer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reviewer can request the executor's hermetic Codex home."""
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.codex_config_provider_dismissed", lambda _c: False
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow._apply_harness_path_override", lambda *_a: None)
+    spec = _make_spec(
+        harness="codex",
+        auth=ApiKeyAuth(api_key="sk-test"),
+        executor_config={"minimal_config": True},
+    )
+
+    env = _build_codex_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CODEX_MINIMAL_CONFIG"] == "1"
 
 
 def test_codex_falls_back_to_first_available_openai_credential(

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -866,6 +866,36 @@ def test_ensure_default_polly_agent_is_idempotent(seed_stores: _SeedStores) -> N
     assert polly_rows[0].version == first.version == 1
 
 
+def test_ensure_default_polly_review_agent_is_idempotent(seed_stores: _SeedStores) -> None:
+    """Startup seeds one stable, retrievable polly-review built-in."""
+    from omnigent.db.utils import builtin_agent_id
+
+    server_app._ensure_default_agents(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    first = seed_stores.agent_store.get_by_name("polly-review")
+    assert first is not None
+    assert first.id == builtin_agent_id("polly-review")
+    assert first.session_id is None
+    assert seed_stores.artifact_store.get(first.bundle_location) is not None
+
+    server_app._ensure_default_agents(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    rows = [
+        agent
+        for agent in seed_stores.agent_store.list(limit=100).data
+        if agent.name == "polly-review"
+    ]
+    assert len(rows) == 1
+    assert rows[0].id == first.id
+    assert rows[0].version == first.version == 1
+
+
 def test_ensure_default_polly_agent_refreshes_on_spec_change(
     seed_stores: _SeedStores, polly_src_copy: Path
 ) -> None:

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -22,8 +22,10 @@ import yaml
 from omnigent.errors import OmnigentError
 from omnigent.harness_plugins import native_provider_for_key
 from omnigent.native_coding_agents import NATIVE_CODING_AGENTS as _NATIVE_CODING_AGENTS
+from omnigent.runtime.workflow import _config_flag_is_true
 from omnigent.server import app
 from omnigent.spec import load, materialize_bundle
+from omnigent.spec.types import SharePolicy
 
 # Native built-ins are seeded through one registry-driven builder,
 # ``_build_native_bundle(provider)`` (PR 1.7). We exercise EVERY native agent
@@ -38,6 +40,7 @@ _NATIVE_BUILDERS = [(agent.key, f"{agent.agent_name}.yaml") for agent in _NATIVE
 _EXAMPLE_BUILDERS = [
     ("_build_debby_bundle", "config.yaml", True),
     ("_build_polly_bundle", "config.yaml", True),
+    ("_build_polly_review_bundle", "config.yaml", True),
 ]
 
 
@@ -50,6 +53,7 @@ def _shipped_example_missing(builder: str) -> bool:
     source = {
         "_build_debby_bundle": app._DEBBY_BUNDLE_SOURCE,
         "_build_polly_bundle": app._POLLY_BUNDLE_SOURCE,
+        "_build_polly_review_bundle": app._POLLY_REVIEW_BUNDLE_SOURCE,
     }[builder]
     return not (source / "config.yaml").is_file()
 
@@ -137,7 +141,47 @@ _SHIPPED_SUB_AGENT_EXAMPLES = [
         {"claude_code", "codex", "opencode", "cursor", "hermes", "pi"},
     ),
     ("debby", app._DEBBY_BUNDLE_SOURCE, {"claude", "gpt"}),
+    (
+        "polly-review",
+        app._POLLY_REVIEW_BUNDLE_SOURCE,
+        {"claude_review", "codex_review"},
+    ),
 ]
+
+
+def test_polly_review_workers_are_fixed_and_tool_free() -> None:
+    """The built-in review workers cannot spawn, load skills, or access the OS."""
+    spec = load(app._POLLY_REVIEW_BUNDLE_SOURCE, expand_env=False)
+    assert spec.name == "polly-review"
+    assert spec.tools.agents == ["claude_review", "codex_review"]
+
+    workers = {worker.name: worker for worker in spec.sub_agents}
+    assert set(workers) == {"claude_review", "codex_review"}
+    assert workers["claude_review"].executor.config["harness"] == "claude-sdk"
+    assert workers["codex_review"].executor.config["harness"] == "codex"
+
+    for worker in workers.values():
+        assert worker.spawn is False
+        assert worker.async_enabled is False
+        assert worker.timers is False
+        assert worker.agent_session_sharing is SharePolicy.NONE
+        assert worker.skills_filter == "none"
+        assert worker.skills == []
+        assert worker.os_env is None
+        assert worker.terminals is None
+        assert worker.mcp_servers == []
+        assert worker.sub_agents == []
+        assert worker.tools.agents == []
+        assert worker.tools.builtins == []
+        assert worker.local_tools == []
+        assert worker.tool_free is True
+
+    assert not any(path.is_dir() for path in app._POLLY_REVIEW_BUNDLE_SOURCE.rglob("skills"))
+
+    codex_config = workers["codex_review"].executor.config
+    assert _config_flag_is_true(codex_config["disable_native_tools"])
+    assert not _config_flag_is_true(codex_config["enable_web_search"])
+    assert _config_flag_is_true(codex_config["minimal_config"])
 
 
 @pytest.mark.parametrize(("name", "source", "expected_sub_agents"), _SHIPPED_SUB_AGENT_EXAMPLES)

--- a/tests/server/test_device_auth.py
+++ b/tests/server/test_device_auth.py
@@ -17,13 +17,23 @@ from __future__ import annotations
 
 import logging
 import secrets
+import time
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
+import httpx
+import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from jwt.algorithms import RSAAlgorithm
 
+from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.device_grant_store import DeviceGrantStore, hash_secret
+from omnigent.server.oidc import OIDCConfig
 
 _KEY = b"k" * 32
 
@@ -31,19 +41,112 @@ _KEY = b"k" * 32
 # ── Router mount guard (unit) ─────────────────────────────────────
 
 
-@pytest.mark.parametrize("source", ["oidc", "header"])
-def test_router_factory_rejects_non_accounts_mode(source: str, tmp_path: Path) -> None:
-    """The device grant is accounts-mode only. OIDC delegates login to the IdP
-    (cli-ticket flow) and never uses these routes; header can't mint identity.
-    ``create_device_auth_router`` must refuse to build for either."""
+def test_router_factory_rejects_header_mode(tmp_path: Path) -> None:
+    """Header auth cannot safely mint a delegated browser identity."""
     from types import SimpleNamespace
 
     from omnigent.server.routes.device_auth import create_device_auth_router
 
-    provider = SimpleNamespace(_source=source)
+    provider = SimpleNamespace(_source="header")
     store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
-    with pytest.raises(RuntimeError, match="accounts"):
+    with pytest.raises(RuntimeError, match="no server-minted session"):
         create_device_auth_router(provider, store)  # type: ignore[arg-type]
+
+
+def test_router_factory_rejects_github_oauth(tmp_path: Path) -> None:
+    """GitHub OAuth cannot attest a forced OIDC reauthentication."""
+    from omnigent.server.routes.device_auth import create_device_auth_router
+
+    config = replace(_oidc_config(), provider_type="github")
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
+    with pytest.raises(RuntimeError, match="not full OIDC"):
+        create_device_auth_router(provider, store)
+
+
+def _oidc_config() -> OIDCConfig:
+    return OIDCConfig(
+        issuer="https://accounts.google.com",
+        client_id="test-client",
+        client_secret="test-secret",
+        redirect_uri="http://localhost:8000/auth/callback",
+        cookie_secret=_KEY,
+        scopes="openid email profile",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type="oidc",
+        authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+        token_endpoint="https://oauth2.googleapis.com/token",
+        jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
+        userinfo_endpoint=None,
+        allow_invites=False,
+    )
+
+
+def test_oidc_router_allows_reauthenticated_browser_to_approve(tmp_path: Path) -> None:
+    """A verified OIDC browser identity can bind a pending device grant."""
+    from omnigent.server.routes.device_auth import create_device_auth_router
+
+    config = _oidc_config()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
+    api = FastAPI()
+    api.include_router(create_device_auth_router(provider, store))
+
+    with TestClient(api) as client:
+        started = client.post("/oauth/device/authorize", json={"client_id": "polly"})
+        assert started.status_code == 200, started.text
+        user_code = started.json()["user_code"]
+        now = int(time.time())
+        session = jwt.encode(
+            {
+                "sub": "alice@example.com",
+                "iat": now - 3600,
+                "auth_time": now,
+                "exp": now + 3600,
+                "provider": "oidc",
+            },
+            config.cookie_secret,
+            algorithm="HS256",
+        )
+        client.cookies.set(config.session_cookie_name, session)
+
+        approved = client.post(
+            "/oauth/device/approve",
+            data={"user_code": user_code},
+            headers={"Origin": "http://localhost:8000"},
+        )
+
+    assert approved.status_code == 200, approved.text
+    assert "Connected" in approved.text
+    assert store.get_by_user_code(user_code).user_id == "alice@example.com"
+
+
+def test_login_bounce_is_forced_and_percent_encodes_return_target(tmp_path: Path) -> None:
+    """Every OIDC bounce forces login and keeps the consent URL in one value."""
+    from urllib.parse import parse_qs, urlsplit
+
+    from omnigent.server.routes.device_auth import create_device_auth_router
+
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
+    api = FastAPI()
+    api.include_router(create_device_auth_router(provider, store))
+
+    with TestClient(api) as client:
+        response = client.get(
+            "/oauth/device?user_code=ABCD%3Frole%3Dadmin%23fragment",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "%3F" in location and "%3D" in location and "%23" in location
+    assert parse_qs(urlsplit(location).query) == {
+        "return_to": ["/oauth/device?user_code=ABCD?role=admin#fragment"],
+        "reauth": ["1"],
+    }
 
 
 # ── Store invariants (unit) ───────────────────────────────────────
@@ -174,6 +277,88 @@ def test_refresh_refused_past_absolute_lifetime(store: DeviceGrantStore) -> None
     assert store.is_revoked(g.id) is False
 
 
+def test_refresh_cas_loser_reuse_revokes_winner_token(
+    store: DeviceGrantStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rotation CAS loser rechecks r1 and revokes the winner's r2."""
+    from omnigent.server.routes.device_auth import create_device_auth_router
+
+    now = int(time.time())
+    grant = _new_grant(store, now=now)
+    store.approve(grant.id, user_id="a@x", now_epoch_seconds=now + 1)
+    store.redeem_approved(
+        grant.id, refresh_token_hash=hash_secret("r1", _KEY), now_epoch_seconds=now + 2
+    )
+    rotate = store.rotate_refresh_token
+
+    def lose_race(*args: object, **kwargs: object) -> None:
+        winner = rotate(
+            grant.id,
+            expected_hash=hash_secret("r1", _KEY),
+            new_hash=hash_secret("r2", _KEY),
+            now_epoch_seconds=now + 3,
+            max_lifetime_seconds=_LIFETIME,
+        )
+        assert winner is not None
+
+    monkeypatch.setattr(store, "rotate_refresh_token", lose_race)
+    api = FastAPI()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+    api.include_router(create_device_auth_router(provider, store))
+
+    with TestClient(api) as client:
+        response = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "r1"}
+        )
+        monkeypatch.setattr(store, "rotate_refresh_token", rotate)
+        winner_token = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "r2"}
+        )
+
+    assert response.status_code == 400 and response.json()["error"] == "invalid_grant"
+    assert winner_token.status_code == 400 and winner_token.json()["error"] == "invalid_grant"
+    assert store.is_revoked(grant.id) is True
+
+
+def test_refresh_age_out_during_rotation_does_not_revoke(
+    store: DeviceGrantStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed rotation from grant age-out is not refresh-token reuse."""
+    from omnigent.server.routes.device_auth import create_device_auth_router
+
+    grant = _new_grant(store)
+    approved_at = int(time.time()) - _LIFETIME + 10
+    store.approve(grant.id, user_id="a@x", now_epoch_seconds=approved_at)
+    store.redeem_approved(
+        grant.id,
+        refresh_token_hash=hash_secret("r1", _KEY),
+        now_epoch_seconds=approved_at + 1,
+    )
+    rotate = store.rotate_refresh_token
+
+    def age_out(*args: object, **kwargs: object) -> object:
+        return rotate(
+            grant.id,
+            expected_hash=hash_secret("r1", _KEY),
+            new_hash=hash_secret("r2", _KEY),
+            now_epoch_seconds=approved_at + _LIFETIME,
+            max_lifetime_seconds=_LIFETIME,
+        )
+
+    monkeypatch.setattr(store, "rotate_refresh_token", age_out)
+    api = FastAPI()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+    api.include_router(create_device_auth_router(provider, store))
+
+    with TestClient(api) as client:
+        response = client.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "r1"}
+        )
+
+    assert response.status_code == 400 and response.json()["error"] == "invalid_grant"
+    assert store.is_revoked(grant.id) is False
+
+
 def test_purge_reclaims_aged_redeemed_grants(store: DeviceGrantStore) -> None:
     """purge_expired removes redeemed grants past their absolute lifetime."""
     g = _new_grant(store)
@@ -205,7 +390,11 @@ def test_revoke_is_fail_closed(store: DeviceGrantStore) -> None:
 
 
 def _build_accounts_app(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, device_grant_enabled: bool = True
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    device_grant_enabled: bool = True,
+    auth_provider: UnifiedAuthProvider | None = None,
 ) -> Iterator[TestClient]:
     monkeypatch.delenv("OMNIGENT_OIDC_ISSUER", raising=False)
     monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "accounts")
@@ -257,7 +446,7 @@ def _build_accounts_app(
         artifact_store=artifact_store,
         comment_store=comment_store,
     )
-    auth_provider = create_auth_provider()
+    auth_provider = auth_provider or create_auth_provider()
     account_store = SqlAlchemyAccountStore(db_url)
     app = create_app(
         agent_store=agent_store,
@@ -280,9 +469,105 @@ def app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]
     yield from _build_accounts_app(tmp_path, monkeypatch)
 
 
+@pytest.fixture
+def oidc_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+    yield from _build_accounts_app(tmp_path, monkeypatch, auth_provider=provider)
+
+
 def _login_admin(client: TestClient) -> None:
     r = client.post("/auth/login", json={"username": "admin", "password": "admin-pw-12345"})
     assert r.status_code == 200, r.text
+
+
+def test_oidc_app_mounts_device_routes(oidc_app: TestClient) -> None:
+    """The production app mounts the opted-in device router for OIDC."""
+    response = oidc_app.post("/oauth/device/authorize", json={"client_id": "polly"})
+    assert response.status_code == 200, response.text
+
+
+def _complete_oidc_callback(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    user_code: str,
+    *,
+    reauth: bool,
+) -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    signing_key = jwt.PyJWK.from_json(RSAAlgorithm.to_jwk(private_key.public_key()))
+    now = int(time.time())
+    id_token = jwt.encode(
+        {
+            "iss": _oidc_config().issuer,
+            "aud": _oidc_config().client_id,
+            "sub": "idp-user",
+            "email": "alice@example.com",
+            "email_verified": True,
+            "iat": now,
+            "auth_time": now,
+            "exp": now + 300,
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    async def token_exchange(*args: object, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json={"id_token": id_token})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", token_exchange)
+    monkeypatch.setattr(
+        jwt.PyJWKClient,
+        "get_signing_key_from_jwt",
+        lambda self, token: signing_key,
+    )
+    params = {"return_to": f"/oauth/device?user_code={user_code}"}
+    if reauth:
+        params["reauth"] = "1"
+    login = client.get("/auth/login", params=params, follow_redirects=False)
+    state = parse_qs(urlsplit(login.headers["location"]).query)["state"][0]
+    callback = client.get(
+        "/auth/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+    assert callback.status_code == 302, callback.text
+
+
+def test_ordinary_oidc_callback_cannot_approve_device_grant(
+    oidc_app: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An attacker-selected unforced login cannot manufacture consent proof."""
+    started = oidc_app.post("/oauth/device/authorize", json={"client_id": "polly"})
+    user_code = started.json()["user_code"]
+    _complete_oidc_callback(oidc_app, monkeypatch, user_code, reauth=False)
+
+    approved = oidc_app.post(
+        "/oauth/device/approve",
+        data={"user_code": user_code},
+        headers={"Origin": "http://localhost:8000"},
+    )
+
+    assert "Connected" not in approved.text
+    assert "too old" in approved.text.lower()
+
+
+def test_forced_oidc_callback_can_approve_device_grant(
+    oidc_app: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real login/callback path carries verified proof into approval."""
+    started = oidc_app.post("/oauth/device/authorize", json={"client_id": "polly"})
+    user_code = started.json()["user_code"]
+    _complete_oidc_callback(oidc_app, monkeypatch, user_code, reauth=True)
+
+    approved = oidc_app.post(
+        "/oauth/device/approve",
+        data={"user_code": user_code},
+        headers={"Origin": "http://localhost:8000"},
+    )
+
+    assert "Connected" in approved.text
 
 
 def test_full_device_flow(app: TestClient) -> None:

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -186,7 +186,11 @@ def callback_client(
         yield client, keys
 
 
-def _do_callback(client: TestClient, id_token: str) -> httpx.Response:
+def _do_callback(
+    client: TestClient,
+    id_token: str,
+    extra_state: dict[str, object] | None = None,
+) -> httpx.Response:
     """Drive a full ``/auth/callback`` with a valid state cookie.
 
     Crafts the signed state cookie the way ``/auth/login`` would, sets
@@ -206,6 +210,7 @@ def _do_callback(client: TestClient, id_token: str) -> httpx.Response:
             "code_verifier": "verifier",
             "return_to": "/",
             "exp": int(time.time()) + 300,
+            **(extra_state or {}),
         },
         _TEST_SECRET,
         algorithm="HS256",
@@ -478,3 +483,107 @@ def test_callback_accepts_boolean_and_string_true(
     # Accepted as a verified identity → redirect + session.
     assert resp.status_code == 302, resp.text
     assert resp.cookies.get("ap_session") is not None
+
+
+def _session_claims(response: httpx.Response) -> dict[str, object]:
+    token = response.headers["set-cookie"].split("ap_session=", 1)[1].split(";", 1)[0]
+    return jwt.decode(token, _TEST_SECRET, algorithms=["HS256"])
+
+
+def test_reauth_callback_requires_fresh_idp_auth_time(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """A forced login fails closed when the verified IdP token is stale."""
+    client, keys = callback_client
+    now = int(time.time())
+    token = keys.sign_id_token(
+        {
+            "email": "alice@example.com",
+            "email_verified": True,
+            "auth_time": now - 3600,
+        }
+    )
+
+    response = _do_callback(client, token, extra_state={"reauth_at": now})
+
+    assert response.status_code == 403
+    assert response.cookies.get("ap_session") is None
+
+
+def test_reauth_callback_rejects_fresh_token_that_predates_signed_boundary(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """A freshly issued token cannot satisfy a later signed reauth demand."""
+    client, keys = callback_client
+    reauth_at = int(time.time())
+    token = keys.sign_id_token(
+        {
+            "email": "alice@example.com",
+            "email_verified": True,
+            "iat": reauth_at - 121,
+            "auth_time": reauth_at - 121,
+        }
+    )
+
+    response = _do_callback(client, token, extra_state={"reauth_at": reauth_at})
+
+    assert response.status_code == 403
+    assert response.cookies.get("ap_session") is None
+
+
+def test_reauth_callback_carries_proof_separately_from_iat(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """Only an IdP-attested reauthentication stamps session auth_time."""
+    client, keys = callback_client
+    now = int(time.time())
+    proven = keys.sign_id_token(
+        {"email": "alice@example.com", "email_verified": True, "auth_time": now}
+    )
+    ordinary = keys.sign_id_token({"email": "alice@example.com", "email_verified": True})
+
+    proven_response = _do_callback(client, proven, extra_state={"reauth_at": now})
+    ordinary_response = _do_callback(client, ordinary)
+
+    assert proven_response.status_code == 302
+    assert _session_claims(proven_response)["auth_time"] >= now
+    assert "iat" in _session_claims(ordinary_response)
+    assert "auth_time" not in _session_claims(ordinary_response)
+
+
+def test_ordinary_callback_does_not_stamp_unsolicited_auth_time(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """Fresh IdP metadata is not device-consent proof without signed demand."""
+    client, keys = callback_client
+    now = int(time.time())
+    token = keys.sign_id_token(
+        {"email": "alice@example.com", "email_verified": True, "auth_time": now}
+    )
+
+    response = _do_callback(client, token)
+
+    assert response.status_code == 302
+    assert "auth_time" not in _session_claims(response)
+
+
+def test_callback_verifies_id_token_once(
+    callback_client: tuple[TestClient, _IdpKeys],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Email and reauthentication consume the same verified claim set."""
+    client, keys = callback_client
+    calls = 0
+
+    def signing_key(self: object, token: str) -> jwt.PyJWK:
+        nonlocal calls
+        calls += 1
+        return keys.signing_key
+
+    monkeypatch.setattr(jwt.PyJWKClient, "get_signing_key_from_jwt", signing_key)
+    token = keys.sign_id_token({"email": "alice@example.com", "email_verified": True})
+
+    response = _do_callback(client, token)
+
+    assert response.status_code == 302
+    assert calls == 1

--- a/tests/server/test_oidc_open_redirect.py
+++ b/tests/server/test_oidc_open_redirect.py
@@ -250,7 +250,11 @@ def test_callback_redirects_to_root_for_hostile_cookie(
     # Rebind on the auth module's own namespace (contained, auto-undone)
     # rather than walking through the global httpx module.
     monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeAsyncClient)
-    monkeypatch.setattr(auth_module, "_resolve_oidc_email", lambda token_json, config: "u@x.com")
+    monkeypatch.setattr(
+        auth_module,
+        "_verified_id_token_claims",
+        lambda token_json, config: {"email": "u@x.com", "email_verified": True},
+    )
 
     oidc_client.cookies.set(_STATE_COOKIE, _mint_state_cookie(state=state, return_to=malicious))
     resp = oidc_client.get(
@@ -277,7 +281,11 @@ def test_callback_preserves_safe_cookie_return_to(
     """A same-origin ``return_to`` in the cookie is honored at callback."""
     state = "csrf-state-token"
     monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeAsyncClient)
-    monkeypatch.setattr(auth_module, "_resolve_oidc_email", lambda token_json, config: "u@x.com")
+    monkeypatch.setattr(
+        auth_module,
+        "_verified_id_token_claims",
+        lambda token_json, config: {"email": "u@x.com", "email_verified": True},
+    )
 
     oidc_client.cookies.set(
         _STATE_COOKIE, _mint_state_cookie(state=state, return_to="/sessions/abc?tab=files")

--- a/tests/server/test_oidc_reauth_prompt.py
+++ b/tests/server/test_oidc_reauth_prompt.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.oidc import OIDCConfig
+from omnigent.server.routes.auth import create_auth_router
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+_SECRET = bytes.fromhex("aa" * 32)
+
+
+@pytest.fixture
+def oidc_client(tmp_path: Path, db_uri: str) -> Iterator[TestClient]:
+    config = OIDCConfig(
+        issuer="https://accounts.google.com",
+        client_id="cid",
+        client_secret="secret",
+        redirect_uri="http://localhost:8000/auth/callback",
+        cookie_secret=_SECRET,
+        scopes="openid email profile",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type="oidc",
+        authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+        token_endpoint="https://oauth2.googleapis.com/token",
+        jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
+        userinfo_endpoint=None,
+        allow_invites=False,
+    )
+    admins = tmp_path / "admins"
+    admins.write_text("")
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(provider, SqlAlchemyPermissionStore(db_uri), AdminList(admins)),
+        prefix="/auth",
+    )
+    with TestClient(app) as client:
+        yield client
+
+
+def test_reauth_request_is_forwarded_and_attested(oidc_client: TestClient) -> None:
+    response = oidc_client.get(
+        "/auth/login?reauth=1&return_to=%2Foauth%2Fdevice%3Fuser_code%3DABCD-2345",
+        follow_redirects=False,
+    )
+    params = parse_qs(urlsplit(response.headers["location"]).query)
+    state = jwt.decode(oidc_client.cookies["ap_auth_state"], _SECRET, algorithms=["HS256"])
+
+    assert params["prompt"] == ["login"]
+    assert params["max_age"] == ["0"]
+    assert isinstance(state["reauth_at"], int)
+    assert state["return_to"] == "/oauth/device?user_code=ABCD-2345"
+
+
+def test_ordinary_login_does_not_force_reauthentication(oidc_client: TestClient) -> None:
+    response = oidc_client.get("/auth/login", follow_redirects=False)
+    params = parse_qs(urlsplit(response.headers["location"]).query)
+    state = jwt.decode(oidc_client.cookies["ap_auth_state"], _SECRET, algorithms=["HS256"])
+
+    assert "prompt" not in params and "max_age" not in params
+    assert "reauth_at" not in state

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -16,6 +16,7 @@ from omnigent.errors import OmnigentError
 from omnigent.spec.types import (
     AgentSpec,
     BuiltinToolConfig,
+    ExecutorSpec,
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
@@ -30,6 +31,21 @@ from omnigent.tools.client_specified import ClientSideTool, ClientSideToolSpec
 from omnigent.tools.mcp import clear_discovery_cache
 
 _TEST_CTX = ToolContext(task_id="task_test", agent_id="agent_test")
+
+
+def test_tool_free_spec_registers_no_automatic_or_declared_tools() -> None:
+    spec = AgentSpec(
+        spec_version=1,
+        executor=ExecutorSpec(config={"tool_free": True}),
+        skills=[SkillSpec(name="review", description="Review.", content="Review it.")],
+        tools=ToolsConfig(agents=["worker"]),
+        sub_agents=[AgentSpec(spec_version=1, name="worker")],
+        spawn=True,
+        async_enabled=True,
+    )
+
+    assert ToolManager(spec).get_tool_schemas() == []
+
 
 # Tools that ToolManager registers unconditionally on every
 # spec these tests construct: the lifecycle ``sys_cancel_task``


### PR DESCRIPTION
## Related issue

N/A — draft proposal; link the tracking issue before marking ready for review.

## Summary

- Add a first-class `omni integration polly` GitHub App integration with guided setup, lifecycle commands, diagnostics, durable SQLite jobs, retry/recovery, repository scoping, and one deterministic review per PR head.
- Seed an isolated `polly-review` bundle that runs exactly two tool-free reviewers (Claude and Codex), uploads the diff once, strictly validates both results, and publishes one merged GitHub review.
- Add scoped OIDC device authorization, daemon ownership hardening, runtime tool isolation, and packaging needed for independent Omnigent installations.

ELI5: GitHub sends one PR event to Polly, Omnigent asks two isolated reviewers to inspect the same diff, and Polly combines their findings into one review.

```text
GitHub App webhook
        |
        v
 durable Polly job ----> Claude reviewer
        |              \\-> Codex reviewer
        v
 deterministic merge ----> one GitHub review
```

## Test Plan

- `pytest` relevant integration/runtime/auth matrix: 874 passed, 1 skipped.
- Full Codex executor suite: 110 passed.
- Polly integration suite: 122 passed.
- Staged `pre-commit run`: all applicable hooks passed, including Ruff, Pyrefly, YAML, whitespace, and conflict checks.
- Built both wheel and sdist; verified the Polly runtime and bundled review agent are included.
- Independent whole-branch review followed by a scoped re-review of tool isolation, retry cardinality, cleanup, publication, and ordinary-agent compatibility.

## Demo

N/A — backend/CLI integration; no UI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The draft has automated coverage for onboarding, authentication, webhook filtering, persistence, recovery, reviewer isolation, deterministic merging, GitHub publication, and foreground/background daemon ownership. Live GitHub App installation testing remains for the draft review phase.

## Changelog

Install and operate Polly Review as a native Omnigent GitHub integration with isolated Claude and Codex review fanout.
