### PR TITLE
Resume paused sessions from Terminal view

### DIFF
--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -246,6 +246,32 @@ def register_resources_routes(
             raise _session_not_found()
         return conv
 
+    @router.post(
+        "/sessions/{session_id}/resume",
+        status_code=204,
+        response_class=Response,
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def resume_session(
+        request: Request,
+        session_id: str,
+    ) -> Response:
+        """Wake a resumable session without dispatching a chat event."""
+        conv = await _validate_session(session_id, request, LEVEL_EDIT)
+        runner_client, _ = await ensure_runner_connected(
+            session_id=session_id,
+            conv=conv,
+            app_state=request.app.state,
+            conversation_store=conversation_store,
+            runner_router=runner_router or get_server_runner_router(),
+        )
+        if runner_client is None:
+            raise OmnigentError(
+                "Session cannot be resumed from this server. Reconnect its host and try again.",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        return Response(status_code=204)
+
     async def _proxy_get_to_runner(
         session_id: str,
         path: str,

--- a/openapi.json
+++ b/openapi.json
@@ -12839,6 +12839,42 @@
         ]
       }
     },
+    "/v1/sessions/{session_id}/resume": {
+      "post": {
+        "description": "Wake a resumable session without dispatching a chat event.",
+        "operationId": "resume_session_v1_sessions__session_id__resume_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resume Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
     "/v1/sessions/{session_id}/stream": {
       "get": {
         "description": "Subscribe to the session's live SSE event stream.\n\nDoes NOT replay history; clients reconcile via the snapshot\nendpoint. The generator emits `[DONE]` on normal completion\nand uses `finally` only for presence cleanup \u2014 see\n`_stream_live_events`.\n\nHolding this stream open registers the caller as a session\n*viewer* (presence): co-viewers' streams receive\n`session.presence` events on join/leave/idle edges, and\nthis stream's snapshot-on-connect includes the current\nviewer list. Presence is scoped to the session tree's root\nconversation, so viewers of different agents/sub-agents in\none session see each other. See\n`omnigent/server/presence.py`.\n\n**Returns:** An SSE `StreamingResponse`.\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if no session exists.",

--- a/tests/e2e_ui/sessions/test_terminal_resume.py
+++ b/tests/e2e_ui/sessions/test_terminal_resume.py
@@ -1,0 +1,145 @@
+"""E2E: a paused terminal-first session resumes without a chat message."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+from playwright.sync_api import Page, Route, expect
+
+_OLD_CREATED_AT = 1_700_000_000
+
+
+def _save_demo(page: Page, name: str) -> None:
+    """Save optional PR evidence without making screenshots test artifacts."""
+    output_dir = os.environ.get("E2E_SCREENSHOT_DIR")
+    if not output_dir:
+        return
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    page.screenshot(path=str(path / f"{name}.png"), full_page=True)
+
+
+def _message_count(base_url: str, session_id: str) -> int:
+    """Count committed chat messages, excluding terminal resource events."""
+    response = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/items?order=asc&limit=1000",
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return sum(item.get("type") == "message" for item in response.json().get("data", []))
+
+
+def test_terminal_view_resumes_paused_session_without_message(
+    page: Page,
+    terminal_session: tuple[str, str],
+) -> None:
+    """Terminal stays selectable while paused and resumes through its prompt."""
+    base_url, session_id = terminal_session
+    messages_before = _message_count(base_url, session_id)
+
+    state = {"asleep": True}
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["created_at"] = _OLD_CREATED_AT
+        payload["host_id"] = "host_demo"
+        payload["labels"] = {**payload.get("labels", {}), "omnigent.ui": "terminal"}
+        route.fulfill(
+            status=response.status,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_session_list(route: Route) -> None:
+        response = route.fetch()
+        payload = response.json()
+        for row in payload.get("data", []):
+            if row.get("id") != session_id:
+                continue
+            row["created_at"] = _OLD_CREATED_AT
+            row["host_id"] = "host_demo"
+            row["labels"] = {**row.get("labels", {}), "omnigent.ui": "terminal"}
+        route.fulfill(
+            status=response.status,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        response = route.fetch()
+        if not state["asleep"]:
+            route.fulfill(status=response.status, headers=response.headers, body=response.body())
+            return
+        payload = response.json()
+        live = {"runner_online": False, "host_online": True}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = live
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **live}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _hide_terminals_while_asleep(route: Route) -> None:
+        if route.request.method != "GET" or not state["asleep"]:
+            route.continue_()
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"object": "list", "data": [], "has_more": False}),
+        )
+
+    def _observe_resume(route: Route) -> None:
+        response = route.fetch()
+        if response.ok:
+            created = httpx.post(
+                f"{base_url}/v1/sessions/{session_id}/resources/terminals",
+                json={"terminal": "zsh", "session_key": "main"},
+                timeout=30.0,
+            )
+            created.raise_for_status()
+            state["asleep"] = False
+        route.fulfill(status=response.status, headers=response.headers, body=response.body())
+
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(
+        re.compile(rf"/v1/sessions/{re.escape(session_id)}/resources/terminals(\?|$)"),
+        _hide_terminals_while_asleep,
+    )
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}/resume$"), _observe_resume)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route(re.compile(r"/v1/sessions(\?|$)"), _patch_session_list)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    terminal_option = page.get_by_role("button", name="Terminal view", exact=True)
+    expect(terminal_option).to_be_enabled(timeout=20_000)
+    terminal_option.click()
+
+    prompt = page.get_by_test_id("terminal-resume-prompt")
+    expect(prompt).to_be_visible()
+    expect(terminal_option).to_have_attribute("aria-pressed", "true")
+    _save_demo(page, "terminal-resume-prompt")
+
+    prompt.get_by_role("button", name="Resume session").click()
+
+    expect(prompt).to_be_hidden(timeout=30_000)
+    terminal = page.get_by_test_id("terminal-view").last
+    expect(terminal).to_be_visible(timeout=20_000)
+    expect(terminal).to_have_attribute("data-state", "connected", timeout=20_000)
+    assert _message_count(base_url, session_id) == messages_before
+    _save_demo(page, "terminal-resumed")

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1270,6 +1270,59 @@ def bash_terminal_spec(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resume_session_wakes_runner_without_dispatching_event(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /resume invokes the resource wake ladder and returns no content."""
+    from omnigent.server.routes.sessions import routes_resources
+
+    called: dict[str, Any] = {}
+    runner_client = object()
+
+    async def _ensure_runner_connected(**kwargs: Any) -> tuple[object, Conversation]:
+        called.update(kwargs)
+        return runner_client, kwargs["conv"]
+
+    monkeypatch.setattr(
+        routes_resources,
+        "ensure_runner_connected",
+        _ensure_runner_connected,
+    )
+
+    resp = await client.post("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resume")
+
+    assert resp.status_code == 204
+    assert resp.content == b""
+    assert called["session_id"] == "79b22ebd2309e48fdeb450c65611d51b"
+    assert called["conv"].id == "79b22ebd2309e48fdeb450c65611d51b"
+
+
+@pytest.mark.asyncio
+async def test_resume_session_reports_non_wakeable_runner(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /resume preserves reconnect guidance for a stranded session."""
+    from omnigent.server.routes.sessions import routes_resources
+
+    async def _ensure_runner_connected(**kwargs: Any) -> tuple[None, Conversation]:
+        return None, kwargs["conv"]
+
+    monkeypatch.setattr(
+        routes_resources,
+        "ensure_runner_connected",
+        _ensure_runner_connected,
+    )
+
+    resp = await client.post("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resume")
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == ErrorCode.RUNNER_UNAVAILABLE
+    assert "Reconnect its host" in resp.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_create_terminal_proxies_to_runner(
     client: httpx.AsyncClient,
     bash_terminal_spec: None,

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -19,6 +19,7 @@ import {
   listRunners,
   openSessionStream,
   postEvent,
+  resumeSession,
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
@@ -853,6 +854,35 @@ describe("postEvent", () => {
     });
     expect(out.pendingId).toBe("pending_abc123");
     expect(out.itemId).toBeUndefined();
+  });
+});
+
+describe("resumeSession", () => {
+  it("POSTs the no-message resume action", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse(undefined, { status: 204 }));
+
+    await resumeSession("conv with space");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv%20with%20space/resume");
+    expect(init.method).toBe("POST");
+  });
+
+  it("surfaces the server reconnect guidance", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse(
+        {
+          error: {
+            code: "runner_unavailable",
+            message: "Reconnect the host and try again.",
+          },
+        },
+        { ok: false, status: 503 },
+      ),
+    );
+
+    await expect(resumeSession("conv_abc")).rejects.toThrow("Reconnect the host and try again.");
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -804,6 +804,20 @@ export async function getSession(sessionId: string): Promise<Session> {
 }
 
 /**
+ * Wake a paused session without dispatching a chat event.
+ *
+ * The server reuses the session's existing host/workspace binding. The call is
+ * idempotent when the runner is already connected and creates no transcript
+ * item.
+ */
+export async function resumeSession(sessionId: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sessionId)}/resume`, {
+    method: "POST",
+  });
+  if (!res.ok) throw await apiErrorFromResponse(res);
+}
+
+/**
  * Snapshot a session WITHOUT its committed items or liveness fields.
  *
  * Use this (not `getSession`) when the caller hydrates the transcript

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2078,6 +2078,10 @@ function MainAgentSurface({
           initialTerminalKey={isActive ? terminalFirst?.terminalViewKey : null}
           visible={isShown}
           onSurfaceElement={isActive ? setTerminalSurfaceEl : undefined}
+          resumeRequired={
+            isActive && (liveness.kind === "runner_asleep" || liveness.kind === "host_asleep")
+          }
+          canResume={permissionLevel === null || permissionLevel >= 2}
           readOnly={entry.readOnly}
         />
         {isShown && (
@@ -3497,6 +3501,7 @@ function useNativeChatTerminalBar(
   const native = isIOSShell();
   const view = ctx?.view ?? "chat";
   const terminalsAvailable = ctx?.terminalsAvailable ?? false;
+  const terminalResumable = ctx?.terminalResumable ?? false;
   const terminalStartingUp = ctx?.terminalStartingUp ?? false;
 
   // Keep `setView` reachable from the subscribe-once effect without
@@ -3509,11 +3514,11 @@ function useNativeChatTerminalBar(
     if (!native) return;
     setNativeViewMode({
       mode: view,
-      terminalEnabled: terminalsAvailable,
+      terminalEnabled: terminalsAvailable || terminalResumable,
       terminalStartingUp,
       visible,
     });
-  }, [native, view, terminalsAvailable, terminalStartingUp, visible]);
+  }, [native, view, terminalsAvailable, terminalResumable, terminalStartingUp, visible]);
 
   // Belt-and-suspenders: hide the bar if the host component ever unmounts.
   useEffect(() => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1487,10 +1487,12 @@ export function AppShell() {
   // `terminals` is already runner-accurate (useTerminals empties it when the
   // runner is offline), so a non-empty list means an openable PTY.
   const terminalsAvailable = terminals.length > 0;
+  const terminalResumable = liveness.kind === "runner_asleep" || liveness.kind === "host_asleep";
   // Single pill-facing "loading" signal: not yet openable, but coming up —
   // either the runner is launching/relaunching (liveness `starting`, known the
   // instant a message is sent) or it's up and auto-creating the PTY
-  // (`terminalPending`). Idle stopped sessions are neither → greyed, not spinning.
+  // (`terminalPending`). Idle resumable sessions are neither: they stay
+  // selectable via `terminalResumable` and show the resume prompt, not a spinner.
   // Suppressed once the session has failed AND no send is in flight: a runner
   // that crashed before connecting (`runner_failed_to_start`), or a host that
   // refused the launch (`harness_not_configured`), sits in the `starting` grace
@@ -1549,6 +1551,7 @@ export function AppShell() {
       terminalViewKey: panelInitialKey,
       setView,
       terminalsAvailable,
+      terminalResumable,
       terminalStartingUp,
     }),
     [
@@ -1560,6 +1563,7 @@ export function AppShell() {
       panelInitialKey,
       setView,
       terminalsAvailable,
+      terminalResumable,
       terminalStartingUp,
     ],
   );

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -1,9 +1,10 @@
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
+import { resumeSession } from "@/lib/sessionsApi";
 import { MainTerminalView } from "./MainTerminalView";
 import type { TerminalFirstContextValue } from "./TerminalFirstContext";
 import { TerminalFirstContextProvider } from "./TerminalFirstContext";
@@ -47,6 +48,10 @@ vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   useTerminals: vi.fn(),
 }));
 
+vi.mock("@/lib/sessionsApi", () => ({
+  resumeSession: vi.fn(),
+}));
+
 // Marker stand-in: MainTerminalView must NOT render the new-shell
 // affordance in any state (creation lives in the rail's Shells tab) —
 // the mock makes a regression visible if the import ever returns.
@@ -55,6 +60,7 @@ vi.mock("./NewTerminalButton", () => ({
 }));
 
 const useTerminalsMock = vi.mocked(useTerminals);
+const resumeSessionMock = vi.mocked(resumeSession);
 
 const REPL_TERMINAL: TerminalInfo = {
   id: "terminal_tui_main",
@@ -99,6 +105,8 @@ function renderView({
   initialTerminalKey = null,
   readOnly = false,
   conversationId = "conv_sdk",
+  resumeRequired = false,
+  canResume = true,
   setView,
 }: {
   terminals: TerminalInfo[];
@@ -106,6 +114,8 @@ function renderView({
   initialTerminalKey?: string | null;
   readOnly?: boolean;
   conversationId?: string;
+  resumeRequired?: boolean;
+  canResume?: boolean;
   setView?: (view: "chat" | "terminal") => void;
 }) {
   useTerminalsMock.mockReturnValue({ terminals, isLoading: false, error: null });
@@ -115,6 +125,8 @@ function renderView({
         conversationId={conversationId}
         initialTerminalKey={initialTerminalKey}
         readOnly={readOnly}
+        resumeRequired={resumeRequired}
+        canResume={canResume}
       />
     </TerminalFirstContextProvider>,
   );
@@ -122,9 +134,53 @@ function renderView({
 
 beforeEach(() => {
   useTerminalsMock.mockReset();
+  resumeSessionMock.mockReset();
 });
 
 afterEach(cleanup);
+
+describe("MainTerminalView — paused sessions", () => {
+  it("resumes from the terminal prompt without sending a message", async () => {
+    let resolveResume: (() => void) | undefined;
+    resumeSessionMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveResume = resolve;
+      }),
+    );
+    renderView({ terminals: [], resumeRequired: true });
+
+    expect(screen.getByText("Session paused")).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "Resume session" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(resumeSessionMock).toHaveBeenCalledOnce();
+    expect(resumeSessionMock).toHaveBeenCalledWith("conv_sdk");
+    expect(screen.getByRole("button", { name: "Resuming session…" })).toBeDisabled();
+
+    resolveResume?.();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Resuming session…" })).toBeDisabled(),
+    );
+  });
+
+  it("shows resume failures and allows retry", async () => {
+    resumeSessionMock.mockRejectedValueOnce(new Error("Reconnect its host and try again."));
+    renderView({ terminals: [], resumeRequired: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume session" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Reconnect its host and try again.");
+    expect(screen.getByRole("button", { name: "Resume session" })).toBeEnabled();
+  });
+
+  it("does not offer a resume action to read-only viewers", () => {
+    renderView({ terminals: [], resumeRequired: true, canResume: false });
+
+    expect(screen.getByText(/an editor must resume/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+  });
+});
 
 describe("MainTerminalView — terminal-first SDK sessions", () => {
   it("renders the REPL chrome-free: shells and the + stay out of the pill view", () => {

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -13,10 +13,11 @@
 // single header row (identity + close X). There is no tab strip here —
 // shells are opened and created from the rail's tab strip ("+" menu).
 
-import { TerminalIcon, XIcon } from "lucide-react";
+import { LoaderCircleIcon, PauseCircleIcon, TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
+import { resumeSession } from "@/lib/sessionsApi";
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
@@ -49,6 +50,10 @@ interface MainTerminalViewProps {
    * instead. Default false (owner / single-user).
    */
   readOnly?: boolean;
+  /** True when the runner or resumable host is asleep and can be woken here. */
+  resumeRequired?: boolean;
+  /** Whether the current viewer has edit access to invoke the resume action. */
+  canResume?: boolean;
   /**
    * Exposes the outer terminal surface so the iOS native shell can show its
    * server switcher only while this surface is actually frontmost.
@@ -61,10 +66,14 @@ export function MainTerminalView({
   initialTerminalKey,
   visible = true,
   readOnly = false,
+  resumeRequired = false,
+  canResume = true,
   onSurfaceElement,
 }: MainTerminalViewProps) {
   const { terminals } = useTerminals(conversationId);
   const terminalFirstCtx = useTerminalFirst();
+  const [resumeState, setResumeState] = useState<"idle" | "resuming" | "error">("idle");
+  const [resumeError, setResumeError] = useState<string | null>(null);
   // The agent's own terminal (SDK REPL / native vendor pane) — the
   // auto-selection target and the pane the pill's Terminal view shows.
   const agentTerminals = useMemo(
@@ -91,6 +100,11 @@ export function MainTerminalView({
   useEffect(() => {
     if (initialTerminalKey) setActiveKey(initialTerminalKey);
   }, [initialTerminalKey]);
+
+  useEffect(() => {
+    setResumeState("idle");
+    setResumeError(null);
+  }, [conversationId, resumeRequired]);
 
   // Auto-select on mount / when the active terminal disappears. The
   // fallback prefers the agent's own terminal so a closed shell drops
@@ -132,6 +146,19 @@ export function MainTerminalView({
     [onSurfaceElement],
   );
 
+  const handleResume = useCallback(async () => {
+    if (!canResume || resumeState === "resuming") return;
+    setResumeState("resuming");
+    setResumeError(null);
+    try {
+      await resumeSession(conversationId);
+      // Keep the connecting state until liveness flips and this prompt unmounts.
+    } catch (error) {
+      setResumeState("error");
+      setResumeError(error instanceof Error ? error.message : "Unable to resume this session.");
+    }
+  }, [canResume, conversationId, resumeState]);
+
   return (
     // Outer wrapper fills the main column. `pt-14` clears the 56px
     // absolute-positioned AppShell header on desktop. The workspace rail now
@@ -154,7 +181,38 @@ export function MainTerminalView({
       className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-14 pb-1.5"
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
-        {terminals.length === 0 ? (
+        {resumeRequired ? (
+          <div
+            data-testid="terminal-resume-prompt"
+            className="flex flex-1 flex-col items-center justify-center gap-3 text-center"
+          >
+            <PauseCircleIcon className="size-6 text-muted-foreground" />
+            <div>
+              <p className="font-medium text-foreground">Session paused</p>
+              <p className="mt-1 text-muted-foreground text-sm">
+                {canResume
+                  ? "Resume the session to reconnect and view its terminal."
+                  : "An editor must resume the session before its terminal is available."}
+              </p>
+            </div>
+            {canResume && (
+              <button
+                type="button"
+                onClick={() => void handleResume()}
+                disabled={resumeState === "resuming"}
+                className="inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-2 font-medium text-primary-foreground text-sm hover:bg-primary/90 disabled:cursor-default disabled:opacity-60"
+              >
+                {resumeState === "resuming" && <LoaderCircleIcon className="size-4 animate-spin" />}
+                {resumeState === "resuming" ? "Resuming session…" : "Resume session"}
+              </button>
+            )}
+            {resumeError && (
+              <p role="alert" className="max-w-md text-destructive text-sm">
+                {resumeError}
+              </p>
+            )}
+          </div>
+        ) : terminals.length === 0 ? (
           <div className="flex flex-1 items-center justify-center text-muted-foreground text-ui">
             No terminals available.
           </div>

--- a/web/src/shell/TerminalFirstContext.tsx
+++ b/web/src/shell/TerminalFirstContext.tsx
@@ -62,9 +62,16 @@ export interface TerminalFirstContextValue {
   /**
    * True when a terminal exists AND is reachable (the runner is online) —
    * i.e. there's a PTY the "Terminal" pill can open right now. False on a
-   * stopped/offline runner, which greys the button.
+   * stopped/offline runner; `terminalResumable` decides whether the button
+   * stays available with a resume prompt or is disabled.
    */
   terminalsAvailable: boolean;
+  /**
+   * True when no PTY is currently reachable but the session's existing host
+   * binding can resume it. Keeps Terminal selectable so the view can present
+   * its explicit resume prompt.
+   */
+  terminalResumable?: boolean;
   /**
    * True while the terminal is coming up but not yet openable — drives the
    * spinner on the "Terminal" pill so it reads as "loading" rather than a

--- a/web/src/shell/ViewModeToggle.test.tsx
+++ b/web/src/shell/ViewModeToggle.test.tsx
@@ -147,4 +147,20 @@ describe("ViewModeToggle", () => {
     fireEvent.click(chatSegment());
     expect(setView).toHaveBeenCalledWith("chat");
   });
+
+  it("keeps Terminal selectable when the paused session can be resumed", () => {
+    const setView = vi.fn();
+    renderToggle(
+      makeCtx({
+        setView,
+        terminalsAvailable: false,
+        terminalResumable: true,
+        terminalStartingUp: false,
+      }),
+    );
+    const terminal = terminalSegment();
+    expect(terminal).not.toBeDisabled();
+    fireEvent.click(terminal);
+    expect(setView).toHaveBeenCalledWith("terminal");
+  });
 });

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -22,7 +22,8 @@ export function ViewModeToggle() {
   const ctx = useTerminalFirst();
   if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return null;
 
-  const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
+  const { view, setView, terminalsAvailable, terminalResumable = false, terminalStartingUp } = ctx;
+  const terminalEnabled = terminalsAvailable || terminalResumable;
   const terminalLabel = terminalStartingUp ? "Terminal is starting up…" : "Terminal view";
 
   return (
@@ -42,12 +43,13 @@ export function ViewModeToggle() {
       >
         <MessagesSquareIcon className="size-3.5" />
       </ViewModeSegment>
-      {/* Terminal stays disabled until a PTY is reachable; the spinner while
-          it's coming up reads as "loading" rather than a dead segment. */}
+      {/* A paused session remains selectable so its terminal surface can
+          offer the explicit resume action. Other unavailable terminals stay
+          disabled; a spinner marks active startup. */}
       <ViewModeSegment
         label={terminalLabel}
         active={view === "terminal"}
-        disabled={!terminalsAvailable}
+        disabled={!terminalEnabled}
         onClick={() => setView("terminal")}
         testId="view-mode-terminal"
       >


### PR DESCRIPTION
## Related issue

Closes #4833

## Summary

- Add an edit-gated `POST /v1/sessions/{id}/resume` action that wakes the existing runner/host binding without creating a chat message.
- Keep Terminal selectable for resumable sessions and show a one-click resume prompt with loading, retry, and read-only states across web and iOS view controls.
- Add unit, route, and browser coverage for the paused → resume → connected-terminal flow.

**ELI5:** A sleeping session now has a wake button in its Terminal view. Waking it does not add a fake note to the conversation.

```mermaid
flowchart LR
  A[Open Terminal] --> B[Session paused prompt]
  B --> C[POST resume]
  C --> D[Reconnect existing runner]
  D --> E[Connected terminal]
```

## Test Plan

- `uv run --frozen pytest tests/server/routes/test_session_resources.py tests/server/test_openapi_drift.py` → 149 passed; regenerated `openapi.json` matches the current server schema.
- `pnpm exec vitest run src/lib/sessionsApi.test.ts src/shell/MainTerminalView.test.tsx src/shell/ViewModeToggle.test.tsx` → 73 passed.
- `pnpm run type-check` → passed.
- `uv run --frozen pytest tests/e2e_ui/sessions/test_terminal_resume.py --ui-skip-build` → 1 passed against the real local server/runner path; confirmed no chat message was added.
- `uv run --no-sync pre-commit run --files <PR files>` → all applicable hooks passed.

## Demo

Paused session prompt:

![Paused session resume prompt](https://github.com/randypitcherii/omnigent/releases/download/demo-resume-paused-terminal-session/terminal-resume-prompt.png)

Terminal after resume:

![Reconnected terminal](https://github.com/randypitcherii/omnigent/releases/download/demo-resume-paused-terminal-session/terminal-resumed.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The browser test drives the rendered SPA against a real local Omnigent server and runner, patches only the browser's liveness view to model an asleep session, invokes the real resume endpoint, waits for the terminal WebSocket to reconnect, and verifies the committed chat-message count is unchanged.

## Changelog

Resume a paused session from Terminal view without sending a new message