### PR TITLE
fix(runner): dedupe repeat sub-agent inbox re-wake notices

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2115,11 +2115,6 @@ def create_runner_app(
     app.state.desync_terminalized = _desync_terminalized
     _background_tasks: set[asyncio.Task[Any]] = set()
     _subagent_wake_pending: set[str] = set()
-    # parent_session_id -> the last stranded-inbox RE-WAKE notice delivered to
-    # that parent. A completion wake always fires; only a repeat re-wake that
-    # matches the previous re-wake verbatim (parent idled again without
-    # draining anything) is skipped, so the parent isn't re-notified with the
-    # same line at every turn boundary.
     _last_rewake_notice: dict[str, str] = {}
 
     _session_histories = _session_histories_ref
@@ -5674,10 +5669,6 @@ def create_runner_app(
             status=entry.status,
             pending=inbox.qsize(),
         )
-        # The first stranded-inbox re-wake still fires (it's the recovery nudge
-        # for a parent that idled without draining). Only a follow-up re-wake
-        # identical to the previous one is skipped — the parent idled again
-        # without draining, so repeating the same line just spams it.
         if is_rewake and notice == _last_rewake_notice.get(entry.parent_session_id):
             return
         _subagent_wake_pending.add(entry.parent_session_id)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2115,6 +2115,12 @@ def create_runner_app(
     app.state.desync_terminalized = _desync_terminalized
     _background_tasks: set[asyncio.Task[Any]] = set()
     _subagent_wake_pending: set[str] = set()
+    # parent_session_id -> the last stranded-inbox RE-WAKE notice delivered to
+    # that parent. A completion wake always fires; only a repeat re-wake that
+    # matches the previous re-wake verbatim (parent idled again without
+    # draining anything) is skipped, so the parent isn't re-notified with the
+    # same line at every turn boundary.
+    _last_rewake_notice: dict[str, str] = {}
 
     _session_histories = _session_histories_ref
     _last_server_item_id: dict[str, str] = {}
@@ -3524,6 +3530,7 @@ def create_runner_app(
         _session_event_queues.pop(session_id, None)
         _session_inboxes.pop(session_id, None)
         _subagent_wake_pending.discard(session_id)
+        _last_rewake_notice.pop(session_id, None)
         _session_sub_agent_names.pop(session_id, None)
         unregister_child_session(session_id)
         unregister_subagent_work_for_session(session_id)
@@ -5626,12 +5633,20 @@ def create_runner_app(
                 _cond.notify_all()
 
     async def _post_subagent_wake_notice(
-        parent_id: str, notice: str, child_id: str, created_by: str | None
+        parent_id: str,
+        notice: str,
+        child_id: str,
+        created_by: str | None,
+        *,
+        is_rewake: bool = False,
     ) -> None:
         delivered = await _deliver_subagent_wake_post(
             server_client, parent_id, notice, created_by=created_by
         )
-        if not delivered:
+        if delivered:
+            if is_rewake:
+                _last_rewake_notice[parent_id] = notice
+        else:
             _subagent_wake_pending.discard(parent_id)
             _logger.warning(
                 "Sub-agent wake POST failed for parent=%s child=%s after %d attempt(s); "
@@ -5641,7 +5656,7 @@ def create_runner_app(
                 _WAKE_POST_MAX_ATTEMPTS,
             )
 
-    def _schedule_subagent_wake(entry: _SubagentWorkEntry) -> None:
+    def _schedule_subagent_wake(entry: _SubagentWorkEntry, *, is_rewake: bool = False) -> None:
         if entry.parent_session_id == entry.child_session_id:
             return
         inbox = _session_inboxes.get(entry.parent_session_id)
@@ -5653,19 +5668,26 @@ def create_runner_app(
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
-        _subagent_wake_pending.add(entry.parent_session_id)
         notice = _format_subagent_wake_notice(
             agent=entry.agent,
             title=entry.title,
             status=entry.status,
             pending=inbox.qsize(),
         )
+        # The first stranded-inbox re-wake still fires (it's the recovery nudge
+        # for a parent that idled without draining). Only a follow-up re-wake
+        # identical to the previous one is skipped — the parent idled again
+        # without draining, so repeating the same line just spams it.
+        if is_rewake and notice == _last_rewake_notice.get(entry.parent_session_id):
+            return
+        _subagent_wake_pending.add(entry.parent_session_id)
         _wake_task = loop.create_task(
             _post_subagent_wake_notice(
                 entry.parent_session_id,
                 notice,
                 entry.child_session_id,
                 entry.created_by,
+                is_rewake=is_rewake,
             )
         )
         _wake_task.add_done_callback(_background_tasks.discard)
@@ -5685,7 +5707,7 @@ def create_runner_app(
             entries,
             key=lambda entry: entry.completed_at if entry.completed_at is not None else 0.0,
         )
-        _schedule_subagent_wake(latest)
+        _schedule_subagent_wake(latest, is_rewake=True)
 
     def _mark_subagent_terminal_and_wake(
         child_session_id: str, *, status: str, output: str | None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5685,11 +5685,17 @@ def create_runner_app(
         _background_tasks.add(_wake_task)
 
     def _rewake_parent_if_inbox_stranded(parent_session_id: str) -> None:
+        inbox = _session_inboxes.get(parent_session_id)
+        drained = inbox is None or inbox.empty()
+        if drained:
+            # A drained inbox ends the stranding episode, so the recorded
+            # re-wake no longer describes outstanding work; forget it or a
+            # later episode's matching notice is wrongly deduped.
+            _last_rewake_notice.pop(parent_session_id, None)
         if parent_session_id not in _subagent_wake_pending:
             return
         _subagent_wake_pending.discard(parent_session_id)
-        inbox = _session_inboxes.get(parent_session_id)
-        if inbox is None or inbox.empty():
+        if drained:
             return
         entries = list_subagent_work(parent_session_id)
         if not entries:

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -1832,6 +1832,174 @@ async def test_parent_idle_with_stuck_wake_flag_and_drained_inbox_clears_flag() 
 
 
 @pytest.mark.asyncio
+async def test_repeat_identical_recovery_wake_is_suppressed() -> None:
+    """
+    A recovery wake identical to the previous one is skipped, not re-posted.
+
+    The stranded-inbox recovery wake (``_rewake_parent_if_inbox_stranded``)
+    re-nudges a parent that idled without draining. In a steady-state
+    homogeneous fan-out — many same-named children, the parent draining at
+    roughly the completion rate so the inbox count plateaus — the latest
+    child's label and the pending count don't change between turn boundaries,
+    so the recovery wake would repeat the *same* ``[System: ...]`` line every
+    round. That verbatim repeat is pure spam: the parent already holds that
+    exact instruction. The fix records the last delivered re-wake per parent
+    and skips a follow-up re-wake that matches it.
+
+    The critical companion guarantee — the FIRST recovery wake still fires
+    even when it matches an earlier *completion* wake — is pinned by
+    ``test_parent_idle_with_stuck_wake_flag_posts_recovery_wake``; only
+    repeat *re-wakes* are deduped, never completion notices.
+
+    Sequence (wake counts bracketed): children share the ``gp/fanout`` label so
+    the notices can match. (1) child A completes idle → wake [1]; parent turn
+    T1 starts (clears flag); (2) child B completes mid-T1 → completion wake [2],
+    re-arms flag; (3) T1 ends → recovery wake [3] ``gp/fanout … 2 results``
+    (recorded as the last re-wake); (4) parent turn T2 starts (clears flag),
+    the test drains one inbox item then child C completes mid-T2, bringing the
+    count back to 2 → completion wake [4] (a fresh completion always posts);
+    (5) T2 ends → the recovery wake would again be ``gp/fanout … 2 results`` —
+    identical to step 3 — so it is SKIPPED (count stays [4]). Without the fix
+    step 5 posts a 5th, duplicate wake — the discriminator.
+    """
+    from omnigent.runner import app as runner_app
+
+    parent_id = "b3d5c9f1a26e4708b1f0c4d29e7a6f13"
+    child_a = "5f2a1c8b90d34e6fa7c1b2d3e4f50617"
+    child_b = "6a3b2d9c81e45f70b8d2c3e4f5061728"
+    child_c = "7b4c3e0d92f560810c9e4d5a6b172839"
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    server_client = _WakeRecordingServerClient(parent_id)
+    gate = asyncio.Event()
+    harness_client = _BlockingHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_dedupe"}}),
+            _sse({"type": "response.completed", "response": {"id": "resp_dedupe"}}),
+        ],
+        gate,
+    )
+    pm = _FakeProcessManager(harness_client)  # type: ignore[arg-type]
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    runner_app._session_inboxes_ref[parent_id] = session_inbox
+    for child in (child_a, child_b, child_c):
+        runner_app.register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=child,
+            agent="gp",
+            title="fanout",
+        )
+
+    async def _start_blocking_parent_turn() -> None:
+        """Post a parent message and wait for the (blocking) turn to start.
+
+        ``post_seen`` resolves only after ``_run_turn_bg`` clears the wake
+        flag, so callers know the flag is clear before completing a child.
+        """
+        harness_client.post_seen.clear()
+        parent_resp = await client.post(
+            f"/v1/sessions/{parent_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "c1d2e3f4a5b60718293a4b5c6d7e8f90",
+                "model": "test-agent",
+                "harness": "openai-agents",
+                "content": [{"type": "input_text", "text": "wake notice"}],
+            },
+        )
+        assert parent_resp.status_code == 202, parent_resp.text
+        await asyncio.wait_for(harness_client.post_seen.wait(), timeout=5.0)
+
+    async def _complete_child(child_id: str, output: str) -> None:
+        resp = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={"type": "external_session_status", "data": {"status": "idle", "output": output}},
+        )
+        assert resp.status_code == 204, resp.text
+
+    async def _wait_turn_idle() -> None:
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while app.state.has_active_work():
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("parent turn did not end within 5s")
+            await asyncio.sleep(0.01)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    try:
+        async with _runner_client(app) as client:
+            # 1. Child A completes idle → first wake.
+            await _complete_child(child_a, "A_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+
+            # 2. Start T1, then child B completes mid-turn → completion wake,
+            #    re-arms the flag with no later turn to clear it.
+            await _start_blocking_parent_turn()
+            await _complete_child(child_b, "B_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            assert len(server_client.wake_posts) == 2, (
+                f"Expected A + B wakes before T1 ends, got {len(server_client.wake_posts)}."
+            )
+
+            # 3. End T1 → recovery wake (the first re-wake). It matches child
+            #    B's completion wake verbatim yet must still fire — that
+            #    contract is guarded elsewhere; here it seeds the last-re-wake
+            #    record used to dedupe step 5.
+            gate.set()
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            assert len(server_client.wake_posts) == 3, (
+                f"Expected the recovery wake to bring the count to 3, got "
+                f"{len(server_client.wake_posts)}."
+            )
+            recovery_text = server_client.wake_posts[2]["data"]["content"][0]["text"]
+            assert "sub-agent gp/fanout finished (completed)" in recovery_text
+            assert "2 results waiting in inbox" in recovery_text
+            await _wait_turn_idle()
+
+            # 4. Start T2 (clears the flag). Drain one inbox item, then child C
+            #    completes mid-T2 — the count returns to 2, so C's completion
+            #    wake is identical text to the step-3 recovery wake. A fresh
+            #    completion always posts (never deduped), so this is wake [4].
+            gate.clear()
+            await _start_blocking_parent_turn()
+            assert not session_inbox.empty()
+            session_inbox.get_nowait()
+            await _complete_child(child_c, "C_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            assert len(server_client.wake_posts) == 4, (
+                f"Expected child C's completion wake as the 4th, got "
+                f"{len(server_client.wake_posts)}."
+            )
+
+            # 5. End T2 → the recovery wake would repeat "gp/fanout … 2 results"
+            #    verbatim (identical to step 3), so it must be SUPPRESSED. Give a
+            #    wrongly-scheduled 5th wake room to land before asserting.
+            gate.set()
+            await _wait_turn_idle()
+    finally:
+        gate.set()
+        for child in (child_a, child_b, child_c):
+            runner_app.unregister_subagent_work(child)
+        runner_app._session_inboxes_ref.pop(parent_id, None)
+
+    # Exactly 4 wakes: A + B + recovery + C's completion. A 5th would be the
+    # duplicate recovery wake this fix suppresses; 3 would mean C's genuine
+    # completion notice was wrongly swallowed.
+    assert len(server_client.wake_posts) == 4, (
+        f"Expected the repeat recovery wake to be suppressed (4 wakes total), "
+        f"got {len(server_client.wake_posts)}."
+    )
+
+
+@pytest.mark.asyncio
 async def test_replayed_idle_status_after_inbox_drain_is_acknowledged() -> None:
     """
     Replayed terminal status after parent drain is a benign duplicate.

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import uuid
 from typing import Any
 
@@ -1997,6 +1998,175 @@ async def test_repeat_identical_recovery_wake_is_suppressed() -> None:
         f"Expected the repeat recovery wake to be suppressed (4 wakes total), "
         f"got {len(server_client.wake_posts)}."
     )
+
+
+@pytest.mark.asyncio
+async def test_recovery_wake_fires_again_for_an_episode_after_a_full_drain() -> None:
+    """
+    A full inbox drain ends the stranding episode, so dedupe must not carry over.
+
+    ``_last_rewake_notice`` suppresses a recovery wake that repeats the previous
+    one verbatim (see
+    ``test_repeat_identical_recovery_wake_is_suppressed``). That record describes
+    *outstanding* work, so it goes stale the moment the parent drains: a later
+    fan-out round that happens to produce the same label and pending count is a
+    genuinely new stranding episode and is still owed its nudge. Without
+    clearing the record on drain the parent is left holding undelivered results
+    with the wake flag cleared — nothing re-arms it once every child has
+    finished, which is the exact strand ``_rewake_parent_if_inbox_stranded``
+    exists to break.
+
+    Sequence (wake counts bracketed), all children sharing the ``gp/fanout``
+    label so the notices can match. Episode 1: (1) child A completes idle →
+    wake [1]; (2) parent turn T1 starts, child B completes mid-T1 → wake [2],
+    re-arming the flag; (3) T1 ends → recovery wake [3] ``… 2 results``,
+    recorded. (4) Turn T2 drains BOTH items and ends with the inbox empty —
+    episode over. Episode 2: (5) child C completes → wake [4]; (6) turn T3
+    starts, child D completes mid-T3 → wake [5], count back to 2. (7) T3 ends →
+    the recovery wake reads ``… 2 results``, matching step 3, but the drain in
+    step 4 cleared the record, so it MUST still fire → wake [6]. Carrying the
+    record across the drain yields 5 and a parent stranded on 2 results — the
+    discriminator.
+    """
+    from omnigent.runner import app as runner_app
+
+    parent_id = "a1b2c3d4e5f60718293a4b5c6d7e8f01"
+    child_a = "11112c8b90d34e6fa7c1b2d3e4f50617"
+    child_b = "22222d9c81e45f70b8d2c3e4f5061728"
+    child_c = "33333e0d92f560810c9e4d5a6b172839"
+    child_d = "44444f1e03a671920dae5e6b7c28394a"
+    children = (child_a, child_b, child_c, child_d)
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    server_client = _WakeRecordingServerClient(parent_id)
+    gate = asyncio.Event()
+    harness_client = _BlockingHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_drain"}}),
+            _sse({"type": "response.completed", "response": {"id": "resp_drain"}}),
+        ],
+        gate,
+    )
+    pm = _FakeProcessManager(harness_client)  # type: ignore[arg-type]
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    runner_app._session_inboxes_ref[parent_id] = session_inbox
+    for child in children:
+        runner_app.register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=child,
+            agent="gp",
+            title="fanout",
+        )
+
+    async def _start_blocking_parent_turn() -> None:
+        """Post a parent message and wait for the (blocking) turn to start.
+
+        ``post_seen`` resolves only after ``_run_turn_bg`` clears the wake flag,
+        so callers know the flag is clear before completing a child.
+        """
+        harness_client.post_seen.clear()
+        parent_resp = await client.post(
+            f"/v1/sessions/{parent_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "c1d2e3f4a5b60718293a4b5c6d7e8f90",
+                "model": "test-agent",
+                "harness": "openai-agents",
+                "content": [{"type": "input_text", "text": "wake notice"}],
+            },
+        )
+        assert parent_resp.status_code == 202, parent_resp.text
+        await asyncio.wait_for(harness_client.post_seen.wait(), timeout=5.0)
+
+    async def _complete_child(child_id: str, output: str) -> None:
+        resp = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={"type": "external_session_status", "data": {"status": "idle", "output": output}},
+        )
+        assert resp.status_code == 204, resp.text
+
+    async def _wait_turn_idle() -> None:
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while app.state.has_active_work():
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("parent turn did not end within 5s")
+            await asyncio.sleep(0.01)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    try:
+        async with _runner_client(app) as client:
+            # Episode 1, steps 1-3: strand the inbox at 2 and take the recovery
+            # wake, which records "… 2 results" as the last re-wake.
+            await _complete_child(child_a, "A_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            await _start_blocking_parent_turn()
+            await _complete_child(child_b, "B_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            gate.set()
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            await _wait_turn_idle()
+            assert len(server_client.wake_posts) == 3, (
+                f"Expected A + B + recovery wakes to end episode 1, got "
+                f"{len(server_client.wake_posts)}."
+            )
+            assert (
+                "2 results waiting in inbox"
+                in (server_client.wake_posts[2]["data"]["content"][0]["text"])
+            )
+
+            # Step 4: the parent fully drains during T2, ending the episode.
+            gate.clear()
+            await _start_blocking_parent_turn()
+            while not session_inbox.empty():
+                session_inbox.get_nowait()
+            gate.set()
+            await _wait_turn_idle()
+            assert len(server_client.wake_posts) == 3, (
+                f"A drained inbox owes no wake, got {len(server_client.wake_posts)}."
+            )
+
+            # Episode 2, steps 5-6: two new children bring the count back to 2,
+            # so the pending recovery notice matches episode 1's verbatim.
+            gate.clear()
+            await _complete_child(child_c, "C_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            await _start_blocking_parent_turn()
+            await _complete_child(child_d, "D_DONE")
+            await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            server_client.wake_seen.clear()
+            assert len(server_client.wake_posts) == 5, (
+                f"Expected C + D completion wakes in episode 2, got "
+                f"{len(server_client.wake_posts)}."
+            )
+
+            # Step 7: T3 ends → the new episode's recovery wake must fire even
+            # though its text matches episode 1's. Swallow the wait timeout so a
+            # missing wake surfaces as the count assertion below, not a
+            # TimeoutError.
+            gate.set()
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(server_client.wake_seen.wait(), timeout=5.0)
+            await _wait_turn_idle()
+    finally:
+        gate.set()
+        for child in children:
+            runner_app.unregister_subagent_work(child)
+        runner_app._session_inboxes_ref.pop(parent_id, None)
+
+    assert len(server_client.wake_posts) == 6, (
+        f"Expected episode 2's recovery wake to fire after the drain (6 wakes "
+        f"total), got {len(server_client.wake_posts)}."
+    )
+    assert not session_inbox.empty(), "The stranded results should still be waiting."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- A parent that idles holding undrained sub-agent results is re-nudged with a stranded-inbox **recovery wake** notice (`[System: sub-agent X/Y finished (completed) — N results waiting in inbox. Call sys_read_inbox to collect.]`).
- In a large **homogeneous** fan-out (e.g. dozens of same-named children, the parent draining at roughly the completion rate), the latest child's label and the pending count plateau, so that nudge repeats the **identical line at every turn boundary** — visible spam in the parent's stream.
- Fix: record the last re-wake notice delivered per parent and **skip a follow-up re-wake that matches it verbatim**. The first recovery nudge for any state still fires (a stranded inbox is never left silent), and distinct new-completion notices always post (their count differs), so **no results are lost** — only redundant repeats are dropped.

**ELI5:** the runner reminds a busy parent "you have results waiting". If the parent keeps ignoring it and nothing has changed, we stop repeating the exact same reminder — but we always send the first reminder, and always speak up when something new actually finished.

```mermaid
flowchart TD
    NC[Child completes -> new-completion wake] -->|count differs| POST[Post notice]
    RW[Parent idles, inbox not drained -> re-wake] --> Q{notice == last<br/>delivered re-wake?}
    Q -->|no / first nudge| POST
    Q -->|yes, verbatim repeat| SKIP[Skip - no spam]
```

## Test Plan

Automated (against latest `main`):

```bash
uv run python -m pytest tests/runner/test_app_sessions_native_supervision.py \
  -k "repeat_identical_recovery or recovery_wake or drained_inbox_clears_flag or wakes_idle_parent" -q
```

- New test `test_repeat_identical_recovery_wake_is_suppressed` is a discriminator: it **fails without** this change (a 5th, duplicate recovery wake posts) and **passes with** it. Verified by stashing the `app.py` change and re-running.
- The existing `test_parent_idle_with_stuck_wake_flag_posts_recovery_wake` (first recovery nudge must fire even when its text matches an earlier completion wake) and `..._drained_inbox_clears_flag` still pass — the load-bearing recovery path is preserved.
- Full `test_app_sessions_native_supervision.py` module and `tests/e2e/test_subagent_autowake_e2e.py` pass. `ruff format`/`ruff check`/`pyrefly` clean.

Manual: kick off a wide same-agent sub-agent fan-out and watch the parent session's stream. Checked for theinitial wake nudges, but the identical `… N results waiting in inbox …` line does **not** keep reappearing at every turn boundary while the parent hasn't drained; a genuinely new completion (different count) still posts a notice.

## Demo

N/A — backend behavior change, no UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new test drives the runner through its HTTP surface to reproduce two identical stranded-inbox recovery wakes and asserts the second is suppressed while the first (and any distinct new-completion notice) still fires; confirmed to fail on baseline and pass with the fix.

## Changelog

Sub-agent inbox wake notices no longer repeat the same "results waiting in inbox" line while a parent's results sit undrained.

---

This pull request and its description were written by Isaac.
