### PR TITLE
Add Cmd/Ctrl+N new-session shortcut

### DIFF
--- a/tests/e2e_ui/sessions/test_new_session_hotkey.py
+++ b/tests/e2e_ui/sessions/test_new_session_hotkey.py
@@ -1,0 +1,32 @@
+"""E2E: Ctrl+N opens the new-session composer from focused chat input."""
+
+from __future__ import annotations
+
+import sys
+
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+
+
+def test_new_session_hotkey_from_focused_composer(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Ctrl+N follows the command-palette action to a clean, focused composer."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("draft that belongs to the existing session")
+    expect(composer).to_be_focused()
+
+    modifier = "Meta" if sys.platform == "darwin" else "Control"
+    page.keyboard.press(f"{modifier}+n")
+
+    expect(page).to_have_url(f"{base_url}/", timeout=10_000)
+    new_session_composer = page.get_by_placeholder("Describe a task to start a new session…")
+    expect(new_session_composer).to_be_visible()
+    expect(new_session_composer).to_be_focused()
+    expect(new_session_composer).to_have_value("")

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -1781,11 +1781,14 @@ function buildMenu() {
   /** @type {Electron.MenuItemConstructorOptions[]} */
   const serverSubmenu = [
     {
+      id: "new_session",
+      label: "New Session",
+      accelerator: "CmdOrCtrl+N",
+      click: () => sendOpenPath(activeWindow(), "/"),
+    },
+    {
       id: "new_window",
       label: "New Window",
-      // Own the standard new-window accelerator here — there is no
-      // role-based File menu in this app.
-      accelerator: "CmdOrCtrl+N",
       click: () => newWindow(),
     },
     {

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -214,6 +214,26 @@ function findMenuItem(menu, id) {
   return null;
 }
 
+describe("new session menu action", () => {
+  it("routes Cmd/Ctrl+N to the current window without replacing the New Window action", (t) => {
+    const harness = loadMainHarness();
+    t.after(harness.cleanup);
+
+    harness.api.buildMenu();
+    const menu = harness.calls.setApplicationMenu.at(-1);
+    const newSessionItem = findMenuItem(menu, "new_session");
+    const newWindowItem = findMenuItem(menu, "new_window");
+
+    assert.equal(newSessionItem.label, "New Session");
+    assert.equal(newSessionItem.accelerator, "CmdOrCtrl+N");
+    assert.equal(newWindowItem.accelerator, undefined);
+
+    newSessionItem.click();
+
+    assert.deepEqual(harness.calls.sent, [{ channel: "omnigent:open-path", payload: "/" }]);
+  });
+});
+
 describe("auto-update main-process wiring", () => {
   it("preserves unrelated settings keys when writing update config", (t) => {
     const harness = loadMainHarness({

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -35,6 +35,7 @@ describe("KeyboardShortcutsDialog", () => {
 
     expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
     // General / In chats / Navigation / View / Slash commands — one each.
+    expect(screen.getByText("Start a new session")).toBeTruthy();
     expect(screen.getByText("Open command palette")).toBeTruthy();
     expect(screen.getByText("Show keyboard shortcuts")).toBeTruthy();
     expect(screen.getByText("Send message")).toBeTruthy();

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -66,6 +66,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "General",
     items: [
+      { label: "Start a new session", keys: [MOD_KEY, "N"] },
       { label: "Open command palette", keys: [MOD_KEY, "K"] },
       { label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] },
     ],

--- a/web/src/hooks/useNewSessionHotkey.test.tsx
+++ b/web/src/hooks/useNewSessionHotkey.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isNewSessionHotkey, useNewSessionHotkey } from "./useNewSessionHotkey";
+
+const navigate = vi.fn();
+vi.mock("@/lib/routing", () => ({ useNavigate: () => navigate }));
+
+afterEach(() => {
+  cleanup();
+  navigate.mockReset();
+  document.body.innerHTML = "";
+});
+
+function event(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+function press(init: KeyboardEventInit, target: HTMLElement = document.body): KeyboardEvent {
+  const e = event(init);
+  target.dispatchEvent(e);
+  return e;
+}
+
+describe("isNewSessionHotkey", () => {
+  it("uses Cmd on macOS and Ctrl on other platforms", () => {
+    expect(isNewSessionHotkey(event({ key: "n", metaKey: true }), true)).toBe(true);
+    expect(isNewSessionHotkey(event({ key: "n", ctrlKey: true }), true)).toBe(false);
+    expect(isNewSessionHotkey(event({ key: "n", ctrlKey: true }), false)).toBe(true);
+    expect(isNewSessionHotkey(event({ key: "n", metaKey: true }), false)).toBe(false);
+  });
+
+  it("rejects modified chords and unrelated keys", () => {
+    expect(isNewSessionHotkey(event({ key: "n", metaKey: true, shiftKey: true }), true)).toBe(
+      false,
+    );
+    expect(isNewSessionHotkey(event({ key: "n", ctrlKey: true, altKey: true }), false)).toBe(false);
+    expect(isNewSessionHotkey(event({ key: "m", metaKey: true }), true)).toBe(false);
+  });
+});
+
+describe("useNewSessionHotkey", () => {
+  it("navigates to the shared new-session route and claims Ctrl+N", () => {
+    renderHook(() => useNewSessionHotkey(true, false));
+
+    const e = press({ key: "n", ctrlKey: true });
+
+    expect(navigate).toHaveBeenCalledWith("/");
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("works from editable fields so the global action is focus-independent", () => {
+    renderHook(() => useNewSessionHotkey(true, false));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    press({ key: "N", ctrlKey: true }, input);
+
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("ignores auto-repeat", () => {
+    renderHook(() => useNewSessionHotkey(true, false));
+
+    press({ key: "n", ctrlKey: true, repeat: true });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("leaves the shortcut to the host page when disabled", () => {
+    renderHook(() => useNewSessionHotkey(false, false));
+
+    const e = press({ key: "n", ctrlKey: true });
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+});

--- a/web/src/hooks/useNewSessionHotkey.ts
+++ b/web/src/hooks/useNewSessionHotkey.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+import { useNavigate } from "@/lib/routing";
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  const platform = uaData?.platform ?? navigator.platform ?? navigator.userAgent ?? "";
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+/** True for Cmd+N on Apple platforms or Ctrl+N elsewhere, without extra modifiers. */
+export function isNewSessionHotkey(e: globalThis.KeyboardEvent, isMac = isMacPlatform()): boolean {
+  const platformModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  if (!platformModifier || e.altKey || e.shiftKey || e.getModifierState("AltGraph")) return false;
+  return e.key === "n" || e.key === "N";
+}
+
+/** Navigate to the same new-session route used by the command palette. */
+export function useNewSessionHotkey(enabled = true, isMac = isMacPlatform()): void {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      if (e.repeat || !isNewSessionHotkey(e, isMac)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      navigate("/");
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled, isMac, navigate]);
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
 import { useCommandPaletteHotkey } from "@/hooks/useCommandPaletteHotkey";
+import { useNewSessionHotkey } from "@/hooks/useNewSessionHotkey";
 import { useIsEmbedded } from "@/lib/embedded";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
@@ -1125,6 +1126,7 @@ export function AppShell() {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const isEmbedded = useIsEmbedded();
   useCommandPaletteHotkey(() => setCommandPaletteOpen((prev) => !prev), !isEmbedded);
+  useNewSessionHotkey(!isEmbedded);
 
   // Mobile back button: close the open file and return to the files/changes
   // list. On mobile the tab strip is hidden, so a "back" should fully drop the


### PR DESCRIPTION
## Related issue

Closes #4498
Closes #4499

## Summary

- Add a platform-aware Cmd/Ctrl+N shortcut that opens the same clean new-session route as the command palette, including while an editable field is focused.
- Move Electron's native Cmd/Ctrl+N accelerator from New Window to New Session so macOS navigates the focused window in place; New Window remains available from the Server menu.
- List the shortcut in the keyboard-shortcuts dialog and cover browser, hook, and Electron behavior.

ELI5: pressing “new” now clears the current task surface and opens a fresh session composer instead of creating another desktop window.

```text
Cmd/Ctrl+N
    ├─ Web ────────► AppShell hotkey ─► navigate("/")
    └─ Electron ───► native menu ─────► focused window ─► navigate("/")
```

## Test Plan

- `cd web && pnpm exec vitest run src/hooks/useNewSessionHotkey.test.tsx src/components/KeyboardShortcutsDialog.test.tsx` → 12 passed.
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_new_session_hotkey.py -q --video=on --output=demo-test-results` → 1 passed in Chromium on macOS, including focused-composer navigation and post-navigation focus.
- `cd web/electron && node --test` → 242 passed.
- `cd web && pnpm run lint && pnpm run format:check && pnpm run type-check && pnpm run build` → passed.
- `uv run --no-sync pre-commit run --all-files` → all hooks passed.
- Full web Vitest run: 5,765 passed; 3 pre-existing `NewChatDialog` custom-agent sandbox-gating tests failed and reproduce unchanged when that file runs alone.

## Demo

[Watch the Cmd+N new-session recording](https://github.com/randypitcherii/omnigent/releases/download/gh-attach-assets/video.webm). It shows a draft in the focused existing-session composer, Cmd+N, and the clean focused new-session composer.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused Vitest suite verifies exact platform modifiers, extra-modifier rejection, editable-field behavior, repeat suppression, embedded-host opt-out, navigation, and shortcut-list rendering. The Playwright test drives the real assembled UI from a focused composer. Electron's full test suite verifies the native menu accelerator targets the focused window and no longer belongs to New Window. The recorded passing Playwright run provides the manual visual review artifact.

## Changelog

Cmd/Ctrl+N now starts a new session, including in the macOS desktop app without opening another app window.