### PR TITLE
feat(server): expose non-destructive session stop API

### DIFF
--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -841,6 +841,31 @@ runner id. The write replaces any previous value in
 Codex-native session routes, including the Codex Goal subresource, are
 documented in [codex-API.md](codex-API.md).
 
+### Stop Session Without Deleting It
+
+```
+POST /v1/sessions/{session_id}/stop
+```
+
+Stops the session's live execution while preserving its conversation,
+transcript, and other durable evidence. This owner-only operation is
+idempotent: repeating it after the runner is already stopped returns the same
+successful acknowledgement.
+
+```json
+{"session_id": "conv_abc123", "stopped": true}
+```
+
+The stop is non-sticky. Posting a later user message may relaunch execution on
+a still-available host. Use `DELETE /v1/sessions/{session_id}` only when the
+session and its resources should be removed.
+
+200 OK - stop accepted, including when no live runner remains
+403 Forbidden - caller lacks owner access
+404 Not Found - no session with that id
+503 Service Unavailable - the bound runner was reachable but rejected or could
+not complete the stop
+
 ### Post Event
 
 ```

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -197,6 +197,7 @@ from omnigent.server.schemas import (
     ErrorDetail,
     McpServerStartup,
     SessionEventInput,
+    SessionStopResponse,
 )
 from omnigent.session_lifecycle import (
     is_session_closed,
@@ -1715,6 +1716,33 @@ def register_events_routes(
         if dispatch.pending_id is not None:
             response["pending_id"] = dispatch.pending_id
         return response
+
+    @router.post(
+        "/sessions/{session_id}/stop",
+        response_model=SessionStopResponse,
+        status_code=200,
+    )
+    async def stop_session(
+        request: Request,
+        session_id: str,
+    ) -> SessionStopResponse:
+        """Stop live execution without deleting the session or transcript.
+
+        The operation is owner-only and idempotent. A stopped host-launched
+        session may be started again by posting a new message.
+
+        :param request: Incoming authenticated request.
+        :param session_id: Session/conversation identifier.
+        :returns: A stable acknowledgement for the requested session.
+        :raises OmnigentError: 403 without owner access, 404 for an unknown
+            session, or 503 when a reachable runner rejects the stop.
+        """
+        await post_event(
+            request,
+            session_id,
+            SessionEventInput(type=_STOP_SESSION_TYPE),
+        )
+        return SessionStopResponse(session_id=session_id)
 
     # ── GET /sessions/{session_id}/stream ────────────────────────
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1197,6 +1197,18 @@ class SessionEventInput(BaseModel):
     created_by: str | None = None
 
 
+class SessionStopResponse(BaseModel):
+    """Acknowledgement for a non-destructive session stop request.
+
+    :param session_id: Session whose live execution was stopped.
+    :param stopped: ``True`` when the request has been accepted. Repeating
+        the request for a session with no live runner is also successful.
+    """
+
+    session_id: str
+    stopped: Literal[True] = True
+
+
 class SessionGitOptions(BaseModel):
     """
     Git worktree options for ``POST /v1/sessions``.

--- a/openapi.json
+++ b/openapi.json
@@ -5847,6 +5847,28 @@
         "title": "SessionStatusEvent",
         "type": "object"
       },
+      "SessionStopResponse": {
+        "description": "Acknowledgement for a non-destructive session stop request.",
+        "properties": {
+          "session_id": {
+            "description": "Session whose live execution was stopped.",
+            "title": "Session Id",
+            "type": "string"
+          },
+          "stopped": {
+            "const": true,
+            "default": true,
+            "description": "`True` when the request has been accepted. Repeating the request for a session with no live runner is also successful.",
+            "title": "Stopped",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "SessionStopResponse",
+        "type": "object"
+      },
       "SessionSupersededEvent": {
         "description": "This conversation was superseded by another and clients should\nfollow to it.\n\nEmitted by `_publish_session_superseded` in\n`omnigent/server/routes/sessions.py` when the claude-native\nforwarder rotates a session away on a Claude `/clear` (the old\nconversation keeps its history but the live terminal moves to a\nfresh conversation \u2014 see `_post_clear_supersession` in\n`omnigent/claude_native_forwarder.py`). A client actively viewing\nthe superseded conversation auto-redirects to `target_conversation_id`.\n\nCategory: **transient** (SSE-only), live-only by design. There is no\nSSE replay: a client that connects after the rotation does not get\nthis event. The durable counterpart is the persisted notice message\nappended to the old conversation (a `message` item linking to the\nnew conversation), which a reloading client renders instead of being\nforce-redirected.\n\nThe wire shape is FLAT (not enveloped):\n`{\"type\": \"session.superseded\", \"conversation_id\": <old>, \"target_conversation_id\": <new>, \"reason\": \"clear\"}`.",
         "properties": {
@@ -12614,6 +12636,50 @@
         "summary": "Get Session Resource",
         "tags": [
           "session_resources"
+        ]
+      }
+    },
+    "/v1/sessions/{session_id}/stop": {
+      "post": {
+        "description": "Stop live execution without deleting the session or transcript.\n\nThe operation is owner-only and idempotent. A stopped host-launched\nsession may be started again by posting a new message.\n\n**Returns:** A stable acknowledgement for the requested session.\n\n**Raises**\n\n- `OmnigentError` \u2014 403 without owner access, 404 for an unknown session, or 503 when a reachable runner rejects the stop.",
+        "operationId": "stop_session_v1_sessions__session_id__stop_post",
+        "parameters": [
+          {
+            "description": "Session/conversation identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStopResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stop Session",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7196,6 +7196,73 @@ async def test_stop_session_forwards_stop_session_event_to_runner(
     )
 
 
+async def test_public_stop_session_is_typed_non_destructive_and_idempotent(
+    client: httpx.AsyncClient,
+) -> None:
+    """The public stop route preserves evidence and tolerates retries."""
+    from omnigent.runtime import set_runner_client
+
+    forwarded: list[_ForwardedEffort] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            forwarded.append(
+                _ForwardedEffort(
+                    url=str(request.url),
+                    body=json.loads(request.content) if request.content else None,
+                )
+            )
+        return httpx.Response(204)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    set_runner_client(fake_runner)
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(client, agent["id"], initial_message="Keep this evidence")
+        before = await client.get(f"/v1/sessions/{session['id']}")
+
+        first = await client.post(f"/v1/sessions/{session['id']}/stop")
+        second = await client.post(f"/v1/sessions/{session['id']}/stop")
+        after = await client.get(f"/v1/sessions/{session['id']}")
+    finally:
+        await fake_runner.aclose()
+        set_runner_client(None)
+
+    expected = {"session_id": session["id"], "stopped": True}
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json() == expected
+    assert second.json() == expected
+    assert after.status_code == 200
+    assert after.json()["items"] == before.json()["items"]
+    stop_forwards = [
+        item
+        for item in forwarded
+        if item.url == f"http://runner/v1/sessions/{session['id']}/events"
+    ]
+    assert [item.body for item in stop_forwards] == [
+        {"type": "stop_session"},
+        {"type": "stop_session"},
+    ]
+
+
+async def test_public_stop_session_is_in_openapi(
+    client: httpx.AsyncClient,
+) -> None:
+    """Generated clients can discover the dedicated stop contract."""
+    response = await client.get("/openapi.json")
+
+    assert response.status_code == 200
+    operation = response.json()["paths"]["/v1/sessions/{session_id}/stop"]["post"]
+    assert operation["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/SessionStopResponse"
+    }
+    assert "/v1/sessions/{session_id}/events" not in response.json()["paths"]
+
+
 @pytest.mark.parametrize(
     "failure_mode",
     [

--- a/tests/server/integration/test_sessions_permissions.py
+++ b/tests/server/integration/test_sessions_permissions.py
@@ -679,6 +679,17 @@ async def test_edit_grant_blocked_from_stop_session_requires_owner(
         f"owner's session."
     )
 
+    # The dedicated public endpoint shares the same owner-only authority
+    # boundary; exposing a typed route must not weaken lifecycle control.
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/stop",
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert resp.status_code == 403, (
+        "the public stop endpoint must reject a shared editor; "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
     # The owner (user-a) is NOT blocked by the gate. No runner is bound
     # in this app, so the forward is a best-effort no-op and the route
     # returns 202 — what matters is that it's not a 403.
@@ -691,6 +702,13 @@ async def test_edit_grant_blocked_from_stop_session_requires_owner(
         f"The session owner should pass the stop_session owner gate "
         f"and get 202, got {resp.status_code}: {resp.text}"
     )
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/stop",
+        headers={"X-Forwarded-Email": "user-a"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"session_id": session_id, "stopped": True}
 
 
 # ── Grant edit: can POST events but not manage permissions ───


### PR DESCRIPTION
## Related issue

Part of #4861

## Summary

- Add a dedicated owner-only `POST /v1/sessions/{session_id}/stop` endpoint that reuses the existing harness-agnostic `stop_session` control path.
- Return a typed, retry-safe `SessionStopResponse` while preserving the conversation and transcript.
- Keep the broad internal `/events` ingestion route hidden from OpenAPI; regenerate the checked-in OpenAPI 3.2 artifact and document the supported stop contract.

ELI5: automation can now press a supported Stop button without pressing Delete or relying on an undocumented internal API.

```text
external orchestrator
        |
        | POST /v1/sessions/{id}/stop
        v
owner authorization -> existing stop control -> runner/host teardown
        |
        +-> {session_id, stopped: true}; conversation remains
```

## Test Plan

- `uv run --no-sync pytest -q tests/server/integration/test_sessions_endpoints.py` (213 passed)
- focused multi-user owner/editor authority regression (1 passed)
- OpenAPI drift and stream schema suite (21 passed)
- `uv run --no-sync pyrefly check` (0 errors)
- `pre-commit run --all-files` (all hooks passed)
- Repeated-stop integration test verifies stable typed receipts, preserved items, exact control forwarding, and hidden internal event route.

## Demo

N/A - server API only. The OpenAPI operation is generated at `/v1/sessions/{session_id}/stop` and returns `{"session_id":"conv_...","stopped":true}`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Generated OpenAPI was inspected to confirm the dedicated stop operation and response schema are public while the generic internal event route remains absent. No live provider session was created, stopped, or deleted during verification.

## Changelog

External automation can stop live session execution through a documented API without deleting the conversation or transcript.