### PR TITLE
feat(web): add Chat/Terminal view shortcut

### DIFF
--- a/tests/e2e_ui/hotkeys/test_view_mode_toggle_hotkey.py
+++ b/tests/e2e_ui/hotkeys/test_view_mode_toggle_hotkey.py
@@ -1,0 +1,74 @@
+"""Assembled UI: Ctrl+Alt+T toggles Chat/Terminal from both focus surfaces.
+
+The terminal-first mock-Claude fixture supplies a real connected xterm without
+live model traffic. The test leaves an unsent composer draft, enters Terminal
+from that focused editor, then returns while xterm's helper textarea owns
+focus. The unchanged draft proves neither chord submitted or inserted text.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+_CHORD = "Control+Alt+KeyT"
+_COMPOSER = "Ask the agent anything…"
+_DRAFT = "keep this draft unsent while toggling views"
+_TERMINAL_VIEW = '[data-testid="terminal-view"]'
+_XTERM_INPUT = ".xterm-helper-textarea"
+_READY_TIMEOUT_MS = 120_000
+
+
+@pytest.mark.timeout(180)
+def test_view_mode_hotkey_from_composer_and_focused_terminal(
+    page: Page,
+    native_claude_mock_session: tuple[str, str],
+) -> None:
+    """Chat → Terminal from composer, then Terminal → Chat from focused xterm."""
+    base_url, session_id = native_claude_mock_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    toggle = page.get_by_test_id("view-mode-toggle")
+    expect(toggle).to_be_visible(timeout=_READY_TIMEOUT_MS)
+
+    # Native sessions may restore Terminal as their last/default view. Establish
+    # Chat before testing the keyboard-only round trip.
+    chat_button = page.get_by_test_id("view-mode-chat")
+    if chat_button.get_attribute("aria-pressed") != "true":
+        chat_button.click()
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.fill(_DRAFT)
+    expect(composer).to_be_focused()
+
+    # The app-level chord must win while the editable composer owns focus.
+    page.keyboard.press(_CHORD)
+    visible_terminal = page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
+    expect(visible_terminal).to_be_visible(timeout=30_000)
+
+    terminal = page.locator(_TERMINAL_VIEW).last
+    expect(terminal).to_have_attribute("data-state", "connected", timeout=_READY_TIMEOUT_MS)
+    xterm_input = terminal.locator(_XTERM_INPUT)
+    expect(xterm_input).to_be_attached()
+    xterm_input.focus()
+    expect(xterm_input).to_be_focused()
+
+    # Deliberately unlike ⌘K, the same chord is claimed inside xterm so the
+    # user can leave Terminal without typing the chord into the PTY.
+    page.keyboard.press(_CHORD)
+    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_focused()
+    expect(composer).to_have_value(_DRAFT)
+    expect(
+        page.locator('[data-testid="message-bubble"][data-role="user"]').filter(has_text=_DRAFT)
+    ).to_have_count(0)
+
+    # The command-palette action uses the same guarded setView transition.
+    page.keyboard.press("Control+k")
+    palette = page.get_by_role("dialog")
+    expect(palette).to_be_visible()
+    palette.get_by_text("Toggle chat / terminal view", exact=True).click()
+    expect(visible_terminal).to_be_visible(timeout=30_000)
+    page.get_by_test_id("view-mode-chat").click()
+    expect(composer).to_be_visible()

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -42,6 +42,11 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Recall previous prompt")).toBeTruthy();
     expect(screen.getByText("Previous session")).toBeTruthy();
     expect(screen.getByText("Toggle conversations sidebar")).toBeTruthy();
+    const viewToggle = screen.getByText("Toggle chat / terminal view").closest("li");
+    expect(viewToggle).toBeTruthy();
+    expect(within(viewToggle!).getByText("Ctrl")).toBeTruthy();
+    expect(within(viewToggle!).getByText("Alt")).toBeTruthy();
+    expect(within(viewToggle!).getByText("T")).toBeTruthy();
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();
   });
 

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -88,6 +88,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     items: [
       { label: "Previous session", keys: [MOD_KEY, UP] },
       { label: "Next session", keys: [MOD_KEY, DOWN] },
+      { label: "Toggle chat / terminal view", keys: [MOD_KEY, ALT, "T"] },
     ],
   },
   {

--- a/web/src/hooks/useViewModeToggleHotkey.test.tsx
+++ b/web/src/hooks/useViewModeToggleHotkey.test.tsx
@@ -110,6 +110,9 @@ describe("useViewModeToggleHotkey", () => {
     xterm.append(textarea);
     document.body.append(xterm);
     textarea.focus();
+    // xterm may stop bubbling after handling a key. The app-level escape
+    // chord must be captured before the PTY surface can consume it.
+    textarea.addEventListener("keydown", (event) => event.stopPropagation());
 
     press(textarea);
 

--- a/web/src/hooks/useViewModeToggleHotkey.test.tsx
+++ b/web/src/hooks/useViewModeToggleHotkey.test.tsx
@@ -1,0 +1,178 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TerminalFirstContextValue } from "@/shell/TerminalFirstContext";
+import { canToggleTerminalFirstView, useViewModeToggleHotkey } from "./useViewModeToggleHotkey";
+
+const isIOSShellMock = vi.fn(() => false);
+vi.mock("@/lib/nativeBridge", () => ({
+  isIOSShell: () => isIOSShellMock(),
+}));
+
+function makeCtx(overrides: Partial<TerminalFirstContextValue> = {}): TerminalFirstContextValue {
+  return {
+    isClaudeNative: false,
+    isNativeWrapper: false,
+    isTerminalFirst: true,
+    isShellView: false,
+    view: "chat",
+    terminalViewKey: null,
+    setView: vi.fn(),
+    terminalsAvailable: true,
+    terminalStartingUp: false,
+    ...overrides,
+  };
+}
+
+function press(
+  target: Element = document.body,
+  mods: Partial<Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey" | "repeat">> = {
+    ctrlKey: true,
+    altKey: true,
+  },
+  code = "KeyT",
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    code,
+    key: "t",
+    bubbles: true,
+    cancelable: true,
+    ...mods,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  isIOSShellMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("canToggleTerminalFirstView", () => {
+  it("requires a live terminal-first view toggle", () => {
+    expect(canToggleTerminalFirstView(makeCtx())).toBe(true);
+    expect(canToggleTerminalFirstView(makeCtx({ isTerminalFirst: false }))).toBe(false);
+    expect(canToggleTerminalFirstView(makeCtx({ isShellView: true }))).toBe(false);
+    expect(canToggleTerminalFirstView(makeCtx({ view: "chat", terminalsAvailable: false }))).toBe(
+      false,
+    );
+    expect(
+      canToggleTerminalFirstView(makeCtx({ view: "terminal", terminalsAvailable: false })),
+    ).toBe(true);
+  });
+
+  it("is unavailable in the iOS shell where the native bar owns switching", () => {
+    isIOSShellMock.mockReturnValue(true);
+    expect(canToggleTerminalFirstView(makeCtx())).toBe(false);
+  });
+});
+
+describe("useViewModeToggleHotkey", () => {
+  it("toggles Chat to Terminal with Ctrl+Alt+T and Cmd+Option+T", () => {
+    const chatCtx = makeCtx();
+    const { rerender } = renderHook(({ ctx }) => useViewModeToggleHotkey(ctx), {
+      initialProps: { ctx: chatCtx },
+    });
+
+    press(document.body, { ctrlKey: true, altKey: true });
+    expect(chatCtx.setView).toHaveBeenCalledWith("terminal");
+
+    const terminalCtx = makeCtx({ view: "terminal" });
+    rerender({ ctx: terminalCtx });
+    press(document.body, { metaKey: true, altKey: true });
+    expect(terminalCtx.setView).toHaveBeenCalledWith("chat");
+  });
+
+  it("fires from editable fields without inserting text", () => {
+    const ctx = makeCtx();
+    renderHook(() => useViewModeToggleHotkey(ctx));
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+
+    const event = press(input);
+
+    expect(ctx.setView).toHaveBeenCalledWith("terminal");
+    expect(event.defaultPrevented).toBe(true);
+    expect(input.value).toBe("");
+  });
+
+  it("deliberately fires while xterm owns focus", () => {
+    const ctx = makeCtx({ view: "terminal" });
+    renderHook(() => useViewModeToggleHotkey(ctx));
+    const xterm = document.createElement("div");
+    xterm.className = "xterm";
+    const textarea = document.createElement("textarea");
+    xterm.append(textarea);
+    document.body.append(xterm);
+    textarea.focus();
+
+    press(textarea);
+
+    expect(ctx.setView).toHaveBeenCalledWith("chat");
+    expect(textarea.value).toBe("");
+  });
+
+  it("does not switch to an unavailable or starting terminal", () => {
+    const ctx = makeCtx({ terminalsAvailable: false, terminalStartingUp: true });
+    renderHook(() => useViewModeToggleHotkey(ctx));
+
+    press();
+
+    expect(ctx.setView).not.toHaveBeenCalled();
+  });
+
+  it("is inert outside terminal-first mode, in shell view, on iOS, and when disabled", () => {
+    const contexts = [makeCtx({ isTerminalFirst: false }), makeCtx({ isShellView: true })];
+    for (const ctx of contexts) {
+      const { unmount } = renderHook(() => useViewModeToggleHotkey(ctx));
+      press();
+      expect(ctx.setView).not.toHaveBeenCalled();
+      unmount();
+    }
+
+    const iosCtx = makeCtx();
+    isIOSShellMock.mockReturnValue(true);
+    const { unmount } = renderHook(() => useViewModeToggleHotkey(iosCtx));
+    press();
+    expect(iosCtx.setView).not.toHaveBeenCalled();
+    unmount();
+
+    isIOSShellMock.mockReturnValue(false);
+    const embeddedCtx = makeCtx();
+    renderHook(() => useViewModeToggleHotkey(embeddedCtx, false));
+    press();
+    expect(embeddedCtx.setView).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeat, Shift, AltGraph, and unrelated chords", () => {
+    const ctx = makeCtx();
+    renderHook(() => useViewModeToggleHotkey(ctx));
+    press(document.body, { ctrlKey: true, altKey: true, repeat: true });
+    press(document.body, { ctrlKey: true, altKey: true, shiftKey: true });
+    press(document.body, { ctrlKey: true }, "KeyT");
+    press(document.body, { ctrlKey: true, altKey: true }, "KeyY");
+    vi.spyOn(KeyboardEvent.prototype, "getModifierState").mockImplementation(
+      (modifier) => modifier === "AltGraph",
+    );
+    press();
+
+    expect(ctx.setView).not.toHaveBeenCalled();
+  });
+
+  it("claims the chord and unbinds on unmount", () => {
+    const ctx = makeCtx();
+    const { unmount } = renderHook(() => useViewModeToggleHotkey(ctx));
+    const event = press();
+    expect(event.defaultPrevented).toBe(true);
+    expect(ctx.setView).toHaveBeenCalledTimes(1);
+
+    unmount();
+    press();
+    expect(ctx.setView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useViewModeToggleHotkey.ts
+++ b/web/src/hooks/useViewModeToggleHotkey.ts
@@ -1,0 +1,66 @@
+// ⌘⌥T (Ctrl+Alt+T on Win/Linux) flips terminal-first sessions between Chat
+// and Terminal. It belongs to the same app-level view family as ⌘⌥[ / ⌘⌥].
+
+import { useEffect, useRef } from "react";
+
+import { isIOSShell } from "@/lib/nativeBridge";
+import type { TerminalFirstContextValue } from "@/shell/TerminalFirstContext";
+
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
+
+/** Platform-specific label used by shortcut discovery surfaces. */
+export const VIEW_MODE_TOGGLE_SHORTCUT = IS_MAC ? "⌘⌥T" : "Ctrl+Alt+T";
+
+/** Whether the current state has a usable Chat/Terminal destination. */
+export function canToggleTerminalFirstView(
+  ctx: TerminalFirstContextValue | null,
+): ctx is TerminalFirstContextValue {
+  if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return false;
+  return ctx.view === "terminal" || ctx.terminalsAvailable;
+}
+
+/** True for Cmd/Ctrl+Alt+T without Shift, repeat, or AltGraph. */
+function isViewModeToggleHotkey(event: globalThis.KeyboardEvent): boolean {
+  if (!(event.metaKey || event.ctrlKey) || !event.altKey || event.shiftKey || event.repeat) {
+    return false;
+  }
+  if (typeof event.getModifierState === "function" && event.getModifierState("AltGraph")) {
+    return false;
+  }
+  // Option changes the produced character on macOS, so match the physical key.
+  return event.code === "KeyT";
+}
+
+/**
+ * Bind the terminal-first Chat/Terminal flip once at AppShell.
+ *
+ * `enabled` is false in embedded mode, where the host page owns global chords.
+ */
+export function useViewModeToggleHotkey(
+  ctx: TerminalFirstContextValue | null,
+  enabled = true,
+): void {
+  const latest = useRef(ctx);
+  latest.current = ctx;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (event: globalThis.KeyboardEvent): void => {
+      if (!isViewModeToggleHotkey(event)) return;
+      const current = latest.current;
+      if (!canToggleTerminalFirstView(current)) return;
+
+      // Unlike ⌘K, this deliberately fires inside xterm: otherwise users could
+      // enter Terminal with the chord but could not use it to return to Chat.
+      event.preventDefault();
+      event.stopPropagation();
+      current.setView(current.view === "chat" ? "terminal" : "chat");
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled]);
+}

--- a/web/src/hooks/useViewModeToggleHotkey.ts
+++ b/web/src/hooks/useViewModeToggleHotkey.ts
@@ -60,7 +60,9 @@ export function useViewModeToggleHotkey(
       current.setView(current.view === "chat" ? "terminal" : "chat");
     };
 
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    // Capture before xterm's target listener can stop propagation or forward
+    // the chord to the PTY.
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
   }, [enabled]);
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
 import { useCommandPaletteHotkey } from "@/hooks/useCommandPaletteHotkey";
 import { useNewSessionHotkey } from "@/hooks/useNewSessionHotkey";
+import { useViewModeToggleHotkey } from "@/hooks/useViewModeToggleHotkey";
 import { useIsEmbedded } from "@/lib/embedded";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
@@ -1672,6 +1673,10 @@ export function AppShell() {
       terminalStartingUp,
     ],
   );
+
+  // ⌘⌥T / Ctrl+Alt+T uses the same TerminalFirstContext transition as the
+  // header control and native bridge. Embedded hosts retain their own chords.
+  useViewModeToggleHotkey(terminalFirstContextValue, !isEmbedded);
 
   // Opener for the fork/clone dialog, shared with descendants via
   // ForkDialogContext. ChatPage's per-message "Fork from here" action is

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ComponentProps } from "react";
 
 import { CommandPalette } from "./CommandPalette";
+import {
+  TerminalFirstContextProvider,
+  type TerminalFirstContextValue,
+} from "./TerminalFirstContext";
 
 const navigate = vi.fn();
 vi.mock("@/lib/routing", () => ({
@@ -27,13 +31,33 @@ function setSessions(sessions: ReturnType<typeof conv>[], isFetching = false) {
   useConversations.mockReturnValue({ data: { pages: [{ data: sessions }] }, isFetching });
 }
 
+function terminalFirstCtx(
+  overrides: Partial<TerminalFirstContextValue> = {},
+): TerminalFirstContextValue {
+  return {
+    isClaudeNative: false,
+    isNativeWrapper: false,
+    isTerminalFirst: true,
+    isShellView: false,
+    view: "chat",
+    terminalViewKey: null,
+    setView: vi.fn(),
+    terminalsAvailable: true,
+    terminalStartingUp: false,
+    ...overrides,
+  };
+}
+
 /** Find a session row by its full label text even when the highlighter has
     split it around a <mark> (so the text lives across several nodes). */
 function labelRow(text: string) {
   return screen.getByText((_content, el) => el?.tagName === "SPAN" && el.textContent === text);
 }
 
-function renderPalette(overrides: Partial<ComponentProps<typeof CommandPalette>> = {}) {
+function renderPalette(
+  overrides: Partial<ComponentProps<typeof CommandPalette>> = {},
+  terminalCtx: TerminalFirstContextValue | null = null,
+) {
   const props = {
     open: true,
     onOpenChange: vi.fn(),
@@ -41,7 +65,15 @@ function renderPalette(overrides: Partial<ComponentProps<typeof CommandPalette>>
     onToggleRightSidebar: vi.fn(),
     ...overrides,
   };
-  render(<CommandPalette {...props} />);
+  render(
+    terminalCtx ? (
+      <TerminalFirstContextProvider value={terminalCtx}>
+        <CommandPalette {...props} />
+      </TerminalFirstContextProvider>
+    ) : (
+      <CommandPalette {...props} />
+    ),
+  );
   return props;
 }
 
@@ -322,6 +354,38 @@ describe("CommandPalette — actions", () => {
 
     fireEvent.click(screen.getByText("Toggle workspace sidebar"));
     expect(onToggleRightSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists and runs the view toggle only when the active terminal-first view can switch", () => {
+    const ctx = terminalFirstCtx();
+    const onOpenChange = vi.fn();
+    renderPalette({ onOpenChange }, ctx);
+
+    fireEvent.click(screen.getByText("Toggle chat / terminal view"));
+
+    expect(ctx.setView).toHaveBeenCalledWith("terminal");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it.each([
+    ["outside a terminal-first session", terminalFirstCtx({ isTerminalFirst: false })],
+    ["while a user shell owns the view", terminalFirstCtx({ isShellView: true })],
+    [
+      "while the terminal destination is unavailable",
+      terminalFirstCtx({ terminalsAvailable: false }),
+    ],
+  ])("hides the view toggle %s", (_scenario, ctx) => {
+    renderPalette({}, ctx);
+    expect(screen.queryByText("Toggle chat / terminal view")).toBeNull();
+  });
+
+  it("keeps the action available to leave Terminal if the PTY disappears", () => {
+    const ctx = terminalFirstCtx({ view: "terminal", terminalsAvailable: false });
+    renderPalette({}, ctx);
+
+    fireEvent.click(screen.getByText("Toggle chat / terminal view"));
+
+    expect(ctx.setView).toHaveBeenCalledWith("chat");
   });
 
   it("filters actions client-side against the query", () => {

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -26,11 +26,13 @@ import {
   PanelRightIcon,
   SettingsIcon,
   SquarePenIcon,
+  TerminalIcon,
   XIcon,
 } from "lucide-react";
 import { useNavigate } from "@/lib/routing";
 import { useConversations } from "@/hooks/useConversations";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { canToggleTerminalFirstView } from "@/hooks/useViewModeToggleHotkey";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -43,6 +45,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { conversationDisplayLabel, getConversationAgentType } from "./sidebarNav";
+import { useTerminalFirst } from "./TerminalFirstContext";
 
 export interface CommandPaletteProps {
   open: boolean;
@@ -106,6 +109,7 @@ export function CommandPalette({
 }: CommandPaletteProps) {
   const navigate = useNavigate();
   const isMobile = useIsMobileViewport();
+  const terminalFirst = useTerminalFirst();
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -168,8 +172,19 @@ export function CommandPalette({
         keywords: ["panel", "right", "files", "terminal"],
         run: onToggleRightSidebar,
       },
+      ...(canToggleTerminalFirstView(terminalFirst)
+        ? [
+            {
+              id: "toggle-view-mode",
+              label: "Toggle chat / terminal view",
+              icon: TerminalIcon,
+              keywords: ["terminal", "chat", "view", "shell", "pty"],
+              run: () => terminalFirst.setView(terminalFirst.view === "chat" ? "terminal" : "chat"),
+            },
+          ]
+        : []),
     ],
-    [navigate, onToggleLeftSidebar, onToggleRightSidebar],
+    [navigate, onToggleLeftSidebar, onToggleRightSidebar, terminalFirst],
   );
 
   const filteredActions = useMemo(() => {

--- a/web/src/shell/ViewModeToggle.test.tsx
+++ b/web/src/shell/ViewModeToggle.test.tsx
@@ -122,7 +122,7 @@ describe("ViewModeToggle", () => {
     // Radix opens on a real pointer move over the trigger (the wrapper span),
     // so a bare pointerEnter on the button wouldn't surface the tooltip.
     fireEvent.pointerMove(chatSegment().parentElement!, { pointerType: "mouse" });
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("Chat view");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(/Chat view · (⌘⌥T|Ctrl\+Alt\+T)/);
   });
 
   it("keeps the Terminal segment usable and shows a spinner while the terminal is coming up", () => {

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -1,6 +1,7 @@
 import { Loader2Icon, MessagesSquareIcon, TerminalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { VIEW_MODE_TOGGLE_SHORTCUT } from "@/hooks/useViewModeToggleHotkey";
 import { isIOSShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 import { useTerminalFirst } from "./TerminalFirstContext";
@@ -110,7 +111,9 @@ function ViewModeSegment({
       </TooltipTrigger>
       {/* Bottom placement: the header sits at top-0, so a top-side tooltip
           would render above the viewport edge and get clipped. */}
-      <TooltipContent side="bottom">{label}</TooltipContent>
+      <TooltipContent side="bottom">
+        {label} · {VIEW_MODE_TOGGLE_SHORTCUT}
+      </TooltipContent>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Related issue

Closes #4253

## Summary

- Add `⌘⌥T` / `Ctrl+Alt+T` to toggle terminal-first sessions between Chat and Terminal from composers and focused xterm surfaces.
- Reuse the guarded `TerminalFirstContext.setView` transition for a conditional command-palette action, including terminal availability, shell-view, iOS, and embedded-mode constraints.
- Add shortcut discovery, focused Vitest coverage, and a PR-gated assembled browser journey that proves no text is sent.

**ELI5:** Chat and Terminal are two windows onto the same session. One keyboard chord now flips between them, even when the cursor is inside the terminal.

```text
Chat composer ── ⌘⌥T / Ctrl+Alt+T ──> Terminal
      ^                                     │
      └────── ⌘⌥T / Ctrl+Alt+T from xterm ──┘
```

## Test Plan

- `pnpm exec vitest run src/hooks/useViewModeToggleHotkey.test.tsx src/shell/CommandPalette.test.tsx src/components/KeyboardShortcutsDialog.test.tsx src/shell/ViewModeToggle.test.tsx` — 49 passed.
- `NODE_OPTIONS="--localstorage-file=/tmp/omnigent-appshell-vitest-4253" pnpm exec vitest run src/shell/AppShell.test.tsx` — 101 passed.
- `uv run --no-sync pytest -q tests/e2e_ui/hotkeys/test_view_mode_toggle_hotkey.py` — 1 passed in Chromium.
- `pnpm run type-check` — passed.
- `pnpm run lint` — passed.
- `pnpm run build` — passed.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed.

## Demo

[Chat → Terminal → Chat keyboard toggle and command-palette action (WebM)](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-assets/demos/issue-4253-chat-terminal-toggle.webm)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Recorded the real assembled UI toggling from a focused composer into Terminal, returning from focused xterm without submitting the draft, and invoking the command-palette action.

## Changelog

Switch terminal-first sessions between Chat and Terminal with `⌘⌥T` / `Ctrl+Alt+T` or the command palette.