### PR TITLE
Dock the landing composer to the bottom on phones

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -913,6 +913,18 @@ describe("NewChatLandingScreen", () => {
     expect(footer.parentElement).toHaveClass("gap-1");
   });
 
+  it("docks the composer to the bottom on phones and keeps it centered on desktop", () => {
+    renderLanding();
+
+    const landing = screen.getByTestId("new-chat-landing");
+    expect(landing).toHaveClass("flex-col", "md:items-center", "md:justify-center");
+    expect(landing.className.split(/\s+/)).not.toContain("items-center");
+    expect(landing.className.split(/\s+/)).not.toContain("justify-center");
+
+    const column = landing.firstElementChild;
+    expect(column).toHaveClass("flex-1", "md:flex-none");
+  });
+
   it("preserves the typed message and attachments when the landing screen unmounts and remounts", () => {
     // Navigating into an existing session and back unmounts the landing
     // screen; the draft is stashed at module scope so the half-composed

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3916,19 +3916,20 @@ export function NewChatLandingScreen() {
   );
 
   return (
-    // pb-12 lifts the content slightly above the geometric center, where
-    // the hero reads better optically.
+    // Phone: column fills the pane so the composer docks at the bottom
+    // (same place as the in-session chat box). Desktop: the block stays
+    // optically centered; pb-16 lifts it slightly above geometric center.
     <div
       ref={setLandingSurface}
-      className="relative flex flex-1 items-center justify-center"
+      className="relative flex min-h-0 flex-1 flex-col md:items-center md:justify-center"
       data-testid="new-chat-landing"
     >
       {/* Padding lives inside the 840px cap, so the composer renders at
           840 − 80 = 760px max on desktop. px-4 on phones (16px gutters)
           keeps the composer from feeling cramped against the viewport
           edges; widens to the full px-10 at the md breakpoint and up. */}
-      <div className="flex w-full max-w-[840px] flex-col items-center gap-6 px-4 pt-8 pb-16 md:select-none md:px-10">
-        <div className="flex w-full flex-col items-center justify-center gap-3.5">
+      <div className="flex min-h-0 w-full max-w-[840px] flex-1 flex-col items-center px-4 pt-8 pb-[max(1rem,var(--omnigent-inset-bottom))] md:flex-none md:gap-6 md:select-none md:px-10 md:pb-16">
+        <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center gap-3.5 md:flex-none">
           {selectedProject ? (
             // Landing inside a project: swap Otto's eyes for the same folder
             // icon the sidebar uses for a project, and name the project. Sized
@@ -4918,7 +4919,7 @@ export function NewChatLandingScreen() {
       </div>
 
       {poweredBy ? (
-        <footer className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-4">
+        <footer className="pointer-events-none absolute inset-x-0 bottom-0 hidden justify-center pb-4 md:flex">
           <div className="pointer-events-auto">
             <PoweredByOmnigent />
           </div>


### PR DESCRIPTION
## Related issue

Closes #4860

## Summary

On phones the new-session chat box sat in the middle of the screen, then jumped to the bottom once a session started. That reach is awkward on a phone. This docks the landing composer to the bottom under `md`, so it stays in the same place from empty landing through an in-session thread. Desktop landing stays optically centered.

- Landing column is `flex-col` on phone (logo/heading take leftover space; composer at the bottom, with safe-area padding).
- From `md` up, `justify-center` + `flex-none` keep the existing centered hero.
- Powered-by footer is hidden on phone so it does not cover the docked box.

## Test Plan

- [ ] Open `/` on a phone (or DevTools at <768px): chat box is at the bottom, logo/heading sit in the space above.
- [ ] Start a session from that landing: composer does not jump; it was already at the bottom.
- [ ] Open `/` on desktop: landing is still centered (same as before).
- [ ] Rotate / resize across the `md` breakpoint: layout switches between docked and centered.
- [ ] On a notched phone, the box clears the home indicator.

## Demo

Screenshots attached in a follow-up comment once the local server is up.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Class-level unit test asserts the phone (`flex-col`) vs desktop (`md:justify-center`, `md:flex-none`) split. Visual check on a real phone is still the useful confirmation.

## Changelog

On phones, the new-session chat box stays at the bottom instead of floating in the middle of the screen