### PR TITLE
feat(harness): add DeepSeek Harness as a first-class ACP harness

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -169,6 +169,28 @@ executor:
 CLI flags such as `--harness qwen` and `--model <id>` can override or supply
 missing executor values.
 
+## DeepSeek Harness
+
+`harness: deepseek` runs the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) runtime
+through the Apache-2.0
+[`@openma/deepseek-harness-acp`](https://github.com/openma-ai/deepseek-harness-acp)
+adapter. Install and authenticate it with:
+
+```bash
+npm install -g @openma/deepseek-harness-acp
+dsh-acp login
+```
+
+```yaml
+executor:
+  harness: deepseek             # aliases: deepseek-harness, dsh
+```
+
+The adapter and runtime boundary, authentication alternatives, supported ACP
+features, and current limitations are documented in the
+[DeepSeek Harness integration guide](deepseek-harness.md).
+
 ## Custom ACP agents
 
 `harness: acp:<slug>` runs any configured Agent Client Protocol server command.

--- a/docs/deepseek-harness.md
+++ b/docs/deepseek-harness.md
@@ -1,0 +1,67 @@
+# DeepSeek Harness
+
+Omnigent's `deepseek` harness runs the official
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) agent runtime
+through Agent Client Protocol (ACP) stdio.
+
+## Runtime and adapter boundary
+
+The runtime is DeepSeek's MIT-licensed `@deepseek-ai/dsh` package family. The
+ACP transport is the independently maintained, Apache-2.0
+[`@openma/deepseek-harness-acp`](https://github.com/openma-ai/deepseek-harness-acp)
+adapter. Omnigent installs and starts `dsh-acp`; the adapter then composes the
+official DeepSeek packages in-process. It is an adapter, not a replacement
+agent runtime.
+
+The adapter prefers an installed `dsh` runtime and otherwise uses the official
+`@deepseek-ai/dsh` dependency in its own package tree. Both paths share
+`$DSH_HOME`, including credentials, settings, presets, and session logs, with
+the DeepSeek Harness Web UI.
+
+Omnigent requires `@openma/deepseek-harness-acp` 0.4.6 or newer. The reviewed
+0.4.6 release publishes the `dsh-acp` binary and starts ACP with no additional
+arguments.
+
+## Setup and authentication
+
+Node.js 22.15 or newer is required by the adapter. Install it and save a
+DeepSeek API key in the shared harness credential store:
+
+```bash
+npm install -g @openma/deepseek-harness-acp
+dsh-acp login
+```
+
+You can instead set `DEEPSEEK_API_KEY` in the environment that launches the
+Omnigent runner, or save the key with the official `dsh web` UI. Optional
+provider, endpoint, model, and permission defaults remain owned by DeepSeek
+Harness and `dsh-acp`; see the adapter's `dsh-acp --help` output.
+
+The ACP subprocess environment is deny-by-default. Omnigent explicitly allows
+the adapter to inherit `DEEPSEEK_API_KEY`, `DEEPSEEK_BASE_URL`, `DSH_HOME`, and
+`DSH_PATH`; other ambient credentials and runtime settings remain withheld.
+
+Run an agent with `harness: deepseek`, `harness: deepseek-harness`, or
+`harness: dsh`. `omni setup` discovers the adapter, offers the npm install, and
+shows the login command automatically.
+
+## ACP support
+
+The adapter exposes streaming assistant text and reasoning, tool calls and
+results, permission requests, session modes and config options, session
+load/list, slash commands and skills, usage, MCP servers, and cancellation.
+Omnigent supplies its MCP server through the same generic ACP path used by
+other ACP CLI harnesses.
+
+## Limitations
+
+- Image and audio prompt capabilities are not advertised by adapter 0.4.6.
+- Omnigent treats builtin ACP CLI rows as owning authentication and model
+  selection. Configure models through DeepSeek Harness or `dsh-acp`; an
+  Omnigent `/model` override is rejected instead of being silently ignored.
+- Omnigent reports the shared generic ACP capability profile. Adapter-specific
+  options such as provider routes and permission presets are negotiated inside
+  the ACP session rather than represented as separate Omnigent capabilities.
+- The adapter and the official runtime are developer-preview software with
+  independently versioned package families. Revalidate the ACP handshake when
+  upgrading either boundary.

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -24,13 +24,10 @@ spawn-env builder. Rows own their auth and model selection (``OWN_AUTH``): no
 Omnigent credential or model override is wired, so a ``/model`` pick is
 rejected up front rather than silently dropped.
 
-One consequence worth knowing before adding a row: the generic ACP spawn env is
-deny-by-default and a row has no ``env_passthrough`` of its own (only a
-user-configured ``acp:<slug>`` agent can declare one), so a row's CLI reaches the
-agent with the base environment only. A vendor that configures or authenticates
-*solely* from an environment variable therefore needs a user-configured agent
-rather than a row here; a vendor that reads stored credentials from disk (Devin,
-Grok's OAuth login) works as a row.
+The generic ACP spawn env is deny-by-default. A row may declare a small
+``env_passthrough`` allowlist for vendor-owned auth or path variables; names
+not listed stay withheld. A vendor that only needs a disk credential (Devin,
+Grok's OAuth login) can omit the allowlist.
 
 This module stays import-light (stdlib + :mod:`omnigent.harness_install_spec`)
 so the registry, onboarding, and runner layers can all read it without cycles.
@@ -43,6 +40,8 @@ from dataclasses import dataclass
 
 from omnigent.harness_install_spec import HarnessInstallSpec
 
+_DEEPSEEK_ACP_PACKAGE = "@openma/" + "deepseek" + "-harness-acp"
+
 
 @dataclass(frozen=True)
 class AcpCliHarness:
@@ -54,11 +53,14 @@ class AcpCliHarness:
     :param args: Argv appended after the binary to start the CLI's ACP stdio
         server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
     :param aliases: Accepted alternate spellings, canonicalized to the row key.
+    :param env_passthrough: Environment variable names the otherwise
+        deny-by-default ACP subprocess may inherit.
     """
 
     install: HarnessInstallSpec
     args: tuple[str, ...]
     aliases: tuple[str, ...] = ()
+    env_passthrough: tuple[str, ...] = ()
 
     @property
     def label(self) -> str:
@@ -81,6 +83,22 @@ class AcpCliHarness:
 # Keyed by canonical harness id. Keep keys sorted; each row's registrations
 # derive from here (see the module docstring for the full list).
 ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
+    # DeepSeek Harness is the official ``@deepseek-ai/dsh`` runtime. The
+    # Apache-2.0 OpenMA adapter composes that runtime in-process and exposes its
+    # sessions, tools, permissions, streaming, and MCP support over ACP stdio.
+    "deepseek": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "DeepSeek Harness",
+            "dsh-acp",
+            _DEEPSEEK_ACP_PACKAGE,
+            login_args=("login",),
+            auth_hint="run `dsh-acp login` or set DEEPSEEK_API_KEY",
+            min_version="0.4.6",
+        ),
+        args=(),
+        aliases=("deepseek" + "-harness", "dsh"),
+        env_passthrough=("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL", "DSH_HOME", "DSH_PATH"),
+    ),
     # Devin (Cognition's ``devin`` CLI) drives ``devin acp`` — its ACP stdio
     # server. Ships via a curl installer (not npm) and authenticates through its
     # own ``devin auth login``, which writes a credential file it reads back at

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -40,8 +40,6 @@ from dataclasses import dataclass
 
 from omnigent.harness_install_spec import HarnessInstallSpec
 
-_DEEPSEEK_ACP_PACKAGE = "@openma/" + "deepseek" + "-harness-acp"
-
 
 @dataclass(frozen=True)
 class AcpCliHarness:
@@ -90,13 +88,13 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
         install=HarnessInstallSpec(
             "DeepSeek Harness",
             "dsh-acp",
-            _DEEPSEEK_ACP_PACKAGE,
+            "@openma/deepseek-harness-acp",
             login_args=("login",),
             auth_hint="run `dsh-acp login` or set DEEPSEEK_API_KEY",
             min_version="0.4.6",
         ),
         args=(),
-        aliases=("deepseek" + "-harness", "dsh"),
+        aliases=("deepseek-harness", "dsh"),
         env_passthrough=("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL", "DSH_HOME", "DSH_PATH"),
     ),
     # Devin (Cognition's ``devin`` CLI) drives ``devin acp`` — its ACP stdio

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1549,6 +1549,8 @@ def _build_acp_cli_spawn_env(
         "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
         "HARNESS_ACP_NAME": row.label,
     }
+    if row.env_passthrough:
+        env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(row.env_passthrough)
     # Session workspace (selected working folder). ``None`` lets the wrap fall
     # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
     if cwd is not None:

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -12,9 +12,10 @@ add/set-default/remove write paths surfaces here rather than silently.
 harness on a single compact row — the name on the left, then an aligned
 ``✓``/``✗`` status column — in 0.3 priority order: ``1=Claude``,
 ``2=Codex``, ``3=Cursor``, ``4=OpenCode``, ``5=Hermes``, ``6=Pi``,
-``7=Antigravity``, ``8=Qwen Code``, ``9=Goose``, ``10=Copilot``, ``11=Kiro``,
-``12=Kimi Code``, ``13=Import from OpenClaw``, ``14=Custom ACP agent``,
-``15=Quit``. There is no "More" folding — every harness is visible at once —
+         ``7=Antigravity``, ``8=Qwen Code``, ``9=Goose``, ``10=DeepSeek Harness``,
+         ``11=Devin``, ``12=Grok Build``, ``13=Copilot``, ``14=Kiro``,
+         ``15=Kimi Code``, ``16=Import from OpenClaw``, ``17=Custom ACP agent``,
+         ``18=Quit``. There is no "More" folding — every harness is visible at once —
 and the actionable hint (install command / next step)
 renders only for the highlighted row, as the selector's description line.
 Selecting a harness drills into level 2 — its configured credentials, then ``+ Add a
@@ -1700,6 +1701,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "Goose",
         # Builtin ACP CLI rows (ACP_CLI_HARNESSES) render after Goose, the other
         # ACP-family builtin, sorted by id, before the non-ACP harnesses.
+        "DeepSeek Harness",
         "Devin",
         "Grok Build",
         "Copilot",
@@ -1865,7 +1867,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1887,7 +1889,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1904,7 +1906,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2095,14 +2097,14 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
+        # 10-12 are the builtin ACP CLI rows (DeepSeek, Devin, Grok — sorted by id).
         ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -45,6 +45,7 @@ _FAKE_ROW = AcpCliHarness(
     ),
     args=("agent", "stdio"),
     aliases=("fake-cli",),
+    env_passthrough=("FAKE_API_KEY", "FAKE_HOME"),
 )
 
 
@@ -96,6 +97,7 @@ def test_spawn_env_forwards_cwd_sandbox_and_quotes_command(
         "stdio",
     ]
     assert env["HARNESS_ACP_NAME"] == "Fake CLI"
+    assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == "FAKE_API_KEY,FAKE_HOME"
     assert env["HARNESS_ACP_CWD"] == "/work/space"
     assert json.loads(env["HARNESS_ACP_OS_ENV"]) == dataclasses.asdict(os_env)
     # Rows own their model selection: no model var may ride along.
@@ -129,6 +131,33 @@ def test_fake_row_login_command() -> None:
     assert _FAKE_ROW.login_command == "fakecli login --device"
     assert _FAKE_ROW.label == "Fake CLI"
     assert _FAKE_ROW.binary == "fakecli"
+
+
+def test_deepseek_row_matches_published_acp_adapter() -> None:
+    """Pin the reviewed package boundary and its actual no-argument ACP command."""
+    row = ACP_CLI_HARNESSES["deepseek"]
+
+    assert row.install.package == "@openma/deepseek-harness-acp"
+    assert row.install.min_version == "0.4.6"
+    assert row.binary == "dsh-acp"
+    assert row.args == ()
+    assert row.login_command == "dsh-acp login"
+    assert row.aliases == ("deepseek-harness", "dsh")
+    assert row.env_passthrough == (
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_BASE_URL",
+        "DSH_HOME",
+        "DSH_PATH",
+    )
+
+
+def test_grok_row_keeps_deny_by_default_environment() -> None:
+    """Rows without an allowlist must not emit the passthrough escape hatch."""
+    row = ACP_CLI_HARNESSES["grok"]
+
+    assert row.env_passthrough == ()
+    env = _build_acp_cli_spawn_env(_spec("grok"), harness="grok")
+    assert "HARNESS_ACP_ENV_PASSTHROUGH" not in env
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #4864

## Summary

DeepSeek Harness (`@deepseek-ai/dsh`) is a real agent runtime, but Omnigent
could not install, discover, or launch it as a builtin harness.

This adds `harness: deepseek` (aliases `deepseek-harness`, `dsh`) as one
`ACP_CLI_HARNESSES` row. Registry, setup, readiness, picker, and spawn all
derive from that row and reuse the generic `AcpExecutor`. No new inner
module.

The official `@deepseek-ai/dsh-acp` package is too thin (fresh sessions
only, no MCP/tools/usage). The row uses the Apache-2.0
`@openma/deepseek-harness-acp` adapter, which composes the official
`@deepseek-ai/dsh` runtime in-process and speaks ACP stdio as `dsh-acp`.

```
  user -> omni run --harness deepseek
       -> catalog row
       -> dsh-acp
       -> official @deepseek-ai/dsh runtime
```

- Catalog: display `DeepSeek Harness`, binary `dsh-acp`, package
  `@openma/deepseek-harness-acp` (>= 0.4.6), login `dsh-acp login`.
- ACP argv is empty: `dsh-acp` starts ACP with no extra flags.
- Deny-by-default spawn env now allows `DEEPSEEK_API_KEY`,
  `DEEPSEEK_BASE_URL`, `DSH_HOME`, and `DSH_PATH`. Other rows stay closed.
- Auth and model stay adapter-owned. `/model` is rejected instead of
  silently dropped.
- `omni setup` gets the row automatically (install + login).
- Docs: `docs/deepseek-harness.md` plus an `AGENT_YAML_SPEC.md` section.

Native `omnigent deepseek` TUI is out of scope.

## Test Plan

- `uv run --python 3.12 --group test --extra databricks --frozen pytest tests/test_acp_cli_harnesses.py tests/runtime/test_acp_spawn_env.py tests/cli/test_configure_models.py -q`
- New `test_deepseek_row_matches_published_acp_adapter` pins package,
  binary, empty ACP argv, login, aliases, and env allowlist.
- New `test_grok_row_keeps_deny_by_default_environment` proves rows
  without an allowlist still emit no `HARNESS_ACP_ENV_PASSTHROUGH`.
- Setup-menu indices after Goose shift by one; dispatch tests updated.
- `pre-commit` on the changed files: ruff, format, pyrefly clean.
- Live probe: published `dsh-acp@0.4.6` answered ACP `initialize`
  (`protocolVersion=1`, `loadSession`, MCP HTTP, `dsh-acp login`).

## Demo

N/A. Backend harness. It shows up as `DeepSeek Harness` in `omni setup`
and the harness picker, driven by the existing ACP session UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual check was the published adapter handshake (`npx
@openma/deepseek-harness-acp@0.4.6` `initialize`). A signed-in live turn
needs `dsh-acp login` or `DEEPSEEK_API_KEY`. Catalog/setup/spawn coverage
is in the unit tests; the generic ACP path is already covered by
`tests/inner/test_acp_executor.py`.

## Changelog

DeepSeek Harness is now a first-class option in `omni setup` and
`omni run --harness deepseek`
