### PR TITLE
feat(server): add durable turn operation journal

### DIFF
--- a/designs/TURN_OPERATIONS.md
+++ b/designs/TURN_OPERATIONS.md
@@ -1,0 +1,67 @@
+# Durable turn operations
+
+Status: proposed foundation for [#4861](https://github.com/omnigent-ai/omnigent/issues/4861)
+
+## Purpose
+
+External orchestrators need a typed, replay-safe way to submit one turn to an
+existing Omnigent session. The existing internal `POST /v1/sessions/{id}/events`
+surface is intentionally broad and generates a new response identifier for each
+request, so it cannot safely be retried after a timeout.
+
+An external operation is a turn submission, not the lifetime of the containing
+session. Session-shell creation and turn submission therefore use separate
+idempotency domains.
+
+## Durable state machine
+
+```text
+accepted -> input_persisted -> dispatched -> succeeded
+                              |          \-> failed
+                              |          \-> cancelled
+                              |          \-> timed_out
+                              |
+                              \-> dispatch_unknown -> terminal or reconciled dispatched
+```
+
+- `accepted`: the canonical request and replay key are durable; no conversation
+  input is yet guaranteed.
+- `input_persisted`: the journal is durably bound to one conversation item.
+- `dispatched`: runner acceptance was observed for this operation identifier.
+- `dispatch_unknown`: the server cannot prove whether the runner accepted the
+  request. Automated code must query runner status before redispatching.
+- terminal states are immutable; an exact repeated report is a no-op and any
+  changed report is a conflict.
+
+## Replay boundary
+
+The database enforces uniqueness over:
+
+```text
+(workspace_id, conversation_id, principal_hash, idempotency_key_hash)
+```
+
+Raw principals and idempotency keys are never persisted. The canonical request
+is stored because recovery from `accepted` must not depend on a client resending
+the body. The request digest is checked together with the canonical JSON, so an
+exact replay returns the same operation while the same key with another body is
+a conflict.
+
+## Crash and ambiguity rules
+
+1. Persist the operation before appending conversation input.
+2. Bind the operation to exactly one persisted input item before forwarding.
+3. Propagate the operation identifier through the server-runner boundary.
+4. A runner must deduplicate that identifier before this API can automate
+   redispatch.
+5. A transport timeout after forwarding records `dispatch_unknown`; it is not
+   treated as proof that nothing ran.
+6. Runner status/reconciliation must resolve ambiguity before retry. A terminal
+   observation may resolve `dispatch_unknown` directly.
+7. Durable cursor publication and terminal evidence are separate follow-up
+   contracts. Live SSE remains an optimization, never the recovery source of
+   truth.
+
+This foundation deliberately exposes no public turn endpoint yet. The endpoint
+must not be enabled until runner-side deduplication and status lookup exist, or
+client retries could duplicate billable work and tool side effects.

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1365,6 +1365,57 @@ class SqlUserDailyCost(OmnigentBase):
     updated_at: Mapped[int] = mapped_column(Integer)
 
 
+class SqlTurnOperation(OmnigentBase):
+    """Durable idempotency and lifecycle journal for a submitted turn.
+
+    The four-column unique key is the external replay boundary. Digests keep
+    raw principals and idempotency keys out of the database while preserving
+    database-enforced uniqueness on SQLite, PostgreSQL, and MySQL.
+    """
+
+    __tablename__ = "turn_operations"
+
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    id: Mapped[str] = mapped_column(Uuid16, primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
+    principal_hash: Mapped[bytes] = mapped_column(_CKSUM32, nullable=False)
+    idempotency_key_hash: Mapped[bytes] = mapped_column(_CKSUM32, nullable=False)
+    request_hash: Mapped[bytes] = mapped_column(_CKSUM32, nullable=False)
+    request_json: Mapped[str] = mapped_column(CompressedText, nullable=False)
+    state: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    item_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    terminal_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    error: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("state IN (1, 2, 3, 4, 5, 6, 7, 8)", name="ck_turn_operations_state"),
+        UniqueConstraint(
+            "workspace_id",
+            "conversation_id",
+            "principal_hash",
+            "idempotency_key_hash",
+            name="uq_turn_operations_replay_key",
+        ),
+        Index(
+            "ix_turn_operations_conversation_state",
+            "workspace_id",
+            "conversation_id",
+            "state",
+            "created_at",
+            "id",
+        ),
+    )
+
+
 class SqlScheduledTask(OmnigentBase):
     """
     SQLAlchemy model for the ``scheduled_tasks`` table.

--- a/omnigent/db/enum_codecs.py
+++ b/omnigent/db/enum_codecs.py
@@ -127,6 +127,20 @@ SCHEDULED_TASK_RUN_STATUS: dict[str, int] = {
     "skipped": 5,
 }
 
+# Durable public turn-operation lifecycle. ``dispatch_unknown`` is distinct
+# from ``dispatched``: it records a transport ambiguity that must be reconciled
+# with runner status before any automated redispatch.
+TURN_OPERATION_STATE: dict[str, int] = {
+    "accepted": 1,
+    "input_persisted": 2,
+    "dispatched": 3,
+    "dispatch_unknown": 4,
+    "succeeded": 5,
+    "failed": 6,
+    "cancelled": 7,
+    "timed_out": 8,
+}
+
 
 def _assert_item_type_codes_cover_data_classes() -> None:
     """
@@ -338,3 +352,13 @@ def encode_scheduled_task_run_status(name: str) -> int:
 def decode_scheduled_task_run_status(code: int) -> str:
     """Decode a ``scheduled_task_runs.status`` int code to its name."""
     return _decode(SCHEDULED_TASK_RUN_STATUS, code, field="scheduled_task_runs.status")
+
+
+def encode_turn_operation_state(name: str) -> int:
+    """Encode a ``turn_operations.state`` name to its int code."""
+    return _encode(TURN_OPERATION_STATE, name, field="turn_operations.state")
+
+
+def decode_turn_operation_state(code: int) -> str:
+    """Decode a ``turn_operations.state`` int code to its name."""
+    return _decode(TURN_OPERATION_STATE, code, field="turn_operations.state")

--- a/omnigent/db/migrations/versions/zb2c3d4e5f6a_add_turn_operations.py
+++ b/omnigent/db/migrations/versions/zb2c3d4e5f6a_add_turn_operations.py
@@ -1,0 +1,75 @@
+"""add durable turn_operations journal
+
+Revision ID: zb2c3d4e5f6a
+Revises: za2b3c4d5e6f
+Create Date: 2026-08-16 00:00:00.000000
+
+The journal is the database-enforced replay boundary for a public turn API.
+It intentionally records ``dispatch_unknown`` separately so a transport
+timeout cannot trigger an unsafe blind redispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BINARY as MySQLBinary
+
+from omnigent.db.db_models import Uuid16
+
+revision: str = "zb2c3d4e5f6a"
+down_revision: str | None = "za2b3c4d5e6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_DIGEST32 = sa.LargeBinary(32).with_variant(MySQLBinary(32), "mysql")
+
+
+def upgrade() -> None:
+    """Create the durable turn-operation journal and replay key."""
+    op.create_table(
+        "turn_operations",
+        sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("id", Uuid16(), nullable=False),
+        sa.Column("conversation_id", Uuid16(), nullable=False),
+        sa.Column("principal_hash", _DIGEST32, nullable=False),
+        sa.Column("idempotency_key_hash", _DIGEST32, nullable=False),
+        sa.Column("request_hash", _DIGEST32, nullable=False),
+        sa.Column("request_json", sa.LargeBinary(), nullable=False),
+        sa.Column("state", sa.SmallInteger(), nullable=False),
+        sa.Column("item_id", Uuid16(), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.Integer(), nullable=True),
+        sa.Column("terminal_at", sa.Integer(), nullable=True),
+        sa.Column("error_code", sa.String(64), nullable=True),
+        sa.Column("error", sa.LargeBinary(), nullable=True),
+        sa.CheckConstraint(
+            "state IN (1, 2, 3, 4, 5, 6, 7, 8)",
+            name="ck_turn_operations_state",
+        ),
+        sa.PrimaryKeyConstraint("workspace_id", "id"),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "conversation_id",
+            "principal_hash",
+            "idempotency_key_hash",
+            name="uq_turn_operations_replay_key",
+        ),
+    )
+    op.create_index(
+        "ix_turn_operations_conversation_state",
+        "turn_operations",
+        ["workspace_id", "conversation_id", "state", "created_at", "id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the turn-operation journal."""
+    op.drop_index(
+        "ix_turn_operations_conversation_state",
+        table_name="turn_operations",
+    )
+    op.drop_table("turn_operations")

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -37,10 +37,19 @@ from omnigent.entities.session_resources import (
     get_resource_by_id,
     resolve_terminal_entry_by_resource_id,
 )
+from omnigent.entities.turn_operation import (
+    TURN_OPERATION_ACTIVE_STATES,
+    TURN_OPERATION_STATES,
+    TURN_OPERATION_TERMINAL_STATES,
+    TurnOperation,
+)
 
 __all__ = [
     "DEFAULT_ENVIRONMENT_ID",
     "NON_CONTENT_ITEM_TYPES",
+    "TURN_OPERATION_ACTIVE_STATES",
+    "TURN_OPERATION_STATES",
+    "TURN_OPERATION_TERMINAL_STATES",
     "Account",
     "AccountToken",
     "Agent",
@@ -72,6 +81,7 @@ __all__ = [
     "SlashCommandData",
     "StoredFile",
     "TerminalCommandData",
+    "TurnOperation",
     "filter_resources_by_type",
     "get_resource_by_id",
     "parse_item_data",

--- a/omnigent/entities/turn_operation.py
+++ b/omnigent/entities/turn_operation.py
@@ -1,0 +1,36 @@
+"""Durable lifecycle record for one externally submitted session turn."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+TURN_OPERATION_ACTIVE_STATES = frozenset(
+    {"accepted", "input_persisted", "dispatched", "dispatch_unknown"}
+)
+TURN_OPERATION_TERMINAL_STATES = frozenset({"succeeded", "failed", "cancelled", "timed_out"})
+TURN_OPERATION_STATES = TURN_OPERATION_ACTIVE_STATES | TURN_OPERATION_TERMINAL_STATES
+
+
+@dataclass(frozen=True)
+class TurnOperation:
+    """A replay-safe, durable turn-operation journal entry.
+
+    ``request_json`` is the canonical request envelope needed to resume an
+    operation that crashed after acceptance but before input persistence.
+    Idempotency keys and actor identities are stored only as SHA-256 digests.
+    """
+
+    id: str
+    conversation_id: str
+    principal_hash: str
+    idempotency_key_hash: str
+    request_hash: str
+    request_json: str
+    state: str
+    created_at: int
+    workspace_id: int = 0
+    item_id: str | None = None
+    updated_at: int | None = None
+    terminal_at: int | None = None
+    error_code: str | None = None
+    error: str | None = None

--- a/omnigent/stores/turn_operation_store/__init__.py
+++ b/omnigent/stores/turn_operation_store/__init__.py
@@ -1,0 +1,74 @@
+"""Persistence contract for durable, replay-safe session turn operations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from omnigent.entities import TurnOperation
+
+
+class TurnOperationConflict(ValueError):
+    """An idempotency key was reused for a different canonical request."""
+
+
+class TurnOperationStateError(ValueError):
+    """A requested lifecycle transition conflicts with durable state."""
+
+
+class TurnOperationStore(ABC):
+    """Abstract store for the turn-operation journal."""
+
+    def __init__(self, storage_location: str) -> None:
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def create_or_get(
+        self,
+        *,
+        conversation_id: str,
+        principal: str,
+        idempotency_key: str,
+        request: dict[str, Any],
+    ) -> tuple[TurnOperation, bool]:
+        """Create an ``accepted`` operation or replay the existing row."""
+        ...
+
+    @abstractmethod
+    def get(self, operation_id: str) -> TurnOperation | None:
+        """Return one workspace-scoped operation by id."""
+        ...
+
+    @abstractmethod
+    def mark_input_persisted(self, operation_id: str, item_id: str) -> TurnOperation:
+        """Advance ``accepted`` to ``input_persisted`` idempotently."""
+        ...
+
+    @abstractmethod
+    def mark_dispatch_result(
+        self,
+        operation_id: str,
+        *,
+        state: str,
+        error_code: str | None = None,
+        error: str | None = None,
+    ) -> TurnOperation:
+        """Record ``dispatched`` or the explicit ``dispatch_unknown`` ambiguity."""
+        ...
+
+    @abstractmethod
+    def mark_terminal(
+        self,
+        operation_id: str,
+        *,
+        state: str,
+        error_code: str | None = None,
+        error: str | None = None,
+    ) -> TurnOperation:
+        """Advance a dispatched operation to a terminal state idempotently."""
+        ...
+
+    @abstractmethod
+    def delete_for_conversation(self, conversation_id: str) -> int:
+        """Delete journal rows when their owning conversation is deleted."""
+        ...

--- a/omnigent/stores/turn_operation_store/sqlalchemy_store.py
+++ b/omnigent/stores/turn_operation_store/sqlalchemy_store.py
@@ -1,0 +1,261 @@
+"""SQLAlchemy-backed durable turn-operation journal."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import Any, cast
+
+from sqlalchemy import delete, select
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlTurnOperation, current_workspace_id
+from omnigent.db.enum_codecs import decode_turn_operation_state, encode_turn_operation_state
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker, now_epoch
+from omnigent.entities import TURN_OPERATION_TERMINAL_STATES, TurnOperation
+from omnigent.stores.turn_operation_store import (
+    TurnOperationConflict,
+    TurnOperationStateError,
+    TurnOperationStore,
+)
+
+_DISPATCH_STATES = frozenset({"dispatched", "dispatch_unknown"})
+
+
+def _digest(domain: str, value: str) -> bytes:
+    payload = f"omnigent.turn-operation/v1/{domain}\0{value}".encode()
+    return hashlib.sha256(payload).digest()
+
+
+def _digest_hex(value: bytes) -> str:
+    return bytes(value).hex()
+
+
+def _canonical_request(request: dict[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            request,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("turn request must be canonical JSON data") from exc
+    if len(encoded.encode()) > 8 * 1024 * 1024:
+        raise ValueError("turn request exceeds the 8 MiB journal limit")
+    return encoded
+
+
+def _validate_key(key: str) -> None:
+    if not 1 <= len(key) <= 255 or any(ord(ch) < 0x21 or ord(ch) > 0x7E for ch in key):
+        raise ValueError("idempotency key must be 1-255 visible ASCII characters")
+
+
+def _validate_principal(principal: str) -> None:
+    if not principal or len(principal.encode()) > 512:
+        raise ValueError("principal must be non-empty and at most 512 UTF-8 bytes")
+
+
+def _to_entity(row: SqlTurnOperation) -> TurnOperation:
+    return TurnOperation(
+        id=row.id,
+        conversation_id=row.conversation_id,
+        principal_hash=_digest_hex(row.principal_hash),
+        idempotency_key_hash=_digest_hex(row.idempotency_key_hash),
+        request_hash=_digest_hex(row.request_hash),
+        request_json=row.request_json,
+        state=decode_turn_operation_state(row.state),
+        created_at=row.created_at,
+        workspace_id=row.workspace_id or DEFAULT_WORKSPACE_ID,
+        item_id=row.item_id,
+        updated_at=row.updated_at,
+        terminal_at=row.terminal_at,
+        error_code=row.error_code,
+        error=row.error,
+    )
+
+
+class SqlAlchemyTurnOperationStore(TurnOperationStore):
+    """Database-enforced replay journal for externally submitted turns."""
+
+    def __init__(self, storage_location: str) -> None:
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.turn_operation_store",
+        )
+        self._write_session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.turn_operation_store",
+            immediate=True,
+        )
+
+    def _find_by_replay_key(
+        self,
+        conversation_id: str,
+        principal_hash: bytes,
+        key_hash: bytes,
+    ) -> SqlTurnOperation | None:
+        with self._session("select_by_replay_key") as session:
+            return session.execute(
+                select(SqlTurnOperation).where(
+                    SqlTurnOperation.workspace_id == current_workspace_id(),
+                    SqlTurnOperation.conversation_id == conversation_id,
+                    SqlTurnOperation.principal_hash == principal_hash,
+                    SqlTurnOperation.idempotency_key_hash == key_hash,
+                )
+            ).scalar_one_or_none()
+
+    def create_or_get(
+        self,
+        *,
+        conversation_id: str,
+        principal: str,
+        idempotency_key: str,
+        request: dict[str, Any],
+    ) -> tuple[TurnOperation, bool]:
+        _validate_principal(principal)
+        _validate_key(idempotency_key)
+        request_json = _canonical_request(request)
+        principal_hash = _digest("principal", principal)
+        key_hash = _digest("idempotency-key", idempotency_key)
+        request_hash = _digest("request", request_json)
+
+        existing = self._find_by_replay_key(conversation_id, principal_hash, key_hash)
+        if existing is not None:
+            return self._validate_replay(existing, request_hash, request_json), False
+
+        row = SqlTurnOperation(
+            id=uuid.uuid4().hex,
+            conversation_id=conversation_id,
+            principal_hash=principal_hash,
+            idempotency_key_hash=key_hash,
+            request_hash=request_hash,
+            request_json=request_json,
+            state=encode_turn_operation_state("accepted"),
+            item_id=None,
+            created_at=now_epoch(),
+            updated_at=None,
+            terminal_at=None,
+            error_code=None,
+            error=None,
+        )
+        try:
+            with self._write_session("insert_operation") as session:
+                session.add(row)
+                session.flush()
+                created = _to_entity(row)
+        except IntegrityError:
+            # A concurrent insert won the database unique key. Read and validate
+            # that row instead of inventing an application-level lock.
+            winner = self._find_by_replay_key(conversation_id, principal_hash, key_hash)
+            if winner is None:
+                raise
+            return self._validate_replay(winner, request_hash, request_json), False
+        return created, True
+
+    @staticmethod
+    def _validate_replay(
+        row: SqlTurnOperation,
+        request_hash: bytes,
+        request_json: str,
+    ) -> TurnOperation:
+        if bytes(row.request_hash) != request_hash or row.request_json != request_json:
+            raise TurnOperationConflict("idempotency key was already used for another request")
+        return _to_entity(row)
+
+    def get(self, operation_id: str) -> TurnOperation | None:
+        with self._session("select_by_id") as session:
+            row = session.get(SqlTurnOperation, (current_workspace_id(), operation_id))
+            return None if row is None else _to_entity(row)
+
+    def _require_row(self, session: Any, operation_id: str) -> SqlTurnOperation:
+        # PostgreSQL/MySQL need a row lock for read-check-write lifecycle
+        # transitions. SQLite ignores FOR UPDATE but the write session already
+        # holds BEGIN IMMEDIATE, so all supported databases serialize here.
+        row = session.get(
+            SqlTurnOperation,
+            (current_workspace_id(), operation_id),
+            with_for_update=True,
+        )
+        if row is None:
+            raise KeyError(operation_id)
+        return row
+
+    def mark_input_persisted(self, operation_id: str, item_id: str) -> TurnOperation:
+        with self._write_session("mark_input_persisted") as session:
+            row = self._require_row(session, operation_id)
+            state = decode_turn_operation_state(row.state)
+            if state == "accepted":
+                row.state = encode_turn_operation_state("input_persisted")
+                row.item_id = item_id
+                row.updated_at = now_epoch()
+            elif row.item_id != item_id:
+                raise TurnOperationStateError("operation is already bound to another input item")
+            return _to_entity(row)
+
+    def mark_dispatch_result(
+        self,
+        operation_id: str,
+        *,
+        state: str,
+        error_code: str | None = None,
+        error: str | None = None,
+    ) -> TurnOperation:
+        if state not in _DISPATCH_STATES:
+            raise ValueError("dispatch result must be dispatched or dispatch_unknown")
+        with self._write_session("mark_dispatch_result") as session:
+            row = self._require_row(session, operation_id)
+            current = decode_turn_operation_state(row.state)
+            if current == "input_persisted" or (
+                current == "dispatch_unknown" and state == "dispatched"
+            ):
+                row.state = encode_turn_operation_state(state)
+                row.updated_at = now_epoch()
+                row.error_code = error_code
+                row.error = error
+            elif current != state:
+                raise TurnOperationStateError(f"cannot transition {current} to {state}")
+            elif row.error_code != error_code or row.error != error:
+                raise TurnOperationStateError("dispatch replay changed the recorded outcome")
+            return _to_entity(row)
+
+    def mark_terminal(
+        self,
+        operation_id: str,
+        *,
+        state: str,
+        error_code: str | None = None,
+        error: str | None = None,
+    ) -> TurnOperation:
+        if state not in TURN_OPERATION_TERMINAL_STATES:
+            raise ValueError("terminal state is invalid")
+        with self._write_session("mark_terminal") as session:
+            row = self._require_row(session, operation_id)
+            current = decode_turn_operation_state(row.state)
+            if current in _DISPATCH_STATES:
+                now = now_epoch()
+                row.state = encode_turn_operation_state(state)
+                row.updated_at = now
+                row.terminal_at = now
+                row.error_code = error_code
+                row.error = error
+            elif current != state:
+                raise TurnOperationStateError(f"cannot transition {current} to {state}")
+            elif row.error_code != error_code or row.error != error:
+                raise TurnOperationStateError("terminal replay changed the recorded outcome")
+            return _to_entity(row)
+
+    def delete_for_conversation(self, conversation_id: str) -> int:
+        with self._write_session("delete_for_conversation") as session:
+            result = session.execute(
+                delete(SqlTurnOperation).where(
+                    SqlTurnOperation.workspace_id == current_workspace_id(),
+                    SqlTurnOperation.conversation_id == conversation_id,
+                )
+            )
+            return int(cast(CursorResult[Any], result).rowcount or 0)

--- a/tests/db/test_migration_turn_operations.py
+++ b/tests/db/test_migration_turn_operations.py
@@ -1,0 +1,54 @@
+"""Migration coverage for the durable turn-operation journal."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from sqlalchemy import create_engine, inspect
+
+from omnigent.db.utils import _build_alembic_config
+
+
+def test_turn_operations_upgrade_and_downgrade(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path}/turn-operations-migration.db"
+    config = _build_alembic_config(uri)
+
+    command.upgrade(config, "head")
+    engine = create_engine(uri)
+    inspector = inspect(engine)
+    assert "turn_operations" in inspector.get_table_names()
+    assert {column["name"] for column in inspector.get_columns("turn_operations")} == {
+        "workspace_id",
+        "id",
+        "conversation_id",
+        "principal_hash",
+        "idempotency_key_hash",
+        "request_hash",
+        "request_json",
+        "state",
+        "item_id",
+        "created_at",
+        "updated_at",
+        "terminal_at",
+        "error_code",
+        "error",
+    }
+    unique_constraints = {
+        constraint["name"]: tuple(constraint["column_names"])
+        for constraint in inspector.get_unique_constraints("turn_operations")
+    }
+    assert unique_constraints["uq_turn_operations_replay_key"] == (
+        "workspace_id",
+        "conversation_id",
+        "principal_hash",
+        "idempotency_key_hash",
+    )
+    indexes = {index["name"] for index in inspector.get_indexes("turn_operations")}
+    assert "ix_turn_operations_conversation_state" in indexes
+
+    engine.dispose()
+    command.downgrade(config, "za2b3c4d5e6f")
+    downgraded = create_engine(uri)
+    assert "turn_operations" not in inspect(downgraded).get_table_names()
+    downgraded.dispose()

--- a/tests/stores/test_turn_operation_store.py
+++ b/tests/stores/test_turn_operation_store.py
@@ -1,0 +1,263 @@
+"""Tests for the durable turn-operation replay journal."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from omnigent.db.db_models import workspace_scope
+from omnigent.stores.turn_operation_store import (
+    TurnOperationConflict,
+    TurnOperationStateError,
+)
+from omnigent.stores.turn_operation_store.sqlalchemy_store import (
+    SqlAlchemyTurnOperationStore,
+)
+
+
+def _uid(seed: str) -> str:
+    return uuid.uuid5(uuid.NAMESPACE_DNS, seed).hex
+
+
+@pytest.fixture()
+def store(db_uri: str) -> SqlAlchemyTurnOperationStore:
+    return SqlAlchemyTurnOperationStore(db_uri)
+
+
+def _create(
+    store: SqlAlchemyTurnOperationStore,
+    *,
+    conversation_id: str | None = None,
+    key: str = "attempt-1",
+    request: dict[str, object] | None = None,
+):
+    return store.create_or_get(
+        conversation_id=conversation_id or _uid("conversation"),
+        principal="agentfactory:workflow-principal",
+        idempotency_key=key,
+        request=request or {"message": {"content": "build it"}, "version": "v1alpha1"},
+    )
+
+
+def test_create_and_exact_replay_return_one_operation(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    first, created = _create(store)
+    replay, replay_created = _create(
+        store,
+        request={"version": "v1alpha1", "message": {"content": "build it"}},
+    )
+
+    assert created is True
+    assert replay_created is False
+    assert replay == first
+    assert first.state == "accepted"
+    assert first.item_id is None
+    assert json.loads(first.request_json) == {
+        "message": {"content": "build it"},
+        "version": "v1alpha1",
+    }
+    assert len(first.principal_hash) == 64
+    assert len(first.idempotency_key_hash) == 64
+    assert len(first.request_hash) == 64
+    assert "attempt-1" not in first.request_json
+    assert "workflow-principal" not in first.request_json
+
+
+def test_same_key_changed_body_conflicts(store: SqlAlchemyTurnOperationStore) -> None:
+    _create(store)
+    with pytest.raises(TurnOperationConflict, match="another request"):
+        _create(store, request={"message": {"content": "different"}})
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["", "contains space", "line\nbreak", "x" * 256, "snowman-☃"],
+)
+def test_invalid_idempotency_keys_are_rejected(
+    store: SqlAlchemyTurnOperationStore,
+    key: str,
+) -> None:
+    with pytest.raises(ValueError, match="visible ASCII"):
+        _create(store, key=key)
+
+
+@pytest.mark.parametrize("principal", ["", "☃" * 257])
+def test_invalid_principal_is_rejected(
+    store: SqlAlchemyTurnOperationStore,
+    principal: str,
+) -> None:
+    with pytest.raises(ValueError, match="principal"):
+        store.create_or_get(
+            conversation_id=_uid("conversation"),
+            principal=principal,
+            idempotency_key="attempt-1",
+            request={"message": {"content": "build it"}},
+        )
+
+
+def test_request_must_be_finite_json_and_bounded(store: SqlAlchemyTurnOperationStore) -> None:
+    with pytest.raises(ValueError, match="canonical JSON"):
+        _create(store, request={"value": float("nan")})
+    with pytest.raises(ValueError, match="8 MiB"):
+        _create(store, key="large", request={"value": "x" * (8 * 1024 * 1024)})
+
+
+def test_lifecycle_and_exact_replays_are_idempotent(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    operation, _ = _create(store)
+    item_id = _uid("input-item")
+
+    persisted = store.mark_input_persisted(operation.id, item_id)
+    assert persisted.state == "input_persisted"
+    assert store.mark_input_persisted(operation.id, item_id) == persisted
+
+    dispatched = store.mark_dispatch_result(operation.id, state="dispatched")
+    assert dispatched.state == "dispatched"
+    assert store.mark_dispatch_result(operation.id, state="dispatched") == dispatched
+
+    terminal = store.mark_terminal(operation.id, state="succeeded")
+    assert terminal.state == "succeeded"
+    assert terminal.terminal_at is not None
+    assert store.mark_terminal(operation.id, state="succeeded") == terminal
+    assert store.get(operation.id) == terminal
+
+
+def test_transport_ambiguity_requires_explicit_reconciliation(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    operation, _ = _create(store)
+    store.mark_input_persisted(operation.id, _uid("input-item"))
+    unknown = store.mark_dispatch_result(
+        operation.id,
+        state="dispatch_unknown",
+        error_code="runner_timeout",
+        error="runner acceptance was not observed",
+    )
+    assert unknown.state == "dispatch_unknown"
+
+    with pytest.raises(TurnOperationStateError, match="recorded outcome"):
+        store.mark_dispatch_result(operation.id, state="dispatch_unknown")
+
+    reconciled = store.mark_dispatch_result(operation.id, state="dispatched")
+    assert reconciled.state == "dispatched"
+    assert reconciled.error is None
+
+
+def test_terminal_report_can_resolve_dispatch_unknown(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    operation, _ = _create(store)
+    store.mark_input_persisted(operation.id, _uid("input-item"))
+    store.mark_dispatch_result(operation.id, state="dispatch_unknown")
+    terminal = store.mark_terminal(
+        operation.id,
+        state="failed",
+        error_code="provider_failed",
+        error="provider returned a terminal failure",
+    )
+    assert terminal.state == "failed"
+    assert terminal.error_code == "provider_failed"
+
+
+def test_invalid_or_conflicting_transitions_fail_closed(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    operation, _ = _create(store)
+    with pytest.raises(TurnOperationStateError, match="accepted to dispatched"):
+        store.mark_dispatch_result(operation.id, state="dispatched")
+    with pytest.raises(TurnOperationStateError, match="accepted to succeeded"):
+        store.mark_terminal(operation.id, state="succeeded")
+
+    item_id = _uid("input-item")
+    store.mark_input_persisted(operation.id, item_id)
+    with pytest.raises(TurnOperationStateError, match="another input item"):
+        store.mark_input_persisted(operation.id, _uid("other-item"))
+    with pytest.raises(ValueError, match="dispatch result"):
+        store.mark_dispatch_result(operation.id, state="failed")
+    with pytest.raises(ValueError, match="terminal state"):
+        store.mark_terminal(operation.id, state="running")
+
+    store.mark_dispatch_result(operation.id, state="dispatched")
+    store.mark_terminal(operation.id, state="failed", error="first report")
+    with pytest.raises(TurnOperationStateError, match="terminal replay changed"):
+        store.mark_terminal(operation.id, state="failed", error="changed report")
+
+
+def test_unknown_operation_reads_none_and_mutations_raise_key_error(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    operation_id = _uid("unknown-operation")
+    assert store.get(operation_id) is None
+    with pytest.raises(KeyError, match=operation_id):
+        store.mark_input_persisted(operation_id, _uid("input-item"))
+
+
+def test_workspace_and_conversation_scope_are_independent(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    conversation_id = _uid("conversation")
+    with workspace_scope(1):
+        first, _ = _create(store, conversation_id=conversation_id)
+    with workspace_scope(2):
+        second, _ = _create(store, conversation_id=conversation_id)
+    assert first.id != second.id
+    assert first.workspace_id == 1
+    assert second.workspace_id == 2
+
+
+def test_concurrent_create_converges_on_database_unique_key(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path}/turn-operations.db"
+    store = SqlAlchemyTurnOperationStore(uri)
+
+    def create() -> tuple[str, bool]:
+        operation, created = _create(store)
+        return operation.id, created
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: create(), range(24)))
+
+    assert len({operation_id for operation_id, _ in results}) == 1
+    assert sum(1 for _, created in results if created) == 1
+
+
+def test_concurrent_conflicting_terminal_reports_have_one_winner(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path}/turn-terminal.db"
+    store = SqlAlchemyTurnOperationStore(uri)
+    operation, _ = _create(store)
+    store.mark_input_persisted(operation.id, _uid("input-item"))
+    store.mark_dispatch_result(operation.id, state="dispatched")
+
+    def report(state: str) -> str:
+        try:
+            return store.mark_terminal(operation.id, state=state).state
+        except TurnOperationStateError:
+            return "conflict"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(report, ["succeeded", "failed"]))
+
+    assert results.count("conflict") == 1
+    winner = next(state for state in results if state != "conflict")
+    durable = store.get(operation.id)
+    assert durable is not None
+    assert durable.state == winner
+
+
+def test_delete_for_conversation_is_scoped_and_idempotent(
+    store: SqlAlchemyTurnOperationStore,
+) -> None:
+    conversation = _uid("conversation")
+    other = _uid("other-conversation")
+    _create(store, conversation_id=conversation, key="one")
+    _create(store, conversation_id=conversation, key="two")
+    survivor, _ = _create(store, conversation_id=other)
+
+    assert store.delete_for_conversation(conversation) == 2
+    assert store.delete_for_conversation(conversation) == 0
+    assert store.get(survivor.id) == survivor


### PR DESCRIPTION
## Related issue

Part of #4861

## Summary

- add a database-enforced replay journal for one external turn operation, scoped by workspace, session, authenticated-principal digest, and idempotency-key digest
- persist the canonical request for crash recovery and reject same-key/different-body reuse
- model `dispatch_unknown` explicitly so a runner timeout can never be treated as proof that execution did not start
- add serialized lifecycle transitions, immutable terminal reports, a portable Alembic migration, and the safety contract in `designs/TURN_OPERATIONS.md`

ELI5: Omnigent now has a durable receipt for a future external turn request. Retrying the same request finds the same receipt; changing the request under the same key is rejected. The receipt is not wired to dispatch yet, so this PR cannot start work or change current runtime behavior.

```text
accepted -> input_persisted -> dispatched -> terminal
                              \\-> dispatch_unknown -> reconcile before retry
```

## Test Plan

- `python -m pytest -q tests/stores/test_turn_operation_store.py tests/db/test_migration_turn_operations.py tests/db/test_enum_codecs.py` — 70 passed post-commit
- focused journal suite — 19 passed, including concurrent create and conflicting terminal reports
- migration upgrade -> downgrade -> upgrade — passed
- store/database regression run — 960 passed, 2 skipped; the three optional psycopg-driver tests initially failed before assertions because the reused local venv lacked psycopg, then passed 3/3 with an isolated temporary `psycopg[binary]`
- focused coverage — 97% for `omnigent.stores.turn_operation_store`
- Ruff check/format, changed-file Pyrefly, and `git diff --check` — passed

## Demo

N/A — persistence foundation only; no public route or UI is enabled.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The migration test exercises a real SQLite upgrade/downgrade. PostgreSQL/MySQL portability is encoded with fixed-size binary digest variants and will be exercised by the repository's authoritative store CI. Public endpoint, runner dedupe/status, and cursor E2E coverage belong to the follow-up tranches and are deliberately not claimed here.

## Changelog

External orchestrators can build on a durable, replay-safe journal for session turn operations.
