### PR TITLE
fix(pi-native): select a served Databricks Claude default

### DIFF
--- a/omnigent/databricks_model_discovery.py
+++ b/omnigent/databricks_model_discovery.py
@@ -111,6 +111,43 @@ def _all_claude_models(model_ids: list[str], *, marker: str) -> tuple[str, ...]:
     return tuple(sorted(claude_ids, key=_natural_model_key, reverse=True))
 
 
+def preferred_served_claude_model(
+    served_ids: Iterable[str], *, preferred_model_id: str
+) -> str | None:
+    """Choose a served Claude id closest to *preferred_model_id*.
+
+    Equivalent ``databricks-`` and ``system.ai.`` spellings identify the same
+    endpoint. Otherwise, the newest served model in the requested family wins,
+    followed by the standard family order.
+
+    :param served_ids: Model ids an authoritative workspace listing returned.
+    :param preferred_model_id: The implicit catalog default to match.
+    :returns: A served id, or ``None`` when no compatible Claude id is known.
+    """
+    preferred_family = _claude_family_of(preferred_model_id, marker="claude-")
+    if preferred_family is None:
+        return None
+    claude_ids = _prefer_databricks_spelling(
+        model_id
+        for model_id in served_ids
+        if _claude_family_of(model_id, marker="claude-") is not None
+    )
+    if not claude_ids:
+        return None
+    preferred_bare_id = _bare_model_id(preferred_model_id)
+    equivalent = next(
+        (model_id for model_id in claude_ids if _bare_model_id(model_id) == preferred_bare_id),
+        None,
+    )
+    if equivalent is not None:
+        return equivalent
+    newest_by_family = _models_by_claude_family(claude_ids, marker="claude-")
+    for family in (preferred_family, *CLAUDE_MODEL_FAMILIES):
+        if family in newest_by_family:
+            return newest_by_family[family]
+    return None
+
+
 def _list_model_service_ids(
     client: httpx.Client,
     workspace_url: str,

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -36,6 +36,7 @@ from omnigent.databricks_ai_gateway import (
     DATABRICKS_TRUSTED_HOST_SUFFIXES,
     is_databricks_ai_gateway_url,
 )
+from omnigent.databricks_model_discovery import preferred_served_claude_model
 from omnigent.model_metadata import ModelWireAPI
 from omnigent.model_override import normalize_model_for_provider
 from omnigent.onboarding.provider_config import (
@@ -356,6 +357,27 @@ class PiProviderConfig:
         )
 
 
+def _select_databricks_claude_model(model: str | None, claude_models: list[_PiModelEntry]) -> str:
+    """Resolve an implicit Databricks default to an equivalent served Claude id."""
+    selected_model = (
+        model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+    )
+    if model is not None or not claude_models:
+        return selected_model
+    served_model = preferred_served_claude_model(
+        (model_id for item in claude_models if isinstance((model_id := item.get("id")), str)),
+        preferred_model_id=selected_model,
+    )
+    if served_model is None or served_model == selected_model:
+        return selected_model
+    _LOGGER.warning(
+        "pi-native: resolved default model %s to workspace-served model %s",
+        selected_model,
+        served_model,
+    )
+    return served_model
+
+
 def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
     """Resolve a Databricks-profile provider into Pi gateway config.
 
@@ -407,6 +429,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
             _LOGGER.info(
                 "pi-native: could not fetch workspace model list; showing default model only"
             )
+    selected_model = _select_databricks_claude_model(model, claude_models)
     additional: dict[str, _PiProviderPayload] = {}
     if gpt_models:
         additional[_PI_OPENAI_PROVIDER_ID] = _databricks_openai_provider(
@@ -424,7 +447,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
         api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=selected_model,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is re-read per request (the auth command attempts a
         # refresh), matching codex-native's refresh semantics.
@@ -840,7 +863,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=_gateway_anthropic_base_url(transport.base_url),
         api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=_select_databricks_claude_model(model, claude_models),
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token (the codex auth command prints it) is refreshed per
         # request — matching codex-native's refresh semantics.

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1012,6 +1012,7 @@ def test_cli_config_databricks_registers_gpt_provider(
     """
     _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
     monkeypatch.setenv("HOME", str(tmp_path))
+    _set_catalog_default(monkeypatch, "databricks-claude-fable-5")
     # Workspace URL comes from resolve_databricks_workspace (DEFAULT profile),
     # but the token for the API call comes from the auth_command — the SDK's
     # minted token may not have serving-endpoints access.
@@ -1038,6 +1039,7 @@ def test_cli_config_databricks_registers_gpt_provider(
 
     provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
     assert provider is not None
+    assert provider.model == "databricks-claude-sonnet-4-6"
 
     cfg = provider.to_models_config()
     openai_entry = cfg["providers"].get("omnigent-openai")
@@ -1293,6 +1295,126 @@ def _mock_databricks_profile(monkeypatch: pytest.MonkeyPatch) -> None:
         "resolve_databricks_workspace",
         lambda profile: db_creds_mod.WorkspaceCreds(host="https://wkspc.example.com", token="tok"),
     )
+
+
+def _mock_databricks_model_lists(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    claude: list[str] | None = None,
+    gpt: list[str] | None = None,
+) -> None:
+    """Resolve a Databricks profile with deterministic live model lists."""
+    _mock_databricks_profile(monkeypatch)
+
+    def _entries(model_ids: list[str] | None) -> list[dict[str, object]]:
+        return [{"id": model_id, "input": ["text", "image"]} for model_id in (model_ids or [])]
+
+    monkeypatch.setattr(
+        creds,
+        "_fetch_pi_model_lists",
+        lambda *_: (_entries(claude), _entries(gpt), [], []),
+    )
+
+
+def _set_catalog_default(monkeypatch: pytest.MonkeyPatch, model_id: str) -> None:
+    """Set the release-curated Databricks Claude default for one test."""
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: SimpleNamespace(model_id=model_id),
+    )
+
+
+def test_unserved_catalog_default_falls_back_to_served_claude(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable implicit default selects a model the workspace serves."""
+    _set_catalog_default(monkeypatch, "databricks-claude-fable-5")
+    _mock_databricks_model_lists(
+        monkeypatch,
+        claude=[
+            "system.ai.claude-opus-4-8",
+            "system.ai.claude-sonnet-4-6",
+            "system.ai.claude-opus-5",
+        ],
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "system.ai.claude-opus-5"
+
+
+def test_unserved_catalog_default_prefers_same_claude_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A served model in the requested family wins over a newer other tier."""
+    _set_catalog_default(monkeypatch, "databricks-claude-sonnet-5")
+    _mock_databricks_model_lists(
+        monkeypatch,
+        claude=["system.ai.claude-opus-5", "system.ai.claude-sonnet-4-6"],
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "system.ai.claude-sonnet-4-6"
+
+
+def test_served_catalog_default_accepts_equivalent_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equivalent Databricks/system spellings identify the same served default."""
+    _set_catalog_default(monkeypatch, "databricks-claude-sonnet-4-6")
+    _mock_databricks_model_lists(
+        monkeypatch,
+        claude=["system.ai.claude-opus-5", "system.ai.claude-sonnet-4-6"],
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "system.ai.claude-sonnet-4-6"
+
+
+def test_explicit_databricks_model_is_not_substituted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit unavailable model remains the caller's verbatim choice."""
+    _mock_databricks_model_lists(monkeypatch, claude=["system.ai.claude-opus-5"])
+
+    provider = creds.resolve_pi_native_provider(
+        model="databricks-claude-fable-5",
+        config_loader=_databricks_config,
+    )
+
+    assert provider is not None
+    assert provider.model == "databricks-claude-fable-5"
+
+
+def test_empty_databricks_discovery_keeps_catalog_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty live listing gives no safe evidence for substitution."""
+    _set_catalog_default(monkeypatch, "databricks-claude-fable-5")
+    _mock_databricks_model_lists(monkeypatch)
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "databricks-claude-fable-5"
+
+
+def test_non_claude_discovery_does_not_replace_claude_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-Claude-only listing cannot justify a cross-family substitution."""
+    _set_catalog_default(monkeypatch, "databricks-claude-fable-5")
+    _mock_databricks_model_lists(monkeypatch, gpt=["system.ai.gpt-5-5"])
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "databricks-claude-fable-5"
 
 
 def _databricks_provider_without_catalog(


### PR DESCRIPTION
## Related issue

Closes #4805

## Summary

- Pi-native could select a release-catalog Claude default that a Databricks workspace did not serve, causing every turn to fail even when compatible Claude models were available.
- For implicit defaults only, compare the selected model with the successful live workspace catalog, preserve equivalent aliases, prefer the same Claude family, then choose the newest served model in the documented family order. Explicit model overrides and failed or empty discovery remain unchanged.
- Apply the same selector to both Databricks profile and adopted Databricks `cli-config` providers. Gateway routing and authentication are unchanged.

**ELI5:** if Omnigent's default is not on the workspace's menu, Pi now picks the closest Claude model that is on the menu. If the user named a model explicitly, Omnigent still uses exactly that choice.

```text
implicit default
      |
live Claude catalog available? -- no --> keep catalog default
      |
     yes
      |
exact/equivalent served? -- yes --> use served spelling
      |
     no
      |
same family, then fable -> opus -> sonnet -> haiku
      |
use newest model that the workspace actually serves
```

## Test Plan

- `OMNIGENT_SKIP_WEB_UI=true .venv/bin/pre-commit run --all-files` — passed.
- `OMNIGENT_SKIP_WEB_UI=true .venv/bin/python -m pytest -q tests/test_pi_native_credentials.py tests/test_databricks_model_discovery.py` — 103 passed.
- `OMNIGENT_SKIP_WEB_UI=true uv run --no-sync pyrefly check omnigent/databricks_model_discovery.py omnigent/pi_native_credentials.py` — 0 errors.
- `uv run --no-sync ruff check omnigent/databricks_model_discovery.py omnigent/pi_native_credentials.py tests/test_pi_native_credentials.py` — passed.
- `uv run --no-sync ruff format --check omnigent/databricks_model_discovery.py omnigent/pi_native_credentials.py tests/test_pi_native_credentials.py` — passed.
- Independent requirements, edge-case, security/data, and regression review reproduced and closed a Databricks `cli-config` coverage gap; final adjudication found no unresolved blocker or high-severity findings.

## Demo

N/A — non-visual provider-selection fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover unavailable and equivalent implicit defaults, same-family preference, explicit overrides, empty and non-Claude discovery, and both Databricks profile and `cli-config` resolution paths.

## Changelog

Pi-native now selects an actually served Claude model when a Databricks workspace lacks the implicit catalog default
