### PR TITLE
feat(web): move project rename into settings

### DIFF
--- a/tests/e2e_ui/sessions/test_project_settings_dialog.py
+++ b/tests/e2e_ui/sessions/test_project_settings_dialog.py
@@ -1,6 +1,6 @@
 """Browser e2e for the Project settings dialog (project ``config`` defaults).
 
-A project carries owner-private session defaults in its ``config`` JSON
+A project carries a name and owner-private session defaults in its ``config`` JSON
 (``{ host_id?, workspace?, agent_id?, use_worktree?, base_branch? }``). The "Project settings"
 dialog (``web/src/shell/ProjectSettingsDialog.tsx``, reached from the
 project-folder kebab) reads and writes that config via ``GET /v1/projects/{id}``
@@ -20,7 +20,9 @@ host-free path (the worktree toggle is a plain Switch, no host needed).
 
 from __future__ import annotations
 
+import os
 import uuid
+from pathlib import Path
 
 import httpx
 from playwright.sync_api import Page, expect
@@ -57,6 +59,39 @@ def _open_project_settings(page: Page, project: str) -> None:
     # The dialog's Save button confirms the editor mounted + the config fetch
     # settled (Save is disabled while loading).
     expect(page.get_by_test_id("project-settings-save")).to_be_enabled()
+
+
+def _screenshot(page: Page, name: str) -> None:
+    """Save optional local demo evidence without affecting CI runs."""
+    if shot_dir := os.environ.get("E2E_SCREENSHOT_DIR"):
+        output = Path(shot_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        page.screenshot(path=output / f"{name}.png")
+
+
+def test_project_settings_renames_project(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Editing the settings name updates the project row in the sidebar."""
+    base_url, session_id = seeded_session
+    old_name = f"Before {uuid.uuid4().hex[:6]}"
+    new_name = f"After {uuid.uuid4().hex[:6]}"
+    _create_project(base_url, old_name)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_project_settings(page, old_name)
+
+    name_input = page.get_by_test_id("project-settings-name")
+    expect(name_input).to_have_value(old_name)
+    name_input.fill(new_name)
+    _screenshot(page, "project-settings-name-edited")
+    page.get_by_test_id("project-settings-save").click()
+
+    expect(page.get_by_test_id("project-settings-save")).to_have_count(0)
+    expect(page.get_by_role("button", name=new_name, exact=True)).to_be_visible()
+    expect(page.get_by_role("button", name=old_name, exact=True)).to_have_count(0)
+    _screenshot(page, "project-renamed-in-sidebar")
 
 
 def test_project_settings_worktree_toggle_persists(

--- a/web/src/components/ProjectIconPicker.test.tsx
+++ b/web/src/components/ProjectIconPicker.test.tsx
@@ -10,12 +10,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ProjectLandingIcon } from "./ProjectIconPicker";
-import { createProject, updateProjectConfig } from "@/lib/projectsApi";
+import { createProject, updateProjectSettings } from "@/lib/projectsApi";
 import type { ProjectConfig } from "@/lib/projectsApi";
 
 vi.mock("@/lib/projectsApi", () => ({
   getProject: vi.fn(),
-  updateProjectConfig: vi.fn(),
+  updateProjectSettings: vi.fn(),
   createProject: vi.fn(),
 }));
 vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
@@ -31,7 +31,7 @@ vi.mock("@emoji-mart/react", () => ({
 }));
 vi.mock("@emoji-mart/data", () => ({ default: {} }));
 
-const updateMock = vi.mocked(updateProjectConfig);
+const updateMock = vi.mocked(updateProjectSettings);
 const createMock = vi.mocked(createProject);
 
 interface Overrides {
@@ -80,7 +80,7 @@ describe("ProjectLandingIcon", () => {
 
     await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
     // The whole prior config survives; only `icon` is added.
-    expect(updateMock).toHaveBeenCalledWith("p_1", { ...config, icon: "🔥" });
+    expect(updateMock).toHaveBeenCalledWith("p_1", "Work", { ...config, icon: "🔥" });
   });
 
   it("removes the icon while preserving the other defaults", async () => {
@@ -89,7 +89,7 @@ describe("ProjectLandingIcon", () => {
     fireEvent.click(screen.getByTestId("project-icon-remove"));
 
     await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
-    expect(updateMock).toHaveBeenCalledWith("p_1", { host_id: "h1" });
+    expect(updateMock).toHaveBeenCalledWith("p_1", "Work", { host_id: "h1" });
   });
 
   it("does not write before the config has loaded (guards the data-loss race)", async () => {
@@ -109,10 +109,10 @@ describe("ProjectLandingIcon", () => {
     fireEvent.click(screen.getByTestId("project-icon-tile"));
     fireEvent.click(await screen.findByTestId("pick-fire"));
 
-    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
-    // The label-only folder is promoted (created) first, then the icon is set
-    // on the fresh first-class id.
-    expect(createMock).toHaveBeenCalledWith("Work");
-    expect(updateMock).toHaveBeenCalledWith("p_new", { icon: "🔥" });
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    // Promotion creates the first-class project with its initial config in one
+    // request, avoiding a second PATCH against the freshly-created id.
+    expect(createMock).toHaveBeenCalledWith("Work", { icon: "🔥" });
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -1682,7 +1682,7 @@ describe("useProjects", () => {
   });
 });
 
-describe("useUpdateProjectConfig cache seeding", () => {
+describe("useUpdateProjectConfig", () => {
   it("seeds the fresh config + upserts the projects list on success (no stale read)", async () => {
     // The composer prefill settles once from the cache, so a save must write
     // the fresh value in — not merely invalidate — or the next visit within the
@@ -1695,22 +1695,124 @@ describe("useUpdateProjectConfig cache seeding", () => {
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
 
-    // The PATCH (label-only folder → promoted, so a create precedes it) returns
-    // the fresh first-class project with its stored config.
-    fetchMock
-      .mockResolvedValueOnce(mockResponse({ id: "p_new", name: "Work" })) // apiCreateProject
-      .mockResolvedValueOnce(
-        mockResponse({ id: "p_new", name: "Work", config: { agent_id: "ag_x" } }),
-      );
+    // A label-only folder is created with its config in the same request.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "p_new", name: "Work", config: { agent_id: "ag_x" } }),
+    );
 
     const { result } = renderHook(() => useUpdateProjectConfig(), { wrapper });
-    result.current.mutate({ id: null, name: "Work", config: { agent_id: "ag_x" } });
+    result.current.mutate({
+      id: null,
+      oldName: "Work",
+      newName: "Work",
+      config: { agent_id: "ag_x" },
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects");
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "Work",
+      config: { agent_id: "ag_x" },
+    });
     // The config cache holds the fresh value keyed by the NEW id.
     expect(queryClient.getQueryData(["project-config", "p_new"])).toEqual({ agent_id: "ag_x" });
     // The projects list now resolves "Work" → the promoted first-class id.
     expect(queryClient.getQueryData(["projects"])).toEqual([{ id: "p_new", name: "Work" }]);
+  });
+
+  it("promotes and renames a legacy label project while preserving its members", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(["projects"], [{ id: null, name: "Old" }]);
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ id: "p_new", name: "New", config: { agent_id: "ag_x" } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          data: [{ id: "session_1" }],
+          first_id: "session_1",
+          last_id: "session_1",
+          has_more: false,
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse({ id: "session_1" }));
+
+    const { result } = renderHook(() => useUpdateProjectConfig(), { wrapper });
+    result.current.mutate({
+      id: null,
+      oldName: "Old",
+      newName: "New",
+      config: { agent_id: "ag_x" },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [createUrl, createInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(createUrl).toBe("/v1/projects");
+    expect(JSON.parse(createInit.body as string)).toEqual({
+      name: "New",
+      config: { agent_id: "ag_x" },
+    });
+    expect(fetchMock.mock.calls[1][0]).toContain("project=Old");
+    const [sessionUrl, sessionInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(sessionUrl).toBe("/v1/sessions/session_1");
+    expect(JSON.parse(sessionInit.body as string)).toEqual({
+      project_id: "p_new",
+      labels: { omni_project: "" },
+    });
+    expect(queryClient.getQueryData(["projects"])).toEqual([{ id: "p_new", name: "New" }]);
+    expect(queryClient.getQueryData(["project-config", "p_new"])).toEqual({
+      agent_id: "ag_x",
+    });
+  });
+
+  it("updates name and config together, migrates legacy labels, and replaces the cached name", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(["projects"], [{ id: "p_1", name: "Old" }]);
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ id: "p_1", name: "New", config: { use_worktree: true } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          data: [{ id: "session_1" }],
+          first_id: "session_1",
+          last_id: "session_1",
+          has_more: false,
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse({ id: "session_1" }));
+
+    const { result } = renderHook(() => useUpdateProjectConfig(), { wrapper });
+    result.current.mutate({
+      id: "p_1",
+      oldName: "Old",
+      newName: "New",
+      config: { use_worktree: true },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [projectUrl, projectInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(projectUrl).toBe("/v1/projects/p_1");
+    expect(JSON.parse(projectInit.body as string)).toEqual({
+      name: "New",
+      config: { use_worktree: true },
+    });
+    expect(fetchMock.mock.calls[1][0]).toContain("project=Old");
+    const [sessionUrl, sessionInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(sessionUrl).toBe("/v1/sessions/session_1");
+    expect(JSON.parse(sessionInit.body as string)).toEqual({
+      project_id: "p_1",
+      labels: { omni_project: "" },
+    });
+    expect(queryClient.getQueryData(["projects"])).toEqual([{ id: "p_1", name: "New" }]);
+    expect(queryClient.getQueryData(["project-config", "p_1"])).toEqual({
+      use_worktree: true,
+    });
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -50,7 +50,7 @@ import {
   listProjects as apiListProjects,
   type ProjectConfig,
   renameProject as apiRenameProject,
-  updateProjectConfig as apiUpdateProjectConfig,
+  updateProjectSettings as apiUpdateProjectSettings,
 } from "@/lib/projectsApi";
 import { releaseConversation, useChatStore } from "@/store/chatStore";
 import type { Session } from "@/lib/types";
@@ -1926,6 +1926,23 @@ export function useCreateProject() {
   });
 }
 
+async function migrateLegacyProjectMembers(oldName: string, projectId: string): Promise<void> {
+  const memberIds = await fetchAllProjectSessionIds(oldName);
+  await Promise.all(
+    memberIds.map(async (sid) => {
+      const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sid)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          project_id: projectId,
+          labels: { [PROJECT_LABEL_KEY]: "" },
+        }),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    }),
+  );
+}
+
 /**
  * Rename a project. A first-class project renames its row via
  * `PATCH /v1/projects/{id}`; a label-only folder (`id === null`) is promoted on
@@ -1964,25 +1981,7 @@ export function useRenameProject() {
       // omni_project label; re-file each onto project_id and clear that label so
       // the rename is coherent for both membership representations and nothing
       // is left behind in an oldName folder.
-      const memberIds = await fetchAllProjectSessionIds(oldName);
-      await Promise.all(
-        memberIds.map(async (sid) => {
-          const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sid)}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              project_id: projectId,
-              labels: { [PROJECT_LABEL_KEY]: "" },
-            }),
-          });
-          // Surface a failed re-file: a resolved-but-4xx/5xx response would
-          // otherwise report success while leaving members behind.
-          if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-        }),
-      );
-      // Return the resolved id so a caller promoting a label-only folder can
-      // target the just-created row for a follow-up write instead of passing
-      // the stale `null` and re-creating it (which 409s on the duplicate name).
+      await migrateLegacyProjectMembers(oldName, projectId);
       return projectId;
     },
     onSuccess: () => {
@@ -2010,27 +2009,37 @@ export function useProjectConfig(id: string | null) {
 }
 
 /**
- * Replace a project's stored `config` defaults (`PATCH /v1/projects/{id}`).
- * A label-only folder (`id === null`) is promoted on demand — a row created
- * under its name — so its defaults can be stored, mirroring `useRenameProject`.
- * Passing `config: {}` clears the stored defaults.
+ * Update a project's name and stored defaults together. A label-only folder is
+ * promoted on demand, and a rename migrates any members still using its legacy
+ * label onto the first-class project id.
  */
 export function useUpdateProjectConfig() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      id,
-      name,
-      config,
-    }: {
+    mutationFn: async (args: {
       id: string | null;
-      name: string;
+      name?: string;
+      oldName?: string;
+      newName?: string;
       config: ProjectConfig;
     }) => {
-      const projectId = id ?? (await apiCreateProject(name)).id;
-      return apiUpdateProjectConfig(projectId, config);
+      const { id, config } = args;
+      const oldName = args.oldName ?? args.name;
+      const newName = args.newName ?? args.name;
+      if (!oldName || !newName) throw new Error("Project name is required");
+      const project =
+        id === null
+          ? await apiCreateProject(newName, config)
+          : await apiUpdateProjectSettings(id, newName, config);
+      if (newName !== oldName) {
+        await migrateLegacyProjectMembers(oldName, project.id);
+      }
+      return project;
     },
-    onSuccess: (project) => {
+    onSuccess: (project, args) => {
+      const { id } = args;
+      const oldName = args.oldName ?? args.name ?? project.name;
+      const newName = args.newName ?? args.name ?? project.name;
       // Seed the fresh config into the cache (not just invalidate) so the
       // composer's prefill reads the just-saved defaults on the very next visit
       // — the prefill settles once and would otherwise latch onto the stale
@@ -2044,10 +2053,15 @@ export function useUpdateProjectConfig() {
       queryClient.setQueryData<ProjectSummary[]>(["projects"], (prev) => {
         if (!prev) return prev;
         const summary = { id: project.id, name: project.name, icon: project.config?.icon };
-        return prev.some((p) => p.name === project.name)
-          ? prev.map((p) => (p.name === project.name ? summary : p))
+        return prev.some((p) => p.id === id || p.name === oldName)
+          ? prev.map((p) => (p.id === id || p.name === oldName ? summary : p))
           : [...prev, summary];
       });
+      if (newName !== oldName) {
+        void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+        void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+        void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+      }
       void queryClient.invalidateQueries({ queryKey: ["project-config"] });
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
     },

--- a/web/src/lib/projectsApi.test.ts
+++ b/web/src/lib/projectsApi.test.ts
@@ -10,6 +10,7 @@ import {
   listProjects,
   renameProject,
   updateProjectConfig,
+  updateProjectSettings,
 } from "./projectsApi";
 
 function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
@@ -106,6 +107,22 @@ describe("updateProjectConfig", () => {
     await updateProjectConfig("p_1", {});
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).toEqual({ config: {} });
+  });
+});
+
+describe("updateProjectSettings", () => {
+  it("PATCHes the name and config together", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "p a", name: "Renamed", config: { agent_id: "ag_1" } }),
+    );
+    await updateProjectSettings("p a", "Renamed", { agent_id: "ag_1" });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects/p%20a");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "Renamed",
+      config: { agent_id: "ag_1" },
+    });
   });
 });
 

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -125,6 +125,21 @@ export async function updateProjectConfig(id: string, config: ProjectConfig): Pr
   return (await res.json()) as Project;
 }
 
+/** Update a project's name and stored defaults in one request. */
+export async function updateProjectSettings(
+  id: string,
+  name: string,
+  config: ProjectConfig,
+): Promise<Project> {
+  const res = await authenticatedFetch(`/v1/projects/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, config }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as Project;
+}
+
 /**
  * Delete a project. Only the container is removed; member sessions are kept
  * (never cascade-deleted). Their `project_id` is left dangling server-side, but

--- a/web/src/shell/ProjectSettingsDialog.test.tsx
+++ b/web/src/shell/ProjectSettingsDialog.test.tsx
@@ -173,7 +173,7 @@ describe("ProjectSettingsDialog", () => {
     fireEvent.click(screen.getByTestId("project-settings-save"));
 
     await waitFor(() =>
-      expect(updateMock).toHaveBeenCalledWith("p_1", { icon: "🔥", use_worktree: true }),
+      expect(updateMock).toHaveBeenCalledWith("p_1", "Work", { icon: "🔥", use_worktree: true }),
     );
   });
 

--- a/web/src/shell/ProjectSettingsDialog.test.tsx
+++ b/web/src/shell/ProjectSettingsDialog.test.tsx
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
-import { getProject, updateProjectConfig, createProject } from "@/lib/projectsApi";
+import { getProject, updateProjectSettings, createProject } from "@/lib/projectsApi";
 
 vi.mock("@/lib/projectsApi", () => ({
   getProject: vi.fn(),
-  updateProjectConfig: vi.fn(),
+  updateProjectSettings: vi.fn(),
   createProject: vi.fn(),
 }));
 vi.mock("@/hooks/useHosts", () => ({
@@ -51,7 +51,7 @@ vi.mock("./WorkspacePicker", () => ({
 }));
 
 const getProjectMock = vi.mocked(getProject);
-const updateMock = vi.mocked(updateProjectConfig);
+const updateMock = vi.mocked(updateProjectSettings);
 const createMock = vi.mocked(createProject);
 
 function renderDialog(projectId: string | null = "p_1") {
@@ -96,6 +96,45 @@ describe("ProjectSettingsDialog", () => {
     expect(screen.getByTestId("project-settings-workspace")).toHaveTextContent(
       /pick a host first/i,
     );
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Work");
+  });
+
+  it("trims and saves the project name with its config in one update", async () => {
+    getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+    renderDialog();
+    await waitFor(() =>
+      expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "  Renamed  " },
+    });
+    fireEvent.click(screen.getByTestId("project-settings-worktree"));
+    fireEvent.click(screen.getByTestId("project-settings-save"));
+
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith("p_1", "Renamed", { use_worktree: true }),
+    );
+  });
+
+  it("requires a non-blank project name", async () => {
+    getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+    renderDialog();
+    await waitFor(() =>
+      expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "   " },
+    });
+
+    expect(screen.getByTestId("project-settings-save")).toBeDisabled();
+    fireEvent.submit(screen.getByTestId("project-settings-save").closest("form")!);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   it("saves only the fields that are set (unset slots omitted)", async () => {
@@ -114,7 +153,7 @@ describe("ProjectSettingsDialog", () => {
     fireEvent.click(screen.getByTestId("project-settings-save"));
 
     await waitFor(() => expect(updateMock).toHaveBeenCalled());
-    expect(updateMock).toHaveBeenCalledWith("p_1", { use_worktree: true });
+    expect(updateMock).toHaveBeenCalledWith("p_1", "Work", { use_worktree: true });
   });
 
   it("preserves the project icon when saving settings", async () => {
@@ -148,7 +187,7 @@ describe("ProjectSettingsDialog", () => {
     );
     // Leave the toggle OFF (default) → config clears to {} (use_worktree absent).
     fireEvent.click(screen.getByTestId("project-settings-save"));
-    await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", {}));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", "Work", {}));
   });
 
   it("shows the base-branch field only when the worktree default is on, and saves it", async () => {
@@ -170,7 +209,10 @@ describe("ProjectSettingsDialog", () => {
 
     // Trimmed and stored alongside the worktree default.
     await waitFor(() =>
-      expect(updateMock).toHaveBeenCalledWith("p_1", { use_worktree: true, base_branch: "main" }),
+      expect(updateMock).toHaveBeenCalledWith("p_1", "Work", {
+        use_worktree: true,
+        base_branch: "main",
+      }),
     );
   });
 
@@ -190,7 +232,7 @@ describe("ProjectSettingsDialog", () => {
     // Turn the worktree default OFF → base branch drops, config clears to {}.
     fireEvent.click(screen.getByTestId("project-settings-worktree"));
     fireEvent.click(screen.getByTestId("project-settings-save"));
-    await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", {}));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", "Work", {}));
   });
 
   it("hides the sandbox option when managed sandboxes are disabled", async () => {
@@ -215,8 +257,8 @@ describe("ProjectSettingsDialog", () => {
     fireEvent.click(screen.getByTestId("project-settings-worktree"));
     fireEvent.click(screen.getByTestId("project-settings-save"));
 
-    await waitFor(() => expect(createMock).toHaveBeenCalledWith("Work"));
-    expect(updateMock).toHaveBeenCalledWith("p_new", { use_worktree: true });
+    await waitFor(() => expect(createMock).toHaveBeenCalledWith("Work", { use_worktree: true }));
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   it("persists host, workspace, and agent from a seeded config on save", async () => {
@@ -234,7 +276,7 @@ describe("ProjectSettingsDialog", () => {
     // Save without touching anything — the seeded fields round-trip back out.
     fireEvent.click(screen.getByTestId("project-settings-save"));
     await waitFor(() =>
-      expect(updateMock).toHaveBeenCalledWith("p_1", {
+      expect(updateMock).toHaveBeenCalledWith("p_1", "Work", {
         host_id: "h1",
         workspace: "/repo",
         agent_id: "ag_1",
@@ -262,7 +304,10 @@ describe("ProjectSettingsDialog", () => {
 
     fireEvent.click(screen.getByTestId("project-settings-save"));
     await waitFor(() =>
-      expect(updateMock).toHaveBeenCalledWith("p_1", { host_id: "h1", workspace: "/picked/dir" }),
+      expect(updateMock).toHaveBeenCalledWith("p_1", "Work", {
+        host_id: "h1",
+        workspace: "/picked/dir",
+      }),
     );
   });
 

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -43,6 +43,7 @@ import { SANDBOX_HOST_CHOICE } from "@/lib/hostPreferences";
 import { isNativeCodingAgent } from "@/lib/nativeCodingAgents";
 import type { ProjectConfig } from "@/lib/projectsApi";
 import { shouldGuardDialogDismiss } from "@/lib/dialogDismissGuard";
+import { ProjectLandingIcon } from "@/components/ProjectIconPicker";
 import { AgentHarnessPicker } from "./NewChatDialog";
 import { isNavigablePath, WorkspacePicker } from "./WorkspacePicker";
 
@@ -118,6 +119,7 @@ export function ProjectSettingsDialog({
 
   // Draft fields. Seeded from the stored config each time the dialog opens (or
   // the fetched config arrives); local until saved.
+  const [name, setName] = useState(projectName);
   const [hostId, setHostId] = useState<string>(NONE);
   const [workspace, setWorkspace] = useState("");
   // Worktree default for the project. The toggle seeds from the project's
@@ -167,6 +169,11 @@ export function ProjectSettingsDialog({
 
   useEffect(() => {
     if (!open) return;
+    setName(projectName);
+  }, [open, projectName]);
+
+  useEffect(() => {
+    if (!open) return;
     // Don't seed a blank draft from a failed load — Save is blocked anyway, and
     // clobbering the fields would risk sending `{}` if the guard ever regressed.
     if (loadFailed) return;
@@ -183,7 +190,9 @@ export function ProjectSettingsDialog({
     e.preventDefault();
     // Guard against submitting a blank draft seeded from a failed load, which
     // the server would read as "clear the stored defaults".
-    if (loadFailed) return;
+    // A blank name would rename the project to nothing, so hold the submit.
+    const newName = name.trim();
+    if (loadFailed || newName === "") return;
     // Preserve config keys owned by other dialogs, then replace only the fields
     // this form edits.
     const config: ProjectConfig = { ...(stored ?? {}) };
@@ -211,7 +220,7 @@ export function ProjectSettingsDialog({
     else delete config.base_branch;
 
     updateConfig.mutate(
-      { id: projectId, name: projectName, config },
+      { id: projectId, oldName: projectName, newName, config },
       { onSuccess: () => onOpenChange(false) },
     );
   };
@@ -259,11 +268,33 @@ export function ProjectSettingsDialog({
         <DialogHeader>
           <DialogTitle>Project settings</DialogTitle>
           <DialogDescription>
-            Defaults for new sessions in <span className="font-medium">{projectName}</span>. Each is
-            a starting point you can change per session; leave a field blank for no default.
+            Update this project and its defaults for new sessions. Each default is a starting point
+            you can change per session; leave a field blank for no default.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          <Field label="Name" htmlFor="project-settings-name">
+            <input
+              id="project-settings-name"
+              data-testid="project-settings-name"
+              className="w-full rounded-md border bg-transparent px-3 py-2 text-ui outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={updateConfig.isPending}
+              maxLength={100}
+              required
+            />
+          </Field>
+
+          <Field label="Icon" hint="Shown beside the project in the sidebar">
+            <ProjectLandingIcon
+              projectId={projectId}
+              projectName={projectName}
+              config={stored}
+              configReady={projectId === null || stored !== undefined}
+            />
+          </Field>
+
           <Field label="Host" hint="Where new sessions run by default">
             <Select
               value={hostId}
@@ -490,7 +521,7 @@ export function ProjectSettingsDialog({
               type="submit"
               data-testid="project-settings-save"
               loading={updateConfig.isPending}
-              disabled={isLoading || loadFailed}
+              disabled={isLoading || loadFailed || name.trim() === ""}
             >
               Save
             </Button>

--- a/web/src/shell/Sidebar.projectContextMenu.test.tsx
+++ b/web/src/shell/Sidebar.projectContextMenu.test.tsx
@@ -168,7 +168,7 @@ function dispatchTouchPointer(
 
 function expectProjectMenuActions() {
   expect(screen.getByTestId("project-new-session-menu")).toBeInTheDocument();
-  expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+  expect(screen.queryByTestId("rename-project")).toBeNull();
   expect(screen.getByTestId("project-settings")).toBeInTheDocument();
   expect(screen.getByTestId("delete-project")).toBeInTheDocument();
 }
@@ -187,7 +187,7 @@ describe("project folder header context menu", () => {
     renderSidebar();
     const header = folderHeader();
 
-    expect(screen.queryByTestId("rename-project")).toBeNull();
+    expect(screen.queryByTestId("project-settings")).toBeNull();
     fireEvent.contextMenu(header);
 
     expectProjectMenuActions();
@@ -217,28 +217,9 @@ describe("project folder header context menu", () => {
 
     expect(contextTrigger()).toBe(folderHeader());
     fireEvent.pointerDown(screen.getByTestId("project-actions"), { button: 0 });
-    fireEvent.click(screen.getByTestId("rename-project"));
+    fireEvent.click(screen.getByTestId("project-settings"));
 
-    expect(screen.getByTestId("rename-project-confirm")).toBeInTheDocument();
-  });
-
-  it("drives Rename into the shared dialog and mutation", async () => {
-    renderSidebar();
-
-    fireEvent.contextMenu(folderHeader());
-    fireEvent.click(screen.getByTestId("rename-project"));
-    fireEvent.change(screen.getByDisplayValue(PROJECT_NAME), {
-      target: { value: "Sprint 43" },
-    });
-    fireEvent.click(screen.getByTestId("rename-project-confirm"));
-
-    await waitFor(() =>
-      expect(mocks.renameProject.mutateAsync).toHaveBeenCalledWith({
-        id: PROJECT_ID,
-        oldName: PROJECT_NAME,
-        newName: "Sprint 43",
-      }),
-    );
+    expect(screen.getByRole("dialog")).toHaveTextContent("Project settings");
   });
 
   it("drives Project settings from the context menu", () => {
@@ -294,7 +275,7 @@ describe("project folder header context menu", () => {
     renderSidebar();
 
     fireEvent.contextMenu(folderHeader());
-    expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+    expect(screen.getByTestId("project-settings")).toBeInTheDocument();
     expect(folderHeader()).toHaveAttribute("aria-expanded", "false");
     dismissMenu();
     fireEvent.click(folderHeader());
@@ -332,7 +313,7 @@ describe("project folder header context menu", () => {
 
       dispatchTouchPointer(header, "pointerdown");
       act(() => vi.advanceTimersByTime(699));
-      expect(screen.queryByTestId("rename-project")).toBeNull();
+      expect(screen.queryByTestId("project-settings")).toBeNull();
       act(() => vi.advanceTimersByTime(1));
 
       // Long-press exposes the complete action set on touch.
@@ -355,14 +336,14 @@ describe("project folder header context menu", () => {
       // Prove the same touch path can open before exercising cancellation.
       dispatchTouchPointer(header, "pointerdown");
       act(() => vi.advanceTimersByTime(700));
-      expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+      expect(screen.getByTestId("project-settings")).toBeInTheDocument();
       dismissMenu();
 
       dispatchTouchPointer(header, "pointerdown");
       dispatchTouchPointer(header, "pointermove");
       act(() => vi.advanceTimersByTime(700));
 
-      expect(screen.queryByTestId("rename-project")).toBeNull();
+      expect(screen.queryByTestId("project-settings")).toBeNull();
     } finally {
       cleanup();
       vi.useRealTimers();
@@ -375,7 +356,7 @@ describe("project folder header context menu", () => {
     header.focus();
 
     fireEvent.contextMenu(header, { detail: 0 });
-    expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+    expect(screen.getByTestId("project-settings")).toBeInTheDocument();
   });
 
   it("toggles on the first keyboard activation after dismissal", async () => {
@@ -384,7 +365,7 @@ describe("project folder header context menu", () => {
     header.focus();
 
     fireEvent.contextMenu(header, { detail: 0 });
-    expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+    expect(screen.getByTestId("project-settings")).toBeInTheDocument();
     dismissMenu();
     await waitFor(() => expect(header).toHaveFocus());
     fireEvent.click(header, { detail: 0 });
@@ -413,7 +394,7 @@ describe("project folder header context menu", () => {
 
     expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
     expect(screen.getByTestId("archive-conversation")).toBeInTheDocument();
-    expect(screen.queryByTestId("rename-project")).toBeNull();
+    expect(screen.queryByTestId("project-settings")).toBeNull();
   });
 
   it("suppresses the context menu in bulk-selection mode", () => {
@@ -427,7 +408,7 @@ describe("project folder header context menu", () => {
     expect(folderHeader().closest('[data-slot="context-menu-trigger"]')).toBeNull();
     expect(folderHeader()).toHaveClass("select-none", "[-webkit-touch-callout:none]");
     fireEvent.contextMenu(folderHeader());
-    expect(screen.queryByTestId("rename-project")).toBeNull();
+    expect(screen.queryByTestId("project-settings")).toBeNull();
   });
 
   it("keeps the collapse toggle active when selection mode unmounts an open menu", () => {
@@ -438,7 +419,7 @@ describe("project folder header context menu", () => {
 
     fireEvent.pointerDown(screen.getByTestId("project-list-actions"), { button: 0 });
     fireEvent.contextMenu(header);
-    expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+    expect(screen.getByTestId("project-settings")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("projects-select-sessions"));
     const selectionHeader = folderHeader();
     expect(selectionHeader.closest('[data-slot="context-menu-trigger"]')).toBeNull();

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -1704,6 +1704,22 @@ describe("Sidebar project sections", () => {
     expect(screen.getByRole("button", { name: "Exit selection mode" })).toBeInTheDocument();
   });
 
+  it("offers project settings with the name field and no standalone rename action", async () => {
+    projectsMock.push("Customer X");
+    mockConversations([]);
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project actions for Customer X" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.queryByText("Rename project")).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId("project-settings"));
+    expect(await screen.findByRole("dialog", { name: "Project settings" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Customer X");
+  });
+
   it("deletes a project (and all its sessions) from the folder kebab after confirming", async () => {
     projectsMock.push("Customer X");
     mockConversations([

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -45,7 +45,6 @@ import {
   SearchIcon,
   Settings2Icon,
   ShareIcon,
-  SmilePlusIcon,
   SquareIcon,
   SquareCheckIcon,
   SquarePenIcon,
@@ -104,7 +103,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   type Conversation,
   type PinnedConversationsResult,
@@ -118,9 +116,6 @@ import {
   useLeaveSession,
   useMoveToProject,
   useDeleteProject,
-  useRenameProject,
-  useProjectConfig,
-  useUpdateProjectConfig,
   PROJECT_LABEL_KEY,
   PINNED_CONVERSATIONS_KEY,
   usePinnedConversations,
@@ -141,7 +136,6 @@ import { showToast } from "@/components/ui/toast";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 import { ProjectRowIcon } from "./ProjectPicker";
-import { EmojiPicker } from "@/components/ProjectIconPicker";
 import { SessionStateBadge } from "@/components/SessionStateBadge";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useActiveRootSessionId } from "@/hooks/useSession";
@@ -1250,11 +1244,7 @@ function ProjectFolder({
     data: { type: "project", name },
   });
 
-  const { actions: menuActions, dialogs: menuDialogs } = useProjectFolderMenu(
-    name,
-    projectId,
-    icon,
-  );
+  const { actions: menuActions, dialogs: menuDialogs } = useProjectFolderMenu(name, projectId);
 
   return (
     <div
@@ -4185,12 +4175,6 @@ function ProjectFolderMenuItems({
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
   actions: ProjectFolderMenuActions;
 }) {
-  useEffect(() => {
-    // Config loading follows the Radix content lifecycle; do not force-mount it.
-    actions.onMenuOpen();
-    return actions.onMenuClose;
-  }, [actions]);
-
   return (
     <>
       <C.Item asChild data-testid="project-new-session-menu">
@@ -4218,254 +4202,32 @@ function ProjectFolderMenuItems({
 }
 
 interface ProjectFolderMenuActions {
-  openRename: () => void;
   openSettings: () => void;
   openDelete: () => void;
-  onMenuOpen: () => void;
-  onMenuClose: () => void;
 }
 
 /** Owns the dialogs and mutations shared by both project-folder menus. */
 function useProjectFolderMenu(
   projectName: string,
   projectId: string | null,
-  icon?: string | null,
 ): { actions: ProjectFolderMenuActions; dialogs: ReactNode } {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [renameOpen, setRenameOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [emojiOpen, setEmojiOpen] = useState(false);
-  const [renameValue, setRenameValue] = useState(projectName);
-  // The icon staged in the rename modal, committed only on Confirm:
-  //   undefined = untouched (show the saved icon), string = a picked emoji,
-  //   null = staged removal. Reset to `undefined` each time the modal opens.
-  const [pendingIcon, setPendingIcon] = useState<string | null | undefined>(undefined);
   const deleteProject = useDeleteProject();
-  const renameProject = useRenameProject();
-  const updateConfig = useUpdateProjectConfig();
-  // Fetch the full config only while the menu or rename modal is open, so we can
-  // merge the icon onto the other stored defaults (host / workspace / agent)
-  // without a per-folder request on every sidebar render — and without wiping
-  // those defaults on save.
-  const { data: iconConfig, isError: iconConfigError } = useProjectConfig(
-    menuOpen || renameOpen ? projectId : null,
-  );
-  // The config PATCH replaces the whole blob, so an ICON save must merge onto a
-  // fully-loaded config or it silently wipes the other defaults. "Ready" means
-  // the config actually resolved (`!== undefined` — `isLoading` alone is false
-  // on a query *error* too, leaving no data to merge onto) — except a
-  // label-only folder (`projectId === null`), whose base is legitimately `{}`.
-  // This gates only the icon path; renaming the name never needs the config.
-  const configReady = projectId === null || iconConfig !== undefined;
-  const savedIcon = iconConfig !== undefined ? iconConfig?.icon : icon;
-  // What the modal's tile shows: the staged pick when touched, else the saved
-  // icon. `null` (staged removal) renders as the empty folder.
-  const displayIcon = pendingIcon !== undefined ? pendingIcon : savedIcon;
 
   const actions = useMemo<ProjectFolderMenuActions>(
     () => ({
-      openRename: () => {
-        setRenameValue(projectName);
-        setPendingIcon(undefined);
-        setRenameOpen(true);
-      },
       openSettings: () => setSettingsOpen(true),
       openDelete: () => setDeleteOpen(true),
-      onMenuOpen: () => setMenuOpen(true),
-      onMenuClose: () => setMenuOpen(false),
     }),
-    [projectName],
+    [],
   );
 
   const dialogs = (
     <>
-      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
-        <DialogContent
-          onClick={(e) => e.stopPropagation()}
-          // emoji-mart preventDefaults the pointer event, so Radix's own
-          // outside-dismissal never fires for clicks elsewhere in the modal.
-          // Catch them in the capture phase and close the picker ourselves,
-          // unless the pointer is inside the picker or on its trigger tile.
-          onPointerDownCapture={(e) => {
-            if (!emojiOpen) return;
-            const target = e.target as Element;
-            if (
-              target.closest('[data-slot="popover-content"]') ||
-              target.closest('[data-testid="rename-project-icon"]')
-            )
-              return;
-            setEmojiOpen(false);
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>Rename project</DialogTitle>
-          </DialogHeader>
-          {/* A <form> so Enter in the input submits natively (Radix Dialog
-              doesn't wrap children in one) instead of relying on a manual
-              key handler + button lookup. */}
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              const newName = renameValue.trim();
-              const nameChanged = newName !== "" && newName !== projectName;
-              const iconChanged = pendingIcon !== undefined && pendingIcon !== (savedIcon ?? null);
-              // Only the icon write needs a loaded config to merge onto; a
-              // name-only rename must proceed even if the config fetch failed.
-              if (iconChanged && !configReady) return;
-              try {
-                // Name first: it promotes a label-only folder (creating the
-                // first-class row) and reconciles members. Capture the resolved
-                // id so the icon write below targets that row — passing the
-                // stale render-time `null` would make the config write try to
-                // create the project a second time and 409 on the duplicate.
-                let targetId = projectId;
-                if (nameChanged) {
-                  targetId = await renameProject.mutateAsync({
-                    id: projectId,
-                    oldName: projectName,
-                    newName,
-                  });
-                }
-                if (iconChanged) {
-                  const next = { ...(iconConfig ?? {}) };
-                  if (pendingIcon === null) delete next.icon;
-                  else next.icon = pendingIcon;
-                  await updateConfig.mutateAsync({
-                    id: targetId,
-                    name: nameChanged ? newName : projectName,
-                    config: next,
-                  });
-                }
-              } catch {
-                // Errors surface via the mutation state below. A rename that
-                // lands before a failed icon write is already persisted; only
-                // the icon needs retrying.
-                return;
-              }
-              setRenameOpen(false);
-              setMenuOpen(false);
-            }}
-          >
-            {/* One combined control: emoji tile (left) + name (right) share a
-                single border, so it reads as a single input. The tile opens a
-                picker popover; the pick is staged and committed on Confirm. */}
-            <div className="flex items-stretch overflow-hidden rounded-lg border border-input">
-              <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Change project icon"
-                    data-testid="rename-project-icon"
-                    disabled={!configReady}
-                    className={cn(
-                      "flex size-[38px] shrink-0 cursor-pointer items-center justify-center outline-none transition-colors disabled:cursor-default disabled:opacity-50",
-                      displayIcon ? "bg-muted" : "bg-tag-pink",
-                    )}
-                  >
-                    {displayIcon ? (
-                      <span className="text-xl leading-none">{displayIcon}</span>
-                    ) : (
-                      <SmilePlusIcon className="size-4 text-brand-accent" />
-                    )}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  align="start"
-                  // Publish the collision-aware available viewport height (Radix
-                  // exposes it as a CSS var), less the optional "Remove icon"
-                  // header and capped at the picker's natural size, so the
-                  // .emoji-picker-popover rule in index.css shrinks emoji-mart to
-                  // fit — it then scrolls its grid internally (nav + search
-                  // pinned) instead of clipping on short screens.
-                  collisionPadding={8}
-                  style={
-                    {
-                      "--emoji-picker-height": `min(420px, calc(var(--radix-popover-content-available-height) - ${displayIcon ? "38px" : "0px"}))`,
-                    } as CSSProperties
-                  }
-                  className="emoji-picker-popover flex max-h-[var(--radix-popover-content-available-height)] w-auto flex-col overflow-hidden p-0"
-                  // The rename Dialog's scroll lock (react-remove-scroll)
-                  // preventDefaults wheel events over the picker — it can't see
-                  // emoji-mart's scroll region inside shadow DOM. Stop the wheel
-                  // from reaching the document-level lock so the grid scrolls.
-                  onWheel={(e) => e.stopPropagation()}
-                  // Nested in the rename Dialog, emoji-mart's own focus handling
-                  // swallows Radix's default outside-pointer dismissal, so a
-                  // click elsewhere in the modal wouldn't close the picker.
-                  // Close it explicitly on any outside interaction.
-                >
-                  {displayIcon ? (
-                    <div className="shrink-0 border-b p-1">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="w-full justify-start"
-                        data-testid="rename-project-remove-icon"
-                        onClick={() => {
-                          setPendingIcon(null);
-                          setEmojiOpen(false);
-                        }}
-                      >
-                        <Trash2Icon className="size-3.5" />
-                        Remove icon
-                      </Button>
-                    </div>
-                  ) : null}
-                  <EmojiPicker
-                    onSelect={(native) => {
-                      setPendingIcon(native);
-                      setEmojiOpen(false);
-                    }}
-                  />
-                </PopoverContent>
-              </Popover>
-              <input
-                className="w-full bg-transparent px-3 py-2 text-ui outline-none"
-                value={renameValue}
-                onChange={(e) => setRenameValue(e.target.value)}
-              />
-            </div>
-            {iconConfigError && (
-              <p className="text-ui text-destructive" role="alert">
-                Couldn&apos;t load this project&apos;s icon settings. You can still rename it;
-                changing the icon is unavailable until this loads.
-              </p>
-            )}
-            {(renameProject.isError || updateConfig.isError) && (
-              <p className="text-ui text-destructive" role="alert">
-                {((renameProject.error ?? updateConfig.error) as Error).message}
-              </p>
-            )}
-            <DialogFooter className="border-t-0 bg-transparent">
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => setRenameOpen(false)}
-                disabled={renameProject.isPending || updateConfig.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                data-testid="rename-project-confirm"
-                loading={renameProject.isPending || updateConfig.isPending}
-                disabled={renameValue.trim() === ""}
-                componentId="sidebar.project.rename"
-              >
-                Confirm
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
       <ProjectSettingsDialog
         open={settingsOpen}
-        onOpenChange={(o) => {
-          setSettingsOpen(o);
-          if (!o) setMenuOpen(false);
-        }}
+        onOpenChange={setSettingsOpen}
         projectId={projectId}
         projectName={projectName}
       />
@@ -4506,7 +4268,6 @@ function useProjectFolderMenu(
                   {
                     onSuccess: () => {
                       setDeleteOpen(false);
-                      setMenuOpen(false);
                     },
                   },
                 );

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4205,10 +4205,6 @@ function ProjectFolderMenuItems({
           New session
         </Link>
       </C.Item>
-      <C.Item data-testid="rename-project" onSelect={actions.openRename}>
-        <PencilIcon className="size-3.5" />
-        Rename project
-      </C.Item>
       <C.Item data-testid="project-settings" onSelect={actions.openSettings}>
         <Settings2Icon className="size-3.5" />
         Project settings


### PR DESCRIPTION
## Related issue

Closes #4415
Closes #5552

## Summary

- Adds an accessible, validated Name field to Project Settings and saves the name with project defaults in one request.
- Removes the separate Rename project menu item **and the dialog itself**, along with the `renameOpen`/`renameValue`/`pendingIcon` state and the `useProjectConfig` gate that existed only to seed its emoji picker — while retaining legacy-label member migration and immediate project/config cache updates.
- Adds the project icon picker to Project Settings (#5552), so the icon that used to live in the rename dialog has a home.
- Keeps label-only projects promotable during a combined rename + settings save.

**ELI5:** Project Settings now edits the whole project, including its name, so users no longer need a second rename dialog.

```text
Project menu → Project settings → edit name + defaults → one save → renamed sidebar project
```

## Test Plan

- `NODE_OPTIONS=--localstorage-file=/tmp/omnigent-issue-4415-vitest-storage pnpm exec vitest run src/lib/projectsApi.test.ts src/shell/ProjectSettingsDialog.test.tsx src/shell/Sidebar.test.tsx` → 101 passed.
- `NODE_OPTIONS=--localstorage-file=/tmp/omnigent-issue-4415-vitest-storage-hooks pnpm exec vitest run src/hooks/useConversations.test.ts -t useUpdateProjectConfig` → 3 passed.
- `E2E_SCREENSHOT_DIR=/tmp/omnigent-issue-4415-demo uv run --no-sync pytest tests/e2e_ui/sessions/test_project_settings_dialog.py::test_project_settings_renames_project -q` → 1 passed in Chromium; verified opening settings, editing the name, saving, and the renamed sidebar row.
- `pnpm run lint`, `pnpm run type-check`, `pnpm run format:check`, and `pnpm run build` → passed.
- `uv run --no-sync pre-commit run --all-files` → all hooks passed.
- After deleting the orphaned dialog: `vitest run src/shell/Sidebar.projectContextMenu.test.tsx src/shell/Sidebar.test.tsx src/shell/ProjectSettingsDialog.test.tsx` → 119 passed, 0 failed. `npx tsc -b` → exit 0. `npx oxlint --deny-warnings --report-unused-disable-directives src/shell/` → exit 0.

## Demo

[Short Chromium recording of the complete rename flow](https://github.com/randypitcherii/omnigent/releases/download/demo-issue-4415-b10586e8/video.webm)

Name edited in Project Settings:

![Project Settings with edited name](https://github.com/randypitcherii/omnigent/releases/download/demo-issue-4415-b10586e8/project-settings-name-edited.png)

Renamed project in the sidebar:

![Renamed project in sidebar](https://github.com/randypitcherii/omnigent/releases/download/demo-issue-4415-b10586e8/project-renamed-in-sidebar.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The browser test uses the real built SPA and server persistence path; unit tests cover blank-name validation, combined payloads, legacy label-project promotion/migration, cache replacement, and removal of the standalone rename action.

## Changelog

Rename projects directly from Project Settings alongside their session defaults.
