### PR TITLE
feat(server): add idempotent session shell creation

### DIFF
--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -584,6 +584,7 @@ bundle parsing fails, no database row is written.
 ```
 POST /v1/sessions
 Content-Type: application/json
+Idempotency-Key: agentfactory-attempt-42  # optional; see below
 
 {
   "agent_id": "ag_abc123",
@@ -600,6 +601,21 @@ Content-Type: application/json
 This preserves the existing sessions API contract for clients that
 already uploaded or registered an agent. The response is the full
 `SessionResponse` shape with `id` set to the new conversation id.
+
+  Idempotency-Key (header, optional)
+    Creates or replays one automation-safe session shell. The first
+    supported slice is intentionally limited to `agent_id` plus an optional
+    `title` on an empty, top-level, external session. The server binds the
+    key to the authenticated principal, workspace, and complete normalized
+    request. An exact replay returns the same session with `201`; reusing the
+    key with a changed request returns `409`. Keys must contain 1-255 visible
+    ASCII characters without whitespace. If the keyed request includes an
+    initial turn, labels, parent/sub-agent fields, host/sandbox/worktree
+    provisioning, model/routing/harness overrides, or multipart bundle
+    creation, the server returns `400` rather than silently weakening the
+    idempotency guarantee. The binding survives a process crash between the
+    durable conversation write and operational metadata creation; a replay
+    repairs missing default metadata without overwriting existing state.
 
   host_type (string, "external" | "managed", default "external")
     How the session's host is obtained. `"external"` (the default,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -274,6 +274,7 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
     PINNED_LABEL_KEY,
+    SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX,
     ConversationNotFoundError,
     NameAlreadyExistsError,
 )
@@ -8186,6 +8187,16 @@ def _reject_server_reserved_label_seed(labels: dict[str, str] | None) -> None:
     """
     if not labels:
         return
+    idempotency_key = next(
+        (key for key in labels if key.startswith(SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX)),
+        None,
+    )
+    if idempotency_key is not None:
+        raise OmnigentError(
+            f"label {idempotency_key!r} is in the server-internal "
+            f"{SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX}* namespace and cannot be set by clients",
+            code=ErrorCode.INVALID_INPUT,
+        )
     if _TURN_ACTOR_LABEL in labels:
         raise OmnigentError(
             f"label {_TURN_ACTOR_LABEL!r} is server-internal and cannot be set by clients",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -321,6 +321,7 @@ from omnigent.server.schemas import (
     SessionUsageEvent,
     SkillSummary,
 )
+from omnigent.server.session_create_idempotency import SessionCreateIdempotency
 from omnigent.session_lifecycle import (
     labels_with_closed_status,
     title_without_closed_marker,
@@ -334,6 +335,8 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
     PINNED_LABEL_KEY,
+    SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX,
+    ConversationAlreadyExistsError,
     ConversationNotFoundError,
     pinned_label_key,
 )
@@ -752,7 +755,9 @@ def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str,
     cleaned = {
         k: v
         for k, v in labels.items()
-        if k != PINNED_LABEL_KEY and not k.startswith(f"{PINNED_LABEL_KEY}.")
+        if k != PINNED_LABEL_KEY
+        and not k.startswith(f"{PINNED_LABEL_KEY}.")
+        and not k.startswith(SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX)
     }
     if my_pin is not None:
         cleaned[PINNED_LABEL_KEY] = my_pin
@@ -7546,6 +7551,7 @@ async def _create_session_from_existing_agent(
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
     background_title_coordinator: BackgroundSessionTitleCoordinator | None = None,
+    idempotency: SessionCreateIdempotency | None = None,
 ) -> SessionResponse:
     """
     Create a session bound to an already-registered agent.
@@ -7575,6 +7581,8 @@ async def _create_session_from_existing_agent(
         ``file_id`` references in ``initial_items`` before forwarding
         to the runner.
     :param artifact_store: Optional binary content store for the same.
+    :param idempotency: Optional server-owned binding for a replay-safe,
+        side-effect-free session-shell create.
     :returns: The newly created session snapshot.
     :raises OmnigentError: 404 if no agent matches ``body.agent_id``;
         403/404 if ``parent_session_id`` or session-scoped ``agent_id``
@@ -7590,6 +7598,12 @@ async def _create_session_from_existing_agent(
         permission_store=permission_store,
         conversation_store=conversation_store,
     )
+    if idempotency is not None and native_coding_agent_for_agent_name(agent.name) is not None:
+        raise OmnigentError(
+            "Idempotency-Key session-shell creation does not yet support native "
+            "terminal wrapper agents",
+            code=ErrorCode.INVALID_INPUT,
+        )
 
     # Top-level Smart Routing: "auto" on a native wrapper agent means the client
     # picked Smart Routing with no bundle agent, and its ``agent_id`` is only a
@@ -7950,6 +7964,35 @@ async def _create_session_from_existing_agent(
             workspace=canonical_workspace,
             git_branch=git_branch,
             terminal_launch_args=validated_launch_args,
+            conversation_id=idempotency.conversation_id if idempotency is not None else None,
+            initial_labels=idempotency.labels if idempotency is not None else None,
+        )
+    except ConversationAlreadyExistsError as exc:
+        if idempotency is None:
+            raise
+        existing = await asyncio.to_thread(
+            conversation_store.get_conversation,
+            idempotency.conversation_id,
+        )
+        if existing is None or not idempotency.matches(existing.labels):
+            raise OmnigentError(
+                "Idempotency-Key is already bound to a different session-create request",
+                code=ErrorCode.CONFLICT,
+            ) from exc
+        repaired = await asyncio.to_thread(
+            conversation_store.ensure_conversation_metadata,
+            existing.id,
+        )
+        if repaired is None:  # pragma: no cover - collision proves the row exists
+            raise RuntimeError(
+                f"idempotent session {existing.id!r} disappeared during replay"
+            ) from exc
+        return await _get_session_snapshot(
+            conversation_store,
+            repaired.id,
+            agent_store=agent_store,
+            agent_cache=agent_cache,
+            liveness_lookup=liveness_lookup,
         )
     except Exception:
         # Broad catch is intentional: ANY create_conversation failure

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -8,13 +8,14 @@ import json
 import secrets
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    Header,
     HTTPException,
     Query,
     Request,
@@ -173,6 +174,10 @@ from omnigent.server.schemas import (
     SessionSwitchAgentRequest,
     UpdateSessionRequest,
 )
+from omnigent.server.session_create_idempotency import (
+    IDEMPOTENCY_KEY_HEADER,
+    build_session_create_idempotency,
+)
 from omnigent.session_lifecycle import (
     labels_with_closed_status,
 )
@@ -229,6 +234,17 @@ def register_core_routes(
     )
     async def create_session(
         request: Request,
+        idempotency_key: Annotated[
+            str | None,
+            Header(
+                alias=IDEMPOTENCY_KEY_HEADER,
+                description=(
+                    "Replay key for an empty top-level external session shell. "
+                    "Unsupported create shapes fail closed instead of silently "
+                    "weakening idempotency."
+                ),
+            ),
+        ] = None,
     ) -> SessionResponse | CreatedSessionResponse:
         """
         Create a session.
@@ -243,6 +259,9 @@ def register_core_routes(
 
         :param request: FastAPI request containing either JSON or
             multipart form data.
+        :param idempotency_key: Optional replay key for an empty top-level
+            external JSON session shell. Multipart and side-effecting JSON
+            creates fail closed when this header is present.
         :returns: :class:`SessionResponse` for JSON create, or
             :class:`CreatedSessionResponse` for bundled create.
         :raises OmnigentError: If metadata, bundle, or agent lookup
@@ -252,6 +271,11 @@ def register_core_routes(
         user_id = _require_user(request, auth_provider)
         content_type = request.headers.get("content-type", "").split(";", 1)[0].lower()
         if content_type == "multipart/form-data":
+            if idempotency_key is not None:
+                raise OmnigentError(
+                    "Idempotency-Key is not supported for multipart bundled session creation",
+                    code=ErrorCode.INVALID_INPUT,
+                )
             result = await _create_bundled_session_from_multipart(request, user_id)
             if permission_store is not None and user_id is not None:
                 await asyncio.to_thread(permission_store.ensure_user, user_id)
@@ -286,6 +310,12 @@ def register_core_routes(
             # message survives in each entry's `msg`.
             raise HTTPException(status_code=422, detail=exc.errors(include_context=False)) from exc
 
+        idempotency = build_session_create_idempotency(
+            idempotency_key,
+            body,
+            user_id,
+        )
+
         resp = await _create_session_from_existing_agent(
             conversation_store,
             agent_store,
@@ -299,6 +329,7 @@ def register_core_routes(
             file_store=file_store,
             artifact_store=artifact_store,
             background_title_coordinator=background_title_coordinator,
+            idempotency=idempotency,
         )
         # Notify the runner about the new session so it can resolve
         # the spec and cache sub_agent_name before the first turn.

--- a/omnigent/server/session_create_idempotency.py
+++ b/omnigent/server/session_create_idempotency.py
@@ -1,0 +1,124 @@
+"""Idempotency binding for automation-safe session-shell creation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from omnigent.db.db_models import current_workspace_id
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import RESERVED_USER_LOCAL
+from omnigent.server.schemas import SessionCreateRequest
+from omnigent.stores.conversation_store import (
+    SESSION_CREATE_KEY_HASH_LABEL,
+    SESSION_CREATE_OWNER_HASH_LABEL,
+    SESSION_CREATE_REQUEST_HASH_LABEL,
+)
+
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+_MAX_IDEMPOTENCY_KEY_BYTES = 255
+_CREATE_BINDING_VERSION = "session-create-v1"
+
+
+@dataclass(frozen=True)
+class SessionCreateIdempotency:
+    """Server-owned binding for one idempotent session-create request."""
+
+    conversation_id: str
+    labels: dict[str, str]
+
+    def matches(self, labels: dict[str, str]) -> bool:
+        """Return whether persisted labels exactly match this binding."""
+        return all(labels.get(key) == value for key, value in self.labels.items())
+
+
+def build_session_create_idempotency(
+    raw_key: str | None,
+    body: SessionCreateRequest,
+    user_id: str | None,
+) -> SessionCreateIdempotency | None:
+    """Validate and bind an optional create idempotency key.
+
+    The first safe slice intentionally supports only an empty, top-level,
+    external session shell. Host provisioning, worktree creation, routing,
+    label mutation, and initial turn dispatch all have side effects outside
+    the conversation-row transaction; claiming idempotency for those shapes
+    before they carry their own durable operation state would be unsafe.
+
+    :param raw_key: Raw ``Idempotency-Key`` header, or ``None`` when omitted.
+    :param body: Validated session-create body.
+    :param user_id: Authenticated principal, or ``None`` in single-user mode.
+    :returns: A deterministic binding, or ``None`` when the header is absent.
+    :raises OmnigentError: If the key or request shape is unsupported.
+    """
+    if raw_key is None:
+        return None
+    key_bytes = raw_key.encode("utf-8")
+    if (
+        not key_bytes
+        or len(key_bytes) > _MAX_IDEMPOTENCY_KEY_BYTES
+        or any(byte < 0x21 or byte > 0x7E for byte in key_bytes)
+    ):
+        raise OmnigentError(
+            "Idempotency-Key must be 1-255 visible ASCII characters without whitespace",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    _require_safe_shell_shape(body)
+
+    principal = user_id if user_id is not None else RESERVED_USER_LOCAL
+    workspace = str(current_workspace_id())
+    request_json = json.dumps(
+        body.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    key_hash = hashlib.sha256(key_bytes).hexdigest()
+    owner_hash = hashlib.sha256(principal.encode("utf-8")).hexdigest()
+    request_hash = hashlib.sha256(request_json).hexdigest()
+    identity = b"\0".join(
+        (
+            _CREATE_BINDING_VERSION.encode("ascii"),
+            workspace.encode("ascii"),
+            principal.encode("utf-8"),
+            key_bytes,
+        )
+    )
+    conversation_id = hashlib.sha256(identity).digest()[:16].hex()
+    return SessionCreateIdempotency(
+        conversation_id=conversation_id,
+        labels={
+            SESSION_CREATE_KEY_HASH_LABEL: key_hash,
+            SESSION_CREATE_OWNER_HASH_LABEL: owner_hash,
+            SESSION_CREATE_REQUEST_HASH_LABEL: request_hash,
+        },
+    )
+
+
+def _require_safe_shell_shape(body: SessionCreateRequest) -> None:
+    """Reject create side effects that do not yet have durable replay state."""
+    unsupported = (
+        bool(body.initial_items)
+        or bool(body.labels)
+        or body.parent_session_id is not None
+        or body.sub_agent_name is not None
+        or body.host_type != "external"
+        or body.host_id is not None
+        or body.sandbox_provider is not None
+        or body.workspace is not None
+        or body.git is not None
+        or body.terminal_launch_args is not None
+        or body.model_override is not None
+        or body.reasoning_effort is not None
+        or body.cost_control_mode_override is not None
+        or body.subagent_routing_override is not None
+        or body.harness_override is not None
+        or body.smart_routing_message is not None
+    )
+    if unsupported:
+        raise OmnigentError(
+            "Idempotency-Key currently supports only an empty top-level external "
+            "session shell (agent_id and optional title)",
+            code=ErrorCode.INVALID_INPUT,
+        )

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -104,6 +104,15 @@ PROJECT_LABEL_KEY = "omni_project"
 # mirrors the canonical key as ``PINNED_LABEL_KEY``.
 PINNED_LABEL_KEY = "omnigent.pinned"
 
+# Server-owned binding for replay-safe JSON session-shell creation. The entire
+# namespace is hidden from API label surfaces, rejected on client writes, and
+# dropped when a conversation is forked so a new session never inherits the
+# source request's identity.
+SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX = "omnigent.idempotency.create."
+SESSION_CREATE_KEY_HASH_LABEL = f"{SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX}key_hash"
+SESSION_CREATE_OWNER_HASH_LABEL = f"{SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX}owner_hash"
+SESSION_CREATE_REQUEST_HASH_LABEL = f"{SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX}request_hash"
+
 # Single-user / no-auth sentinel for the per-user pin key suffix, mirroring the
 # reserved ``"local"`` identity used elsewhere (see ``RESERVED_USER_LOCAL``).
 _PINNED_LABEL_LOCAL_USER = "local"
@@ -339,6 +348,7 @@ class ConversationStore(ABC):
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
         conversation_id: str | None = None,
+        initial_labels: dict[str, str] | None = None,
     ) -> Conversation:
         """
         Create a new conversation. Generates a unique
@@ -394,6 +404,10 @@ class ConversationStore(ABC):
         :param conversation_id: Optional caller-supplied identifier.
             ``None`` generates a new random id. Reserved for flows that
             require database-enforced idempotency.
+        :param initial_labels: Optional labels inserted in the same Agent
+            Platform transaction as the conversation row. This is reserved
+            for identity or idempotency metadata that must never be visible
+            on a partially-created row without its binding.
         :returns: The newly created :class:`Conversation`.
         :raises NameAlreadyExistsError: If
             ``parent_conversation_id`` is not ``None`` and a
@@ -404,6 +418,20 @@ class ConversationStore(ABC):
             row does not exist (root id can't be inherited).
         :raises ConversationAlreadyExistsError: If a caller-supplied
             ``conversation_id`` is already in use.
+        """
+        ...
+
+    @abstractmethod
+    def ensure_conversation_metadata(self, conversation_id: str) -> Conversation | None:
+        """Ensure default operational metadata exists for a safe session shell.
+
+        This is a recovery primitive for a conversation whose durable Agent
+        Platform row committed before the separate Omnigent metadata
+        transaction. It must never overwrite an existing metadata row.
+
+        :param conversation_id: Existing top-level conversation identifier.
+        :returns: The repaired conversation, or ``None`` if its durable row
+            does not exist.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -85,6 +85,7 @@ from omnigent.stores.conversation_store import (
     FORK_SOURCE_LABEL_KEY,
     PINNED_LABEL_KEY,
     PROJECT_LABEL_KEY,
+    SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX,
     SWITCH_PREVIOUS_BUILTIN_LABEL_KEY,
     ConversationAlreadyExistsError,
     ConversationNotFoundError,
@@ -868,6 +869,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
         conversation_id: str | None = None,
+        initial_labels: dict[str, str] | None = None,
     ) -> Conversation:
         """
         Create a new conversation in the database.
@@ -916,6 +918,9 @@ class SqlAlchemyConversationStore(ConversationStore):
             terminal.
         :param conversation_id: Optional caller-supplied identifier.
             ``None`` generates a new random id.
+        :param initial_labels: Optional labels inserted atomically with the
+            conversation row. Intended for server-owned identity metadata;
+            ordinary callers should continue to use :meth:`set_labels`.
         :returns: The newly created :class:`Conversation`.
         :raises NameAlreadyExistsError: If
             ``parent_conversation_id`` is set and a sibling row
@@ -931,6 +936,22 @@ class SqlAlchemyConversationStore(ConversationStore):
             ConversationNotFoundError,
             NameAlreadyExistsError,
         )
+
+        if initial_labels is not None and (
+            conversation_id is None
+            or kind != "default"
+            or parent_conversation_id is not None
+            or runner_id is not None
+            or sub_agent_name is not None
+            or host_id is not None
+            or workspace is not None
+            or git_branch is not None
+            or terminal_launch_args is not None
+        ):
+            raise ValueError(
+                "initial_labels are reserved for a caller-identified, empty, "
+                "top-level default session shell"
+            )
 
         now = now_epoch()
         new_id = conversation_id if conversation_id is not None else generate_conversation_id()
@@ -988,6 +1009,15 @@ class SqlAlchemyConversationStore(ConversationStore):
                     agent_id=agent_id,
                 )
                 ap_sess.add(row)
+                if initial_labels:
+                    _upsert_labels(ap_sess, new_id, initial_labels, now)
+            if initial_labels is not None:
+                recovered = self.ensure_conversation_metadata(new_id)
+                if recovered is None:  # pragma: no cover - committed row must be readable
+                    raise RuntimeError(
+                        f"conversation {new_id!r} disappeared during metadata creation"
+                    )
+                return recovered
             meta = SqlConversationMetadata(
                 id=new_id,
                 kind=encode_conversation_kind(kind),
@@ -1030,6 +1060,74 @@ class SqlAlchemyConversationStore(ConversationStore):
                     f"conversation id {conversation_id!r} already exists"
                 ) from exc
             raise
+
+    def ensure_conversation_metadata(self, conversation_id: str) -> Conversation | None:
+        """Create missing default metadata without overwriting existing state.
+
+        Session creation spans the Agent Platform and Omnigent databases. A
+        process crash after the durable conversation+label transaction can
+        therefore leave a correctly bound shell without its operational
+        metadata row. This method repairs exactly that default top-level shell.
+        Dialect-native conflict-ignore makes concurrent original/replay calls
+        converge without clobbering runner, host, or other metadata.
+
+        :param conversation_id: Existing top-level conversation identifier.
+        :returns: The complete conversation, or ``None`` when the durable row
+            does not exist.
+        """
+        with self._conv_session("ensure_conversation_metadata.read") as ap_sess:
+            row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
+            if row is None:
+                return None
+            if row.parent_conversation_id is not None:
+                raise ValueError("metadata repair is limited to top-level session shells")
+            labels = _fetch_labels(ap_sess, conversation_id)
+
+        workspace_id = current_workspace_id()
+        values = {
+            "workspace_id": workspace_id,
+            "id": conversation_id,
+            "kind": encode_conversation_kind("default"),
+        }
+        with self._session("ensure_conversation_metadata.write") as meta_sess:
+            dialect = meta_sess.bind.dialect.name if meta_sess.bind is not None else ""
+            if dialect == "sqlite":
+                from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+                stmt = sqlite_insert(SqlConversationMetadata).values(**values)
+                meta_sess.execute(
+                    stmt.on_conflict_do_nothing(index_elements=["workspace_id", "id"])
+                )
+            elif dialect == "postgresql":
+                from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+                stmt = pg_insert(SqlConversationMetadata).values(**values)
+                meta_sess.execute(
+                    stmt.on_conflict_do_nothing(index_elements=["workspace_id", "id"])
+                )
+            elif dialect == "mysql":
+                from sqlalchemy.dialects.mysql import insert as mysql_insert
+
+                meta_sess.execute(
+                    mysql_insert(SqlConversationMetadata).values(**values).prefix_with("IGNORE")
+                )
+            else:
+                meta = meta_sess.get(
+                    SqlConversationMetadata,
+                    (workspace_id, conversation_id),
+                )
+                if meta is None:
+                    meta_sess.add(SqlConversationMetadata(**values))
+                    meta_sess.flush()
+            meta = meta_sess.get(
+                SqlConversationMetadata,
+                (workspace_id, conversation_id),
+            )
+            if meta is None:  # pragma: no cover - insert/get invariant
+                raise RuntimeError(
+                    f"failed to ensure metadata for conversation {conversation_id!r}"
+                )
+            return _to_conversation(row, meta, labels)
 
     def get_conversation(self, conversation_id: str) -> Conversation | None:
         """
@@ -3703,6 +3801,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 for key, value in _fetch_labels(session, source_conversation_id).items()
                 if key not in (_INSTANCE_SCOPED_LABEL_KEYS | _FORK_ONLY_DROPPED_LABEL_KEYS)
                 and not key.startswith(f"{PINNED_LABEL_KEY}.")
+                and not key.startswith(SESSION_CREATE_IDEMPOTENCY_LABEL_PREFIX)
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None

--- a/openapi.json
+++ b/openapi.json
@@ -9153,8 +9153,28 @@
         ]
       },
       "post": {
-        "description": "Create a session.\n\n`application/json` preserves the existing contract: bind to\nan already-registered agent by `agent_id` and return the full\nsession snapshot. `multipart/form-data` is the Alpha\nrunner-state create path: the request carries a JSON\n`metadata` part and a `bundle` file part, then the server\nstores the bundle and creates the conversation row plus\nsession-scoped agent row in one database transaction.\n\n**Returns:** `SessionResponse` for JSON create, or `CreatedSessionResponse` for bundled create.\n\n**Raises**\n\n- `OmnigentError` \u2014 If metadata, bundle, or agent lookup validation fails, artifact storage is unavailable, or database creation fails.",
+        "description": "Create a session.\n\n`application/json` preserves the existing contract: bind to\nan already-registered agent by `agent_id` and return the full\nsession snapshot. `multipart/form-data` is the Alpha\nrunner-state create path: the request carries a JSON\n`metadata` part and a `bundle` file part, then the server\nstores the bundle and creates the conversation row plus\nsession-scoped agent row in one database transaction.\n\n**Parameters**\n\n- `idempotency_key` \u2014 Optional replay key for an empty top-level external JSON session shell. Multipart and side-effecting JSON creates fail closed when this header is present.\n\n**Returns:** `SessionResponse` for JSON create, or `CreatedSessionResponse` for bundled create.\n\n**Raises**\n\n- `OmnigentError` \u2014 If metadata, bundle, or agent lookup validation fails, artifact storage is unavailable, or database creation fails.",
         "operationId": "create_session_v1_sessions_post",
+        "parameters": [
+          {
+            "description": "Replay key for an empty top-level external session shell. Unsupported create shapes fail closed instead of silently weakening idempotency.",
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Replay key for an empty top-level external session shell. Unsupported create shapes fail closed instead of silently weakening idempotency.",
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "responses": {
           "201": {
             "content": {
@@ -9163,6 +9183,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Create Session",

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -21,7 +21,9 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from sqlalchemy import delete
 
+from omnigent.db.db_models import SqlConversationMetadata, current_workspace_id
 from omnigent.llms.context_window import ModelPricing
 from omnigent.runtime.tool_output import MAX_TOOL_OUTPUT_BYTES
 from omnigent.server.background_session_titles import BackgroundTitleRequest
@@ -143,6 +145,110 @@ async def test_create_session_without_title_returns_none(
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
     assert session["title"] is None
+
+
+async def test_idempotent_session_shell_replay_converges_without_exposing_binding(
+    client: httpx.AsyncClient,
+) -> None:
+    agent = await create_test_agent(client)
+    payload = {"agent_id": agent["id"], "title": "automation shell"}
+    headers = {"Idempotency-Key": "agentfactory-attempt-42"}
+
+    first, replay = await asyncio.gather(
+        client.post("/v1/sessions", json=payload, headers=headers),
+        client.post("/v1/sessions", json=payload, headers=headers),
+    )
+
+    assert first.status_code == 201, first.text
+    assert replay.status_code == 201, replay.text
+    assert first.json()["id"] == replay.json()["id"]
+    assert not any(
+        key.startswith("omnigent.idempotency.create.")
+        for key in first.json()["labels"] | replay.json()["labels"]
+    )
+
+
+async def test_idempotent_session_shell_rejects_key_reuse_with_changed_body(
+    client: httpx.AsyncClient,
+) -> None:
+    agent = await create_test_agent(client)
+    headers = {"Idempotency-Key": "agentfactory-attempt-43"}
+
+    first = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "title": "first"},
+        headers=headers,
+    )
+    conflict = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "title": "changed"},
+        headers=headers,
+    )
+
+    assert first.status_code == 201, first.text
+    assert conflict.status_code == 409, conflict.text
+
+
+async def test_idempotent_session_shell_repairs_missing_metadata(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    agent = await create_test_agent(client)
+    headers = {"Idempotency-Key": "agentfactory-attempt-44"}
+    payload = {"agent_id": agent["id"], "title": "repair shell"}
+    first = await client.post("/v1/sessions", json=payload, headers=headers)
+    assert first.status_code == 201, first.text
+
+    store = SqlAlchemyConversationStore(db_uri)
+    with store._session("test_delete_metadata") as session:
+        session.execute(
+            delete(SqlConversationMetadata).where(
+                SqlConversationMetadata.workspace_id == current_workspace_id(),
+                SqlConversationMetadata.id == first.json()["id"],
+            )
+        )
+
+    replay = await client.post("/v1/sessions", json=payload, headers=headers)
+    repaired = store.get_conversation(first.json()["id"])
+
+    assert replay.status_code == 201, replay.text
+    assert replay.json()["id"] == first.json()["id"]
+    assert repaired is not None
+
+
+async def test_idempotent_session_shell_isolated_by_key_and_rejects_side_effects(
+    client: httpx.AsyncClient,
+) -> None:
+    agent = await create_test_agent(client)
+    payload = {"agent_id": agent["id"]}
+    first = await client.post(
+        "/v1/sessions",
+        json=payload,
+        headers={"Idempotency-Key": "agentfactory-key-a"},
+    )
+    second = await client.post(
+        "/v1/sessions",
+        json=payload,
+        headers={"Idempotency-Key": "agentfactory-key-b"},
+    )
+    unsupported = await client.post(
+        "/v1/sessions",
+        json={**payload, "labels": {"client": "value"}},
+        headers={"Idempotency-Key": "agentfactory-key-c"},
+    )
+    reserved = await client.post(
+        "/v1/sessions",
+        json={
+            **payload,
+            "labels": {"omnigent.idempotency.create.request_hash": "forged"},
+        },
+    )
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 201, second.text
+    assert first.json()["id"] != second.json()["id"]
+    assert unsupported.status_code == 400, unsupported.text
+    assert reserved.status_code == 400, reserved.text
 
 
 async def test_first_message_schedules_background_semantic_title(

--- a/tests/server/test_session_create_idempotency.py
+++ b/tests/server/test_session_create_idempotency.py
@@ -1,0 +1,87 @@
+"""Unit tests for the public session-create idempotency binding."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.errors import OmnigentError
+from omnigent.server.schemas import SessionCreateRequest
+from omnigent.server.session_create_idempotency import (
+    build_session_create_idempotency,
+)
+
+
+def _request(**updates: object) -> SessionCreateRequest:
+    payload: dict[str, object] = {"agent_id": "a" * 32}
+    payload.update(updates)
+    return SessionCreateRequest.model_validate(payload)
+
+
+def test_binding_is_deterministic_and_scoped_to_owner() -> None:
+    body = _request(title="automation shell")
+
+    first = build_session_create_idempotency("workflow-42", body, "alice@example.com")
+    replay = build_session_create_idempotency("workflow-42", body, "alice@example.com")
+    other_owner = build_session_create_idempotency("workflow-42", body, "bob@example.com")
+
+    assert first is not None
+    assert first == replay
+    assert other_owner is not None
+    assert first.conversation_id != other_owner.conversation_id
+
+
+def test_same_key_changed_request_keeps_identity_but_breaks_binding() -> None:
+    first = build_session_create_idempotency(
+        "workflow-42",
+        _request(title="first title"),
+        "alice@example.com",
+    )
+    changed = build_session_create_idempotency(
+        "workflow-42",
+        _request(title="changed title"),
+        "alice@example.com",
+    )
+
+    assert first is not None and changed is not None
+    assert first.conversation_id == changed.conversation_id
+    assert not first.matches(changed.labels)
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["", "contains space", "line\nbreak", "\x1f", "x" * 256],
+)
+def test_invalid_keys_fail_closed(key: str) -> None:
+    with pytest.raises(OmnigentError, match="visible ASCII"):
+        build_session_create_idempotency(key, _request(), "alice@example.com")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("labels", {"client": "value"}),
+        ("initial_items", [{"type": "message", "data": {"role": "user", "content": []}}]),
+        ("host_id", "b" * 32),
+        ("workspace", "/tmp/workspace"),
+        ("model_override", "test-model"),
+        ("harness_override", "openai-agents"),
+    ],
+)
+def test_side_effecting_request_shapes_fail_closed(field: str, value: object) -> None:
+    with pytest.raises(OmnigentError, match="empty top-level external session shell"):
+        build_session_create_idempotency(
+            "workflow-42",
+            _request(**{field: value}),
+            "alice@example.com",
+        )
+
+
+def test_missing_header_preserves_existing_non_idempotent_contract() -> None:
+    assert (
+        build_session_create_idempotency(
+            None,
+            _request(labels={"client": "value"}),
+            None,
+        )
+        is None
+    )

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import event, text
+from sqlalchemy import delete, event, text
 
+from omnigent.db.db_models import SqlConversationMetadata, current_workspace_id
 from omnigent.db.utils import get_or_create_engine
 from omnigent.entities import (
     ErrorData,
@@ -74,6 +75,24 @@ def test_fork_drops_per_user_pin_labels(
     assert pinned_label_key("bob") not in fork.labels
 
 
+def test_fork_drops_session_create_idempotency_binding(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A new fork must not inherit the source request's replay identity."""
+    source = conversation_store.create_conversation(
+        conversation_id="e" * 32,
+        initial_labels={
+            "omnigent.idempotency.create.key_hash": "key",
+            "omnigent.idempotency.create.owner_hash": "owner",
+            "omnigent.idempotency.create.request_hash": "request",
+        },
+    )
+
+    fork = conversation_store.fork_conversation(source.id)
+
+    assert not any(key.startswith("omnigent.idempotency.create.") for key in fork.labels)
+
+
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:
     conv = conversation_store.create_conversation()
     assert len(conv.id) == 32
@@ -95,6 +114,47 @@ def test_create_with_existing_caller_supplied_id_raises(db_uri: str) -> None:
     assert created.id == conversation_id
     with pytest.raises(ConversationAlreadyExistsError):
         second_store.create_conversation(conversation_id=conversation_id)
+
+
+def test_create_with_initial_labels_binds_and_repairs_default_metadata(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The durable binding survives and repairs a cross-DB crash window."""
+    conversation_id = "b" * 32
+    labels = {"omnigent.idempotency.create.request_hash": "request-hash"}
+    created = conversation_store.create_conversation(
+        conversation_id=conversation_id,
+        initial_labels=labels,
+    )
+
+    assert created.labels == labels
+    with conversation_store._session("test_delete_metadata") as session:
+        session.execute(
+            delete(SqlConversationMetadata).where(
+                SqlConversationMetadata.workspace_id == current_workspace_id(),
+                SqlConversationMetadata.id == conversation_id,
+            )
+        )
+
+    repaired = conversation_store.ensure_conversation_metadata(conversation_id)
+
+    assert repaired is not None
+    assert repaired.id == conversation_id
+    assert repaired.labels == labels
+    assert repaired.kind == "default"
+    assert repaired.runner_id is None
+    assert repaired.host_id is None
+
+
+def test_initial_labels_reject_non_shell_store_shapes(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    with pytest.raises(ValueError, match="empty, top-level default session shell"):
+        conversation_store.create_conversation(
+            conversation_id="c" * 32,
+            initial_labels={"server-owned": "binding"},
+            runner_id="runner-1",
+        )
 
 
 def test_get_nonexistent(conversation_store: SqlAlchemyConversationStore) -> None:

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -101,6 +101,40 @@ def test_create_conversation_rows_land_in_correct_db(
     assert _col(omnigent_db, "omnigent_conversation_metadata", "workspace") == ["/tmp/proj"]
 
 
+def test_idempotent_shell_binding_and_metadata_repair_cross_databases(
+    omnigent_db: Path,
+    conv_db: Path,
+    store: SqlAlchemyConversationStore,
+) -> None:
+    conversation_id = "d" * 32
+    labels = {"omnigent.idempotency.create.request_hash": "request-hash"}
+
+    created = store.create_conversation(
+        conversation_id=conversation_id,
+        initial_labels=labels,
+    )
+
+    assert created.labels == labels
+    assert _count(conv_db, "conversations") == 1
+    assert _count(conv_db, "conversation_labels") == 1
+    assert _count(omnigent_db, "omnigent_conversation_metadata") == 1
+
+    with sqlite3.connect(str(omnigent_db)) as conn:
+        conn.execute(
+            "DELETE FROM omnigent_conversation_metadata WHERE id = ?",
+            (bytes.fromhex(conversation_id),),
+        )
+
+    repaired = store.ensure_conversation_metadata(conversation_id)
+
+    assert repaired is not None
+    assert repaired.id == conversation_id
+    assert repaired.labels == labels
+    assert _count(conv_db, "conversations") == 1
+    assert _count(conv_db, "conversation_labels") == 1
+    assert _count(omnigent_db, "omnigent_conversation_metadata") == 1
+
+
 def test_create_sub_agent_conversation(
     omnigent_db: Path, conv_db: Path, store: SqlAlchemyConversationStore
 ) -> None:


### PR DESCRIPTION
## Related issue

Part of #4861. This is the session-shell foundation only; it intentionally does not close the durable turn-operation or cursor work tracked there.

## Summary

- Add optional `Idempotency-Key` support to JSON `POST /v1/sessions` for an empty top-level external session shell (`agent_id` plus optional `title`).
- Bind the key to workspace, authenticated principal, and normalized request with server-owned hashed labels written atomically with the conversation row. Exact replay returns the same session; changed-body reuse returns 409.
- Repair the split-database crash window by recreating only missing default metadata without overwriting existing operational state. Internal bindings are hidden, client writes are rejected, and forks drop the namespace.

ELI5: retrying the same safe create request now opens the same empty folder instead of creating a second folder. If the request changes, the server refuses to pretend it is the same operation.

```text
principal + workspace + key
             |
             v
 deterministic session id
             |
             v
 conversation + hashed binding  -- replay --> validate binding
             |                                  |
             v                                  v
 default metadata <---------------------- repair if missing
```

Side-effecting shapes fail closed: initial turns, labels, parents/sub-agents, hosts/sandboxes/worktrees, model/routing/harness overrides, native terminal wrappers, and multipart bundle creation are not yet claimed as idempotent.

## Test Plan

- `pytest -q tests/server/test_openapi_drift.py tests/server/test_session_create_idempotency.py tests/server/integration/test_sessions_endpoints.py` — 230 passed.
- `pytest -q tests/stores/test_conversation_store.py tests/stores/test_conversation_store_split_db.py` — 214 passed, 1 pre-existing skip.
- Exact post-commit focused acceptance packet — 23 passed, including concurrent replay, changed-body conflict, metadata repair, split-DB repair, reserved-label rejection, and fork isolation.
- Changed Python files: Pyrefly 0 errors; Ruff format/check pass; generated OpenAPI matches.
- Changed-file pre-commit hygiene hooks pass. Repository-wide Pyrefly in the minimal local lint environment reports missing optional boto3/OpenTelemetry/Hindsight/Nimble dependencies outside this diff; CI remains authoritative for the fully provisioned project gate.

## Demo

N/A — API/server change with automated integration coverage.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration tests issue concurrent requests through the real FastAPI route and SQLAlchemy stores. Store tests cover both single-DB and split-DB metadata recovery.

## Changelog

I can safely retry creating an empty session shell by sending an `Idempotency-Key` header.
