### PR TITLE
fix(host): auto-reclaim a wedged local host daemon on start

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2914,19 +2914,67 @@ def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None
     return None
 
 
+def _conflicting_daemon_is_stale_zombie(conflict: _HostDaemonRecord) -> bool:
+    """
+    Return whether a conflicting daemon is a zombie safe to auto-reap.
+
+    A conflict is a live PID, but a live process is not a working host: a
+    local daemon whose server tunnel is offline and does not recover within
+    the grace window (local server restart, laptop sleep, dropped loopback,
+    ungraceful exit) can't serve anyone, yet blocks a fresh foreground
+    ``host`` with an "already running" error until the user runs
+    ``omnigent host stop`` by hand.
+
+    Scoped like the background reuse path's tunnel-health heal
+    (:func:`_reuse_existing_daemon_record`):
+
+    * only ``"local"`` conflicts are judged — a remote daemon connects to a
+      server we don't own and can't restart, so its own reconnect loop owns
+      transient tunnel drops; we never reap it off a health probe that a
+      local network blip could fail; and
+    * a daemon younger than :data:`_DAEMON_REUSE_MIN_AGE_S` is assumed to be
+      a concurrent invocation's process still connecting, and is never
+      judged a zombie.
+
+    :param conflict: Live conflicting daemon record.
+    :returns: ``True`` when the conflict is a local daemon old enough to
+        judge whose tunnel is offline (and does not recover within the
+        grace window).
+    """
+    if conflict.mode != "local":
+        return False
+    age_s = time.time() - conflict.started_at
+    if age_s < _DAEMON_REUSE_MIN_AGE_S:
+        return False
+    return not _daemon_tunnel_recovers(conflict)
+
+
 def _claim_foreground_daemon_record(
     record: _HostDaemonRecord,
 ) -> _HostDaemonRecord | None:
     """
     Persist a foreground daemon record unless a live duplicate exists.
 
+    A conflicting daemon whose process is alive but whose server tunnel is
+    offline and won't recover (a zombie) is torn down automatically and this
+    process takes over, so a wedged host no longer forces a manual
+    ``omnigent host stop`` before restarting. A conflict that is still
+    serving its tunnel — or a teardown that does not take — is surfaced as
+    before rather than killed out from under whoever is using it.
+
     :param record: Foreground process record, e.g. one with
         ``pid == os.getpid()``.
     :returns: Previous record for the same target, or ``None``.
-    :raises click.ClickException: If a live daemon already serves the
-        same target.
+    :raises click.ClickException: If a live, tunnel-healthy daemon already
+        serves the same target.
     """
     conflict = _live_daemon_conflict(record)
+    if conflict is not None and _conflicting_daemon_is_stale_zombie(conflict):
+        _terminate_host_unit(conflict, reason="host tunnel is offline")
+        # Re-evaluate: a separate live daemon could still serve this target,
+        # or the teardown may not have taken. Never start a duplicate host —
+        # surface a surviving conflict rather than heal blindly.
+        conflict = _live_daemon_conflict(record)
     if conflict is not None:
         raise click.ClickException(
             "A host daemon is already running for this server "
@@ -7991,6 +8039,13 @@ def host(
     The server URL may be given positionally (``omnigent host
     <url>``) or via ``--server <url>``. A leading ``status``, ``stop``,
     or ``stop-session`` token still runs that management subcommand.
+
+    If a local host from an earlier run is wedged — its process is alive
+    but its server tunnel is dead (laptop sleep, dropped connection, local
+    server restart) — this reclaims it automatically instead of failing
+    with "already running", so you no longer have to run ``omnigent host
+    stop`` first. A local host still actively serving its tunnel, and any
+    remote host, are left alone.
 
     When the target server is Databricks-fronted and you are not signed
     in, ``host`` runs the same flow ``omnigent login`` would before

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -544,6 +544,220 @@ def test_ensure_host_daemon_young_offline_daemon_not_torn_down(
     assert "args" not in captured  # reused despite being offline (still connecting)
 
 
+def _foreground_claim_record(pid: int = 9999) -> cli._HostDaemonRecord:
+    """Build the record a foreground ``host`` process wants to claim.
+
+    :param pid: This foreground process's pid, distinct from any conflict.
+    :returns: A local-mode foreground record (``log_path is None``).
+    """
+    return cli._HostDaemonRecord(
+        pid=pid,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=None,
+        started_at=1_000_100,
+        host_id="host_abc",
+        resolved_server_url="http://127.0.0.1:8123",
+        config_sig=cli.server_config_signature(),
+    )
+
+
+def test_claim_foreground_heals_offline_tunnel_zombie(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A foreground ``host`` auto-reaps a live-but-offline conflicting daemon.
+
+    The manual-``host stop`` fix: an old conflicting daemon whose process is
+    alive but whose tunnel is offline can't serve anyone, so tear it down and
+    let this process claim the target instead of erroring.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        config_sig=cli.server_config_signature(),
+        resolved_server_url="http://127.0.0.1:8123",
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)  # past min-age
+    monkeypatch.setattr(cli, "_daemon_tunnel_recovers", lambda record, **_kw: False)
+    torn_down: list[str] = []
+
+    def _teardown(record: cli._HostDaemonRecord, *, reason: str) -> None:
+        torn_down.append(reason)
+        cli._delete_daemon_record(record)  # real teardown clears the record
+
+    monkeypatch.setattr(cli, "_terminate_host_unit", _teardown)
+
+    previous = cli._claim_foreground_daemon_record(_foreground_claim_record())
+
+    assert len(torn_down) == 1 and "offline" in torn_down[0]
+    assert previous is None  # the reaped zombie is not handed back for restore
+    claimed = cli._find_daemon_record("local")
+    assert claimed is not None and claimed.pid == 9999  # this process took over
+
+
+def test_claim_foreground_refuses_healthy_conflict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A live, tunnel-healthy conflicting daemon is never killed out from under.
+
+    The auto-heal is scoped to zombies: a daemon still serving its tunnel
+    keeps the original "already running — stop it first" guard.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        config_sig=cli.server_config_signature(),
+        resolved_server_url="http://127.0.0.1:8123",
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)  # past min-age
+    monkeypatch.setattr(cli, "_daemon_tunnel_recovers", lambda record, **_kw: True)
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    with pytest.raises(click.ClickException, match="already running"):
+        cli._claim_foreground_daemon_record(_foreground_claim_record())
+
+    assert torn_down == []  # healthy daemon left alone
+
+
+def test_claim_foreground_young_conflict_not_reaped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A freshly-spawned conflicting daemon (still connecting) is not reaped.
+
+    Below the min-age threshold a concurrent invocation's just-spawned daemon
+    is assumed to be mid-connect: don't probe it, don't kill it — surface the
+    conflict so we never race it.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        config_sig=cli.server_config_signature(),
+        resolved_server_url="http://127.0.0.1:8123",
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_002.0)  # younger than min-age
+
+    def _must_not_probe(record: object, **_kw: object) -> bool:
+        raise AssertionError("young daemon must not be probed/torn down")
+
+    monkeypatch.setattr(cli, "_daemon_tunnel_recovers", _must_not_probe)
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    with pytest.raises(click.ClickException, match="already running"):
+        cli._claim_foreground_daemon_record(_foreground_claim_record())
+
+    assert torn_down == []
+
+
+def test_claim_foreground_surfaces_conflict_when_teardown_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A zombie that survives teardown is surfaced, not overwritten.
+
+    Guards the re-evaluation: if the reap does not take (record still live
+    afterwards), never start a duplicate host — raise instead.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        config_sig=cli.server_config_signature(),
+        resolved_server_url="http://127.0.0.1:8123",
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)  # past min-age
+    monkeypatch.setattr(cli, "_daemon_tunnel_recovers", lambda record, **_kw: False)
+    torn_down: list[str] = []
+    # Teardown "runs" but leaves the record in place (kill did not take).
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    with pytest.raises(click.ClickException, match="already running"):
+        cli._claim_foreground_daemon_record(_foreground_claim_record())
+
+    assert len(torn_down) == 1 and "offline" in torn_down[0]  # reap was attempted once
+
+
+def test_claim_foreground_remote_conflict_not_probed_or_reaped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A remote conflict keeps the fast refuse — never probed, never reaped.
+
+    Auto-heal is local-only: a remote daemon connects to a server we don't
+    own, so its own reconnect loop owns transient drops. Reaping it off a
+    tunnel probe (that a local network blip could fail) would be wrong, and
+    the probe itself would add latency to a previously-instant refuse.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        started_at=1_000_000,
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)  # old, but remote
+
+    def _must_not_probe(record: object, **_kw: object) -> bool:
+        raise AssertionError("remote conflict must not be tunnel-probed")
+
+    monkeypatch.setattr(cli, "_daemon_tunnel_recovers", _must_not_probe)
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    record = cli._HostDaemonRecord(
+        pid=9999,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=None,
+        started_at=1_000_100,
+        host_id="host_abc",
+        config_sig=cli.server_config_signature(),
+    )
+    with pytest.raises(click.ClickException, match="already running"):
+        cli._claim_foreground_daemon_record(record)
+
+    assert torn_down == []
+
+
 def _online_record() -> cli._HostDaemonRecord:
     """Build a local daemon record suitable for host-online probing.
 


### PR DESCRIPTION
## Related issue

<!-- No tracked issue; this is a resilience fix for a recurring manual step. -->

Closes #

## Summary

`omnigent host` (foreground) refused to start whenever a process with the
recorded PID was alive, printing *"A host daemon is already running… run
`omnigent host stop` first"*. That guard fired even when the existing local
host was a **zombie** — process alive, but its WebSocket tunnel to the server
dead (laptop sleep, dropped connection, local server restart). So restarting a
wedged host meant running `omnigent host stop` by hand every time.

- The **background** reuse path (`_ensure_host_daemon` → `_reuse_existing_daemon_record`)
  already self-heals this exact case; the **foreground** claim path
  (`_claim_foreground_daemon_record` → `_live_daemon_conflict`) only ever did a
  bare PID-liveness check. This brings the same tunnel-health teardown to the
  foreground path.
- A conflicting **local** daemon, old enough to judge, whose tunnel is offline
  and does not recover within the grace window, is torn down automatically and
  this process takes over — no manual stop.
- Left alone (unchanged behavior): a local host still serving its tunnel, a
  very young daemon still connecting (concurrent-spawn race), and **any remote
  host** (it owns its own reconnect loop and connects to a server we don't own,
  so we never reap it off a health probe a local blip could fail). If a
  teardown doesn't take, the original "already running" error is re-surfaced
  rather than starting a duplicate host.

**ELI5:** If your local host got stuck (alive but not actually connected), you
used to have to kill it yourself before starting again. Now `omnigent host`
notices the stuck one is dead-in-the-water and clears it for you — but it won't
touch one that's actually working, or one pointed at someone else's server.

```
omnigent host  (foreground)
      │
      ▼
 conflict for this target?
      │
      ├── none ─────────────────────────────► claim + run
      │
      └── live PID found
             │
             ├── remote target ──────────────► refuse ("run host stop")   [unchanged]
             ├── local, healthy tunnel ───────► refuse ("run host stop")   [unchanged]
             ├── local, still connecting ─────► refuse ("run host stop")   [unchanged]
             └── local, tunnel dead > grace ──► reap zombie ─► claim + run [NEW: was "refuse"]
```

## Test Plan

- New unit tests in `tests/cli/test_backend.py` (all green, suite runs in ~3s):
  - `test_claim_foreground_heals_offline_tunnel_zombie` — offline-tunnel local
    zombie is torn down and this process claims the target.
  - `test_claim_foreground_refuses_healthy_conflict` — a tunnel-healthy local
    daemon is never killed; original error stands.
  - `test_claim_foreground_young_conflict_not_reaped` — a still-connecting
    daemon (below the min-age grace) is not probed or reaped.
  - `test_claim_foreground_surfaces_conflict_when_teardown_fails` — a zombie
    that survives teardown re-surfaces the error instead of starting a duplicate.
  - `test_claim_foreground_remote_conflict_not_probed_or_reaped` — remote
    conflicts keep the fast refuse (no probe, no teardown). This also fixes a
    latent ~12s slowdown the initial version introduced in the existing
    `test_foreground_connect_refuses_duplicate_live_daemon`.
- `pre-commit run --files omnigent/cli.py tests/cli/test_backend.py` — passes
  (ruff, pyrefly, etc.).

Manual verification:
1. `omnigent host ""` to start a local host, then simulate a wedge — e.g.
   `omnigent server stop` (kill the local server out from under the daemon) or
   suspend/resume the machine so the tunnel drops without the daemon exiting.
2. Confirm `omnigent host status` shows the host process alive but **offline**.
3. Run `omnigent host ""` again. It should reclaim the wedged host
   automatically (`Restarting host daemon for 'local' (host tunnel is
   offline).`) and connect — no `omnigent host stop` needed.
4. Sanity: with a genuinely healthy host still running, a second
   `omnigent host` still refuses with "already running"; a remote
   `omnigent host <url>` conflict still refuses immediately.

## Demo

N/A — CLI behavior change, covered by the diagram and tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added five focused unit tests around `_claim_foreground_daemon_record`
covering the heal, the healthy/young/remote no-op cases, and the
failed-teardown guard. Manual verification steps above exercise the real
wedged-host → auto-reclaim flow, which is best confirmed by a human
(suspend/resume or killing the local server mid-session).

## Changelog

`omnigent host` now auto-reclaims a wedged local host (alive but its server tunnel is dead) instead of failing with "already running", so you no longer have to run `omnigent host stop` first

This pull request and its description were written by Isaac.
