### PR TITLE
fix(polly): ground worker roster in host readiness

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -71,15 +71,15 @@ prompt: |
   Extra vendors widen cross-vendor review (any implementer's diff can be judged
   by a DIFFERENT vendor). Route to whichever workers the preflight finds.
 
-  Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
-  CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `opencode` for
-  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`,
-  `agy` for `agy`.
-  Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy || true")`. A worker is AVAILABLE
-  only if its binary resolved in that output; record the available set and route
+  Roster preflight (FIRST turn, before any dispatch). Before delegating
+  anything, run exactly ONE `sys_session_get_info({})` and read its
+  `configured_harnesses` map. Map workers to readiness keys as follows:
+  `claude_code` -> `claude-native`, `codex` -> `codex-native`, `opencode` ->
+  `opencode-native`, `cursor` -> `cursor-native`, `hermes` -> `hermes-native`,
+  `agy` -> `antigravity-native`, and `pi` -> `pi`. A worker is AVAILABLE only
+  when its readiness value is exactly `true`; record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
-  turn you start planning (the preflight `sys_os_shell` call counts as acting —
+  turn you start planning (the preflight tool call counts as acting —
   don't end the turn on the preflight alone). The preflight is SILENT internal
   plumbing: do not announce it, explain it, or report its result in chat — when
   every worker resolves, say nothing about the roster and get straight to the

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -73,11 +73,23 @@ prompt: |
 
   Roster preflight (FIRST turn, before any dispatch). Before delegating
   anything, run exactly ONE `sys_session_get_info({})` and read its
-  `configured_harnesses` map. Map workers to readiness keys as follows:
+  `configured_harnesses` map — the bound host's authoritative readiness report.
+  Map workers to readiness keys as follows:
   `claude_code` -> `claude-native`, `codex` -> `codex-native`, `opencode` ->
   `opencode-native`, `cursor` -> `cursor-native`, `hermes` -> `hermes-native`,
   `agy` -> `antigravity-native`, and `pi` -> `pi`. A worker is AVAILABLE only
-  when its readiness value is exactly `true`; record the available set and route
+  when its readiness value is exactly `true` — every other value (`false`,
+  `"binary-missing"`, `"needs-auth"`, `"version-too-low"`) means it cannot boot
+  on this host. If `configured_harnesses` is absent or `null` (the session has
+  no bound host, or the readiness lookup failed), readiness is UNKNOWN — fall
+  back to exactly ONE
+  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy || true")`
+  and treat a worker as available only if its binary resolved there. The
+  fallback is weaker (a shell PATH probe cannot see auth state), so a
+  fallback-approved worker may still fail loud at dispatch — read that error,
+  drop the worker, and do not retry it. Readiness is the HOST's view, not each
+  dispatch's guarantee: a `true` worker can still fail at dispatch; the same
+  fail-loud rule applies. Record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight tool call counts as acting —
   don't end the turn on the preflight alone). The preflight is SILENT internal
@@ -85,7 +97,8 @@ prompt: |
   every worker resolves, say nothing about the roster and get straight to the
   task. A missing worker is the ONLY roster fact worth words: it is not
   launchable on this machine — do not dispatch to it, and tell the human which
-  workers are unavailable so they can install the missing CLI if they want it.
+  workers are unavailable and why (e.g. `needs-auth`) so they can install or
+  authenticate the missing CLI if they want it.
 
   Every dispatch may carry an explicit `args.model` for the worker — useful
   when the task's difficulty or cost profile warrants it (cheap and fast for

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3698,8 +3698,8 @@ async def _execute_session_query_tool(
 
     - ``sys_session_list`` → ``GET /v1/sessions/{caller}/child_sessions``
     - ``sys_session_get_history`` → ``GET /v1/sessions/{target}/items``
-    - ``sys_session_get_info`` → ``GET /v1/sessions/{target}`` (plus a
-      best-effort ``GET /v1/runners/{id}/status`` for connectivity)
+    - ``sys_session_get_info`` → ``GET /v1/sessions/{target}`` (plus
+      best-effort runner connectivity and host readiness lookups)
     - ``sys_session_close`` → ``GET`` the target snapshot then ``PATCH
       /v1/sessions/{target}`` with a tombstoned title
     - ``sys_session_share`` → ``PUT /v1/sessions/{target}/permissions``
@@ -3776,6 +3776,23 @@ async def _runner_online_or_none(
     return online if isinstance(online, bool) else None
 
 
+async def _host_harnesses_or_none(
+    host_id: str | None,
+    server_client: httpx.AsyncClient,
+) -> _JsonObject | None:
+    """Return the bound host's reported harness readiness, best-effort."""
+    if not host_id:
+        return None
+    try:
+        resp = await server_client.get(f"/v1/hosts/{host_id}", timeout=30.0)
+        if resp.status_code != 200:
+            return None
+        readiness = resp.json().get("configured_harnesses")
+    except Exception:  # noqa: BLE001
+        return None
+    return readiness if isinstance(readiness, dict) else None
+
+
 async def _session_get_info_via_rest(
     args: _JsonObject,
     conversation_id: str,
@@ -3787,13 +3804,15 @@ async def _session_get_info_via_rest(
     Resolves the target from ``args["session_id"]`` (falling back to the
     caller's own ``conversation_id`` when omitted), fetches the session
     snapshot, and projects the metadata fields — status, title, agent
-    binding, runner binding, host, reasoning effort, effective model,
+    binding, runner binding, host and its reported harness readiness,
+    reasoning effort, effective model,
     parent linkage, workspace / git branch, persisted last-activity time,
     and the outstanding approval prompts (the prompts themselves plus a
     count). Runner connectivity
     is resolved best-effort via
     ``GET /v1/runners/{id}/status`` (``runner_online`` is ``None`` when
-    the lookup fails or no runner is bound). The full transcript is
+    the lookup fails or no runner is bound); host readiness is likewise
+    best-effort via ``GET /v1/hosts/{id}``. The full transcript is
     intentionally omitted — that is what ``sys_session_get_history`` returns.
 
     Maps a 404 to ``session_not_found`` and 401/403 to ``access_denied``
@@ -3830,6 +3849,11 @@ async def _session_get_info_via_rest(
     pending = pending_value if isinstance(pending_value, list) else []
     snap_agent_name = _optional_string(snap.get("agent_name"))
     snap_runner_id = _optional_string(snap.get("runner_id"))
+    snap_host_id = _optional_string(snap.get("host_id"))
+    runner_online, configured_harnesses = await asyncio.gather(
+        _runner_online_or_none(snap_runner_id, server_client),
+        _host_harnesses_or_none(snap_host_id, server_client),
+    )
     return json.dumps(
         {
             "session_id": snap.get("id"),
@@ -3847,8 +3871,9 @@ async def _session_get_info_via_rest(
             # unchanged.
             "agent_name": public_agent_name(snap_agent_name),
             "runner_id": snap.get("runner_id"),
-            "runner_online": await _runner_online_or_none(snap_runner_id, server_client),
+            "runner_online": runner_online,
             "host_id": snap.get("host_id"),
+            "configured_harnesses": configured_harnesses,
             "parent_session_id": snap.get("parent_session_id"),
             "sub_agent_name": snap.get("sub_agent_name"),
             "reasoning_effort": snap.get("reasoning_effort"),

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -598,7 +598,8 @@ class SysSessionGetInfoTool(Tool):
     permitted to access (bounded by the server's per-user permission
     model), not just the caller's spawn subtree. Reports lifecycle
     status, title, agent binding (id + name), runner binding and live
-    connectivity, host, reasoning effort, effective model, parent
+    connectivity, host and its reported harness readiness, reasoning effort,
+    effective model, parent
     linkage, workspace / git branch, persisted last-activity time, and
     the count of outstanding approval prompts. Comparing
     ``last_activity_at`` across polls distinguishes a running session that
@@ -610,8 +611,8 @@ class SysSessionGetInfoTool(Tool):
     session is described.
 
     Runner-dispatched: the runner proxies ``GET /v1/sessions/{id}``
-    (plus a best-effort ``GET /v1/runners/{id}/status`` for live
-    connectivity) and projects the result. Returns
+    (plus best-effort runner status and host readiness lookups) and projects
+    the result. Returns
     ``session_not_found`` when the id is unknown and ``access_denied``
     when the server refuses the read.
     """
@@ -627,7 +628,8 @@ class SysSessionGetInfoTool(Tool):
         return (
             "Return a session's metadata: lifecycle status, title, "
             "agent binding (id/name), runner binding + connectivity, "
-            "host, reasoning effort, model, parent session, workspace, "
+            "host + configured harness readiness, reasoning effort, model, "
+            "parent session, workspace, "
             "persisted last-activity time, and outstanding approval "
             "prompts. Global read — any "
             "session you can access. Pass session_id to target another "

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -113,6 +113,13 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
         assert "EXPLORE / SEARCH — answer a specific question" in prompt
 
 
+def test_polly_preflights_host_harness_readiness() -> None:
+    config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
+    assert "sys_session_get_info({})" in config
+    assert "`configured_harnesses` map" in config
+    assert "command -v claude codex" not in config
+
+
 def test_pi_subagent_is_headless_scaffold_worker(polly_spec: AgentSpec) -> None:
     """
     The ``pi`` sub-agent is a headless scaffold-harness child: pi harness,

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -117,7 +117,9 @@ def test_polly_preflights_host_harness_readiness() -> None:
     config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
     assert "sys_session_get_info({})" in config
     assert "`configured_harnesses` map" in config
-    assert "command -v claude codex" not in config
+    # The shell probe survives only as the fallback for sessions with no
+    # bound host (configured_harnesses null); readiness stays the primary gate.
+    assert config.index("configured_harnesses") < config.index("command -v")
 
 
 def test_pi_subagent_is_headless_scaffold_worker(polly_spec: AgentSpec) -> None:

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -117,8 +117,6 @@ def test_polly_preflights_host_harness_readiness() -> None:
     config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
     assert "sys_session_get_info({})" in config
     assert "`configured_harnesses` map" in config
-    # The shell probe survives only as the fallback for sessions with no
-    # bound host (configured_harnesses null); readiness stays the primary gate.
     assert config.index("configured_harnesses") < config.index("command -v")
 
 

--- a/tests/e2e/test_polly_preflight_host_readiness.py
+++ b/tests/e2e/test_polly_preflight_host_readiness.py
@@ -1,20 +1,4 @@
-"""Polly's roster preflight must gate workers on host harness readiness.
-
-Bug: a ``command -v`` shell probe only checks the runner shell PATH, so it
-marks an installed-but-unauthenticated harness (e.g. OpenCode reporting
-``needs-auth``) as available; Polly then dispatches to a worker that cannot
-boot. The authoritative source is the bound host's ``configured_harnesses``
-readiness map (surfaced via ``sys_session_get_info``), where a worker is truly
-available only when its readiness value is exactly ``true``.
-
-These tests pin the preflight contract in ``examples/polly/config.yaml``:
-readiness-map first, ``command -v`` only as the explicit fallback for the
-no-bound-host / lookup-failed case.
-
-Run::
-
-    pytest tests/e2e/test_polly_preflight_host_readiness.py -v
-"""
+"""Tests for Polly's host-readiness preflight."""
 
 from __future__ import annotations
 
@@ -22,106 +6,40 @@ from pathlib import Path
 
 import yaml
 
-# tests/e2e/<this file> -> repo root is 2 parents up.
-_REPO = Path(__file__).resolve().parents[2]
-_POLLY = _REPO / "examples" / "polly"
+_POLLY = Path(__file__).resolve().parents[2] / "examples" / "polly"
 
 
 def _polly_prompt() -> str:
-    """Return the raw prompt string from ``examples/polly/config.yaml``."""
     cfg = yaml.safe_load((_POLLY / "config.yaml").read_text(encoding="utf-8"))
     return cfg.get("prompt", "")
 
 
 def test_polly_preflight_references_host_readiness() -> None:
-    """The preflight must consult ``configured_harnesses``, not only ``command -v``.
-
-    ``command -v`` checks the runner shell PATH only. It cannot distinguish:
-
-    - a harness installed but unauthenticated (readiness ``"needs-auth"``)
-    - a harness available via the Omnigent resolver but absent from PATH
-    - a harness that fails the version check (``"version-too-low"``)
-
-    The prompt must instruct the brain to read the host readiness map so Polly
-    never dispatches to a worker that cannot boot.
-    """
     prompt = _polly_prompt()
-    assert "configured_harnesses" in prompt, (
-        "Polly's roster preflight must consult the bound host's "
-        "`configured_harnesses` readiness map (via sys_session_get_info); a "
-        "shell `command -v` probe alone cannot distinguish "
-        "installed-but-unauthenticated workers from truly available ones."
-    )
-    assert "sys_session_get_info" in prompt, (
-        "The preflight must name the tool that surfaces the readiness map "
-        "(sys_session_get_info) so the brain knows how to fetch it."
-    )
+    assert "configured_harnesses" in prompt
+    assert "sys_session_get_info" in prompt
 
 
 def test_polly_preflight_uses_readiness_true_filter() -> None:
-    """The prompt must require readiness exactly ``true`` to route to a worker.
-
-    The readiness map carries non-true values (``"needs-auth"``,
-    ``"binary-missing"``, ``"version-too-low"``, ``false``); all must be
-    treated as unavailable.
-    """
     prompt = _polly_prompt()
-    lp = prompt.lower()
-    assert "configured_harnesses" in prompt and "exactly `true`" in lp, (
-        "The polly prompt must require readiness == true when filtering "
-        "workers from the configured_harnesses map; values like 'needs-auth', "
-        "'binary-missing', and 'version-too-low' must all be treated as "
-        "unavailable."
-    )
-    # Non-true readiness values must be spelled out as unavailable states.
+    lowered = prompt.lower()
+    assert "configured_harnesses" in prompt
+    assert "exactly `true`" in lowered
     for state in ("needs-auth", "binary-missing", "version-too-low"):
-        assert state in lp, (
-            f"The preflight paragraph should name {state!r} as an unavailable "
-            "readiness state so the brain treats it as not routable."
-        )
+        assert state in lowered
 
 
 def test_polly_preflight_readiness_map_is_primary_gate() -> None:
-    """The readiness map is the primary gate; ``command -v`` only the fallback.
-
-    A prompt that leads with a PATH probe reintroduces the bug: the shell
-    check would win before the readiness map is consulted. The readiness-map
-    instruction must come first, and any ``command -v`` mention must be
-    scoped to the no-bound-host / lookup-failed fallback.
-    """
     prompt = _polly_prompt()
-    readiness_pos = prompt.find("configured_harnesses")
-    command_v_pos = prompt.find("command -v")
-    assert readiness_pos != -1, "prompt must reference configured_harnesses"
-    if command_v_pos != -1:
-        assert readiness_pos < command_v_pos, (
-            "The configured_harnesses readiness check must come before any "
-            "`command -v` mention: the shell probe is only the fallback for "
-            "sessions with no bound host, never the primary availability gate."
-        )
-        # The fallback must be explicitly conditioned on the readiness map
-        # being unavailable, not offered as an equal alternative.
-        window = " ".join(prompt[readiness_pos:command_v_pos].lower().split())
-        assert "absent" in window or "null" in window or "fall back" in window, (
-            "The `command -v` probe must be framed as the fallback for an "
-            "absent/null configured_harnesses map, not as a primary check."
-        )
+    readiness_pos = prompt.index("configured_harnesses")
+    command_v_pos = prompt.index("command -v")
+    assert readiness_pos < command_v_pos
+
+    window = " ".join(prompt[readiness_pos:command_v_pos].lower().split())
+    assert any(marker in window for marker in ("absent", "null", "fall back"))
 
 
 def test_polly_preflight_defines_no_host_fallback() -> None:
-    """The prompt must define behavior when ``configured_harnesses`` is null.
-
-    ``host_id`` is legitimately ``None`` for CLI-initiated sessions and
-    caller-managed runners, and the host lookup is best-effort — in both
-    cases ``configured_harnesses`` is ``null``. Without an explicit fallback
-    the 'exactly true' rule matches nothing and Polly would treat every
-    worker as unavailable, stalling all dispatch.
-    """
-    # Normalize whitespace: YAML block-scalar line wraps can split phrases.
-    lp = " ".join(_polly_prompt().lower().split())
-    assert ("absent" in lp or "null" in lp) and "fall back" in lp, (
-        "The preflight must state what to do when configured_harnesses is "
-        "absent/null (no bound host, or the readiness lookup failed): fall "
-        "back to the shell probe rather than concluding no worker is "
-        "available."
-    )
+    prompt = " ".join(_polly_prompt().lower().split())
+    assert "absent" in prompt or "null" in prompt
+    assert "fall back" in prompt

--- a/tests/e2e/test_polly_preflight_host_readiness.py
+++ b/tests/e2e/test_polly_preflight_host_readiness.py
@@ -1,0 +1,127 @@
+"""Polly's roster preflight must gate workers on host harness readiness.
+
+Bug: a ``command -v`` shell probe only checks the runner shell PATH, so it
+marks an installed-but-unauthenticated harness (e.g. OpenCode reporting
+``needs-auth``) as available; Polly then dispatches to a worker that cannot
+boot. The authoritative source is the bound host's ``configured_harnesses``
+readiness map (surfaced via ``sys_session_get_info``), where a worker is truly
+available only when its readiness value is exactly ``true``.
+
+These tests pin the preflight contract in ``examples/polly/config.yaml``:
+readiness-map first, ``command -v`` only as the explicit fallback for the
+no-bound-host / lookup-failed case.
+
+Run::
+
+    pytest tests/e2e/test_polly_preflight_host_readiness.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# tests/e2e/<this file> -> repo root is 2 parents up.
+_REPO = Path(__file__).resolve().parents[2]
+_POLLY = _REPO / "examples" / "polly"
+
+
+def _polly_prompt() -> str:
+    """Return the raw prompt string from ``examples/polly/config.yaml``."""
+    cfg = yaml.safe_load((_POLLY / "config.yaml").read_text(encoding="utf-8"))
+    return cfg.get("prompt", "")
+
+
+def test_polly_preflight_references_host_readiness() -> None:
+    """The preflight must consult ``configured_harnesses``, not only ``command -v``.
+
+    ``command -v`` checks the runner shell PATH only. It cannot distinguish:
+
+    - a harness installed but unauthenticated (readiness ``"needs-auth"``)
+    - a harness available via the Omnigent resolver but absent from PATH
+    - a harness that fails the version check (``"version-too-low"``)
+
+    The prompt must instruct the brain to read the host readiness map so Polly
+    never dispatches to a worker that cannot boot.
+    """
+    prompt = _polly_prompt()
+    assert "configured_harnesses" in prompt, (
+        "Polly's roster preflight must consult the bound host's "
+        "`configured_harnesses` readiness map (via sys_session_get_info); a "
+        "shell `command -v` probe alone cannot distinguish "
+        "installed-but-unauthenticated workers from truly available ones."
+    )
+    assert "sys_session_get_info" in prompt, (
+        "The preflight must name the tool that surfaces the readiness map "
+        "(sys_session_get_info) so the brain knows how to fetch it."
+    )
+
+
+def test_polly_preflight_uses_readiness_true_filter() -> None:
+    """The prompt must require readiness exactly ``true`` to route to a worker.
+
+    The readiness map carries non-true values (``"needs-auth"``,
+    ``"binary-missing"``, ``"version-too-low"``, ``false``); all must be
+    treated as unavailable.
+    """
+    prompt = _polly_prompt()
+    lp = prompt.lower()
+    assert "configured_harnesses" in prompt and "exactly `true`" in lp, (
+        "The polly prompt must require readiness == true when filtering "
+        "workers from the configured_harnesses map; values like 'needs-auth', "
+        "'binary-missing', and 'version-too-low' must all be treated as "
+        "unavailable."
+    )
+    # Non-true readiness values must be spelled out as unavailable states.
+    for state in ("needs-auth", "binary-missing", "version-too-low"):
+        assert state in lp, (
+            f"The preflight paragraph should name {state!r} as an unavailable "
+            "readiness state so the brain treats it as not routable."
+        )
+
+
+def test_polly_preflight_readiness_map_is_primary_gate() -> None:
+    """The readiness map is the primary gate; ``command -v`` only the fallback.
+
+    A prompt that leads with a PATH probe reintroduces the bug: the shell
+    check would win before the readiness map is consulted. The readiness-map
+    instruction must come first, and any ``command -v`` mention must be
+    scoped to the no-bound-host / lookup-failed fallback.
+    """
+    prompt = _polly_prompt()
+    readiness_pos = prompt.find("configured_harnesses")
+    command_v_pos = prompt.find("command -v")
+    assert readiness_pos != -1, "prompt must reference configured_harnesses"
+    if command_v_pos != -1:
+        assert readiness_pos < command_v_pos, (
+            "The configured_harnesses readiness check must come before any "
+            "`command -v` mention: the shell probe is only the fallback for "
+            "sessions with no bound host, never the primary availability gate."
+        )
+        # The fallback must be explicitly conditioned on the readiness map
+        # being unavailable, not offered as an equal alternative.
+        window = " ".join(prompt[readiness_pos:command_v_pos].lower().split())
+        assert "absent" in window or "null" in window or "fall back" in window, (
+            "The `command -v` probe must be framed as the fallback for an "
+            "absent/null configured_harnesses map, not as a primary check."
+        )
+
+
+def test_polly_preflight_defines_no_host_fallback() -> None:
+    """The prompt must define behavior when ``configured_harnesses`` is null.
+
+    ``host_id`` is legitimately ``None`` for CLI-initiated sessions and
+    caller-managed runners, and the host lookup is best-effort — in both
+    cases ``configured_harnesses`` is ``null``. Without an explicit fallback
+    the 'exactly true' rule matches nothing and Polly would treat every
+    worker as unavailable, stalling all dispatch.
+    """
+    # Normalize whitespace: YAML block-scalar line wraps can split phrases.
+    lp = " ".join(_polly_prompt().lower().split())
+    assert ("absent" in lp or "null" in lp) and "fall back" in lp, (
+        "The preflight must state what to do when configured_harnesses is "
+        "absent/null (no bound host, or the readiness lookup failed): fall "
+        "back to the shell probe rather than concluding no worker is "
+        "available."
+    )

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7020,6 +7020,41 @@ async def test_sys_session_get_info_tolerates_host_readiness_failure(
 
 
 @pytest.mark.asyncio
+async def test_sys_session_get_info_reports_null_readiness_without_host() -> None:
+    """A session with no bound host reports ``configured_harnesses: null``.
+
+    ``host_id`` is legitimately ``None`` for CLI-initiated sessions and
+    caller-managed runners; the readiness lookup must be skipped (no
+    ``/v1/hosts/`` call) and the field projected as ``null`` (unknown).
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    host_calls: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(200, json={"id": "conv_target", "host_id": None})
+        if request.url.path.startswith("/v1/hosts/"):
+            host_calls.append(request.url.path)
+            return httpx.Response(404)
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_get_info",
+            arguments=json.dumps({"session_id": "conv_target"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    assert json.loads(output)["configured_harnesses"] is None
+    assert host_calls == []
+
+
+@pytest.mark.asyncio
 async def test_sys_session_get_info_hides_native_ui_wrapper_agent_name() -> None:
     """A native-UI session describes itself with its clean public name.
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7021,12 +7021,7 @@ async def test_sys_session_get_info_tolerates_host_readiness_failure(
 
 @pytest.mark.asyncio
 async def test_sys_session_get_info_reports_null_readiness_without_host() -> None:
-    """A session with no bound host reports ``configured_harnesses: null``.
-
-    ``host_id`` is legitimately ``None`` for CLI-initiated sessions and
-    caller-managed runners; the readiness lookup must be skipped (no
-    ``/v1/hosts/`` call) and the field projected as ``null`` (unknown).
-    """
+    """Skip the host lookup when the session has no bound host."""
     from omnigent.runner.tool_dispatch import execute_tool
 
     host_calls: list[str] = []

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6900,7 +6900,8 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     """
     ``sys_session_get_info`` projects ``GET /v1/sessions/{id}`` metadata
     and folds in live runner connectivity from ``GET
-    /v1/runners/{id}/status``.
+    /v1/runners/{id}/status`` and host harness readiness from ``GET
+    /v1/hosts/{id}``.
 
     Proves the full runner-dispatch path: read the session snapshot,
     derive the effective model (a per-session ``model_override`` wins
@@ -6928,7 +6929,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
                     "updated_at": 84,
                     "title": "auth flow",
                     "runner_id": "runner_1",
-                    "host_id": None,
+                    "host_id": "host_1",
                     "reasoning_effort": "high",
                     "parent_session_id": "conv_parent",
                     "sub_agent_name": "researcher",
@@ -6941,6 +6942,11 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
             )
         if request.method == "GET" and request.url.path == "/v1/runners/runner_1/status":
             return httpx.Response(200, json={"runner_id": "runner_1", "online": True})
+        if request.method == "GET" and request.url.path == "/v1/hosts/host_1":
+            return httpx.Response(
+                200,
+                json={"configured_harnesses": {"codex-native": True, "cursor-native": False}},
+            )
         return httpx.Response(404, json={"error": str(request.url)})
 
     async with httpx.AsyncClient(
@@ -6965,6 +6971,11 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     # Live connectivity folded in from the runners status endpoint —
     # None here would mean the best-effort status call was skipped.
     assert info["runner_online"] is True
+    assert info["host_id"] == "host_1"
+    assert info["configured_harnesses"] == {
+        "codex-native": True,
+        "cursor-native": False,
+    }
     assert info["parent_session_id"] == "conv_parent"
     # Effective model: the per-session override wins over the spec
     # default. "anthropic/claude-sonnet-4-6" here would mean the
@@ -6978,6 +6989,34 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     assert info["pending_elicitations"] == [{"id": "el_1"}, {"id": "el_2"}]
     # Metadata-only: the full transcript is never embedded.
     assert "items" not in info
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host_response", [httpx.Response(503), httpx.Response(200, text="bad")])
+async def test_sys_session_get_info_tolerates_host_readiness_failure(
+    host_response: httpx.Response,
+) -> None:
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_target":
+            return httpx.Response(200, json={"id": "conv_target", "host_id": "host_1"})
+        if request.url.path == "/v1/hosts/host_1":
+            return host_response
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_get_info",
+            arguments=json.dumps({"session_id": "conv_target"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    assert json.loads(output)["configured_harnesses"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #4853

## Summary

- Expose the bound host `configured_harnesses` map through `sys_session_get_info`.
- Keep the host lookup best-effort so a readiness endpoint failure does not break session metadata.
- Make Polly preflight its upstream worker roster from authoritative host readiness instead of shell `command -v`.

ELI5: Polly now asks Omnigent whether each worker is actually ready on this host, rather than only checking whether a similarly named executable is visible in one shell.

```text
Polly -> sys_session_get_info -> bound host configured_harnesses -> route only to true workers
```

## Test Plan

- `uv run pytest tests/runner/test_runner_dispatch.py -k sys_session_get_info -q` — 8 passed.
- `uv run pytest tests/e2e/omnigent/test_example_polly.py -q` — 15 passed.
- Ruff check and format checks passed on all changed Python files.
- `git diff --check` passed.

## Demo

N/A — orchestration metadata and prompt behavior with automated coverage; no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The runner tests cover successful host readiness projection plus unavailable and malformed host responses. The Polly bundle test pins the readiness-based preflight contract.

## Changelog

Polly now routes work only to harnesses reported ready on the session bound host.