### PR TITLE
fix(build): enforce Node 22.13 minimum and improve web-build diagnostics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,9 +125,9 @@ class _GenerateBuildInfo(build_py):
           ``OMNIGENT_BUILD_WEB_UI=1`` forces a rebuild. This keeps
           repeat ``uv sync`` fast for backend devs (build once, reuse)
           while letting release builds force a fresh bundle.
-        - Otherwise the build MUST succeed: a missing Node.js 22+,
-          a missing pnpm, or a failing ``pnpm install`` / ``pnpm
-          --filter web run build`` aborts the install with an
+        - Otherwise the build MUST succeed: a Node.js older than 22.12
+          (or absent), a missing pnpm, or a failing ``pnpm install`` /
+          ``pnpm --filter web run build`` aborts the install with an
           actionable error. Omnigent needs Node 22 LTS + pnpm at
           runtime anyway (the Claude / Codex / Pi harness CLIs are
           npm packages, and the web UI is a pnpm workspace), so a
@@ -142,9 +142,9 @@ class _GenerateBuildInfo(build_py):
         confirmation before downloading the pinned pnpm, which a
         non-interactive install can never answer.
 
-        :raises SystemExit: If Node.js < 22 (or absent), pnpm is not
-            on PATH (and corepack can't supply it), or the web UI
-            build fails, and no skip condition applies.
+        :raises SystemExit: If the on-PATH Node.js is older than 22.12
+            (or absent), pnpm is not on PATH (and corepack can't supply
+            it), or the web UI build fails, and no skip condition applies.
         """
         import os
         import shutil
@@ -167,12 +167,9 @@ class _GenerateBuildInfo(build_py):
         )
         if bundle.is_file() and not force:
             return
-        # Enforce the Node.js 22 LTS floor up front. The web UI's
-        # toolchain (pnpm@11, Vite 8, oxlint) and the runtime harness
-        # CLIs all require Node 22; building on an older Node fails
-        # deep inside the toolchain with an opaque error, so we fail
-        # fast here with a single actionable message instead.
-        _require_node_22()
+        # Vite 8 and oxlint support Node 22.12 and newer. Keep this a
+        # minimum so newer LTS releases remain usable.
+        node_version = _require_supported_node()
 
         # pnpm first; fall back to corepack (bundled with Node 22+),
         # which downloads the pnpm version pinned by the root
@@ -227,12 +224,12 @@ class _GenerateBuildInfo(build_py):
             )
         except (subprocess.SubprocessError, OSError) as exc:
             raise SystemExit(
-                f"omnigent build: web UI build failed ({exc}). Fix the "
-                "failure above (it usually means Node.js is older than "
-                "the required 22 LTS, pnpm is missing, or `pnpm install` "
-                "could not reach the npm registry) and rerun the install. "
-                "To deliberately install without the web UI (API-only "
-                "server), set OMNIGENT_SKIP_WEB_UI=true."
+                f"omnigent build: web UI build failed on Node.js {node_version} "
+                f"({exc}). Fix the failure above and rerun the install. If "
+                "this Node.js release is incompatible with pnpm or Vite, "
+                "install Node 22 LTS and retry. To deliberately install "
+                "without the web UI (API-only server), set "
+                "OMNIGENT_SKIP_WEB_UI=true."
             ) from exc
 
     def _write_build_info(self) -> None:
@@ -267,17 +264,15 @@ class _GenerateBuildInfo(build_py):
         )
 
 
-def _require_node_22() -> None:
-    """Abort the build unless Node.js >= 22 is on PATH.
+def _require_supported_node() -> str:
+    """Return the Node.js version or abort when it is older than 22.12.
 
-    The web UI toolchain (pnpm 11, Vite 8, oxlint) and the runtime
-    harness CLIs (Claude / Codex / Pi, all npm packages) require Node 22
-    LTS. Building on an older Node fails deep inside the toolchain with
-    an opaque error; this check fails fast with a single actionable
-    message instead.
+    Vite 8 and oxlint declare Node 22.12 as their minimum on the
+    project's supported 22+ line. Newer Node releases remain valid.
 
-    :raises SystemExit: If ``node`` is missing or reports a major
-        version below 22.
+    :returns: The normalized Node.js version string.
+    :raises SystemExit: If ``node`` is missing, ``node --version`` fails,
+        or the reported version is older than 22.12.
     """
     import shutil
 
@@ -285,13 +280,10 @@ def _require_node_22() -> None:
     if node is None:
         raise SystemExit(
             "omnigent build: Node.js not found on PATH, so the web UI "
-            "cannot be built. Omnigent requires Node.js 22 LTS or newer "
-            "(the web UI toolchain — pnpm 11 / Vite 8 / oxlint — and the "
-            "Claude / Codex / Pi harness CLIs all need it). Install it "
-            "from https://nodejs.org/en/download (the 22 LTS line or "
-            "newer) and rerun the install. To deliberately install "
-            "without the web UI (API-only server), set "
-            "OMNIGENT_SKIP_WEB_UI=true."
+            "cannot be built. Node.js 22.12 or newer is required. Install "
+            "Node 22 LTS from https://nodejs.org/en/download and retry, "
+            "or run with OMNIGENT_SKIP_WEB_UI=true to skip the web UI "
+            "build."
         )
     try:
         result = subprocess.run(
@@ -304,30 +296,30 @@ def _require_node_22() -> None:
     except (subprocess.SubprocessError, OSError) as exc:
         raise SystemExit(
             f"omnigent build: could not determine the Node.js version "
-            f"(`node --version` failed: {exc}). Omnigent requires "
-            "Node.js 22 LTS or newer. Ensure Node 22+ is installed and "
-            "on PATH, then rerun the install. To deliberately install "
-            "without the web UI (API-only server), set "
-            "OMNIGENT_SKIP_WEB_UI=true."
+            f"(`node --version` failed: {exc}). Node.js 22.12 or newer "
+            "is required. Install Node 22 LTS and retry, or run with "
+            "OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
         ) from exc
-    # ``node --version`` prints ``v22.14.0``; split off the leading ``v``
-    # and read the major. A non-numeric result is treated as too old.
+    # ``node --version`` prints ``v22.14.0``.
     version_str = result.stdout.strip().lstrip("v")
     try:
-        major = int(version_str.split(".")[0])
+        version_parts = tuple(int(part) for part in version_str.split(".")[:3])
+        if len(version_parts) != 3:
+            raise ValueError
     except ValueError:
-        major = -1
-    if major < 22:
         raise SystemExit(
-            f"omnigent build: Node.js {version_str or 'unknown'} is "
-            f"installed, but Omnigent requires Node.js 22 LTS or newer "
-            "(the web UI toolchain — pnpm 11 / Vite 8 / oxlint — and "
-            "the Claude / Codex / Pi harness CLIs all need Node 22+). "
-            "Upgrade from https://nodejs.org/en/download (pick the 22 "
-            "LTS line or newer) and rerun the install. To deliberately "
-            "install without the web UI (API-only server), set "
-            "OMNIGENT_SKIP_WEB_UI=true."
+            f"omnigent build: could not parse Node.js version "
+            f"{version_str or 'unknown'}. Node.js 22.12 or newer is "
+            "required. Install Node 22 LTS and retry, or run with "
+            "OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
+        ) from None
+    if version_parts < (22, 12, 0):
+        raise SystemExit(
+            f"omnigent build: Node.js 22.12 or newer is required but found "
+            f"Node.js {version_str}. Install Node 22 LTS and retry, or run "
+            "with OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
         )
+    return version_str
 
 
 def _git_sha() -> str:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ from pathlib import Path
 from setuptools import setup
 from setuptools.command.build_py import build_py
 
+_MINIMUM_NODE_VERSION = (22, 13, 0)
+_MINIMUM_NODE_VERSION_TEXT = ".".join(str(part) for part in _MINIMUM_NODE_VERSION)
+
 
 class _GenerateBuildInfo(build_py):
     """Subclass of ``build_py`` that writes ``_build_info.py``.
@@ -125,7 +128,7 @@ class _GenerateBuildInfo(build_py):
           ``OMNIGENT_BUILD_WEB_UI=1`` forces a rebuild. This keeps
           repeat ``uv sync`` fast for backend devs (build once, reuse)
           while letting release builds force a fresh bundle.
-        - Otherwise the build MUST succeed: a Node.js older than 22.12
+        - Otherwise the build MUST succeed: a Node.js older than 22.13
           (or absent), a missing pnpm, or a failing ``pnpm install`` /
           ``pnpm --filter web run build`` aborts the install with an
           actionable error. Omnigent needs Node 22 LTS + pnpm at
@@ -142,7 +145,7 @@ class _GenerateBuildInfo(build_py):
         confirmation before downloading the pinned pnpm, which a
         non-interactive install can never answer.
 
-        :raises SystemExit: If the on-PATH Node.js is older than 22.12
+        :raises SystemExit: If the on-PATH Node.js is older than 22.13
             (or absent), pnpm is not on PATH (and corepack can't supply
             it), or the web UI build fails, and no skip condition applies.
         """
@@ -167,8 +170,8 @@ class _GenerateBuildInfo(build_py):
         )
         if bundle.is_file() and not force:
             return
-        # Vite 8 and oxlint support Node 22.12 and newer. Keep this a
-        # minimum so newer LTS releases remain usable.
+        # pnpm 11.15.1 requires Node 22.13 and is stricter than Vite 8 and
+        # oxlint. Enforce the effective toolchain floor before invoking pnpm.
         node_version = _require_supported_node()
 
         # pnpm first; fall back to corepack (bundled with Node 22+),
@@ -225,9 +228,11 @@ class _GenerateBuildInfo(build_py):
         except (subprocess.SubprocessError, OSError) as exc:
             raise SystemExit(
                 f"omnigent build: web UI build failed on Node.js {node_version} "
-                f"({exc}). Fix the failure above and rerun the install. If "
+                f"({_subprocess_failure_details(exc)}). Fix the failure above "
+                "and rerun the install. If "
                 "this Node.js release is incompatible with pnpm or Vite, "
-                "install Node 22 LTS and retry. To deliberately install "
+                f"upgrade to Node.js {_MINIMUM_NODE_VERSION_TEXT} or newer and "
+                "retry. To deliberately install "
                 "without the web UI (API-only server), set "
                 "OMNIGENT_SKIP_WEB_UI=true."
             ) from exc
@@ -265,14 +270,14 @@ class _GenerateBuildInfo(build_py):
 
 
 def _require_supported_node() -> str:
-    """Return the Node.js version or abort when it is older than 22.12.
+    """Return the Node.js version or abort when it is older than 22.13.
 
-    Vite 8 and oxlint declare Node 22.12 as their minimum on the
-    project's supported 22+ line. Newer Node releases remain valid.
+    The pinned pnpm 11.15.1 requires Node 22.13. Newer Node releases
+    remain valid.
 
     :returns: The normalized Node.js version string.
     :raises SystemExit: If ``node`` is missing, ``node --version`` fails,
-        or the reported version is older than 22.12.
+        or the reported version is older than 22.13.
     """
     import shutil
 
@@ -280,9 +285,9 @@ def _require_supported_node() -> str:
     if node is None:
         raise SystemExit(
             "omnigent build: Node.js not found on PATH, so the web UI "
-            "cannot be built. Node.js 22.12 or newer is required. Install "
-            "Node 22 LTS from https://nodejs.org/en/download and retry, "
-            "or run with OMNIGENT_SKIP_WEB_UI=true to skip the web UI "
+            f"cannot be built. Node.js {_MINIMUM_NODE_VERSION_TEXT} or newer "
+            "is required. Install it from https://nodejs.org/en/download and "
+            "retry, or run with OMNIGENT_SKIP_WEB_UI=true to skip the web UI "
             "build."
         )
     try:
@@ -296,8 +301,9 @@ def _require_supported_node() -> str:
     except (subprocess.SubprocessError, OSError) as exc:
         raise SystemExit(
             f"omnigent build: could not determine the Node.js version "
-            f"(`node --version` failed: {exc}). Node.js 22.12 or newer "
-            "is required. Install Node 22 LTS and retry, or run with "
+            f"(`node --version` failed: {exc}). Node.js "
+            f"{_MINIMUM_NODE_VERSION_TEXT} or newer is required. Install it "
+            "from https://nodejs.org/en/download and retry, or run with "
             "OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
         ) from exc
     # ``node --version`` prints ``v22.14.0``.
@@ -309,17 +315,32 @@ def _require_supported_node() -> str:
     except ValueError:
         raise SystemExit(
             f"omnigent build: could not parse Node.js version "
-            f"{version_str or 'unknown'}. Node.js 22.12 or newer is "
-            "required. Install Node 22 LTS and retry, or run with "
+            f"{version_str or 'unknown'}. Node.js "
+            f"{_MINIMUM_NODE_VERSION_TEXT} or newer is required. Install it "
+            "from https://nodejs.org/en/download and retry, or run with "
             "OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
         ) from None
-    if version_parts < (22, 12, 0):
+    if version_parts < _MINIMUM_NODE_VERSION:
         raise SystemExit(
-            f"omnigent build: Node.js 22.12 or newer is required but found "
-            f"Node.js {version_str}. Install Node 22 LTS and retry, or run "
-            "with OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
+            f"omnigent build: Node.js {_MINIMUM_NODE_VERSION_TEXT} or newer "
+            f"is required but found Node.js {version_str}. Upgrade from "
+            "https://nodejs.org/en/download and retry, or run with "
+            "OMNIGENT_SKIP_WEB_UI=true to skip the web UI build."
         )
     return version_str
+
+
+def _subprocess_failure_details(exc: BaseException) -> str:
+    """Return an actionable subprocess failure summary, including stderr."""
+    details = str(exc)
+    stderr = getattr(exc, "stderr", None)
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    if isinstance(stderr, str):
+        stderr = stderr.strip()
+        if stderr and stderr not in details:
+            details = f"{details}; stderr: {stderr}"
+    return details
 
 
 def _git_sha() -> str:

--- a/tests/test_setup_web_ui_build.py
+++ b/tests/test_setup_web_ui_build.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -49,25 +52,26 @@ def _run_node_version_check(module: ModuleType, version_output: str) -> str:
         return module._require_supported_node()
 
 
-def test_node_22_12_passes() -> None:
+def test_node_22_13_passes() -> None:
     module = _load_setup_module()
-    assert _run_node_version_check(module, "v22.12.0\n") == "22.12.0"
+    assert _run_node_version_check(module, "v22.13.0\n") == "22.13.0"
 
 
-@pytest.mark.parametrize("version", ["v24.14.0\n", "v25.2.1\n"])
+@pytest.mark.parametrize("version", ["v23.0.0\n", "v24.14.0\n", "v25.2.1\n"])
 def test_newer_node_versions_pass(version: str) -> None:
     module = _load_setup_module()
     assert _run_node_version_check(module, version) == version.strip().lstrip("v")
 
 
-@pytest.mark.parametrize("version", ["v22.11.0\n", "v20.11.0\n"])
+@pytest.mark.parametrize("version", ["v22.12.0\n", "v20.20.1\n"])
 def test_older_node_fails(version: str) -> None:
     module = _load_setup_module()
     with pytest.raises(SystemExit) as excinfo:
         _run_node_version_check(module, version)
     message = str(excinfo.value)
-    assert "Node.js 22.12 or newer is required" in message
+    assert "Node.js 22.13.0 or newer is required" in message
     assert version.strip().lstrip("v") in message
+    assert "https://nodejs.org/en/download" in message
     assert "OMNIGENT_SKIP_WEB_UI=true" in message
 
 
@@ -77,6 +81,8 @@ def test_unparseable_version_fails() -> None:
         _run_node_version_check(module, "not-a-version\n")
     message = str(excinfo.value)
     assert "could not parse Node.js version not-a-version" in message
+    assert "Node.js 22.13.0 or newer is required" in message
+    assert "https://nodejs.org/en/download" in message
     assert "OMNIGENT_SKIP_WEB_UI=true" in message
 
 
@@ -87,6 +93,8 @@ def test_node_missing_fails() -> None:
             module._require_supported_node()
     message = str(excinfo.value)
     assert "Node.js not found on PATH" in message
+    assert "Node.js 22.13.0 or newer is required" in message
+    assert "https://nodejs.org/en/download" in message
     assert "OMNIGENT_SKIP_WEB_UI=true" in message
 
 
@@ -104,6 +112,8 @@ def test_node_version_probe_failure_fails() -> None:
             module._require_supported_node()
     message = str(excinfo.value)
     assert "could not determine the Node.js version" in message
+    assert "Node.js 22.13.0 or newer is required" in message
+    assert "https://nodejs.org/en/download" in message
     assert "OMNIGENT_SKIP_WEB_UI=true" in message
 
 
@@ -120,7 +130,11 @@ def test_newer_node_build_failure_is_actionable(monkeypatch: pytest.MonkeyPatch)
     module = _load_setup_module()
     monkeypatch.delenv("OMNIGENT_SKIP_WEB_UI", raising=False)
     monkeypatch.setenv("OMNIGENT_BUILD_WEB_UI", "1")
-    failure = module.subprocess.CalledProcessError(1, ["pnpm", "install"])
+    failure = module.subprocess.CalledProcessError(
+        1,
+        ["pnpm", "install"],
+        stderr="ERR_PNPM_UNSUPPORTED_ENGINE: use Node.js 22.13.0 or newer",
+    )
     with (
         mock.patch.object(module, "_require_supported_node", return_value="25.2.1"),
         mock.patch("shutil.which", return_value="/usr/bin/pnpm"),
@@ -130,5 +144,75 @@ def test_newer_node_build_failure_is_actionable(monkeypatch: pytest.MonkeyPatch)
         module._GenerateBuildInfo._build_web_ui(object())
     message = str(excinfo.value)
     assert "web UI build failed on Node.js 25.2.1" in message
-    assert "install Node 22 LTS and retry" in message
+    assert "ERR_PNPM_UNSUPPORTED_ENGINE" in message
+    assert "upgrade to Node.js 22.13.0 or newer" in message
     assert "OMNIGENT_SKIP_WEB_UI=true" in message
+    assert excinfo.value.__cause__ is failure
+
+
+def test_real_node_floor_matches_pinned_pnpm() -> None:
+    """Exercise the setup gate and pinned pnpm with real boundary binaries.
+
+    Set both environment variables to opt in. Keeping this test explicit avoids
+    downloading Node during ordinary pytest runs while providing a real
+    toolchain check that cannot pass from mocked ``node --version`` output.
+    """
+    node_paths = {
+        "22.12.0": os.environ.get("OMNIGENT_TEST_NODE_22_12"),
+        "22.13.0": os.environ.get("OMNIGENT_TEST_NODE_22_13"),
+    }
+    if not any(node_paths.values()):
+        pytest.skip(
+            "set OMNIGENT_TEST_NODE_22_12 and OMNIGENT_TEST_NODE_22_13 "
+            "to run the real toolchain boundary check"
+        )
+    assert all(node_paths.values()), "both real Node boundary binaries are required"
+
+    root = Path(__file__).resolve().parents[1]
+    package_manager = json.loads((root / "package.json").read_text())["packageManager"]
+    assert package_manager == "pnpm@11.15.1"
+    module = _load_setup_module()
+
+    for expected_version, raw_node_path in node_paths.items():
+        assert raw_node_path is not None
+        node_path = Path(raw_node_path).resolve()
+        assert node_path.is_file(), f"Node binary not found: {node_path}"
+        version_result = subprocess.run(
+            [node_path, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert version_result.stdout.strip() == f"v{expected_version}"
+
+        with mock.patch("shutil.which", return_value=str(node_path)):
+            if expected_version == "22.12.0":
+                with pytest.raises(SystemExit):
+                    module._require_supported_node()
+            else:
+                assert module._require_supported_node() == expected_version
+
+        corepack_path = node_path.parent / "corepack"
+        assert corepack_path.is_file(), f"Corepack not found: {corepack_path}"
+        env = {
+            **os.environ,
+            "COREPACK_DEFAULT_TO_LATEST": "0",
+            "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+            "PATH": f"{node_path.parent}{os.pathsep}{os.environ['PATH']}",
+        }
+        pnpm_result = subprocess.run(
+            [corepack_path, "pnpm", "--version"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        output = f"{pnpm_result.stdout}\n{pnpm_result.stderr}"
+        if expected_version == "22.12.0":
+            assert pnpm_result.returncode != 0
+            assert "requires at least Node.js v22.13" in output
+        else:
+            assert pnpm_result.returncode == 0, output
+            assert "11.15.1" in pnpm_result.stdout

--- a/tests/test_setup_web_ui_build.py
+++ b/tests/test_setup_web_ui_build.py
@@ -1,0 +1,134 @@
+"""Tests for the web UI build prerequisites in ``setup.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+
+def _load_setup_module() -> ModuleType:
+    """Load repo-root ``setup.py`` without running the real ``setup()``.
+
+    ``setup.py`` calls ``setup(...)`` at module scope, which would drive
+    setuptools off pytest's argv; patch it to a no-op during load so we
+    can exercise the module's helpers in isolation.
+    """
+    path = Path(__file__).resolve().parents[1] / "setup.py"
+    spec = importlib.util.spec_from_file_location("_omnigent_setup_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    setuptools = ModuleType("setuptools")
+    setuptools.setup = mock.Mock()  # type: ignore[attr-defined]
+    setuptools_command = ModuleType("setuptools.command")
+    setuptools_build_py = ModuleType("setuptools.command.build_py")
+    setuptools_build_py.build_py = type("build_py", (), {})  # type: ignore[attr-defined]
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "setuptools": setuptools,
+            "setuptools.command": setuptools_command,
+            "setuptools.command.build_py": setuptools_build_py,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _run_node_version_check(module: ModuleType, version_output: str) -> str:
+    """Invoke the Node.js gate with ``node --version`` stubbed."""
+    completed = mock.Mock(stdout=version_output)
+    with (
+        mock.patch("shutil.which", return_value="/usr/bin/node"),
+        mock.patch.object(module.subprocess, "run", return_value=completed),
+    ):
+        return module._require_supported_node()
+
+
+def test_node_22_12_passes() -> None:
+    module = _load_setup_module()
+    assert _run_node_version_check(module, "v22.12.0\n") == "22.12.0"
+
+
+@pytest.mark.parametrize("version", ["v24.14.0\n", "v25.2.1\n"])
+def test_newer_node_versions_pass(version: str) -> None:
+    module = _load_setup_module()
+    assert _run_node_version_check(module, version) == version.strip().lstrip("v")
+
+
+@pytest.mark.parametrize("version", ["v22.11.0\n", "v20.11.0\n"])
+def test_older_node_fails(version: str) -> None:
+    module = _load_setup_module()
+    with pytest.raises(SystemExit) as excinfo:
+        _run_node_version_check(module, version)
+    message = str(excinfo.value)
+    assert "Node.js 22.12 or newer is required" in message
+    assert version.strip().lstrip("v") in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message
+
+
+def test_unparseable_version_fails() -> None:
+    module = _load_setup_module()
+    with pytest.raises(SystemExit) as excinfo:
+        _run_node_version_check(module, "not-a-version\n")
+    message = str(excinfo.value)
+    assert "could not parse Node.js version not-a-version" in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message
+
+
+def test_node_missing_fails() -> None:
+    module = _load_setup_module()
+    with mock.patch("shutil.which", return_value=None):
+        with pytest.raises(SystemExit) as excinfo:
+            module._require_supported_node()
+    message = str(excinfo.value)
+    assert "Node.js not found on PATH" in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message
+
+
+def test_node_version_probe_failure_fails() -> None:
+    module = _load_setup_module()
+    with (
+        mock.patch("shutil.which", return_value="/usr/bin/node"),
+        mock.patch.object(
+            module.subprocess,
+            "run",
+            side_effect=OSError("boom"),
+        ),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            module._require_supported_node()
+    message = str(excinfo.value)
+    assert "could not determine the Node.js version" in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message
+
+
+def test_skip_web_ui_bypasses_node_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_setup_module()
+    monkeypatch.setenv("OMNIGENT_SKIP_WEB_UI", "true")
+    require_node = mock.Mock()
+    with mock.patch.object(module, "_require_supported_node", require_node):
+        module._GenerateBuildInfo._build_web_ui(object())
+    require_node.assert_not_called()
+
+
+def test_newer_node_build_failure_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_setup_module()
+    monkeypatch.delenv("OMNIGENT_SKIP_WEB_UI", raising=False)
+    monkeypatch.setenv("OMNIGENT_BUILD_WEB_UI", "1")
+    failure = module.subprocess.CalledProcessError(1, ["pnpm", "install"])
+    with (
+        mock.patch.object(module, "_require_supported_node", return_value="25.2.1"),
+        mock.patch("shutil.which", return_value="/usr/bin/pnpm"),
+        mock.patch.object(module.subprocess, "run", side_effect=failure),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        module._GenerateBuildInfo._build_web_ui(object())
+    message = str(excinfo.value)
+    assert "web UI build failed on Node.js 25.2.1" in message
+    assert "install Node 22 LTS and retry" in message
+    assert "OMNIGENT_SKIP_WEB_UI=true" in message


### PR DESCRIPTION
## Related issue

Related to #4686

## Summary

- Require Node.js 22.13.0 or newer before `setup.py` builds the web UI, matching the effective minimum of the pinned pnpm 11.15.1 toolchain while continuing to accept Node 23, 24, and 25.
- Report the detected Node version, exact floor, upgrade URL, and `OMNIGENT_SKIP_WEB_UI=true` recovery path when Node is too old.
- Preserve downstream pnpm/Vite stderr in build failures and preserve the existing API-only skip behavior. This changes source-install setup enforcement only; it does not change app or server runtime behavior.

## Test Plan
with an old version of node
```
omnigent build: Node.js 22.13.0 or newer is required but found Node.js 20.20.1. Upgrade from https://nodejs.org/en/download and retry, or run with OMNIGENT_SKIP_WEB_UI=true to skip the web UI build.
```

25.xx also works now


- `OMNIGENT_SKIP_WEB_UI=true OMNIGENT_TEST_NODE_22_12=... OMNIGENT_TEST_NODE_22_13=... uv run --no-sync pytest tests/test_setup_web_ui_build.py -q` (12 passed, including the real pinned-pnpm boundary test)
- `OMNIGENT_SKIP_WEB_UI=true uv run --no-sync pre-commit run --files setup.py tests/test_setup_web_ui_build.py` (passed)
- Canonical `quality-gates` steps for the changed files: pre-commit, web format, lint, type-check, and production build (all passed)
- Real Node binaries against `_require_supported_node`:
  - Node 20.20.1: rejected with detected version, Node 22.13.0 floor, upgrade URL, and skip guidance
  - Node 22.12.0: rejected with detected version, Node 22.13.0 floor, upgrade URL, and skip guidance
  - Node 22.13.0: accepted
  - Node 24.20.0 (current LTS): accepted
  - Node 25.2.1: accepted
- `nvm exec 22.13.0 env OMNIGENT_BUILD_WEB_UI=1 uv run --no-sync python setup.py build_py` (passed with pnpm 11.15.1 and Vite 8.1.0 production build)
- `nvm exec 25.2.1 env OMNIGENT_BUILD_WEB_UI=1 uv build --wheel --out-dir <temp>` (passed; 17 MB wheel built with production web bundle)
- Node-less PATH with `OMNIGENT_SKIP_WEB_UI=true`: setup web-build step returned successfully

No app or server needed to run these checks.

## Demo

N/A. This is a non-visual build-time prerequisite and error-message change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused tests cover missing, failed, malformed, old, minimum, and newer Node versions, the node-less skip path, and build-failure stderr. The opt-in real-toolchain test runs the setup gate and pinned pnpm 11.15.1 with actual Node 22.12.0 and 22.13.0 binaries to prevent the preflight and pnpm floors from drifting apart again.

## Changelog

Source installs now reject Node.js versions older than 22.13.0 before the web build and report a clearer recovery path.