### PR TITLE
fix(cli): show a fix hint instead of a crash report on stale omnigent-client

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2083,9 +2083,17 @@ def main() -> None:
         # and recovery advice would contradict the crash screen's reassurance.
         # `handle_crash` renders the UX and we exit with code 1 (SystemExit
         # does NOT re-trigger sys.excepthook, so there's no double render).
+        from omnigent.client_compat import client_skew_message
         from omnigent.crash_handler import handle_crash
 
         log_cli_error_hint(exc)
+        # A stale sibling `omnigent-client` fails deep in a lazy import; that
+        # is an install-sync problem, not a bug — show the fix, not a crash
+        # report + bug-filing prompt.
+        skew = client_skew_message(exc)
+        if skew is not None:
+            click.echo(skew, err=True)
+            raise SystemExit(1) from exc
         handle_crash(exc)
         raise SystemExit(1) from exc
 

--- a/omnigent/client_compat.py
+++ b/omnigent/client_compat.py
@@ -11,6 +11,12 @@ symbol the newer server added fails deep in a lazy import:
 Without help that surfaces as the generic crash screen + bug-filing prompt,
 which sends users chasing a phantom bug. This module recognises the skew and
 turns it into a one-line "your client is out of date, run this" message.
+
+The tell is a failed ``omnigent_client`` import *plus* a version that differs
+from the running code (``omnigent.version.VERSION``). Requiring the mismatch
+matters: a genuine missing-symbol bug committed at the *same* version is a
+real bug, not a skew, and must still reach the crash handler with its
+traceback rather than be papered over with "run an upgrade".
 """
 
 from __future__ import annotations
@@ -29,8 +35,8 @@ def installed_client_version() -> str | None:
     """Return the installed ``omnigent-client`` version, or ``None``.
 
     ``None`` means the distribution metadata is absent (not installed, or a
-    source tree not on the metadata path) — we still report the skew, just
-    without a concrete version to name.
+    bare source tree on ``sys.path`` with no dist-info) — a state that is
+    itself a skew symptom, so callers treat it as one.
     """
     try:
         return _metadata.version(_CLIENT_DIST)
@@ -38,46 +44,69 @@ def installed_client_version() -> str | None:
         return None
 
 
-def is_client_skew_error(exc: BaseException) -> bool:
+def _failed_client_import(exc: BaseException) -> bool:
     """True if *exc* (or its cause/context chain) is a failed
     ``omnigent_client`` import — a missing module or a missing symbol.
 
-    Both :class:`ModuleNotFoundError` ("No module named 'omnigent_client'")
-    and the "cannot import name X from 'omnigent_client'" form set
-    ``exc.name`` to the module, so that single attribute is the signal.
+    Both ``ModuleNotFoundError`` ("No module named 'omnigent_client'") and the
+    "cannot import name X from 'omnigent_client'" form set ``exc.name`` to the
+    module, so that attribute is the signal. A dotted submodule miss (e.g.
+    ``omnigent_client.foo``) is matched by prefix.
     """
     seen: set[int] = set()
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, ImportError) and getattr(current, "name", None) == _CLIENT_MODULE:
-            return True
+        if isinstance(current, ImportError):
+            name = getattr(current, "name", None)
+            if name == _CLIENT_MODULE or (
+                name is not None and name.startswith(f"{_CLIENT_MODULE}.")
+            ):
+                return True
         current = current.__cause__ or current.__context__
     return False
 
 
-def client_skew_message(exc: BaseException) -> str | None:
-    """Actionable guidance for a client-skew *exc*, or ``None`` if *exc*
-    is not one.
+def is_client_skew_error(exc: BaseException) -> bool:
+    """True if *exc* is a failed ``omnigent_client`` import **and** the
+    installed client is a different version than the running code.
 
-    The message names the running ``omnigent`` version and the stale client
-    version (when resolvable) and points at both the installed-wheel and
-    dev-clone update paths, so it is correct regardless of how the user
-    installed omnigent.
+    A same-version failure is a genuine bug, not a stale install, and returns
+    ``False`` so it reaches the normal crash handler. A missing client
+    (metadata absent) cannot be ruled out, so it counts as a skew.
+    """
+    if not _failed_client_import(exc):
+        return False
+    client = installed_client_version()
+    return client is None or client != VERSION
+
+
+def client_skew_message(exc: BaseException) -> str | None:
+    """Actionable guidance for a client-skew *exc*, or ``None`` when *exc*
+    is not one (unrelated error, or a same-version genuine bug).
+
+    Names the running ``omnigent`` version and the installed client version,
+    and points at both the installed-wheel and dev-clone update paths, so it
+    is correct regardless of how omnigent was installed.
     """
     if not is_client_skew_error(exc):
         return None
 
     client = installed_client_version()
     if client is not None:
-        mismatch = f"omnigent-client {client} is out of sync with omnigent {VERSION}"
+        headline = (
+            f"omnigent-client {client} does not match omnigent {VERSION} — "
+            "they ship as a version-locked pair."
+        )
     else:
-        mismatch = f"omnigent-client is not installed for omnigent {VERSION}"
+        headline = (
+            f"omnigent-client is not installed for omnigent {VERSION} — "
+            "they ship as a version-locked pair."
+        )
 
     return (
-        f"{mismatch}.\n"
-        "They ship as a version-locked pair; update your install so they "
-        "match:\n"
+        f"{headline}\n"
+        "Update your install so they match:\n"
         "  • installed:  omni upgrade\n"
         "  • dev clone:  uv sync   (or: uv pip install -e sdks/python-client)\n"
         f"\nUnderlying import error: {exc}"

--- a/omnigent/client_compat.py
+++ b/omnigent/client_compat.py
@@ -1,0 +1,84 @@
+"""Detect a stale ``omnigent-client`` install and explain the fix.
+
+``omnigent`` and ``omnigent-client`` ship as a version-locked pair (each
+pins ``==`` the other in ``pyproject.toml``). When the installed client
+lags the running ``omnigent`` code — e.g. a build refreshed one package but
+not its sibling, or a checkout runs against an older wheel — importing a
+symbol the newer server added fails deep in a lazy import:
+
+    ImportError: cannot import name 'RegisteredAgent' from 'omnigent_client'
+
+Without help that surfaces as the generic crash screen + bug-filing prompt,
+which sends users chasing a phantom bug. This module recognises the skew and
+turns it into a one-line "your client is out of date, run this" message.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as _metadata
+
+from omnigent.version import VERSION
+
+# The sibling distribution that pairs with the running ``omnigent`` code.
+_CLIENT_DIST = "omnigent-client"
+# Import name of the same package (``exc.name`` on the failed import).
+_CLIENT_MODULE = "omnigent_client"
+
+
+def installed_client_version() -> str | None:
+    """Return the installed ``omnigent-client`` version, or ``None``.
+
+    ``None`` means the distribution metadata is absent (not installed, or a
+    source tree not on the metadata path) — we still report the skew, just
+    without a concrete version to name.
+    """
+    try:
+        return _metadata.version(_CLIENT_DIST)
+    except _metadata.PackageNotFoundError:
+        return None
+
+
+def is_client_skew_error(exc: BaseException) -> bool:
+    """True if *exc* (or its cause/context chain) is a failed
+    ``omnigent_client`` import — a missing module or a missing symbol.
+
+    Both :class:`ModuleNotFoundError` ("No module named 'omnigent_client'")
+    and the "cannot import name X from 'omnigent_client'" form set
+    ``exc.name`` to the module, so that single attribute is the signal.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ImportError) and getattr(current, "name", None) == _CLIENT_MODULE:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def client_skew_message(exc: BaseException) -> str | None:
+    """Actionable guidance for a client-skew *exc*, or ``None`` if *exc*
+    is not one.
+
+    The message names the running ``omnigent`` version and the stale client
+    version (when resolvable) and points at both the installed-wheel and
+    dev-clone update paths, so it is correct regardless of how the user
+    installed omnigent.
+    """
+    if not is_client_skew_error(exc):
+        return None
+
+    client = installed_client_version()
+    if client is not None:
+        mismatch = f"omnigent-client {client} is out of sync with omnigent {VERSION}"
+    else:
+        mismatch = f"omnigent-client is not installed for omnigent {VERSION}"
+
+    return (
+        f"{mismatch}.\n"
+        "They ship as a version-locked pair; update your install so they "
+        "match:\n"
+        "  • installed:  omni upgrade\n"
+        "  • dev clone:  uv sync   (or: uv pip install -e sdks/python-client)\n"
+        f"\nUnderlying import error: {exc}"
+    )

--- a/tests/cli/test_client_compat.py
+++ b/tests/cli/test_client_compat.py
@@ -1,9 +1,11 @@
 """Tests for the stale-``omnigent-client`` skew guard
-(``omnigent.client_compat``).
+(``omnigent.client_compat``) and its wiring into ``omnigent.cli.main``.
 
-Covers detection of both skew import-error shapes, rejection of unrelated
-errors, cause/context chain walking, and the shape of the actionable
-message (version + update commands + underlying error).
+Covers: structural detection of both import-error shapes (incl. dotted
+submodule and cause/context chains), the version-mismatch gate that keeps a
+same-version genuine bug on the crash path, the message shape, and the
+``main()`` handoff (skew → hint + exit, no crash report; unrelated / genuine
+bug → ``handle_crash``).
 """
 
 from __future__ import annotations
@@ -13,75 +15,186 @@ import pytest
 from omnigent import client_compat
 from omnigent.version import VERSION
 
+_OTHER_VERSION = "0.0.0-stale"
+assert _OTHER_VERSION != VERSION
+
 
 def _cannot_import_name() -> ImportError:
     """The "cannot import name X from 'omnigent_client'" shape."""
     try:
-        # omnigent_client exists but (pretend) lacks this symbol.
         exec("from omnigent_client import __definitely_missing_symbol__")
-    except ImportError as e:  # pragma: no branch
+    except ImportError as e:
         return e
     raise AssertionError("expected ImportError")
 
 
-def _module_not_found() -> ModuleNotFoundError:
-    """The "No module named 'omnigent_client'" shape."""
-    try:
-        __import__("omnigent_client.__nope__")
-    except ModuleNotFoundError as e:
-        # Re-point name in case the submodule import reports the submodule.
-        e.name = "omnigent_client"
-        return e
-    raise AssertionError("expected ModuleNotFoundError")
+def _module_not_found(name: str = "omnigent_client") -> ModuleNotFoundError:
+    """A ``ModuleNotFoundError`` with ``name`` set as CPython would."""
+    exc = ModuleNotFoundError(f"No module named {name!r}")
+    exc.name = name
+    return exc
 
 
-def test_detects_cannot_import_name() -> None:
+# --------------------------------------------------------------------------- #
+# Structural detection (version-independent)
+# --------------------------------------------------------------------------- #
+def test_structural_detects_cannot_import_name() -> None:
+    assert client_compat._failed_client_import(_cannot_import_name()) is True
+
+
+def test_structural_detects_module_not_found() -> None:
+    assert client_compat._failed_client_import(_module_not_found()) is True
+
+
+def test_structural_detects_dotted_submodule() -> None:
+    assert client_compat._failed_client_import(_module_not_found("omnigent_client.foo")) is True
+
+
+def test_structural_ignores_unrelated_import_error() -> None:
+    assert client_compat._failed_client_import(_module_not_found("some.other.pkg")) is False
+
+
+def test_structural_ignores_non_import_error() -> None:
+    assert client_compat._failed_client_import(ValueError("boom")) is False
+
+
+def test_structural_detects_in_cause_chain() -> None:
+    wrapper = RuntimeError("auth failed")
+    wrapper.__cause__ = _cannot_import_name()
+    assert client_compat._failed_client_import(wrapper) is True
+
+
+def test_structural_chain_walk_terminates_on_cycle() -> None:
+    exc = ValueError("loop")
+    exc.__context__ = exc
+    assert client_compat._failed_client_import(exc) is False
+
+
+# --------------------------------------------------------------------------- #
+# Version-mismatch gate
+# --------------------------------------------------------------------------- #
+def test_skew_true_when_versions_differ(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: _OTHER_VERSION)
     assert client_compat.is_client_skew_error(_cannot_import_name()) is True
 
 
-def test_detects_module_not_found() -> None:
+def test_skew_false_when_versions_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A genuine missing-symbol bug at the *same* version is not a skew — it
+    # must stay on the crash path so the traceback is not hidden.
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: VERSION)
+    assert client_compat.is_client_skew_error(_cannot_import_name()) is False
+    assert client_compat.client_skew_message(_cannot_import_name()) is None
+
+
+def test_skew_true_when_client_metadata_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: None)
     assert client_compat.is_client_skew_error(_module_not_found()) is True
 
 
-def test_ignores_unrelated_import_error() -> None:
-    exc = ImportError("cannot import name 'x' from 'some.other.pkg'")
-    exc.name = "some.other.pkg"
-    assert client_compat.is_client_skew_error(exc) is False
-    assert client_compat.client_skew_message(exc) is None
-
-
-def test_ignores_non_import_error() -> None:
+def test_skew_false_for_unrelated_error() -> None:
     assert client_compat.is_client_skew_error(ValueError("boom")) is False
+    assert client_compat.client_skew_message(ValueError("boom")) is None
 
 
-def test_detects_skew_in_cause_chain() -> None:
-    skew = _cannot_import_name()
-    wrapper = RuntimeError("auth failed")
-    wrapper.__cause__ = skew
-    assert client_compat.is_client_skew_error(wrapper) is True
-
-
-def test_chain_walk_terminates_on_cycle() -> None:
-    # A self-referential context must not loop forever.
-    exc = ValueError("loop")
-    exc.__context__ = exc
-    assert client_compat.is_client_skew_error(exc) is False
-
-
-def test_message_contents(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(client_compat, "installed_client_version", lambda: "0.9.0.dev1")
+# --------------------------------------------------------------------------- #
+# Message shape
+# --------------------------------------------------------------------------- #
+def test_message_names_versions_and_both_fixes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: _OTHER_VERSION)
     msg = client_compat.client_skew_message(_cannot_import_name())
     assert msg is not None
-    assert "0.9.0.dev1" in msg  # stale client version named
+    assert _OTHER_VERSION in msg  # installed client version named
     assert VERSION in msg  # running omnigent version named
     assert "omni upgrade" in msg  # installed-wheel fix
     assert "uv sync" in msg  # dev-clone fix
     assert "__definitely_missing_symbol__" in msg  # underlying error preserved
 
 
-def test_message_when_client_version_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_message_when_client_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(client_compat, "installed_client_version", lambda: None)
-    msg = client_compat.client_skew_message(_cannot_import_name())
+    msg = client_compat.client_skew_message(_module_not_found())
     assert msg is not None
     assert "not installed" in msg
     assert VERSION in msg
+
+
+# --------------------------------------------------------------------------- #
+# main() handoff
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def stubbed_main(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Neutralise ``main()``'s startup side effects and record whether the
+    friendly crash handler runs. Returns a dict the test reads afterwards.
+
+    Yields control to the test to set the exception ``cli()`` raises via
+    ``state["raise"]``.
+    """
+    from omnigent import cli as cli_mod
+    from omnigent import cli_diagnostics, crash_handler
+
+    state: dict = {"raise": None, "handle_crash_called": False}
+
+    monkeypatch.setattr(crash_handler, "install_crash_handler", lambda **_: None)
+    monkeypatch.setattr(
+        crash_handler, "handle_crash", lambda exc: state.__setitem__("handle_crash_called", True)
+    )
+    monkeypatch.setattr(cli_mod, "_migrate_legacy_state_dir", lambda: None)
+    monkeypatch.setattr(cli_mod, "_maybe_fast_backfill_install_ledger", lambda argv: None)
+    monkeypatch.setattr(cli_mod, "_should_skip_update_check", lambda argv: True)
+    monkeypatch.setattr(cli_diagnostics, "setup_cli_logging", lambda argv: None)
+
+    def _cli(*_a, **_k):
+        raise state["raise"]
+
+    monkeypatch.setattr(cli_mod, "cli", _cli)
+    monkeypatch.setattr("sys.argv", ["omnigent", "run"])
+    return state
+
+
+def test_main_prints_hint_and_skips_crash_on_skew(
+    stubbed_main: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    from omnigent import cli as cli_mod
+
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: _OTHER_VERSION)
+    stubbed_main["raise"] = _cannot_import_name()
+
+    with pytest.raises(SystemExit) as ei:
+        cli_mod.main()
+
+    assert ei.value.code == 1
+    err = capsys.readouterr().err
+    assert "does not match omnigent" in err
+    assert "omni upgrade" in err
+    assert stubbed_main["handle_crash_called"] is False  # no crash report
+
+
+def test_main_uses_crash_handler_for_same_version_bug(
+    stubbed_main: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    from omnigent import cli as cli_mod
+
+    # Same version → genuine bug, not skew: the crash handler must run.
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: VERSION)
+    stubbed_main["raise"] = _cannot_import_name()
+
+    with pytest.raises(SystemExit) as ei:
+        cli_mod.main()
+
+    assert ei.value.code == 1
+    assert stubbed_main["handle_crash_called"] is True
+    assert "does not match omnigent" not in capsys.readouterr().err
+
+
+def test_main_uses_crash_handler_for_unrelated_error(
+    stubbed_main: dict, capsys: pytest.CaptureFixture
+) -> None:
+    from omnigent import cli as cli_mod
+
+    stubbed_main["raise"] = ValueError("something else broke")
+
+    with pytest.raises(SystemExit) as ei:
+        cli_mod.main()
+
+    assert ei.value.code == 1
+    assert stubbed_main["handle_crash_called"] is True

--- a/tests/cli/test_client_compat.py
+++ b/tests/cli/test_client_compat.py
@@ -1,0 +1,87 @@
+"""Tests for the stale-``omnigent-client`` skew guard
+(``omnigent.client_compat``).
+
+Covers detection of both skew import-error shapes, rejection of unrelated
+errors, cause/context chain walking, and the shape of the actionable
+message (version + update commands + underlying error).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent import client_compat
+from omnigent.version import VERSION
+
+
+def _cannot_import_name() -> ImportError:
+    """The "cannot import name X from 'omnigent_client'" shape."""
+    try:
+        # omnigent_client exists but (pretend) lacks this symbol.
+        exec("from omnigent_client import __definitely_missing_symbol__")
+    except ImportError as e:  # pragma: no branch
+        return e
+    raise AssertionError("expected ImportError")
+
+
+def _module_not_found() -> ModuleNotFoundError:
+    """The "No module named 'omnigent_client'" shape."""
+    try:
+        __import__("omnigent_client.__nope__")
+    except ModuleNotFoundError as e:
+        # Re-point name in case the submodule import reports the submodule.
+        e.name = "omnigent_client"
+        return e
+    raise AssertionError("expected ModuleNotFoundError")
+
+
+def test_detects_cannot_import_name() -> None:
+    assert client_compat.is_client_skew_error(_cannot_import_name()) is True
+
+
+def test_detects_module_not_found() -> None:
+    assert client_compat.is_client_skew_error(_module_not_found()) is True
+
+
+def test_ignores_unrelated_import_error() -> None:
+    exc = ImportError("cannot import name 'x' from 'some.other.pkg'")
+    exc.name = "some.other.pkg"
+    assert client_compat.is_client_skew_error(exc) is False
+    assert client_compat.client_skew_message(exc) is None
+
+
+def test_ignores_non_import_error() -> None:
+    assert client_compat.is_client_skew_error(ValueError("boom")) is False
+
+
+def test_detects_skew_in_cause_chain() -> None:
+    skew = _cannot_import_name()
+    wrapper = RuntimeError("auth failed")
+    wrapper.__cause__ = skew
+    assert client_compat.is_client_skew_error(wrapper) is True
+
+
+def test_chain_walk_terminates_on_cycle() -> None:
+    # A self-referential context must not loop forever.
+    exc = ValueError("loop")
+    exc.__context__ = exc
+    assert client_compat.is_client_skew_error(exc) is False
+
+
+def test_message_contents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: "0.9.0.dev1")
+    msg = client_compat.client_skew_message(_cannot_import_name())
+    assert msg is not None
+    assert "0.9.0.dev1" in msg  # stale client version named
+    assert VERSION in msg  # running omnigent version named
+    assert "omni upgrade" in msg  # installed-wheel fix
+    assert "uv sync" in msg  # dev-clone fix
+    assert "__definitely_missing_symbol__" in msg  # underlying error preserved
+
+
+def test_message_when_client_version_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_compat, "installed_client_version", lambda: None)
+    msg = client_compat.client_skew_message(_cannot_import_name())
+    assert msg is not None
+    assert "not installed" in msg
+    assert VERSION in msg


### PR DESCRIPTION
## Related issue

Closes #

<!-- No separate tracked issue: the stale-client crash was reproduced locally
while diagnosing a CLI startup failure. This PR hardens that path. Happy to
file/link an issue if the process requires one. -->

## Summary

- `omnigent` and `omnigent-client` ship as a **version-locked pair** (each pins `==` the other in `pyproject.toml`). When the installed client lags the running `omnigent` code — a build refreshed one package but not its sibling, or a checkout runs against an older wheel — importing a symbol the newer server added fails deep in a lazy import (e.g. `cannot import name 'RegisteredAgent' from 'omnigent_client'`).
- Today that surfaces as the **generic crash screen + "file a GitHub issue?" prompt**, sending users to chase a phantom bug when the real fix is a one-line reinstall.
- This adds `omnigent.client_compat` and, in `main()`'s crash handoff, prints an **actionable message** (running omnigent version, installed client version, and both update paths) instead of a crash report. Unrelated exceptions still go to `handle_crash`.

**Classification requires *both* signals**, which is the load-bearing detail:
1. a failed `omnigent_client` import — matched via `exc.name`, walking the `__cause__`/`__context__` chain, including dotted submodules; **and**
2. an installed client version that **differs** from the runtime `omnigent.version.VERSION`.

Requiring (2) avoids a false positive that a bare "import failed" check gets wrong: a genuine missing-symbol bug committed at the *same* version is a real bug, not a stale install — it must keep its traceback via `handle_crash`, not be papered over with "run an upgrade". Comparing against `VERSION` (a constant compiled into the running code) rather than `omnigent`'s dist-info is deliberate: it reflects the code actually executing even when an older wheel's metadata is what's on the path. A missing client (no metadata at all) counts as a skew.

**ELI5:** two packages must match. When they don't, the CLI used to "crash and ask you to report a bug." Now it says "your client is out of date — run this." When they *do* match, a real bug still crashes normally.

Before → after (stderr):

```
# before
⚠️  Omnigent ran into an issue.
  ImportError: cannot import name 'RegisteredAgent' from 'omnigent_client'
  A crash report was saved to: …/crashes/crash-….md
  Help us fix it — file a GitHub issue with this report? [Y/n]

# after
omnigent-client 0.9.0.dev1 does not match omnigent 0.10.0.dev0 — they ship as a version-locked pair.
Update your install so they match:
  • installed:  omni upgrade
  • dev clone:  uv sync   (or: uv pip install -e sdks/python-client)

Underlying import error: cannot import name 'RegisteredAgent' from 'omnigent_client' (…)
```

## Test Plan

- `pytest tests/cli/test_client_compat.py` — **16 passed**. Covers structural detection (both import-error shapes, dotted submodule, cause-chain, cycle-safety), the version-mismatch gate (differ → skew; **same version → not a skew**; missing metadata → skew), the message shape, and the `main()` handoff **end-to-end**: skew → hint printed + exit 1 + `handle_crash` not called; same-version bug and unrelated error → `handle_crash` runs.
- `pre-commit run --files …` — all hooks pass on the changed files.

## Demo

N/A — CLI stderr text, non-visual (before/after shown in Summary).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The `main()`-level tests neutralise `main()`'s startup side effects (crash-handler install, state migration, ledger backfill, logging setup, update check) and stub the click entry point to raise, then assert the real `main()` handoff routes a skew to the hint (no crash report) and a same-version / unrelated failure to `handle_crash`. This locks in both the wiring and the version gate, not just the helper in isolation.

## Changelog

A stale `omnigent-client` install now prints a one-line "update" hint instead of a crash report + bug-filing prompt.

This pull request and its description were written by Isaac.
