### PR TITLE
fix(electron): normalize saved API-endpoint server_url to workspace root at boot

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -41,6 +41,7 @@ const {
   normalizeUrl,
   normalizeRecentServers,
   expandDatabricksWorkspaceUrl,
+  normalizeSavedServerUrl,
   fetchServerManifest,
   PRE_MANIFEST_BASELINE,
 } = require("./url");
@@ -1218,7 +1219,8 @@ function createWindow(targetUrl, opts = {}) {
   });
   const explicit =
     typeof targetUrl === "string" && /^https?:\/\//i.test(targetUrl) ? targetUrl : undefined;
-  const saved = loadSettings().server_url;
+  // CLI config stores the API mount; Electron boots the browser-facing SPA.
+  const saved = normalizeSavedServerUrl(loadSettings().server_url);
   // serverUrl: the window's server IDENTITY for host/server CLI commands
   // (``omnigent host --server``, ``omnigent login``, ``serverAuthed``) — the
   // origin or origin+mount, WITHOUT the conversation path. Prefer an explicit

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -200,6 +200,38 @@
     return url.toString();
   }
 
+  const WORKSPACE_API_PATHS = new Set([
+    "/api/2.0/omnigent",
+    // Databricks keeps this plural route for older clients.
+    "/api/2.0/omnigents",
+  ]);
+
+  /**
+   * Map a saved Databricks API URL to the browser-facing workspace mount.
+   *
+   * The CLI records the API mount, but Electron must load the SPA mount.
+   * Query and fragment state survive so workspace selectors and deep-link
+   * state are not lost. Non-workspace hosts and existing UI paths stay exact.
+   *
+   * @param {string} rawUrl A saved server URL (may be undefined/empty/garbage).
+   * @returns {string} The browser-facing URL, or the input unchanged.
+   */
+  function normalizeSavedServerUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || rawUrl === "") return rawUrl;
+    let url;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return rawUrl;
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") return rawUrl;
+    if (!isDatabricksWorkspaceHost(url.hostname)) return rawUrl;
+    const pathWithoutTrailingSlash = url.pathname.replace(/\/+$/, "");
+    if (!WORKSPACE_API_PATHS.has(pathWithoutTrailingSlash)) return rawUrl;
+    url.pathname = WORKSPACE_UI_PATH;
+    return url.toString();
+  }
+
   /**
    * Probe timeout for Databricks workspace detection. Deliberately short: a
    * slow or unreachable host must not stall the connect flow — on timeout we
@@ -363,6 +395,7 @@
     normalizeRecentServers,
     serverDisplayLabel,
     isPlainHttpRemote,
+    normalizeSavedServerUrl,
     WORKSPACE_UI_PATH,
     WORKSPACE_PROBE_TIMEOUT_MS,
     databricksWorkspaceUiUrl,

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -27,17 +27,25 @@ const vm = require("node:vm");
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 const preloadSource = readFileSync(path.join(__dirname, "../src/preload.js"), "utf8");
 const setupSource = readFileSync(path.join(__dirname, "../setup/index.html"), "utf8");
+const urlHelpers = require("../src/url");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
 const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
 
 function loadNavigationHarness({
   serverUrl = "https://host.example/ml/omnigents",
+  savedServerUrl,
   registerFallbacks = true,
 } = {}) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-navigation-test-"));
+  if (savedServerUrl) {
+    fs.writeFileSync(
+      path.join(userData, "settings.json"),
+      JSON.stringify({ server_url: savedServerUrl }),
+    );
+  }
   const listeners = new Map();
-  const calls = { loadFile: [] };
+  const calls = { loadFile: [], loadURL: [] };
   const bannerCalls = { show: [], hide: 0 };
   let currentUrl = serverUrl;
   const appEvents = new Map();
@@ -68,7 +76,10 @@ function loadNavigationHarness({
       calls.loadFile.push(args);
       return Promise.resolve();
     },
-    loadURL: () => Promise.resolve(),
+    loadURL: (...args) => {
+      calls.loadURL.push(args);
+      return Promise.resolve();
+    },
   };
 
   function createDesktopUpdater() {
@@ -130,6 +141,7 @@ function loadNavigationHarness({
     },
     "./localhost_cors": { registerLocalhostCors: () => {} },
     "./url": {
+      ...urlHelpers,
       normalizeUrl: (url) => url,
       expandDatabricksWorkspaceUrl: async (url) => url,
       fetchServerManifest: async () => ({}),
@@ -441,6 +453,22 @@ describe("workspace chrome injection wiring (src/main.js)", () => {
 });
 
 describe("navigation fallback wiring (src/main.js)", () => {
+  it("boots a saved Databricks API URL on the UI mount without losing URL state", () => {
+    const saved = "https://workspace.cloud.databricks.com/api/2.0/omnigent/?o=123#conversation";
+    const harness = loadNavigationHarness({
+      savedServerUrl: saved,
+      registerFallbacks: false,
+    });
+
+    harness.api.createWindow();
+
+    assert.equal(
+      harness.calls.loadURL[0][0],
+      "https://workspace.cloud.databricks.com/omnigent?o=123#conversation",
+    );
+    harness.cleanup();
+  });
+
   it("registers navigation fallbacks when createWindow builds a window", () => {
     const harness = loadNavigationHarness({ registerFallbacks: false });
 

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -12,6 +12,7 @@ const {
   normalizeRecentServers,
   serverDisplayLabel,
   isPlainHttpRemote,
+  normalizeSavedServerUrl,
   databricksWorkspaceUiUrl,
   expandDatabricksWorkspaceUrl,
   WORKSPACE_UI_PATH,
@@ -165,6 +166,59 @@ describe("isPlainHttpRemote", () => {
     assert.equal(isPlainHttpRemote("https://example.databricks.com"), false);
     assert.equal(isPlainHttpRemote(""), false);
     assert.equal(isPlainHttpRemote("ht tp://nope"), false);
+  });
+});
+
+describe("normalizeSavedServerUrl", () => {
+  it("maps the current Databricks API mount to the UI mount", () => {
+    assert.equal(
+      normalizeSavedServerUrl("https://ws.cloud.databricks.com/api/2.0/omnigent"),
+      "https://ws.cloud.databricks.com/omnigent",
+    );
+  });
+
+  it("maps the legacy plural API mount to the current UI mount", () => {
+    assert.equal(
+      normalizeSavedServerUrl("https://ws.azuredatabricks.net/api/2.0/omnigents"),
+      "https://ws.azuredatabricks.net/omnigent",
+    );
+  });
+
+  it("handles trailing slashes while preserving port, query, and fragment", () => {
+    assert.equal(
+      normalizeSavedServerUrl(
+        "https://ws.cloud.databricks.com:8443/api/2.0/omnigent/?o=123#conversation",
+      ),
+      "https://ws.cloud.databricks.com:8443/omnigent?o=123#conversation",
+    );
+  });
+
+  it("leaves workspace roots and current or legacy UI mounts exact", () => {
+    for (const url of [
+      "https://ws.cloud.databricks.com",
+      "https://ws.cloud.databricks.com/",
+      "https://ws.cloud.databricks.com/omnigent?o=123#state",
+      "https://ws.cloud.databricks.com/ml/omnigents",
+    ]) {
+      assert.equal(normalizeSavedServerUrl(url), url);
+    }
+  });
+
+  it("does not rewrite matching paths on non-workspace hosts or nested paths", () => {
+    for (const url of [
+      "https://example.com/api/2.0/omnigent",
+      "https://databricks.com.example.org/api/2.0/omnigent",
+      "https://ws.cloud.databricks.com/prefix/api/2.0/omnigent",
+      "ftp://ws.cloud.databricks.com/api/2.0/omnigent",
+    ]) {
+      assert.equal(normalizeSavedServerUrl(url), url);
+    }
+  });
+
+  it("returns empty/undefined/invalid input unchanged", () => {
+    assert.equal(normalizeSavedServerUrl(""), "");
+    assert.equal(normalizeSavedServerUrl(undefined), undefined);
+    assert.equal(normalizeSavedServerUrl("not a url"), "not a url");
   });
 });
 


### PR DESCRIPTION
## Related issue

Closes #4684

## Summary

Two sub-symptoms of the same dead-end 401 bug are fixed here:

**Sub-symptom 1 — Boot-time URL normalization (boot path)**
- The desktop shell loads its saved `server_url` directly into the Electron window. If that value is the CLI's **API endpoint** (`https://<workspace>.cloud.databricks.com/api/2.0/omnigent`) rather than the web-UI mount, a top-level navigation to the raw API path with no credential returns a `401` JSON body, dead-ending the window on the raw error with no way back to SSO.
- At boot, before the window loads the saved URL, strip a trailing `/api/2.0/omnigent` (with or without a trailing slash) down to the workspace root so the shell never navigates to the raw API endpoint.
- Adds `stripApiMountFromServerUrl` to `web/electron/src/url.js` and applies it in `createWindow` where the saved `server_url` is read.

**Sub-symptom 2 — JSON-401 recovery (runtime path)**
- Even when the URL is the correct web-UI mount, a top-level navigation returning HTTP 401 with `application/json` body dead-ends the window: `did-fail-load` never fires for HTTP-level errors (Chromium considers a 401 a "successful" load), so the user is stranded on raw JSON with no SPA, no SSO prompt, and no way back.
- Adds `json401ResponseHook` to intercept `mainFrame` 401 JSON responses from a window's own pinned origin via `onHeadersReceived`, then asynchronously redirects the window to the setup page with an error message.
- Composed alongside `popupResponseHeadersHook` in a `composedResponseHeadersHook` passed to `registerLocalhostAccess`, preserving the existing single-listener constraint.

## Test Plan

- `cd web/electron && node --test test/url.test.js` — 37 pass, including the `stripApiMountFromServerUrl` cases (strip, trailing-slash, root-unchanged, unrelated-mount, empty/undefined/invalid input).
- `cd web/electron && node --test test/main.test.js` — 24 pass, including the updated `popupResponseHeadersHook` composition guard.
- `cd web/electron && node --test test/boot_api_url_normalization.test.js` — 3 pass: both sub-symptoms (boot-time normalization + JSON-401 recovery wiring) confirmed fail on the unfixed tree and pass with the fix.
- Manual (sub-symptom 1): set `server_url` to `https://<ws>.cloud.databricks.com/api/2.0/omnigent` in the desktop config, launch the app, confirm the window loads the workspace root instead of the dead-end 401 JSON body.
- Manual (sub-symptom 2): connect the desktop to a workspace-hosted Omnigent, let the SSO session expire, confirm the window redirects to the setup page with a reconnect prompt rather than stranding on raw JSON.

## Demo


https://github.com/user-attachments/assets/aece57d0-596d-4467-aa49-051982543334



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the new normalization helper directly. Manual verification: reproduced the dead-end 401 with an API-endpoint `server_url`, then confirmed the boot-time strip leaves the window on the workspace root.

## Changelog

Desktop app no longer dead-ends on a raw 401 when the saved server URL is the API endpoint; it normalizes to the workspace root at boot.

