### PR TITLE
Add safe Codex hook review for automations

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -49,6 +49,7 @@ from omnigent.inner.codex_executor import (
     _databricks_codex_base_url,
     _databricks_codex_config_overrides,
     _find_codex_cli,
+    _merge_codex_user_hook_trust_back,
     _populate_codex_home_config,
     _provider_codex_config_overrides,
     codex_extended_catalog_requested,
@@ -1176,6 +1177,7 @@ class CodexNativeAppServer:
             except asyncio.TimeoutError:
                 _kill_process_tree(self.proc)
                 await self.proc.wait()
+        self.persist_user_hook_trust()
         if self.process_registry_tag is not None:
             unregister_codex_native_process(self.process_registry_tag)
         if self.process_owner_lock is not None:
@@ -1188,6 +1190,13 @@ class CodexNativeAppServer:
         self.stderr_task = None
         self.process_registry_tag = None
         self.process_owner_lock = None
+
+    def persist_user_hook_trust(self) -> None:
+        """Carry user hook approvals from this private home into the shared config."""
+        _merge_codex_user_hook_trust_back(
+            self.codex_home,
+            _codex_home_config_source_from_env(),
+        )
 
     async def _wait_until_ready(self) -> None:
         """

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1480,6 +1480,39 @@ def _our_policy_hooks_from_list(listed: _JsonObject, cwd: str) -> list[_JsonObje
     return _our_hooks_from_list(listed, cwd, _POLICY_HOOK_MODULE)
 
 
+async def codex_user_hooks_audit_status(request: CodexRequestFn, *, cwd: str) -> str:
+    """Return ``trusted``, ``review_required``, or ``unavailable`` for user hooks."""
+    listed = await request("hooks/list", {"cwds": [cwd]})
+    result = _string_object_dict(listed.get("result")) or listed
+    data = _object_list(result.get("data")) or []
+    entry = next(
+        (
+            item
+            for raw in data
+            if (item := _string_object_dict(raw)) is not None and item.get("cwd") == cwd
+        ),
+        None,
+    )
+    if entry is None:
+        return "unavailable"
+    hooks = [
+        hook
+        for raw in (_object_list(entry.get("hooks")) or [])
+        if (hook := _string_object_dict(raw)) is not None
+        and _POLICY_HOOK_MODULE not in str(hook.get("command", ""))
+        and _CODEX_ROUTER_HOOK_MODULE not in str(hook.get("command", ""))
+    ]
+    if not hooks:
+        return "trusted"
+    if any(hook.get("currentHash") is None or hook.get("trustStatus") is None for hook in hooks):
+        return "unavailable"
+    return (
+        "trusted"
+        if all(hook.get("trustStatus") in _TRUSTED_HOOK_STATUSES for hook in hooks)
+        else "review_required"
+    )
+
+
 def _hooks_list_diagnostics(listed: _JsonObject, cwd: str) -> str:
     """
     Summarize a ``hooks/list`` response for a discovery-failure error.

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1483,6 +1483,9 @@ class SqlScheduledTask(OmnigentBase):
     last_run_conversation_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    requires_hook_review: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false()
+    )
 
     __table_args__ = (
         CheckConstraint("state IN (1, 2, 3)", name="ck_scheduled_tasks_state"),

--- a/omnigent/db/migrations/versions/zb2c3d4e5f6a_require_hook_review_for_scheduled_tasks.py
+++ b/omnigent/db/migrations/versions/zb2c3d4e5f6a_require_hook_review_for_scheduled_tasks.py
@@ -1,0 +1,25 @@
+"""Persist scheduled-task hook review state.
+
+Revision ID: zb2c3d4e5f6a
+Revises: za2b3c4d5e6f
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "zb2c3d4e5f6a"
+down_revision = "za2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_tasks",
+        sa.Column("requires_hook_review", sa.Boolean(), server_default=sa.false(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("scheduled_tasks") as batch_op:
+        batch_op.drop_column("requires_hook_review")

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -82,6 +82,7 @@ class ScheduledTask:
     last_run_at: int | None = None
     last_run_conversation_id: str | None = None
     updated_at: int | None = None
+    requires_hook_review: bool = False
 
 
 @dataclass

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -146,6 +146,7 @@ _CODEX_HOME_COPY_FILES = ("config.toml",)
 _CODEX_HOME_SYMLINK_DIRS = (Path("plugins") / "cache",)
 _CODEX_MINIMAL_CONFIG_ENV = "HARNESS_CODEX_MINIMAL_CONFIG"
 _CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
+_CODEX_HOOK_TRUST_LOCK = threading.Lock()
 
 # Environment variables explicitly excluded from the codex subprocess even
 # when their prefix is in the allowlist. ``OPENAI_API_KEY`` is stripped so
@@ -1096,6 +1097,191 @@ def merge_codex_hook_payloads(payloads: Iterable[Mapping[str, Any]]) -> dict[str
     return {"hooks": merged_hooks}
 
 
+def _codex_hook_event_key(event: str) -> str:
+    """Return Codex's trust-key spelling for a hooks.json event name."""
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", event).lower()
+
+
+def _codex_user_hook_trust_key_map(
+    source_hooks_path: Path,
+    private_hooks_path: Path,
+) -> dict[str, str]:
+    """Map source user-hook trust keys to their indices in a merged private file."""
+    try:
+        source = json.loads(source_hooks_path.read_text(encoding="utf-8"))
+        private = json.loads(private_hooks_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    source_hooks = source.get("hooks") if isinstance(source, dict) else None
+    private_hooks = private.get("hooks") if isinstance(private, dict) else None
+    if not isinstance(source_hooks, dict) or not isinstance(private_hooks, dict):
+        return {}
+
+    source_path = str(source_hooks_path.absolute())
+    private_path = str(private_hooks_path.absolute())
+    mapped: dict[str, str] = {}
+    for event, source_groups in source_hooks.items():
+        private_groups = private_hooks.get(event)
+        if (
+            not isinstance(event, str)
+            or not isinstance(source_groups, list)
+            or not source_groups
+            or not isinstance(private_groups, list)
+            or len(private_groups) < len(source_groups)
+        ):
+            continue
+        offset = len(private_groups) - len(source_groups)
+        # Omnigent appends user groups after generated groups. Refuse to map
+        # when either file changed and that invariant no longer holds.
+        if private_groups[offset:] != source_groups:
+            continue
+        event_key = _codex_hook_event_key(event)
+        for source_group_index, group in enumerate(source_groups):
+            hooks = group.get("hooks") if isinstance(group, dict) else None
+            if not isinstance(hooks, list):
+                continue
+            for hook_index in range(len(hooks)):
+                source_key = f"{source_path}:{event_key}:{source_group_index}:{hook_index}"
+                private_key = (
+                    f"{private_path}:{event_key}:{offset + source_group_index}:{hook_index}"
+                )
+                mapped[source_key] = private_key
+    return mapped
+
+
+def _write_codex_config_document(path: Path, document: Any) -> None:  # type: ignore[explicit-any]
+    """Atomically write one Codex TOML document with owner-only permissions."""
+    import tomlkit
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(tomlkit.dumps(document))
+        os.replace(tmp_name, path)
+    finally:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+
+
+def _retarget_codex_user_hook_trust(
+    private_config_path: Path,
+    source_hooks_path: Path,
+    private_hooks_path: Path,
+) -> None:
+    """Seed a merged private hooks file with trust already granted to user hooks."""
+    key_map = _codex_user_hook_trust_key_map(source_hooks_path, private_hooks_path)
+    if not key_map:
+        return
+    try:
+        import tomlkit
+
+        document = tomlkit.parse(private_config_path.read_text(encoding="utf-8"))
+        state = document.get("hooks", {}).get("state", {})
+    except (OSError, ValueError, TypeError):
+        return
+    if not isinstance(state, MutableMapping):
+        return
+
+    changed = False
+    for source_key, private_key in key_map.items():
+        source_entry = state.get(source_key)
+        trusted_hash = (
+            source_entry.get("trusted_hash") if isinstance(source_entry, MutableMapping) else None
+        )
+        if isinstance(trusted_hash, str) and state.get(private_key) != source_entry:
+            entry = tomlkit.table()
+            entry["trusted_hash"] = trusted_hash
+            state[private_key] = entry
+            changed = True
+    if changed:
+        try:
+            _write_codex_config_document(private_config_path, document)
+        except OSError:
+            logger.warning(
+                "could not carry user hook trust into %s",
+                private_config_path,
+                exc_info=True,
+            )
+
+
+def _merge_codex_user_hook_trust_back(private_home: Path, source_home: Path) -> None:
+    """Persist newly approved private user hooks into the shared Codex config."""
+    private_config_path = private_home / "config.toml"
+    source_hooks_path = source_home / _CODEX_HOOKS_FILENAME
+    private_hooks_path = private_home / _CODEX_HOOKS_FILENAME
+    key_map = _codex_user_hook_trust_key_map(source_hooks_path, private_hooks_path)
+    if not key_map:
+        return
+
+    try:
+        import tomlkit
+
+        private = tomlkit.parse(private_config_path.read_text(encoding="utf-8"))
+        private_state = private.get("hooks", {}).get("state", {})
+    except (OSError, ValueError, TypeError):
+        return
+    if not isinstance(private_state, MutableMapping):
+        return
+
+    approved: dict[str, str] = {}
+    for source_key, private_key in key_map.items():
+        private_entry = private_state.get(private_key)
+        trusted_hash = (
+            private_entry.get("trusted_hash")
+            if isinstance(private_entry, MutableMapping)
+            else None
+        )
+        if isinstance(trusted_hash, str):
+            approved[source_key] = trusted_hash
+    if not approved:
+        return
+
+    source_config_path = source_home / "config.toml"
+    write_path = (
+        source_config_path.resolve() if source_config_path.is_symlink() else source_config_path
+    )
+    with _CODEX_HOOK_TRUST_LOCK:
+        try:
+            source = (
+                tomlkit.parse(write_path.read_text(encoding="utf-8"))
+                if write_path.is_file()
+                else tomlkit.document()
+            )
+        except (OSError, ValueError, TypeError):
+            logger.warning("could not read shared Codex config for hook-trust persistence")
+            return
+        if "hooks" not in source:
+            source["hooks"] = tomlkit.table()
+        hooks = source["hooks"]
+        if not isinstance(hooks, MutableMapping):
+            return
+        if "state" not in hooks:
+            hooks["state"] = tomlkit.table()
+        state = hooks["state"]
+        if not isinstance(state, MutableMapping):
+            return
+        changed = False
+        for source_key, trusted_hash in approved.items():
+            current = state.get(source_key)
+            current_hash = (
+                current.get("trusted_hash") if isinstance(current, MutableMapping) else None
+            )
+            if current_hash == trusted_hash:
+                continue
+            entry = tomlkit.table()
+            entry["trusted_hash"] = trusted_hash
+            state[source_key] = entry
+            changed = True
+        if changed:
+            try:
+                _write_codex_config_document(write_path, source)
+            except OSError:
+                logger.warning(
+                    "could not persist user hook trust to %s", write_path, exc_info=True
+                )
+
+
 def write_codex_hooks_file(
     codex_home: Path,
     payloads: Sequence[Mapping[str, Any]],
@@ -1135,6 +1321,12 @@ def write_codex_hooks_file(
     finally:
         if os.path.exists(tmp_name):
             os.unlink(tmp_name)
+    if merge_source is not None:
+        _retarget_codex_user_hook_trust(
+            codex_home / "config.toml",
+            merge_source,
+            path,
+        )
     return path
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -467,6 +467,7 @@ class _CodexNativeLaunchConfig:
     auto_harness: bool = False
     routing_enabled: bool = False
     turn_routing: bool = False
+    scheduled_task_trigger: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1019,6 +1020,7 @@ async def _codex_native_launch_config(
     # conversation label ("1" to enable). Read here so the runner applies
     # it at launch; any other value (incl. absent) leaves the normal stance.
     bypass_sandbox = False
+    scheduled_task_trigger: str | None = None
     labels = snapshot.get("labels")
     if isinstance(labels, dict):
         _fsi = labels.get(FORK_SOURCE_LABEL_KEY)
@@ -1029,6 +1031,9 @@ async def _codex_native_launch_config(
             fork_source_external_id = _fse
         fork_carry_history = labels.get(FORK_CARRY_HISTORY_LABEL_KEY) == "1"
         bypass_sandbox = labels.get(CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY) == "1"
+        raw_trigger = labels.get("omnigent.scheduled_task.trigger")
+        if raw_trigger in {"manual", "scheduled"}:
+            scheduled_task_trigger = raw_trigger
     # One derivation of the session's Smart Routing class, shared with the SDK
     # codex path, so "pinned" and "auto-harness" mean the same on both.
     routing_class = routing_class_from_snapshot(
@@ -1049,6 +1054,7 @@ async def _codex_native_launch_config(
         auto_harness=routing_class.auto_harness,
         routing_enabled=routing_class.routing_enabled,
         turn_routing=routing_class.turn_routing,
+        scheduled_task_trigger=scheduled_task_trigger,
     )
 
 
@@ -3733,6 +3739,7 @@ async def _auto_create_codex_terminal(
         build_codex_remote_args,
         codex_session_meta_model_provider,
         codex_terminal_env,
+        codex_user_hooks_audit_status,
         preload_codex_thread_for_resume,
         resolve_native_codex_launch,
     )
@@ -4047,6 +4054,39 @@ async def _auto_create_codex_terminal(
     await app_server.start()
     _AUTO_CODEX_APP_SERVERS[session_id] = app_server
 
+    bypass_hook_trust = (
+        app_server.codex_cli_version is not None
+        and app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+    )
+    if launch_config.scheduled_task_trigger == "scheduled":
+        audit_client = CodexAppServerClient(ws_url=codex_ws_url, client_name="omnigent-hook-audit")
+        await audit_client.connect()
+        try:
+            audit = await codex_user_hooks_audit_status(audit_client.request, cwd=workspace)
+        finally:
+            await audit_client.close()
+        if audit != "trusted":
+            code = (
+                "hook_audit_required" if audit == "review_required" else "hook_audit_unavailable"
+            )
+            publish_event(
+                session_id,
+                {
+                    "type": "session.status",
+                    "status": "failed",
+                    "error": {
+                        "code": code,
+                        "message": "Run this automation manually to review its Codex hooks.",
+                    },
+                },
+            )
+            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+            await app_server.close()
+            raise RuntimeError(code)
+        bypass_hook_trust = True
+    elif launch_config.scheduled_task_trigger == "manual":
+        bypass_hook_trust = False
+
     event_client = CodexAppServerClient(
         ws_url=codex_ws_url,
         client_name="omnigent-codex-native-auto",
@@ -4126,23 +4166,9 @@ async def _auto_create_codex_terminal(
                     # OpenAI built-in (which would force the first-run
                     # login screen and block thread creation).
                     config_overrides=tuple(app_server.config_overrides),
-                    # Omnigent provisions the private CODEX_HOME and vets
-                    # hook sources itself; skip the interactive trust prompt
-                    # that headless sub-agents can never answer.
-                    #
-                    # Requires a *positively parsed* version, unlike the
-                    # hooks-file gate in ``codex_native_app_server``, which
-                    # treats an unknown version as supported. The two differ
-                    # because their failure modes do: an unsupported hooks
-                    # file is ignored by codex and caught downstream at the
-                    # trust check, whereas an unknown CLI flag aborts argv
-                    # parsing — so a transient ``codex --version`` hiccup on a
-                    # pre-0.131 codex would turn a recoverable trust prompt
-                    # into a dead terminal.
-                    bypass_hook_trust=(
-                        app_server.codex_cli_version is not None
-                        and app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
-                    ),
+                    # Scheduled runs only bypass after an audit; manual runs
+                    # keep new or changed hooks reviewable in terminal view.
+                    bypass_hook_trust=bypass_hook_trust,
                 ),
                 env=codex_terminal_env(app_server),
                 # Match the local ``omnigent codex`` terminal scrollback.
@@ -4184,8 +4210,11 @@ async def _auto_create_codex_terminal(
                 bridge_dir=bridge_dir,
                 codex_ws_url=codex_ws_url,
                 codex_home=codex_home,
+                require_user_hook_trust=launch_config.scheduled_task_trigger == "manual",
+                hook_audit_cwd=workspace,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
+                publish_event=publish_event,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4235,6 +4264,9 @@ async def _codex_discover_thread_and_forward(
     codex_home: Path,
     event_client: CodexAppServerClient,
     routing_summary: str,
+    require_user_hook_trust: bool = False,
+    hook_audit_cwd: str = "",
+    publish_event: Callable[[str, _JsonObject], None] | None = None,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4261,6 +4293,11 @@ async def _codex_discover_thread_and_forward(
         routing (provider / profile / model, or the login-fallback state),
         threaded into the startup-timeout error so hosted users can diagnose
         without runner-log access (see #2745).
+    :param require_user_hook_trust: Verify manual automation hook approval
+        after Codex starts its thread.
+    :param hook_audit_cwd: Workspace used for manual automation hook audit.
+    :param publish_event: Optional session event publisher. Production launch
+        supplies it; tests that do not exercise hook review may omit it.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4308,6 +4345,26 @@ async def _codex_discover_thread_and_forward(
             return
 
         app_server = _AUTO_CODEX_APP_SERVERS.get(session_id)
+        if require_user_hook_trust and app_server is not None:
+            from omnigent.codex_native_app_server import codex_user_hooks_audit_status
+
+            audit = await codex_user_hooks_audit_status(event_client.request, cwd=hook_audit_cwd)
+            if audit != "trusted":
+                code = (
+                    "hook_audit_required"
+                    if audit == "review_required"
+                    else "hook_audit_unavailable"
+                )
+                if publish_event is not None:
+                    publish_event(
+                        session_id,
+                        {
+                            "type": "session.status",
+                            "status": "failed",
+                            "error": {"code": code, "message": "Hooks were not approved."},
+                        },
+                    )
+                return
         persist_user_hook_trust = getattr(app_server, "persist_user_hook_trust", None)
         if callable(persist_user_hook_trust):
             try:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4307,6 +4307,21 @@ async def _codex_discover_thread_and_forward(
             )
             return
 
+        app_server = _AUTO_CODEX_APP_SERVERS.get(session_id)
+        persist_user_hook_trust = getattr(app_server, "persist_user_hook_trust", None)
+        if callable(persist_user_hook_trust):
+            try:
+                # Hook review happens before thread creation. Persist here so
+                # the next concurrently-opened session inherits the approval;
+                # close() repeats this as a teardown fallback.
+                await asyncio.to_thread(persist_user_hook_trust)
+            except Exception:  # noqa: BLE001 - trust carry must not block chat startup
+                _logger.warning(
+                    "Could not persist Codex user hook trust for %s",
+                    session_id,
+                    exc_info=True,
+                )
+
         write_bridge_state(
             bridge_dir,
             CodexNativeBridgeState(

--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -127,6 +127,7 @@ def _to_response(
         "last_run_at": task.last_run_at,
         "last_run_status": last_run_status,
         "last_run_conversation_id": task.last_run_conversation_id,
+        "requires_hook_review": task.requires_hook_review,
         "next_run_at": next_run_at,
         "updated_at": task.updated_at,
     }
@@ -448,15 +449,15 @@ def create_scheduled_tasks_router(
                 "scheduled task scheduler is not running",
                 code=ErrorCode.RUNNER_UNAVAILABLE,
             )
-        started = await run_now(task.workspace_id, task.id)
-        if not started:
+        run_id = await run_now(task.workspace_id, task.id)
+        if not run_id:
             # The row exists (we just loaded it) and paused is allowed, so the
             # only skip reason is an already-in-flight fire for this task.
             raise OmnigentError(
                 "a run for this scheduled task is already in flight",
                 code=ErrorCode.CONFLICT,
             )
-        return {"triggered": True, "id": task.id}
+        return {"triggered": True, "id": task.id, "run_id": run_id}
 
     @router.patch("/scheduled-tasks/{scheduled_task_id}")
     async def update_scheduled_task(

--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -173,7 +173,7 @@ def build_run_now(
     deps: FireDeps,
     *,
     launch_dispatch: LaunchDispatch | None = None,
-) -> Callable[[int, str], Awaitable[bool]]:
+) -> Callable[[int, str], Awaitable[str | None]]:
     """Build the manual "run now" trigger — an immediate fire of a task.
 
     Reuses the exact scheduled-fire machinery (the same
@@ -200,7 +200,7 @@ def build_run_now(
     else:
         dispatch = launch_dispatch
 
-    async def run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+    async def run_now(workspace_id: int, scheduled_task_id: str) -> str | None:
         return await _trigger_fire(
             deps,
             workspace_id,
@@ -221,7 +221,7 @@ async def _trigger_fire(
     preflight: ConnectedHostPreflight | None,
     *,
     require_active: bool,
-) -> bool:
+) -> str | None:
     """Synchronously guard a fire, then dispatch the run in the background.
 
     Shared by the scheduled fire path (``require_active=True``) and the manual
@@ -239,32 +239,68 @@ async def _trigger_fire(
         task = await asyncio.to_thread(deps.scheduled_task_store.get, scheduled_task_id)
         if task is None:
             _logger.info("scheduled fire: task %s no longer exists — skipping", scheduled_task_id)
-            return False
+            return None
         if require_active and task.state != "active":
             _logger.info(
                 "scheduled fire: task %s is %s (not active) — skipping",
                 scheduled_task_id,
                 task.state,
             )
-            return False
+            return None
+        if require_active and task.requires_hook_review:
+            _logger.info("scheduled fire: task %s needs manual hook review", scheduled_task_id)
+            return None
+        latest_runs, _ = await asyncio.to_thread(
+            deps.scheduled_task_store.list_runs, scheduled_task_id, limit=1
+        )
+        if latest_runs and latest_runs[0].status in {"scheduled", "running"}:
+            _logger.info(
+                "scheduled fire: task %s has a persisted in-flight run", scheduled_task_id
+            )
+            return None
 
     key = (workspace_id, scheduled_task_id)
     if key in _IN_FLIGHT_TASKS:
         _logger.info("scheduled fire: task %s already in flight — skipping", scheduled_task_id)
-        return False
+        return None
     _IN_FLIGHT_TASKS.add(key)
+
+    run_id = _new_id()
+    scheduled_at = int(time.time())
+    with workspace_scope(workspace_id):
+        await asyncio.to_thread(
+            deps.scheduled_task_store.create_run,
+            run_id,
+            scheduled_task_id,
+            "scheduled",
+            scheduled_at,
+        )
+        await asyncio.to_thread(
+            deps.scheduled_task_store.update,
+            scheduled_task_id,
+            last_run_at=scheduled_at,
+        )
 
     # Fire-and-forget: the session create + launch runs in the background so the
     # caller returns immediately (the scheduler re-arms the timer now; the route
     # returns 202).
     fire_task = asyncio.create_task(
-        _run_fire(deps, workspace_id, scheduled_task_id, dispatch, preflight, require_active),
+        _run_fire(
+            deps,
+            workspace_id,
+            scheduled_task_id,
+            dispatch,
+            preflight,
+            require_active,
+            run_id,
+            scheduled_at,
+        ),
         name=f"scheduled-fire-{scheduled_task_id}",
     )
     _PENDING_FIRES.add(fire_task)
     fire_task.add_done_callback(_PENDING_FIRES.discard)
     fire_task.add_done_callback(lambda _task: _IN_FLIGHT_TASKS.discard(key))
-    return True
+    return run_id
 
 
 async def _run_fire(
@@ -274,6 +310,8 @@ async def _run_fire(
     dispatch: LaunchDispatch,
     preflight: ConnectedHostPreflight | None,
     require_active: bool = True,
+    run_id: str | None = None,
+    scheduled_at: int | None = None,
 ) -> None:
     """Background body of a firing: create session, grant, launch, record run.
 
@@ -294,9 +332,17 @@ async def _run_fire(
             )
             return
 
-        scheduled_at = int(time.time())
+        scheduled_at = scheduled_at or int(time.time())
         try:
-            await _run_fire_for_task(deps, task, dispatch, preflight, scheduled_at)
+            await _run_fire_for_task(
+                deps,
+                task,
+                dispatch,
+                preflight,
+                scheduled_at,
+                run_id=run_id,
+                manual=not require_active,
+            )
         except Exception:
             _logger.exception("scheduled fire: task %s failed", task.id)
 
@@ -307,6 +353,9 @@ async def _run_fire_for_task(
     dispatch: LaunchDispatch,
     preflight: ConnectedHostPreflight | None,
     scheduled_at: int,
+    *,
+    run_id: str | None = None,
+    manual: bool = False,
 ) -> None:
     """Run a freshly re-read active task inside its workspace scope."""
     try:
@@ -323,6 +372,7 @@ async def _run_fire_for_task(
                 None,
                 scheduled_at,
                 "skipped",
+                run_id=run_id,
                 error=f"execution_target {task.execution_target!r} not supported yet",
                 error_code="unsupported_target",
             )
@@ -351,6 +401,7 @@ async def _run_fire_for_task(
                 status="failed",
                 error=str(exc),
                 error_code=exc.error_code,
+                run_id=run_id,
             )
             return
 
@@ -366,6 +417,7 @@ async def _run_fire_for_task(
                 status="failed",
                 error=error,
                 error_code=error_code,
+                run_id=run_id,
             )
             return
 
@@ -382,6 +434,7 @@ async def _run_fire_for_task(
                     status="failed",
                     error=str(exc),
                     error_code=exc.error_code,
+                    run_id=run_id,
                 )
                 return
 
@@ -407,11 +460,12 @@ async def _run_fire_for_task(
                 status="failed",
                 error=error,
                 error_code=error_code,
+                run_id=run_id,
             )
             return
 
         try:
-            conv = await _create_session(deps, effective)
+            conv = await _create_session(deps, effective, manual=manual)
         except Exception:
             _logger.exception("scheduled fire: failed to create session for task %s", task.id)
             await _record_run(
@@ -422,6 +476,7 @@ async def _run_fire_for_task(
                 status="failed",
                 error="session creation failed",
                 error_code="session_create_failed",
+                run_id=run_id,
             )
             return
 
@@ -441,8 +496,24 @@ async def _run_fire_for_task(
                 status="failed",
                 error="owner grant failed",
                 error_code="owner_grant_failed",
+                run_id=run_id,
             )
             return
+
+        if run_id is not None:
+            fired_at = int(time.time())
+            await asyncio.to_thread(
+                deps.scheduled_task_store.update_run,
+                run_id,
+                status="running",
+                conversation_id=conv.id,
+                fired_at=fired_at,
+            )
+            await asyncio.to_thread(
+                deps.scheduled_task_store.update,
+                task.id,
+                last_run_conversation_id=conv.id,
+            )
 
         try:
             await dispatch(conv, effective)
@@ -462,10 +533,12 @@ async def _run_fire_for_task(
                 status="failed",
                 error="runner launch/dispatch failed",
                 error_code="launch_failed",
+                run_id=run_id,
             )
             return
 
-        await _record_run(deps, task, conv.id, scheduled_at, status="running")
+        if run_id is None:
+            await _record_run(deps, task, conv.id, scheduled_at, status="running")
         _logger.info("scheduled fire: task %s fired session %s", task.id, conv.id)
     except Exception:
         _logger.exception("scheduled fire: task %s failed", task.id)
@@ -583,7 +656,9 @@ async def _resolve_default_workspace(deps: FireDeps, host_id: str) -> str:
     return canonical
 
 
-async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
+async def _create_session(
+    deps: FireDeps, task: ScheduledTask, *, manual: bool = False
+) -> Conversation:
     """Create a conversation bound to the task's agent, carrying the stored spec."""
     # Connected-host, existing-workspace runs create the conversation directly.
     # Future execution modes such as managed sandbox, branch selection, and
@@ -594,6 +669,12 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         title=task.name,
         host_id=task.host_id,
         workspace=task.workspace,
+        labels={
+            "omnigent.ui": "terminal",
+            "omnigent.wrapper": "codex-native-ui",
+            "omnigent.scheduled_task.id": task.id,
+            "omnigent.scheduled_task.trigger": "manual" if manual else "scheduled",
+        },
     )
     if task.model_override is not None or task.reasoning_effort is not None:
         updated: Conversation | None = await asyncio.to_thread(
@@ -631,6 +712,7 @@ async def _record_run(
     status: str,
     error: str | None = None,
     error_code: str | None = None,
+    run_id: str | None = None,
 ) -> None:
     """Stamp last_run_* on the task and write a scheduled_task_runs row."""
     await asyncio.to_thread(
@@ -642,6 +724,7 @@ async def _record_run(
         status,
         error=error,
         error_code=error_code,
+        run_id=run_id,
     )
 
 
@@ -654,6 +737,7 @@ def _record_run_sync(
     *,
     error: str | None = None,
     error_code: str | None = None,
+    run_id: str | None = None,
 ) -> None:
     """Synchronous run recording body for ``asyncio.to_thread`` callers."""
     now = int(time.time())
@@ -661,16 +745,27 @@ def _record_run_sync(
     if conversation_id is not None:
         update_fields["last_run_conversation_id"] = conversation_id
     deps.scheduled_task_store.update(task.id, **update_fields)
-    deps.scheduled_task_store.create_run(
-        _new_id(),
-        task.id,
-        status,
-        scheduled_at,
-        conversation_id=conversation_id,
-        fired_at=now,
-        error=error,
-        error_code=error_code,
-    )
+    if run_id is not None:
+        deps.scheduled_task_store.update_run(
+            run_id,
+            status=status,
+            conversation_id=conversation_id,
+            fired_at=now,
+            finished_at=now if status not in {"scheduled", "running"} else None,
+            error=error,
+            error_code=error_code,
+        )
+    else:
+        deps.scheduled_task_store.create_run(
+            _new_id(),
+            task.id,
+            status,
+            scheduled_at,
+            conversation_id=conversation_id,
+            fired_at=now,
+            error=error,
+            error_code=error_code,
+        )
 
 
 async def _validate_fire_session_inputs(

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -233,6 +233,10 @@ def persist_scheduled_run_completion(
             error=error,
             error_code=error_code,
         )
+        if error_code in {"hook_audit_required", "hook_audit_unavailable"}:
+            store.update(run.scheduled_task_id, requires_hook_review=True)
+        elif run_status == "succeeded":
+            store.update(run.scheduled_task_id, requires_hook_review=False)
 
     _submit("scheduled_run_completion", _transition)
 

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -136,6 +136,7 @@ class ScheduledTaskStore(ABC):
         state: str | None = None,
         last_run_at: int | None = None,
         last_run_conversation_id: str | None = _UNSET,
+        requires_hook_review: bool | None = None,
     ) -> ScheduledTask | None:
         """
         Update mutable fields of a task.
@@ -230,7 +231,9 @@ class ScheduledTaskStore(ABC):
         run_id: str,
         *,
         status: str,
-        finished_at: int,
+        finished_at: int | None = None,
+        conversation_id: str | None = None,
+        fired_at: int | None = None,
         error: str | None = None,
         error_code: str | None = None,
     ) -> ScheduledTaskRun | None:

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -61,6 +61,7 @@ def _to_entity(row: SqlScheduledTask) -> ScheduledTask:
         last_run_at=row.last_run_at,
         last_run_conversation_id=row.last_run_conversation_id,
         updated_at=row.updated_at,
+        requires_hook_review=row.requires_hook_review,
     )
 
 
@@ -251,6 +252,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         state: str | None = None,
         last_run_at: int | None = None,
         last_run_conversation_id: str | None = _UNSET,
+        requires_hook_review: bool | None = None,
     ) -> ScheduledTask | None:
         """Update mutable fields.
 
@@ -301,6 +303,12 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
                 row.last_run_conversation_id != last_run_conversation_id
             ):
                 row.last_run_conversation_id = last_run_conversation_id
+                changed = True
+            if (
+                requires_hook_review is not None
+                and row.requires_hook_review != requires_hook_review
+            ):
+                row.requires_hook_review = requires_hook_review
                 changed = True
             if changed:
                 row.updated_at = now_epoch()
@@ -413,23 +421,32 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         run_id: str,
         *,
         status: str,
-        finished_at: int,
+        finished_at: int | None = None,
+        conversation_id: str | None = None,
+        fired_at: int | None = None,
         error: str | None = None,
         error_code: str | None = None,
     ) -> ScheduledTaskRun | None:
-        """Transition a still-``running`` run to a terminal status.
+        """Advance a still-pending run without clobbering a terminal run.
 
         Conditional on the current status being ``running`` so an
         already-terminal run is never clobbered and concurrent sweeps cannot
         double-transition (see the interface docstring).
         """
-        running_code = encode_scheduled_task_run_status("running")
+        active_codes = {
+            encode_scheduled_task_run_status("scheduled"),
+            encode_scheduled_task_run_status("running"),
+        }
         with self._session("update_task_run") as session:
             row = session.get(SqlScheduledTaskRun, (current_workspace_id(), run_id))
-            if row is None or row.status != running_code:
+            if row is None or row.status not in active_codes:
                 return None
             row.status = encode_scheduled_task_run_status(status)
             row.finished_at = finished_at
+            if conversation_id is not None:
+                row.conversation_id = conversation_id
+            if fired_at is not None:
+                row.fired_at = fired_at
             row.error = error
             row.error_code = error_code
             session.flush()
@@ -471,13 +488,16 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         """
         if not scheduled_task_ids:
             return []
-        running_code = encode_scheduled_task_run_status("running")
+        active_codes = (
+            encode_scheduled_task_run_status("scheduled"),
+            encode_scheduled_task_run_status("running"),
+        )
         with self._session("list_running_runs_for_tasks") as session:
             stmt = (
                 select(SqlScheduledTaskRun)
                 .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
                 .where(SqlScheduledTaskRun.scheduled_task_id.in_(scheduled_task_ids))
-                .where(SqlScheduledTaskRun.status == running_code)
+                .where(SqlScheduledTaskRun.status.in_(active_codes))
                 .order_by(desc(SqlScheduledTaskRun.scheduled_at), desc(SqlScheduledTaskRun.id))
             )
             rows = session.execute(stmt).scalars().all()

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -68,6 +68,7 @@ def test_scheduled_tasks_columns(db_engine: Engine) -> None:
         "state",
         "last_run_at",
         "last_run_conversation_id",
+        "requires_hook_review",
         "created_at",
         "updated_at",
     }

--- a/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
+++ b/tests/e2e_ui/scheduled/test_scheduled_tasks_page.py
@@ -24,6 +24,11 @@ import httpx
 from playwright.sync_api import Page, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
+    SqlAlchemyScheduledTaskStore,
+)
+from tests.e2e_ui.conftest import _server_state
+
 
 def _builtin_agent_id(base_url: str, name: str) -> str:
     """Look up a built-in agent's id by name via ``GET /v1/agents``.
@@ -96,6 +101,16 @@ def _create_task(
 def _row_by_name(page: Page, name: str):
     """The scheduled-task row whose title matches ``name``."""
     return page.locator('[data-testid="scheduled-task-row"]').filter(has_text=name)
+
+
+def _require_hook_review(task_id: str) -> None:
+    """Mark a seeded task as requiring review in the isolated test database."""
+    database_uri = _server_state.get("database_uri")
+    assert database_uri, "live_server did not publish its isolated database URI"
+    updated = SqlAlchemyScheduledTaskStore(str(database_uri)).update(
+        task_id, requires_hook_review=True
+    )
+    assert updated is not None
 
 
 def _pick_minute(page: Page, minute: int) -> None:
@@ -396,6 +411,26 @@ def test_scheduled_task_row_run_controls(
         page.wait_for_timeout(200)
         deadline += 1
     assert _has_failed_run(), "Run now did not record a failed run within the timeout"
+
+
+def test_scheduled_task_row_surfaces_required_hook_review(
+    page: Page,
+    live_server: str,
+) -> None:
+    """A task blocked by changed Codex hooks exposes its manual review action."""
+    agent_id = _builtin_agent_id(live_server, "hello_world")
+    task_id = _create_task(
+        live_server, agent_id, "Review target", "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+    )
+    _require_hook_review(task_id)
+
+    page.goto(f"{live_server}/tasks")
+    row = _row_by_name(page, "Review target")
+    expect(row).to_contain_text("Needs hook review", timeout=30_000)
+
+    row.hover()
+    row.get_by_test_id("task-row-menu").click()
+    expect(page.get_by_test_id("task-run-now")).to_have_text("Review hooks")
 
 
 # ── Model + reasoning-effort selectors (PR #3331) ──────────────────────────

--- a/tests/inner/test_codex_hooks_generation.py
+++ b/tests/inner/test_codex_hooks_generation.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import tomllib
 
 from omnigent.inner import codex_executor
 from omnigent.inner.codex_executor import (
@@ -17,12 +18,14 @@ from omnigent.inner.codex_executor import (
     CODEX_ROUTER_DIR_ENV_VAR,
     CODEX_ROUTER_SESSION_ID_ENV_VAR,
     _CodexAppServerSession,
+    _merge_codex_user_hook_trust_back,
     _populate_codex_home_config,
     codex_extended_catalog_requested,
     codex_router_bridge_dir,
     codex_router_hooks_settings,
     codex_router_session_id,
     merge_codex_user_hooks,
+    write_codex_hooks_file,
     write_codex_router_hooks_file,
 )
 from omnigent.inner.hook_scripts.subagent_router import REQUEST_TIMEOUT_S
@@ -307,6 +310,57 @@ def test_app_server_keeps_symlinked_hooks_when_routing_off(
 
     assert argv[:2] == ("/bin/echo", "app-server")
     assert hooks.is_symlink
+
+
+def test_generated_hooks_retarget_existing_user_hook_trust(tmp_path: Path) -> None:
+    """Previously approved user hooks stay trusted after generated hooks shift indices."""
+    source = _write_user_home(tmp_path, hooks=_USER_HOOKS)
+    source_key = f"{source / 'hooks.json'}:pre_tool_use:0:0"
+    source_config = (
+        f'model = "gpt-5.4-mini"\n[hooks.state."{source_key}"]\ntrusted_hash = "sha256:user-pre"\n'
+    )
+    (source / "config.toml").write_text(source_config)
+    private = tmp_path / "private-codex"
+    private.mkdir()
+    _populate_codex_home_config(private, source, inject_hooks=True)
+
+    generated = {
+        "hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "generated"}]}]}
+    }
+    write_codex_hooks_file(private, [generated], user_hooks_source=source / "hooks.json")
+
+    config = tomllib.loads((private / "config.toml").read_text())
+    state = config["hooks"]["state"]
+    private_user_key = f"{private / 'hooks.json'}:pre_tool_use:1:0"
+    private_generated_key = f"{private / 'hooks.json'}:pre_tool_use:0:0"
+    assert state[private_user_key]["trusted_hash"] == "sha256:user-pre"
+    assert private_generated_key not in state
+    assert (source / "config.toml").read_text() == source_config
+
+
+def test_user_hook_trust_merges_back_without_generated_hooks(tmp_path: Path) -> None:
+    """Session approval persists under source indices; generated trust does not leak back."""
+    source = _write_user_home(tmp_path, hooks=_USER_HOOKS)
+    private = tmp_path / "private-codex"
+    private.mkdir()
+    generated = {
+        "hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "generated"}]}]}
+    }
+    write_codex_hooks_file(private, [generated], user_hooks_source=source / "hooks.json")
+    private_config = (
+        f'[hooks.state."{private / "hooks.json"}:pre_tool_use:0:0"]\n'
+        'trusted_hash = "sha256:generated"\n'
+        f'[hooks.state."{private / "hooks.json"}:pre_tool_use:1:0"]\n'
+        'trusted_hash = "sha256:user-approved"\n'
+    )
+    (private / "config.toml").write_text(private_config)
+
+    _merge_codex_user_hook_trust_back(private, source)
+
+    config = tomllib.loads((source / "config.toml").read_text())
+    state = config["hooks"]["state"]
+    source_user_key = f"{source / 'hooks.json'}:pre_tool_use:0:0"
+    assert state == {source_user_key: {"trusted_hash": "sha256:user-approved"}}
 
 
 # ── The three codex session classes (SDK arm) ───────────────────────

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -3078,6 +3078,59 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
 
 
 @pytest.mark.asyncio
+async def test_codex_discovery_persists_hook_trust_before_bridge_ready(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Approval is shared immediately, without waiting for session teardown."""
+    from omnigent import codex_native_bridge, codex_native_forwarder
+    from omnigent.runner.app import (
+        _AUTO_CODEX_APP_SERVERS,
+        _codex_discover_thread_and_forward,
+    )
+
+    persisted = 0
+
+    class _StopAfterPersist(Exception):
+        pass
+
+    class _Client:
+        async def close(self) -> None:
+            return None
+
+    class _AppServer:
+        def persist_user_hook_trust(self) -> None:
+            nonlocal persisted
+            persisted += 1
+
+        async def close(self) -> None:
+            return None
+
+    async def _thread_started(_client: object) -> str:
+        return "thread-1"
+
+    def _stop_before_bridge_ready(*_args: object, **_kwargs: object) -> None:
+        assert persisted == 1
+        raise _StopAfterPersist
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _thread_started)
+    monkeypatch.setattr(codex_native_bridge, "write_bridge_state", _stop_before_bridge_ready)
+
+    session_id = "4f49d70cecb04eeabdc7390a1e92b4af"
+    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    with pytest.raises(_StopAfterPersist):
+        await _codex_discover_thread_and_forward(
+            session_id=session_id,
+            bridge_dir=tmp_path,
+            codex_ws_url="ws://127.0.0.1:1",
+            codex_home=tmp_path / "codex-home",
+            event_client=_Client(),  # type: ignore[arg-type]
+            routing_summary="provider 'test'",
+        )
+
+    assert persisted == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("exc", "expected_cause"),
     [

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -1075,26 +1075,27 @@ async def test_run_now_triggers_and_records_a_run(
 
     calls: list[tuple[int, str]] = []
     now = int(time.time())
+    run_id = uuid.uuid4().hex
 
-    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> bool:
+    async def _fake_run_now(workspace_id: int, scheduled_task_id: str) -> str:
         calls.append((workspace_id, scheduled_task_id))
         # Use a current-time fire so the LIST endpoint's stale backstop (6h age
         # from fired_at) does NOT reap this fresh in-flight run to ``failed``.
         SqlAlchemyScheduledTaskStore(db_uri).create_run(
-            run_id=uuid.uuid4().hex,
+            run_id=run_id,
             scheduled_task_id=scheduled_task_id,
             status="running",
             scheduled_at=now,
             conversation_id=uuid.uuid4().hex,
             fired_at=now,
         )
-        return True
+        return run_id
 
     auth_app.state.scheduled_task_run_now = _fake_run_now
 
     resp = await auth_client.post(f"/v1/scheduled-tasks/{task_id}/run", headers=_headers())
     assert resp.status_code == 202, resp.text
-    assert resp.json() == {"triggered": True, "id": task_id}
+    assert resp.json() == {"triggered": True, "id": task_id, "run_id": run_id}
     # The trigger was invoked with the task's workspace + id.
     assert calls == [(0, task_id)]
 

--- a/tests/server/scheduled/test_fire.py
+++ b/tests/server/scheduled/test_fire.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -91,6 +92,17 @@ class FakeScheduledTaskStore:
             }
         )
         return None
+
+    def list_runs(self, scheduled_task_id: str, *, limit: int = 100) -> tuple[list[Any], None]:
+        rows = [SimpleNamespace(**row, id=row["run_id"]) for row in reversed(self.runs)]
+        return rows[:limit], None
+
+    def update_run(self, run_id: str, *, status: str, **kwargs: Any) -> Any:
+        run = next((item for item in self.runs if item["run_id"] == run_id), None)
+        if run is None:
+            return None
+        run.update(status=status, **kwargs)
+        return run
 
 
 class SequencedScheduledTaskStore(FakeScheduledTaskStore):
@@ -284,7 +296,7 @@ async def test_pause_between_on_fire_and_run_fire_is_noop() -> None:
 
     assert launches == []
     assert conv_store.created == []
-    assert store.runs == []
+    assert store.runs[0]["status"] == "scheduled"
 
 
 @pytest.mark.asyncio
@@ -302,7 +314,7 @@ async def test_delete_between_on_fire_and_run_fire_is_noop() -> None:
 
     assert launches == []
     assert conv_store.created == []
-    assert store.runs == []
+    assert store.runs[0]["status"] == "scheduled"
 
 
 @pytest.mark.asyncio
@@ -355,7 +367,7 @@ async def test_fire_runs_under_task_workspace_scope() -> None:
     assert store.get_workspace_ids == [42, 42]
     assert conv_store.create_workspace_ids == [42]
     assert perm.grant_workspace_ids == [42]
-    assert store.update_workspace_ids == [42]
+    assert store.update_workspace_ids == [42, 42]
     assert store.run_workspace_ids == [42]
 
 
@@ -1001,7 +1013,7 @@ async def test_run_now_active_creates_session_grant_and_run() -> None:
     started = await run_now(0, "task_1")
     await _drain()
 
-    assert started is True
+    assert isinstance(started, str)
     assert len(conv_store.created) == 1
     assert perm.grants and perm.grants[0][2] == LEVEL_OWNER
     assert len(launched) == 1
@@ -1026,7 +1038,7 @@ async def test_run_now_fires_paused_task() -> None:
     started = await run_now(0, "task_1")
     await _drain()
 
-    assert started is True
+    assert isinstance(started, str)
     assert len(conv_store.created) == 1
     assert len(launched) == 1
     assert len(store.runs) == 1
@@ -1046,7 +1058,7 @@ async def test_run_now_missing_row_is_noop() -> None:
     started = await run_now(0, "task_1")
     await _drain()
 
-    assert started is False
+    assert started is None
     assert launched == []
     assert store.runs == []
 
@@ -1076,8 +1088,8 @@ async def test_run_now_skips_when_already_in_flight() -> None:
         if conv_store.created:
             break
         await asyncio.sleep(0.01)
-    assert first is True
-    assert second is False
+    assert isinstance(first, str)
+    assert second is None
     assert len(conv_store.created) == 1
     release.set()
     await _drain()

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -27,6 +27,7 @@ from omnigent.codex_native_app_server import (
     _our_policy_hooks_from_list,
     _sync_codex_developer_instructions,
     build_codex_native_server,
+    codex_user_hooks_audit_status,
     discover_codex_model_options,
     framework_approved_tools,
     trust_codex_router_hooks,
@@ -37,6 +38,34 @@ from omnigent.inner.codex_executor import (
     _populate_codex_home_config,
     _provider_codex_config_overrides,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trust_status", "expected"),
+    [("trusted", "trusted"), ("untrusted", "review_required"), (None, "unavailable")],
+)
+async def test_codex_user_hooks_audit_status(trust_status: str | None, expected: str) -> None:
+    async def request(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        assert method == "hooks/list"
+        return {
+            "result": {
+                "data": [
+                    {
+                        "cwd": "/repo",
+                        "hooks": [
+                            {
+                                "command": "/repo/my-hook.sh",
+                                "currentHash": "abc" if trust_status is not None else None,
+                                "trustStatus": trust_status,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+
+    assert await codex_user_hooks_audit_status(request, cwd="/repo") == expected
 
 
 async def test_discover_codex_model_options_strips_secrets_and_stops_process(

--- a/web/src/components/scheduled/ScheduledTaskRow.test.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.test.tsx
@@ -29,6 +29,7 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     lastRunAt: null,
     lastRunStatus: null,
     lastRunConversationId: null,
+    requiresHookReview: false,
     nextRunAt: null,
     ...overrides,
   };
@@ -95,6 +96,13 @@ describe("⋯ menu actions", () => {
     expect(runNow).toBeInTheDocument();
     fireEvent.click(runNow);
     expect(onRunNow).toHaveBeenCalledWith(t);
+  });
+
+  it("labels tasks that need hook review and offers the review action", () => {
+    renderRow(task({ requiresHookReview: true }));
+    expect(screen.getByText("Needs hook review")).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByTestId("task-row-menu"), { button: 0 });
+    expect(screen.getByTestId("task-run-now")).toHaveTextContent("Review hooks");
   });
 
   it("disables the menu trigger while the row is busy", () => {

--- a/web/src/components/scheduled/ScheduledTaskRow.tsx
+++ b/web/src/components/scheduled/ScheduledTaskRow.tsx
@@ -57,6 +57,7 @@ export function ScheduledTaskRow({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const paused = task.state === "paused";
+  const needsReview = task.requiresHookReview;
   // Subtitle: the schedule summary, plus the SERVER's next-run time when armed
   // (active tasks only — a paused task has null nextRunAt). We only format the
   // delta from the server value against the ticking `now`; we never recompute
@@ -91,6 +92,11 @@ export function ScheduledTaskRow({
               className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
             >
               Paused
+            </span>
+          )}
+          {needsReview && (
+            <span className="shrink-0 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              Needs hook review
             </span>
           )}
         </span>
@@ -133,7 +139,7 @@ export function ScheduledTaskRow({
         <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={() => onRunNow(task)} data-testid="task-run-now">
             <ZapIcon className="size-4" />
-            Run now
+            {needsReview ? "Review hooks" : "Run now"}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => onEdit(task)} data-testid="task-edit">
             <PencilIcon className="size-4" />

--- a/web/src/hooks/useScheduledTasks.test.tsx
+++ b/web/src/hooks/useScheduledTasks.test.tsx
@@ -60,7 +60,7 @@ beforeEach(() => {
   vi.mocked(api.createScheduledTask).mockResolvedValue(TASK);
   vi.mocked(api.updateScheduledTask).mockResolvedValue({ ...TASK, state: "paused" });
   vi.mocked(api.deleteScheduledTask).mockResolvedValue(undefined);
-  vi.mocked(api.runScheduledTaskNow).mockResolvedValue(undefined);
+  vi.mocked(api.runScheduledTaskNow).mockResolvedValue({ runId: "run_1" });
 });
 
 afterEach(() => {

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -50,7 +50,7 @@ export function useScheduledTasks() {
     // page-scoped poll into app-wide 60s background traffic. If you need a
     // persistent scheduled-tasks indicator, add a SEPARATE lightweight query
     // (no short refetchInterval, or a much longer one) — don't reuse this one.
-    refetchInterval: 60_000,
+    refetchInterval: 5_000,
   });
 }
 

--- a/web/src/lib/scheduledTasksApi.ts
+++ b/web/src/lib/scheduledTasksApi.ts
@@ -53,6 +53,7 @@ export interface ScheduledTask {
    */
   lastRunStatus: ScheduledTaskRunStatus | null;
   lastRunConversationId: string | null;
+  requiresHookReview?: boolean;
   /**
    * ISO-8601 timestamp of the next scheduled fire, computed by the SERVER's
    * live scheduler (its authoritative anchor), or `null` when the task is
@@ -126,6 +127,7 @@ interface ScheduledTaskWire {
   last_run_at: number | null;
   last_run_status: ScheduledTaskRunStatus | null;
   last_run_conversation_id: string | null;
+  requires_hook_review?: boolean;
   next_run_at: string | null;
 }
 
@@ -200,6 +202,7 @@ function taskFromWire(wire: ScheduledTaskWire): ScheduledTask {
     lastRunAt: wire.last_run_at,
     lastRunStatus: wire.last_run_status,
     lastRunConversationId: wire.last_run_conversation_id,
+    requiresHookReview: wire.requires_hook_review,
     nextRunAt: wire.next_run_at,
   };
 }
@@ -305,9 +308,10 @@ export async function deleteScheduledTask(id: string): Promise<void> {
  * `void` — callers invalidate the list + runs queries to pick up the new run's
  * status. A `409` (already in flight) surfaces as a {@link ScheduledTaskApiError}.
  */
-export async function runScheduledTaskNow(id: string): Promise<void> {
+export async function runScheduledTaskNow(id: string): Promise<{ runId: string }> {
   const res = await authenticatedFetch(`/v1/scheduled-tasks/${encodeURIComponent(id)}/run`, {
     method: "POST",
   });
-  if (!res.ok) throw await errorFromResponse(res);
+  const body = await readJsonOrThrow<{ run_id: string }>(res);
+  return { runId: body.run_id };
 }

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -31,6 +31,9 @@ import { useNow } from "@/hooks/useNow";
 import type { ScheduledTask } from "@/lib/scheduledTasksApi";
 import { nextRunAtMs } from "@/lib/scheduleText";
 import { cn } from "@/lib/utils";
+import { useNavigate } from "@/lib/routing";
+import { listScheduledTaskRuns } from "@/lib/scheduledTasksApi";
+import { showToast } from "@/components/ui/toast";
 
 type FilterTab = "all" | "active" | "paused";
 
@@ -49,6 +52,7 @@ export function TasksPage() {
   const updateMutation = useUpdateScheduledTask();
   const deleteMutation = useDeleteScheduledTask();
   const runNowMutation = useRunScheduledTaskNow();
+  const navigate = useNavigate();
 
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<FilterTab>("all");
@@ -134,8 +138,30 @@ export function TasksPage() {
     deleteMutation.mutate(task.id);
   }
 
-  function handleRunNow(task: ScheduledTask) {
-    runNowMutation.mutate(task.id);
+  async function handleRunNow(task: ScheduledTask) {
+    try {
+      showToast(task.requiresHookReview ? "Opening hook review…" : "Starting automation…");
+      const { runId } = await runNowMutation.mutateAsync(task.id);
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        // Sequential polling is intentional: each request observes later server state.
+        // eslint-disable-next-line no-await-in-loop
+        const run = (await listScheduledTaskRuns(task.id)).find((item) => item.id === runId);
+        if (run?.conversationId) {
+          navigate(`/c/${run.conversationId}?view=terminal`);
+          return;
+        }
+        if (run && ["failed", "skipped", "incomplete"].includes(run.status)) {
+          throw new Error(`Automation could not start (${run.errorCode ?? run.status})`);
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, 500);
+        });
+      }
+      throw new Error("Automation is taking too long to start");
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Automation could not start");
+    }
   }
 
   function handleEdit(task: ScheduledTask) {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -416,6 +416,11 @@ export function AppShell() {
   // toggle. Snapshot wins on conflict; spreading undefined is a no-op.
   const sessionLabels = { ...activeConv?.labels, ...activeSession?.labels };
   const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
+  useEffect(() => {
+    if (terminalFirst && searchParams.get("view") === "terminal" && panelInitialKey === null) {
+      setPanelInitialKeyState(PANEL_NO_TERMINAL_KEY);
+    }
+  }, [terminalFirst, searchParams, panelInitialKey]);
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
   const todos = useChatStore((s) => s.todos);
   // The session.todos contract is harness-agnostic; show Tasks when it has data.


### PR DESCRIPTION
## Draft status

There needs to be a new UI element to review hooks. The PR and attached screenshot show a proposal.

## Related issue

Closes #4937

## Summary

- Carry unchanged user-hook trust between Omnigent's per-session private `CODEX_HOME` directories while preserving Codex's hash checks.
- Fail unattended scheduled runs closed when hooks need review; manual runs remain interactive and persist successful approval.
- Show `Needs hook review` and `Review hooks` on the Tasks page, then open the run's terminal view for approval.

ELI5: approve unchanged hooks once. If hooks change, scheduled work stops safely and points you to a manual review button.

```text
scheduled run -> audit trusted? -- yes -> run
                              \-- no --> mark task "Needs hook review"
manual Review hooks -> terminal approval -> persist trusted hash -> future scheduled run
```

## Test Plan

- Focused backend suite: 217 passed.
- Frontend Vitest suite: 5,785 passed, 3 expected failures, 1 skipped.
- `pnpm run type-check`: passed.
- New Playwright hook-review test: 1 passed on Chromium.
- Ruff check and format check: passed for changed Python files.

## Demo

Screenshot pending attachment before review. The Playwright journey verifies the `Needs hook review` badge and `Review hooks` action against a live isolated server.

<img width="1280" height="720" alt="omnigent-hook-review" src="https://github.com/user-attachments/assets/120a9d15-8603-486c-9ee4-e6a021f09ed8" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes trust-key translation, changed-hook rejection, private/shared config persistence, scheduled/manual dispatch behavior, migration round-trip safety, API serialization, row labels/actions, and the live-server Playwright journey.

## Changelog

Scheduled Codex automations now stop safely for changed hooks and offer a manual review flow before resuming.
