### PR TITLE
feat(harness): add ZCode as a first-class ACP harness

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -169,6 +169,24 @@ executor:
 CLI flags such as `--harness qwen` and `--model <id>` can override or supply
 missing executor values.
 
+## ZCode
+
+`harness: zcode` runs the installed ZCode Agent through the Apache-2.0
+[`zcode-acp-server`](https://github.com/william0wang/zcode-acp) adapter.
+Install ZCode, configure its model credentials, then install the adapter:
+
+```bash
+npm install -g zcode-acp-server
+```
+
+```yaml
+executor:
+  harness: zcode               # alias: z-code
+```
+
+See the [ZCode integration guide](zcode.md) for desktop-app discovery and the
+supported boundary.
+
 ## Custom ACP agents
 
 `harness: acp:<slug>` runs any configured Agent Client Protocol server command.

--- a/docs/zcode.md
+++ b/docs/zcode.md
@@ -1,0 +1,63 @@
+# ZCode
+
+Omnigent's `zcode` harness runs the ZCode Agent through Agent Client Protocol
+(ACP) stdio. ZCode is an Agentic Development Environment, not merely a model
+provider: a Z.ai API key alone provides GLM model access but does not expose
+ZCode's agent runtime.
+
+## Runtime and adapter boundary
+
+ZCode currently ships a structured `app-server --stdio` interface but does not
+document ACP as an official product surface. Omnigent uses the independently
+maintained, Apache-2.0
+[`zcode-acp-server`](https://github.com/william0wang/zcode-acp) adapter, which
+launches that interface and translates its sessions, events, interactions, and
+configuration to ACP. The adapter is not affiliated with Z.ai.
+
+The reviewed `zcode-acp-server` 0.1.0 release supports ZCode CLI 0.15.0 and
+newer. Omnigent verified its published ACP handshake against ZCode 3.7.7,
+whose bundled CLI reports 0.16.3.
+
+## Setup
+
+Install the ZCode desktop app, sign in or configure an API key in its model
+settings, then install the adapter:
+
+```bash
+npm install -g zcode-acp-server
+```
+
+The adapter normally resolves `zcode` from `PATH`. Desktop installations do
+not always add it there. Set `ZCODE_BIN` to the bundled `zcode.cjs` path when
+needed:
+
+```bash
+export ZCODE_BIN="/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"
+```
+
+On macOS, the adapter discovers a Node runtime that supports `node:sqlite`.
+`ZCODE_NODE` can select one explicitly. Omnigent forwards `ZCODE_BIN`,
+`ZCODE_NODE`, `ZCODE_MODEL`, and `ZCODE_BASE_URL` through its otherwise
+deny-by-default ACP subprocess environment.
+
+Run the harness as `zcode` or `z-code`.
+
+## Support
+
+Adapter 0.1.0 exposes session create, list, load, resume, prompt, cancellation,
+model/mode/thought configuration, text and reasoning streams, tool lifecycle
+events, permission and form interactions, commands, compaction, and usage
+updates. Omnigent consumes the subset supported by its generic ACP
+executor and supplies its builtin tools through ACP MCP configuration.
+
+## Limitations
+
+- The adapter depends on ZCode's undocumented `app-server` protocol. A ZCode
+  update can require a matching adapter update even when ACP remains stable.
+- The adapter is early-stage community software. Omnigent requires version
+  0.1.0 or newer but cannot guarantee compatibility with every ZCode build.
+- ZCode owns authentication and provider configuration. Omnigent does not read
+  or store ZCode credentials.
+- Adapter 0.1.0 does not advertise image or audio prompt support.
+- Adapter 0.1.0 advertises stdio MCP only; remote HTTP and SSE MCP servers are
+  not forwarded through ACP.

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -24,13 +24,10 @@ spawn-env builder. Rows own their auth and model selection (``OWN_AUTH``): no
 Omnigent credential or model override is wired, so a ``/model`` pick is
 rejected up front rather than silently dropped.
 
-One consequence worth knowing before adding a row: the generic ACP spawn env is
-deny-by-default and a row has no ``env_passthrough`` of its own (only a
-user-configured ``acp:<slug>`` agent can declare one), so a row's CLI reaches the
-agent with the base environment only. A vendor that configures or authenticates
-*solely* from an environment variable therefore needs a user-configured agent
-rather than a row here; a vendor that reads stored credentials from disk (Devin,
-Grok's OAuth login) works as a row.
+The generic ACP spawn env is deny-by-default. A row may declare a small
+``env_passthrough`` allowlist for vendor-owned auth or path variables; names
+not listed stay withheld. A vendor that only needs a disk credential (Devin,
+Grok's OAuth login) can omit the allowlist.
 
 This module stays import-light (stdlib + :mod:`omnigent.harness_install_spec`)
 so the registry, onboarding, and runner layers can all read it without cycles.
@@ -54,11 +51,14 @@ class AcpCliHarness:
     :param args: Argv appended after the binary to start the CLI's ACP stdio
         server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
     :param aliases: Accepted alternate spellings, canonicalized to the row key.
+    :param env_passthrough: Environment variable names the otherwise
+        deny-by-default ACP subprocess may inherit.
     """
 
     install: HarnessInstallSpec
     args: tuple[str, ...]
     aliases: tuple[str, ...] = ()
+    env_passthrough: tuple[str, ...] = ()
 
     @property
     def label(self) -> str:
@@ -114,5 +114,20 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
         ),
         args=("agent", "stdio"),
         aliases=("grok-build",),
+    ),
+    # ZCode is a desktop ADE. The Apache-2.0 community adapter drives its
+    # bundled ``app-server --stdio`` interface and translates that stream to ACP.
+    "zcode": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "ZCode",
+            "zcode-acp-server",
+            "zcode-acp-server",
+            install_hint="install the ZCode desktop app and sign in before running the adapter",
+            auth_hint="sign in or configure an API key in the ZCode desktop app",
+            min_version="0.1.0",
+        ),
+        args=(),
+        aliases=("z-code",),
+        env_passthrough=("ZCODE_BIN", "ZCODE_NODE", "ZCODE_MODEL", "ZCODE_BASE_URL"),
     ),
 }

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1549,6 +1549,8 @@ def _build_acp_cli_spawn_env(
         "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
         "HARNESS_ACP_NAME": row.label,
     }
+    if row.env_passthrough:
+        env["HARNESS_ACP_ENV_PASSTHROUGH"] = ",".join(row.env_passthrough)
     # Session workspace (selected working folder). ``None`` lets the wrap fall
     # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
     if cwd is not None:

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -12,9 +12,10 @@ add/set-default/remove write paths surfaces here rather than silently.
 harness on a single compact row — the name on the left, then an aligned
 ``✓``/``✗`` status column — in 0.3 priority order: ``1=Claude``,
 ``2=Codex``, ``3=Cursor``, ``4=OpenCode``, ``5=Hermes``, ``6=Pi``,
-``7=Antigravity``, ``8=Qwen Code``, ``9=Goose``, ``10=Copilot``, ``11=Kiro``,
-``12=Kimi Code``, ``13=Import from OpenClaw``, ``14=Custom ACP agent``,
-``15=Quit``. There is no "More" folding — every harness is visible at once —
+         ``7=Antigravity``, ``8=Qwen Code``, ``9=Goose``, ``10=Devin``,
+         ``11=Grok Build``, ``12=ZCode``, ``13=Copilot``, ``14=Kiro``,
+         ``15=Kimi Code``, ``16=Import from OpenClaw``, ``17=Custom ACP agent``,
+         ``18=Quit``. There is no "More" folding — every harness is visible at once —
 and the actionable hint (install command / next step)
 renders only for the highlighted row, as the selector's description line.
 Selecting a harness drills into level 2 — its configured credentials, then ``+ Add a
@@ -1702,6 +1703,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         # ACP-family builtin, sorted by id, before the non-ACP harnesses.
         "Devin",
         "Grok Build",
+        "ZCode",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1865,7 +1867,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1887,7 +1889,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1904,7 +1906,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2095,14 +2097,14 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
+        # 10-12 are the builtin ACP CLI rows (Devin, Grok Build, ZCode — sorted by id).
         ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -45,6 +45,7 @@ _FAKE_ROW = AcpCliHarness(
     ),
     args=("agent", "stdio"),
     aliases=("fake-cli",),
+    env_passthrough=("FAKE_API_KEY", "FAKE_HOME"),
 )
 
 
@@ -96,6 +97,7 @@ def test_spawn_env_forwards_cwd_sandbox_and_quotes_command(
         "stdio",
     ]
     assert env["HARNESS_ACP_NAME"] == "Fake CLI"
+    assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == "FAKE_API_KEY,FAKE_HOME"
     assert env["HARNESS_ACP_CWD"] == "/work/space"
     assert json.loads(env["HARNESS_ACP_OS_ENV"]) == dataclasses.asdict(os_env)
     # Rows own their model selection: no model var may ride along.
@@ -129,6 +131,33 @@ def test_fake_row_login_command() -> None:
     assert _FAKE_ROW.login_command == "fakecli login --device"
     assert _FAKE_ROW.label == "Fake CLI"
     assert _FAKE_ROW.binary == "fakecli"
+
+
+def test_zcode_row_matches_published_acp_adapter() -> None:
+    """Pin the reviewed package and ZCode runtime environment boundary."""
+    row = ACP_CLI_HARNESSES["zcode"]
+
+    assert row.install.package == "zcode-acp-server"
+    assert row.install.min_version == "0.1.0"
+    assert row.binary == "zcode-acp-server"
+    assert row.args == ()
+    assert row.login_command is None
+    assert row.aliases == ("z-code",)
+    assert row.env_passthrough == (
+        "ZCODE_BIN",
+        "ZCODE_NODE",
+        "ZCODE_MODEL",
+        "ZCODE_BASE_URL",
+    )
+
+
+def test_grok_row_keeps_deny_by_default_environment() -> None:
+    """Rows without an allowlist must not emit the passthrough escape hatch."""
+    row = ACP_CLI_HARNESSES["grok"]
+
+    assert row.env_passthrough == ()
+    env = _build_acp_cli_spawn_env(_spec("grok"), harness="grok")
+    assert "HARNESS_ACP_ENV_PASSTHROUGH" not in env
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #4865

## Summary

ZCode is a desktop ADE. It ships `app-server --stdio`, but that is not
documented ACP, so Omnigent could not install or launch it as a builtin
harness.

This adds `harness: zcode` (alias `z-code`) as one `ACP_CLI_HARNESSES`
row. Registry, setup, readiness, picker, and spawn all derive from that
row and reuse the generic `AcpExecutor`. No new inner module.

There is no official Z.ai ACP package. The row uses the Apache-2.0
`zcode-acp-server` adapter, which launches ZCode's bundled
`app-server --stdio` and translates that stream to ACP.

```
  user -> omni run --harness zcode
       -> catalog row
       -> zcode-acp-server
       -> zcode app-server --stdio
```

- Catalog: display `ZCode`, binary/package `zcode-acp-server` (>= 0.1.0).
- ACP argv is empty. No `login` command: sign-in stays in the ZCode app.
- Deny-by-default spawn env allows `ZCODE_BIN`, `ZCODE_NODE`,
  `ZCODE_MODEL`, and `ZCODE_BASE_URL`. Other rows stay closed.
- Desktop installs often omit `zcode` from `PATH`; `ZCODE_BIN` points at
  the bundled `zcode.cjs`.
- `omni setup` gets the row automatically.
- Docs: `docs/zcode.md` plus an `AGENT_YAML_SPEC.md` section.

Native `omnigent zcode` TUI is out of scope.

## Test Plan

- `uv run --python 3.12 --group test --extra databricks --frozen pytest tests/test_acp_cli_harnesses.py tests/runtime/test_acp_spawn_env.py tests/cli/test_configure_models.py -q` → 159 passed
- New `test_zcode_row_matches_published_acp_adapter` pins package,
  binary, empty ACP argv, missing login, alias, and env allowlist.
- New `test_grok_row_keeps_deny_by_default_environment` proves rows
  without an allowlist still emit no `HARNESS_ACP_ENV_PASSTHROUGH`.
- Setup-menu indices after Goose shift by one; OpenClaw import moves
  from `14` to `15`.
- `pre-commit` on the changed files: ruff, format, pyrefly clean.
- Live probe: `zcode-acp-server@0.1.0` answered ACP `initialize` and
  started ZCode 3.7.7 / CLI 0.16.3. `session/new` stopped without
  `~/.zcode/v2/config.json`.

## Demo

N/A. Backend harness. It shows up as `ZCode` in `omni setup` and the
harness picker, driven by the existing ACP session UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual check was the published adapter handshake against a mounted
ZCode 3.7.7 DMG. A signed-in live turn needs the desktop app and
`~/.zcode/v2/config.json`. Catalog/setup/spawn coverage is in the unit
tests; the generic ACP path is already covered by
`tests/inner/test_acp_executor.py`.

## Changelog

ZCode is now a first-class option in `omni setup` and
`omni run --harness zcode`
