### PR TITLE
fix(web): keep project actions available on touch devices

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -26,7 +26,7 @@ import re
 import uuid
 
 import httpx
-from playwright.sync_api import Locator, Page, expect
+from playwright.sync_api import Browser, Locator, Page, expect
 
 from tests.e2e_ui.conftest import seed_committed_turn
 
@@ -231,6 +231,42 @@ def test_remove_session_from_project(
 # mobile overlay and the folder header's new-session pencil (`max-md:hidden`)
 # collapses into the kebab.
 _MOBILE_VIEWPORT = {"width": 390, "height": 780}
+_TABLET_VIEWPORT = {"width": 834, "height": 1112}
+
+
+def test_project_header_action_is_clickable_on_mobile(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Projects header keeps its new-project action visible on mobile."""
+    base_url, session_id = seeded_session
+    page.set_viewport_size(_MOBILE_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}?sidebar=open")
+
+    new_project = page.get_by_test_id("new-project")
+    expect(new_project).to_be_visible()
+    new_project.click()
+    expect(page.get_by_placeholder("Project name…")).to_be_visible()
+
+
+def test_project_header_action_is_clickable_on_touch_tablet(
+    browser: Browser,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Projects header action stays visible above ``md`` without hover."""
+    base_url, session_id = seeded_session
+    context = browser.new_context(viewport=_TABLET_VIEWPORT, has_touch=True)
+    page = context.new_page()
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+        assert page.evaluate("matchMedia('(hover: none)').matches")
+        new_project = page.get_by_test_id("new-project")
+        expect(new_project).to_be_visible()
+        expect(new_project.locator("xpath=../..")).to_have_css("opacity", "1")
+        new_project.click()
+        expect(page.get_by_placeholder("Project name…")).to_be_visible()
+    finally:
+        context.close()
 
 
 def test_project_new_session_folds_into_kebab_on_mobile(

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -346,26 +346,30 @@ describe("quick pin/unpin hover button", () => {
     }
   });
 
-  it("keeps the Projects group-header actions visible on mobile, hover-revealed on desktop", () => {
+  it("keeps the Projects group-header actions visible without hover, hover-revealed on desktop", () => {
     // The "New project" (+) button is the only way to create a project, so its
-    // group-header wrapper must stay visible on mobile (no hover there) rather
-    // than fade out like the desktop-only session-header controls. jsdom
-    // doesn't evaluate media queries, so assert the responsive classes: base
-    // `flex` (shown at every breakpoint) with `md:opacity-0` + hover/focus
-    // reveals (so desktop keeps the fade-until-hover behavior unchanged).
+    // group-header wrapper must stay visible wherever hover is unavailable —
+    // phones AND touch tablets at `md`+ widths — rather than fade out like the
+    // desktop-only session-header controls. jsdom doesn't evaluate media
+    // queries, so assert the responsive classes: base `flex` (shown at every
+    // breakpoint) with the fade + hover/focus reveals gated on hover
+    // capability, not just the `md` width.
     mocks.projects = ["Sprint 42"];
     renderSidebar();
 
     const wrapper = screen.getByTestId("new-project").closest(".transition-opacity");
     expect(wrapper).not.toBeNull();
-    // Visible on mobile: base display is `flex`, never `hidden`.
+    // Visible without hover: base display is `flex`, never `hidden`, and the
+    // fade is not applied by viewport width alone.
     expect(wrapper).toHaveClass("flex");
     expect(wrapper).not.toHaveClass("hidden");
-    // Desktop: fades out until the header is hovered / focused / a menu opens.
+    expect(wrapper).not.toHaveClass("md:opacity-0");
+    // Hover-capable desktop: fades out until the header is hovered / focused /
+    // a menu opens.
     expect(wrapper).toHaveClass(
-      "md:opacity-0",
-      "md:group-hover/header:opacity-100",
-      "md:has-[:focus-visible]:opacity-100",
+      "[@media(hover:hover)]:md:opacity-0",
+      "[@media(hover:hover)]:md:group-hover/header:opacity-100",
+      "[@media(hover:hover)]:md:has-[:focus-visible]:opacity-100",
     );
   });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2528,7 +2528,8 @@ function SectionGroup({
   collapsed: boolean;
   onToggleCollapsed: () => void;
   /** Optional control overlaid at the group header's right edge (e.g. the
-      "collapse all projects" toggle). Hover/focus-revealed on desktop. */
+      "collapse all projects" toggle). Always shown without hover support and
+      hover/focus-revealed on hover-capable desktop displays. */
   headerAction?: ReactNode;
   /** Optional content rendered directly under the header, above the children
       (and shown even when collapsed) — e.g. the bulk-selection action bar. */
@@ -2545,14 +2546,15 @@ function SectionGroup({
           onToggleCollapsed={onToggleCollapsed}
         />
         {headerAction && (
-          // Always visible on mobile (no hover there, and the "New project"
-          // control lives here — the only way to create a project). On desktop
-          // it's hover/keyboard-focus-revealed: a group-level control is a
-          // pointer convenience there. Reveal on :focus-visible (keyboard) — NOT
+          // Always visible without hover support (no hover on phones or touch
+          // tablets, and the "New project" control lives here — the only way to
+          // create a project). On hover-capable desktop displays it's
+          // hover/keyboard-focus-revealed: a group-level control is a pointer
+          // convenience there. Reveal on :focus-visible (keyboard) — NOT
           // :focus-within — so clicking the button with the mouse doesn't leave
           // it stuck visible: React reuses the same node when it swaps
           // expand↔revert, so the clicked button keeps focus afterward.
-          <div className="-translate-y-1/2 absolute top-1/2 right-1 flex items-center transition-opacity md:opacity-0 md:has-[:focus-visible]:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100 md:group-hover/header:opacity-100">
+          <div className="-translate-y-1/2 absolute top-1/2 right-1 flex items-center transition-opacity [@media(hover:hover)]:md:opacity-0 [@media(hover:hover)]:md:has-[:focus-visible]:opacity-100 [@media(hover:hover)]:md:group-has-[[data-state=open]]/header:opacity-100 [@media(hover:hover)]:md:group-hover/header:opacity-100">
             {headerAction}
           </div>
         )}


### PR DESCRIPTION
## Related issue

Closes #4904.

## Summary

- Keep the Projects header actions rendered on phone layouts and visible on hoverless touch tablets.
- Preserve hover/focus reveal behavior on hover-capable desktop displays.
- Add unit and browser E2E regressions for both phone and touch-tablet layouts.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage bun run test -- src/shell/Sidebar.test.tsx` (from `web/`) — 78 passed.
- `uv run pytest tests/e2e_ui/sessions/test_sidebar_projects.py::test_project_header_action_is_clickable_on_mobile tests/e2e_ui/sessions/test_sidebar_projects.py::test_project_header_action_is_clickable_on_touch_tablet -q` — 2 passed.
- `bun run lint` (from `web/`) — passed.
- `bun run type-check` (from `web/`) — passed.
- `uv run pre-commit run --files tests/e2e_ui/sessions/test_sidebar_projects.py web/src/shell/Sidebar.test.tsx web/src/shell/Sidebar.tsx` — passed.
- Full web suite: 5,774 passed, 3 baseline failures in `NewChatDialog.test.tsx` where the mocked host picker cannot find `This machine`.
- Full pre-commit: all code/format/type hooks passed; repository-wide pyrefly is locally blocked because parent Git excludes mask Python files in this nested worktree. The same scoped pre-commit invocation passes.
- Manual: at 390×780, open the sidebar and confirm Projects → New project is visible and opens the dialog. At 834×1112 with touch/hover-none emulation, confirm the action is opaque and clickable. On a hover-capable desktop, confirm it remains hover/focus revealed.

## Demo

| Before | After |
| --- | --- |
| ![Before: Projects action missing](https://raw.githubusercontent.com/btli/omnigent/demo/mobile-project-sidebar-icons/mobile-project-sidebar-icons/before.png) | ![After: Projects plus action visible](https://raw.githubusercontent.com/btli/omnigent/demo/mobile-project-sidebar-icons/mobile-project-sidebar-icons/after.png) |

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Mutation checks prove the new coverage detects the old production classes: the unit regression fails on `hidden md:flex md:opacity-0`, and both browser cases fail for hidden phone visibility / zero touch-tablet opacity. All pass after restoring the production fix.

## Changelog

Project sidebar actions now remain available on mobile and touch-only tablets.