### PR TITLE
fix(runner): log auth fallback and show workspace URL in fatal 403 error

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -422,6 +422,10 @@ class _InitialAuthTokenFactory:
             # once a session outlives it. Re-resolve SDK/OIDC in the same call
             # so the request that hit the failure still gets a credential.
             if token is None and getattr(self._fallback_factory, "proxy_auth_failed", False):
+                _logger.info(
+                    "managed-mint proxy bearer expired; re-resolving SDK/OIDC credential for %s",
+                    self._server_url,
+                )
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
                     _allow_initial_token=False,

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -427,11 +427,21 @@ async def serve_tunnel(
                 if http_status is not None and http_status in _REFRESHABLE_HTTP_STATUSES:
                     http_auth_rejection_streak += 1
                     if http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS:
-                        login_hint = (
-                            f"run `databricks auth login --host {server_url}` to re-authenticate"
-                            if server_url
-                            else "check remote server authentication"
-                        )
+                        if server_url:
+                            from omnigent.cli_auth import load_databricks_workspace_host
+
+                            workspace_host = load_databricks_workspace_host(server_url)
+                            login_hint = (
+                                f"run `databricks auth login --host {workspace_host}` "
+                                "to re-authenticate"
+                                if workspace_host
+                                else (
+                                    f"run `databricks auth login --host {server_url}` "
+                                    "or `omnigent login` to re-authenticate"
+                                )
+                            )
+                        else:
+                            login_hint = "check remote server authentication"
                         raise RuntimeError(
                             f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
                             f"(HTTP {http_status} persisted across "


### PR DESCRIPTION
## Related issue

Follows up on OMNI-2529 (the gtm-ai-agent 1h session-brick bug fixed in #4521/#4194). These changes surface two diagnostics gaps that made the incident harder to triage.

## Summary

- **Log when `proxy_auth_failed` triggers SDK/OIDC re-resolve** — `_InitialAuthTokenFactory.__call__` silently replaced the managed-mint factory with an SDK/OIDC one; the new info log names the server URL so operators can see exactly when the fallback fired in `~/.omnigent/logs/`.

- **Show workspace URL (not Apps URL) in the fatal tunnel-403 error** — the existing error said `run 'databricks auth login --host <apps-url>'` where `<apps-url>` is the Omnigent server endpoint (e.g. `gtm-ai-agent.cloud.databricks.com`). Running `databricks auth login` against that URL is a no-op. The fix resolves the stored `omnigent login` pointer record to the backing workspace host and surfaces that instead, matching what the team was already asking affected users to run manually.

## Test Plan

- `python -m pytest tests/runner/test_runner_entry.py -x -q` — 97 passed
- `python -m pytest tests/runner/transports/ -x -q` — 209 passed
- `pre-commit run --files omnigent/runner/_entry.py omnigent/runner/transports/ws_tunnel/serve.py` — ruff format/check passed; pyrefly failures are pre-existing in unrelated files

## Demo

N/A — diagnostic/log changes only

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

N/A — no behavior change in the auth flow itself; logging and error message only.

## Changelog

Runner log now records when the managed-mint proxy bearer expires and SDK/OIDC takes over, and the fatal "HTTP 403 persisted" exit message now names the Databricks workspace URL (from the stored `omnigent login` pointer record) rather than the Omnigent Apps URL.