### PR TITLE
fix(runner): mitigate cross-runner ordinal collisions for auto-named sub-agents

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1826,6 +1826,7 @@ async def _execute_subagent_tool(
                 "after completion."
             )
     else:
+        _auto_ordinal = False
         if not session_name:
             # No title hint — auto-generate a structured session name
             # (e.g. "researcher-1"). Recover ordinals from existing
@@ -1852,6 +1853,7 @@ async def _execute_subagent_tool(
                 str(sub_agent_name),
             )
             session_name = f"{sub_agent_name}-{ordinal}"
+            _auto_ordinal = True
         child_harness = _subagent_harness(str(sub_agent_name), agent_spec)
         # Apply an allowlisted per-dispatch harness override. The sub-agent
         # spec must explicitly opt in via executor.config.allowed_harnesses,
@@ -1954,7 +1956,22 @@ async def _execute_subagent_tool(
                 agent_spec=agent_spec,
                 harness=child_harness,
             )
-        resp = await server_client.post("/v1/sessions", json=create_body, timeout=30.0)
+
+        # Retry loop for auto-ordinal names: a 409 means another runner
+        # (or a restart race) already created a child with this ordinal.
+        # Bump the ordinal and retry with a fresh name.
+        _max_ordinal_retries = 5 if _auto_ordinal else 0
+        for _ordinal_attempt in range(_max_ordinal_retries + 1):
+            resp = await server_client.post("/v1/sessions", json=create_body, timeout=30.0)
+            if resp.status_code == 409 and _auto_ordinal and _ordinal_attempt < _max_ordinal_retries:
+                ordinal = _runner_app.next_subagent_ordinal(
+                    conversation_id,
+                    str(sub_agent_name),
+                )
+                session_name = f"{sub_agent_name}-{ordinal}"
+                create_body["title"] = f"{sub_agent_name}:{session_name}"
+                continue
+            break
         if resp.status_code >= 400:
             return f"Error: failed to create child session: {resp.status_code} {resp.text[:200]}"
         child_data = _string_object_dict(resp.json())

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1957,9 +1957,11 @@ async def _execute_subagent_tool(
                 harness=child_harness,
             )
 
-        # Retry loop for auto-ordinal names: a 409 means another runner
-        # (or a restart race) already created a child with this ordinal.
-        # Bump the ordinal and retry with a fresh name.
+        # Best-effort retry for auto-ordinal name collisions: a 409 means
+        # another runner (or a restart race) already created a child with
+        # this ordinal. Bump and retry. Not watertight — the server's
+        # (parent, title) check is SELECT-then-INSERT with no DB unique
+        # constraint, so truly concurrent creates can still race past it.
         _max_ordinal_retries = 5 if _auto_ordinal else 0
         for _ordinal_attempt in range(_max_ordinal_retries + 1):
             resp = await server_client.post("/v1/sessions", json=create_body, timeout=30.0)

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1963,7 +1963,11 @@ async def _execute_subagent_tool(
         _max_ordinal_retries = 5 if _auto_ordinal else 0
         for _ordinal_attempt in range(_max_ordinal_retries + 1):
             resp = await server_client.post("/v1/sessions", json=create_body, timeout=30.0)
-            if resp.status_code == 409 and _auto_ordinal and _ordinal_attempt < _max_ordinal_retries:
+            if (
+                resp.status_code == 409
+                and _auto_ordinal
+                and _ordinal_attempt < _max_ordinal_retries
+            ):
                 ordinal = _runner_app.next_subagent_ordinal(
                     conversation_id,
                     str(sub_agent_name),

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -335,6 +335,7 @@ from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
     PINNED_LABEL_KEY,
     ConversationNotFoundError,
+    NameAlreadyExistsError,
     pinned_label_key,
 )
 from omnigent.stores.file_store import FileStore
@@ -7914,6 +7915,21 @@ async def _create_session_from_existing_agent(
             git_branch=git_branch,
             terminal_launch_args=validated_launch_args,
         )
+    except NameAlreadyExistsError as exc:
+        if (
+            created_worktree_path is not None
+            and body.host_id is not None
+            and git_branch is not None
+        ):
+            await _remove_session_worktree_best_effort(
+                host_id=body.host_id,
+                worktree_path=created_worktree_path,
+                branch=git_branch,
+                delete_branch=True,
+                request=request,
+                reason="create-rollback",
+            )
+        raise OmnigentError(str(exc), code=ErrorCode.CONFLICT) from exc
     except Exception:
         # Broad catch is intentional: ANY create_conversation failure
         # (integrity error, name clash, ...) must trigger orphan-worktree

--- a/tests/runner/test_subagent_ordinal.py
+++ b/tests/runner/test_subagent_ordinal.py
@@ -1,0 +1,99 @@
+"""Tests for sub-agent ordinal allocation and cross-runner uniqueness."""
+
+from __future__ import annotations
+
+from omnigent.runner import app as runner_app
+
+
+def _reset_ordinal_counters() -> None:
+    runner_app._subagent_ordinal_counters.clear()
+
+
+class TestNextSubagentOrdinal:
+    def setup_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def teardown_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def test_first_ordinal_is_one(self) -> None:
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+
+    def test_ordinals_increment(self) -> None:
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 2
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 3
+
+    def test_ordinals_independent_per_parent(self) -> None:
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+        assert runner_app.next_subagent_ordinal("parent_2", "researcher") == 1
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 2
+
+    def test_ordinals_independent_per_agent_type(self) -> None:
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+        assert runner_app.next_subagent_ordinal("parent_1", "coder") == 1
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 2
+
+
+class TestRecoverSubagentOrdinals:
+    def setup_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def teardown_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def test_recovery_sets_high_water_mark(self) -> None:
+        children = [
+            {"session_name": "researcher-1"},
+            {"session_name": "researcher-3"},
+            {"session_name": "researcher-2"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 4
+
+    def test_recovery_ignores_other_agent_types(self) -> None:
+        children = [
+            {"session_name": "coder-5"},
+            {"session_name": "researcher-2"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 3
+
+    def test_recovery_with_no_matching_children(self) -> None:
+        children = [
+            {"session_name": "coder-5"},
+            {"session_name": "manual-title"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+
+    def test_recovery_skips_when_already_initialized(self) -> None:
+        runner_app.next_subagent_ordinal("parent_1", "researcher")  # sets to 1
+        children = [
+            {"session_name": "researcher-10"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        # Should NOT reset — already initialized
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 2
+
+    def test_recovery_handles_empty_children(self) -> None:
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", [])
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 1
+
+    def test_recovery_handles_non_string_session_name(self) -> None:
+        children = [
+            {"session_name": None},
+            {"session_name": 42},
+            {"session_name": "researcher-2"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 3
+
+    def test_recovery_handles_malformed_ordinals(self) -> None:
+        children = [
+            {"session_name": "researcher-"},
+            {"session_name": "researcher-abc"},
+            {"session_name": "researcher-2"},
+        ]
+        runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
+        assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 3

--- a/tests/runner/test_subagent_ordinal.py
+++ b/tests/runner/test_subagent_ordinal.py
@@ -1,4 +1,12 @@
-"""Tests for sub-agent ordinal allocation and cross-runner uniqueness."""
+"""Tests for sub-agent ordinal allocation and cross-runner collision mitigation.
+
+The ordinal counter is per-runner in-memory state. Cross-runner uniqueness
+relies on the server's application-level ``(parent, title)`` duplicate check
+returning HTTP 409, which the runner retries with a bumped ordinal. This is
+best-effort: the store's SELECT-then-INSERT has no backing DB unique constraint,
+so truly concurrent creates can still race past it. See the ``idx_conversations_parent``
+comment in ``db_models.py`` for the trade-off rationale.
+"""
 
 from __future__ import annotations
 
@@ -97,3 +105,50 @@ class TestRecoverSubagentOrdinals:
         ]
         runner_app.recover_subagent_ordinals("parent_1", "researcher", children)
         assert runner_app.next_subagent_ordinal("parent_1", "researcher") == 3
+
+
+class TestOrdinalRetryBehavior:
+    """Verify the ordinal bumping pattern used by the runner retry loop.
+
+    The runner's retry loop calls ``next_subagent_ordinal`` on each 409 to get
+    the next candidate. These tests verify the counter produces the right
+    sequence of names when the first N ordinals are already taken.
+    """
+
+    def setup_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def teardown_method(self) -> None:
+        _reset_ordinal_counters()
+
+    def test_sequential_bumps_produce_distinct_names(self) -> None:
+        names = []
+        for _ in range(5):
+            ordinal = runner_app.next_subagent_ordinal("parent_1", "researcher")
+            names.append(f"researcher-{ordinal}")
+        assert names == [
+            "researcher-1",
+            "researcher-2",
+            "researcher-3",
+            "researcher-4",
+            "researcher-5",
+        ]
+
+    def test_bumps_after_recovery_continue_from_high_water(self) -> None:
+        runner_app.recover_subagent_ordinals(
+            "parent_1",
+            "researcher",
+            [{"session_name": "researcher-3"}],
+        )
+        names = []
+        for _ in range(3):
+            ordinal = runner_app.next_subagent_ordinal("parent_1", "researcher")
+            names.append(f"researcher-{ordinal}")
+        assert names == ["researcher-4", "researcher-5", "researcher-6"]
+
+    def test_bumps_across_agent_types_are_independent(self) -> None:
+        r1 = runner_app.next_subagent_ordinal("parent_1", "researcher")
+        c1 = runner_app.next_subagent_ordinal("parent_1", "coder")
+        r2 = runner_app.next_subagent_ordinal("parent_1", "researcher")
+        c2 = runner_app.next_subagent_ordinal("parent_1", "coder")
+        assert (r1, c1, r2, c2) == (1, 1, 2, 2)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -8671,3 +8671,33 @@ async def test_message_forward_rejection_surfaces_failed_with_reason(
         assert "harness_spawn_failed" in last_error["message"], last_error
     finally:
         await fake_runner.aclose()
+
+
+async def test_create_child_session_duplicate_title_returns_409(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /v1/sessions returns 409 when a child with the same title already exists."""
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+
+    resp1 = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "parent_session_id": parent["id"],
+            "title": "researcher:researcher-1",
+        },
+    )
+    assert resp1.status_code == 201, resp1.text
+
+    resp2 = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "parent_session_id": parent["id"],
+            "title": "researcher:researcher-1",
+        },
+    )
+    assert resp2.status_code == 409, (
+        f"expected 409 on duplicate child title, got {resp2.status_code}: {resp2.text}"
+    )


### PR DESCRIPTION
## Related issue

Addresses the "Auto-ordinal allocation has no cross-runner uniqueness guarantee" blocking issue from https://github.com/omnigent-ai/omnigent/pull/4489#issuecomment-5289694469

## Summary

- **Server**: Catch `NameAlreadyExistsError` in `_create_session_from_existing_agent` and return HTTP 409 (`ErrorCode.CONFLICT`) instead of letting it bubble up as a 500. Includes worktree cleanup on the conflict path.
- **Runner**: When auto-allocating ordinals, retry the `POST /v1/sessions` call on 409 with a bumped ordinal (up to 5 attempts). Caller-provided titles are unaffected. The retry is best-effort: the server's `(parent, title)` check is a `SELECT`-then-`INSERT` with no DB unique constraint, so truly concurrent creates can still race past it.
- **Tests**: 14 unit tests covering `next_subagent_ordinal`, `recover_subagent_ordinals`, and the ordinal-bumping pattern used by the retry loop. 1 server integration test verifying `POST /v1/sessions` returns 409 on duplicate child titles.

## Test Plan

- `python -m pytest tests/runner/test_subagent_ordinal.py -v` — all 14 tests pass
- `python -m pytest tests/server/integration/test_sessions_endpoints.py::test_create_child_session_duplicate_title_returns_409 -v` — verifies 409 on duplicate
- Manual: start two runners targeting the same parent, auto-spawn subagents from both — the second runner should retry on 409 and get `researcher-2` after the first takes `researcher-1`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the ordinal counter, recovery, and retry-bump logic. Integration test verifies the server returns 409 on duplicate `(parent, title)` child sessions. The retry loop on the runner side is tested indirectly through the ordinal-bumping unit tests. The underlying `(parent, title)` uniqueness is best-effort (application-level SELECT-then-INSERT, no DB constraint) — a future improvement could add a DB unique index for watertight enforcement.