### PR TITLE
perf(permissions): short-lived resolve_access cache on the event path

### DIFF
--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import collections
+import os
+import threading
+import time
+from collections.abc import Callable
 from typing import cast
 
 from sqlalchemy import delete, exists, literal, select, update
@@ -25,6 +30,60 @@ from omnigent.stores.permission_store import PermissionStore
 # actors. Mirrors accounts_store._HIDDEN_LIST_USERS so the admin user
 # list is identical across auth modes.
 _HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_LOCAL})
+
+# Short-lived cache of resolve_access() results. The per-event access-control
+# check on a busy session otherwise re-reads session_permissions + users on
+# every streamed event, for a session whose grants are stable across the turn.
+# Only a *positive* standing is cached — a no-access result is never stored, so
+# a freshly granted user is authorized on their next request, not after the TTL.
+# This store's own grant/revoke/reassign/set_admin writes evict, and a
+# generation counter stops an in-flight reader from re-storing a pre-commit
+# positive on top of that eviction, so once such a write returns this instance
+# serves no stale decision. Role changes made through the separate accounts
+# store (admin demote, user delete) are NOT evicted here and propagate within
+# the TTL. Across replicas there is no invalidation broadcast either, so a
+# revoke can be up to the TTL late elsewhere; that window is LEVEL_EDIT only —
+# the destructive stop/kill path re-gates LEVEL_OWNER separately, and a deleted
+# session still 404s on its uncached conversation read. Entries are keyed by
+# (conversation_id, user_id):
+# conversation ids are globally unique, so eviction needs no workspace context,
+# and the map is an LRU bounded by a hard entry cap so a long-lived replica
+# cannot grow it without limit (resolve_access is on the snapshot path too, not
+# just the hot event path). Set the TTL env to 0 to disable (zero overhead).
+_RESOLVE_ACCESS_CACHE_TTL_ENV = "OMNIGENT_ACL_RESOLVE_CACHE_TTL_S"
+_DEFAULT_RESOLVE_ACCESS_CACHE_TTL_S = 5.0
+_RESOLVE_ACCESS_CACHE_MAX_ENTRIES_ENV = "OMNIGENT_ACL_RESOLVE_CACHE_MAX_ENTRIES"
+_DEFAULT_RESOLVE_ACCESS_CACHE_MAX_ENTRIES = 50_000
+
+
+def _resolve_access_cache_ttl_s() -> float:
+    """Read the resolve_access cache TTL (seconds) from the environment.
+
+    Defaults to :data:`_DEFAULT_RESOLVE_ACCESS_CACHE_TTL_S`; a value <= 0
+    disables the cache. An unparseable value falls back to the default.
+    """
+    raw = os.environ.get(_RESOLVE_ACCESS_CACHE_TTL_ENV)
+    if raw is None:
+        return _DEFAULT_RESOLVE_ACCESS_CACHE_TTL_S
+    try:
+        return max(float(raw), 0.0)
+    except ValueError:
+        return _DEFAULT_RESOLVE_ACCESS_CACHE_TTL_S
+
+
+def _resolve_access_cache_max_entries() -> int:
+    """Read the resolve_access cache entry cap from the environment.
+
+    Defaults to :data:`_DEFAULT_RESOLVE_ACCESS_CACHE_MAX_ENTRIES`; ``0`` means
+    unbounded. An unparseable value falls back to the default.
+    """
+    raw = os.environ.get(_RESOLVE_ACCESS_CACHE_MAX_ENTRIES_ENV)
+    if raw is None:
+        return _DEFAULT_RESOLVE_ACCESS_CACHE_MAX_ENTRIES
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        return _DEFAULT_RESOLVE_ACCESS_CACHE_MAX_ENTRIES
 
 
 def _to_account(row: SqlUser) -> Account:
@@ -78,6 +137,27 @@ class SqlAlchemyPermissionStore(PermissionStore):
             self._engine,
             query_name_prefix="omnigent.permission_store",
         )
+        # resolve_access cache (see _RESOLVE_ACCESS_CACHE_TTL_ENV). An LRU keyed
+        # (conversation_id, user_id) -> (expiry, access). conversation ids are
+        # globally unique, so grant/revoke can drop a whole session's entries —
+        # including the shared __public__ grant, which affects every user of
+        # that session — without depending on the ambient workspace context.
+        # The hard entry cap bounds memory on a long-lived replica. Per store
+        # instance, so each replica caches independently and tests get a fresh
+        # cache with each store. ``_resolve_cache_clock`` is injectable for
+        # deterministic TTL tests.
+        self._resolve_cache_ttl_s = _resolve_access_cache_ttl_s()
+        self._resolve_cache_max_entries = _resolve_access_cache_max_entries()
+        self._resolve_cache: collections.OrderedDict[
+            tuple[str, str], tuple[float, ResolvedAccess]
+        ] = collections.OrderedDict()
+        self._resolve_cache_lock = threading.Lock()
+        self._resolve_cache_clock: Callable[[], float] = time.monotonic
+        # Bumped by every invalidation. resolve_access samples it before its DB
+        # read and refuses to store a result sampled under an older generation,
+        # so a reader whose snapshot predates a concurrent grant/revoke commit
+        # cannot re-poison the cache after that write already evicted.
+        self._resolve_cache_generation = 0
 
     def grant(
         self,
@@ -120,11 +200,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 )
             session.execute(stmt)
             session.flush()
-            return SessionPermission(
-                user_id=user_id,
-                conversation_id=conversation_id,
-                level=level,
-            )
+        # Evict after commit: the grant changed this session's access picture.
+        self._invalidate_resolve_cache_for_session(conversation_id)
+        return SessionPermission(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            level=level,
+        )
 
     def revoke(self, user_id: str, conversation_id: str) -> bool:
         """Remove a permission grant. See base class for contract."""
@@ -139,7 +221,11 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     )
                 ),
             )
-            return result.rowcount > 0
+            deleted = result.rowcount > 0
+        # Evict after commit: a revoke must not be served stale from this
+        # instance's cache.
+        self._invalidate_resolve_cache_for_session(conversation_id)
+        return deleted
 
     def get(self, user_id: str, conversation_id: str) -> SessionPermission | None:
         """Look up a single grant. See base class for contract."""
@@ -222,7 +308,10 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     .values(user_id=to_user_id)
                 )
                 moved = len(reassign_ids)
-            return moved
+        # Grants moved between users across sessions; drop this store's cache
+        # (the no-rows path above returned early, having changed nothing).
+        self._invalidate_resolve_cache_all()
+        return moved
 
     def list_for_session(
         self,
@@ -352,6 +441,9 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 )
                 .values(is_admin=is_admin)
             )
+        # The admin flag flips access on every session for this user; drop
+        # this store's cache.
+        self._invalidate_resolve_cache_all()
 
     def check_access(
         self,
@@ -391,6 +483,66 @@ class SqlAlchemyPermissionStore(PermissionStore):
             return public_grant.level
         return None
 
+    def _resolve_cache_lookup(self, conversation_id: str, user_id: str) -> ResolvedAccess | None:
+        """Return a live cached resolve_access result, or ``None`` on miss/expiry."""
+        now = self._resolve_cache_clock()
+        key = (conversation_id, user_id)
+        with self._resolve_cache_lock:
+            entry = self._resolve_cache.get(key)
+            if entry is None:
+                return None
+            expiry, access = entry
+            if now >= expiry:
+                del self._resolve_cache[key]
+                return None
+            self._resolve_cache.move_to_end(key)  # LRU: mark most-recently used
+            return access
+
+    def _resolve_cache_generation_now(self) -> int:
+        """Sample the invalidation generation before a read begins."""
+        with self._resolve_cache_lock:
+            return self._resolve_cache_generation
+
+    def _resolve_cache_store(
+        self,
+        conversation_id: str,
+        user_id: str,
+        access: ResolvedAccess,
+        generation: int,
+    ) -> None:
+        """Cache one *granted* resolve_access result until now + TTL.
+
+        Dropped when *generation* is stale — an invalidation landed while this
+        result was being read, so the value may predate that write and must not
+        be stored on top of the eviction it already performed. Enforces the LRU
+        entry cap so the cache cannot grow without bound on a long-lived replica.
+        """
+        key = (conversation_id, user_id)
+        expiry = self._resolve_cache_clock() + self._resolve_cache_ttl_s
+        with self._resolve_cache_lock:
+            if generation != self._resolve_cache_generation:
+                return
+            self._resolve_cache[key] = (expiry, access)
+            self._resolve_cache.move_to_end(key)
+            max_entries = self._resolve_cache_max_entries
+            if max_entries > 0:
+                while len(self._resolve_cache) > max_entries:
+                    self._resolve_cache.popitem(last=False)  # drop least-recently used
+
+    def _invalidate_resolve_cache_for_session(self, conversation_id: str) -> None:
+        """Drop every cached decision for one session (all users + ``__public__``)."""
+        with self._resolve_cache_lock:
+            self._resolve_cache_generation += 1
+            stale = [key for key in self._resolve_cache if key[0] == conversation_id]
+            for key in stale:
+                del self._resolve_cache[key]
+
+    def _invalidate_resolve_cache_all(self) -> None:
+        """Drop the whole cache — for admin-flag or bulk-grant changes."""
+        with self._resolve_cache_lock:
+            self._resolve_cache_generation += 1
+            self._resolve_cache.clear()
+
     def resolve_access(
         self,
         user_id: str | None,
@@ -403,6 +555,17 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 user_grant_level=None,
                 public_grant_level=None,
             )
+        workspace_id = current_workspace_id()
+        cache_enabled = self._resolve_cache_ttl_s > 0
+        generation = 0
+        if cache_enabled:
+            cached = self._resolve_cache_lookup(conversation_id, user_id)
+            if cached is not None:
+                return cached
+            # Sampled before the read: an invalidation landing while the rows
+            # below are being fetched makes this result unstorable, so a write
+            # committed mid-read can't be undone by a stale positive.
+            generation = self._resolve_cache_generation_now()
         # One session = one connection checkout + transaction. Against a
         # remote DB (Lakebase) this is the round-trip that matters; the three
         # primary-key reads below pipeline on the same connection rather than
@@ -410,19 +573,29 @@ class SqlAlchemyPermissionStore(PermissionStore):
         # calling is_admin + check_access + get_permission_level separately
         # did — see the GET /v1/sessions/{id} snapshot path).
         with self._session("resolve_access") as session:
-            user_row = session.get(SqlUser, (current_workspace_id(), user_id))
+            user_row = session.get(SqlUser, (workspace_id, user_id))
             user_grant = session.get(
-                SqlSessionPermission, (current_workspace_id(), user_id, conversation_id)
+                SqlSessionPermission, (workspace_id, user_id, conversation_id)
             )
             public_grant = session.get(
                 SqlSessionPermission,
-                (current_workspace_id(), RESERVED_USER_PUBLIC, conversation_id),
+                (workspace_id, RESERVED_USER_PUBLIC, conversation_id),
             )
-            return ResolvedAccess(
+            access = ResolvedAccess(
                 is_admin=user_row is not None and user_row.is_admin,
                 user_grant_level=user_grant.level if user_grant is not None else None,
                 public_grant_level=public_grant.level if public_grant is not None else None,
             )
+        # Cache only a positive standing: a no-access result is left uncached so
+        # a freshly granted user is authorized on their next request, not after
+        # the TTL elapses.
+        if cache_enabled and (
+            access.is_admin
+            or access.user_grant_level is not None
+            or access.public_grant_level is not None
+        ):
+            self._resolve_cache_store(conversation_id, user_id, access, generation)
+        return access
 
     def has_any_grants(self, conversation_id: str) -> bool:
         """Check for any permission rows. See base class for contract."""

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -1467,15 +1467,21 @@ async def _seed_authenticated_session(auth_client: httpx.AsyncClient, db_uri: st
 #
 # Measured (both dialects) for the seed below: one owner grant, one agent
 # declaring one tool_call policy, one conversation, no declared labels, no
-# children. Composition: ACL resolution 3, the handler's conversation load
-# 3, session-policy lookup, agent row, spawn-tree scan 3.
+# children. Composition: the handler's conversation load 3, session-policy
+# lookup, agent row, spawn-tree scan 3.
+#
+# ACL resolution used to add 3 more (users + the user and public grants). The
+# warm-up request below now also warms the permission store's resolve_access
+# cache, so the steady-state route serves the access decision from memory —
+# which is the production hot path, since the check re-runs on every event of a
+# turn. A cold process still pays those 3.
 #
 # This is the number the PR must quote — an earlier description claimed 6.
 # It is also the oracle for the preload optimisation: dropping the
 # ``conversation=`` argument makes the builder re-read the conversation and
 # pushes this up, which no behavioural assertion can see because both
 # variants return the same verdict.
-_EVALUATE_ROUTE_SQL_BUDGET = 11
+_EVALUATE_ROUTE_SQL_BUDGET = 8
 
 
 @pytest.mark.asyncio
@@ -1505,7 +1511,7 @@ async def test_authenticated_evaluate_route_sql_budget(
             "data": {"name": "Bash", "arguments": {"command": "ls"}},
         }
     }
-    # Warm the spec / policy caches so the count is the steady-state one.
+    # Warm the spec / policy / ACL caches so the count is the steady-state one.
     await auth_client.post(
         f"/v1/sessions/{session_id}/policies/evaluate", json=payload, headers=headers
     )

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -11,8 +11,10 @@ SQLite file and tears it down automatically.
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import event
 
 from omnigent.entities import SessionPermission
+from omnigent.server.auth import RESERVED_USER_PUBLIC
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -1121,3 +1123,226 @@ def test_list_for_sessions_no_grants(store: SqlAlchemyPermissionStore, db_uri: s
     conv = _create_conversation(db_uri)
     result = store.list_for_sessions([conv])
     assert result == {conv: []}
+
+
+# ── resolve_access short-lived cache ──────────────────────────────────────────
+
+
+def _checkout_counter(store: SqlAlchemyPermissionStore) -> tuple[list[int], object]:
+    """Count pool checkouts on the store's engine.
+
+    Attach *after* any setup writes so only the reads under test are counted.
+
+    :returns: ``(count, detach)`` — a one-element list incremented per checkout,
+        and a zero-arg callable that removes the listener.
+    """
+    count = [0]
+
+    def _on_checkout(_dbapi: object, _record: object, _proxy: object) -> None:
+        count[0] += 1
+
+    event.listen(store._engine, "checkout", _on_checkout)
+    return count, lambda: event.remove(store._engine, "checkout", _on_checkout)
+
+
+def test_resolve_access_caches_positive_result(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """A repeat resolve for a granted user is served from cache — no DB checkout."""
+    _ensure_user(store, "alice@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("alice@test.com", conv_id, level=2)
+
+    count, detach = _checkout_counter(store)
+    try:
+        first = store.resolve_access("alice@test.com", conv_id)
+        second = store.resolve_access("alice@test.com", conv_id)
+    finally:
+        detach()
+
+    assert first.user_grant_level == 2
+    assert second == first
+    assert count[0] == 1, f"second resolve must hit cache (no checkout), got {count[0]}"
+
+
+def test_resolve_access_does_not_cache_no_access(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """A no-access result is never cached, so a freshly granted user is
+    authorized on their very next request rather than after the TTL."""
+    _ensure_user(store, "bob@test.com")
+    conv_id = _create_conversation(db_uri)
+
+    denied = store.resolve_access("bob@test.com", conv_id)
+    assert denied.user_grant_level is None
+
+    store.grant("bob@test.com", conv_id, level=1)
+    # No stale "deny" is cached — the grant is visible immediately.
+    granted = store.resolve_access("bob@test.com", conv_id)
+    assert granted.user_grant_level == 1
+
+
+def test_grant_evicts_resolve_cache(store: SqlAlchemyPermissionStore, db_uri: str) -> None:
+    """Re-granting at a new level evicts the cached decision."""
+    _ensure_user(store, "carol@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("carol@test.com", conv_id, level=1)
+
+    assert store.resolve_access("carol@test.com", conv_id).user_grant_level == 1
+    store.grant("carol@test.com", conv_id, level=3)
+    assert store.resolve_access("carol@test.com", conv_id).user_grant_level == 3
+
+
+def test_revoke_evicts_resolve_cache(store: SqlAlchemyPermissionStore, db_uri: str) -> None:
+    """A revoke evicts the cache so the removed user is denied on the next check."""
+    _ensure_user(store, "dave@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("dave@test.com", conv_id, level=2)
+
+    assert store.resolve_access("dave@test.com", conv_id).user_grant_level == 2
+    store.revoke("dave@test.com", conv_id)
+    assert store.resolve_access("dave@test.com", conv_id).user_grant_level is None
+
+
+def test_revoking_public_grant_evicts_all_users_for_session(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """The shared __public__ grant is session-scoped, so revoking it evicts
+    every user's cached decision for that session."""
+    _ensure_user(store, "erin@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant(RESERVED_USER_PUBLIC, conv_id, level=1)
+
+    # erin has no personal grant but is allowed via the public grant — cached.
+    assert store.resolve_access("erin@test.com", conv_id).public_grant_level == 1
+    store.revoke(RESERVED_USER_PUBLIC, conv_id)
+    assert store.resolve_access("erin@test.com", conv_id).public_grant_level is None
+
+
+def test_set_admin_evicts_resolve_cache(store: SqlAlchemyPermissionStore, db_uri: str) -> None:
+    """Flipping the admin flag evicts cached decisions across all sessions."""
+    _ensure_user(store, "frank@test.com")
+    store.set_admin("frank@test.com", True)
+    conv_id = _create_conversation(db_uri)
+
+    assert store.resolve_access("frank@test.com", conv_id).is_admin is True
+    store.set_admin("frank@test.com", False)
+    assert store.resolve_access("frank@test.com", conv_id).is_admin is False
+
+
+def test_resolve_access_cache_expires_after_ttl(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """Once the TTL elapses the entry is dropped and the next resolve re-reads."""
+    now = [1000.0]
+    store._resolve_cache_clock = lambda: now[0]
+    _ensure_user(store, "grace@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("grace@test.com", conv_id, level=2)
+
+    count, detach = _checkout_counter(store)
+    try:
+        store.resolve_access("grace@test.com", conv_id)  # miss → read + cache
+        store.resolve_access("grace@test.com", conv_id)  # hit
+        assert count[0] == 1, "within TTL the repeat must be a cache hit"
+        now[0] += store._resolve_cache_ttl_s + 1.0
+        store.resolve_access("grace@test.com", conv_id)  # expired → re-read
+        assert count[0] == 2, "after TTL the entry must be re-read from the DB"
+    finally:
+        detach()
+
+
+def test_resolve_access_cache_disabled_when_ttl_zero(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """With the cache disabled every resolve reads the DB (no staleness at all)."""
+    store._resolve_cache_ttl_s = 0.0
+    _ensure_user(store, "heidi@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("heidi@test.com", conv_id, level=2)
+
+    count, detach = _checkout_counter(store)
+    try:
+        store.resolve_access("heidi@test.com", conv_id)
+        store.resolve_access("heidi@test.com", conv_id)
+    finally:
+        detach()
+    assert count[0] == 2, "a disabled cache must read on every call"
+
+
+def test_reassign_user_grants_evicts_resolve_cache(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """Moving grants between users evicts both users' cached decisions."""
+    _ensure_user(store, "local")
+    _ensure_user(store, "alice@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("local", conv_id, level=3)
+
+    assert store.resolve_access("local", conv_id).user_grant_level == 3  # cached
+    store.reassign_user_grants("local", "alice@test.com")
+    # The grant moved: local must be denied and alice granted, both fresh.
+    assert store.resolve_access("local", conv_id).user_grant_level is None
+    assert store.resolve_access("alice@test.com", conv_id).user_grant_level == 3
+
+
+def test_resolve_access_cache_refuses_store_racing_a_write(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """A reader whose rows predate a revoke must not re-cache that stale positive.
+
+    The read and the eviction are separate operations, so a resolve that read
+    the old grant can finish *after* the revoke evicted. Storing then would
+    keep the removed user authorized for a full TTL on the very instance that
+    performed the revoke. The generation guard drops that store instead.
+    """
+    _ensure_user(store, "judy@test.com")
+    conv_id = _create_conversation(db_uri)
+    store.grant("judy@test.com", conv_id, level=2)
+
+    original_store = store._resolve_cache_store
+
+    def _revoke_then_store(
+        conversation_id: str, user_id: str, access: object, generation: int
+    ) -> None:
+        """Land the revoke between this reader's DB read and its cache store."""
+        store.revoke(user_id, conversation_id)
+        original_store(conversation_id, user_id, access, generation)  # type: ignore[arg-type]
+
+    store._resolve_cache_store = _revoke_then_store  # type: ignore[assignment]
+    racing = store.resolve_access("judy@test.com", conv_id)
+    store._resolve_cache_store = original_store  # type: ignore[assignment]
+
+    # The read legitimately saw the pre-revoke grant...
+    assert racing.user_grant_level == 2
+    # ...but it must not have been cached on top of the revoke's eviction.
+    assert len(store._resolve_cache) == 0, "a read racing a write must not re-poison the cache"
+    assert store.resolve_access("judy@test.com", conv_id).user_grant_level is None
+
+
+def test_resolve_access_cache_evicts_least_recently_used_over_cap(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """The LRU entry cap bounds the cache — the oldest entry is dropped and
+    must be re-read, so a long-lived replica cannot grow it without limit."""
+    store._resolve_cache_max_entries = 2
+    _ensure_user(store, "ivan@test.com")
+    # Distinct conversations so grants don't evict each other's cache entries.
+    conv_a = _create_conversation(db_uri)
+    conv_b = _create_conversation(db_uri)
+    conv_c = _create_conversation(db_uri)
+    for conv_id in (conv_a, conv_b, conv_c):
+        store.grant("ivan@test.com", conv_id, level=1)
+
+    # Populate in order a, b, c → with cap 2, conv_a (oldest) is evicted.
+    for conv_id in (conv_a, conv_b, conv_c):
+        store.resolve_access("ivan@test.com", conv_id)
+    assert len(store._resolve_cache) == 2, "cache must not exceed its entry cap"
+
+    count, detach = _checkout_counter(store)
+    try:
+        store.resolve_access("ivan@test.com", conv_a)  # evicted → re-read
+        store.resolve_access("ivan@test.com", conv_c)  # still cached → hit
+    finally:
+        detach()
+    assert count[0] == 1, f"only the LRU-evicted entry should re-read, got {count[0]}"


### PR DESCRIPTION
## Related issue

Part of #3004 (follow-up to the access-control checkout collapse in #4737).

## Summary

The per-event access-control check on `POST /v1/sessions/{id}/events` re-reads
`session_permissions` + `users` on **every** streamed event, for a session
whose grants are stable across the turn — a large slice of the ~16 queries/event
in #3004. #4737 collapsed the read *burst* into one pool checkout; this removes
the permission reads *entirely* on a cache hit.

`SqlAlchemyPermissionStore.resolve_access()` now caches results with a short TTL
(**default 5s**, `OMNIGENT_ACL_RESOLVE_CACHE_TTL_S`; `0` disables). Design
choices that keep it safe:

- **Positive-only.** A no-access result is **never** cached, so a freshly
  granted user is authorized on their *next* request — **sharing takes effect
  immediately, no grant-latency.**
- **Evicted on every decision-changing write to this store** (`grant`/`revoke` →
  session, incl. the shared `__public__` grant; `reassign_user_grants` /
  `set_admin` → whole cache), and a **generation counter** (sampled before the
  read, re-checked under the lock at store time) stops an in-flight reader from
  re-storing a pre-commit positive on top of that eviction. So **once such a
  write returns, this instance serves no stale decision.**
- **Keyed by `(conversation_id, user_id)`** — conversation ids are globally
  unique, so eviction needs no workspace context.
- **Bounded by an LRU entry cap** (default 50k, `OMNIGENT_ACL_RESOLVE_CACHE_MAX_ENTRIES`)
  so a long-lived replica cannot grow the cache without limit — `resolve_access`
  is on the snapshot/GET path too.
- **Conversation reads stay fresh** — only the permission decision is cached
  (`runner_id`/labels change mid-turn with no clean eviction trigger).
- **Thread-safe** (`threading.Lock`, never held across the DB round-trip), per
  store instance.

### Staleness, stated plainly

Staleness is **one-directional and bounded**: grants/raises are immediate; only
**revoke/downgrade** can lag, and only up to the TTL. Specifically:

- **Same replica:** exact — the write evicts the cache the next read consults.
- **Role changes via the separate accounts store** (`set_admin` demote,
  `delete_user`) are **not** evicted here and **propagate within the TTL**
  (≤5s). This is a deliberate scope choice: the accounts store is an
  independent second writer; rather than a cross-store eviction hook we let
  these rare, admin-initiated changes settle within the TTL. Documented in the
  cache's module comment.
- **Across replicas:** no invalidation broadcast, so a revoke can be ≤TTL late
  on other replicas. On a host-sharded deployment, a single session's
  grant/revoke and its ACL reads share the `host_id` slice key → same replica →
  effectively immediate; the ≤TTL cross-replica window is confined to
  account-level changes and hostless sessions.

Every stale window is `LEVEL_EDIT` only — the destructive stop/kill path
re-gates `LEVEL_OWNER` separately, and a deleted session still 404s on its
uncached conversation read.

### Combined impact with #4737

On a cache hit — every event of a turn after the first — the permission reads
vanish:

| | checkouts / event (ACL) | queries / event (ACL) |
|---|---|---|
| Baseline (#3004) | ~3 | ~5 |
| + #4737 | 1 | ~5 |
| + #4820 (cache hit) | 1 (conv read only) | ~3 (`session_permissions` + `users` gone) |

The authenticated policy-evaluate route's measured SQL budget drops **11 → 8**
accordingly (warm-up warms this cache; a cold process still pays those 3 reads).

## Test Plan

Unit + integration (`uv run --group dev pytest`):

- `tests/stores/test_permission_store.py` — **69 passed**, every cache test by
  name: positive-only, no-cache-on-deny (immediate grant), eviction on
  grant/revoke/`__public__`-revoke/`reassign_user_grants`/`set_admin`, the
  read-racing-a-write **generation guard**, **LRU cap**, TTL expiry (injected
  clock), disabled (`TTL=0`).
- `tests/server/integration/test_sessions_policy_evaluate.py` — **24 passed**,
  including `test_authenticated_evaluate_route_sql_budget` (the 11 → 8 oracle).
- `tests/server/test_accounts.py` — **84 passed** (confirms the accounts-store
  paths are unchanged).
- `ruff format`, `ruff check`, `pyrefly check` clean.

### Live multi-user e2e (real HTTP server)

Beyond the suites, I stood up a **real `uvicorn` server on a TCP port** in
header (multi-user) auth mode and drove it over real HTTP as two distinct users
(`alice`, `bob`, via `X-Forwarded-Email`), running the scenario twice — cache
ON (`TTL=5`) and cache OFF (`TTL=0`, control). Alice creates the session over
HTTP; the flow shares / accesses / revokes as bob.

**The cache, proven live** — permission-table SQL issued during 5 repeated
authenticated reads by bob:

| | `session_permissions` reads | `users` reads |
|---|---|---|
| cache ON (`TTL=5`) | **0** | **0** |
| cache OFF (`TTL=0`) | 10 | 5 |

Same server, same requests, identical auth outcomes — the cache elides **15
permission-table queries → 0** on the repeat reads.

**Correctness identical in both scenarios** (the cache never changes behavior):

- bob GET before share → 404, and a repeat is **still 404** (no-access not cached → positive-only)
- bob `POST /events` before share → 404 (EDIT gate denies the stranger)
- alice shares EDIT → bob GET is **immediately** 200 (no grant-latency)
- bob `POST /events` after share → allowed (EDIT gate opens)
- alice revokes → bob GET is **immediately** 404 (evict-on-write, same instance)

All live checks passed.

## Demo

N/A (non-visual; server-side performance change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests assert the cache mechanics directly (hit-without-checkout,
positive-only, eviction on each write path, the read-vs-write generation guard,
LRU-cap bound, TTL expiry, disable switch). Manual verification = the live
multi-user run above against a real HTTP server (cache ON vs OFF), proving both
the query elision and unchanged auth behavior. Existing permission-store,
accounts, and policy-evaluate suites confirm semantics are unchanged.

## Changelog

Cache session access checks briefly to cut per-event database load on active sessions
