### PR TITLE
feat(sessions): let a top-level session archive itself with sys_session_archive

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -313,6 +313,7 @@ _AGY_ENABLED_TOOLS = [
     "sys_os_shell",
     "sys_os_write",
     "sys_policy_registry",
+    "sys_session_archive",
     "sys_session_close",
     "sys_session_create",
     "sys_session_get_history",

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -56,6 +56,7 @@ _CURSOR_AUTO_APPROVE_TOOLS = [
     "sys_os_shell",
     "sys_os_write",
     "sys_policy_registry",
+    "sys_session_archive",
     "sys_session_close",
     "sys_session_create",
     "sys_session_get_history",

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4543,6 +4543,68 @@ async def _rename_current_session_via_rest(
     return json.dumps(payload)
 
 
+def _archive_status_error(status_code: int, detail: str) -> str:
+    """Typed error for a non-2xx/3xx snapshot GET or archive PATCH.
+
+    A 422 means an older server rejects ``stop_when_idle`` as an unknown
+    field (``UpdateSessionRequest`` is ``extra="forbid"``) — call that out
+    so the model asks the user to archive instead of retrying the tool,
+    which is what stacks repeated archive attempts.
+    """
+    message = f"sys_session_archive returned {status_code}"
+    if status_code == 422:
+        message += (
+            ": self-archive is not supported on this server version; "
+            "ask the user to archive the session instead."
+        )
+    return json.dumps({"error": message, "detail": detail[:200]})
+
+
+async def _fetch_archive_snapshot(
+    conversation_id: str,
+    server_client: httpx.AsyncClient,
+) -> _JsonObject | str:
+    """
+    Fetch + status-classify the archive caller's own session snapshot.
+
+    Mirrors :func:`_fetch_close_target`'s snapshot-then-act shape: archiving
+    a sub-agent session is unrecoverable (its ``(agent, title)`` slot has
+    no way back — see :func:`_archive_current_session_via_rest`), so any
+    snapshot problem fails closed and skips the PATCH entirely, the same
+    way a non-200 snapshot skips close.
+
+    :param conversation_id: The calling session id, e.g. ``"conv_self"``.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: The parsed snapshot dict on HTTP 200; otherwise a JSON error
+        string (``session_not_found`` for 404, ``session_archive_forbidden``
+        for 401/403, a generic status error otherwise).
+    """
+    try:
+        snap = await server_client.get(f"/v1/sessions/{conversation_id}", timeout=30.0)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_archive failed: {exc}"})
+    if snap.status_code == 404:
+        return json.dumps({"error": "session_not_found", "conversation_id": conversation_id})
+    if snap.status_code in (401, 403):
+        return json.dumps(
+            {
+                "error": "session_archive_forbidden",
+                "conversation_id": conversation_id,
+                "message": "only the session owner can archive this session.",
+            }
+        )
+    if snap.status_code != 200:
+        return _archive_status_error(snap.status_code, snap.text)
+    try:
+        parsed = snap.json()
+    except ValueError:
+        return json.dumps({"error": "sys_session_archive returned malformed session data"})
+    body = _string_object_dict(parsed)
+    if body is None:
+        return json.dumps({"error": "sys_session_archive returned malformed session data"})
+    return body
+
+
 async def _archive_current_session_via_rest(
     conversation_id: str | None,
     server_client: httpx.AsyncClient | None,
@@ -4555,16 +4617,40 @@ async def _archive_current_session_via_rest(
     server to hold the teardown until this turn ends; without it the archive's
     stop would kill the turn that made the call.
 
+    A sub-agent caller is refused before the PATCH is issued (a GET
+    snapshot checks first): the find-or-create path that resumes a named
+    sub-agent (``_find_open_child_by_title`` / the runner's child-session
+    lookup) never lists archived rows, and the store's duplicate-title
+    guard does not exempt them either, so an archived sub-agent's
+    ``(agent, title)`` slot can neither be resumed nor recreated. Only its
+    parent retiring it via ``sys_session_close`` can do that safely.
+
     :param conversation_id: The calling session id, e.g. ``"conv_self"``.
     :param server_client: HTTP client pointed at the Omnigent server.
     :returns: JSON ``{"archived": true, "conversation_id": ...}``, or a JSON
         error object (``session_not_found`` for 404,
-        ``session_archive_forbidden`` for 401/403).
+        ``session_archive_forbidden`` for 401/403, ``session_is_a_sub_agent``
+        if the caller is itself a sub-agent session).
     """
     if server_client is None:
         return json.dumps({"error": "sys_session_archive requires server access"})
     if conversation_id is None:
         return json.dumps({"error": "sys_session_archive requires a session id"})
+    snap = await _fetch_archive_snapshot(conversation_id, server_client)
+    if isinstance(snap, str):
+        return snap
+    if snap.get("parent_session_id") is not None:
+        return json.dumps(
+            {
+                "error": "session_is_a_sub_agent",
+                "conversation_id": conversation_id,
+                "message": (
+                    "sys_session_archive retires a top-level session; a "
+                    "sub-agent session is retired by its parent via "
+                    "sys_session_close."
+                ),
+            }
+        )
     try:
         resp = await server_client.patch(
             f"/v1/sessions/{conversation_id}",
@@ -4583,13 +4669,8 @@ async def _archive_current_session_via_rest(
                 "message": "only the session owner can archive this session.",
             }
         )
-    if resp.status_code >= 400:
-        return json.dumps(
-            {
-                "error": f"sys_session_archive returned {resp.status_code}",
-                "detail": resp.text[:200],
-            }
-        )
+    if resp.status_code >= 300:
+        return _archive_status_error(resp.status_code, resp.text)
     return json.dumps({"archived": True, "conversation_id": conversation_id})
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4958,8 +4958,9 @@ async def _close_tree_scope_error(
                 "conversation_id": target_id,
                 "message": (
                     "target conversation is a top-level conversation, not a "
-                    "sub-agent session. To retire the session you are running "
-                    "in, call sys_session_archive (no arguments)."
+                    "sub-agent session. sys_session_archive retires the "
+                    "calling session itself — it takes no arguments and "
+                    "never targets another session."
                 ),
             }
         )

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4952,7 +4952,17 @@ async def _close_tree_scope_error(
     if caller_root is None or target_root != caller_root:
         return json.dumps({"error": "session_out_of_tree", "conversation_id": target_id})
     if target_snap.get("parent_session_id") is None:
-        return json.dumps({"error": "session_not_a_sub_agent", "conversation_id": target_id})
+        return json.dumps(
+            {
+                "error": "session_not_a_sub_agent",
+                "conversation_id": target_id,
+                "message": (
+                    "target conversation is a top-level conversation, not a "
+                    "sub-agent session. To retire the session you are running "
+                    "in, call sys_session_archive (no arguments)."
+                ),
+            }
+        )
     return None
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -82,6 +82,7 @@ from omnigent.tools.builtins.os_env import (
     SysOsShellTool,
     SysOsWriteTool,
 )
+from omnigent.tools.builtins.session_archive import SysSessionArchiveTool
 from omnigent.tools.builtins.session_rename import SysSessionRenameTool
 from omnigent.tools.builtins.spawn import (
     # Shared contract values with the in-process sys_session_* tools. Imported
@@ -294,7 +295,7 @@ _SESSION_QUERY_TOOLS = frozenset(
     }
 )
 
-_SESSION_SELF_WRITE_TOOLS = frozenset({SysSessionRenameTool.name()})
+_SESSION_SELF_WRITE_TOOLS = frozenset({SysSessionRenameTool.name(), SysSessionArchiveTool.name()})
 
 # Grantee sentinel for an anonymous, public read-only share. Mirrors the
 # server's RESERVED_USER_PUBLIC; only specs with
@@ -548,6 +549,7 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
             SysSessionGetHistoryTool,
             SysSessionGetInfoTool,
             SysSessionRenameTool,
+            SysSessionArchiveTool,
             SysAgentGetTool,
             SysAgentListTool,
             SysAgentDownloadTool,
@@ -4541,6 +4543,81 @@ async def _rename_current_session_via_rest(
     return json.dumps(payload)
 
 
+async def _archive_current_session_via_rest(
+    conversation_id: str | None,
+    server_client: httpx.AsyncClient | None,
+) -> str:
+    """
+    Archive the calling session through ``PATCH /v1/sessions/{id}``.
+
+    The target is always the caller — the tool takes no arguments, so an
+    agent can archive itself and nothing else. ``stop_when_idle`` asks the
+    server to hold the teardown until this turn ends; without it the archive's
+    stop would kill the turn that made the call.
+
+    :param conversation_id: The calling session id, e.g. ``"conv_self"``.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: JSON ``{"archived": true, "conversation_id": ...}``, or a JSON
+        error object (``session_not_found`` for 404,
+        ``session_archive_forbidden`` for 401/403).
+    """
+    if server_client is None:
+        return json.dumps({"error": "sys_session_archive requires server access"})
+    if conversation_id is None:
+        return json.dumps({"error": "sys_session_archive requires a session id"})
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{conversation_id}",
+            json={"archived": True, "stop_when_idle": True},
+            timeout=30.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_archive failed: {exc}"})
+    if resp.status_code == 404:
+        return json.dumps({"error": "session_not_found", "conversation_id": conversation_id})
+    if resp.status_code in (401, 403):
+        return json.dumps(
+            {
+                "error": "session_archive_forbidden",
+                "conversation_id": conversation_id,
+                "message": "only the session owner can archive this session.",
+            }
+        )
+    if resp.status_code >= 400:
+        return json.dumps(
+            {
+                "error": f"sys_session_archive returned {resp.status_code}",
+                "detail": resp.text[:200],
+            }
+        )
+    return json.dumps({"archived": True, "conversation_id": conversation_id})
+
+
+async def _execute_session_self_write_tool(
+    tool_name: str,
+    args: _JsonObject,
+    *,
+    conversation_id: str | None,
+    server_client: httpx.AsyncClient | None,
+) -> str:
+    """
+    Runner-local handler for the self-targeted session writes.
+
+    Both tools act on the caller's own session and ignore any target id in
+    ``args``: ``sys_session_rename`` retitles it, ``sys_session_archive``
+    archives it.
+
+    :param tool_name: ``"sys_session_rename"`` or ``"sys_session_archive"``.
+    :param args: Parsed JSON arguments from the LLM.
+    :param conversation_id: The calling session id.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: Tool output JSON string.
+    """
+    if tool_name == SysSessionArchiveTool.name():
+        return await _archive_current_session_via_rest(conversation_id, server_client)
+    return await _rename_current_session_via_rest(args, conversation_id, server_client)
+
+
 async def _collect_sub_agents(
     conversation_id: str,
     server_client: httpx.AsyncClient,
@@ -5148,10 +5225,11 @@ async def execute_tool(
                 runner_workspace=runner_workspace,
             )
         elif tool_name in _SESSION_SELF_WRITE_TOOLS:
-            output = await _rename_current_session_via_rest(
+            output = await _execute_session_self_write_tool(
+                tool_name,
                 args,
-                conversation_id,
-                server_client,
+                conversation_id=conversation_id,
+                server_client=server_client,
             )
         elif tool_name in _SESSION_QUERY_TOOLS:
             output = await _execute_session_query_tool(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -573,6 +573,8 @@ async def _best_effort_stop(
     session_id: str,
     conversation_store: ConversationStore,
     runner_router: Any,
+    *,
+    force_own_stop: bool = False,
 ) -> None:
     """Stop a running session before a destructive lifecycle action.
 
@@ -592,6 +594,12 @@ async def _best_effort_stop(
     :param conversation_store: Store for descendant-id lookup.
     :param runner_router: The ``RunnerRouter`` for runner-client
         resolution, or ``None`` in tests / in-process setups.
+    :param force_own_stop: Stop ``session_id`` itself regardless of its
+        current status. Used by a deferred archive stop, where the
+        session was live at the moment the archive was requested but
+        may have already gone idle by the time this runs — the caller
+        captures that liveness once, upfront, rather than this function
+        re-deriving it from the (now stale) current status.
     """
     try:
         descendant_ids = await _collect_descendant_conversation_ids(conversation_store, session_id)
@@ -611,7 +619,7 @@ async def _best_effort_stop(
     has_background_tasks = (
         own_status != "failed" and _session_background_task_count_cache.get(session_id, 0) > 0
     )
-    if status != "running" and not has_background_tasks:
+    if not force_own_stop and status != "running" and not has_background_tasks:
         return
 
     async def _stop(target_id: str) -> None:
@@ -624,7 +632,7 @@ async def _best_effort_stop(
                 exc_info=True,
             )
 
-    if own_status == "running" or has_background_tasks:
+    if force_own_stop or own_status == "running" or has_background_tasks:
         await _stop(session_id)
     for descendant_id in descendant_ids:
         if _session_status_cache.get(descendant_id) in ("running", "waiting"):
@@ -695,27 +703,27 @@ async def _archive_stop(
         running state (bounded by ``_ARCHIVE_IDLE_WAIT_TIMEOUT_S``). Set by
         a self-archive, which lands mid-turn.
     """
-    # Once the wait settles the session to idle, ``_best_effort_stop``'s own
-    # "is it currently running" gate would read that as nothing to do — but
-    # the wait's whole point was to let a mid-turn self-archive's turn end
-    # so the runner can still be stopped, so that gate must be bypassed here.
-    force_own_stop = False
+    # Capture liveness BEFORE the wait: that is the state the archive was
+    # requested against. By the time the wait resolves the session usually
+    # reads idle, and _best_effort_stop's own current-status gate would
+    # then see nothing to do — force_own_stop carries the pre-wait verdict
+    # through so a session that WAS live still gets stopped once, while a
+    # session that was already idle (nothing to stop) still stops nothing.
+    was_live = False
     if wait_for_idle:
+        own_status_before = _session_status_from_cache(session_id)
+        has_background_tasks_before = (
+            own_status_before != "failed"
+            and _session_background_task_count_cache.get(session_id, 0) > 0
+        )
+        was_live = own_status_before == "running" or has_background_tasks_before
         await _wait_for_session_idle(session_id)
-        force_own_stop = _session_status_from_cache(session_id) != "running"
     # Resolve through the facade so a test's monkeypatch is honored here.
     from omnigent.server.routes import sessions as _facade
 
-    await _facade._best_effort_stop(session_id, conversation_store, runner_router)
-    if force_own_stop:
-        try:
-            await _stop_session_via_runner(session_id, runner_router)
-        except Exception:  # noqa: BLE001
-            _logger.debug(
-                "Deferred archive stop failed for %s; proceeding anyway",
-                session_id,
-                exc_info=True,
-            )
+    await _facade._best_effort_stop(
+        session_id, conversation_store, runner_router, force_own_stop=was_live
+    )
     try:
         conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
     except Exception:  # noqa: BLE001

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -695,12 +695,27 @@ async def _archive_stop(
         running state (bounded by ``_ARCHIVE_IDLE_WAIT_TIMEOUT_S``). Set by
         a self-archive, which lands mid-turn.
     """
+    # Once the wait settles the session to idle, ``_best_effort_stop``'s own
+    # "is it currently running" gate would read that as nothing to do — but
+    # the wait's whole point was to let a mid-turn self-archive's turn end
+    # so the runner can still be stopped, so that gate must be bypassed here.
+    force_own_stop = False
     if wait_for_idle:
         await _wait_for_session_idle(session_id)
+        force_own_stop = _session_status_from_cache(session_id) != "running"
     # Resolve through the facade so a test's monkeypatch is honored here.
     from omnigent.server.routes import sessions as _facade
 
     await _facade._best_effort_stop(session_id, conversation_store, runner_router)
+    if force_own_stop:
+        try:
+            await _stop_session_via_runner(session_id, runner_router)
+        except Exception:  # noqa: BLE001
+            _logger.debug(
+                "Deferred archive stop failed for %s; proceeding anyway",
+                session_id,
+                exc_info=True,
+            )
     try:
         conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
     except Exception:  # noqa: BLE001

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -635,12 +635,42 @@ async def _best_effort_stop(
 # garbage-collected mid-stop (asyncio only holds weak refs to tasks).
 _detached_stop_tasks: set[asyncio.Task[None]] = set()
 
+# Bounds for a deferred archive stop (``stop_when_idle``). A self-archive
+# lands mid-turn, so the teardown waits for that turn to end — but a session
+# that never reports idle (wedged runner, harness that stops publishing) must
+# still be torn down, so the wait is capped.
+_ARCHIVE_IDLE_WAIT_TIMEOUT_S = 300.0
+_ARCHIVE_IDLE_POLL_INTERVAL_S = 0.5
+
+
+async def _wait_for_session_idle(session_id: str) -> None:
+    """
+    Wait for a session to leave the running state, bounded by a timeout.
+
+    Reads the relay-fed ``_session_status_cache``. An unknown status
+    (no cache entry) counts as not-running: a session with no live
+    relay has no turn to protect.
+
+    :param session_id: Session/conversation identifier.
+    """
+    deadline = time.monotonic() + _ARCHIVE_IDLE_WAIT_TIMEOUT_S
+    while _session_status_cache.get(session_id) in ("running", "waiting"):
+        if time.monotonic() >= deadline:
+            _logger.info(
+                "Deferred archive stop for %s timed out waiting for idle; tearing down anyway",
+                session_id,
+            )
+            return
+        await asyncio.sleep(_ARCHIVE_IDLE_POLL_INTERVAL_S)
+
 
 async def _archive_stop(
     session_id: str,
     conversation_store: ConversationStore,
     runner_router: Any,
     host_registry: Any,
+    *,
+    wait_for_idle: bool = False,
 ) -> None:
     """
     Stop an archived session and tear down its host-launched runner.
@@ -661,7 +691,12 @@ async def _archive_stop(
         resolution, or ``None`` in tests / in-process setups.
     :param host_registry: The ``HostRegistry`` tracking live host
         tunnels, or ``None`` when host support is not wired.
+    :param wait_for_idle: Defer the teardown until the session leaves the
+        running state (bounded by ``_ARCHIVE_IDLE_WAIT_TIMEOUT_S``). Set by
+        a self-archive, which lands mid-turn.
     """
+    if wait_for_idle:
+        await _wait_for_session_idle(session_id)
     # Resolve through the facade so a test's monkeypatch is honored here.
     from omnigent.server.routes import sessions as _facade
 
@@ -705,6 +740,8 @@ def _spawn_archive_stop(
     conversation_store: ConversationStore,
     runner_router: Any,
     host_registry: Any = None,
+    *,
+    wait_for_idle: bool = False,
 ) -> None:
     """
     Run :func:`_archive_stop` as a retained background task.
@@ -721,9 +758,17 @@ def _spawn_archive_stop(
         resolution, or ``None`` in tests / in-process setups.
     :param host_registry: The ``HostRegistry`` tracking live host
         tunnels, or ``None`` when host support is not wired.
+    :param wait_for_idle: Defer the teardown until the session leaves the
+        running state. Forwarded to :func:`_archive_stop`.
     """
     task = asyncio.create_task(
-        _archive_stop(session_id, conversation_store, runner_router, host_registry)
+        _archive_stop(
+            session_id,
+            conversation_store,
+            runner_router,
+            host_registry,
+            wait_for_idle=wait_for_idle,
+        )
     )
     _detached_stop_tasks.add(task)
     task.add_done_callback(_detached_stop_tasks.discard)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -643,16 +643,12 @@ async def _best_effort_stop(
 # garbage-collected mid-stop (asyncio only holds weak refs to tasks).
 _detached_stop_tasks: set[asyncio.Task[None]] = set()
 
-# The in-flight deferred archive stop per session, if any. A retried
-# archive PATCH against a session that already has one pending must not
-# stack a second poller — each poller ends in its own own-session stop,
-# so N pollers would issue N stop RPCs for one archive.
+# The in-flight deferred archive stop per session, if any. Guards a
+# retried archive PATCH from stacking a second poller for one archive.
 _in_flight_archive_stops: dict[str, asyncio.Task[None]] = {}
 
-# Bounds for a deferred archive stop (``stop_when_idle``). A self-archive
-# lands mid-turn, so the teardown waits for that turn to end — but a session
-# that never reports idle (wedged runner, harness that stops publishing) must
-# still be torn down, so the wait is capped.
+# Bounds for a deferred archive stop (``stop_when_idle``): how long to
+# wait for the in-progress turn to end before tearing down anyway.
 _ARCHIVE_IDLE_WAIT_TIMEOUT_S = 300.0
 _ARCHIVE_IDLE_POLL_INTERVAL_S = 0.5
 
@@ -664,6 +660,10 @@ async def _wait_for_session_idle(session_id: str) -> None:
     Reads the relay-fed ``_session_status_cache``. An unknown status
     (no cache entry) counts as not-running: a session with no live
     relay has no turn to protect.
+
+    A session that never reports idle (wedged runner, harness that
+    stops publishing) must still be torn down, so the wait is capped
+    at ``_ARCHIVE_IDLE_WAIT_TIMEOUT_S``.
 
     :param session_id: Session/conversation identifier.
     """
@@ -699,6 +699,14 @@ async def _archive_stop(
     Every step is best-effort: a wedged, offline, or already-stopped
     runner must not leave the session un-archived.
 
+    When ``wait_for_idle`` is set, liveness is captured before the wait
+    runs: that is the state the archive was requested against, since by
+    the time the wait resolves the session usually reads idle already
+    and would otherwise look like nothing to stop. Archived status is
+    then re-checked right before stopping, because the wait gives a
+    user time to notice the session, unarchive it, and resume work —
+    and that unarchive must win over a stale stop.
+
     :param session_id: Session/conversation identifier.
     :param conversation_store: Store for descendant and row lookups.
     :param runner_router: The ``RunnerRouter`` for runner-client
@@ -709,12 +717,9 @@ async def _archive_stop(
         running state (bounded by ``_ARCHIVE_IDLE_WAIT_TIMEOUT_S``). Set by
         a self-archive, which lands mid-turn.
     """
-    # Capture liveness BEFORE the wait: that is the state the archive was
-    # requested against. By the time the wait resolves the session usually
-    # reads idle, and _best_effort_stop's own current-status gate would
-    # then see nothing to do — force_own_stop carries the pre-wait verdict
-    # through so a session that WAS live still gets stopped once, while a
-    # session that was already idle (nothing to stop) still stops nothing.
+    # Capture liveness before the wait so force_own_stop carries the
+    # pre-wait verdict through to _best_effort_stop's current-status
+    # gate, which would otherwise see an already-idle session.
     was_live = False
     if wait_for_idle:
         own_status_before = _session_status_from_cache(session_id)
@@ -727,12 +732,9 @@ async def _archive_stop(
     # Resolve through the facade so a test's monkeypatch is honored here.
     from omnigent.server.routes import sessions as _facade
 
-    # Re-check archived status right before stopping: a wait of up to
-    # _ARCHIVE_IDLE_WAIT_TIMEOUT_S gives a user ample time to notice the
-    # session, unarchive it, and resume work, and that unarchive must win
-    # over a stale stop. A lookup failure falls back to the old
-    # unconditional behavior (stop proceeds) rather than raising out of
-    # this detached task.
+    # Re-check archived status right before stopping: an unarchive that
+    # happened during the wait must win over a stale stop. A lookup
+    # failure lets the stop proceed rather than raise out of this task.
     try:
         conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
     except Exception:  # noqa: BLE001
@@ -794,6 +796,11 @@ def _spawn_archive_stop(
     stop's per-runner timeouts (seconds per running session against a
     wedged or asleep runner) even though the archive proceeds
     regardless of the stop's outcome.
+
+    Only one poller runs per session (see ``_in_flight_archive_stops``):
+    each ends in its own own-session stop, so a retried archive PATCH
+    that stacked a second poller would issue duplicate stop RPCs for
+    one archive.
 
     :param session_id: Session/conversation identifier.
     :param conversation_store: Store for descendant and row lookups.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -797,10 +797,10 @@ def _spawn_archive_stop(
     wedged or asleep runner) even though the archive proceeds
     regardless of the stop's outcome.
 
-    Only one poller runs per session (see ``_in_flight_archive_stops``):
-    each ends in its own own-session stop, so a retried archive PATCH
-    that stacked a second poller would issue duplicate stop RPCs for
-    one archive.
+    Only one *live* poller runs per session (see
+    ``_in_flight_archive_stops``): a retried archive PATCH must not stack
+    a second poller alongside one that is still parked or running, but a
+    finished poller's entry does not block a new one — it is replaced.
 
     :param session_id: Session/conversation identifier.
     :param conversation_store: Store for descendant and row lookups.
@@ -811,7 +811,8 @@ def _spawn_archive_stop(
     :param wait_for_idle: Defer the teardown until the session leaves the
         running state. Forwarded to :func:`_archive_stop`.
     """
-    if session_id in _in_flight_archive_stops:
+    existing = _in_flight_archive_stops.get(session_id)
+    if existing is not None and not existing.done():
         # A poller is already parked (or running) for this session — a
         # retried archive PATCH must not stack a second one.
         return

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -643,6 +643,12 @@ async def _best_effort_stop(
 # garbage-collected mid-stop (asyncio only holds weak refs to tasks).
 _detached_stop_tasks: set[asyncio.Task[None]] = set()
 
+# The in-flight deferred archive stop per session, if any. A retried
+# archive PATCH against a session that already has one pending must not
+# stack a second poller — each poller ends in its own own-session stop,
+# so N pollers would issue N stop RPCs for one archive.
+_in_flight_archive_stops: dict[str, asyncio.Task[None]] = {}
+
 # Bounds for a deferred archive stop (``stop_when_idle``). A self-archive
 # lands mid-turn, so the teardown waits for that turn to end — but a session
 # that never reports idle (wedged runner, harness that stops publishing) must
@@ -721,18 +727,32 @@ async def _archive_stop(
     # Resolve through the facade so a test's monkeypatch is honored here.
     from omnigent.server.routes import sessions as _facade
 
-    await _facade._best_effort_stop(
-        session_id, conversation_store, runner_router, force_own_stop=was_live
-    )
+    # Re-check archived status right before stopping: a wait of up to
+    # _ARCHIVE_IDLE_WAIT_TIMEOUT_S gives a user ample time to notice the
+    # session, unarchive it, and resume work, and that unarchive must win
+    # over a stale stop. A lookup failure falls back to the old
+    # unconditional behavior (stop proceeds) rather than raising out of
+    # this detached task.
     try:
         conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
     except Exception:  # noqa: BLE001
         _logger.debug(
-            "Archive host-runner teardown lookup failed for %s",
+            "Archive re-check lookup failed for %s; stopping anyway",
             session_id,
             exc_info=True,
         )
-        return
+        conv = None
+    else:
+        if conv is None or not conv.archived:
+            _logger.info(
+                "Session %s is no longer archived; skipping its deferred stop",
+                session_id,
+            )
+            return
+
+    await _facade._best_effort_stop(
+        session_id, conversation_store, runner_router, force_own_stop=was_live
+    )
     if conv is None or not conv.host_id or not conv.runner_id:
         return
     # Mark the tunnel drop intentional BEFORE tearing it down so the relay
@@ -784,6 +804,10 @@ def _spawn_archive_stop(
     :param wait_for_idle: Defer the teardown until the session leaves the
         running state. Forwarded to :func:`_archive_stop`.
     """
+    if session_id in _in_flight_archive_stops:
+        # A poller is already parked (or running) for this session — a
+        # retried archive PATCH must not stack a second one.
+        return
     task = asyncio.create_task(
         _archive_stop(
             session_id,
@@ -794,7 +818,14 @@ def _spawn_archive_stop(
         )
     )
     _detached_stop_tasks.add(task)
-    task.add_done_callback(_detached_stop_tasks.discard)
+    _in_flight_archive_stops[session_id] = task
+
+    def _clear(completed: asyncio.Task[None]) -> None:
+        _detached_stop_tasks.discard(completed)
+        if _in_flight_archive_stops.get(session_id) is completed:
+            del _in_flight_archive_stops[session_id]
+
+    task.add_done_callback(_clear)
 
 
 def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str, str]:
@@ -9236,6 +9267,7 @@ __all__ = [
     "_handle_mcp_tools_call",
     "_heal_subagent_runner_binding_via_parent",
     "_hold_native_ask_gate",
+    "_in_flight_archive_stops",
     "_is_native_terminal_session",
     "_kick_managed_relaunch",
     "_kick_managed_wake",

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -1786,6 +1786,7 @@ def register_core_routes(
                 conversation_store,
                 runner_router,
                 getattr(request.app.state, "host_registry", None),
+                wait_for_idle=body.stop_when_idle,
             )
         # Notify the runner of effort / model changes so harnesses
         # that can't re-read these from store at turn boundaries

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2006,6 +2006,14 @@ class UpdateSessionRequest(BaseModel):
         session from the default sidebar listing), ``False`` unarchives,
         ``None`` leaves unchanged. Owner-only (unlike ``title``, which
         needs only edit access).
+    :param stop_when_idle: Only meaningful alongside ``archived: true``.
+        When ``True``, the archive's teardown waits for the session to
+        leave the running state before stopping it, instead of stopping
+        it immediately. A session archiving ITSELF (``sys_session_archive``)
+        is mid-turn by definition, so an immediate stop would kill the
+        turn that asked to be archived. Bounded: the teardown proceeds
+        anyway once the wait times out. Default ``False`` keeps the
+        user-driven archive's stop-now behaviour.
     :param project_id: File this session into a first-class project (see
         ``designs/PROJECTS_PRD.md``). A non-empty id moves the session into
         that project; the empty string ``""`` unfiles it. **Omitting** the
@@ -2027,6 +2035,7 @@ class UpdateSessionRequest(BaseModel):
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
     archived: bool | None = None
+    stop_when_idle: bool = False
     project_id: str | None = None
     silent: bool = False
 

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -55,6 +55,7 @@ from omnigent.tools.builtins.scheduled_tasks import (
     SysScheduledTaskListTool,
     SysScheduledTaskUpdateTool,
 )
+from omnigent.tools.builtins.session_archive import SysSessionArchiveTool
 from omnigent.tools.builtins.session_rename import SysSessionRenameTool
 from omnigent.tools.builtins.spawn import (
     SysSessionCloseTool,
@@ -92,6 +93,7 @@ __all__ = [
     "SysScheduledTaskDeleteTool",
     "SysScheduledTaskListTool",
     "SysScheduledTaskUpdateTool",
+    "SysSessionArchiveTool",
     "SysSessionCloseTool",
     "SysSessionCreateTool",
     "SysSessionGetHistoryTool",

--- a/omnigent/tools/builtins/session_archive.py
+++ b/omnigent/tools/builtins/session_archive.py
@@ -21,8 +21,8 @@ class SysSessionArchiveTool(Tool):
         return (
             "Archive the current session: hide it from the default session list and "
             "shut its runner down once this turn ends. Call it as the last action of "
-            "an unattended run (a scheduled task or similar automation) that has "
-            "finished its work, so the run does not leave an open session behind. "
+            "a top-level unattended run (a scheduled task or similar automation) that "
+            "has finished its work, so the run does not leave an open session behind. "
             "Do not call it while a person is still working in this session. "
             "Nothing is deleted — the full transcript stays readable and the user can "
             "unarchive the session at any time. Takes no arguments; it always targets "

--- a/omnigent/tools/builtins/session_archive.py
+++ b/omnigent/tools/builtins/session_archive.py
@@ -1,0 +1,45 @@
+"""Tool for archiving the current session when its work is done."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent.tools.base import Tool
+
+
+class SysSessionArchiveTool(Tool):
+    """Schema-only tool that archives the calling session."""
+
+    @classmethod
+    def name(cls) -> str:
+        """Return the tool name."""
+        return "sys_session_archive"
+
+    @classmethod
+    def description(cls) -> str:
+        """Return the LLM-facing description."""
+        return (
+            "Archive the current session: hide it from the default session list and "
+            "shut its runner down once this turn ends. Call it as the last action of "
+            "an unattended run (a scheduled task or similar automation) that has "
+            "finished its work, so the run does not leave an open session behind. "
+            "Do not call it while a person is still working in this session. "
+            "Nothing is deleted — the full transcript stays readable and the user can "
+            "unarchive the session at any time. Takes no arguments; it always targets "
+            "the session you are running in."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """Return the OpenAI-format schema."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        }

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -1242,8 +1242,9 @@ def _resolve_session_call(
             }
         )
     if target.parent_conversation_id is None:
-        # Close frees a child's ``(agent, title)`` slot, which a top-level
-        # conversation does not have; archiving is its lifecycle action.
+        # _agent_title_from_conversation raises on a title with no colon,
+        # which every top-level conversation has; close also has no
+        # (agent, title) slot to free for one.
         return json.dumps(
             {
                 "error": "session_not_a_sub_agent",

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -1251,8 +1251,9 @@ def _resolve_session_call(
                 "message": (
                     "target conversation is a top-level conversation, not a "
                     "sub-agent session; peek/close only operate on sub-agents. "
-                    "To retire the session you are running in, call "
-                    "sys_session_archive (no arguments)."
+                    "sys_session_archive retires the calling session itself "
+                    "— it takes no arguments and never targets another "
+                    "session."
                 ),
             }
         )

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -1242,19 +1242,17 @@ def _resolve_session_call(
             }
         )
     if target.parent_conversation_id is None:
-        # Top-level conversations don't carry the
-        # ``<agent>:<title>`` invariant on ``title`` that
-        # downstream :func:`_agent_title_from_conversation`
-        # depends on. Refuse here with a typed error rather
-        # than letting the title parse blow up.
+        # Close frees a child's ``(agent, title)`` slot, which a top-level
+        # conversation does not have; archiving is its lifecycle action.
         return json.dumps(
             {
                 "error": "session_not_a_sub_agent",
                 "conversation_id": target_id,
                 "message": (
-                    "target conversation is a top-level "
-                    "conversation, not a sub-agent session; "
-                    "peek/close only operate on sub-agents."
+                    "target conversation is a top-level conversation, not a "
+                    "sub-agent session; peek/close only operate on sub-agents. "
+                    "To retire the session you are running in, call "
+                    "sys_session_archive (no arguments)."
                 ),
             }
         )
@@ -1497,7 +1495,8 @@ class SysSessionCloseTool(Tool):
             "continuing this one. Returns session_not_found if "
             "conversation_id is unknown, session_out_of_tree if it "
             "isn't part of the caller's tree, or sub_agent_busy if "
-            "the child has a non-terminal task in flight."
+            "the child has a non-terminal task in flight. To retire "
+            "your OWN session instead, use sys_session_archive."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -34,6 +34,7 @@ from omnigent.tools.builtins import (
     SysScheduledTaskDeleteTool,
     SysScheduledTaskListTool,
     SysScheduledTaskUpdateTool,
+    SysSessionArchiveTool,
     SysSessionCloseTool,
     SysSessionCreateTool,
     SysSessionGetHistoryTool,
@@ -502,8 +503,17 @@ class ToolManager:
             self._tools[SysSessionCreateTool.name()] = SysSessionCreateTool()
 
     def _register_session_tools(self) -> None:
-        """Register framework-owned tools for the current session."""
+        """
+        Register framework-owned tools for the current session.
+
+        Both act on the CALLING session only and take no target id, so
+        neither grants reach the caller did not already have:
+        ``sys_session_rename`` retitles it, ``sys_session_archive``
+        archives it when its work is finished (the one cleanup path an
+        unattended top-level run can take for itself).
+        """
         self._tools[SysSessionRenameTool.name()] = SysSessionRenameTool()
+        self._tools[SysSessionArchiveTool.name()] = SysSessionArchiveTool()
 
     def _register_agent_mgmt_tools(self) -> None:
         """

--- a/openapi.json
+++ b/openapi.json
@@ -6686,6 +6686,12 @@
             "title": "Silent",
             "type": "boolean"
           },
+          "stop_when_idle": {
+            "default": false,
+            "description": "Only meaningful alongside `archived: true`. When `True`, the archive's teardown waits for the session to leave the running state before stopping it, instead of stopping it immediately. A session archiving ITSELF (`sys_session_archive`) is mid-turn by definition, so an immediate stop would kill the turn that asked to be archived. Bounded: the teardown proceeds anyway once the wait times out. Default `False` keeps the user-driven archive's stop-now behaviour.",
+            "title": "Stop When Idle",
+            "type": "boolean"
+          },
           "subagent_routing_override": {
             "anyOf": [
               {

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5518,6 +5518,65 @@ async def test_session_close_rejects_top_level_target() -> None:
     assert patched is False
 
 
+@pytest.mark.asyncio
+async def test_session_close_rejects_top_level_target_named_by_a_different_caller() -> None:
+    """
+    A nested sub-agent naming the tree's top-level root (its ancestor,
+    not itself) hits the same refusal — and the message must not claim
+    the caller is running in the target, since here it isn't.
+
+    ``sys_session_archive`` ignores its arguments and always archives
+    the *calling* session, so a message phrased as "the session you are
+    running in" would be actively wrong advice for this caller.
+    """
+    from omnigent.runner.tool_dispatch import _execute_session_query_tool
+
+    patched = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal patched
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_root":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_root",
+                    "title": "some top-level title",
+                    "root_conversation_id": "conv_root",
+                    "parent_session_id": None,
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_nested":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_nested",
+                    "root_conversation_id": "conv_root",
+                    "parent_session_id": "conv_root",
+                },
+            )
+        if request.method == "PATCH":
+            patched = True
+            return httpx.Response(200, json={"id": "conv_root"})
+        raise AssertionError(f"unexpected {request.method} {request.url.path}")
+
+    async with _session_query_client(handler) as client:
+        out = json.loads(
+            await _execute_session_query_tool(
+                "sys_session_close",
+                json.dumps({"conversation_id": "conv_root"}),
+                # Caller is a nested sub-agent naming its own ancestor, NOT
+                # itself.
+                conversation_id="conv_nested",
+                server_client=client,
+            )
+        )
+    assert out["error"] == "session_not_a_sub_agent"
+    assert out["conversation_id"] == "conv_root"
+    assert "sys_session_archive" in out["message"]
+    assert "you are running in" not in out["message"]
+    assert patched is False
+
+
 def test_agent_tools_are_runner_local() -> None:
     """
     ``sys_agent_get`` / ``sys_agent_download`` dispatch locally in the

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7639,3 +7639,134 @@ async def test_spawn_async_tool_phase_tool_call_policy_allow(
     item = inbox.get_nowait()
     assert item["status"] == "completed"
     assert item["output"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_patches_own_session_with_deferred_stop() -> None:
+    """
+    The tool archives the CALLER and asks the server to defer the stop
+    until this turn ends — the PATCH pairs ``archived: true`` with
+    ``stop_when_idle: true`` so a session archiving itself mid-turn still
+    finishes that turn before the runner is stopped.
+    """
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(200, json={"id": "conv_self", "archived": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    assert requests == [
+        ("PATCH", "/v1/sessions/conv_self", {"archived": True, "stop_when_idle": True})
+    ]
+    assert json.loads(output) == {"archived": True, "conversation_id": "conv_self"}
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_ignores_any_supplied_target() -> None:
+    """
+    A model that invents a ``conversation_id`` argument still only archives
+    itself — the tool takes no arguments, so the URL is built from the
+    caller's own session id, never from ``args``.
+    """
+    from omnigent.runner.tool_dispatch import _execute_session_self_write_tool
+
+    requested_paths: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        return httpx.Response(200, json={"id": "conv_self", "archived": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        await _execute_session_self_write_tool(
+            "sys_session_archive",
+            {"conversation_id": "conv_someone_else"},
+            conversation_id="conv_self",
+            server_client=server_client,
+        )
+
+    assert requested_paths == ["/v1/sessions/conv_self"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        pytest.param(404, "session_not_found", id="not-found"),
+        pytest.param(403, "session_archive_forbidden", id="forbidden"),
+        pytest.param(401, "session_archive_forbidden", id="unauthorized"),
+    ],
+)
+async def test_sys_session_archive_maps_error_statuses(
+    status_code: int,
+    expected_error: str,
+) -> None:
+    """
+    HTTP failures become typed tool errors, never tracebacks: a 404 maps
+    to ``session_not_found``; 401/403 (not the session owner) map to
+    ``session_archive_forbidden``.
+    """
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"detail": "nope"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    assert json.loads(output)["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_reports_unsupported_server() -> None:
+    """
+    An older server that rejects the unknown ``stop_when_idle`` field
+    (422, since ``UpdateSessionRequest`` is ``extra="forbid"``) reads as a
+    typed error instead of raising.
+    """
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "extra fields not permitted"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    assert "422" in json.loads(output)["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_requires_a_session_id() -> None:
+    """No caller session id → a clean error, not an f-string with ``None`` in the URL."""
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    output = await _archive_current_session_via_rest(None, object())  # type: ignore[arg-type]
+
+    assert "requires a session id" in json.loads(output)["error"]
+
+
+def test_sys_session_archive_dispatches_locally_and_relays_natively() -> None:
+    """The new tool rides the same local-dispatch and native-relay paths as sys_session_rename."""
+    from omnigent.runner.tool_dispatch import (
+        _NATIVE_RELAY_BUILTIN_TOOLS,
+        should_dispatch_locally,
+    )
+
+    assert should_dispatch_locally("sys_session_archive") is True
+    assert "sys_session_archive" in _NATIVE_RELAY_BUILTIN_TOOLS

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7715,7 +7715,12 @@ async def test_sys_session_archive_patches_own_session_with_deferred_stop() -> N
     requests: list[tuple[str, str, dict[str, Any]]] = []
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
-        requests.append((request.method, request.url.path, json.loads(request.content)))
+        body = json.loads(request.content) if request.content else {}
+        requests.append((request.method, request.url.path, body))
+        if request.method == "GET":
+            return httpx.Response(
+                200, json={"id": "conv_self", "parent_session_id": None, "archived": False}
+            )
         return httpx.Response(200, json={"id": "conv_self", "archived": True})
 
     async with httpx.AsyncClient(
@@ -7725,7 +7730,8 @@ async def test_sys_session_archive_patches_own_session_with_deferred_stop() -> N
         output = await _archive_current_session_via_rest("conv_self", server_client)
 
     assert requests == [
-        ("PATCH", "/v1/sessions/conv_self", {"archived": True, "stop_when_idle": True})
+        ("GET", "/v1/sessions/conv_self", {}),
+        ("PATCH", "/v1/sessions/conv_self", {"archived": True, "stop_when_idle": True}),
     ]
     assert json.loads(output) == {"archived": True, "conversation_id": "conv_self"}
 
@@ -7743,6 +7749,10 @@ async def test_sys_session_archive_ignores_any_supplied_target() -> None:
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         requested_paths.append(request.url.path)
+        if request.method == "GET":
+            return httpx.Response(
+                200, json={"id": "conv_self", "parent_session_id": None, "archived": False}
+            )
         return httpx.Response(200, json={"id": "conv_self", "archived": True})
 
     async with httpx.AsyncClient(
@@ -7756,7 +7766,7 @@ async def test_sys_session_archive_ignores_any_supplied_target() -> None:
             server_client=server_client,
         )
 
-    assert requested_paths == ["/v1/sessions/conv_self"]
+    assert requested_paths == ["/v1/sessions/conv_self", "/v1/sessions/conv_self"]
 
 
 @pytest.mark.asyncio
@@ -7801,6 +7811,10 @@ async def test_sys_session_archive_reports_unsupported_server() -> None:
     from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200, json={"id": "conv_self", "parent_session_id": None, "archived": False}
+            )
         return httpx.Response(422, json={"detail": "extra fields not permitted"})
 
     async with httpx.AsyncClient(
@@ -7809,7 +7823,112 @@ async def test_sys_session_archive_reports_unsupported_server() -> None:
     ) as server_client:
         output = await _archive_current_session_via_rest("conv_self", server_client)
 
-    assert "422" in json.loads(output)["error"]
+    error = json.loads(output)["error"]
+    assert "422" in error
+    assert "ask the user to archive" in error
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_refuses_a_sub_agent_caller() -> None:
+    """
+    A sub-agent that calls ``sys_session_archive`` on itself is refused
+    before the PATCH is issued.
+
+    Archiving a sub-agent is unrecoverable: the find-or-create path that
+    resumes a named sub-agent never lists archived rows, and the store's
+    duplicate-title guard doesn't exempt them either, so the
+    ``(agent, title)`` slot would be dead forever. Only the transport's GET
+    may be seen — the PATCH must never fire.
+    """
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    requests: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        return httpx.Response(
+            200,
+            json={"id": "conv_child", "parent_session_id": "conv_parent", "archived": False},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_child", server_client)
+
+    assert requests == ["GET"]
+    payload = json.loads(output)
+    assert payload["error"] == "session_is_a_sub_agent"
+    assert payload["conversation_id"] == "conv_child"
+    assert "sys_session_close" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_skips_patch_on_snapshot_fetch_failure() -> None:
+    """A snapshot GET that raises fails closed: no PATCH is issued."""
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    requests: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        raise httpx.ConnectError("connection refused")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    assert requests == ["GET"]
+    payload = json.loads(output)
+    assert "sys_session_archive failed" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_skips_patch_on_malformed_snapshot() -> None:
+    """A 200 snapshot with a non-object body fails closed: no PATCH is issued."""
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    requests: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        return httpx.Response(200, content=b"not json")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    assert requests == ["GET"]
+    payload = json.loads(output)
+    assert "malformed session data" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_archive_redirect_is_not_treated_as_success() -> None:
+    """A 3xx PATCH response must not read back as ``{"archived": true}``."""
+    from omnigent.runner.tool_dispatch import _archive_current_session_via_rest
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200, json={"id": "conv_self", "parent_session_id": None, "archived": False}
+            )
+        return httpx.Response(307, text="redirected")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _archive_current_session_via_rest("conv_self", server_client)
+
+    payload = json.loads(output)
+    assert "archived" not in payload
+    assert "307" in payload["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5512,7 +5512,9 @@ async def test_session_close_rejects_top_level_target() -> None:
                 server_client=client,
             )
         )
-    assert out == {"error": "session_not_a_sub_agent", "conversation_id": "conv_root"}
+    assert out["error"] == "session_not_a_sub_agent"
+    assert out["conversation_id"] == "conv_root"
+    assert "sys_session_archive" in out["message"]
     assert patched is False
 
 

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -416,6 +416,109 @@ async def test_unarchive_skips_stop(
         _sessions_common._session_status_cache.pop(session_id, None)
 
 
+# ── stop_when_idle deferred archive stop ─────────────────
+
+
+async def test_stop_when_idle_defers_stop_until_turn_ends(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-archive mid-turn does not stop the runner until the turn ends."""
+    session = await create_test_session(client, name="archive-defer")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["archived"] is True
+            # Still running: the stop must be parked, not issued.
+            for _ in range(20):
+                await asyncio.sleep(0.01)
+            mock_stop.assert_not_awaited()
+            # Turn ends → the deferred stop proceeds.
+            _sessions_common._session_status_cache[session_id] = "idle"
+            await _drain_detached_stops()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
+async def test_stop_when_idle_times_out_and_tears_down_anyway(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session that never reports idle still gets torn down, bounded."""
+    session = await create_test_session(client, name="archive-defer-timeout")
+    session_id = session["id"]
+
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_WAIT_TIMEOUT_S", 0.05)
+    mock_stop = AsyncMock(return_value=True)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp.status_code == 200
+            await _drain_detached_stops()
+        mock_stop.assert_awaited_once()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
+async def test_archive_without_stop_when_idle_stops_immediately(
+    client: httpx.AsyncClient,
+) -> None:
+    """The human-initiated archive keeps stopping a running session at once."""
+    session = await create_test_session(client, name="archive-no-defer")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True},
+            )
+            await _drain_detached_stops()
+        assert resp.status_code == 200
+        mock_stop.assert_awaited_once()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
+async def test_stop_when_idle_is_inert_without_archive(
+    client: httpx.AsyncClient,
+) -> None:
+    """``stop_when_idle`` alone neither archives nor stops anything."""
+    session = await create_test_session(client, name="archive-flag-only")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"title": "still running", "stop_when_idle": True},
+            )
+            await _drain_detached_stops()
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is False
+        mock_stop.assert_not_awaited()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
 # ── Agent contents download ──────────────────────────────
 
 

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -445,6 +445,7 @@ async def test_stop_when_idle_defers_stop_until_turn_ends(
             # Turn ends → the deferred stop proceeds.
             _sessions_common._session_status_cache[session_id] = "idle"
             await _drain_detached_stops()
+            mock_stop.assert_awaited_once()
     finally:
         _sessions_common._session_status_cache.pop(session_id, None)
 

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -577,6 +577,37 @@ async def test_stop_when_idle_on_already_idle_session_stops_nothing(
         _sessions_common._session_background_task_count_cache.pop(session_id, None)
 
 
+async def test_top_level_session_archives_itself_end_to_end(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The issue's scenario: a top-level run retires its own session."""
+    session = await create_test_session(client, name="scheduled-run")
+    session_id = session["id"]
+    assert session.get("parent_session_id") is None
+
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"archived": True, "stop_when_idle": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+
+        listing = await client.get("/v1/sessions")
+        assert session_id not in [s["id"] for s in listing.json()["data"]]
+
+        with_archived = await client.get("/v1/sessions", params={"include_archived": True})
+        assert session_id in [s["id"] for s in with_archived.json()["data"]]
+
+        _sessions_common._session_status_cache[session_id] = "idle"
+        await _drain_detached_stops()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
 # ── Agent contents download ──────────────────────────────
 
 

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -163,7 +163,7 @@ async def test_archive_does_not_block_on_slow_stop(
     release = asyncio.Event()
     stopped: list[str] = []
 
-    async def _parked_stop(sid: str, *_args: object) -> None:
+    async def _parked_stop(sid: str, *_args: object, **_kwargs: object) -> None:
         stopped.append(sid)
         await release.wait()
 
@@ -353,13 +353,13 @@ async def test_archive_proceeds_when_child_lookup_fails(
         ):
             orig = _sessions_orchestration._best_effort_stop
 
-            async def _patched_stop(sid, cs, rr):
+            async def _patched_stop(sid, cs, rr, **kwargs):
                 with patch.object(
                     cs,
                     "list_child_conversation_ids_by_parent",
                     side_effect=RuntimeError("transient DB error"),
                 ):
-                    await orig(sid, cs, rr)
+                    await orig(sid, cs, rr, **kwargs)
 
             with patch.object(_sessions_facade, "_best_effort_stop", _patched_stop):
                 resp = await client.patch(
@@ -518,6 +518,63 @@ async def test_stop_when_idle_is_inert_without_archive(
         mock_stop.assert_not_awaited()
     finally:
         _sessions_common._session_status_cache.pop(session_id, None)
+
+
+async def test_stop_when_idle_with_background_task_stops_exactly_once(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A background shell that outlives the turn still stops exactly once.
+
+    The deferred wait resolves once the session reads idle, at which
+    point ``_best_effort_stop``'s own background-task gate would *also*
+    decide to stop the same session — the own-session stop must not be
+    dispatched twice.
+    """
+    session = await create_test_session(client, name="archive-defer-background")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    _sessions_common._session_status_cache[session_id] = "running"
+    _sessions_common._session_background_task_count_cache[session_id] = 1
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp.status_code == 200
+            # Turn ends, but the background shell is still counted as live.
+            _sessions_common._session_status_cache[session_id] = "idle"
+            await _drain_detached_stops()
+        mock_stop.assert_awaited_once()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+        _sessions_common._session_background_task_count_cache.pop(session_id, None)
+
+
+async def test_stop_when_idle_on_already_idle_session_stops_nothing(
+    client: httpx.AsyncClient,
+) -> None:
+    """A session already idle (no background work) when the PATCH lands has
+    nothing to stop, matching the immediate archive path."""
+    session = await create_test_session(client, name="archive-defer-already-idle")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp.status_code == 200
+            await _drain_detached_stops()
+        mock_stop.assert_not_awaited()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+        _sessions_common._session_background_task_count_cache.pop(session_id, None)
 
 
 # ── Agent contents download ──────────────────────────────

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -662,6 +662,43 @@ async def test_repeated_archive_patches_stop_the_session_exactly_once(
         _sessions_common._session_status_cache.pop(session_id, None)
 
 
+async def test_archive_after_finished_poller_still_dispatches_a_stop(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A finished poller's stale registry entry must not swallow the next stop.
+
+    The done-callback that clears ``_in_flight_archive_stops`` runs on a
+    later event-loop iteration than the task's own completion, so the
+    registry can momentarily hold a task that is done but not yet
+    cleared. Seed that exact state directly rather than racing for it,
+    then confirm a fresh archive PATCH still dispatches its own stop
+    instead of being swallowed by the stale entry.
+    """
+    session = await create_test_session(client, name="archive-stale-entry")
+    session_id = session["id"]
+
+    finished_task: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
+    await finished_task
+    assert finished_task.done()
+    _sessions_orchestration._in_flight_archive_stops[session_id] = finished_task
+
+    mock_stop = AsyncMock(return_value=True)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True},
+            )
+            assert resp.status_code == 200
+            await _drain_detached_stops()
+        mock_stop.assert_awaited_once()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+        _sessions_orchestration._in_flight_archive_stops.pop(session_id, None)
+
+
 async def test_top_level_session_archives_itself_end_to_end(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -577,6 +577,91 @@ async def test_stop_when_idle_on_already_idle_session_stops_nothing(
         _sessions_common._session_background_task_count_cache.pop(session_id, None)
 
 
+async def test_unarchive_while_deferred_stop_is_parked_skips_the_stop(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A user who unarchives while the deferred stop is still parked keeps
+    their session running.
+
+    The wait can take up to 300s — wide enough for someone to notice the
+    session vanish, unarchive it from "Show archived", and resume work
+    before the deferred stop ever fires. The stop must re-check archived
+    status right before acting, not trust the state from when it was
+    scheduled.
+    """
+    session = await create_test_session(client, name="archive-unarchive-race")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp.status_code == 200
+            # Still parked, waiting for idle.
+            for _ in range(20):
+                await asyncio.sleep(0.01)
+            mock_stop.assert_not_awaited()
+
+            # The user notices, unarchives, and resumes work.
+            unarchive_resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": False},
+            )
+            assert unarchive_resp.status_code == 200
+
+            # Turn ends — the wait resolves, but the re-check sees the
+            # session is no longer archived and skips the stop.
+            _sessions_common._session_status_cache[session_id] = "idle"
+            await _drain_detached_stops()
+            mock_stop.assert_not_awaited()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
+async def test_repeated_archive_patches_stop_the_session_exactly_once(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A model that retries the archive tool call must not stack pollers.
+
+    Each deferred stop ends in its own own-session stop RPC, so two
+    archive PATCHes against the same session (a retried call) must still
+    only stop the session once.
+    """
+    session = await create_test_session(client, name="archive-retry")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    monkeypatch.setattr(_sessions_orchestration, "_ARCHIVE_IDLE_POLL_INTERVAL_S", 0.01)
+    _sessions_common._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
+            resp1 = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp1.status_code == 200
+            resp2 = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True, "stop_when_idle": True},
+            )
+            assert resp2.status_code == 200
+
+            _sessions_common._session_status_cache[session_id] = "idle"
+            await _drain_detached_stops()
+            mock_stop.assert_awaited_once()
+    finally:
+        _sessions_common._session_status_cache.pop(session_id, None)
+
+
 async def test_top_level_session_archives_itself_end_to_end(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/builtins/test_session_archive.py
+++ b/tests/tools/builtins/test_session_archive.py
@@ -22,4 +22,10 @@ def test_description_scopes_the_tool_to_finished_unattended_runs() -> None:
     description = SysSessionArchiveTool.description()
 
     assert "current session" in description
+    # The load-bearing safety clause: without it, nothing in the schema
+    # stops the model from archiving a session a person is still using.
+    assert "person is still working" in description
+    # The unattended/finished-work framing that scopes when to call it.
+    assert "unattended" in description
+    # Reversibility is the claim that makes always-on registration defensible.
     assert "unarchive" in description

--- a/tests/tools/builtins/test_session_archive.py
+++ b/tests/tools/builtins/test_session_archive.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``sys_session_archive`` builtin schema."""
+"""Unit tests for :mod:`omnigent.tools.builtins.session_archive`."""
 
 from __future__ import annotations
 

--- a/tests/tools/builtins/test_session_archive.py
+++ b/tests/tools/builtins/test_session_archive.py
@@ -1,0 +1,25 @@
+"""Unit tests for the ``sys_session_archive`` builtin schema."""
+
+from __future__ import annotations
+
+from omnigent.tools.builtins.session_archive import SysSessionArchiveTool
+
+
+def test_schema_shape() -> None:
+    """The tool advertises itself with no arguments."""
+    schema = SysSessionArchiveTool().get_schema()["function"]
+
+    assert schema["name"] == "sys_session_archive"
+    assert schema["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+
+
+def test_description_scopes_the_tool_to_finished_unattended_runs() -> None:
+    """The description must steer the model away from live user sessions."""
+    description = SysSessionArchiveTool.description()
+
+    assert "current session" in description
+    assert "unarchive" in description

--- a/tests/tools/builtins/test_session_archive.py
+++ b/tests/tools/builtins/test_session_archive.py
@@ -27,5 +27,7 @@ def test_description_scopes_the_tool_to_finished_unattended_runs() -> None:
     assert "person is still working" in description
     # The unattended/finished-work framing that scopes when to call it.
     assert "unattended" in description
+    # Scopes the tool away from sub-agent runs, which retire via close.
+    assert "top-level" in description
     # Reversibility is the claim that makes always-on registration defensible.
     assert "unarchive" in description

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -666,6 +666,44 @@ def test_close_top_level_conversation_in_tree_is_rejected(
     assert _CLOSED_TITLE_INFIX not in (parent_after.title or "")
 
 
+def test_close_top_level_target_named_by_a_different_caller_is_rejected(
+    session_fixture: _Fixture,
+) -> None:
+    """
+    A nested sub-agent naming the tree's top-level root (its ancestor,
+    not itself) hits the same refusal — and the message must not claim
+    the caller is running in the target, since here it isn't.
+
+    ``sys_session_archive`` ignores its arguments and always archives
+    the *calling* session, so a message phrased as "the session you are
+    running in" would be actively wrong advice for this caller.
+
+    :param session_fixture: Per-test fixture providing the tool ctx
+        and parent conversation id.
+    """
+    grandchild = session_fixture.conv_store.create_conversation(
+        kind="sub_agent",
+        title="nested:probe",
+        parent_conversation_id=session_fixture.child_conv_id,
+    )
+    nested_ctx = ToolContext(
+        task_id="task_placeholder",
+        agent_id="2759f8a97fd91216cb3e0d7a1f60c7f6",
+        conversation_id=grandchild.id,
+    )
+
+    tool = SysSessionCloseTool()
+    raw = tool.invoke(
+        json.dumps({"conversation_id": session_fixture.parent_conv_id}),
+        nested_ctx,
+    )
+    payload = json.loads(raw)
+    assert payload["error"] == "session_not_a_sub_agent"
+    assert payload["conversation_id"] == session_fixture.parent_conv_id
+    assert "sys_session_archive" in payload["message"]
+    assert "you are running in" not in payload["message"]
+
+
 # ── Close invoke tests ────────────────────────────────────
 
 

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -632,6 +632,7 @@ def test_peek_top_level_conversation_in_tree_is_rejected(
     payload = json.loads(raw)
     assert payload["error"] == "session_not_a_sub_agent"
     assert payload["conversation_id"] == session_fixture.parent_conv_id
+    assert "sys_session_archive" in payload["message"]
 
 
 def test_close_top_level_conversation_in_tree_is_rejected(
@@ -656,6 +657,7 @@ def test_close_top_level_conversation_in_tree_is_rejected(
     payload = json.loads(raw)
     assert payload["error"] == "session_not_a_sub_agent"
     assert payload["conversation_id"] == session_fixture.parent_conv_id
+    assert "sys_session_archive" in payload["message"]
 
     parent_after = session_fixture.conv_store.get_conversation(
         session_fixture.parent_conv_id,

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -64,6 +64,9 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         "sys_session_list",
         "sys_session_get_info",
         "sys_session_rename",
+        # Self-archive is framework-owned and always registered so an
+        # unattended run can tidy up its own session when it finishes.
+        "sys_session_archive",
         # Read-only agent discovery tools are likewise always available
         # (global, permission-bounded reads of any accessible session's
         # agent / bundle).
@@ -124,6 +127,12 @@ def test_session_rename_is_registered_for_every_agent() -> None:
     names = {schema["function"]["name"] for schema in ToolManager(_make_spec()).get_tool_schemas()}
 
     assert "sys_session_rename" in names
+
+
+def test_session_archive_is_registered_for_every_agent() -> None:
+    names = {schema["function"]["name"] for schema in ToolManager(_make_spec()).get_tool_schemas()}
+
+    assert "sys_session_archive" in names
 
 
 @pytest.fixture()

--- a/web/src/lib/toolIcon.ts
+++ b/web/src/lib/toolIcon.ts
@@ -7,6 +7,7 @@
 // (which arrive completed).
 
 import {
+  Archive,
   Ban,
   Bot,
   Code2,
@@ -41,6 +42,7 @@ export function iconForTool(name: string, nativeToolType?: string): LucideIcon {
   if (name === "sys_terminal_close") return Ban;
   if (name.startsWith("sys_terminal_")) return Terminal;
   if (name === "sys_session_close") return Ban;
+  if (name === "sys_session_archive") return Archive;
   if (name.startsWith("sys_session_")) return Bot;
   if (name === "sys_call_async") return Send;
   if (name === "sys_read_inbox") return Inbox;

--- a/web/src/lib/toolTitle.test.ts
+++ b/web/src/lib/toolTitle.test.ts
@@ -68,9 +68,6 @@ describe("formatToolTitle", () => {
       verb: "List tasks",
       body: "",
     });
-  });
-
-  it("formats sys_session_archive with no arguments", () => {
     expect(formatToolTitle("sys_session_archive", {})).toEqual({
       verb: "Archive session",
       body: "",

--- a/web/src/lib/toolTitle.test.ts
+++ b/web/src/lib/toolTitle.test.ts
@@ -70,6 +70,13 @@ describe("formatToolTitle", () => {
     });
   });
 
+  it("formats sys_session_archive with no arguments", () => {
+    expect(formatToolTitle("sys_session_archive", {})).toEqual({
+      verb: "Archive session",
+      body: "",
+    });
+  });
+
   it("formats sys_timer_set with seconds and repeat flag", () => {
     expect(formatToolTitle("sys_timer_set", { seconds: 30 })).toEqual({
       verb: "Set timer:",

--- a/web/src/lib/toolTitle.ts
+++ b/web/src/lib/toolTitle.ts
@@ -68,6 +68,7 @@ const FORMATTERS: Record<string, ArgFormatter> = {
   },
 
   sys_session_close: (args) => sessionTitle("Close child session:", args),
+  sys_session_archive: () => verbOnly("Archive session"),
   sys_session_list: () => verbOnly("List child sessions"),
   sys_session_get_info: (args) => {
     const id = asString(args.session_id);


### PR DESCRIPTION
## Related issue

Closes #4834

## Summary

Scheduled tasks run as **top-level** sessions, and a top-level session had no way to clean itself up — `sys_session_close` against its own id is refused with `session_not_a_sub_agent`. Every unattended run therefore survived as an open session a human had to archive by hand (a daily task leaves ~30 stale rows a month; a 15-minute cron leaves thousands).

- Adds **`sys_session_archive`**, a no-argument builtin registered for every agent that archives the session the agent is running in, over the existing owner-gated `PATCH /v1/sessions/{id}`. That route already carries the whole teardown (`_archive_stop` → best-effort stop + host-runner drop), so this exposes an existing capability as a supported agent-facing verb rather than adding a new one.
- Adds **`stop_when_idle`** to `UpdateSessionRequest`. A self-archive necessarily lands mid-turn, so the archive's already-detached teardown now waits (bounded, 300s) for the session to leave the running state before stopping it — and stops it exactly once, only if it was live when the archive landed. The `archived` flag still commits immediately, so the row is retired even if the turn later dies.
- Rewrites the `session_not_a_sub_agent` refusal on both dispatch paths to name the new tool. The guard itself is unchanged: close frees a child's `(agent, title)` slot that a top-level session does not have, so relaxing close was rejected in favour of a distinct verb.
- The tool **refuses a sub-agent caller** (`session_is_a_sub_agent`). Archiving a child would permanently poison its parent's `(agent, title)` slot: the child lookup lists without `include_archived` (so it can never be resumed) while `create_conversation`'s duplicate-title guard does not filter archived (so it can never be recreated).

### ELI5

An agent could tidy up every session except the one that mattered for automation — its own. Now it can say "I'm done, put this away", and the server waits for it to finish speaking before switching off the lights.

### Flow

```mermaid
sequenceDiagram
    participant A as Agent (top-level run)
    participant R as Runner
    participant S as Server
    participant T as Detached teardown

    A->>R: sys_session_archive (no args)
    R->>S: GET /v1/sessions/{caller}
    S-->>R: snapshot (parent_session_id: null)
    Note over R: a sub-agent caller is refused here
    R->>S: PATCH {archived: true, stop_when_idle: true}
    S->>T: spawn (one per session)
    S-->>R: 200
    R-->>A: {"archived": true}
    A->>A: finishes its turn, writes a closing message
    Note over T: waits for the session to leave "running" (bounded 300s)
    T->>T: re-checks the session is still archived
    T->>S: stop session + tear down host-launched runner
```

## Test Plan

Automated — 281 tests pass across every module this branch touches, including the OpenAPI drift check:

```bash
uv run pytest tests/server/integration/test_sessions_archive.py \
              tests/server/routes/test_sessions_crud.py \
              tests/runner/test_runner_dispatch.py \
              tests/tools/builtins/test_session_archive.py \
              tests/tools/builtins/test_sys_session.py \
              tests/tools/test_manager.py \
              tests/server/test_openapi_drift.py -q
# 281 passed, 1 skipped

cd web && ./node_modules/.bin/vitest run src/lib/toolTitle.test.ts
# 22 passed
```

New coverage worth calling out: the deferred stop fires only after the turn ends; it fires exactly once when the session goes idle with a background shell still live; it does not fire for a session that was already idle when the archive landed; it does not fire at all if the user unarchives while the wait is parked; a hallucinated `conversation_id` argument never reaches the request; and a sub-agent caller is refused without a PATCH being issued.

Manual verification (not yet run — for the reviewer):

```bash
just dev
```

1. `sys_session_get_info()` → confirm `"parent_session_id": null`.
2. Ask the agent to call `sys_session_archive` → returns `{"archived": true, "conversation_id": "<self>"}`, and the agent can still write a closing message in the same turn.
3. Reload the sidebar: the session is gone from the default list, present under "Show archived".
4. Confirm the runner stops only *after* the turn ends (the pane goes quiet at turn end, not mid-sentence).
5. Repeat via `sys_scheduled_task_create` with a prompt ending in "when you are done, call sys_session_archive" — the run leaves no open session behind.

## Demo

N/A — no user-facing UI beyond a tool-call label and icon in the activity list.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage spans both dispatch paths (in-process tool surface and the runner's REST path) and the server's deferred-teardown logic. The live-stack steps above are listed as unrun: nothing in the suites exercises a real runner receiving the deferred stop after a real turn ends, so that path is worth one manual pass before merge.

Known follow-ups, deliberately not in this PR:

- The snapshot GET the sub-agent check performs pulls the caller's full transcript to read one field; `?include_items=false&include_liveness=false` would be equivalent and cheaper. It mirrors the existing `_fetch_close_target`, so this PR inherits the pattern rather than introducing it.
- An *absent* `parent_session_id` key (as opposed to an explicit `null`) fails open into the PATCH, unlike every other branch of the snapshot handling. Unreachable against the current server, which always serializes the field.
- `_detached_stop_tasks` has no shutdown drain. With the old sub-second tasks this was near-invisible; a 300s wait makes a restart mid-wait likelier to drop a teardown.
- The store-level asymmetry behind the sub-agent refusal (child lookups omitting `include_archived` while the duplicate-title guard does not filter it) is untouched. `sys_session_archive` can no longer reach it, but any other path that archives a child row still can.
- Scheduler-side auto-reaping of finished runs — option 3 in the issue — is a separate change: it needs an opt-out column on `scheduled_tasks` plus a migration, and it would hang off `persist_scheduled_run_completion`, the same terminal-status edge this PR's teardown already keys on.

## Changelog

Agents running unattended sessions can call `sys_session_archive` to retire their own session when their work is done, instead of leaving it open.
