### PR TITLE
fix(cli): honor isolated Omnigent state directories

### DIFF
--- a/dev/omnidev/src/omnigent_cmd.rs
+++ b/dev/omnidev/src/omnigent_cmd.rs
@@ -143,6 +143,16 @@ mod tests {
             .find(|(k, _)| k == "OMNIGENT_DATABASE_URI")
             .map(|(_, v)| v.clone());
         assert_eq!(db, Some(pod.db_uri()));
+
+        let config_home = cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_CONFIG_HOME")
+            .map(|(_, v)| v.clone());
+        assert_eq!(config_home, Some(pod.config_dir().display().to_string()));
+
+        assert!(cmd.env.iter().all(|(k, _)| k != "HOME"));
+        assert!(cmd.env.iter().all(|(k, _)| !k.starts_with("XDG_")));
     }
 
     #[test]

--- a/omnigent/claude_native_state.py
+++ b/omnigent/claude_native_state.py
@@ -47,6 +47,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent.process_logging import data_dir
+
 # Env-var override for the persistent state root. Reserved for tests
 # (and for advanced users who want to put state on a non-default
 # volume). When unset, the module falls back to
@@ -91,8 +93,8 @@ def _claude_native_state_root() -> Path:
 
     Honors the :data:`_STATE_ROOT_ENV_VAR` override so tests can
     point the state tree at a per-test ``tmp_path`` without
-    clobbering the user's real home directory. Production callers
-    leave the env unset and get the default
+    clobbering the user's state. Otherwise the root follows
+    ``OMNIGENT_DATA_DIR``, falling back to
     ``~/.omnigent/claude-native``.
 
     Lazy: created on first write, never on read (the resume / picker
@@ -105,7 +107,7 @@ def _claude_native_state_root() -> Path:
     override = os.environ.get(_STATE_ROOT_ENV_VAR)
     if override:
         return Path(override)
-    return Path.home() / ".omnigent" / "claude-native"
+    return data_dir() / "claude-native"
 
 
 def _state_dir_for_conversation_id(conversation_id: str) -> Path:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -70,7 +70,7 @@ from omnigent.inner import _proc, ui
 from omnigent.integration_daemon import IntegrationDaemon
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
-from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
+from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR, data_dir
 
 if TYPE_CHECKING:
     import socket
@@ -2185,7 +2185,7 @@ def _runner_loopback_host(host: str) -> str:
     return "127.0.0.1" if host in {"0.0.0.0", "::", ""} else host
 
 
-_HOST_PID_PATH = Path.home() / ".omnigent" / "host.pid"
+_HOST_PID_PATH = data_dir() / "host.pid"
 
 
 # host.pid records the daemon PID + the "target" it serves: a normalized

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -39,9 +39,10 @@ _TOKEN_FILE_NAME = "auth_tokens.json"
 def _token_file_path() -> Path:
     """Return the path to the auth token storage file.
 
-    Uses the shared ``~/.omnigent`` state directory.
+    Uses the shared Omnigent state directory, honoring
+    ``OMNIGENT_DATA_DIR``.
 
-    :returns: Path to ``~/.omnigent/auth_tokens.json``.
+    :returns: Path to ``<data-dir>/auth_tokens.json``.
     """
     from omnigent_ui_sdk.terminal._config import state_dir
 

--- a/omnigent/codex_native_state.py
+++ b/omnigent/codex_native_state.py
@@ -20,6 +20,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent.process_logging import data_dir
+
 _STATE_ROOT_ENV_VAR = "OMNIGENT_CODEX_NATIVE_STATE_DIR"
 _logger = logging.getLogger(__name__)
 _LAUNCH_FILE = "launch.json"
@@ -44,14 +46,15 @@ def _codex_native_state_root() -> Path:
     Return the root directory for persistent codex-native state.
 
     Honors :data:`_STATE_ROOT_ENV_VAR` for tests and advanced local
-    setups. Production defaults to ``~/.omnigent/codex-native``.
+    setups. Otherwise follows ``OMNIGENT_DATA_DIR``, falling back to
+    ``~/.omnigent/codex-native``.
 
     :returns: Absolute path to the state root.
     """
     override = os.environ.get(_STATE_ROOT_ENV_VAR)
     if override:
         return Path(override)
-    return Path.home() / ".omnigent" / "codex-native"
+    return data_dir() / "codex-native"
 
 
 def _state_dir_for_conversation_id(conversation_id: str) -> Path:

--- a/omnigent/opencode_native_state.py
+++ b/omnigent/opencode_native_state.py
@@ -20,6 +20,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent.process_logging import data_dir
+
 _STATE_ROOT_ENV_VAR = "OMNIGENT_OPENCODE_NATIVE_STATE_DIR"
 _logger = logging.getLogger(__name__)
 _LAUNCH_FILE = "launch.json"
@@ -43,14 +45,15 @@ def _opencode_native_state_root() -> Path:
     Return the root directory for persistent opencode-native state.
 
     Honors :data:`_STATE_ROOT_ENV_VAR` for tests and advanced local setups.
-    Production defaults to ``~/.omnigent/opencode-native``.
+    Otherwise follows ``OMNIGENT_DATA_DIR``, falling back to
+    ``~/.omnigent/opencode-native``.
 
     :returns: Absolute path to the state root.
     """
     override = os.environ.get(_STATE_ROOT_ENV_VAR)
     if override:
         return Path(override)
-    return Path.home() / ".omnigent" / "opencode-native"
+    return data_dir() / "opencode-native"
 
 
 def _state_dir_for_conversation_id(conversation_id: str) -> Path:

--- a/omnigent/repl/_session_log.py
+++ b/omnigent/repl/_session_log.py
@@ -79,11 +79,9 @@ _LOG_SCHEMA_VERSION = 1
 # this module while disambiguating their output via this field.
 _LOG_FORMAT = "omnigent-conversation"
 
-# Default log directory. Derives from the shared ``state_dir()``
-# (``~/.omnigent``) so the root is defined in one place. Mirrors
-# the legacy non-AP path's ``~/.omnigent/logs/`` (see
-# ``_default_session_log_path`` in ``omnigent/inner/cli.py``) so
-# users don't have to learn a new location when migrating. Created
+# Default log directory. Derives from the shared ``state_dir()`` so
+# ``OMNIGENT_DATA_DIR`` isolates it without replacing ``HOME``. The
+# fallback remains the legacy ``~/.omnigent/logs/`` location. Created
 # on first write.
 DEFAULT_LOG_DIR = state_dir() / "logs"
 DEFAULT_LOG_ZIP_DIR = DEFAULT_LOG_DIR

--- a/sdks/ui/omnigent_ui_sdk/terminal/_config.py
+++ b/sdks/ui/omnigent_ui_sdk/terminal/_config.py
@@ -2,8 +2,9 @@
 
 The UI SDK keeps this intentionally small: TUI preferences are persisted
 under the ``tui:`` table of the shared Omnigent YAML config file
-(``$HOME/.omnigent/config.yaml``). Today that means the persisted
-light/dark theme selection.
+(``$OMNIGENT_CONFIG_HOME/config.yaml`` when configured, otherwise
+``$HOME/.omnigent/config.yaml``). Today that means the persisted light/dark
+theme selection.
 
 The same file is also written by the ``omnigent`` CLI (top-level keys
 such as ``default_agent`` and ``profile``). Reads and writes here are
@@ -12,6 +13,7 @@ scoped to ``tui:`` so sibling CLI keys round-trip unchanged.
 
 from __future__ import annotations
 
+import os
 import pathlib
 from collections.abc import Mapping
 from contextlib import suppress
@@ -25,6 +27,8 @@ from ._theme import TerminalThemeName, get_theme
 
 _CONFIG_FILENAME = "config.yaml"
 _STATE_DIRNAME = ".omnigent"
+_DATA_DIR_ENV_VAR = "OMNIGENT_DATA_DIR"
+_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
 _TUI_KEY = "tui"
 
 
@@ -49,27 +53,35 @@ DEFAULT_USER_CONFIG = UserConfig()
 def state_dir() -> pathlib.Path:
     """Return the shared Omnigent per-user state directory.
 
-    The directory is currently ``$HOME/.omnigent``. Callers that only need
-    to compute a path can use this without causing filesystem side effects;
-    writers create the directory when saving.
+    Honors ``OMNIGENT_DATA_DIR`` so worktrees and dev pods can isolate runtime
+    state without replacing ``HOME``. Callers that only compute a path cause
+    no filesystem side effects; writers create the directory when saving.
 
-    :returns: The per-user terminal state directory, e.g.
+    :returns: ``$OMNIGENT_DATA_DIR`` when set, else
         ``Path.home() / ".omnigent"``.
     """
 
-    return pathlib.Path.home() / _STATE_DIRNAME
+    value = os.environ.get(_DATA_DIR_ENV_VAR)
+    return pathlib.Path(value).expanduser() if value else pathlib.Path.home() / _STATE_DIRNAME
 
 
 def user_config_path(root: str | pathlib.Path | None = None) -> pathlib.Path:
     """Return the path to the YAML user config file.
 
-    :param root: Optional explicit state directory. Defaults to
-        :func:`state_dir`, i.e. ``$HOME/.omnigent``.
-    :returns: The config file path, e.g.
+    ``OMNIGENT_CONFIG_HOME`` isolates configuration independently from runtime
+    state. An explicit *root* takes precedence over the environment.
+
+    :param root: Optional explicit config directory.
+    :returns: ``$OMNIGENT_CONFIG_HOME/config.yaml`` when set, else
         ``Path.home() / ".omnigent" / "config.yaml"``.
     """
 
-    base = state_dir() if root is None else pathlib.Path(root).expanduser()
+    if root is not None:
+        base = pathlib.Path(root).expanduser()
+    elif value := os.environ.get(_CONFIG_HOME_ENV_VAR):
+        base = pathlib.Path(value).expanduser()
+    else:
+        base = pathlib.Path.home() / _STATE_DIRNAME
     return base / _CONFIG_FILENAME
 
 

--- a/tests/e2e/omnigent/_pexpect_harness.py
+++ b/tests/e2e/omnigent/_pexpect_harness.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import pexpect
+from omnigent_ui_sdk import UserConfig, save_user_config
 
 # Default PTY geometry. Large enough that the REPL's layout fits
 # without wrapping assistant text onto many rows (which would
@@ -63,12 +64,6 @@ STATE_RUNNING = r"state: running"
 # input prompt itself is ready. Several REPL e2e tests already use
 # this as the visible readiness signal.
 PROMPT_READY = r"❯ "
-
-# Persisted test theme used to bypass the first-run interactive theme
-# picker. REPL tests already exercise prompt-toolkit interactions; the
-# picker has its own focused unit tests and should not sit in front of
-# every pexpect boot.
-_TEST_THEME_CONFIG = "# Omnigent user configuration\ntui:\n  theme: light\n"
 
 
 @dataclass(frozen=True)
@@ -103,23 +98,21 @@ def strip_ansi(text: str) -> str:
 
 def ensure_repl_test_theme_env(env: Mapping[str, str]) -> dict[str, str]:
     """
-    Return an env dict whose HOME contains a persisted TUI theme.
+    Return an env dict whose effective config contains a persisted TUI theme.
 
-    The startup REPL shows an interactive theme picker when
-    ``$HOME/.omnigent/config.yaml`` has no ``tui.theme`` entry.
-    That is correct for users but breaks pexpect tests that expect
-    the normal REPL prompt to be the first interactive surface.
+    The startup REPL shows an interactive theme picker when its config has no
+    ``tui.theme`` entry. That is correct for users but breaks pexpect tests that
+    expect the normal REPL prompt to be the first interactive surface.
 
-    When the caller already supplies an isolated ``HOME`` (typical
-    ``tmp_path`` fixtures), this helper writes the theme config there.
-    When the caller inherits the developer's real ``HOME``, it creates
-    a temporary home instead and symlinks Databricks auth files back
-    to the real home so profile-based harnesses still authenticate.
+    The helper writes to ``OMNIGENT_CONFIG_HOME`` when provided, matching the
+    application resolver, and otherwise uses the isolated ``HOME``. Existing
+    config such as mock auth settings is preserved. When the caller inherits
+    the developer's real ``HOME``, the helper creates a temporary home and
+    symlinks Databricks auth files back so profile-based harnesses authenticate.
 
     :param env: Base subprocess environment, e.g. the
         ``omnigent_credentials_env`` fixture.
-    :returns: A copy of *env* with ``HOME`` pointing at a directory
-        that has ``.omnigent/config.yaml`` seeded.
+    :returns: A copy of *env* whose effective config contains ``tui.theme``.
     """
     prepared = dict(env)
     real_home = Path.home()
@@ -135,10 +128,11 @@ def ensure_repl_test_theme_env(env: Mapping[str, str]) -> dict[str, str]:
         home = requested_home
         home.mkdir(parents=True, exist_ok=True)
 
-    config_path = home / ".omnigent" / "config.yaml"
-    if not config_path.exists():
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(_TEST_THEME_CONFIG, encoding="utf-8")
+    config_home = prepared.get("OMNIGENT_CONFIG_HOME")
+    config_path = (
+        Path(config_home).expanduser() if config_home else home / ".omnigent"
+    ) / "config.yaml"
+    save_user_config(UserConfig(theme="light"), config_path)
     return prepared
 
 

--- a/tests/e2e/omnigent/test_pexpect_harness.py
+++ b/tests/e2e/omnigent/test_pexpect_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tests.e2e.omnigent._pexpect_harness import ensure_repl_test_theme_env
 
@@ -20,6 +21,34 @@ def test_ensure_repl_test_theme_env_seeds_isolated_home(tmp_path: Path) -> None:
     config = home / ".omnigent" / "config.yaml"
     assert env["HOME"] == str(home)
     assert "theme: light" in config.read_text(encoding="utf-8")
+
+
+def test_ensure_repl_test_theme_env_uses_config_home_and_preserves_config(
+    tmp_path: Path,
+) -> None:
+    """Configured config home wins without clobbering existing auth settings.
+
+    :param tmp_path: Pytest temporary directory used for isolated paths.
+    """
+    home = tmp_path / "home"
+    config_home = tmp_path / "config"
+    config_home.mkdir()
+    config_path = config_home / "config.yaml"
+    config_path.write_text("auth:\n  type: api_key\n", encoding="utf-8")
+
+    env = ensure_repl_test_theme_env(
+        {
+            "HOME": str(home),
+            "OMNIGENT_CONFIG_HOME": str(config_home),
+        }
+    )
+
+    assert env["OMNIGENT_CONFIG_HOME"] == str(config_home)
+    assert not (home / ".omnigent" / "config.yaml").exists()
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {
+        "auth": {"type": "api_key"},
+        "tui": {"theme": "light"},
+    }
 
 
 def test_ensure_repl_test_theme_env_does_not_write_real_home(

--- a/tests/frontends/sdk/test_user_config.py
+++ b/tests/frontends/sdk/test_user_config.py
@@ -16,14 +16,31 @@ from omnigent_ui_sdk.terminal import (
 )
 
 
-def test_user_config_path_uses_shared_state_dir(tmp_path, monkeypatch) -> None:
+def test_user_config_path_uses_home_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_DATA_DIR", raising=False)
+    monkeypatch.delenv("OMNIGENT_CONFIG_HOME", raising=False)
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
     assert state_dir() == tmp_path / ".omnigent"
     assert user_config_path() == tmp_path / ".omnigent" / "config.yaml"
 
 
-def test_user_config_path_accepts_explicit_state_dir(tmp_path) -> None:
+def test_state_dir_honors_data_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+
+    assert state_dir() == tmp_path / "data"
+
+
+def test_user_config_path_honors_config_home(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config"))
+
+    assert user_config_path() == tmp_path / "config" / "config.yaml"
+
+
+def test_user_config_path_accepts_explicit_state_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "ignored"))
+
     assert user_config_path(tmp_path) == tmp_path / "config.yaml"
 
 

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -43,6 +43,23 @@ class _HostRun:
     server_url: str
 
 
+def test_host_pid_path_honors_data_dir_at_import(tmp_path: Path) -> None:
+    env = {**os.environ, "OMNIGENT_DATA_DIR": str(tmp_path / "data")}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from omnigent.cli import _HOST_PID_PATH; print(_HOST_PID_PATH)",
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == str(tmp_path / "data" / "host.pid")
+
+
 def test_host_command_registered() -> None:
     """
     Verify that ``host`` is a registered subcommand.

--- a/tests/test_native_state_legacy_dirs.py
+++ b/tests/test_native_state_legacy_dirs.py
@@ -25,9 +25,50 @@ _MODULES = [
     pytest.param(opencode_state, "OMNIGENT_OPENCODE_NATIVE_STATE_DIR", id="opencode"),
 ]
 
+_STATE_ROOTS = [
+    pytest.param(
+        claude_state._claude_native_state_root,
+        "OMNIGENT_CLAUDE_NATIVE_STATE_DIR",
+        "claude-native",
+        id="claude",
+    ),
+    pytest.param(
+        codex_state._codex_native_state_root,
+        "OMNIGENT_CODEX_NATIVE_STATE_DIR",
+        "codex-native",
+        id="codex",
+    ),
+    pytest.param(
+        opencode_state._opencode_native_state_root,
+        "OMNIGENT_OPENCODE_NATIVE_STATE_DIR",
+        "opencode-native",
+        id="opencode",
+    ),
+]
+
 
 def _digest(value: str, module) -> str:
     return hashlib.sha256(value.encode()).hexdigest()[: module._ID_HASH_CHARS]
+
+
+@pytest.mark.parametrize(("resolver", "env_var", "subdir"), _STATE_ROOTS)
+def test_state_root_honors_data_dir(
+    resolver, env_var: str, subdir: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+
+    assert resolver() == tmp_path / "data" / subdir
+
+
+@pytest.mark.parametrize(("resolver", "env_var", "_subdir"), _STATE_ROOTS)
+def test_specific_state_root_override_wins(
+    resolver, env_var: str, _subdir: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv(env_var, str(tmp_path / "specific"))
+
+    assert resolver() == tmp_path / "specific"
 
 
 @pytest.mark.parametrize(("module", "env_var"), _MODULES)


### PR DESCRIPTION
## Related issue

[OMNI-3489](https://linear.app/omnigent/issue/OMNI-3489/honor-omnidev-state-and-config-directories-in-omnigent-cli-paths)

## Summary

- Prevent `omnidev omnigent …` commands from leaking auth tokens, session logs, host daemon records, and native harness launch state into the developer's real `~/.omnigent` directory.
- Make runtime state honor `OMNIGENT_DATA_DIR` while configuration independently honors `OMNIGENT_CONFIG_HOME`; harness-specific native-state overrides still take precedence.
- Keep the real `HOME` and `XDG_*` environment intact so harness credentials and caches remain available.

**ELI5:** omnidev already gives each development pod its own labeled storage boxes, but some Omnigent code still put files in the user's shared box. Those paths now use the pod's boxes without moving the user's home directory.

```text
omnidev omnigent
       |
       +-- OMNIGENT_DATA_DIR ------> tokens, logs, host/native state
       +-- OMNIGENT_CONFIG_HOME ---> config.yaml
       +-- HOME / XDG_* ------------> unchanged credentials and caches
```

## Test Plan

- `uv run --frozen pytest tests/frontends/sdk/test_user_config.py`
- `uv run --frozen pytest tests/test_native_state_legacy_dirs.py`
- `uv run --frozen pytest tests/host/test_cli_host.py::test_host_pid_path_honors_data_dir_at_import`
- `cargo test --manifest-path dev/omnidev/Cargo.toml omnigent_cmd::tests`
- `uv run --frozen ruff check omnigent/claude_native_state.py omnigent/cli.py omnigent/cli_auth.py omnigent/codex_native_state.py omnigent/opencode_native_state.py omnigent/repl/_session_log.py sdks/ui/omnigent_ui_sdk/terminal/_config.py tests/frontends/sdk/test_user_config.py tests/host/test_cli_host.py tests/test_native_state_legacy_dirs.py`
- `cargo fmt --manifest-path dev/omnidev/Cargo.toml --check`
- `pre-commit` hooks passed while committing.

## Demo

N/A — non-visual CLI state-isolation fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover pod environment wiring, data/config override precedence, HOME fallbacks, host pidfile placement, and native harness state roots.

## Changelog

`omnidev omnigent` commands now keep runtime state and configuration inside their development pod.
