### PR TITLE
feat(web): archive a session from the keyboard (A in the menu, ⌘⌥A on the open session)

### DIFF
--- a/tests/e2e_ui/hotkeys/test_keyboard_shortcuts_dialog.py
+++ b/tests/e2e_ui/hotkeys/test_keyboard_shortcuts_dialog.py
@@ -1,0 +1,87 @@
+"""UI e2e: the Ctrl/Cmd+/ keyboard-shortcuts reference.
+
+Two things only a real browser settles:
+
+- The panel is sized against the viewport rather than pinned to a narrow
+  column. It used to cap at ``sm:max-w-md`` (448px), which on any normal
+  window rendered as a tall ribbon of rows in a mostly-empty modal.
+- The archive shortcuts are listed. The dialog's contract is that it mirrors
+  live behavior, so a shortcut that ships without a row here is invisible.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+# The dialog's own box, measured after its open animation settles.
+_DIALOG_BOX_JS = """
+() => {
+  const el = document.querySelector('[role="dialog"]');
+  return el ? el.getBoundingClientRect().width : -1;
+}
+"""
+
+# The pre-change cap (Tailwind's max-w-md). The panel must clear it.
+_OLD_MAX_WIDTH_PX = 448
+
+
+def test_shortcuts_dialog_scales_with_the_viewport(page: Page, live_server: str) -> None:
+    """The panel widens with the window and stops at a readable measure.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param live_server: Base URL of the spawned server.
+    """
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(live_server)
+    expect(page.get_by_test_id("sidebar-search-button")).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("Control+Slash")
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    expect(page.get_by_role("heading", name="Keyboard shortcuts")).to_be_visible()
+
+    # Settle the open animation (zoom-in-95) before measuring.
+    page.wait_for_timeout(400)
+    width = page.evaluate(_DIALOG_BOX_JS)
+    assert width > _OLD_MAX_WIDTH_PX, (
+        f"shortcuts dialog is still pinned to the old narrow column ({width}px); "
+        f"expected wider than {_OLD_MAX_WIDTH_PX}px on a 1440px viewport"
+    )
+    # Capped, not full-bleed — a modal spanning the window is not readable.
+    assert width <= 900, f"shortcuts dialog overshot its readable cap ({width}px)"
+
+
+def test_shortcuts_dialog_narrows_on_a_small_viewport(page: Page, live_server: str) -> None:
+    """On a phone-sized window the panel shrinks to fit instead of overflowing.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param live_server: Base URL of the spawned server.
+    """
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.goto(live_server)
+    page.wait_for_timeout(1_000)
+
+    page.keyboard.press("Control+Slash")
+    expect(page.get_by_role("dialog")).to_be_visible(timeout=30_000)
+    page.wait_for_timeout(400)
+
+    width = page.evaluate(_DIALOG_BOX_JS)
+    assert 0 < width <= 390, f"shortcuts dialog overflows a 390px viewport ({width}px)"
+
+
+def test_shortcuts_dialog_lists_both_archive_routes(page: Page, live_server: str) -> None:
+    """Both archive shortcuts are documented: the chord and the menu key.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param live_server: Base URL of the spawned server.
+    """
+    page.goto(live_server)
+    expect(page.get_by_test_id("sidebar-search-button")).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("Control+Slash")
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+
+    # One row under "In chats" (the chord) and one under "Session menu".
+    expect(dialog.get_by_text("Archive session", exact=True)).to_have_count(2)
+    expect(dialog.get_by_text("Session menu", exact=False)).to_be_visible()

--- a/tests/e2e_ui/sessions/test_sidebar_archive.py
+++ b/tests/e2e_ui/sessions/test_sidebar_archive.py
@@ -156,6 +156,85 @@ def test_archive_session_removes_row_without_stop_event(
     assert stop_events == [], f"archive must not send a stop_session event, sent {stop_events}"
 
 
+def _assert_archived(base_url: str, session_id: str) -> None:
+    """Poll the store until *session_id* reports ``archived: true``.
+
+    Proves the archive is durable rather than a client-side cache splice a
+    refetch would resurrect. Polls because the list refetch that unmounts the
+    row can land marginally before the snapshot reflects the flag.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The session expected to be archived.
+    :raises AssertionError: If the flag never flips within the deadline.
+    """
+    deadline = time.monotonic() + 15.0
+    archived = None
+    while time.monotonic() < deadline:
+        snapshot = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+        if snapshot.status_code == 200:
+            archived = snapshot.json()["archived"]
+            if archived is True:
+                return
+        time.sleep(0.25)
+    raise AssertionError(f"archived session should report archived=true, got {archived}")
+
+
+def test_archive_key_in_row_menu(page: Page, seeded_session: tuple[str, str]) -> None:
+    """ "A" archives the row whose action menu is open.
+
+    The kebab's Archive item advertises the letter, matching the session
+    menus in Claude Code. Radix would otherwise swallow a bare letter as
+    typeahead, so this exercises the real key path in a real browser — the
+    part a jsdom test can only approximate.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Hover first so the desktop hover-revealed kebab trigger is interactable.
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    archive_item = page.get_by_test_id("archive-conversation")
+    expect(archive_item).to_be_visible()
+    # The hint that makes the shortcut discoverable without this test.
+    expect(archive_item).to_contain_text("A")
+
+    page.keyboard.press("a")
+
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    _assert_archived(base_url, session_id)
+
+
+def test_archive_chord_on_the_open_session(page: Page, seeded_session: tuple[str, str]) -> None:
+    """Ctrl/Cmd+Alt+A archives the session currently on screen.
+
+    The keyboard route that needs no menu at all. Bound on the always-mounted
+    session list rather than the row, so it keeps working when the row's
+    section is collapsed or its page hasn't loaded.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(_row(page, session_id)).to_be_visible()
+
+    page.keyboard.press("Control+Alt+KeyA")
+
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    # Archiving the active session redirects home so the user isn't stranded
+    # on a stale URL with no sidebar row to navigate from.
+    page.wait_for_url(f"{base_url}/", timeout=15_000)
+    _assert_archived(base_url, session_id)
+
+
 def test_archiving_spinner_stays_until_row_leaves(
     seeded_session: tuple[str, str],
 ) -> None:

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -44,6 +44,24 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();
   });
 
+  it("lists both archive routes: the ⌘⌥A hotkey and the menu-scoped 'A'", () => {
+    render(<KeyboardShortcutsDialog />);
+    toggleViaHotkey();
+
+    // Two rows share the label — the chat-scoped chord and the menu key.
+    const rows = screen.getAllByText("Archive session").map((el) => el.closest("li"));
+    expect(rows).toHaveLength(2);
+    // jsdom's navigator is non-mac → "Ctrl" / "Alt".
+    const chord = rows.find((row) => within(row!).queryByText("Ctrl") !== null);
+    expect(chord).toBeTruthy();
+    expect(within(chord!).getByText("Alt")).toBeTruthy();
+    expect(within(chord!).getByText("A")).toBeTruthy();
+    // The menu row is the bare letter, with no modifier chips.
+    const menuRow = rows.find((row) => row !== chord);
+    expect(within(menuRow!).getByText("A")).toBeTruthy();
+    expect(within(menuRow!).queryByText("Ctrl")).toBeNull();
+  });
+
   it("toggles closed on a second hotkey press", async () => {
     render(<KeyboardShortcutsDialog />);
     toggleViaHotkey();

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -79,6 +79,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { label: "Recall next prompt", keys: [DOWN] },
       { label: "Accept approval prompt", keys: [MOD_KEY, ENTER] },
       { label: "Toggle voice dictation", keys: [MOD_KEY, ALT, "V"] },
+      { label: "Archive session", keys: [MOD_KEY, ALT, "A"] },
       { label: "Stop response", keys: ["Esc"] },
     ],
   },
@@ -95,6 +96,11 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { label: "Toggle conversations sidebar", keys: [MOD_KEY, ALT, "["] },
       { label: "Toggle workspace sidebar", keys: [MOD_KEY, ALT, "]"] },
     ],
+  },
+  {
+    title: "Session menu",
+    note: "while a session's actions menu is open",
+    items: [{ label: "Archive session", keys: ["A"] }],
   },
   {
     title: "Slash commands",
@@ -144,9 +150,12 @@ export function KeyboardShortcutsList() {
   // Feature-based, stable per session; computed at render so tests can vary it.
   const groups = shortcutGroupsFor(isNativeShell());
   return (
-    <>
+    // Two balanced columns once there's room, so the reference reads as a wide
+    // card rather than one tall ribbon of rows. `break-inside-avoid` keeps a
+    // group's heading with its rows when the columns split.
+    <div className="sm:columns-2 sm:gap-8">
       {groups.map((group) => (
-        <section key={group.title} className="mb-4 last:mb-0">
+        <section key={group.title} className="mb-4 break-inside-avoid last:mb-0">
           <h3 className="mb-1 text-sm font-medium text-muted-foreground">
             {group.title}
             {group.note ? (
@@ -170,7 +179,7 @@ export function KeyboardShortcutsList() {
           </ul>
         </section>
       ))}
-    </>
+    </div>
   );
 }
 
@@ -197,7 +206,10 @@ export function KeyboardShortcutsDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-md">
+      {/* Scales with the viewport (the base `max-w-[calc(100%-2rem)]`) and
+          stops at a readable measure — the old `sm:max-w-md` left a narrow,
+          overly tall column of rows. */}
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Keyboard shortcuts</DialogTitle>
           <DialogDescription className="sr-only">

--- a/web/src/hooks/useArchiveSessionHotkey.test.tsx
+++ b/web/src/hooks/useArchiveSessionHotkey.test.tsx
@@ -1,0 +1,98 @@
+// Chord contract for ⌘⌥A: Cmd/Ctrl AND Alt, no Shift, physical KeyA (so ⌥a's
+// "å" on macOS still matches), no auto-repeat, and inert when there's nothing
+// archivable. Bare ⌘A must stay Select All.
+
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useArchiveSessionHotkey } from "./useArchiveSessionHotkey";
+
+function Harness({ onArchive }: { onArchive: (() => void) | null }) {
+  useArchiveSessionHotkey(onArchive);
+  return null;
+}
+
+function press(init: Partial<KeyboardEventInit> & { code?: string }) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { code: "KeyA", key: "a", bubbles: true, ...init }),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useArchiveSessionHotkey", () => {
+  it("fires on Cmd+Alt+A", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true, altKey: true });
+    expect(onArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires on Ctrl+Alt+A (Windows/Linux)", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ ctrlKey: true, altKey: true });
+    expect(onArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches the physical key, so macOS ⌥a → 'å' still archives", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true, altKey: true, key: "å" });
+    expect(onArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores bare Cmd+A — that's Select All", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true });
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("ignores the chord with Shift, leaving ⌘⌥⇧ free", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true, altKey: true, shiftKey: true });
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("ignores other letters on the same chord", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true, altKey: true, code: "KeyB", key: "b" });
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("ignores auto-repeat so holding the chord doesn't re-PATCH", () => {
+    const onArchive = vi.fn();
+    render(<Harness onArchive={onArchive} />);
+    press({ metaKey: true, altKey: true, repeat: true });
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("is inert when there's nothing archivable", () => {
+    // No handler is registered to call, and the chord must fall through
+    // untouched rather than being swallowed.
+    const { container } = render(<Harness onArchive={null} />);
+    expect(container).toBeEmptyDOMElement();
+    const event = new KeyboardEvent("keydown", {
+      code: "KeyA",
+      key: "a",
+      metaKey: true,
+      altKey: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("unbinds on unmount", () => {
+    const onArchive = vi.fn();
+    const { unmount } = render(<Harness onArchive={onArchive} />);
+    unmount();
+    press({ metaKey: true, altKey: true });
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useArchiveSessionHotkey.ts
+++ b/web/src/hooks/useArchiveSessionHotkey.ts
@@ -1,0 +1,49 @@
+// ⌘⌥A (Ctrl+Alt+A on Win/Linux) archives the session you're currently viewing —
+// the keyboard route to the row menu's Archive item, so an open chat can be
+// filed away without reaching for its kebab. Sibling to the sidebar-toggle
+// (⌘⌥[ / ⌘⌥]) and voice-dictation (⌘⌥V) hotkeys; like them it fires even inside
+// a focused text field, so a session can be archived mid-compose.
+//
+// Why this chord: the ⌘⌥ prefix is already this app's "app action" chord, and
+// bare ⌘A is Select All. Bind ONCE, where the active session is known.
+
+import { useEffect, useRef } from "react";
+
+/**
+ * @param onArchive Archives the active session, or `null` when there's nothing
+ *   archivable (no session open, or the viewer doesn't own it) — the chord then
+ *   falls through untouched.
+ */
+export function useArchiveSessionHotkey(onArchive: (() => void) | null): void {
+  // Held in a ref so the bound handler always calls the latest closure without
+  // re-registering each render.
+  const latest = useRef(onArchive);
+  latest.current = onArchive;
+
+  useEffect(() => {
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      // Require Cmd/Ctrl AND Alt, and reject Shift so ⌘⌥⇧ combos stay free.
+      if (!(e.metaKey || e.ctrlKey) || !e.altKey || e.shiftKey) return;
+      // AltGr often reports as Ctrl+Alt; ignore it so intl-layout typing doesn't
+      // archive a session mid-sentence. Guard the call: not every environment
+      // implements getModifierState, and an unguarded call there would throw
+      // and break the whole keydown handler.
+      if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return;
+      // Ignore auto-repeat: holding the chord would re-fire the PATCH.
+      if (e.repeat) return;
+      // Match the physical key, not the character: ⌥ turns "a" into "å" on
+      // macOS, but e.code is stable across layouts and modifiers.
+      if (e.code !== "KeyA") return;
+      const archive = latest.current;
+      if (archive === null) return;
+      // Claim the chord: preventDefault drops any default action and
+      // stopPropagation keeps it from reaching other keydown listeners.
+      e.preventDefault();
+      e.stopPropagation();
+      archive();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+}

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -17,7 +17,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -108,14 +108,28 @@ function mockConversations(conversations: Conversation[]) {
   useConvMock.mockImplementation(() => withData);
 }
 
-function renderSidebar() {
+function renderSidebar(initialEntry = "/") {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <TooltipProvider>
-        <MemoryRouter initialEntries={["/"]}>
-          <Sidebar open={true} onClose={vi.fn()} />
-          <Toaster />
+        <MemoryRouter initialEntries={[initialEntry]}>
+          {/* Routed (not a bare Sidebar) so `/c/:conversationId` populates the
+              active-session param the ⌘⌥A hotkey reads. */}
+          <Routes>
+            {["/", "/c/:conversationId"].map((path) => (
+              <Route
+                key={path}
+                path={path}
+                element={
+                  <>
+                    <Sidebar open={true} onClose={vi.fn()} />
+                    <Toaster />
+                  </>
+                }
+              />
+            ))}
+          </Routes>
         </MemoryRouter>
       </TooltipProvider>
     </QueryClientProvider>,
@@ -233,5 +247,69 @@ describe("archive flow", () => {
 
     expect(screen.queryByTestId("conversation-archiving")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
+  });
+});
+
+// Two keyboard routes to the same archive: "A" while the row's action menu is
+// open (mirroring the kebab menus in Claude Code), and ⌘⌥A while the session is
+// the one on screen. Both must land on the identical single-PATCH flow above.
+describe("archive shortcuts", () => {
+  it("archives on 'A' with the row's action menu open", () => {
+    mockConversations([CONV]);
+    renderSidebar();
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+
+    const item = screen.getByTestId("archive-conversation");
+    // The item advertises its key so the shortcut is discoverable in the menu.
+    expect(within(item).getByText("A")).toBeInTheDocument();
+
+    fireEvent.keyDown(item, { key: "a" });
+
+    expect(mocks.archive.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.archive.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", archived: true },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("leaves 'A' alone when it carries a modifier (Radix typeahead keeps it)", () => {
+    mockConversations([CONV]);
+    renderSidebar();
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.keyDown(screen.getByTestId("archive-conversation"), { key: "a", metaKey: true });
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+  });
+
+  it("archives the open session on the ⌘⌥A hotkey", () => {
+    mockConversations([CONV]);
+    renderSidebar("/c/conv_1");
+
+    fireEvent.keyDown(window, { code: "KeyA", key: "a", metaKey: true, altKey: true });
+
+    expect(mocks.archive.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.archive.mutate).toHaveBeenCalledWith(
+      { id: "conv_1", archived: true },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(mocks.stop.mutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores the hotkey when no session is open", () => {
+    mockConversations([CONV]);
+    renderSidebar("/");
+
+    fireEvent.keyDown(window, { code: "KeyA", key: "a", metaKey: true, altKey: true });
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a bare ⌘A (Select All) on the open session", () => {
+    mockConversations([CONV]);
+    renderSidebar("/c/conv_1");
+
+    fireEvent.keyDown(window, { code: "KeyA", key: "a", metaKey: true });
+
+    expect(mocks.archive.mutate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -151,6 +151,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
+import { useArchiveSessionHotkey } from "@/hooks/useArchiveSessionHotkey";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
@@ -365,6 +366,69 @@ export function computeShiftSelectRange(
 /** Fire the post-archive toast. Hoisted so it isn't a render-scoped closure. */
 function showArchivedToast() {
   showToast(<ArchivedToast />);
+}
+
+/**
+ * Archive / unarchive one session — the single behavior behind the row menus'
+ * Archive item, its "A" shortcut, and the ⌘⌥A hotkey.
+ *
+ * Archiving sends only the PATCH: the server stops the session (and tears down
+ * a host-spawned runner) in the background once the flag is committed. Sending
+ * a client stop too would race that one against the same runner, and the loser
+ * gets a 503 from the already-killed pane.
+ */
+function useArchiveSessionAction(): (args: {
+  conversation: Conversation;
+  /** Whether the viewer is currently on this session's chat surface. */
+  isActive: boolean;
+  onArchiveStart?: () => void;
+  onArchiveError?: () => void;
+}) => void {
+  const archive = useArchiveConversation();
+  const navigate = useNavigate();
+  return ({ conversation, isActive, onArchiveStart, onArchiveError }) => {
+    // Unarchiving is a quick flag flip — no status row, no toast.
+    if (conversation.archived === true) {
+      archive.mutate({ id: conversation.id, archived: false });
+      return;
+    }
+    onArchiveStart?.();
+    archive.mutate(
+      { id: conversation.id, archived: true },
+      {
+        // Point the user at where the session went — it's no longer in the
+        // sidebar list, so surface its new home in Settings.
+        onSuccess: () => {
+          if (isActive) navigate("/", { replace: true });
+          showArchivedToast();
+        },
+        onError: () => onArchiveError?.(),
+      },
+    );
+  };
+}
+
+/**
+ * "A" archives the session whose row action menu is open — the one-letter
+ * shortcut the Archive item advertises, matching the kebab menus in Claude
+ * Code. Bound on the menu Content so it works under both the kebab dropdown
+ * and the right-click context menu.
+ *
+ * Clicking the item (rather than calling archive directly) is how Radix itself
+ * activates a highlighted item, so select, close, and the non-owner disabled
+ * state all keep working for free.
+ */
+function handleArchiveMenuKey(e: KeyboardEvent<HTMLElement>): void {
+  if (e.key !== "a" && e.key !== "A") return;
+  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  const item = e.currentTarget.querySelector<HTMLElement>('[data-testid="archive-conversation"]');
+  // Non-owners get the item disabled; leave the key alone rather than firing
+  // a no-op (and let Radix's typeahead have it back).
+  if (item === null || item.hasAttribute("data-disabled")) return;
+  // Claim the key before Radix consumes it as typeahead.
+  e.preventDefault();
+  e.stopPropagation();
+  item.click();
 }
 
 /** Stable empty array for the pinned-conversations fallback (referential
@@ -1785,6 +1849,29 @@ function ConversationList({
   );
   usePinnedSessionHotkeys(pinnedSessionIds, activeId);
 
+  // ⌘⌥A archives the session currently open in the chat surface. Bound here
+  // (not on the row) because a row unmounts when its section is collapsed or
+  // its page hasn't loaded, while this list is always mounted. Sub-agent views
+  // resolve to their top-level session, matching what the row menu would act
+  // on. Null — and so inert — when nothing is open or the viewer isn't the
+  // owner, the same gate the menu's Archive item uses.
+  const activeRootId = useActiveRootSessionId(activeId ?? null);
+  const archiveSession = useArchiveSessionAction();
+  const activeConversation = useMemo(() => {
+    const id = activeRootId ?? activeId;
+    if (id === undefined || id === null) return null;
+    return (
+      allConversations.find((c) => c.id === id) ??
+      pinnedConversations.find((c) => c.id === id) ??
+      null
+    );
+  }, [allConversations, pinnedConversations, activeRootId, activeId]);
+  useArchiveSessionHotkey(
+    activeConversation !== null && isOwnedByViewer(activeConversation, viewerId)
+      ? () => archiveSession({ conversation: activeConversation, isActive: true })
+      : null,
+  );
+
   // Pinned membership is server-authoritative (the `omnigent.pinned` label),
   // so there's no client-side list to normalize against the loaded window —
   // the pinned query returns exactly the pinned sessions, unpinning removes the
@@ -2903,6 +2990,9 @@ function ConversationMenuItems({
             <ArchiveIcon className="size-3.5" />
           )}
           {isArchived ? "Unarchive" : "Archive"}
+          {/* The menu-scoped "A" shortcut (see handleArchiveMenuKey). Only the
+              enabled item advertises it — the disabled branch below can't act. */}
+          <span className="ml-auto pl-4 text-sm tracking-widest text-muted-foreground">A</span>
         </C.Item>
       ) : (
         <Tooltip>
@@ -3057,7 +3147,7 @@ function ConversationRow({
   }, [isActive]);
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
-  const archive = useArchiveConversation();
+  const archiveSession = useArchiveSessionAction();
   const leave = useLeaveSession();
   const moveToProject = useMoveToProject();
   // The kebab's user-facing "Stop session" action. Archiving does NOT go
@@ -3294,17 +3384,6 @@ function ConversationRow({
   }
 
   function runArchive() {
-    const nextArchived = !isArchived;
-    // Unarchiving is a quick flag flip — no status row.
-    if (!nextArchived) {
-      archive.mutate({ id: conversation.id, archived: false });
-      return;
-    }
-    // Archiving sends only the PATCH: the server stops the session (and
-    // tears down a host-spawned runner) in the background once the flag is
-    // committed. Sending a client stop too would race that one against the
-    // same runner, and the loser gets a 503 from the already-killed pane.
-    //
     // "Archiving…" must stay up until the row actually LEAVES the sidebar,
     // not merely until the PATCH resolves. The PATCH success only kicks off
     // an async `["conversations"]` refetch (see useArchiveConversation); the
@@ -3315,19 +3394,12 @@ function ConversationRow({
     // was still listed. So we DON'T clear it on success: this row unmounts
     // when the refetch removes it, which tears the spinner down with it.
     // Only an error clears the flag, restoring the interactive row for retry.
-    setIsArchiving(true);
-    archive.mutate(
-      { id: conversation.id, archived: true },
-      {
-        // Point the user at where the session went — it's no longer in
-        // the sidebar list, so surface its new home in Settings.
-        onSuccess: () => {
-          if (isActive) navigate("/", { replace: true });
-          showArchivedToast();
-        },
-        onError: () => setIsArchiving(false),
-      },
-    );
+    archiveSession({
+      conversation,
+      isActive,
+      onArchiveStart: () => setIsArchiving(true),
+      onArchiveError: () => setIsArchiving(false),
+    });
   }
 
   function confirmLeave() {
@@ -3499,7 +3571,7 @@ function ConversationRow({
             <ContextMenuTrigger asChild>
               <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
             </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44">
+            <ContextMenuContent className="min-w-44" onKeyDown={handleArchiveMenuKey}>
               <ConversationMenuItems
                 components={contextBundle}
                 setMenuOpen={() => {}}
@@ -3516,7 +3588,7 @@ function ConversationRow({
       ) : isMobile ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
-          <ContextMenuContent className="min-w-44">
+          <ContextMenuContent className="min-w-44" onKeyDown={handleArchiveMenuKey}>
             <ConversationMenuItems
               components={contextBundle}
               setMenuOpen={() => {}}
@@ -3532,7 +3604,7 @@ function ConversationRow({
                 <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
               </div>
             </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44">
+            <ContextMenuContent className="min-w-44" onKeyDown={handleArchiveMenuKey}>
               <ConversationMenuItems
                 components={contextBundle}
                 setMenuOpen={() => {}}
@@ -3632,7 +3704,7 @@ function ConversationRow({
                 <MoreHorizontalIcon className="size-3.5" data-icon-size="14" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-44">
+            <DropdownMenuContent align="end" className="min-w-44" onKeyDown={handleArchiveMenuKey}>
               <ConversationMenuItems
                 components={dropdownBundle}
                 setMenuOpen={setMenuOpen}


### PR DESCRIPTION
[jlu-agent]

## Related issue

Closes #4825

## Summary

Archiving a session was mouse-only — hover the row, open its kebab, aim for the Archive item. Two keyboard routes now reach it, both landing on the archive PATCH that ships today:

- **`A` with a row's action menu open** (kebab or right-click), matching the session menus in Claude Code. The Archive item advertises the letter.
- **`⌘⌥A` / `Ctrl+Alt+A` on the open session**, no menu needed.

The shortcuts dialog picks up rows for both — its contract is to mirror live behavior, so an unlisted shortcut is an invisible one. While there, it was capped at `sm:max-w-md` (448px), which rendered as a tall ribbon of rows in a mostly-empty modal; it now scales with the viewport up to a readable measure and splits into two balanced columns when there's room.

**ELI5:** the Archive button already existed in the menu — this adds the keyboard's way of pressing it, and makes the shortcut cheat-sheet wide enough to read.

Two implementation notes a reviewer might otherwise have to reverse-engineer:

```text
"A"  ── menu Content onKeyDown ──► finds the Archive item ──► item.click()
                                   (Radix's own path for Enter, so select,
                                    close, and the non-owner disabled state
                                    all keep working; the key is claimed
                                    first so typeahead doesn't eat it)

⌘⌥A ── window keydown ──► ConversationList, not ConversationRow
                          (a row unmounts when its section is collapsed or
                           its page hasn't loaded; the list is always
                           mounted. Sub-agent views resolve to their
                           top-level session, matching the row menu.)
```

The archive behavior itself moved out of `ConversationRow` into a `useArchiveSessionAction` hook so the menus and the hotkey share one code path rather than two drifting copies.

`⌘⌥` is the app's existing chord for this class of action (`⌘⌥[`, `⌘⌥]`, `⌘⌥V`); bare `⌘A` stays Select All. The chord matches `e.code`, so macOS `⌥a` → `å` still works, and auto-repeat is ignored so holding it can't re-fire the PATCH.

## Test Plan

Unit (`pnpm --filter web test`, 5751 passed — the 3 failures in `NewChatDialog.test.tsx` are pre-existing on `main`):

- `web/src/hooks/useArchiveSessionHotkey.test.tsx` (new) — the chord contract: fires on Cmd/Ctrl+Alt+A, matches the physical key so `å` works, ignores bare `⌘A`, Shift variants, other letters, and auto-repeat; inert (and doesn't `preventDefault`) when nothing is archivable; unbinds on unmount.
- `web/src/shell/Sidebar.archive.test.tsx` — `A` in the open menu archives and shows its hint; `A` with a modifier is left to Radix; the hotkey archives the open session, is inert with no session open, and ignores bare `⌘A`.
- `web/src/components/KeyboardShortcutsDialog.test.tsx` — both archive rows are listed, one with the modifier chips and one bare.

E2E (`pytest tests/e2e_ui`, real browser against a spawned server — 10 passed):

- `tests/e2e_ui/sessions/test_sidebar_archive.py` — `test_archive_key_in_row_menu` and `test_archive_chord_on_the_open_session`. Both assert the row leaves the sidebar *and* that the store reports `archived: true`, so neither is a client-side cache splice. This is where the Radix-typeahead interaction is actually settled; jsdom can only approximate it.
- `tests/e2e_ui/hotkeys/test_keyboard_shortcuts_dialog.py` (new) — the dialog measures wider than the old 448px cap on a 1440px viewport, stays capped below 900px, fits inside a 390px viewport, and lists both archive routes.

Also re-ran the neighbouring suites that touch these menus (`Sidebar.rowActions`, `Sidebar.stop`, `test_sidebar_context_menu`) — green.

## Demo

**The `A` accelerator in the row's action menu:**

![Row action menu showing Archive with an A accelerator](https://raw.githubusercontent.com/jlu-samsara/omnigent/fd5ee296881c7fcc8cb858514710b78a99c7dc1d/02-row-menu-archive-key.png)

**The shortcuts dialog — wider, two columns, with both archive rows (`⌘⌥A` under *In chats*, `A` under *Session menu*):**

![Keyboard shortcuts dialog at 1440px](https://raw.githubusercontent.com/jlu-samsara/omnigent/fd5ee296881c7fcc8cb858514710b78a99c7dc1d/01-shortcuts-dialog.png)

**Narrow viewport — it scales down rather than overflowing:**

![Keyboard shortcuts dialog at 390px](https://raw.githubusercontent.com/jlu-samsara/omnigent/fd5ee296881c7fcc8cb858514710b78a99c7dc1d/04-shortcuts-dialog-narrow.png)

**The same list on the Settings page, which embeds `KeyboardShortcutsList` directly:**

![Settings → Keyboard shortcuts](https://raw.githubusercontent.com/jlu-samsara/omnigent/fd5ee296881c7fcc8cb858514710b78a99c7dc1d/05-settings-shortcuts.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the screenshot pass above, driven through the e2e harness on macOS: opened the row menu and pressed `A`, pressed `⌘⌥A` on an open session, and opened the shortcuts dialog at 1440px and 390px plus the Settings page. The archive path itself keeps its existing coverage — the single-PATCH contract and the "Archiving…" spinner-persistence test still pass unchanged, which is the point: both new shortcuts reuse that path rather than adding a second one.

## Changelog

Archive a session from the keyboard — `A` with its menu open, or `⌘⌥A` on the session you're viewing.
