### PR TITLE
fix(runner): fail unresolved sub-agent dispatches

### DIFF
--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -58,6 +58,8 @@ class ErrorCode:
         exists on the selected host (HTTP 410). Retrying cannot recreate
         deleted workspace state; the user must start a session in a valid
         workspace.
+    :cvar SUB_AGENT_UNRESOLVED: A requested sub-agent name is absent from
+        the parent spec tree (HTTP 404).
     """
 
     UNAUTHORIZED = "unauthorized"
@@ -75,6 +77,7 @@ class ErrorCode:
     # the host's wire error code passes through as the API error code.
     HARNESS_NOT_CONFIGURED = "harness_not_configured"
     WORKSPACE_MISSING = "workspace_missing"
+    SUB_AGENT_UNRESOLVED = "sub_agent_unresolved"
 
 
 # Single source of truth for error code → HTTP status.
@@ -105,6 +108,7 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
     # neither a 400 (input is fine) nor a 503 (a retry won't help).
     ErrorCode.HARNESS_NOT_CONFIGURED: 412,
     ErrorCode.WORKSPACE_MISSING: 410,
+    ErrorCode.SUB_AGENT_UNRESOLVED: 404,
 }
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -199,32 +199,6 @@ _CLAUDE_MODEL_LATE_DIALOG_BUDGET_S = 1200.0
 _CLAUDE_MODEL_LATE_DIALOG_POLL_S = 2.0
 
 
-def _warn_unresolved_sub_agent(session_id: str | None, sub_agent_name: str) -> None:
-    """
-    Log that a sub-agent name did not resolve to a declared child spec.
-
-    Every spec-swap site is guarded by ``if sub_spec is not None`` with no
-    ``else`` and falls back to the already-resolved PARENT spec — so a
-    renamed/removed sub-agent or stale session metadata silently boots the
-    child as a parent clone (parent prompt, tools, harness, workdir). The
-    create route now rejects an undeclared name up front, but stale rows
-    and post-create bundle edits can still reach these sites; a loud log
-    makes the fallback diagnosable instead of invisible.
-
-    :param session_id: The session whose turn is resolving the spec.
-    :param sub_agent_name: The name that failed to resolve in the parent
-        spec tree.
-    """
-    _logger.warning(
-        "Sub-agent %r for session %s did not resolve in the parent spec; "
-        "falling back to the parent spec (child runs with the parent's "
-        "prompt, tools and harness). Likely a renamed/removed sub-agent or "
-        "stale session metadata.",
-        sub_agent_name,
-        session_id,
-    )
-
-
 def __getattr__(name: str) -> object:
     """Preserve private native-helper imports during the package move."""
     return cast(object, getattr(_native, name))
@@ -2124,7 +2098,7 @@ def _normalize_turn_error(error: Mapping[str, object]) -> dict[str, str]:
         message = f"turn failed (status {error['status']})"
     else:
         message = "turn failed"
-    raw_code = error.get("type")
+    raw_code = error.get("code") or error.get("type")
     code = raw_code if isinstance(raw_code, str) and raw_code else "runner_error"
     return {"code": code, "message": message}
 
@@ -2416,10 +2390,6 @@ def create_runner_app(
 
     _session_agent_ids = _session_agent_ids_ref  # shared with module-level get_session_agent_id
     _session_sub_agent_names: dict[str, str] = {}
-    # Tracks whether the sub-agent was successfully resolved on session create.
-    # True = child spec is cached; False = parent kept as fallback after miss.
-    # Absent = session has no sub_agent_name or create has not completed.
-    _session_sub_agent_resolved: dict[str, bool] = {}
     # Per-conversation set of (harness, InstructionDelivery) pairs already
     # warned about. Keyed by conversation so a session that switches harnesses
     # warns again for the new pair rather than inheriting the old one's silence.
@@ -3273,13 +3243,8 @@ def create_runner_app(
                 _sub_entry = _native_runtime._resolve_sub_agent_spec_entry(
                     spec_entry, _sa_name_assign
                 )
-                if _sub_entry is None:
-                    _warn_unresolved_sub_agent(session_id, _sa_name_assign)
-                    _session_sub_agent_resolved[session_id] = False
-                else:
-                    spec_entry = _sub_entry
-                    spec = _unwrap_resolved_spec(_sub_entry)
-                    _session_sub_agent_resolved[session_id] = True
+                spec_entry = _sub_entry
+                spec = _unwrap_resolved_spec(_sub_entry)
             harness_name = spec.executor.config.get("harness") or spec.executor.type
             harness_name = canonicalize_harness(harness_name) or harness_name
 
@@ -3947,7 +3912,6 @@ def create_runner_app(
         _session_agent_ids.pop(session_id, None)
         _session_tool_schemas.pop(session_id, None)
         _instruction_delivery_warned.pop(session_id, None)
-        _session_sub_agent_resolved.pop(session_id, None)
         if _binding := _session_comment_relays.pop(session_id, None):
             _binding.relay.close()
         _session_histories.pop(session_id, None)
@@ -6508,6 +6472,12 @@ def create_runner_app(
             )
             _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
             raise
+        except OmnigentError as exc:
+            _logger.error("turn setup failed for %s: %s", conv, exc, exc_info=True)
+            _on_proxy_stream_end(
+                conv,
+                error={"code": exc.code, "message": exc.message},
+            )
         except Exception as exc:
             _logger.error(
                 "turn setup failed for %s: %s",
@@ -6576,6 +6546,7 @@ def create_runner_app(
             _session_agent_ids[conv] = _dispatched_agent_id
 
         cached_spec_entry = _session_spec_cache.get(conv)
+        spec_was_cached = cached_spec_entry is not None
         cached_spec = _unwrap_resolved_spec(cached_spec_entry)
         cached_spec_workdir = _resolved_spec_workdir(cached_spec_entry)
         if cached_spec is None and spec_resolver is not None:
@@ -6616,17 +6587,16 @@ def create_runner_app(
         _sa_name = await _recover_sub_agent_name(conv)
         # The child's workdir is rooted before _spec_with_workdir_paths below,
         # which joins relative local-tool paths onto whatever workdir is current.
-        if _sa_name and cached_spec is not None:
+        if (
+            _sa_name
+            and cached_spec is not None
+            and not (spec_was_cached and cached_spec.name == _sa_name)
+        ):
             sub_entry = _native_runtime._resolve_sub_agent_spec_entry(cached_spec_entry, _sa_name)
-            if sub_entry is None:
-                # Warn unless the child was confirmed resolved (True = already cached).
-                if _session_sub_agent_resolved.get(conv) is not True:
-                    _warn_unresolved_sub_agent(conv, _sa_name)
-            else:
-                cached_spec_entry = sub_entry
-                cached_spec = _unwrap_resolved_spec(sub_entry)
-                cached_spec_workdir = _resolved_spec_workdir(sub_entry)
-                _session_spec_cache[conv] = sub_entry
+            cached_spec_entry = sub_entry
+            cached_spec = _unwrap_resolved_spec(sub_entry)
+            cached_spec_workdir = _resolved_spec_workdir(sub_entry)
+            _session_spec_cache[conv] = sub_entry
 
         cached_spec = _spec_with_workdir_paths(cached_spec, cached_spec_workdir)
         if cached_spec is not None:
@@ -7273,10 +7243,6 @@ def create_runner_app(
                                         _ds_delivery.value,
                                         extra={"session_id": conv_id},
                                     )
-            # Re-warn on every turn when session-create established a miss.
-            _ds_sa = _session_sub_agent_names.get(conv_id)
-            if _ds_sa and _session_sub_agent_resolved.get(conv_id) is False:
-                _warn_unresolved_sub_agent(conv_id, _ds_sa)
             event_body = _wrap_as_message_event(_instr_body)
             _inject_mcp_schemas(event_body, _mcp_schemas)
             _response_id: str | None = None
@@ -9457,12 +9423,7 @@ def create_runner_app(
                     sub_entry = _native_runtime._resolve_sub_agent_spec_entry(
                         spec_entry, sub_agent_name
                     )
-                    if sub_entry is None:
-                        _warn_unresolved_sub_agent(session_id, sub_agent_name)
-                        _session_sub_agent_resolved[session_id] = False
-                    else:
-                        spec_entry = sub_entry
-                        _session_sub_agent_resolved[session_id] = True
+                    spec_entry = sub_entry
             if _session_cache_generation_is_current(session_id, generation):
                 _session_spec_cache[session_id] = spec_entry
             return spec_entry
@@ -9480,7 +9441,9 @@ def create_runner_app(
         """
         try:
             return await _resolve_session_agent_spec(session_id)
-        except OmnigentError:
+        except OmnigentError as exc:
+            if exc.code == ErrorCode.SUB_AGENT_UNRESOLVED:
+                raise
             return None
 
     async def _resolve_session_skills(session_id: str) -> list[SkillSpec]:
@@ -9994,7 +9957,6 @@ def create_runner_app(
         _session_tool_schemas.pop(session_id, None)
         _session_mcp_spec_hash.pop(session_id, None)
         _instruction_delivery_warned.pop(session_id, None)
-        _session_sub_agent_resolved.pop(session_id, None)
         if agent_id:
             _spec_cache.pop(agent_id, None)
 
@@ -10772,11 +10734,8 @@ async def _resolve_harness_config(
                 sub_entry = _native_runtime._resolve_sub_agent_spec_entry(
                     spec_entry, sub_agent_name
                 )
-                if sub_entry is None:
-                    _warn_unresolved_sub_agent(session_id, sub_agent_name)
-                else:
-                    spec = _unwrap_resolved_spec(sub_entry)
-                    workdir = _resolved_spec_workdir(sub_entry)
+                spec = _unwrap_resolved_spec(sub_entry)
+                workdir = _resolved_spec_workdir(sub_entry)
             harness = harness_override or spec.executor.config.get("harness") or spec.executor.type
             harness = canonicalize_harness(harness) or harness
             spawn_env = _build_spawn_env_from_spec(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -8193,7 +8193,7 @@ def _sub_agent_bundle_workdir(parent_entry: Any, parent_spec: Any, child_spec: A
     return workdir if workdir.is_dir() else None
 
 
-def _resolve_sub_agent_spec_entry(parent_entry: Any, sub_agent_name: str) -> ResolvedSpec | None:
+def _resolve_sub_agent_spec_entry(parent_entry: Any, sub_agent_name: str) -> ResolvedSpec:
     """Resolve a sub-agent by name into a spec entry rooted at its own bundle dir.
 
     The returned entry is always wrapped so downstream workdir lookups see
@@ -8203,24 +8203,15 @@ def _resolve_sub_agent_spec_entry(parent_entry: Any, sub_agent_name: str) -> Res
 
     :param parent_entry: Parent spec, bare or wrapped in ``ResolvedSpec``.
     :param sub_agent_name: Name of the sub-agent to resolve.
-    :returns: The wrapped child entry, or ``None`` when the name does not
-        resolve.
+    :returns: The wrapped child entry.
+    :raises OmnigentError: If the name is absent from the parent spec tree.
     """
-    from omnigent.runtime.workflow import _find_spec_by_name
+    from omnigent.runtime.workflow import _find_spec_by_name, _sub_agent_unresolved_error
 
     parent_spec = _unwrap_resolved_spec(parent_entry)
     child_spec = _find_spec_by_name(parent_spec, sub_agent_name)
     if child_spec is None:
-        # Callers in runtime/workflow.py keep the parent spec on a lookup
-        # miss, which boots the child as a clone of the parent. Unsafe, but
-        # pre-existing and out of scope here — tracked separately.
-        _logger.warning(
-            "Sub-agent %r not found under spec %r; no workdir resolved",
-            sub_agent_name,
-            getattr(parent_spec, "name", None),
-            extra={"session_id": runner_primary_session_id()},
-        )
-        return None
+        raise _sub_agent_unresolved_error(parent_spec, sub_agent_name)
     return ResolvedSpec(
         spec=child_spec,
         workdir=_sub_agent_bundle_workdir(parent_entry, parent_spec, child_spec),

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2946,6 +2946,27 @@ def _find_spec_by_name(
     return None
 
 
+def _sub_agent_unresolved_error(spec: AgentSpec, name: str) -> OmnigentError:
+    """Build the structured error for a name absent from a parent spec tree."""
+    available = sorted(_sub_agent_names(spec))
+    searched = ", ".join(repr(candidate) for candidate in available) or "(none)"
+    return OmnigentError(
+        f"Sub-agent {name!r} did not resolve in spec tree {spec.name!r}; "
+        f"searched sub-agents: {searched}",
+        code=ErrorCode.SUB_AGENT_UNRESOLVED,
+    )
+
+
+def _sub_agent_names(spec: AgentSpec) -> list[str]:
+    """Return every declared sub-agent name below *spec*."""
+    names: list[str] = []
+    for sub_agent in spec.sub_agents:
+        if sub_agent.name is not None:
+            names.append(sub_agent.name)
+        names.extend(_sub_agent_names(sub_agent))
+    return names
+
+
 def _search_sub_agent_tree(
     spec: AgentSpec,
     name: str,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -8439,12 +8439,12 @@ def _require_declared_subagent(
     :param sub_agent_name: The requested sub-agent name to validate.
     :param agent_cache: Cache for loading the parsed parent bundle.
         ``None`` skips the check (cannot resolve the tree).
-    :raises OmnigentError: 404 ``NOT_FOUND`` when the bundle loads and
-        declares no sub-agent named ``sub_agent_name``.
+    :raises OmnigentError: 404 ``SUB_AGENT_UNRESOLVED`` when the bundle
+        loads and declares no sub-agent named ``sub_agent_name``.
     """
     if agent_cache is None:
         return
-    from omnigent.runtime.workflow import _find_spec_by_name
+    from omnigent.runtime.workflow import _find_spec_by_name, _sub_agent_unresolved_error
 
     try:
         parent_spec = agent_cache.load(
@@ -8456,10 +8456,7 @@ def _require_declared_subagent(
         # parent spec, rather than rejecting a create we cannot adjudicate.
         return
     if _find_spec_by_name(parent_spec, sub_agent_name) is None:
-        raise OmnigentError(
-            f"Sub-agent not declared in parent spec: {sub_agent_name!r}",
-            code=ErrorCode.NOT_FOUND,
-        )
+        raise _sub_agent_unresolved_error(parent_spec, sub_agent_name)
 
 
 def _spec_harness(spec: AgentSpec) -> str:

--- a/tests/e2e/test_unresolved_subagent_dispatch_fails_loud.py
+++ b/tests/e2e/test_unresolved_subagent_dispatch_fails_loud.py
@@ -1,0 +1,266 @@
+"""An unresolved sub-agent name must fail loud, never clone the parent.
+
+An unresolved sub-agent name must be a *hard error* on dispatch, not a
+silent substitution of the parent spec. On the buggy build the runner's
+spec-swap sites resolve the child's ``sub_agent_name`` against the parent
+spec tree, and on a miss they keep the already-resolved PARENT spec, so the
+child runs with the parent's prompt/tools/harness/model and then reports a
+*successful completion*. An orchestrator that fans out five "sub-agents"
+receives five substituted parent-clones all claiming success.
+
+Two dispatch paths can reach that fallback; this file pins both:
+
+* ``test_external_subagent_start_undeclared_child_fails_loud`` -- the
+  claude-native Task-tool path. Claude Code spawns its own sub-agents and
+  the forwarder registers them via ``POST /events`` ``external_subagent_start``,
+  which mints a ``kind="sub_agent"`` child row stamping ``sub_agent_name``
+  from ``agent_type`` verbatim (e.g. ``"general-purpose"``). Driving a turn
+  on that child must fail loud (``sub_agent_unresolved``), never run on the
+  parent's spec.
+
+* ``test_create_route_rejects_undeclared_subagent`` -- the
+  ``POST /v1/sessions`` create path. An undeclared ``sub_agent_name`` is
+  rejected with 404 before any child row is persisted, so it never reaches
+  the runner's spec-swap sites. This test drives the passing journey so the
+  gate cannot silently regress.
+
+The reproduction runs entirely on the mock LLM: the parent is an
+``openai-agents`` agent declaring NO sub-agents, so if the undeclared child
+falls back to the parent spec it hits the parent's mock queue and echoes
+the parent-clone marker -- proof the child ran on the parent's spec instead
+of failing.
+
+Excluded from default ``pytest`` runs via ``--ignore=tests/e2e``. Invoke::
+
+    pytest tests/e2e/test_unresolved_subagent_dispatch_fails_loud.py -v --timeout=300
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+# The parent-spec marker. It can only surface in the CHILD's output if the
+# child turn ran on the parent's spec (parent model -> parent mock queue).
+_PARENT_CLONE_MARKER = "PARENT_CLONE_FALLBACK_SENTINEL"
+
+# An undeclared sub-agent name (claude-native's default Task agent type).
+# The parent declares no sub-agents at all, so this never resolves in the
+# parent spec tree.
+_UNDECLARED_SUB_AGENT = "general-purpose"
+
+pytestmark = [pytest.mark.timeout(600, method="signal")]
+
+
+def _register_parent_without_subagents(
+    http_client: httpx.Client,
+    *,
+    name: str,
+    model: str,
+    mock_base_url: str,
+) -> str:
+    """Register an ``openai-agents`` parent agent that declares NO sub-agents.
+
+    Its mock queue always echoes :data:`_PARENT_CLONE_MARKER`, so a turn that
+    resolves to this spec is detectable in the output.
+
+    :param http_client: HTTP client pointed at the live server.
+    :param name: Agent display name.
+    :param model: Mock model key (also the mock queue key).
+    :param mock_base_url: Mock LLM base URL including ``/v1``.
+    :returns: The registered agent name (may differ from *name* on rerun).
+    """
+    return register_inline_agent(
+        http_client,
+        name=name,
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt=(
+            "You are the E2E test fixture PARENT orchestrator. You "
+            "declare no sub-agents. Always answer with the literal string "
+            f"{_PARENT_CLONE_MARKER}."
+        ),
+        mock_llm_base_url=mock_base_url,
+    )
+
+
+def test_external_subagent_start_undeclared_child_fails_loud(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """The claude-native Task-tool path must not clone the parent silently.
+
+    Journey:
+
+    1. Register a parent agent whose spec declares NO ``general-purpose``
+       sub-agent, and start a runner-bound session on it.
+    2. Register a sub-agent spawn named ``general-purpose`` through the
+       claude-native forwarder route (``external_subagent_start``), which
+       mints the child row carrying that undeclared name verbatim.
+    3. Drive a turn on the minted child session.
+    4. Observe the outcome.
+
+    Contract: an unresolved sub-agent name is a hard error -- the child turn
+    fails loud (``sub_agent_unresolved``) and never runs on the parent's
+    spec. On the buggy build the child turn instead COMPLETES, echoing the
+    parent's marker, so both assertions below fail.
+    """
+    mock_base = f"{mock_llm_server_url}/v1"
+    uid = uuid.uuid4().hex[:8]
+    parent_model = f"mock-undeclared-sub-parent-{uid}"
+
+    reset_mock_llm(mock_llm_server_url)
+    # If the child falls back to the parent spec, its turn draws from this
+    # parent queue. Several copies absorb any harness retry/continuation.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": _PARENT_CLONE_MARKER} for _ in range(4)],
+        key=parent_model,
+    )
+
+    parent_name = _register_parent_without_subagents(
+        http_client,
+        name=f"undeclared-sub-parent-{uid}",
+        model=parent_model,
+        mock_base_url=mock_base,
+    )
+    parent_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+
+    # The claude-native forwarder path: Claude Code's Task tool spawned a
+    # 'general-purpose' sub-agent; the forwarder registers it here. The
+    # server mints a kind="sub_agent" child stamping sub_agent_name from
+    # agent_type verbatim.
+    resp = http_client.post(
+        f"/v1/sessions/{parent_id}/events",
+        json={
+            "type": "external_subagent_start",
+            "data": {
+                "subagent_id": f"sa_{uid}",
+                "agent_type": _UNDECLARED_SUB_AGENT,
+                "description": "Undeclared sub-agent dispatched by the parent.",
+                "tool_use_id": f"toolu_{uid}",
+            },
+        },
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    assert resp.status_code in (200, 202), (
+        f"external_subagent_start failed: {resp.status_code} {resp.text[:500]}"
+    )
+    child_id = resp.json()["child_session_id"]
+
+    # The child persisted with the undeclared name -- this is what reaches
+    # the runner's spec-swap sites.
+    child_snapshot = http_client.get(f"/v1/sessions/{child_id}")
+    child_snapshot.raise_for_status()
+    assert child_snapshot.json().get("sub_agent_name") == _UNDECLARED_SUB_AGENT
+
+    # Drive a real turn on the undeclared child. On the buggy build the
+    # runner keeps the parent spec on the lookup miss and runs the child on
+    # the parent's openai-agents spec.
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=child_id,
+        content="Do your task and report the result.",
+    )
+    result = poll_session_until_terminal(
+        http_client,
+        session_id=child_id,
+        response_id=response_id,
+        timeout=240,
+    )
+
+    output_blob = str(result.get("output"))
+
+    # Core assertion: the child must NOT have run on the parent's spec.
+    assert _PARENT_CLONE_MARKER not in output_blob, (
+        f"the undeclared sub-agent {_UNDECLARED_SUB_AGENT!r} ran on the PARENT's "
+        f"spec (parent-clone marker {_PARENT_CLONE_MARKER!r} present in the "
+        f"child's output) instead of failing loud. "
+        f"status={result.get('status')!r} output={result.get('output')!r}"
+    )
+
+    # Contract assertion: an unresolved sub-agent dispatch is terminal
+    # failure, not a successful completion the orchestrator would trust.
+    assert result.get("status") == "failed", (
+        f"dispatching undeclared sub-agent {_UNDECLARED_SUB_AGENT!r} COMPLETED "
+        f"(status={result.get('status')!r}) instead of surfacing an explicit "
+        f"sub_agent_unresolved failure. "
+        f"output={result.get('output')!r} error={result.get('error')!r}"
+    )
+
+
+def test_create_route_rejects_undeclared_subagent(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """The ``POST /v1/sessions`` create path rejects an undeclared name.
+
+    A ``sub_agent_name`` the parent's spec does not declare is rejected with
+    404 before any child row is persisted, so it never reaches the runner's
+    parent-spec swap sites. This pins the passing journey so the gate cannot
+    silently regress.
+    """
+    mock_base = f"{mock_llm_server_url}/v1"
+    uid = uuid.uuid4().hex[:8]
+    parent_model = f"mock-undeclared-sub-gate-{uid}"
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": _PARENT_CLONE_MARKER}],
+        key=parent_model,
+    )
+
+    parent_name = _register_parent_without_subagents(
+        http_client,
+        name=f"undeclared-sub-gate-{uid}",
+        model=parent_model,
+        mock_base_url=mock_base,
+    )
+    parent_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+    snapshot = http_client.get(f"/v1/sessions/{parent_id}")
+    snapshot.raise_for_status()
+    agent_id = snapshot.json()["agent_id"]
+
+    # Dispatch a child by an undeclared sub-agent name through the create
+    # route. The gate must reject it up front.
+    resp = http_client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent_id,
+            "parent_session_id": parent_id,
+            "sub_agent_name": _UNDECLARED_SUB_AGENT,
+        },
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    assert resp.status_code == 404, (
+        f"dispatching undeclared sub-agent {_UNDECLARED_SUB_AGENT!r} through "
+        f"the create route should be rejected 404, "
+        f"got {resp.status_code!r}: {resp.text[:500]}"
+    )
+    assert _UNDECLARED_SUB_AGENT in resp.text, (
+        f"404 body should name the undeclared sub-agent; got {resp.text[:500]}"
+    )

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -890,6 +890,17 @@ async def test_create_session_repl_terminal_dispatch(
         spec_version=1,
         name="dispatch-agent",
         executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+        sub_agents=(
+            [
+                AgentSpec(
+                    spec_version=1,
+                    name=sub_agent_name,
+                    executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+                )
+            ]
+            if sub_agent_name is not None
+            else []
+        ),
     )
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7787,26 +7787,18 @@ async def test_create_session_reinit_preserves_existing_inbox() -> None:
 # ── approval-event flattening (elicitation-approval hang regression) ──────
 
 
-@pytest.mark.parametrize("second_turn", ["background", "known_harness"])
 @pytest.mark.asyncio
-async def test_unresolvable_sub_agent_warns_again_on_later_turns(
-    caplog: pytest.LogCaptureFixture,
-    second_turn: str,
-) -> None:
-    """A parent kept after a miss must not become a resolved child on turn 2.
+async def test_unresolvable_sub_agent_create_rejected_despite_name_shadow() -> None:
+    """A root sharing the requested name is never a substitute for its child.
 
-    Session creation misses on ``sub_agent_name``, warns, and caches the
-    PARENT spec for the session. Later turns read that cache instead of
-    resolving again, and decide "is this the already-resolved child?" by
-    comparing the cached spec's name against the requested name. A root
-    whose own name equals the requested sub-agent satisfies that equality,
-    so the cached parent answers as though it were the child — and the
-    warning that made turn 1 honest never fires again.
-
-    :param caplog: Pytest log capture, read once per turn.
-    :param second_turn: Which dispatch path drives the turn after create.
+    Session creation resolves ``sub_agent_name`` against the parent's
+    sub-agent tree. A root whose OWN name equals the requested name — while
+    declaring no such child — must not satisfy that lookup: accepting the
+    root would boot the "child" as a clone of its parent, which is exactly
+    the silent substitution the fail-loud contract forbids. The create is
+    rejected up front and the harness is never spawned.
     """
-    conv = f"conv_fallback_second_turn_{second_turn}"
+    conv = "conv_fallback_create_shadowed_root"
 
     root_spec = AgentSpec(
         spec_version=1,
@@ -7827,54 +7819,22 @@ async def test_unresolvable_sub_agent_warns_again_on_later_turns(
         server_client=NullServerClient(),  # type: ignore[arg-type]
     )
     async with _runner_test_client(app) as http:
-        with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
-            created = await http.post(
-                "/v1/sessions",
-                json={
-                    "session_id": conv,
-                    "agent_id": "ag_root",
-                    "sub_agent_name": "worker",
-                },
-            )
-        assert created.status_code == 201, created.text
-        assert "did not resolve" in caplog.text
+        created = await http.post(
+            "/v1/sessions",
+            json={
+                "session_id": conv,
+                "agent_id": "ag_root",
+                "sub_agent_name": "worker",
+            },
+        )
 
-        caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
-            if second_turn == "background":
-                bg = await http.post(
-                    f"/v1/sessions/{conv}/events",
-                    json={
-                        "type": "message",
-                        "role": "user",
-                        "agent_id": "ag_root",
-                        "model": "x",
-                        "content": [{"role": "user", "content": "hi"}],
-                    },
-                )
-                assert bg.status_code == 202, bg.text
-                await _await_bg_turn_task(conv)
-                statuses = await _drain_published_statuses(
-                    app.state.session_event_queues, conv, until="idle", timeout=2.0
-                )
-                assert "failed" not in statuses
-            else:
-                streamed = await _post_stream_message(
-                    http,
-                    conv,
-                    agent_id="ag_root",
-                    harness="claude-sdk",
-                    instructions="Caller-supplied instructions.",
-                )
-                assert streamed.status_code == 200, streamed.text
-
-    assert "'worker'" in caplog.text and "did not resolve" in caplog.text, (
-        f"The {second_turn} turn reused a PARENT kept after a miss silently; "
-        f"warnings: {caplog.text!r}."
+    assert created.status_code == 404, created.text
+    error = created.json()["error"]
+    assert error["code"] == "sub_agent_unresolved"
+    assert "'worker'" in error["message"]
+    assert not recorder.posted_bodies, (
+        "an unresolved sub-agent create must never reach the harness"
     )
-    assert recorder.posted_bodies
-    composed = recorder.posted_bodies[-1].get("instructions")
-    assert isinstance(composed, str) and "Root instructions." in composed
 
 
 @pytest.mark.asyncio
@@ -10254,6 +10214,20 @@ class _ContractSnapshotClient(NullServerClient):
 _CONTRACT_CALLER_INSTRUCTIONS = "Caller-supplied instructions."
 
 
+def _contract_error_code(resp: httpx.Response) -> object:
+    """Normalize an error body to its stable code for matrix rows.
+
+    Structured error bodies carry ``{"code", "message"}``; some transports
+    report a bare string. Rows compare against the code either way.
+    """
+    if resp.status_code < 400:
+        return None
+    error = resp.json().get("error")
+    if isinstance(error, dict):
+        return error.get("code")
+    return error
+
+
 async def _contract_run_no_harness(
     http: httpx.AsyncClient, conv: str, recording: _RecordingHarnessClient
 ) -> dict[str, Any]:
@@ -10270,7 +10244,7 @@ async def _contract_run_no_harness(
     )
     return {
         "status": resp.status_code,
-        "error": (resp.json().get("error") if resp.status_code >= 400 else None),
+        "error": _contract_error_code(resp),
         "instructions": (
             recording.posted_bodies[-1].get("instructions") if recording.posted_bodies else None
         ),
@@ -10295,7 +10269,7 @@ async def _contract_run_known_harness(
     )
     return {
         "status": resp.status_code,
-        "error": (resp.json().get("error") if resp.status_code >= 400 else None),
+        "error": _contract_error_code(resp),
         "instructions": (
             recording.posted_bodies[-1].get("instructions") if recording.posted_bodies else None
         ),
@@ -10381,28 +10355,31 @@ def _contract_resolver_for(scenario: str, calls: list[str]) -> Any:
             {"terminal_status": "idle", "instructions": "Worker instructions."},
             id="child_present-background",
         ),
-        # child missing: all paths agree — warn, fall back to the parent spec.
+        # child missing: every path fails loud — no transport may run the
+        # child on the parent's spec or report a success the parent would
+        # trust. Shapes are transport-driven, mirroring the resolver
+        # failures below: a synchronous 404, known-harness degradation to
+        # the caller's own text, an async terminal ``failed`` after 202.
         pytest.param(
             "child_missing",
             "no_harness",
-            {"status": 200, "error": None, "instructions": "Root instructions."},
-            id="child_missing-no_harness-parent",
+            {"status": 404, "error": "sub_agent_unresolved", "instructions": None},
+            id="child_missing-no_harness-404",
         ),
         pytest.param(
             "child_missing",
             "known_harness",
-            # same shape as child_present — caller text still composes additively.
-            {
-                "status": 200,
-                "instructions": (f"Root instructions.\n\n{_CONTRACT_CALLER_INSTRUCTIONS}"),
-            },
-            id="child_missing-known_harness-parent",
+            # degrades exactly like resolver_raises on this path: the
+            # caller's text runs; the PARENT's instructions never leak in.
+            {"status": 200, "instructions": _CONTRACT_CALLER_INSTRUCTIONS},
+            id="child_missing-known_harness-degrades",
         ),
         pytest.param(
             "child_missing",
             "background",
-            {"status": 202, "terminal_status": "idle", "instructions": "Root instructions."},
-            id="child_missing-background-parent",
+            # instructions None: the harness never received a turn.
+            {"status": 202, "terminal_status": "failed", "instructions": None},
+            id="child_missing-background-async-failure",
         ),
         # ── Resolver raises: same three-way split, different trigger.
         pytest.param(
@@ -10485,10 +10462,11 @@ async def test_cross_path_resolution_contract(
 ) -> None:
     """Pin the resolution behaviour matrix across all three dispatch paths.
 
-    Reading the table: ``child_present`` and ``child_missing`` are the
-    scenarios where all three paths agree, and for ``child_missing`` the
-    agreement is load-bearing — an unresolvable ``sub_agent_name`` gets one
-    answer (warn, then the parent's spec) no matter which transport asked.
+    Reading the table: ``child_present`` is the scenario where all three
+    paths agree on the same child spec. For ``child_missing`` the agreement
+    is load-bearing the other way — an unresolvable ``sub_agent_name`` is
+    refused on every path, never answered with the parent's spec; only the
+    refusal's shape is transport-driven, like the resolver failures below.
     The remaining scenarios still record transport-driven differences that
     are intended: a synchronous 503, graceful degradation preserving the
     caller's own instructions, and an asynchronous terminal ``failed``

--- a/tests/runner/test_sub_agent_bundle_isolation.py
+++ b/tests/runner/test_sub_agent_bundle_isolation.py
@@ -28,6 +28,7 @@ import pytest
 import yaml
 
 from omnigent.entities.session_resources import SessionResourceView
+from omnigent.errors import OmnigentError
 from omnigent.runner import create_runner_app
 from omnigent.runner import tool_dispatch as _tool_dispatch
 from omnigent.runner.app import _resolve_harness_config, _spec_with_workdir_paths
@@ -198,6 +199,28 @@ async def test_child_harness_still_wins_over_the_parents(tmp_path: Path) -> None
     assert harness == "codex"
     assert spawn_env is not None
     assert spawn_env["HARNESS_CODEX_BUNDLE_DIR"] == str(root / "agents" / "worker")
+
+
+@pytest.mark.asyncio
+async def test_harness_config_rejects_unresolved_sub_agent(tmp_path: Path) -> None:
+    """Harness resolution never substitutes the parent for a missing child."""
+    root, _child = _bundle_with_child(tmp_path)
+
+    async def _resolver(agent_id: str, session_id: str | None) -> Any:
+        return ResolvedSpec(spec=parse(root), workdir=root)
+
+    with pytest.raises(OmnigentError) as exc_info:
+        await _resolve_harness_config(
+            agent_id="agent-1",
+            spec_resolver=_resolver,
+            session_id="sess-1",
+            sub_agent_name="renamed-worker",
+        )
+
+    assert exc_info.value.code == "sub_agent_unresolved"
+    assert "renamed-worker" in exc_info.value.message
+    assert "root" in exc_info.value.message
+    assert "worker" in exc_info.value.message
 
 
 # ── Native harnesses: launch-time bundle root ─────────────────

--- a/tests/runner/test_sub_agent_workdir_resolution.py
+++ b/tests/runner/test_sub_agent_workdir_resolution.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runner.native.orchestration import (
     ResolvedSpec,
     _resolve_sub_agent_spec_entry,
@@ -89,11 +90,16 @@ def test_resolution_always_wraps_never_substitutes_the_parent(bundle: Path) -> N
     assert resolved.spec is not parent_entry.spec
 
 
-def test_unknown_sub_agent_name_returns_none(bundle: Path) -> None:
-    """A lookup miss yields ``None`` so callers can decline to swap."""
+def test_unknown_sub_agent_name_fails_loud(bundle: Path) -> None:
+    """A lookup miss cannot leave callers running with the parent spec."""
     entry = ResolvedSpec(spec=parse(bundle), workdir=bundle)
 
-    assert _resolve_sub_agent_spec_entry(entry, "nope") is None
+    with pytest.raises(OmnigentError) as exc_info:
+        _resolve_sub_agent_spec_entry(entry, "nope")
+
+    assert exc_info.value.code == ErrorCode.SUB_AGENT_UNRESOLVED
+    assert "nope" in exc_info.value.message
+    assert "manager" in exc_info.value.message
 
 
 def test_synthetic_web_researcher_gets_no_workdir(bundle: Path) -> None:

--- a/tests/runner/test_subagent_spec_swap_warning.py
+++ b/tests/runner/test_subagent_spec_swap_warning.py
@@ -1,4 +1,4 @@
-"""Regression: a sub-agent turn must not warn when it already holds the child.
+"""Regression coverage for fail-loud sub-agent spec resolution.
 
 Field symptom (polly dispatching a sub-agent): every turn of a healthy child
 session logged
@@ -16,12 +16,9 @@ caches the CHILD. The turn path then reads that cached spec and searches it
 ``spec.sub_agents``, and the child has no child of its own, so the lookup
 always misses and the warning fires on a session that resolved perfectly.
 
-The warning matters because it names a real, silent failure mode (a child
-booting as a clone of an orchestrator parent), so firing it on healthy
-sessions makes the genuine case unreadable. The turn path therefore still
-looks the sub-agent up unconditionally and still swaps whenever it resolves;
-only the warning is gated, suppressed on a miss where the spec in hand
-already carries the sub-agent's name.
+An unresolved name must stop every runner entry point before it can boot the
+child as a parent clone. The failure names both the requested agent and the
+spec tree searched so the parent can report a useful dispatch error.
 
 Gating the LOOKUP on that same name check would be wrong, which is what the
 third test pins. A root may legally share its sub-agent's name — the
@@ -60,7 +57,7 @@ CHILD_SESSION_ID = "conv_child_worker"
 SUB_AGENT_NAME = "claude_code"
 CHILD_HARNESS = "claude-native"
 UNRESOLVABLE_SUB_AGENT_NAME = "renamed_worker"
-_WARNING_FRAGMENT = "did not resolve in the parent spec"
+_UNRESOLVED_CODE = "sub_agent_unresolved"
 
 # A root may legally carry its own sub-agent's name: the uniqueness check
 # (``_check_unique_sub_agent_names``) seeds its ``seen`` set empty and only
@@ -140,8 +137,7 @@ async def _prime_spec_cache_then_turn(
     ``_session_spec_cache`` before the first turn (the live sequence is ``POST
     /v1/sessions``; the web UI's resource panels hit this one). The log
     capture is cleared between the phases so the assertions only see what the
-    TURN logged — priming legitimately warns for an unresolvable name, and
-    that warning is not what this module is about.
+    TURN logged.
 
     :param sub_agent_name: The name the server snapshot reports.
     :param caplog: pytest log capture, cleared between the phases.
@@ -202,7 +198,7 @@ async def test_declared_sub_agent_turn_does_not_warn_about_resolution(
     """
     pm, records = await _prime_spec_cache_then_turn(SUB_AGENT_NAME, caplog)
 
-    spurious = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
+    spurious = [r for r in records if _UNRESOLVED_CODE in r.getMessage()]
     assert not spurious, (
         "turn for a declared sub-agent logged the unresolved-sub-agent "
         f"warning: {[r.getMessage() for r in spurious]!r}. The cached spec is "
@@ -218,23 +214,93 @@ async def test_declared_sub_agent_turn_does_not_warn_about_resolution(
 
 
 @pytest.mark.asyncio
-async def test_unresolvable_sub_agent_turn_still_warns(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A name absent from the tree must still warn — that case is real.
-
-    Guards the fix against over-reach: when the cached spec is the PARENT
-    (the swap missed while priming too), the turn must keep surfacing the
-    fallback that silently boots the child as a parent clone.
-    """
-    _pm, records = await _prime_spec_cache_then_turn(UNRESOLVABLE_SUB_AGENT_NAME, caplog)
-
-    warned = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
-    assert warned, (
-        "a sub-agent name absent from the parent tree produced no "
-        "unresolved-sub-agent warning; the child silently boots with the "
-        "parent's prompt, tools and harness."
+async def test_unresolvable_sub_agent_session_init_fails_before_spawn() -> None:
+    """Session initialization rejects a stale name instead of spawning the parent."""
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_parent_spec_resolver,
+        server_client=_SubAgentSnapshotServer(UNRESOLVABLE_SUB_AGENT_NAME),  # type: ignore[arg-type]
     )
+
+    async with _runner_client(app) as client:
+        response = await client.post(
+            "/v1/sessions",
+            json={
+                "session_id": CHILD_SESSION_ID,
+                "agent_id": PARENT_AGENT_ID,
+                "sub_agent_name": UNRESOLVABLE_SUB_AGENT_NAME,
+            },
+        )
+
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == _UNRESOLVED_CODE
+    assert UNRESOLVABLE_SUB_AGENT_NAME in error["message"]
+    assert "polly" in error["message"]
+    assert SUB_AGENT_NAME in error["message"]
+    assert not pm.get_client_calls
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_sub_agent_resource_resolution_fails() -> None:
+    """Snapshot-based resolution rejects stale persisted sub-agent metadata."""
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_parent_spec_resolver,
+        server_client=_SubAgentSnapshotServer(UNRESOLVABLE_SUB_AGENT_NAME),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        response = await client.get(f"/v1/sessions/{CHILD_SESSION_ID}/resources")
+
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == _UNRESOLVED_CODE
+    assert UNRESOLVABLE_SUB_AGENT_NAME in error["message"]
+    assert SUB_AGENT_NAME in error["message"]
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_sub_agent_turn_reports_failed_without_spawn() -> None:
+    """A stale child turn reports ``sub_agent_unresolved`` to its parent."""
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_parent_spec_resolver,
+        server_client=_SubAgentSnapshotServer(UNRESOLVABLE_SUB_AGENT_NAME),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        response = await client.post(
+            f"/v1/sessions/{CHILD_SESSION_ID}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": PARENT_AGENT_ID,
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+        )
+        assert response.status_code == 202
+        failed: dict[str, Any] | None = None
+        for _ in range(300):
+            queue = app.state.session_event_queues.get(CHILD_SESSION_ID)
+            while queue is not None and not queue.empty():
+                event = queue.get_nowait()
+                if event.get("type") == "session.status" and event.get("status") == "failed":
+                    failed = event
+                    break
+            if failed is not None:
+                break
+            await asyncio.sleep(0.01)
+
+    assert failed is not None
+    error = failed["error"]
+    assert error["code"] == _UNRESOLVED_CODE
+    assert UNRESOLVABLE_SUB_AGENT_NAME in error["message"]
+    assert "polly" in error["message"]
+    assert SUB_AGENT_NAME in error["message"]
+    assert not pm.get_client_calls
 
 
 def _shadowed_name_spec_tree() -> AgentSpec:
@@ -347,7 +413,7 @@ async def test_sub_agent_sharing_the_parent_name_still_swaps_to_the_child(
         "swap was skipped and the child is running as a clone of its parent."
     )
 
-    spurious = [r for r in records if _WARNING_FRAGMENT in r.getMessage()]
+    spurious = [r for r in records if _UNRESOLVED_CODE in r.getMessage()]
     assert not spurious, (
         "the name-shadowing tree resolves its sub-agent fine, yet the turn "
         f"logged: {[r.getMessage() for r in spurious]!r}"

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1388,8 +1388,10 @@ async def test_subagent_create_rejects_undeclared_name(
     )
     assert resp.status_code == 404, resp.text
     error = resp.json()["error"]
-    assert error["code"] == "not_found"
+    assert error["code"] == "sub_agent_unresolved"
     assert "does-not-exist" in error["message"]
+    assert "orch-undeclared-subagent" in error["message"]
+    assert "impl" in error["message"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -53,6 +53,7 @@ def test_omnigent_error_with_harness_violation_code_returns_500() -> None:
         (ErrorCode.CONFLICT, 409),
         (ErrorCode.INTERNAL_ERROR, 500),
         (ErrorCode.HARNESS_PROTOCOL_VIOLATION, 500),
+        (ErrorCode.SUB_AGENT_UNRESOLVED, 404),
     ],
 )
 def test_all_error_codes_have_http_status_mapping(code: str, expected_status: int) -> None:


### PR DESCRIPTION
## Related issue

Closes #4448

## Summary

An unresolved sub-agent name still runs the **parent** spec as the child, with a log warning as the only signal — so an orchestrator asking for a worker that no longer exists silently gets a second copy of itself.

**Scoped to what `main` explicitly leaves unbounded.** Upstream's `_require_declared_subagent` (`omnigent/server/routes/_sessions/helpers.py:8412`) added a creation-time gate, and its own docstring states the limit:

> It narrows, but does not bound, what can reach the downstream fallback. The check runs only when the bundle LOADS and the name is positively absent: with no agent cache, or on any load failure, it returns without adjudicating, so a never-declared name still reaches a swap site.

Those swap sites are the live defect. `_warn_unresolved_sub_agent` is still the whole response at **five** call sites in `omnigent/runner/app.py` — lines 3277, 6624, 7279, 9461, and 10776 — covering runner initialization, resource re-resolution, harness configuration, and stale-session turns. Each warns and continues against the parent spec.

This PR replaces that fallback with a structured `sub_agent_unresolved` error reporting the requested name, the parent spec, and the searched sub-agent names, and spawns no harness on failure. Valid cached-child and name-shadowing behavior is unchanged.

ELI5: when an orchestrator asks for a worker that no longer exists, Omnigent reports that mistake instead of silently starting another copy of the orchestrator.

```text
requested sub-agent name
          |
          v
    search parent tree
      /          \
   found        missing
     |             |
run child spec   sub_agent_unresolved
                (no harness spawn)
```

## Test Plan

- `HOME=/tmp XDG_CONFIG_HOME=/tmp/omnigent-4842-config uv run --no-sync pytest -n 0 tests/runner/test_subagent_spec_swap_warning.py tests/runner/test_sub_agent_bundle_isolation.py tests/runner/test_sub_agent_workdir_resolution.py tests/runner/test_app_sessions_native_terminal_routing.py tests/server/integration/test_sessions_child_sessions.py tests/test_errors.py -q` -> 121 passed.
- `uv run --no-sync pyrefly check omnigent/errors.py omnigent/runtime/workflow.py omnigent/runner/native/orchestration.py omnigent/runner/app.py omnigent/server/routes/_sessions/helpers.py` -> 0 errors.
- `uv run --no-sync pre-commit run --all-files` -> all hooks passed.

## Demo

![Before and after unresolved sub-agent dispatch behavior](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-4842-review-evidence.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused regressions verify server rejection, each runner resolution entry point, structured stale-turn failure events, no harness spawn on failure, and unchanged behavior for valid cached children and name-shadowed specs.

## Changelog

Unresolved sub-agent dispatches now fail explicitly instead of silently running the parent agent.

## Issues

Resolves [OMNI-2802](https://linear.app/omnigent/issue/OMNI-2802/bug-an-unresolved-sub-agent-name-silently-falls-back-to-the-parent)
