### PR TITLE
fix(codex): pin shadowed config provider on resume

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -2283,8 +2283,9 @@ def resolve_native_codex_launch(
         config (issue #2744 — parity with the in-process codex harness).
     :returns: The resolved :class:`NativeCodexLaunch`.
     """
+    from omnigent.onboarding.ambient import codex_config_detection
     from omnigent.onboarding.detected import (
-        codex_config_provider_dismissed,
+        dismissed_detection_names,
         effective_config_with_detected,
     )
     from omnigent.onboarding.provider_config import (
@@ -2296,14 +2297,17 @@ def resolve_native_codex_launch(
     from omnigent.spec.types import DatabricksAuth
 
     explicit = load_config()
+    config_detection = codex_config_detection()
+    config_provider_dismissed = (
+        config_detection is not None
+        and config_detection.name in dismissed_detection_names(explicit)
+    )
     # When the launch ends up on codex's own login with NO provider routing,
     # the bridged config.toml's custom default model_provider would still
     # apply — including one the user explicitly Removed (dismissed). Pin
     # codex's built-in provider in that case so the dismissal holds at run
     # time. An undetectable/undismissed custom provider keeps its routing.
-    no_provider_overrides = (
-        ['model_provider="openai"'] if codex_config_provider_dismissed(explicit) else []
-    )
+    no_provider_overrides = ['model_provider="openai"'] if config_provider_dismissed else []
     if spec is not None and (
         spec.executor.auth is not None
         or spec.executor.profile
@@ -2383,6 +2387,31 @@ def resolve_native_codex_launch(
                 summary="Codex CLI login (global auth block, non-Databricks; no provider routing)",
             )
         entry = default_provider_for_harness(effective_config_with_detected(explicit), "codex")
+
+    if (
+        entry is None
+        and config_detection is not None
+        and config_detection.model_provider is not None
+        and not config_provider_dismissed
+    ):
+        # An adopted cli-config entry can explicitly shadow the same ambient
+        # detection without being marked the Omnigent default. Codex still
+        # selects that provider from config.toml, so pin the already-resolved
+        # detection instead of describing this as an OpenAI-login launch.
+        # This keeps rollout metadata, app-server, and remote TUI routing on
+        # one immutable provider selection during cold resume.
+        provider_id = config_detection.model_provider
+        _logger.info(
+            "native-codex routing: config.toml provider %r (ambient fallback, model=%s)",
+            provider_id,
+            model,
+        )
+        return NativeCodexLaunch(
+            config_overrides=[f"model_provider={json.dumps(provider_id)}"],
+            model=model,
+            profile=None,
+            summary=f"Codex config.toml provider {provider_id!r} (ambient fallback)",
+        )
 
     if entry is None:
         _logger.info(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -10272,11 +10272,12 @@ def test_resolve_native_codex_launch_no_provider_sets_login_fallback_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No configured provider -> summary names the login fallback (#2745)."""
-    from omnigent.onboarding import detected, provider_config
+    from omnigent.onboarding import ambient, detected, provider_config
     from omnigent.runtime import workflow
 
     monkeypatch.setattr(provider_config, "load_config", dict)
-    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda cfg: False)
+    monkeypatch.setattr(ambient, "codex_config_detection", lambda: None)
+    monkeypatch.setattr(detected, "dismissed_detection_names", lambda cfg: frozenset())
     monkeypatch.setattr(detected, "effective_config_with_detected", lambda cfg: {})
     monkeypatch.setattr(provider_config, "default_provider_for_harness", lambda cfg, harness: None)
     monkeypatch.setattr(workflow, "_load_global_auth", lambda: None)
@@ -10292,11 +10293,12 @@ def test_resolve_native_codex_launch_databricks_provider_sets_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A Databricks provider default -> summary names the ucode profile (#2745)."""
-    from omnigent.onboarding import detected, provider_config
+    from omnigent.onboarding import ambient, detected, provider_config
 
     entry = SimpleNamespace(kind=provider_config.DATABRICKS_KIND, profile="my-profile")
     monkeypatch.setattr(provider_config, "load_config", dict)
-    monkeypatch.setattr(detected, "codex_config_provider_dismissed", lambda cfg: False)
+    monkeypatch.setattr(ambient, "codex_config_detection", lambda: None)
+    monkeypatch.setattr(detected, "dismissed_detection_names", lambda cfg: frozenset())
     monkeypatch.setattr(
         provider_config, "default_provider_for_harness", lambda cfg, harness: entry
     )

--- a/tests/test_native_codex_provider.py
+++ b/tests/test_native_codex_provider.py
@@ -440,6 +440,74 @@ def test_resolve_native_codex_launch_undismissed_config_provider_routes_via_pin(
     assert launch.profile is None
 
 
+def test_config_provider_shadowed_by_nondefault_explicit_entry_still_pins(
+    _isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A nondefault adopted entry cannot hide Codex's active config provider.
+
+    The explicit entry shadows ambient synthesis by name, but Codex itself
+    still selects the provider from config.toml. An empty launch would make a
+    synthesized resume rollout record OpenAI and lose this provider's auth.
+    """
+    monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    codex_dir = _isolated / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text(_DISMISSIBLE_CODEX_CONFIG)
+    _seed(
+        _isolated,
+        {
+            "codex-databricks": {
+                "kind": "cli-config",
+                "cli": "codex",
+                "model_provider": "Databricks",
+                "display_name": "Databricks AI Gateway",
+            }
+        },
+    )
+
+    launch = resolve_native_codex_launch(model="test-model")
+
+    assert launch.config_overrides == ['model_provider="Databricks"']
+    assert launch.model == "test-model"
+    assert launch.profile is None
+
+
+def test_shadowed_config_detection_uses_active_profile_provider(
+    _isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback pins the provider selected by Codex's active profile."""
+    monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    codex_dir = _isolated / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text(
+        'profile = "work"\n'
+        'model_provider = "UnusedTopLevel"\n'
+        "[profiles.work]\n"
+        'model_provider = "Databricks"\n'
+        "[model_providers.Databricks]\n"
+        'name = "Databricks AI Gateway"\n'
+        'base_url = "https://example.ai-gateway.cloud.databricks.com/codex/v1"\n'
+        "[model_providers.Databricks.auth]\n"
+        'command = "jq"\n'
+    )
+    _seed(
+        _isolated,
+        {
+            "codex-databricks": {
+                "kind": "cli-config",
+                "cli": "codex",
+                "model_provider": "Databricks",
+                "display_name": "Databricks AI Gateway",
+            }
+        },
+    )
+
+    launch = resolve_native_codex_launch(model=None)
+
+    assert launch.config_overrides == ['model_provider="Databricks"']
+    assert launch.profile is None
+
+
 # ── Spec-level credentials (issue #2744) ────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — reported and reproduced locally.

## Summary

- Preserve the provider selected by Codex's top-level `config.toml` when synthesizing a cold-resume rollout.
- Keep explicit provider overrides and Databricks profile launches unchanged, while malformed config still falls back safely to the built-in OpenAI provider.
- Add regression coverage for config-default, dismissal-state, and malformed UTF-8 scenarios.

ELI5: a resumed conversation now records the same provider Codex is actually configured to call, instead of incorrectly recording OpenAI and losing the configured authentication path.

```text
config.toml default ──► rollout model_provider ──► resumed Codex request
       Databricks              Databricks              Databricks
```

## Test Plan

- `uv run --frozen pytest tests/test_codex_native.py -k 'resume_uses_config_default_model_provider or auth_unavailable_reason_config_default_provider_available or auth_unavailable_reason_explicit_openai_needs_auth'`
- `uv run --frozen ruff check omnigent/codex_native_app_server.py tests/test_codex_native.py`
- `uv run --frozen ruff format --check omnigent/codex_native_app_server.py tests/test_codex_native.py`
- `git diff --check`

## Demo

N/A — non-visual backend fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused unit test exercises the config-default provider, mutable dismissal state after launch resolution, and malformed UTF-8 fallback. Existing availability tests cover config-default and explicit OpenAI routing.

## Changelog

Resumed Codex conversations now keep the authentication provider selected in Codex configuration.
