### PR TITLE
feat(web): admin-configurable announcements in the top bar

### DIFF
--- a/omnigent/server/announcements_settings.py
+++ b/omnigent/server/announcements_settings.py
@@ -1,0 +1,211 @@
+"""File-backed server-wide announcements for the OSS server.
+
+An admin posts short notices (maintenance windows, new-feature callouts,
+incident banners) that every user sees in the app's top bar. The set is stored
+as a JSON array in :func:`resolve_data_dir` (next to the ``admins`` roster and
+the sharing overrides) so it survives restarts without a database migration and
+takes effect without a redeploy — the read side is mtime-cached, mirroring the
+``admins`` / sharing loaders, and the write side replaces the file atomically.
+
+Each announcement is a small record:
+
+- ``id`` — server-assigned, ``anc_`` + hex. Stable across edits so a user's
+  per-announcement dismissal (client-side) sticks.
+- ``message`` — the notice text (required, trimmed, length-capped).
+- ``level`` — ``info`` / ``warning`` / ``success``, drives the banner styling.
+- ``active`` — whether the banner shows it. Inactive rows stay in the file so an
+  admin can toggle a notice off and back on without retyping it.
+- ``dismissible`` — whether a user may dismiss it (a critical notice can be
+  pinned).
+- ``link_url`` / ``link_label`` — optional call-to-action link.
+- ``created_at`` / ``updated_at`` — epoch seconds, server-managed.
+
+A missing/empty/unreadable file yields an empty list (never raises) so a read on
+the display hot path can't fail the app, and a malformed file is logged and
+treated as empty rather than surfaced as an error.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import secrets
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from omnigent.server.admin_list import resolve_data_dir
+
+logger = logging.getLogger(__name__)
+
+_ANNOUNCEMENTS_FILE = "announcements.json"
+
+#: Levels an announcement may use, most-severe last. Anything else coerces to
+#: ``info`` rather than being rejected on read (fail-safe display).
+LEVELS: tuple[str, ...] = ("info", "warning", "success")
+
+#: Guardrails so a single write can't bloat the file or the banner. The caps are
+#: generous for a notice but bounded — the banner is chrome, not a content store.
+MAX_MESSAGE_LEN = 2000
+MAX_LABEL_LEN = 120
+MAX_URL_LEN = 2000
+MAX_ANNOUNCEMENTS = 50
+
+# mtime cache keyed by absolute path → (mtime, parsed list). Keyed by path so a
+# data-dir change (e.g. across tests) never reads through a stale entry.
+_cache: dict[str, tuple[float, list[Announcement]]] = {}
+
+
+@dataclass(frozen=True)
+class Announcement:
+    """One server-wide announcement (see the module docstring for fields)."""
+
+    id: str
+    message: str
+    level: str
+    active: bool
+    dismissible: bool
+    link_url: str | None
+    link_label: str | None
+    created_at: int
+    updated_at: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the API and for on-disk storage (same shape)."""
+        return {
+            "object": "announcement",
+            "id": self.id,
+            "message": self.message,
+            "level": self.level,
+            "active": self.active,
+            "dismissible": self.dismissible,
+            "link_url": self.link_url,
+            "link_label": self.link_label,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+def resolve_announcements_path() -> Path:
+    """Path of the file holding the announcements list."""
+    return resolve_data_dir() / _ANNOUNCEMENTS_FILE
+
+
+def _coerce_level(value: Any) -> str:
+    """Return a known level, defaulting unknown/empty values to ``info``."""
+    if isinstance(value, str) and value.strip().lower() in LEVELS:
+        return value.strip().lower()
+    return "info"
+
+
+def _coerce_optional_str(value: Any, *, max_len: int) -> str | None:
+    """Trim to a bounded string, or ``None`` for empty/non-string values."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    return trimmed[:max_len]
+
+
+def _announcement_from_stored(raw: Any) -> Announcement | None:
+    """Build an :class:`Announcement` from one stored/JSON record.
+
+    Tolerant on read (missing/dirty fields are coerced or the row is dropped) so
+    a hand-edited or older file never breaks the display path. Returns ``None``
+    for a row with no usable message.
+    """
+    if not isinstance(raw, dict):
+        return None
+    message = raw.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return None
+    now = int(time.time())
+    created = raw.get("created_at")
+    updated = raw.get("updated_at")
+    return Announcement(
+        id=str(raw.get("id") or _new_id()),
+        message=message.strip()[:MAX_MESSAGE_LEN],
+        level=_coerce_level(raw.get("level")),
+        active=bool(raw.get("active", True)),
+        dismissible=bool(raw.get("dismissible", True)),
+        link_url=_coerce_optional_str(raw.get("link_url"), max_len=MAX_URL_LEN),
+        link_label=_coerce_optional_str(raw.get("link_label"), max_len=MAX_LABEL_LEN),
+        created_at=created if isinstance(created, int) else now,
+        updated_at=updated if isinstance(updated, int) else now,
+    )
+
+
+def _new_id() -> str:
+    """Mint a stable announcement id (``anc_`` + 24 hex chars)."""
+    return "anc_" + secrets.token_hex(12)
+
+
+def read_announcements() -> list[Announcement]:
+    """Return all announcements (active and inactive), newest first.
+
+    mtime-cached: re-parses only when the file's modification time changes. A
+    missing, empty, unreadable, or malformed file yields ``[]`` — the display
+    path must never fail because of the announcements file.
+    """
+    path = resolve_announcements_path()
+    key = str(path)
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        _cache.pop(key, None)
+        return []
+    cached = _cache.get(key)
+    if cached is not None and cached[0] == mtime:
+        return list(cached[1])
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        parsed = json.loads(raw) if raw.strip() else []
+    except json.JSONDecodeError:
+        logger.warning("Ignoring malformed announcements file %s", path)
+        _cache[key] = (mtime, [])
+        return []
+    if not isinstance(parsed, list):
+        logger.warning("Ignoring announcements file %s: expected a JSON array", path)
+        _cache[key] = (mtime, [])
+        return []
+    items = [a for a in (_announcement_from_stored(entry) for entry in parsed) if a is not None]
+    items.sort(key=lambda a: a.created_at, reverse=True)
+    _cache[key] = (mtime, items)
+    return list(items)
+
+
+def read_active_announcements() -> list[Announcement]:
+    """Return only the announcements an admin has marked ``active``."""
+    return [a for a in read_announcements() if a.active]
+
+
+def write_announcements(items: list[Announcement]) -> list[Announcement]:
+    """Persist the full announcements list atomically, newest first.
+
+    Writes to a temp file in the data dir and ``os.replace``s it into place so a
+    concurrent read never sees a half-written file, then invalidates the cache.
+    Returns the stored list (sorted newest-first) so the caller can echo it.
+    """
+    ordered = sorted(items, key=lambda a: a.created_at, reverse=True)
+    path = resolve_announcements_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps([a.to_dict() for a in ordered], indent=2)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+        os.replace(tmp, path)
+    except OSError:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    _cache.pop(str(path), None)
+    return ordered

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -58,6 +58,7 @@ from omnigent.server.performance_metrics import (
     set_request_session_id_for_access_log,
     set_request_user_agent_for_access_log,
 )
+from omnigent.server.routes.announcements import create_announcements_router
 from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
@@ -2042,6 +2043,18 @@ def create_app(
         ),
         prefix="/v1",
         tags=["sharing"],
+    )
+
+    # Server-wide announcements shown in the app's top bar. Always mounted:
+    # GET /v1/announcements is public (the banner renders without an admin
+    # session) and the admin editor endpoints self-gate on is_admin.
+    app.include_router(
+        create_announcements_router(
+            auth_provider=auth_provider,
+            permission_store=permission_store,
+        ),
+        prefix="/v1",
+        tags=["announcements"],
     )
 
     # First-class projects (owner-private session containers). Mounted only

--- a/omnigent/server/routes/announcements.py
+++ b/omnigent/server/routes/announcements.py
@@ -1,0 +1,193 @@
+"""Server-wide announcements shown in the app's top bar.
+
+``GET /v1/announcements`` returns the *active* announcements for the banner —
+readable by anyone (like ``GET /v1/info``), so the top bar renders without an
+admin session. ``GET /v1/announcements/all`` returns every announcement (active
+and inactive) for the admin editor, and ``PUT /v1/announcements`` replaces the
+whole list (admin only), persisting ``<data_dir>/announcements.json``.
+
+The full-list replace mirrors ``PUT /v1/sharing``: the admin editor holds the
+list client-side and saves it in one shot, so a single atomic write is the whole
+transaction. Incoming rows carry an ``id`` for edits (``created_at`` is
+preserved) or omit it for new rows (server mints the id and timestamps).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.announcements_settings import (
+    LEVELS,
+    MAX_ANNOUNCEMENTS,
+    MAX_LABEL_LEN,
+    MAX_MESSAGE_LEN,
+    MAX_URL_LEN,
+    Announcement,
+    _new_id,
+    read_active_announcements,
+    read_announcements,
+    write_announcements,
+)
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id
+from omnigent.stores.permission_store import PermissionStore
+
+
+class AnnouncementInput(BaseModel):
+    """One announcement in a ``PUT /v1/announcements`` body.
+
+    ``id`` is present when editing an existing row (its ``created_at`` is
+    preserved) and absent for a new row (the server mints both).
+    """
+
+    id: str | None = None
+    message: str = Field(min_length=1, max_length=MAX_MESSAGE_LEN)
+    level: str = "info"
+    active: bool = True
+    dismissible: bool = True
+    link_url: str | None = Field(default=None, max_length=MAX_URL_LEN)
+    link_label: str | None = Field(default=None, max_length=MAX_LABEL_LEN)
+
+
+class SetAnnouncementsRequest(BaseModel):
+    """Body for ``PUT /v1/announcements`` — the full replacement list."""
+
+    announcements: list[AnnouncementInput]
+
+
+def _validated_link_url(value: str | None) -> str | None:
+    """Return a safe link URL, or raise 400 for an unsupported scheme.
+
+    Only ``http(s)`` absolute URLs and site-relative paths (``/…``) are allowed;
+    ``javascript:`` / ``data:`` and the like are rejected so an admin-set link
+    can't smuggle script into every user's banner.
+    """
+    if value is None:
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if trimmed.startswith("/") and not trimmed.startswith("//"):
+        return trimmed
+    scheme = urlparse(trimmed).scheme.lower()
+    if scheme in ("http", "https"):
+        return trimmed
+    raise OmnigentError(
+        "Announcement links must be an http(s) URL or a site-relative path.",
+        code=ErrorCode.INVALID_INPUT,
+    )
+
+
+def _to_announcement(item: AnnouncementInput, existing: dict[str, Announcement]) -> Announcement:
+    """Build a stored :class:`Announcement` from one request row.
+
+    Rejects an unknown ``level`` with 400 (so a typo surfaces rather than
+    silently downgrading to ``info``). Preserves ``created_at`` for an edited row
+    and stamps ``updated_at`` on every write.
+    """
+    message = item.message.strip()
+    if not message:
+        # ``min_length=1`` only rejects an empty raw string; a whitespace-only
+        # message trims to nothing and would be dropped on read, so reject it
+        # here rather than storing a row that silently vanishes.
+        raise OmnigentError(
+            "Announcement message cannot be empty.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    level = item.level.strip().lower()
+    if level not in LEVELS:
+        raise OmnigentError(
+            f"Unknown announcement level {item.level!r}. Expected one of: "
+            + ", ".join(LEVELS)
+            + ".",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    now = int(time.time())
+    prior = existing.get(item.id) if item.id else None
+    link_url = _validated_link_url(item.link_url)
+    label = (item.link_label or "").strip()
+    return Announcement(
+        id=prior.id if prior else _new_id(),
+        message=message[:MAX_MESSAGE_LEN],
+        level=level,
+        active=item.active,
+        dismissible=item.dismissible,
+        link_url=link_url,
+        # A label with no link is meaningless — drop it so the stored row is
+        # coherent. A link with no label renders with the URL as its own text.
+        link_label=(label[:MAX_LABEL_LEN] if link_url and label else None),
+        created_at=prior.created_at if prior else now,
+        updated_at=now,
+    )
+
+
+async def _require_admin(
+    request: Request,
+    auth_provider: AuthProvider | None,
+    permission_store: PermissionStore | None,
+) -> None:
+    """Verify the caller is an admin, mirroring the sharing-router gate.
+
+    Single-user mode (no permission store) skips the check. Multi-user mode
+    raises 401 if unauthenticated or 403 if the user is not an admin.
+    """
+    if permission_store is None:
+        return
+    user_id = get_user_id(request, auth_provider)
+    if user_id is None:
+        raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+    is_admin = await asyncio.to_thread(permission_store.is_admin, user_id)
+    if not is_admin:
+        raise OmnigentError(
+            "Admin privileges required to manage announcements",
+            code=ErrorCode.FORBIDDEN,
+        )
+
+
+def create_announcements_router(
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> APIRouter:
+    """Build the announcements router (mounted under ``/v1``)."""
+    router = APIRouter()
+
+    @router.get("/announcements")
+    async def list_active(request: Request) -> dict[str, Any]:
+        """Active announcements for the top-bar banner (any caller)."""
+        items = await asyncio.to_thread(read_active_announcements)
+        return {"object": "list", "data": [a.to_dict() for a in items]}
+
+    @router.get("/announcements/all")
+    async def list_all(request: Request) -> dict[str, Any]:
+        """Every announcement, active or not, for the admin editor (admin only)."""
+        await _require_admin(request, auth_provider, permission_store)
+        items = await asyncio.to_thread(read_announcements)
+        return {"object": "list", "data": [a.to_dict() for a in items]}
+
+    @router.put("/announcements")
+    async def replace(request: Request, body: SetAnnouncementsRequest) -> dict[str, Any]:
+        """Replace the full announcements list (admin only).
+
+        Validates and authorizes every row before writing so a bad row (unknown
+        level, unsafe link, over the count cap) rejects the whole request rather
+        than persisting a partial list.
+        """
+        await _require_admin(request, auth_provider, permission_store)
+        if len(body.announcements) > MAX_ANNOUNCEMENTS:
+            raise OmnigentError(
+                f"Too many announcements (max {MAX_ANNOUNCEMENTS}).",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        existing = {a.id: a for a in await asyncio.to_thread(read_announcements)}
+        items = [_to_announcement(item, existing) for item in body.announcements]
+        stored = await asyncio.to_thread(write_announcements, items)
+        return {"object": "list", "data": [a.to_dict() for a in stored]}
+
+    return router

--- a/tests/server/routes/test_announcements.py
+++ b/tests/server/routes/test_announcements.py
@@ -1,0 +1,261 @@
+"""Tests for the announcements routes (``/v1/announcements``).
+
+Two auth setups, mirroring the projects/sharing route tests:
+
+- **Single-user** (``client``) — no auth provider / permission store, so the
+  admin gate is skipped. Covers the read/write happy path and validation.
+- **Multi-user** (``admin_client`` + ``X-Forwarded-Email``) — header auth with a
+  permission store, so the editor endpoints are admin-gated. Proves a non-admin
+  gets 403 while the public GET stays open.
+
+The announcements file lives under ``resolve_data_dir()``; every test redirects
+that at ``tmp_path`` (via ``OMNIGENT_ADMIN_CREDENTIALS_PATH``) so nothing touches
+the real ``~/.omnigent``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server import announcements_settings
+from omnigent.server.app import create_app
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
+)
+
+ADMIN = "admin@example.com"
+MEMBER = "member@example.com"
+
+
+@pytest.fixture(autouse=True)
+def announce_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Point ``resolve_data_dir()`` at ``tmp_path`` and clear the read cache.
+
+    Keeps every test's announcements file isolated in its own temp dir and never
+    writes to the developer's real data directory.
+    """
+    monkeypatch.setenv(
+        "OMNIGENT_ADMIN_CREDENTIALS_PATH", str(tmp_path / "data" / "admin-credentials")
+    )
+    monkeypatch.delenv("OMNIGENT_ADMIN_LIST_PATH", raising=False)
+    announcements_settings._cache.clear()
+    yield
+    announcements_settings._cache.clear()
+
+
+def _base_app(db_uri: str, tmp_path: Path, **overrides: object) -> FastAPI:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        **overrides,  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture()
+def single_user_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """App with no auth — the admin gate is skipped (OSS single-user default)."""
+    return _base_app(db_uri, tmp_path)
+
+
+@pytest_asyncio.fixture()
+async def client(single_user_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=single_user_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture()
+def multi_user_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """Header-auth app with a permission store, so the editor is admin-gated."""
+    permission_store = SqlAlchemyPermissionStore(db_uri)
+    permission_store.ensure_user(ADMIN, is_admin=True)
+    permission_store.ensure_user(MEMBER, is_admin=False)
+    return _base_app(
+        db_uri,
+        tmp_path,
+        permission_store=permission_store,
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+
+@pytest_asyncio.fixture()
+async def admin_client(multi_user_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=multi_user_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _payload(**overrides: object) -> dict:
+    base: dict = {"message": "Scheduled maintenance tonight", "level": "warning"}
+    base.update(overrides)  # type: ignore[arg-type]
+    return base
+
+
+# ── Single-user: read/write happy path + validation ───────────────────
+
+
+async def test_empty_by_default(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/v1/announcements")
+    assert resp.status_code == 200
+    assert resp.json() == {"object": "list", "data": []}
+
+
+async def test_put_then_get_assigns_id_and_timestamps(client: httpx.AsyncClient) -> None:
+    resp = await client.put("/v1/announcements", json={"announcements": [_payload()]})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1
+    row = data[0]
+    assert row["id"].startswith("anc_")
+    assert row["message"] == "Scheduled maintenance tonight"
+    assert row["level"] == "warning"
+    assert row["active"] is True
+    assert row["dismissible"] is True
+    assert isinstance(row["created_at"], int)
+
+    # It now shows on the public active list.
+    active = (await client.get("/v1/announcements")).json()["data"]
+    assert [a["id"] for a in active] == [row["id"]]
+
+
+async def test_inactive_hidden_from_public_but_in_all(client: httpx.AsyncClient) -> None:
+    body = {
+        "announcements": [
+            _payload(message="Live one", active=True),
+            _payload(message="Hidden one", active=False),
+        ]
+    }
+    await client.put("/v1/announcements", json=body)
+
+    active = (await client.get("/v1/announcements")).json()["data"]
+    assert [a["message"] for a in active] == ["Live one"]
+
+    all_rows = (await client.get("/v1/announcements/all")).json()["data"]
+    assert {a["message"] for a in all_rows} == {"Live one", "Hidden one"}
+
+
+async def test_edit_preserves_created_at(client: httpx.AsyncClient) -> None:
+    first = (await client.put("/v1/announcements", json={"announcements": [_payload()]})).json()[
+        "data"
+    ][0]
+
+    edited = {
+        "announcements": [
+            {"id": first["id"], "message": "Edited text", "level": "info", "active": True}
+        ]
+    }
+    row = (await client.put("/v1/announcements", json=edited)).json()["data"][0]
+    assert row["id"] == first["id"]
+    assert row["message"] == "Edited text"
+    assert row["created_at"] == first["created_at"]
+    assert row["updated_at"] >= first["updated_at"]
+
+
+async def test_put_replaces_whole_list(client: httpx.AsyncClient) -> None:
+    await client.put(
+        "/v1/announcements",
+        json={"announcements": [_payload(message="A"), _payload(message="B")]},
+    )
+    # A subsequent PUT with a single row drops the others.
+    row = (
+        await client.put("/v1/announcements", json={"announcements": [_payload(message="C")]})
+    ).json()["data"]
+    assert [a["message"] for a in row] == ["C"]
+
+
+async def test_empty_message_rejected(client: httpx.AsyncClient) -> None:
+    resp = await client.put("/v1/announcements", json={"announcements": [{"message": "  "}]})
+    # Pydantic min_length is on the trimmed-then-stored value; a whitespace-only
+    # message has length after strip == 0 and is rejected as a bad request.
+    assert resp.status_code in (400, 422)
+
+
+async def test_unknown_level_rejected(client: httpx.AsyncClient) -> None:
+    resp = await client.put(
+        "/v1/announcements",
+        json={"announcements": [_payload(level="critical")]},
+    )
+    assert resp.status_code == 400
+
+
+async def test_unsafe_link_rejected(client: httpx.AsyncClient) -> None:
+    resp = await client.put(
+        "/v1/announcements",
+        json={"announcements": [_payload(link_url="javascript:alert(1)")]},
+    )
+    assert resp.status_code == 400
+
+
+async def test_relative_and_https_links_accepted(client: httpx.AsyncClient) -> None:
+    body = {
+        "announcements": [
+            _payload(message="rel", link_url="/docs", link_label="Docs"),
+            _payload(message="abs", link_url="https://example.com"),
+        ]
+    }
+    data = (await client.put("/v1/announcements", json=body)).json()["data"]
+    by_msg = {a["message"]: a for a in data}
+    assert by_msg["rel"]["link_url"] == "/docs"
+    assert by_msg["rel"]["link_label"] == "Docs"
+    # A link with no label stores label as None (banner uses the URL as text).
+    assert by_msg["abs"]["link_url"] == "https://example.com"
+    assert by_msg["abs"]["link_label"] is None
+
+
+async def test_too_many_rejected(client: httpx.AsyncClient) -> None:
+    over = announcements_settings.MAX_ANNOUNCEMENTS + 1
+    body = {"announcements": [_payload(message=f"n{i}") for i in range(over)]}
+    resp = await client.put("/v1/announcements", json=body)
+    assert resp.status_code == 400
+
+
+# ── Multi-user: admin gating ───────────────────────────────────────────
+
+
+async def test_public_get_open_to_anyone(admin_client: httpx.AsyncClient) -> None:
+    # No identity header at all — the active list is still readable.
+    resp = await admin_client.get("/v1/announcements")
+    assert resp.status_code == 200
+
+
+async def test_non_admin_cannot_edit(admin_client: httpx.AsyncClient) -> None:
+    resp = await admin_client.put(
+        "/v1/announcements",
+        json={"announcements": [_payload()]},
+        headers={"X-Forwarded-Email": MEMBER},
+    )
+    assert resp.status_code == 403
+
+    # And can't read the admin-only "all" list.
+    resp = await admin_client.get(
+        "/v1/announcements/all", headers={"X-Forwarded-Email": MEMBER}
+    )
+    assert resp.status_code == 403
+
+
+async def test_admin_can_edit(admin_client: httpx.AsyncClient) -> None:
+    resp = await admin_client.put(
+        "/v1/announcements",
+        json={"announcements": [_payload()]},
+        headers={"X-Forwarded-Email": ADMIN},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 1

--- a/web/src/components/AnnouncementsBanner.test.tsx
+++ b/web/src/components/AnnouncementsBanner.test.tsx
@@ -1,0 +1,104 @@
+// Tests for the top-bar AnnouncementsBanner. The react-query hook is mocked so
+// no QueryClient or network is needed; localStorage (jsdom) backs dismissals.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnnouncementsBanner } from "./AnnouncementsBanner";
+import type { Announcement } from "@/hooks/useAnnouncements";
+import * as hook from "@/hooks/useAnnouncements";
+
+vi.mock("@/hooks/useAnnouncements", () => ({ useAnnouncements: vi.fn() }));
+
+function announcement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    object: "announcement",
+    id: "anc_1",
+    message: "Heads up",
+    level: "info",
+    active: true,
+    dismissible: true,
+    link_url: null,
+    link_label: null,
+    created_at: 100,
+    updated_at: 100,
+    ...overrides,
+  };
+}
+
+function setData(data: Announcement[] | undefined) {
+  vi.mocked(hook.useAnnouncements).mockReturnValue({
+    data,
+  } as unknown as ReturnType<typeof hook.useAnnouncements>);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe("AnnouncementsBanner", () => {
+  it("renders nothing when there are no announcements", () => {
+    setData([]);
+    const { container } = render(<AnnouncementsBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while the query is loading (undefined data)", () => {
+    setData(undefined);
+    const { container } = render(<AnnouncementsBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders each active announcement with its message", () => {
+    setData([
+      announcement({ id: "anc_1", message: "First" }),
+      announcement({ id: "anc_2", message: "Second", level: "warning" }),
+    ]);
+    render(<AnnouncementsBanner />);
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+    expect(screen.getAllByTestId("announcement")).toHaveLength(2);
+  });
+
+  it("renders a link with its label", () => {
+    setData([announcement({ link_url: "https://x.example", link_label: "Details" })]);
+    render(<AnnouncementsBanner />);
+    const link = screen.getByRole("link", { name: "Details" });
+    expect(link).toHaveAttribute("href", "https://x.example");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("dismissing hides the row and persists to localStorage", () => {
+    setData([announcement({ id: "anc_1", updated_at: 100 })]);
+    render(<AnnouncementsBanner />);
+
+    fireEvent.click(screen.getByTestId("announcement-dismiss"));
+
+    expect(screen.queryByTestId("announcement")).not.toBeInTheDocument();
+    const stored = JSON.parse(window.localStorage.getItem("omnigent:dismissed-announcements")!);
+    expect(stored).toContain("anc_1:100");
+  });
+
+  it("stays hidden on next mount when previously dismissed", () => {
+    window.localStorage.setItem("omnigent:dismissed-announcements", JSON.stringify(["anc_1:100"]));
+    setData([announcement({ id: "anc_1", updated_at: 100 })]);
+    render(<AnnouncementsBanner />);
+    expect(screen.queryByTestId("announcement")).not.toBeInTheDocument();
+  });
+
+  it("re-surfaces a dismissed announcement after it is edited (updated_at changes)", () => {
+    window.localStorage.setItem("omnigent:dismissed-announcements", JSON.stringify(["anc_1:100"]));
+    // Same id, newer updated_at → the stored token no longer matches.
+    setData([announcement({ id: "anc_1", updated_at: 200, message: "Edited" })]);
+    render(<AnnouncementsBanner />);
+    expect(screen.getByText("Edited")).toBeInTheDocument();
+  });
+
+  it("shows no dismiss control for a non-dismissible announcement", () => {
+    setData([announcement({ dismissible: false })]);
+    render(<AnnouncementsBanner />);
+    expect(screen.getByTestId("announcement")).toBeInTheDocument();
+    expect(screen.queryByTestId("announcement-dismiss")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/AnnouncementsBanner.tsx
+++ b/web/src/components/AnnouncementsBanner.tsx
@@ -1,0 +1,144 @@
+/**
+ * Top-bar announcements banner.
+ *
+ * Renders the server-wide notices an admin publishes (Settings → Announcements)
+ * as full-width strips pinned above the app chrome. Each active, non-dismissed
+ * announcement is one strip, styled by its level (info / warning / success).
+ *
+ * Dismissals are per-device (localStorage), keyed by ``id:updated_at`` so an
+ * admin editing a dismissed notice re-surfaces it, while an untouched one stays
+ * hidden. A non-dismissible notice shows no close button and can't be hidden.
+ */
+
+import { useCallback, useState } from "react";
+import { CheckCircle2Icon, InfoIcon, TriangleAlertIcon, XIcon } from "lucide-react";
+import { type Announcement, useAnnouncements } from "@/hooks/useAnnouncements";
+import { cn } from "@/lib/utils";
+
+const DISMISSED_KEY = "omnigent:dismissed-announcements";
+
+/** Dismissal token for an announcement — re-surfaces when the row is edited. */
+function dismissalToken(a: Announcement): string {
+  return `${a.id}:${a.updated_at}`;
+}
+
+function readDismissed(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((x): x is string => typeof x === "string"))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissed(tokens: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DISMISSED_KEY, JSON.stringify([...tokens]));
+  } catch {
+    // localStorage failures are non-fatal — the banner just won't persist.
+  }
+}
+
+const LEVEL_STYLES: Record<
+  Announcement["level"],
+  { bar: string; icon: typeof InfoIcon; iconClass: string }
+> = {
+  info: { bar: "bg-info/10 border-info/30", icon: InfoIcon, iconClass: "text-info" },
+  warning: {
+    bar: "bg-warning/10 border-warning/40",
+    icon: TriangleAlertIcon,
+    iconClass: "text-warning",
+  },
+  success: {
+    bar: "bg-success/10 border-success/30",
+    icon: CheckCircle2Icon,
+    iconClass: "text-success",
+  },
+};
+
+/** A single announcement strip. */
+function AnnouncementRow({
+  announcement,
+  onDismiss,
+}: {
+  announcement: Announcement;
+  onDismiss: (a: Announcement) => void;
+}) {
+  const style = LEVEL_STYLES[announcement.level] ?? LEVEL_STYLES.info;
+  const Icon = style.icon;
+  // Server-validated to http(s) or a site-relative path. External links open in
+  // a new tab; relative ones navigate in place.
+  const isExternal = /^https?:/i.test(announcement.link_url ?? "");
+  return (
+    <div
+      role="status"
+      data-testid="announcement"
+      className={cn(
+        "flex w-full items-center gap-2.5 border-b px-4 py-2 text-sm text-foreground",
+        style.bar,
+      )}
+    >
+      <Icon className={cn("size-4 shrink-0", style.iconClass)} aria-hidden />
+      <span className="min-w-0 flex-1">
+        <span className="[overflow-wrap:anywhere]">{announcement.message}</span>
+        {announcement.link_url && (
+          <a
+            href={announcement.link_url}
+            target={isExternal ? "_blank" : undefined}
+            rel={isExternal ? "noopener noreferrer" : undefined}
+            className="ml-2 font-medium underline underline-offset-2 hover:no-underline"
+          >
+            {announcement.link_label ?? announcement.link_url}
+          </a>
+        )}
+      </span>
+      {announcement.dismissible && (
+        <button
+          type="button"
+          aria-label="Dismiss announcement"
+          data-testid="announcement-dismiss"
+          onClick={() => onDismiss(announcement)}
+          className="shrink-0 rounded-sm p-0.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+        >
+          <XIcon className="size-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The banner stack. Renders nothing (no reserved space) when there are no
+ * active, non-dismissed announcements, so the layout is unchanged in the common
+ * case. Mounted at the top of the app shell.
+ */
+export function AnnouncementsBanner() {
+  const { data } = useAnnouncements();
+  const [dismissed, setDismissed] = useState<Set<string>>(readDismissed);
+
+  const dismiss = useCallback((a: Announcement) => {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(dismissalToken(a));
+      writeDismissed(next);
+      return next;
+    });
+  }, []);
+
+  const visible = (data ?? []).filter((a) => !dismissed.has(dismissalToken(a)));
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="shrink-0" data-testid="announcements-banner">
+      {visible.map((a) => (
+        <AnnouncementRow key={a.id} announcement={a} onDismiss={dismiss} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/hooks/useAnnouncements.ts
+++ b/web/src/hooks/useAnnouncements.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { authenticatedFetch } from "@/lib/identity";
+
+/** Banner styling tier for an announcement. */
+export type AnnouncementLevel = "info" | "warning" | "success";
+
+/** A server-wide announcement, as returned by ``GET /v1/announcements``. */
+export interface Announcement {
+  object: "announcement";
+  id: string;
+  message: string;
+  level: AnnouncementLevel;
+  active: boolean;
+  dismissible: boolean;
+  link_url: string | null;
+  link_label: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/** One row in a ``PUT /v1/announcements`` body (id omitted for new rows). */
+export interface AnnouncementInput {
+  id?: string;
+  message: string;
+  level: AnnouncementLevel;
+  active: boolean;
+  dismissible: boolean;
+  link_url: string | null;
+  link_label: string | null;
+}
+
+interface AnnouncementList {
+  object: "list";
+  data: Announcement[];
+}
+
+const ACTIVE_KEY = ["announcements", "active"];
+const ALL_KEY = ["announcements", "all"];
+
+async function readError(res: Response): Promise<string> {
+  const body = await res.json().catch(() => ({}));
+  return body?.error?.message ?? `${res.status} ${res.statusText}`;
+}
+
+async function fetchList(url: string): Promise<Announcement[]> {
+  const res = await authenticatedFetch(url);
+  if (!res.ok) throw new Error(await readError(res));
+  const body = (await res.json()) as AnnouncementList;
+  return body.data;
+}
+
+/**
+ * Active announcements for the top-bar banner. Polled so a newly-published (or
+ * retracted) notice appears without a reload; served to any signed-in user.
+ */
+export function useAnnouncements() {
+  return useQuery({
+    queryKey: ACTIVE_KEY,
+    queryFn: () => fetchList("/v1/announcements"),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+/** Every announcement (active + inactive) for the admin editor. */
+export function useAllAnnouncements() {
+  return useQuery({
+    queryKey: ALL_KEY,
+    queryFn: () => fetchList("/v1/announcements/all"),
+    staleTime: 5_000,
+  });
+}
+
+/** PUT /v1/announcements — replace the full list (admin). */
+export function useSetAnnouncements() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (announcements: AnnouncementInput[]) => {
+      const res = await authenticatedFetch("/v1/announcements", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ announcements }),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      return ((await res.json()) as AnnouncementList).data;
+    },
+    onSuccess: (data) => {
+      // The editor query gets the authoritative saved list immediately; the
+      // banner query is invalidated so it re-derives its active subset.
+      queryClient.setQueryData(ALL_KEY, data);
+      void queryClient.invalidateQueries({ queryKey: ACTIVE_KEY });
+    },
+  });
+}

--- a/web/src/pages/AnnouncementsPage.test.tsx
+++ b/web/src/pages/AnnouncementsPage.test.tsx
@@ -1,0 +1,131 @@
+// Tests for the admin AnnouncementsPage. Browser e2e is impractical (admin-
+// gated), so the surface is pinned here by mocking the identity probe and the
+// react-query announcement hooks — no QueryClient or network needed.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnnouncementsPage } from "./AnnouncementsPage";
+import type { Announcement } from "@/hooks/useAnnouncements";
+import * as identity from "@/lib/identity";
+import * as hook from "@/hooks/useAnnouncements";
+
+const serverInfoMocks = vi.hoisted(() => ({ singleUser: false }));
+
+vi.mock("@/lib/CapabilitiesContext", () => ({
+  useServerInfo: () => ({ single_user: serverInfoMocks.singleUser, login_url: "/login" }),
+}));
+vi.mock("@/lib/identity", () => ({
+  resolveIdentity: vi.fn(),
+  getCurrentIsAdmin: vi.fn(),
+}));
+vi.mock("@/hooks/useAnnouncements", () => ({
+  useAllAnnouncements: vi.fn(),
+  useSetAnnouncements: vi.fn(),
+}));
+
+const saveMutate = vi.fn();
+
+function setAll(data: Announcement[] | undefined, isLoading = false) {
+  vi.mocked(hook.useAllAnnouncements).mockReturnValue({
+    data,
+    isLoading,
+  } as unknown as ReturnType<typeof hook.useAllAnnouncements>);
+}
+
+beforeEach(() => {
+  vi.mocked(identity.resolveIdentity).mockResolvedValue("admin@example.com");
+  vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(true);
+  saveMutate.mockReset();
+  vi.mocked(hook.useSetAnnouncements).mockReturnValue({
+    mutate: saveMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hook.useSetAnnouncements>);
+  serverInfoMocks.singleUser = false;
+});
+
+afterEach(cleanup);
+
+describe("AnnouncementsPage", () => {
+  it("shows a no-permission message to a non-admin", async () => {
+    vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(false);
+    setAll([]);
+    render(<AnnouncementsPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByText("You don't have permission to manage announcements."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the empty state and lets an admin add a row", async () => {
+    setAll([]);
+    render(<AnnouncementsPage />);
+
+    await waitFor(() => expect(screen.getByTestId("announcement-add")).toBeInTheDocument());
+    expect(screen.getByText(/No announcements yet/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("announcement-add"));
+    expect(screen.getByTestId("announcement-editor-row")).toBeInTheDocument();
+  });
+
+  it("blocks saving when a row has an empty message", async () => {
+    setAll([]);
+    render(<AnnouncementsPage />);
+    await waitFor(() => expect(screen.getByTestId("announcement-add")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("announcement-add")); // empty message row
+    fireEvent.click(screen.getByTestId("announcement-save"));
+
+    expect(screen.getByText("Every announcement needs a message.")).toBeInTheDocument();
+    expect(saveMutate).not.toHaveBeenCalled();
+  });
+
+  it("saves the drafted announcements via the mutation", async () => {
+    setAll([]);
+    render(<AnnouncementsPage />);
+    await waitFor(() => expect(screen.getByTestId("announcement-add")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("announcement-add"));
+    fireEvent.change(screen.getByTestId("announcement-message"), {
+      target: { value: "Welcome aboard" },
+    });
+    fireEvent.click(screen.getByTestId("announcement-save"));
+
+    expect(saveMutate).toHaveBeenCalledTimes(1);
+    const [payload] = saveMutate.mock.calls[0];
+    expect(payload).toEqual([
+      expect.objectContaining({
+        message: "Welcome aboard",
+        level: "info",
+        active: true,
+        dismissible: true,
+        link_url: null,
+        link_label: null,
+      }),
+    ]);
+  });
+
+  it("prefills existing announcements from the server", async () => {
+    setAll([
+      {
+        object: "announcement",
+        id: "anc_1",
+        message: "Maintenance tonight",
+        level: "warning",
+        active: true,
+        dismissible: true,
+        link_url: null,
+        link_label: null,
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    render(<AnnouncementsPage />);
+
+    await waitFor(() =>
+      expect((screen.getByTestId("announcement-message") as HTMLTextAreaElement).value).toBe(
+        "Maintenance tonight",
+      ),
+    );
+  });
+});

--- a/web/src/pages/AnnouncementsPage.tsx
+++ b/web/src/pages/AnnouncementsPage.tsx
@@ -1,0 +1,344 @@
+/**
+ * Admin announcements editor (``/settings/announcements``). Rendered as a
+ * Settings sub-category alongside Members, Policies, and Sharing.
+ *
+ * Lets an admin manage the server-wide notices shown in every user's top bar
+ * (see {@link AnnouncementsBanner}). Gated on the client by an admin check
+ * (non-admins see a "no permission" message) AND on the server by the route
+ * handler — client-side gating is just UX.
+ *
+ * The editor holds the full list as a local draft; "Save" replaces the
+ * server-side list in one atomic ``PUT /v1/announcements`` (mirroring the
+ * sharing editor's single-shot save).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { PageScroll } from "@/components/PageScroll";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  type AnnouncementInput,
+  type AnnouncementLevel,
+  useAllAnnouncements,
+  useSetAnnouncements,
+} from "@/hooks/useAnnouncements";
+import { isSingleUserMode } from "@/lib/capabilities";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
+import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
+
+const LEVELS: { value: AnnouncementLevel; label: string }[] = [
+  { value: "info", label: "Info" },
+  { value: "warning", label: "Warning" },
+  { value: "success", label: "Success" },
+];
+
+/** A form row — an {@link AnnouncementInput} plus a stable React key. */
+interface Draft {
+  key: string;
+  id?: string;
+  message: string;
+  level: AnnouncementLevel;
+  active: boolean;
+  dismissible: boolean;
+  link_url: string;
+  link_label: string;
+}
+
+let draftSeq = 0;
+function newDraft(): Draft {
+  draftSeq += 1;
+  return {
+    key: `draft-${draftSeq}`,
+    message: "",
+    level: "info",
+    active: true,
+    dismissible: true,
+    link_url: "",
+    link_label: "",
+  };
+}
+
+function toDraft(a: {
+  id: string;
+  message: string;
+  level: AnnouncementLevel;
+  active: boolean;
+  dismissible: boolean;
+  link_url: string | null;
+  link_label: string | null;
+}): Draft {
+  draftSeq += 1;
+  return {
+    key: `existing-${a.id}-${draftSeq}`,
+    id: a.id,
+    message: a.message,
+    level: a.level,
+    active: a.active,
+    dismissible: a.dismissible,
+    link_url: a.link_url ?? "",
+    link_label: a.link_label ?? "",
+  };
+}
+
+function toInput(d: Draft): AnnouncementInput {
+  const url = d.link_url.trim();
+  const label = d.link_label.trim();
+  return {
+    id: d.id,
+    message: d.message.trim(),
+    level: d.level,
+    active: d.active,
+    dismissible: d.dismissible,
+    link_url: url || null,
+    link_label: url && label ? label : null,
+  };
+}
+
+export function AnnouncementsPage() {
+  const info = useServerInfo();
+  const isSingleUser = isSingleUserMode(info);
+  const [meIsAdmin, setMeIsAdmin] = useState<boolean | null>(null);
+
+  const { data, isLoading } = useAllAnnouncements();
+  const save = useSetAnnouncements();
+  const [drafts, setDrafts] = useState<Draft[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Admin probe via the mode-agnostic `/v1/me` identity (works under OIDC too).
+  // Skipped in single-user mode where no auth endpoints exist.
+  useEffect(() => {
+    if (isSingleUser) return;
+    void (async () => {
+      const userId = await resolveIdentity();
+      if (userId === null) return;
+      setMeIsAdmin(getCurrentIsAdmin());
+    })();
+  }, [isSingleUser]);
+
+  // Seed the draft list from the server once it arrives. Only while untouched
+  // (drafts === null) so a background refetch never clobbers an in-progress
+  // edit; "Reset" re-seeds explicitly.
+  useEffect(() => {
+    if (data && drafts === null) setDrafts(data.map(toDraft));
+  }, [data, drafts]);
+
+  const patch = (key: string, next: Partial<Draft>) => {
+    setError(null);
+    setDrafts((prev) => (prev ?? []).map((d) => (d.key === key ? { ...d, ...next } : d)));
+  };
+  const remove = (key: string) => {
+    setError(null);
+    setDrafts((prev) => (prev ?? []).filter((d) => d.key !== key));
+  };
+  const add = () => {
+    setError(null);
+    setDrafts((prev) => [newDraft(), ...(prev ?? [])]);
+  };
+
+  const dirty = useMemo(() => {
+    if (drafts === null || data === undefined) return false;
+    return JSON.stringify(data.map(toDraft).map(toInput)) !== JSON.stringify(drafts.map(toInput));
+  }, [drafts, data]);
+
+  function onSave() {
+    if (drafts === null) return;
+    if (drafts.some((d) => d.message.trim() === "")) {
+      setError("Every announcement needs a message.");
+      return;
+    }
+    setError(null);
+    save.mutate(drafts.map(toInput), {
+      onSuccess: (saved) => setDrafts(saved.map(toDraft)),
+      onError: (err) => setError(err.message),
+    });
+  }
+
+  if (!isSingleUser && meIsAdmin === null) {
+    return (
+      <div className="flex min-h-full items-center justify-center text-sm text-muted-foreground">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!isSingleUser && meIsAdmin === false) {
+    return (
+      <PageScroll contentClassName="px-8" extraBottom="2.5rem">
+        <h1 className="mb-2 text-2xl font-semibold">Announcements</h1>
+        <p className="text-sm text-muted-foreground">
+          You don't have permission to manage announcements.
+        </p>
+      </PageScroll>
+    );
+  }
+
+  return (
+    <PageScroll contentClassName="px-8" extraBottom="2.5rem">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Announcements</h1>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            Post notices shown in the top bar for every user on this server — maintenance windows,
+            new features, incidents. Active announcements appear immediately; inactive ones are kept
+            so you can toggle them back on without retyping.
+          </p>
+        </div>
+        <Button type="button" onClick={add} data-testid="announcement-add" className="gap-1.5">
+          <PlusIcon className="size-4" />
+          New announcement
+        </Button>
+      </div>
+
+      {isLoading || drafts === null ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : drafts.length === 0 ? (
+        <p className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+          No announcements yet. Add one to show a notice in the top bar.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {drafts.map((d) => (
+            <div
+              key={d.key}
+              data-testid="announcement-editor-row"
+              className="flex flex-col gap-3 rounded-xl border bg-card/40 p-4"
+            >
+              <div className="flex items-start gap-3">
+                <Textarea
+                  aria-label="Announcement message"
+                  data-testid="announcement-message"
+                  placeholder="What do you want everyone to see?"
+                  value={d.message}
+                  rows={2}
+                  onChange={(e) => patch(d.key, { message: e.target.value })}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove announcement"
+                  data-testid="announcement-remove"
+                  onClick={() => remove(d.key)}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2Icon className="size-4" />
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-end gap-4">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-muted-foreground">Level</span>
+                  <Select
+                    value={d.level}
+                    onValueChange={(value) => patch(d.key, { level: value as AnnouncementLevel })}
+                  >
+                    <SelectTrigger className="w-40" data-testid="announcement-level">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LEVELS.map((lvl) => (
+                        <SelectItem key={lvl.value} value={lvl.value}>
+                          {lvl.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+
+                <label className="flex items-center gap-2">
+                  <Switch
+                    checked={d.active}
+                    onCheckedChange={(active) => patch(d.key, { active })}
+                    aria-label="Active"
+                    data-testid="announcement-active"
+                  />
+                  <span className="text-sm">Active</span>
+                </label>
+
+                <label className="flex items-center gap-2">
+                  <Switch
+                    checked={d.dismissible}
+                    onCheckedChange={(dismissible) => patch(d.key, { dismissible })}
+                    aria-label="Dismissible"
+                    data-testid="announcement-dismissible"
+                  />
+                  <span className="text-sm">Dismissible</span>
+                </label>
+              </div>
+
+              <div className="flex flex-wrap gap-4">
+                <label className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Link URL (optional)
+                  </span>
+                  <Input
+                    type="text"
+                    inputMode="url"
+                    placeholder="https://… or /path"
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    value={d.link_url}
+                    data-testid="announcement-link-url"
+                    onChange={(e) => patch(d.key, { link_url: e.target.value })}
+                  />
+                </label>
+                <label className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Link label (optional)
+                  </span>
+                  <Input
+                    type="text"
+                    placeholder="Learn more"
+                    value={d.link_label}
+                    data-testid="announcement-link-label"
+                    onChange={(e) => patch(d.key, { link_label: e.target.value })}
+                  />
+                </label>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+
+      {drafts !== null && (
+        <div className="mt-6 flex items-center gap-3">
+          <Button
+            type="button"
+            onClick={onSave}
+            loading={save.isPending}
+            disabled={!dirty || save.isPending}
+            data-testid="announcement-save"
+          >
+            Save changes
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={!dirty || save.isPending}
+            onClick={() => {
+              setError(null);
+              setDrafts(data ? data.map(toDraft) : []);
+            }}
+          >
+            Discard
+          </Button>
+          {dirty && <span className="text-xs text-muted-foreground">Unsaved changes</span>}
+        </div>
+      )}
+    </PageScroll>
+  );
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -184,6 +184,9 @@ const PoliciesPage = lazy(() =>
 const SharingPage = lazy(() =>
   import("@/pages/SharingPage").then((m) => ({ default: m.SharingPage })),
 );
+const AnnouncementsPage = lazy(() =>
+  import("@/pages/AnnouncementsPage").then((m) => ({ default: m.AnnouncementsPage })),
+);
 
 /**
  * Settings content panel. The section nav lives in the sidebar card
@@ -210,15 +213,22 @@ export function SettingsPage() {
   // Rendered in ANY multi-user mode (accounts AND OIDC), not gated on
   // `accountsEnabled` — the nav + pages handle admin gating, and Members runs
   // read-only under OIDC (no password actions).
-  if (section === "members" || section === "policies" || section === "sharing") {
+  if (
+    section === "members" ||
+    section === "policies" ||
+    section === "sharing" ||
+    section === "announcements"
+  ) {
     return (
       <Suspense fallback={null}>
         {section === "members" ? (
           <MembersPage />
         ) : section === "policies" ? (
           <PoliciesPage />
-        ) : (
+        ) : section === "sharing" ? (
           <SharingPage />
+        ) : (
+          <AnnouncementsPage />
         )}
       </Suspense>
     );

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -81,6 +81,7 @@ import {
 } from "./TerminalFirstContext";
 import { TerminalsPanel } from "./TerminalsPanel";
 import { TodoPanel } from "./TodoPanel";
+import { AnnouncementsBanner } from "@/components/AnnouncementsBanner";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "./CommandPalette";
@@ -1342,7 +1343,7 @@ export function AppShell() {
         "hiddenInset"), so the web layer drops the sidebar below the
         traffic lights and supplies a drag strip in the freed space. */}
           <div
-            className="app-shell relative flex h-dvh bg-sidebar text-foreground"
+            className="app-shell relative flex h-dvh flex-col bg-sidebar text-foreground"
             data-electron-mac={isMacElectronShell() ? "true" : undefined}
             data-ios-native={isIOSShell() ? "true" : undefined}
             data-android-native={isAndroidShell() ? "true" : undefined}
@@ -1358,18 +1359,25 @@ export function AppShell() {
             {isMacElectronShell() && (
               <TitleBarServerPicker threadTitle={activeSession?.title ?? activeConv?.title} />
             )}
-            <Sidebar
-              open={sidebarOpen}
-              dragProgress={sidebarDragProgress}
-              onClose={() => setSidebarOpen(false)}
-              onOpenSearch={() => setCommandPaletteOpen(true)}
-            />
+            {/* Server-wide announcements (admin-configured). Full-width strips
+          above the sidebar + content row; renders nothing when there are no
+          active, non-dismissed notices, so the layout is unchanged otherwise. */}
+            <AnnouncementsBanner />
+            {/* Sidebar + content row. Sits below the announcements banner (the
+          app shell is a column), so the two share the remaining height. */}
+            <div className="relative flex min-h-0 min-w-0 flex-1">
+              <Sidebar
+                open={sidebarOpen}
+                dragProgress={sidebarDragProgress}
+                onClose={() => setSidebarOpen(false)}
+                onOpenSearch={() => setCommandPaletteOpen(true)}
+              />
 
-            {/* Content region (everything right of the sidebar): a relative
+              {/* Content region (everything right of the sidebar): a relative
           flex row holding the chat+workspace group and the push panels
           as siblings. */}
-            <div className="relative flex min-h-0 min-w-0 flex-1">
-              {/* Chat + workspace group. The full-width header overlay is
+              <div className="relative flex min-h-0 min-w-0 flex-1">
+                {/* Chat + workspace group. The full-width header overlay is
             scoped to this group, so it spans the chat *and* the right
             workspace card but never reaches over the push panels (which
             render their own top chrome as siblings outside the group).
@@ -1377,73 +1385,73 @@ export function AppShell() {
             over — *except* in terminal-first sessions, where the terminal
             renders inline in main (via MainTerminalView) and the
             workspace card stays visible alongside. */}
-              <div
-                className={cn(
-                  "relative flex min-h-0 min-w-0 flex-1",
-                  panelOpen && !terminalFirst && "md:hidden",
-                )}
-                style={
-                  {
-                    "--workspace-panel-offset": workspacePanelVisible
-                      ? `${inlinePanelWidth + 16}px`
-                      : "0px",
-                  } as CSSProperties
-                }
-              >
-                <ChatHeader
-                  sidebarOpen={sidebarOpen}
-                  onOpenSidebar={() => setSidebarOpen(true)}
-                  isChildSession={isChildSession}
-                  parentSessionId={activeSession?.parentSessionId}
-                  conversationId={conversationId}
-                  boundAgent={boundAgent}
-                  canShare={canShare}
-                  shareDisabled={shareDisabled}
-                  shareDisabledReason={shareDisabledReason}
-                  onShare={() => setShareOpen(true)}
-                  hasAgentInfo={hasAgentInfo}
-                  onAgentInfo={() => setAgentInfoOpen(true)}
-                  hasHeaderMenu={hasHeaderMenu}
-                  showFilesPanel={showFilesPanel}
-                  hasRailContent={hasRailContent}
-                  rightPanelOpen={rightPanelOpen}
-                  onToggleRightPanel={toggleRightPanel}
-                  mobileMenu={{
-                    fileViewerOpen,
-                    panelOpen,
-                    terminalFirst,
-                    executionLogsOpen,
-                    filesPanelOpen,
-                    subagentsPanelOpen,
-                    shellsPanelOpen,
-                    todosPanelOpen,
-                    hideTerminalsTab,
-                    // Mobile: reachable when a shell exists OR the agent
-                    // declares shell access (so the drawer's "+ New shell" row
-                    // can create the first one). Desktop rail tab stays gated
-                    // on an existing shell (railTabsAvailable.terminals).
-                    showShellsTab:
-                      !hideTerminalsTab && (railTerminals.length > 0 || agentSupportsShells),
-                    terminalsLength: railTerminals.length,
-                    todosSupported,
-                    todosCompleted,
-                    todosTotal: todos.length,
-                    debugMode,
-                    changedCount,
-                    subagentsWorking,
-                    agentCount,
-                    onOpenFiles: openFilesPanel,
-                    onOpenShells: openShellsPanel,
-                    onOpenSubagents: openSubagentsPanel,
-                    onOpenTodos: openTodosPanel,
-                    onOpenMainExecutionLog: openMainExecutionLog,
-                  }}
-                />
-                <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-                  <Outlet />
-                </main>
+                <div
+                  className={cn(
+                    "relative flex min-h-0 min-w-0 flex-1",
+                    panelOpen && !terminalFirst && "md:hidden",
+                  )}
+                  style={
+                    {
+                      "--workspace-panel-offset": workspacePanelVisible
+                        ? `${inlinePanelWidth + 16}px`
+                        : "0px",
+                    } as CSSProperties
+                  }
+                >
+                  <ChatHeader
+                    sidebarOpen={sidebarOpen}
+                    onOpenSidebar={() => setSidebarOpen(true)}
+                    isChildSession={isChildSession}
+                    parentSessionId={activeSession?.parentSessionId}
+                    conversationId={conversationId}
+                    boundAgent={boundAgent}
+                    canShare={canShare}
+                    shareDisabled={shareDisabled}
+                    shareDisabledReason={shareDisabledReason}
+                    onShare={() => setShareOpen(true)}
+                    hasAgentInfo={hasAgentInfo}
+                    onAgentInfo={() => setAgentInfoOpen(true)}
+                    hasHeaderMenu={hasHeaderMenu}
+                    showFilesPanel={showFilesPanel}
+                    hasRailContent={hasRailContent}
+                    rightPanelOpen={rightPanelOpen}
+                    onToggleRightPanel={toggleRightPanel}
+                    mobileMenu={{
+                      fileViewerOpen,
+                      panelOpen,
+                      terminalFirst,
+                      executionLogsOpen,
+                      filesPanelOpen,
+                      subagentsPanelOpen,
+                      shellsPanelOpen,
+                      todosPanelOpen,
+                      hideTerminalsTab,
+                      // Mobile: reachable when a shell exists OR the agent
+                      // declares shell access (so the drawer's "+ New shell" row
+                      // can create the first one). Desktop rail tab stays gated
+                      // on an existing shell (railTabsAvailable.terminals).
+                      showShellsTab:
+                        !hideTerminalsTab && (railTerminals.length > 0 || agentSupportsShells),
+                      terminalsLength: railTerminals.length,
+                      todosSupported,
+                      todosCompleted,
+                      todosTotal: todos.length,
+                      debugMode,
+                      changedCount,
+                      subagentsWorking,
+                      agentCount,
+                      onOpenFiles: openFilesPanel,
+                      onOpenShells: openShellsPanel,
+                      onOpenSubagents: openSubagentsPanel,
+                      onOpenTodos: openTodosPanel,
+                      onOpenMainExecutionLog: openMainExecutionLog,
+                    }}
+                  />
+                  <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+                    <Outlet />
+                  </main>
 
-                {/* Right workspace card — gated on conversationId (panels have
+                  {/* Right workspace card — gated on conversationId (panels have
               no workspace to read without a session), default-open,
               hidden when any push panel takes the right side, *except* in
               terminal-first sessions where the terminal renders inline
@@ -1453,141 +1461,142 @@ export function AppShell() {
               rectangle (e.g. a no-filesystem agent with no terminals).
               Sits inside the group so the header overlay spans it; the
               push panels below sit outside the group. */}
-                {conversationId && workspacePanelVisible && (
-                  <WorkspacePanel
-                    conversationId={conversationId}
-                    width={inlinePanelWidth}
-                    inert={inlinePanelWidth === 0}
-                    handleProps={inlinePanelHandleProps}
-                    rightRailTab={rightRailTab}
-                    onRightRailTabChange={handleRightRailTabChange}
-                    showFilesPanel={showFilesPanel}
-                    showBrowserTab={railTabsAvailable.browser}
-                    changedCount={changedCount}
-                    showShellsTab={railTabsAvailable.terminals}
-                    terminalsLength={railTerminals.length}
-                    subagentsWorking={subagentsWorking}
-                    agentCount={agentCount}
-                    todosSupported={todosSupported}
-                    todosCompleted={todosCompleted}
-                    todosTotal={todos.length}
-                    rootSessionId={rootSessionId}
-                    selectedFilePath={selectedFilePath}
-                    openFiles={openFiles}
-                    openFileViewer={openFileViewer}
-                    onCloseFile={closeFile}
-                    onShowScopeView={showScopeView}
-                    onCommentsOpenChange={setFileViewerCommentsOpen}
-                    openTerminalTab={openTerminalTab}
-                    openTerminals={openTerminals}
-                    selectedTerminalKey={selectedTerminalKey}
-                    onCloseTerminal={closeTerminalTab}
-                    maximized={rightPanelMaximized}
-                    onToggleMaximized={toggleRightPanelMaximized}
-                    permissionLevel={permissionLevel}
-                    filesPanelSort={filesPanelSort}
-                    onSortChange={handleFilesSortChange}
-                    filesPanelFlatView={filesPanelFlatView}
-                    onFlatViewChange={handleFilesFlatViewChange}
-                    filesPanelShowHidden={filesPanelShowHidden}
-                    onShowHiddenChange={setFilesPanelShowHidden}
-                    liveness={liveness}
-                  />
-                )}
-              </div>
+                  {conversationId && workspacePanelVisible && (
+                    <WorkspacePanel
+                      conversationId={conversationId}
+                      width={inlinePanelWidth}
+                      inert={inlinePanelWidth === 0}
+                      handleProps={inlinePanelHandleProps}
+                      rightRailTab={rightRailTab}
+                      onRightRailTabChange={handleRightRailTabChange}
+                      showFilesPanel={showFilesPanel}
+                      showBrowserTab={railTabsAvailable.browser}
+                      changedCount={changedCount}
+                      showShellsTab={railTabsAvailable.terminals}
+                      terminalsLength={railTerminals.length}
+                      subagentsWorking={subagentsWorking}
+                      agentCount={agentCount}
+                      todosSupported={todosSupported}
+                      todosCompleted={todosCompleted}
+                      todosTotal={todos.length}
+                      rootSessionId={rootSessionId}
+                      selectedFilePath={selectedFilePath}
+                      openFiles={openFiles}
+                      openFileViewer={openFileViewer}
+                      onCloseFile={closeFile}
+                      onShowScopeView={showScopeView}
+                      onCommentsOpenChange={setFileViewerCommentsOpen}
+                      openTerminalTab={openTerminalTab}
+                      openTerminals={openTerminals}
+                      selectedTerminalKey={selectedTerminalKey}
+                      onCloseTerminal={closeTerminalTab}
+                      maximized={rightPanelMaximized}
+                      onToggleMaximized={toggleRightPanelMaximized}
+                      permissionLevel={permissionLevel}
+                      filesPanelSort={filesPanelSort}
+                      onSortChange={handleFilesSortChange}
+                      filesPanelFlatView={filesPanelFlatView}
+                      onFlatViewChange={handleFilesFlatViewChange}
+                      filesPanelShowHidden={filesPanelShowHidden}
+                      onShowHiddenChange={setFilesPanelShowHidden}
+                      liveness={liveness}
+                    />
+                  )}
+                </div>
 
-              {/* Push panels — flex siblings to main, animate width. Only one is open at a time.
+                {/* Push panels — flex siblings to main, animate width. Only one is open at a time.
           Terminal-first sessions render the terminal inline inside main
           (via MainTerminalView in ChatPage) and never mount the drawer. */}
-              {conversationId && !terminalFirst && (
-                <TerminalsPanel
-                  open={panelOpen}
-                  conversationId={conversationId}
-                  initialTerminalKey={panelInitialKey}
-                  // No neighbor to resize against (chat is hidden, FilesPanel
-                  // owns its own width) — grow via flex-1.
-                  fluid={panelOpen}
-                  // Non-owners attach read-only: a shared PTY can't attribute
-                  // input per-user, so only the owner may type (server-enforced).
-                  readOnly={!isOwnerLevel(permissionLevel)}
-                  onClose={() => setPanelInitialKey(null)}
-                />
-              )}
-              {conversationId && (
-                <ExecutionLogsPanel
-                  open={executionLogsOpen}
-                  conversationId={conversationId}
-                  initialKey={executionLogsKey}
-                  onClose={() => setExecutionLogsKey(null)}
-                />
-              )}
-              {conversationId && showFilesPanel && (
-                <FilesPanelDrawer
-                  open={filesPanelOpen}
-                  onClose={() => setFilesPanelOpen(false)}
-                  onFileSelect={openFileViewer}
-                  flatView={filesPanelFlatView}
-                  onFlatViewChange={handleFilesFlatViewChange}
-                  showHidden={filesPanelShowHidden}
-                  onShowHiddenChange={setFilesPanelShowHidden}
-                  sort={filesPanelSort}
-                  onSortChange={handleFilesSortChange}
-                />
-              )}
-              {/* Mobile-only full-screen drawers for the rail tabs that have no
+                {conversationId && !terminalFirst && (
+                  <TerminalsPanel
+                    open={panelOpen}
+                    conversationId={conversationId}
+                    initialTerminalKey={panelInitialKey}
+                    // No neighbor to resize against (chat is hidden, FilesPanel
+                    // owns its own width) — grow via flex-1.
+                    fluid={panelOpen}
+                    // Non-owners attach read-only: a shared PTY can't attribute
+                    // input per-user, so only the owner may type (server-enforced).
+                    readOnly={!isOwnerLevel(permissionLevel)}
+                    onClose={() => setPanelInitialKey(null)}
+                  />
+                )}
+                {conversationId && (
+                  <ExecutionLogsPanel
+                    open={executionLogsOpen}
+                    conversationId={conversationId}
+                    initialKey={executionLogsKey}
+                    onClose={() => setExecutionLogsKey(null)}
+                  />
+                )}
+                {conversationId && showFilesPanel && (
+                  <FilesPanelDrawer
+                    open={filesPanelOpen}
+                    onClose={() => setFilesPanelOpen(false)}
+                    onFileSelect={openFileViewer}
+                    flatView={filesPanelFlatView}
+                    onFlatViewChange={handleFilesFlatViewChange}
+                    showHidden={filesPanelShowHidden}
+                    onShowHiddenChange={setFilesPanelShowHidden}
+                    sort={filesPanelSort}
+                    onSortChange={handleFilesSortChange}
+                  />
+                )}
+                {/* Mobile-only full-screen drawers for the rail tabs that have no
           desktop push panel of their own. `MobilePanelDrawer` is `md:hidden`,
           so these never collide with the desktop rail; they're opened from
           the session-menu FAB above. */}
-              {conversationId && rootSessionId && (
-                <MobilePanelDrawer
-                  open={subagentsPanelOpen}
-                  title="Agents"
-                  onClose={() => setSubagentsPanelOpen(false)}
-                  testId="subagents-panel-drawer"
-                >
-                  <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
-                </MobilePanelDrawer>
-              )}
-              {conversationId && (
-                <MobilePanelDrawer
-                  open={shellsPanelOpen}
-                  title="Shells"
-                  onClose={() => setShellsPanelOpen(false)}
-                  testId="shells-panel-drawer"
-                >
-                  <InlineTerminalsSection
-                    conversationId={conversationId}
-                    onExpand={openTerminalsPanel}
-                    // Mobile has no tab strip "+" menu, so the drawer carries
-                    // the "+ New shell" create row.
-                    showNewShell
-                  />
-                </MobilePanelDrawer>
-              )}
-              {conversationId && (
-                <MobilePanelDrawer
-                  open={todosPanelOpen}
-                  title="Tasks"
-                  onClose={() => setTodosPanelOpen(false)}
-                  testId="todos-panel-drawer"
-                >
-                  <TodoPanel frameless />
-                </MobilePanelDrawer>
-              )}
-              {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}
-              {conversationId && selectedFilePath !== null && (
-                <div className="md:hidden">
-                  <FileViewer
-                    open
-                    conversationId={conversationId}
-                    path={selectedFilePath}
-                    onClose={closeFileViewer}
-                    onNavigateTo={openFileViewer}
-                    permissionLevel={permissionLevel}
-                    sort={filesPanelSort}
-                  />
-                </div>
-              )}
+                {conversationId && rootSessionId && (
+                  <MobilePanelDrawer
+                    open={subagentsPanelOpen}
+                    title="Agents"
+                    onClose={() => setSubagentsPanelOpen(false)}
+                    testId="subagents-panel-drawer"
+                  >
+                    <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+                  </MobilePanelDrawer>
+                )}
+                {conversationId && (
+                  <MobilePanelDrawer
+                    open={shellsPanelOpen}
+                    title="Shells"
+                    onClose={() => setShellsPanelOpen(false)}
+                    testId="shells-panel-drawer"
+                  >
+                    <InlineTerminalsSection
+                      conversationId={conversationId}
+                      onExpand={openTerminalsPanel}
+                      // Mobile has no tab strip "+" menu, so the drawer carries
+                      // the "+ New shell" create row.
+                      showNewShell
+                    />
+                  </MobilePanelDrawer>
+                )}
+                {conversationId && (
+                  <MobilePanelDrawer
+                    open={todosPanelOpen}
+                    title="Tasks"
+                    onClose={() => setTodosPanelOpen(false)}
+                    testId="todos-panel-drawer"
+                  >
+                    <TodoPanel frameless />
+                  </MobilePanelDrawer>
+                )}
+                {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}
+                {conversationId && selectedFilePath !== null && (
+                  <div className="md:hidden">
+                    <FileViewer
+                      open
+                      conversationId={conversationId}
+                      path={selectedFilePath}
+                      onClose={closeFileViewer}
+                      onNavigateTo={openFileViewer}
+                      permissionLevel={permissionLevel}
+                      sort={filesPanelSort}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
           {conversationId && (

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -112,21 +112,32 @@ describe("settingsNavGroups", () => {
     expect(ids(false, false)).not.toContain("members");
     // Admin on an accounts deploy → all appear, grouped under "Admin".
     const accountsAdmin = settingsNavGroups(true, false, true).find((g) => g.title === "Admin");
-    expect(accountsAdmin?.items.map((i) => i.id)).toEqual(["members", "policies", "sharing"]);
+    expect(accountsAdmin?.items.map((i) => i.id)).toEqual([
+      "members",
+      "policies",
+      "sharing",
+      "announcements",
+    ]);
     // Admin under OIDC (accountsEnabled false) → still appears. This is the
     // #1489 fix: OIDC previously had no admin chrome at all.
     const oidcAdmin = settingsNavGroups(false, false, true).find((g) => g.title === "Admin");
-    expect(oidcAdmin?.items.map((i) => i.id)).toEqual(["members", "policies", "sharing"]);
+    expect(oidcAdmin?.items.map((i) => i.id)).toEqual([
+      "members",
+      "policies",
+      "sharing",
+      "announcements",
+    ]);
   });
 
-  it("drops Members and Sharing from the Admin group in single-user mode, keeping Policies", () => {
+  it("drops Members and Sharing from the Admin group in single-user mode, keeping Policies and Announcements", () => {
     // 4th arg is isSingleUser. Members (manage accounts) and Sharing (grant to
     // other users) are meaningless with no other users, so both are hidden;
-    // Policies stays — global policies apply to the solo user's own sessions.
+    // Policies stays — global policies apply to the solo user's own sessions —
+    // and Announcements stays since the top-bar banner still renders solo.
     const singleUserAdmin = settingsNavGroups(false, false, true, true).find(
       (g) => g.title === "Admin",
     );
-    expect(singleUserAdmin?.items.map((i) => i.id)).toEqual(["policies"]);
+    expect(singleUserAdmin?.items.map((i) => i.id)).toEqual(["policies", "announcements"]);
   });
 });
 

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -13,6 +13,7 @@ import {
   DownloadIcon,
   GitBranchIcon,
   KeyboardIcon,
+  MegaphoneIcon,
   PaletteIcon,
   PanelRightOpenIcon,
   Share2Icon,
@@ -38,6 +39,7 @@ export type SettingsSectionId =
   | "members"
   | "policies"
   | "sharing"
+  | "announcements"
   | "archived"
   | "cli"
   | "updates";
@@ -50,6 +52,7 @@ const SECTION_IDS: readonly SettingsSectionId[] = [
   "members",
   "policies",
   "sharing",
+  "announcements",
   "archived",
   "cli",
   "updates",
@@ -122,6 +125,10 @@ export function settingsNavGroups(
     if (!isSingleUser) adminItems.push({ id: "members", label: "Members", icon: UsersIcon });
     adminItems.push({ id: "policies", label: "Policies", icon: ShieldCheckIcon });
     if (!isSingleUser) adminItems.push({ id: "sharing", label: "Sharing", icon: Share2Icon });
+    // Announcements stays even in single-user mode — the top-bar banner still
+    // renders for a solo user, so managing it is meaningful (unlike Members /
+    // Sharing, which only concern other users).
+    adminItems.push({ id: "announcements", label: "Announcements", icon: MegaphoneIcon });
     groups.push({ title: "Admin", items: adminItems });
   }
   groups.push({


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a **server-wide announcements banner** that admins configure from
**Settings → Announcements**. Notices — maintenance windows, new features,
incidents — render as full-width strips in the app's top bar for every user.

- **Backend**: a file-backed JSON store (`<data_dir>/announcements.json`,
  mtime-cached read + atomic write, mirroring the existing sharing overrides) and
  a router — `GET /v1/announcements` (active list, readable by anyone like
  `/v1/info`), plus admin-gated `GET /v1/announcements/all` and
  `PUT /v1/announcements`. Each notice has a message, level (info/warning/success),
  active + dismissible toggles, and an optional link. Links are validated to
  `http(s)`/site-relative so an admin-set URL can't smuggle script into the banner.
- **Frontend**: `AnnouncementsBanner` mounted at the top of the app shell (polled
  so a published/retracted notice appears without a reload; dismissals are stored
  per-device and re-surface when the notice is edited), and an admin editor page
  wired into the Settings **Admin** group next to Members / Policies / Sharing.

No new env vars, no DB migration — it reuses the same operator-editable data dir
as the `admins` roster and the sharing settings, so it survives restarts and
takes effect without a redeploy.

### ELI5

An admin types a short notice in Settings. Every user's app grows a thin colored
bar at the very top showing that notice until they dismiss it (or the admin turns
it off). It's the site-wide "heads up" bar you've seen on other apps.

### Flow

```
Admin → Settings → Announcements   ──PUT /v1/announcements──►  <data_dir>/announcements.json
                                                                        │
   every user's AppShell ◄── GET /v1/announcements (active, polled 60s) ┘
        │
        └─► AnnouncementsBanner  (info / warning / success strip, optional link, dismiss ✕)
```

## Test Plan

- **Backend** (`pytest tests/server/routes/test_announcements.py`, 13 tests):
  empty default, PUT→GET assigns id/timestamps, active-vs-all filtering, edit
  preserves `created_at`, full-list replace, and validation (empty/whitespace
  message, unknown level, `javascript:`/protocol-relative links, count cap). Admin
  gating: public GET open to anyone, non-admin `PUT`/`/all` → 403, admin → 200.
- **Frontend** (`vitest`): `AnnouncementsBanner.test.tsx` (renders active notices,
  dismiss hides + persists, stays hidden on remount, re-surfaces after edit,
  non-dismissible has no ✕) and `AnnouncementsPage.test.tsx` (non-admin message,
  add/edit rows, empty-message blocks save, save calls the mutation, prefills from
  server). Updated `settingsNav.test.tsx` for the new nav item.
- `tsc -b`, `oxlint`, and `prettier` clean; existing `AppShell` (91) and
  `SettingsPage` suites still pass after the shell layout wrap.

### Manual verification

1. Start the app, sign in as an admin, open **Settings → Announcements**.
2. Add a notice (e.g. "Maintenance tonight 22:00 UTC", level *Warning*, a link),
   toggle *Active*, and **Save changes**.
3. Confirm the strip appears in the top bar for every user; dismiss it and confirm
   it stays gone on reload; edit the notice and confirm it re-appears.

## Demo

UI mock of the top-bar strip (real styling uses the `warning`/`info`/`success`
tokens in both light and dark themes):

```
┌───────────────────────────────────────────────────────────────────────────┐
│ ⚠  Scheduled maintenance tonight 22:00–23:00 UTC.   Details            ✕   │
├───────────────────────────────────────────────────────────────────────────┤
│  ☰                                              (rest of the app below)      │
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification exercised the full admin-post → banner-render → dismiss loop
in the running app (steps above). Automated tests cover the store, route
(including admin gating and link validation), the banner, and the editor page.

## Changelog

Admins can post server-wide announcements that appear in every user's top bar (Settings → Announcements)
