### PR TITLE
fix ACP model truth and completed runner disconnects

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -302,6 +302,7 @@ class AcpExecutor(Executor):
         # and the live model value, both learned from ``config_option_update``.
         self._config_option_ids: set[str] = set()
         self._active_model: str | None = None
+        self._model_config_option_id: str | None = None
         # Latches off once an agent proves it can't warm-switch, so we don't
         # retry a failing request on every turn.
         self._model_switch_supported: bool = True
@@ -681,6 +682,12 @@ class AcpExecutor(Executor):
             )
         result = resp.get("result", {})
         server_session_id = result.get("sessionId") if isinstance(result, dict) else None
+        if isinstance(result, dict):
+            self._note_config_options(result.get("configOptions"))
+        models = result.get("models") if isinstance(result, dict) else None
+        current_model = models.get("currentModelId") if isinstance(models, dict) else None
+        if self._active_model is None and isinstance(current_model, str) and current_model:
+            self._active_model = current_model
         session_id = server_session_id or client_id
         if not session_id:
             raise RuntimeError(
@@ -1125,7 +1132,8 @@ class AcpExecutor(Executor):
             if not isinstance(opt_id, str):
                 continue
             self._config_option_ids.add(opt_id)
-            if opt_id == _CONFIG_OPTION_MODEL:
+            if opt.get("category") == _CONFIG_OPTION_MODEL or opt_id == _CONFIG_OPTION_MODEL:
+                self._model_config_option_id = opt_id
                 current = opt.get("currentValue")
                 if isinstance(current, str) and current:
                     self._active_model = current
@@ -1153,7 +1161,7 @@ class AcpExecutor(Executor):
             return
         # Before the first ``config_option_update`` we don't know what's settable;
         # attempting is harmless because a rejection just latches the feature off.
-        if self._config_option_ids and _CONFIG_OPTION_MODEL not in self._config_option_ids:
+        if self._config_option_ids and self._model_config_option_id is None:
             self._model_switch_supported = False
             logger.info(
                 "acp[%s] agent exposes no %r config option; leaving model as-is",
@@ -1164,7 +1172,11 @@ class AcpExecutor(Executor):
 
         response = await self._rpc(
             _AGENT_METHOD_SET_CONFIG_OPTION,
-            {"sessionId": session_id, "configId": _CONFIG_OPTION_MODEL, "value": model},
+            {
+                "sessionId": session_id,
+                "configId": self._model_config_option_id or _CONFIG_OPTION_MODEL,
+                "value": model,
+            },
         )
         if "error" in response:
             self._model_switch_supported = False
@@ -1279,7 +1291,14 @@ class AcpExecutor(Executor):
                 stale = self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-            if isinstance(stale, dict) and stale.get("id") is not None and stale.get("method"):
+            if stale.get("method") == _CLIENT_NOTIFICATION_SESSION_UPDATE:
+                update = (stale.get("params") or {}).get("update")
+                if (
+                    isinstance(update, dict)
+                    and update.get("sessionUpdate") == _UPDATE_CONFIG_OPTION
+                ):
+                    self._note_config_options(update.get("configOptions"))
+            elif stale.get("id") is not None and stale.get("method"):
                 await self._respond_to_agent_request(stale)
 
         self._rpc_id += 1
@@ -1325,6 +1344,8 @@ class AcpExecutor(Executor):
                     return
                 result = response.get("result", {}) if isinstance(response, dict) else {}
                 usage = self._usage_from_result(result) if isinstance(result, dict) else None
+                if self._active_model:
+                    usage = {**(usage or {}), "model": self._active_model}
                 yield TurnComplete(response="".join(accumulated_text), usage=usage)
                 return
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -57,6 +57,7 @@ from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
     native_coding_agent_for_harness,
 )
+from omnigent.onboarding.provider_config import harness_owns_its_credential
 from omnigent.policies.types import (
     ElicitationRequest,
     EvaluationContext,
@@ -250,6 +251,7 @@ from omnigent.server.routes._sessions.helpers import (
     _parse_external_conversation_item,
     _pending_elicitation_snapshot_for_session,
     _permission_level_from_grants,
+    _persist_external_model_change,
     _persist_native_policy_notice,
     _persist_session_status_error_labels,
     _persist_stored_session_bundle,
@@ -6067,6 +6069,29 @@ async def _relay_runner_stream_once(
                     # response so policy callables can read
                     # event["context"]["usage"]["total_cost_usd"].
                     if evt_type == "response.completed":
+                        response = event.get("response")
+                        usage = response.get("usage") if isinstance(response, dict) else None
+                        reported_model = usage.get("model") if isinstance(usage, dict) else None
+                        if isinstance(reported_model, str) and reported_model:
+                            conv = await asyncio.to_thread(
+                                conversation_store.get_conversation,
+                                session_id,
+                            )
+                            harness = _resolve_harness(conv)
+                            if (
+                                conv is not None
+                                and harness is not None
+                                and harness_owns_its_credential(harness)
+                            ):
+                                await _persist_external_model_change(
+                                    session_id,
+                                    conv,
+                                    SessionEventInput(
+                                        type="external_model_change",
+                                        data={"model": reported_model},
+                                    ),
+                                    conversation_store,
+                                )
                         # Persist the turn's usage (cost + token buckets) so
                         # policy callables can read
                         # event["context"]["usage"]["total_cost_usd"] and the
@@ -9109,6 +9134,7 @@ async def _get_session_snapshot(
     llm_model: str | None = None
     context_window: int | None = None
     agent_name: str | None = None
+    harness_owns_model = False
     if agent_store is not None and agent_cache is not None and conv.agent_id is not None:
         try:
             agent = await asyncio.to_thread(agent_store.get, conv.agent_id)
@@ -9130,6 +9156,8 @@ async def _get_session_snapshot(
                         child_spec = _find_spec_by_name(spec, conv.sub_agent_name)
                         if child_spec is not None:
                             spec = child_spec
+                    effective_harness = conv.harness_override or _spec_harness(spec)
+                    harness_owns_model = harness_owns_its_credential(effective_harness)
                     # Prefer the spec's name over the agent row's: a
                     # switch-created session-scoped clone is named
                     # "<builtin> (switch ag_…)" for row disambiguation,
@@ -9137,7 +9165,7 @@ async def _get_session_snapshot(
                     # carries the clean identity (e.g. "claude-native-ui").
                     if spec.name:
                         agent_name = spec.name
-                    llm_model = spec.executor.model
+                    llm_model = None if harness_owns_model else spec.executor.model
 
                     # Size the context ring against whatever the next turn will
                     # actually run, using the SAME resolver the runner uses to
@@ -9158,7 +9186,7 @@ async def _get_session_snapshot(
                     # event loop and serialize every concurrent snapshot.
                     context_window = await asyncio.to_thread(
                         resolve_effective_context_window,
-                        spec.executor.context_window,
+                        None if harness_owns_model else spec.executor.context_window,
                         llm_model,
                         model_override=conv.model_override,
                     )

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5675,7 +5675,7 @@ async def _relay_runner_stream(
                     None,
                     conversation_store,
                 )
-            else:
+            elif _session_status_cache.get(session_id) != "idle":
                 # Publish a failed status so the client's SSE stream sees a
                 # clean error event instead of silent truncation (#1114).
                 disconnect_error = ErrorDetail(

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -88,6 +88,51 @@ async def test_session_new_server_mode_adopts_returned_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_new_records_standard_model_config_option() -> None:
+    """ACP config-option categories identify the live model; option ids are agent-defined."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+
+    async def fake_rpc(method, params, timeout=30.0):
+        return {
+            "result": {
+                "sessionId": "srv-42",
+                "configOptions": [
+                    {
+                        "id": "active-model",
+                        "category": "model",
+                        "currentValue": "grok-4.6",
+                    }
+                ],
+            }
+        }
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._ensure_session()
+
+    assert ex._active_model == "grok-4.6"
+    assert ex._model_config_option_id == "active-model"
+
+
+@pytest.mark.asyncio
+async def test_session_new_records_legacy_model_state() -> None:
+    """Grok 1.0.4's preview ``models`` state still reports its real launch model."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+
+    async def fake_rpc(method, params, timeout=30.0):
+        return {
+            "result": {
+                "sessionId": "srv-42",
+                "models": {"currentModelId": "grok-4.6", "availableModels": []},
+            }
+        }
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._ensure_session()
+
+    assert ex._active_model == "grok-4.6"
+
+
+@pytest.mark.asyncio
 async def test_session_new_sends_empty_mcp_servers_when_omnigent_mcp_disabled() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
     captured: dict = {}
@@ -602,7 +647,13 @@ for line in sys.stdin:
             "agentCapabilities": {"promptCapabilities": {"image": False}},
         }})
     elif method == "session/new":
-        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "fake-session-1"}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "sessionId": "fake-session-1",
+            "models": {"currentModelId": "grok-4.5", "availableModels": []},
+        }})
+        update("fake-session-1", {"sessionUpdate": "config_option_update", "configOptions": [
+            {"id": "active-model", "category": "model", "currentValue": "grok-4.6"},
+        ]})
     elif method == "session/prompt":
         sid = msg["params"]["sessionId"]
         chunk(sid, "agent_thought_chunk", "planning")
@@ -663,7 +714,12 @@ async def test_end_to_end_against_fake_acp_agent(tmp_path: Path) -> None:
 
     completions = [e for e in events if isinstance(e, TurnComplete)]
     assert len(completions) == 1
-    assert completions[0].usage == {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    assert completions[0].usage == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "model": "grok-4.6",
+    }
 
     tool_reqs = [e for e in events if isinstance(e, ToolCallRequest)]
     assert tool_reqs[0].name == "shell" and tool_reqs[0].args == {"command": "echo hi"}

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -828,6 +828,36 @@ class _ScriptedThenDropRunnerClient:
 
 
 @pytest.mark.asyncio
+async def test_relay_keeps_completed_session_idle_when_tunnel_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later tunnel close must not retroactively fail a completed turn."""
+    from omnigent.server.routes._sessions import orchestration
+
+    monkeypatch.setattr(orchestration, "RUNNER_DISCONNECT_GRACE_S", 0.0)
+
+    async def drop(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise orchestration._RelayTransportLost(intentional=False)
+
+    monkeypatch.setattr(orchestration, "_relay_runner_stream_once", drop)
+    session_id = "6d8fd21e91f746929cdf56ed9a9f5032"
+    orchestration._session_status_cache[session_id] = "idle"
+    store = _RecordingLabelStore()
+
+    try:
+        await orchestration._relay_runner_stream(
+            session_id,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            store,  # type: ignore[arg-type]
+        )
+        assert orchestration._session_status_cache.get(session_id) == "idle"
+        assert store.labels.get(session_id) is None
+    finally:
+        orchestration._session_status_cache.pop(session_id, None)
+
+
+@pytest.mark.asyncio
 async def test_relay_running_edge_clears_stale_intentional_stop_marker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -249,6 +249,59 @@ class _ScriptedRunnerClient:
 
 
 @pytest.mark.asyncio
+async def test_relay_persists_acp_reported_model(db_uri: str) -> None:
+    """A vendor-owned ACP model becomes the session's durable active model."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation()
+    store.update_conversation(conv.id, harness_override="grok")
+    release = asyncio.Event()
+    fake_runner = _ScriptedRunnerClient(
+        release,
+        [
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_grok_model",
+                    "model": "polly",
+                    "usage": {"model": "grok-4.6"},
+                },
+            }
+        ],
+    )
+
+    collector = None
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            conv.id,
+            "runner_grok_model",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,
+        )
+        assert handle is not None
+        collector = await start_session_stream_collector(conv.id)
+        release.set()
+
+        model_event = await collector.next_event()
+        assert model_event["type"] == "session.model"
+        assert model_event["conversation_id"] == conv.id
+        assert model_event["model"] == "grok-4.6"
+        assert store.get_conversation(conv.id).model_override == "grok-4.6"
+    finally:
+        release.set()
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(conv.id)
+        if handle is not None:
+            await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        session_stream.close(conv.id)
+
+
+@pytest.mark.asyncio
 async def test_relay_text_flush_publishes_persisted_item(db_uri: str) -> None:
     """
     The relay's text flush publishes the persisted message to live clients.

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -349,6 +349,64 @@ async def test_session_snapshot_uses_child_spec_metadata(
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_does_not_claim_agent_model_for_vendor_owned_acp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Grok override must not inherit the bound agent's unrelated model pin."""
+    spec = AgentSpec(
+        spec_version=1,
+        name="polly",
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="claude-opus-5",
+            context_window=1_000_000,
+        ),
+    )
+    conv = Conversation(
+        id="conv_grok",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_grok",
+        agent_id="ag_polly",
+        harness_override="grok",
+    )
+    store = _ConversationStore([], conversations={conv.id: conv})
+
+    class _AgentStore:
+        @staticmethod
+        def get(agent_id: str) -> Any:
+            return type(
+                "StoredAgent",
+                (),
+                {
+                    "id": agent_id,
+                    "name": "polly",
+                    "bundle_location": "bundle",
+                    "session_id": None,
+                },
+            )()
+
+    class _AgentCache:
+        @staticmethod
+        def load(agent_id: str, bundle_location: str, *, expand_env: bool = False) -> Any:
+            return type("LoadedAgent", (), {"spec": spec})()
+
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: None)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+
+    snapshot = await _get_session_snapshot(
+        store,  # type: ignore[arg-type]
+        conv.id,
+        agent_store=_AgentStore(),  # type: ignore[arg-type]
+        agent_cache=_AgentCache(),  # type: ignore[arg-type]
+    )
+
+    assert snapshot.harness == "grok"
+    assert snapshot.llm_model is None
+    assert snapshot.context_window is None
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_populates_runner_online_from_session_lookup() -> None:
     """GET /sessions/{id} carries session-scoped runner + host liveness."""
     conv_store = _ConversationStore([_message_item("item_1", "hi")])


### PR DESCRIPTION
## Related issue

Closes #4869
Closes #4872

## Summary

- Read the active model from standard ACP session config options, with compatibility for the legacy model state returned by Grok Build 1.0.4.
- Carry the ACP-reported model through turn completion, persist it as the session model override, and publish the existing `session.model` event.
- Do not present the bound agent spec model as the model for a self-authenticated ACP harness before that harness reports its own model.
- Preserve an already-idle session when its host runner later disconnects instead of retroactively publishing `runner_disconnected`.

ELI5: the UI was reading the model written on the agent definition even when a separate ACP program chose the real model. The ACP program now reports its selection through the existing completion path, and completed sessions keep that successful state if their runner later exits.

```text
ACP session state -> TurnComplete usage -> response.completed -> model_override -> session snapshot/UI
idle session + later tunnel close -> remain idle
```

## Test Plan

- `uv run pytest tests/inner/test_acp_executor.py tests/server/routes/test_sessions_runner_relay.py tests/server/routes/test_sessions_snapshot.py -q` (132 passed)
- `uv run ruff check` and `uv run ruff format --check` on all changed files
- `uv run pyrefly check omnigent/inner/acp_executor.py omnigent/server/routes/_sessions/orchestration.py`
- Live Grok Build 1.0.4 verification: a Polly session initially displayed `Polly (Grok Build)`, replied `grok-4.6`, persisted that reported model, updated the composer label to `grok-4.6`, and returned to idle.

## Demo

N/A — no frontend component changed. The server now supplies truthful state to the existing model label and status UI; automated snapshot/relay tests and the live verification above cover both visible transitions.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

ACP protocol tests cover standard `configOptions`, Grok Build legacy `models`, and a pre-prompt config update. Server tests cover durable model persistence, the live `session.model` event, truthful pre-observation snapshots, and an idle session surviving a later tunnel close. Manual verification used a live authenticated Grok Build 1.0.4 session on `ubuntu-root`.

## Changelog

ACP-backed sessions now display the model selected by the running harness, and completed host sessions no longer become failed when their runner later disconnects.
