### PR TITLE
Keep Codex hook review interactive

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -105,11 +105,6 @@ _TRUSTED_HOOK_STATUSES = frozenset({"trusted", "managed"})
 # — we detect the old version up front and skip registration with a loud
 # warning rather than crash startup on an un-trustable hook.
 _MIN_POLICY_HOOK_CODEX_VERSION = (0, 129, 0)
-# Minimum codex CLI version that accepts ``--dangerously-bypass-hook-trust``.
-# Older binaries exit immediately on the unknown flag, so below this floor
-# (including a version we could not parse) the flag is omitted and the
-# interactive trust prompt may appear instead.
-_MIN_BYPASS_HOOK_TRUST_CODEX_VERSION = (0, 131, 0)
 
 
 def _string_object_dict(value: object) -> _JsonObject | None:

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6835,7 +6835,7 @@ def _thread_started_is_subagent(event: CodexMessage) -> bool:
 async def wait_for_thread_started(
     client: CodexAppServerClient,
     *,
-    timeout: float = _THREAD_START_TIMEOUT_SECONDS,
+    timeout: float | None = _THREAD_START_TIMEOUT_SECONDS,
 ) -> str:
     """
     Wait for a freshly launched Codex TUI to create its app-server thread.
@@ -6851,7 +6851,8 @@ async def wait_for_thread_started(
 
     :param client: A connected :class:`CodexAppServerClient` listening for
         app-server notifications.
-    :param timeout: Seconds to wait for ``thread/started`` before failing.
+    :param timeout: Seconds to wait for ``thread/started`` before failing;
+        ``None`` waits until a thread starts or the event stream ends.
     :returns: The Codex thread id, e.g.
         ``"019e8720-98d7-7b23-ac0a-bfb0eb02e0c9"``.
     :raises TimeoutError: If no ``thread/started`` arrives within *timeout*.

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -220,21 +220,20 @@ class CodexNativeExecutor(Executor):
             return
         # Wait for the bridge to boot OUTSIDE the injection lock: this is a
         # one-time poll for the state file to appear (first turn, app-server
-        # starting), with no shared-state mutation, so holding the lock
-        # across its up-to-60s wait would needlessly block concurrent
-        # steering (enqueue_session_message). Once the state exists, the
-        # decision/RPC/write below runs under the lock — re-reading state so
+        # starting), with no shared-state mutation. A cold TUI can wait on
+        # interactive hook review before it creates a thread, so there is no
+        # arbitrary deadline here; cancellation still stops the wait, and the
+        # runner writes a startup error when the TUI exits. Once state exists,
+        # the decision/RPC/write below runs under the lock — re-reading state so
         # it's atomic with respect to a steer that landed during the wait.
         state = read_bridge_state(self._bridge_dir)
         if state is None:
-            for _ in range(60):
+            while state is None:
                 # Startup already failed; the runner recorded the cause — stop waiting.
                 if read_bridge_startup_error(self._bridge_dir) is not None:
                     break
                 await asyncio.sleep(1.0)
                 state = read_bridge_state(self._bridge_dir)
-                if state is not None:
-                    break
 
         # No client-side wait for Codex MCP startup: the app-server accepts
         # ``turn/start`` mid-startup and defers execution until the round

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -158,6 +158,9 @@ _AUTO_FORWARDER_TASKS: dict[str, asyncio.Task[object]] = {}
 # Bound how long terminal (re)creation waits for a cancelled forwarder.
 _AUTO_FORWARDER_CANCEL_TIMEOUT_S = 10.0
 
+# Avoid flashing a terminal-setup notice during ordinary fast Codex startup.
+_CODEX_THREAD_WAIT_NOTICE_DELAY_S = 2.0
+
 # Delegated runner bearers last 30 minutes and refresh five minutes before
 # expiry. A one-minute cadence allows several retries without giving the child
 # the runner binding token; cached factory calls stay local and cheap.
@@ -3727,7 +3730,6 @@ async def _auto_create_codex_terminal(
     from pathlib import Path
 
     from omnigent.codex_native_app_server import (
-        _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION,
         CodexAppServerClient,
         build_codex_native_server,
         build_codex_remote_args,
@@ -4009,8 +4011,10 @@ async def _auto_create_codex_terminal(
         trust_project=True,
         **routed_spawn_extras,
     )
-    # Generate routing hooks.json (and bypass codex's hook-trust prompt): the
-    # app-server reads the endpoint out of its own process env at start, and
+    # Generate routing hooks.json. Omnigent-owned policy/routing hooks are
+    # trusted explicitly by the app-server handshake; user hooks remain
+    # reviewable in the terminal TUI.
+    # The app-server reads the endpoint out of its own process env at start, and
     # the server decides per spawn whether to route. Any Smart Routing session,
     # pinned or auto — the advertisement is also what makes this session's
     # codex-home diverge from a plain one (generated hooks.json, routed-spawn
@@ -4069,11 +4073,17 @@ async def _auto_create_codex_terminal(
     else:
         from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
 
-        await preload_codex_thread_for_resume(
-            codex_ws_url,
-            launch_config.external_session_id,
-            terminal_launch_args=launch_config.terminal_launch_args,
-        )
+        try:
+            await preload_codex_thread_for_resume(
+                codex_ws_url,
+                launch_config.external_session_id,
+                terminal_launch_args=launch_config.terminal_launch_args,
+            )
+        except Exception:
+            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+            with contextlib.suppress(Exception):
+                await app_server.close()
+            raise
         write_bridge_state(
             bridge_dir,
             CodexNativeBridgeState(
@@ -4126,23 +4136,8 @@ async def _auto_create_codex_terminal(
                     # OpenAI built-in (which would force the first-run
                     # login screen and block thread creation).
                     config_overrides=tuple(app_server.config_overrides),
-                    # Omnigent provisions the private CODEX_HOME and vets
-                    # hook sources itself; skip the interactive trust prompt
-                    # that headless sub-agents can never answer.
-                    #
-                    # Requires a *positively parsed* version, unlike the
-                    # hooks-file gate in ``codex_native_app_server``, which
-                    # treats an unknown version as supported. The two differ
-                    # because their failure modes do: an unsupported hooks
-                    # file is ignored by codex and caught downstream at the
-                    # trust check, whereas an unknown CLI flag aborts argv
-                    # parsing — so a transient ``codex --version`` hiccup on a
-                    # pre-0.131 codex would turn a recoverable trust prompt
-                    # into a dead terminal.
-                    bypass_hook_trust=(
-                        app_server.codex_cli_version is not None
-                        and app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
-                    ),
+                    # Keep new or changed hooks reviewable in terminal view.
+                    bypass_hook_trust=False,
                 ),
                 env=codex_terminal_env(app_server),
                 # Match the local ``omnigent codex`` terminal scrollback.
@@ -4186,6 +4181,7 @@ async def _auto_create_codex_terminal(
                 codex_home=codex_home,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
+                publish_event=publish_event,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4235,6 +4231,7 @@ async def _codex_discover_thread_and_forward(
     codex_home: Path,
     event_client: CodexAppServerClient,
     routing_summary: str,
+    publish_event: Callable[[str, _JsonObject], None],
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4261,6 +4258,9 @@ async def _codex_discover_thread_and_forward(
         routing (provider / profile / model, or the login-fallback state),
         threaded into the startup-timeout error so hosted users can diagnose
         without runner-log access (see #2745).
+    :param publish_event: Runner session event publisher. After a short grace,
+        reports that chat is blocked on Codex setup in Terminal and clears the
+        reason as soon as thread discovery finishes.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4282,8 +4282,40 @@ async def _codex_discover_thread_and_forward(
     )
 
     try:
+        notice_published = False
+
+        async def _publish_terminal_setup_notice() -> None:
+            nonlocal notice_published
+            await asyncio.sleep(_CODEX_THREAD_WAIT_NOTICE_DELAY_S)
+            publish_event(
+                session_id,
+                {
+                    "type": "session.status",
+                    "status": "running",
+                    "blocked_on": "Codex setup in Terminal",
+                },
+            )
+            notice_published = True
+
+        notice_task = asyncio.create_task(
+            _publish_terminal_setup_notice(),
+            name=f"codex-terminal-setup-notice-{session_id}",
+        )
         try:
-            thread_id = await wait_for_thread_started(event_client)
+            try:
+                # A cold TUI may pause indefinitely for interactive hook review.
+                # Keep its app-server and the initial chat turn alive until the
+                # user answers in Terminal; stream closure still fails promptly.
+                thread_id = await wait_for_thread_started(event_client, timeout=None)
+            finally:
+                notice_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await notice_task
+                if notice_published:
+                    publish_event(
+                        session_id,
+                        {"type": "session.status", "status": "running"},
+                    )
         except (TimeoutError, RuntimeError) as exc:
             # Expected failure modes of wait_for_thread_started: the TUI exited
             # at startup, or the event stream ended before a thread was

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -194,6 +194,52 @@ def test_web_started_codex_turn_returns_without_waiting_for_terminal_event(
     ]
 
 
+def test_initial_turn_waits_for_late_thread_after_hook_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A cold chat turn survives while terminal hook review blocks thread creation."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    sleep_calls = 0
+
+    async def _approve_hooks_after_old_timeout(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 61:
+            write_bridge_state(
+                tmp_path,
+                CodexNativeBridgeState(
+                    session_id="conv_123",
+                    socket_path=str(tmp_path / "app-server.sock"),
+                    thread_id="thread_after_review",
+                    codex_home=str(tmp_path / "codex-home"),
+                ),
+            )
+
+    monkeypatch.setattr(asyncio, "sleep", _approve_hooks_after_old_timeout)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "test")
+
+    assert sleep_calls == 61
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_after_review",
+                "input": [{"type": "text", "text": "test"}],
+            },
+        )
+    ]
+
+
 def test_goal_command_sets_goal_before_starting_objective_turn(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -421,6 +421,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             self.codex_home = tmp_path / "unconfigured-codex-home"
             self.listen_url: str | None = None
             self.started = False
+            self.close_calls = 0
             # Provider/model -c overrides the runner forwards to the
             # --remote TUI; empty here (no profile in this test).
             self.config_overrides: list[str] = []
@@ -435,6 +436,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
 
         async def close(self) -> None:
             """:returns: None."""
+            self.close_calls += 1
 
     app_server = _FakeCodexAppServer()
     build_calls: list[dict[str, Any]] = []
@@ -518,6 +520,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     published_events: list[dict[str, Any]] = []
     forward_calls: list[dict[str, Any]] = []
     preload_calls: list[tuple[str, str, list[str] | None]] = []
+    preload_error: RuntimeError | None = RuntimeError("thread already has an active writer")
 
     async def _fake_preload_thread(
         transport: str,
@@ -536,6 +539,8 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             "stale bridge state must be cleared until the new app-server has "
             "loaded the resume thread"
         )
+        if preload_error is not None:
+            raise preload_error
         preload_calls.append((transport, loaded_thread_id, terminal_launch_args))
 
     async def _fake_forward_known_thread(**kwargs: Any) -> None:
@@ -565,6 +570,18 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
         ),
     )
 
+    with pytest.raises(RuntimeError, match="active writer"):
+        await _auto_create_codex_terminal(
+            session_id,
+            _FakeResourceRegistry(),  # type: ignore[arg-type]
+            lambda _sid, event: published_events.append(event),
+            agent_spec=agent_spec,
+            server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+        )
+    assert app_server.close_calls == 1
+    assert session_id not in runner_app_mod._AUTO_CODEX_APP_SERVERS
+
+    preload_error = None
     try:
         terminal_view = await _auto_create_codex_terminal(
             session_id,
@@ -590,15 +607,15 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     assert len(launched_specs) == 1
     launched = launched_specs[0]
     assert launched.command == "/opt/codex/bin/codex"
-    assert launched.args[0] == "--dangerously-bypass-hook-trust"
-    assert launched.args[1:4] == [
+    assert "--dangerously-bypass-hook-trust" not in launched.args
+    assert launched.args[0:3] == [
         "--config",
         "approval_policy=on-request",
         "resume",
     ]
-    assert launched.args[4] == "--remote"
-    assert launched.args[5].startswith("ws://127.0.0.1:")
-    assert launched.args[6] == thread_id
+    assert launched.args[3] == "--remote"
+    assert launched.args[4].startswith("ws://127.0.0.1:")
+    assert launched.args[5] == thread_id
     assert launched.env["OPENAI_API_KEY"] == "sk-test"
     assert "IGNORED" not in launched.env
     assert launched.env["CODEX_HOME"] == str(app_server.codex_home)
@@ -1421,12 +1438,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     assert launched_sandbox is not None and launched_sandbox.type == "none"
     assert launch_captured["parent_os_env"] is codex_os_env
 
-    # This fake app-server reports no codex version (an unparseable / failed
-    # probe). The argv flag requires a positively parsed version: on a
-    # pre-0.131 codex an unknown flag aborts argv parsing outright, which is
-    # strictly worse than the recoverable trust prompt. (The app-server's
-    # hooks-file gate keeps the opposite "unknown = supported" policy, since
-    # an unsupported hooks file is only ignored.)
+    # Hook trust remains interactive even when the Codex version is unknown.
     assert app_server.codex_cli_version is None
     assert "--dangerously-bypass-hook-trust" not in launch_captured["spec"].args
 
@@ -3049,7 +3061,8 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
         async def close(self) -> None:
             closed["app_server"] = True
 
-    async def _raise_no_thread(*_args: object, **_kwargs: object) -> str:
+    async def _raise_no_thread(_client: object, *, timeout: float | None) -> str:
+        assert timeout is None
         raise TimeoutError("no thread/started observed")
 
     # The helper lazily imports wait_for_thread_started from the forwarder
@@ -3066,6 +3079,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
             codex_home=tmp_path / "codex-home",
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            publish_event=lambda _session_id, _event: None,
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3075,6 +3089,68 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     assert closed["client"] is True
     assert closed["app_server"] is True
     assert session_id not in _AUTO_CODEX_APP_SERVERS
+
+
+@pytest.mark.asyncio
+async def test_codex_discovery_surfaces_terminal_setup_wait_in_chat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A cold TUI dialog must replace chat's unexplained Working spinner."""
+    from omnigent import codex_native_forwarder
+    from omnigent.runner.app import (
+        _AUTO_CODEX_APP_SERVERS,
+        _codex_discover_thread_and_forward,
+    )
+    from omnigent.runner.native import orchestration as native_orchestration
+
+    class _Client:
+        async def close(self) -> None:
+            return None
+
+    class _AppServer:
+        async def close(self) -> None:
+            return None
+
+    notice_seen = asyncio.Event()
+    events: list[dict[str, object]] = []
+
+    def _publish(_session_id: str, event: dict[str, object]) -> None:
+        events.append(event)
+        if event.get("blocked_on") == "Codex setup in Terminal":
+            notice_seen.set()
+
+    async def _end_after_notice(_client: object, *, timeout: float | None) -> str:
+        assert timeout is None
+        await notice_seen.wait()
+        raise RuntimeError("event stream ended")
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _end_after_notice)
+    monkeypatch.setattr(native_orchestration, "_CODEX_THREAD_WAIT_NOTICE_DELAY_S", 0.0)
+
+    session_id = "86c52de207c7473788730cc393ebd100"
+    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    try:
+        await _codex_discover_thread_and_forward(
+            session_id=session_id,
+            bridge_dir=tmp_path,
+            codex_ws_url="ws://127.0.0.1:1",
+            codex_home=tmp_path / "codex-home",
+            event_client=_Client(),  # type: ignore[arg-type]
+            routing_summary="provider 'test' (model=gpt-test)",
+            publish_event=_publish,
+        )
+    finally:
+        _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    assert events == [
+        {
+            "type": "session.status",
+            "status": "running",
+            "blocked_on": "Codex setup in Terminal",
+        },
+        {"type": "session.status", "status": "running"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -3129,6 +3205,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
             codex_home=tmp_path / "codex-home",
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            publish_event=lambda _session_id, _event: None,
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -10320,7 +10320,8 @@ def test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout(
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    async def _timeout(_client: object) -> str:
+    async def _timeout(_client: object, *, timeout: float | None) -> str:
+        assert timeout is None
         raise TimeoutError("no thread event")
 
     monkeypatch.setattr(_fwd, "wait_for_thread_started", _timeout)
@@ -10337,6 +10338,7 @@ def test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout(
             codex_home=tmp_path / "codex-home",
             event_client=_FakeClient(),
             routing_summary="Codex CLI login (no provider configured) -- SENTINEL",
+            publish_event=lambda _session_id, _event: None,
         )
     )
 


### PR DESCRIPTION
## Related issue

Closes #4936

## Summary

- Stop auto-created Codex terminals from injecting `--dangerously-bypass-hook-trust`.
- Let cold startup wait while Codex displays hook review in terminal view.
- Publish a waiting status so chat view explains where approval is needed instead of timing out or spinning silently.

ELI5: Omnigent now waits at the door while you inspect new hooks, then continues after you approve them in terminal view.

```text
new session -> Codex hook review in terminal -> user approves -> thread starts -> chat continues
```

## Test Plan

- `uv run --no-sync pytest tests/test_codex_native.py tests/runner/test_app_sessions_native_terminals_runtime.py -q --tb=short`
- Result: 255 passed.
- Live session: hook review appeared in terminal view and chat continued after approval.

## Demo

N/A — behavior occurs in Codex's native terminal prompt; no Omnigent UI component changed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover omission of the bypass flag, indefinite cold-thread wait, status publication, and cancellation. Manual verification used a new Codex-native session with untrusted hooks.

## Changelog

Codex-native sessions now let you review new or changed hooks in terminal view before chat continues.
