### PR TITLE
fix(web): quote server URLs in generated commands

### DIFF
--- a/web/src/lib/shell.test.ts
+++ b/web/src/lib/shell.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { quoteShellArgument } from "./shell";
+
+describe("quoteShellArgument", () => {
+  it("keeps shell metacharacters inside one quoted argument", () => {
+    expect(quoteShellArgument("https://example.com/api?profile=dev&glob=*")).toBe(
+      "'https://example.com/api?profile=dev&glob=*'",
+    );
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(quoteShellArgument("don't-expand")).toBe("'don'\"'\"'t-expand'");
+  });
+});

--- a/web/src/lib/shell.ts
+++ b/web/src/lib/shell.ts
@@ -1,0 +1,4 @@
+/** Quote a value so a POSIX shell parses it as one literal argument. */
+export function quoteShellArgument(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1359,14 +1359,24 @@ describe("NewChatLandingScreen", () => {
     );
   });
 
-  it("opens the connect-host instructions from the host dropdown", () => {
-    renderLanding();
+  it("quotes server URLs in host and Lakebox connect commands", () => {
+    setOmnigentHostConfig({ cliServerUrlSuffix: "/api?profile=dev&glob=*" });
+    renderLanding({ databricks_features: true });
     // Radix dropdowns open on pointerdown (a bare click doesn't in jsdom).
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-connect-host"));
-    // The modal mounts the connect instructions with the runnable command.
+
     expect(screen.getByTestId("connect-host-dialog")).toBeTruthy();
-    expect(screen.getByTestId("connect-host-command")).toBeTruthy();
+    expect(screen.getByTestId("connect-host-command")).toHaveTextContent(
+      `omni host --server '${window.location.origin}/api?profile=dev&glob=*'`,
+    );
+
+    const lakeboxTab = screen.getByRole("tab", { name: "Databricks Lakebox" });
+    fireEvent.mouseDown(lakeboxTab);
+    fireEvent.click(lakeboxTab);
+    expect(screen.getByTestId("connect-lakebox-connect-command")).toHaveTextContent(
+      `omni sandbox connect --provider lakebox --sandbox-id <id> --server '${window.location.origin}/api?profile=dev&glob=*'`,
+    );
   });
 
   it("offers connect-host even when no hosts are online (no dead end)", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -102,6 +102,7 @@ import {
   type ProjectPrefillState,
 } from "./projectPrefill";
 import { getCliServerUrl, getOmnigentHostConfig } from "@/lib/host";
+import { quoteShellArgument } from "@/lib/shell";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
 import {
   readLastHostChoice,
@@ -468,6 +469,7 @@ export function ConnectHostInstructions({
   // "loading" before the boot probe resolves → treat as OSS (no Databricks
   // hints) until known, so the clean UI shows first and lakebox never flashes.
   const databricksFeatures = info !== "loading" && info.databricks_features;
+  const quotedServerUrl = quoteShellArgument(serverUrl);
   return (
     <div className="flex flex-col gap-4 rounded-lg border border-dashed border-border p-4">
       {label && <p className="text-sm text-muted-foreground">{label}</p>}
@@ -483,7 +485,7 @@ export function ConnectHostInstructions({
           </TabsList>
           <TabsContent value="local">
             <CliCommandBlock
-              command={`omni host --server ${serverUrl}`}
+              command={`omni host --server ${quotedServerUrl}`}
               testIdPrefix="connect-host"
             />
           </TabsContent>
@@ -493,13 +495,16 @@ export function ConnectHostInstructions({
               testIdPrefix="connect-lakebox-create"
             />
             <CliCommandBlock
-              command={`omni sandbox connect --provider lakebox --sandbox-id <id> --server ${serverUrl}`}
+              command={`omni sandbox connect --provider lakebox --sandbox-id <id> --server ${quotedServerUrl}`}
               testIdPrefix="connect-lakebox-connect"
             />
           </TabsContent>
         </Tabs>
       ) : (
-        <CliCommandBlock command={`omni host --server ${serverUrl}`} testIdPrefix="connect-host" />
+        <CliCommandBlock
+          command={`omni host --server ${quotedServerUrl}`}
+          testIdPrefix="connect-host"
+        />
       )}
     </div>
   );

--- a/web/src/shell/ReconnectSessionDialog.test.tsx
+++ b/web/src/shell/ReconnectSessionDialog.test.tsx
@@ -72,7 +72,7 @@ describe("buildReconnectCommand", () => {
       state: "host_offline",
     });
     expect(cmd).toContain("omnigent host");
-    expect(cmd).toContain("--server https://example.databricksapps.com");
+    expect(cmd).toContain("--server 'https://example.databricksapps.com'");
     // The --profile flag was removed from the CLI; emitting it here would
     // hand users a command that errors with "No such option".
     expect(cmd).not.toContain("--profile");
@@ -103,8 +103,17 @@ describe("buildReconnectCommand", () => {
     });
     expect(cmd).toContain("omnigent run path/to/agent.yaml");
     expect(cmd).toContain("--resume conv_abc123");
-    expect(cmd).toContain("--server https://example.databricksapps.com");
+    expect(cmd).toContain("--server 'https://example.databricksapps.com'");
     expect(cmd).not.toContain("--profile");
+  });
+
+  it("quotes server URLs containing shell metacharacters", () => {
+    const cmd = buildReconnectCommand({
+      conversationId: "conv_query",
+      serverUrl: "https://example.com/api?profile=dev&glob=*",
+      state: "host_offline",
+    });
+    expect(cmd).toContain("--server 'https://example.com/api?profile=dev&glob=*'");
   });
 
   it("emits `omnigent claude --resume` for a claude-native local_stranded session", () => {

--- a/web/src/shell/ReconnectSessionDialog.tsx
+++ b/web/src/shell/ReconnectSessionDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { quoteShellArgument } from "@/lib/shell";
 import { CliCommandBlock } from "./CliCommandBlock";
 import { ForkSessionForm } from "./ForkSessionDialog";
 import { SwitchHostDialog } from "./SwitchHostDialog";
@@ -68,20 +69,21 @@ export function buildReconnectCommand({
 }): string {
   // Backslash-continued so the command stays readable inside a narrow
   // dialog AND remains valid when pasted into a shell.
+  const quotedServerUrl = quoteShellArgument(serverUrl);
   if (state === "host_offline") {
-    return ["omnigent host \\", `  --server ${serverUrl}`].join("\n");
+    return ["omnigent host \\", `  --server ${quotedServerUrl}`].join("\n");
   }
   if (wrapper === CLAUDE_NATIVE_WRAPPER) {
     return [
       "omnigent claude \\",
       `  --resume ${conversationId} \\`,
-      `  --server ${serverUrl}`,
+      `  --server ${quotedServerUrl}`,
     ].join("\n");
   }
   return [
     "omnigent run path/to/agent.yaml \\",
     `  --resume ${conversationId} \\`,
-    `  --server ${serverUrl}`,
+    `  --server ${quotedServerUrl}`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-3481/quote-server-urls-in-ui-connection-commands

## Summary

- Prevent shells from interpreting query strings and other metacharacters in server URLs shown by the web UI.
- Quote server URLs as single POSIX shell arguments across host, Lakebox, reconnect, and resume commands.
- Cover command rendering and embedded quote escaping with focused tests.

## Test Plan

- `cd web && npm test -- src/lib/shell.test.ts src/shell/ReconnectSessionDialog.test.tsx`
- `cd web && npm test -- src/shell/NewChatDialog.test.tsx -t "quotes server URLs"`
- `cd web && npm run type-check`
- `cd web && ./node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives src/lib/shell.ts src/lib/shell.test.ts src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx src/shell/ReconnectSessionDialog.tsx src/shell/ReconnectSessionDialog.test.tsx`
- `cd web && npm exec -- prettier --check src/lib/shell.ts src/lib/shell.test.ts src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx src/shell/ReconnectSessionDialog.tsx src/shell/ReconnectSessionDialog.test.tsx`

## Demo

Before:

```sh
omni host --server https://example.com/api?profile=dev&glob=*
```

After:

```sh
omni host --server 'https://example.com/api?profile=dev&glob=*'
```

<img width="728" height="416" alt="image" src="https://github.com/user-attachments/assets/2ba2a5ce-6dd4-4e86-954f-9c63e72af89e" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies shell quoting directly and rendering through both connection-command UI paths.

## Changelog

Server URLs in copyable connection and reconnect commands are now safely quoted.
