### PR TITLE
fix(cli): self-heal `host stop` over un-signalable daemon PIDs

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9095,6 +9095,36 @@ def _stop_daemon_sessions(
     return stopped
 
 
+def _signal_daemon(record: _HostDaemonRecord, sig: int) -> bool:
+    """
+    Deliver ``sig`` to a daemon, healing over PIDs that cannot be signalled.
+
+    A ``PermissionError`` (``EPERM``) means the recorded PID was recycled to a
+    process owned by another user, so our daemon is already gone — the record
+    is stale. Drop it and tell the caller to stop rather than crashing.
+
+    :param record: Daemon record whose process should receive the signal.
+    :param sig: Signal number to deliver, e.g. ``signal.SIGTERM``.
+    :returns: ``True`` to keep going (signal sent, or the process had already
+        exited); ``False`` if the PID was stale and its record was cleared.
+    """
+    try:
+        os.kill(record.pid, sig)
+    except ProcessLookupError:
+        # Exited between the liveness check and the signal — the poll loop
+        # below will notice and delete the record.
+        return True
+    except PermissionError:
+        click.echo(
+            f"{record.target}: daemon pid={record.pid} is no longer ours "
+            "(cannot signal it); clearing the stale record.",
+            err=True,
+        )
+        _delete_daemon_record(record)
+        return False
+    return True
+
+
 def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     """
     Terminate one local daemon process.
@@ -9106,8 +9136,8 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     if not _pid_alive(record.pid):
         _delete_daemon_record(record)
         return
-    with contextlib.suppress(ProcessLookupError):
-        os.kill(record.pid, signal.SIGTERM)
+    if not _signal_daemon(record, signal.SIGTERM):
+        return
     deadline = time.monotonic() + _HOST_DAEMON_STOP_GRACE_S
     while time.monotonic() < deadline:
         if not _pid_alive(record.pid):
@@ -9115,8 +9145,8 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
             return
         time.sleep(0.1)
     if force:
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(record.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        if not _signal_daemon(record, getattr(signal, "SIGKILL", signal.SIGTERM)):
+            return
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline:
             if not _pid_alive(record.pid):

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -377,6 +377,33 @@ def test_stop_surfaces_failures_and_suggests_force(monkeypatch: pytest.MonkeyPat
     assert "retry with --force" in result.output
 
 
+def test_terminate_daemon_heals_stale_pid_owned_by_another_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recycled PID owned by another user is healed, not crashed on.
+
+    ``_pid_alive`` reports an ``AccessDenied`` process as alive, so
+    ``os.kill`` raises ``PermissionError`` (EPERM). ``_terminate_daemon``
+    must clear the stale record and return instead of letting the
+    ``PermissionError`` escape and crash the CLI.
+    """
+    from omnigent.cli import _terminate_daemon
+
+    record = _record("https://example.com", mode="server", pid=4242)
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda pid: True)
+
+    def _kill(pid: int, sig: int) -> None:
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr("omnigent.cli.os.kill", _kill)
+    deleted: list[_HostDaemonRecord] = []
+    monkeypatch.setattr("omnigent.cli._delete_daemon_record", lambda rec: deleted.append(rec))
+
+    _terminate_daemon(record, force=False)  # must not raise
+
+    assert deleted == [record]  # stale record cleared so it stops reappearing
+
+
 def test_stop_clears_stale_legacy_host_pid(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

No tracked issue — filed directly from a user-reported crash report
(`omnigent host stop` traceback below). Bug fix; happy to link an issue
if one is preferred.

Closes #

## Summary

`omnigent host stop` (and any code path that tears down a host daemon)
crashed with an uncaught `PermissionError` when a recorded daemon PID had
been recycled to a process owned by **another user**:

```
File "omnigent/cli.py", in _terminate_daemon
    os.kill(record.pid, signal.SIGTERM)
PermissionError: [Errno 1] Operation not permitted
```

- `_pid_alive()` deliberately treats a `psutil.AccessDenied` process as
  **alive**, so `_terminate_daemon` sailed past its "already dead?" guard
  and tried to signal the foreign PID.
- `os.kill` only suppressed `ProcessLookupError` — not `PermissionError`
  (EPERM) — so the exception escaped and crashed the CLI.
- Because the stale record was never cleared, **every** subsequent
  `host stop` / `host status` hit the same recycled PID and crashed again.

The fix routes both the SIGTERM and SIGKILL sends through a new
`_signal_daemon()` helper that self-heals: on EPERM it warns on stderr,
deletes the stale daemon record, and returns cleanly so the daemon-stop
sweep continues instead of aborting.

**ELI5:** We wrote down a process's ID so we could stop it later. By the
time we tried, the OS had handed that ID to someone else's program we're
not allowed to touch. Instead of throwing up its hands and crashing, the
CLI now realizes "that's not ours anymore," forgets the stale note, and
moves on.

```mermaid
flowchart TD
    A["_terminate_daemon(record)"] --> B{"_pid_alive(pid)?"}
    B -- "no" --> C["delete record, return"]
    B -- "yes (incl. foreign / AccessDenied)" --> D["_signal_daemon(pid, SIG)"]
    D -->|ProcessLookupError| E["gone: poll loop deletes record"]
    D -->|"PermissionError (EPERM)"| F["stale: warn, delete record, return ✅"]
    D -->|sent| G["wait for exit / SIGKILL if --force"]
```

Before: EPERM propagated → CLI crash, repeated on every retry.
After: EPERM → stale record cleared, command continues.

## Test Plan

- Added a unit test that stubs `os.kill` to raise `PermissionError` and a
  live-looking `_pid_alive`, then asserts `_terminate_daemon` does **not**
  raise and clears the record:
  ```
  .venv/bin/python -m pytest \
    tests/cli/test_server_lifecycle.py::test_terminate_daemon_heals_stale_pid_owned_by_another_user
  ```
- Full lifecycle suite green: `.venv/bin/python -m pytest tests/cli/test_server_lifecycle.py` (17 passed).
- `pre-commit run --files omnigent/cli.py tests/cli/test_server_lifecycle.py` clean (ruff format/check, pyrefly).

## Demo

N/A — CLI crash fix, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test reproduces the exact crash path (EPERM from `os.kill`
on a "live" foreign-owned PID) and asserts the self-heal (no raise +
record cleared). The existing lifecycle tests cover the unchanged
already-dead and stubborn-daemon paths.

## Changelog

`omnigent host stop` no longer crashes when a daemon's recorded PID was recycled to another user's process — it clears the stale record and continues.

This pull request and its description were written by Isaac.
