### PR TITLE
feat(runner): add replay-safe turn operations

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6769,6 +6769,10 @@ def create_runner_app(
             message_body = dict(body)
             message_body["conversation_id"] = conversation_id
             operation_request = dict(message_body) if operation_id is not None else None
+            _note_session_harness_override(
+                conversation_id,
+                cast(str | None, message_body.get("harness_override")),
+            )
 
             if operation_id is None and _is_native_harness(conversation_id):
                 resource_registry.note_session_turn_started(conversation_id)
@@ -6939,15 +6943,20 @@ def create_runner_app(
                         )
                     _turn_operation_registry.mark_running(operation_id)
                     _active_operation_ids[conversation_id] = operation_id
-                    if _is_native_harness(conversation_id):
+                try:
+                    if operation_id is not None and _is_native_harness(conversation_id):
                         resource_registry.note_session_turn_started(conversation_id)
 
-                if loaded_history is None:
-                    _session_histories[conversation_id].append(new_item)
-                else:
-                    loaded_history.append(new_item)
-                    _session_histories[conversation_id] = loaded_history
-                _begin_turn_slot(conversation_id)
+                    if loaded_history is None:
+                        _session_histories[conversation_id].append(new_item)
+                    else:
+                        loaded_history.append(new_item)
+                        _session_histories[conversation_id] = loaded_history
+                    _begin_turn_slot(conversation_id)
+                except Exception:
+                    if operation_id is not None:
+                        _terminalize_turn_operation(conversation_id, "failed")
+                    raise
                 _logger.info(
                     "post_session_events: starting background turn conv=%s",
                     conversation_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -151,6 +151,13 @@ from omnigent.runner.subagent_routing import (
     routing_class_from_snapshot,
     session_routing_class,
 )
+from omnigent.runner.turn_operations import (
+    InvalidTurnOperation,
+    RunnerTurnOperationRegistry,
+    TurnOperationCapacityError,
+    TurnOperationConflict,
+    TurnOperationStateError,
+)
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
 from omnigent.server.schemas import (
     BackgroundSessionTitleRequest,
@@ -2069,6 +2076,12 @@ def create_runner_app(
     _repl_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _active_turns: dict[str, asyncio.Task[None] | None] = {}
     app.state.active_turns = _active_turns
+    _runner_incarnation_id = uuid.uuid4().hex
+    _turn_operation_registry = RunnerTurnOperationRegistry()
+    _active_operation_ids: dict[str, str] = {}
+    app.state.runner_incarnation_id = _runner_incarnation_id
+    app.state.turn_operation_registry = _turn_operation_registry
+    app.state.active_operation_ids = _active_operation_ids
     _native_pane_status: dict[str, str] = {}
     _session_message_buffers: dict[str, list[dict[str, Any]]] = {}
     app.state.session_message_buffers = _session_message_buffers
@@ -3422,6 +3435,9 @@ def create_runner_app(
 
     @app.delete("/v1/sessions/{session_id}")
     async def delete_session(session_id: str) -> JSONResponse:
+        if session_id in _active_turns:
+            _interrupted_sessions.add(session_id)
+        _terminalize_turn_operation(session_id, "cancelled")
         turn_task = _active_turns.pop(session_id, None)
         if turn_task is not None and isinstance(turn_task, asyncio.Task):
             turn_task.cancel()
@@ -4979,6 +4995,24 @@ def create_runner_app(
         if process_manager is not None:
             process_manager.clear_in_flight(conv_id)
 
+    def _terminalize_turn_operation(conv_id: str, terminal_state: str) -> None:
+        """Finalize and unbind the operation owned by one live turn, if any."""
+        operation_id = _active_operation_ids.pop(conv_id, None)
+        if operation_id is None:
+            return
+        try:
+            _turn_operation_registry.mark_terminal(operation_id, terminal_state)
+        except (KeyError, TurnOperationStateError, ValueError):
+            # Lifecycle disagreement must never wedge normal turn cleanup.
+            # The status endpoint remains fail-closed at its last runner-local
+            # state and the server coordinator will reconcile.
+            _logger.exception(
+                "turn operation terminal update failed: session=%s operation=%s target=%s",
+                conv_id,
+                operation_id,
+                terminal_state,
+            )
+
     def _sweep_dead_turn_slot(conv_id: str, occupant: asyncio.Task[None] | None) -> bool:
         """Remove a completed turn and all its per-turn tokens together (identity-guarded).
 
@@ -4986,6 +5020,21 @@ def create_runner_app(
         """
         if _active_turns.get(conv_id) is not occupant:
             return False
+        was_interrupted = conv_id in _interrupted_sessions
+        occupant_failed = False
+        if isinstance(occupant, asyncio.Task) and not occupant.cancelled():
+            occupant_failed = occupant.exception() is not None
+        terminal_state = (
+            "failed"
+            if conv_id in _desynced_sessions
+            else "cancelled"
+            if was_interrupted
+            else "failed"
+            if occupant_failed
+            else "succeeded"
+        )
+        _terminalize_turn_operation(conv_id, terminal_state)
+
         _active_turns.pop(conv_id, None)
         _release_live_turn_markers(conv_id)
         _interrupted_sessions.discard(conv_id)
@@ -5008,13 +5057,24 @@ def create_runner_app(
             )
             return
 
+        was_interrupted = conv_id in _interrupted_sessions
+        terminal_state = (
+            "failed"
+            if conv_id in _desynced_sessions
+            else "cancelled"
+            if was_interrupted
+            else "failed"
+            if error is not None
+            else "succeeded"
+        )
+        _terminalize_turn_operation(conv_id, terminal_state)
+
         _active_turns.pop(conv_id, None)
         _release_live_turn_markers(conv_id)
         # Transport-loss ending desyncs harness from runner; flag for clean rebind.
         if error is not None and error.get("code") == "connection_error":
             _desynced_sessions.add(conv_id)
         has_buffered = bool(_session_message_buffers.get(conv_id))
-        was_interrupted = conv_id in _interrupted_sessions
         # Suppress terminal only if desync recovery claimed the token for THIS generation's epoch.
         _suppress_status = _desync_terminalized.get(conv_id) == _turn_bind_epoch.get(conv_id, 0)
         if _suppress_status:
@@ -5224,6 +5284,7 @@ def create_runner_app(
         )
         if stream_sentinel:
             _active_turns.pop(conv_id, None)
+            _terminalize_turn_operation(conv_id, "failed")
             await _forward_harness_interrupt(conv_id)
         else:
             await _cancel_inprocess_turn(conv_id)
@@ -6609,6 +6670,33 @@ def create_runner_app(
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
+    @app.get("/v1/turn-operations/{operation_id}")
+    async def get_turn_operation(operation_id: str) -> JSONResponse:
+        """Return runner-observed status for one operation in this incarnation."""
+        try:
+            operation = _turn_operation_registry.get(operation_id)
+        except InvalidTurnOperation as exc:
+            return JSONResponse(
+                status_code=400,
+                content={"error": "invalid_operation_id", "detail": str(exc)},
+            )
+        if operation is None:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "error": "operation_not_found",
+                    "detail": (
+                        "Operation is not known to this runner incarnation; "
+                        "do not infer that it was never dispatched."
+                    ),
+                    "runner_incarnation_id": _runner_incarnation_id,
+                },
+            )
+        return JSONResponse(
+            status_code=200,
+            content=operation.public_dict(runner_incarnation_id=_runner_incarnation_id),
+        )
+
     @app.post("/v1/sessions/{conversation_id}/events")
     async def post_session_events(
         conversation_id: str,
@@ -6630,6 +6718,33 @@ def create_runner_app(
 
         body = await request.json()
         body_type = body.get("type") if isinstance(body, dict) else None
+        raw_operation_id = body.get("operation_id") if isinstance(body, dict) else None
+        operation_id: str | None = None
+        if raw_operation_id is not None:
+            if body_type not in ("message", None):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "invalid_operation_request",
+                        "detail": "operation_id is supported only for message turns",
+                    },
+                )
+            if not isinstance(raw_operation_id, str):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "invalid_operation_id",
+                        "detail": "operation_id must be a string",
+                    },
+                )
+            try:
+                _turn_operation_registry.validate_operation_id(raw_operation_id)
+            except InvalidTurnOperation as exc:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "invalid_operation_id", "detail": str(exc)},
+                )
+            operation_id = raw_operation_id
         _logger.info(
             "post_session_events: conv=%s type=%s active=%s buffer_len=%d content_types=%s "
             "model_override=%s",
@@ -6653,8 +6768,9 @@ def create_runner_app(
                 )
             message_body = dict(body)
             message_body["conversation_id"] = conversation_id
+            operation_request = dict(message_body) if operation_id is not None else None
 
-            if _is_native_harness(conversation_id):
+            if operation_id is None and _is_native_harness(conversation_id):
                 resource_registry.note_session_turn_started(conversation_id)
 
             _seq = _ingest_next_seq.get(conversation_id, 0)
@@ -6667,6 +6783,48 @@ def create_runner_app(
                 while _ingest_now_serving.get(conversation_id, 0) != _seq:
                     await _cond.wait()
             try:
+                if operation_id is not None and operation_request is not None:
+                    existing_operation = _turn_operation_registry.get(operation_id)
+                    if existing_operation is not None:
+                        try:
+                            replay, _created = _turn_operation_registry.reserve(
+                                operation_id=operation_id,
+                                session_id=conversation_id,
+                                request=operation_request,
+                            )
+                        except InvalidTurnOperation as exc:
+                            return JSONResponse(
+                                status_code=400,
+                                content={
+                                    "error": "invalid_operation_request",
+                                    "detail": str(exc),
+                                },
+                            )
+                        except TurnOperationConflict as exc:
+                            return JSONResponse(
+                                status_code=409,
+                                content={"error": "operation_conflict", "detail": str(exc)},
+                            )
+                        return JSONResponse(
+                            status_code=202,
+                            content={
+                                **replay.public_dict(runner_incarnation_id=_runner_incarnation_id),
+                                "detail": "Idempotent operation replay; no new turn started.",
+                            },
+                        )
+                    if conversation_id in _active_turns:
+                        return JSONResponse(
+                            status_code=409,
+                            content={
+                                "error": "session_busy",
+                                "detail": (
+                                    "A durable operation turn is already active; retry after "
+                                    "its terminal status instead of buffering or merging turns."
+                                ),
+                                "runner_incarnation_id": _runner_incarnation_id,
+                            },
+                        )
+
                 _raw_content = message_body.get("content")
                 if isinstance(_raw_content, list):
                     message_body["content"] = await _resolve_forwarded_message_content(
@@ -6734,22 +6892,61 @@ def create_runner_app(
                         },
                     )
 
-                new_item = {
+                new_item: dict[str, Any] = {
                     "type": "message",
                     "role": message_body.get("role", "user"),
                     "content": message_body.get("content", []),
                 }
-                if conversation_id in _session_histories:
-                    _session_histories[conversation_id].append(new_item)
-                else:
+                loaded_history: list[dict[str, Any]] | None = None
+                if conversation_id not in _session_histories:
                     persisted_item_id = message_body.get("persisted_item_id")
-                    loaded = await _load_history_as_input(
+                    loaded_history = await _load_history_as_input(
                         conversation_id,
                         drop_item_id=persisted_item_id,
                     )
-                    loaded.append(new_item)
-                    _session_histories[conversation_id] = loaded
 
+                if operation_id is not None and operation_request is not None:
+                    try:
+                        operation, created = _turn_operation_registry.reserve(
+                            operation_id=operation_id,
+                            session_id=conversation_id,
+                            request=operation_request,
+                        )
+                    except InvalidTurnOperation as exc:
+                        return JSONResponse(
+                            status_code=400,
+                            content={"error": "invalid_operation_request", "detail": str(exc)},
+                        )
+                    except TurnOperationConflict as exc:
+                        return JSONResponse(
+                            status_code=409,
+                            content={"error": "operation_conflict", "detail": str(exc)},
+                        )
+                    except TurnOperationCapacityError as exc:
+                        return JSONResponse(
+                            status_code=503,
+                            content={"error": "operation_registry_full", "detail": str(exc)},
+                        )
+                    if not created:
+                        return JSONResponse(
+                            status_code=202,
+                            content={
+                                **operation.public_dict(
+                                    runner_incarnation_id=_runner_incarnation_id
+                                ),
+                                "detail": "Idempotent operation replay; no new turn started.",
+                            },
+                        )
+                    _turn_operation_registry.mark_running(operation_id)
+                    _active_operation_ids[conversation_id] = operation_id
+                    if _is_native_harness(conversation_id):
+                        resource_registry.note_session_turn_started(conversation_id)
+
+                if loaded_history is None:
+                    _session_histories[conversation_id].append(new_item)
+                else:
+                    loaded_history.append(new_item)
+                    _session_histories[conversation_id] = loaded_history
                 _begin_turn_slot(conversation_id)
                 _logger.info(
                     "post_session_events: starting background turn conv=%s",
@@ -6777,13 +6974,17 @@ def create_runner_app(
                 )
                 _background_tasks.add(_turn_task)
 
-                return JSONResponse(
-                    status_code=202,
-                    content={
-                        "status": "accepted",
-                        "detail": "Turn started.",
-                    },
-                )
+                response_content: dict[str, Any] = {
+                    "status": "accepted",
+                    "detail": "Turn started.",
+                }
+                if operation_id is not None:
+                    operation = _turn_operation_registry.get(operation_id)
+                    if operation is not None:
+                        response_content.update(
+                            operation.public_dict(runner_incarnation_id=_runner_incarnation_id)
+                        )
+                return JSONResponse(status_code=202, content=response_content)
             finally:
                 async with _cond:
                     _ingest_now_serving[conversation_id] = _seq + 1

--- a/omnigent/runner/turn_operations.py
+++ b/omnigent/runner/turn_operations.py
@@ -1,0 +1,163 @@
+"""Fail-closed runner-local deduplication for durable turn operation IDs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from typing import Any
+
+_OPERATION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_TERMINAL_STATES = frozenset({"succeeded", "failed", "cancelled"})
+
+
+class InvalidTurnOperation(ValueError):
+    """An operation identifier or request envelope is malformed."""
+
+
+class TurnOperationConflict(ValueError):
+    """An operation identifier was rebound or its request changed."""
+
+
+class TurnOperationCapacityError(RuntimeError):
+    """The fail-closed in-process replay registry reached its bound."""
+
+
+class TurnOperationStateError(RuntimeError):
+    """A lifecycle transition contradicts the runner's observed state."""
+
+
+@dataclass(frozen=True)
+class RunnerTurnOperation:
+    """Runner-observed state for one server-owned operation identifier."""
+
+    operation_id: str
+    session_id: str
+    request_hash: str
+    state: str
+    created_at: float
+    updated_at: float
+
+    def public_dict(self, *, runner_incarnation_id: str) -> dict[str, str | float]:
+        """Return the bounded status shape exposed to the server coordinator."""
+        return {
+            "operation_id": self.operation_id,
+            "session_id": self.session_id,
+            "state": self.state,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "runner_incarnation_id": runner_incarnation_id,
+        }
+
+
+def _canonical_hash(request: Mapping[str, Any]) -> str:
+    body = dict(request)
+    body.pop("operation_id", None)
+    try:
+        encoded = json.dumps(
+            body,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError) as exc:
+        raise InvalidTurnOperation("operation request must be canonical JSON data") from exc
+    return hashlib.sha256(b"omnigent.runner-turn/v1\0" + encoded).hexdigest()
+
+
+class RunnerTurnOperationRegistry:
+    """Exact in-process replay registry with a fail-closed capacity bound.
+
+    Records are never evicted during a runner incarnation: eviction would let
+    an old operation ID execute twice. A caller that reaches ``max_operations``
+    receives a capacity error instead. A runner restart creates a new
+    ``runner_incarnation_id``; the server must treat a missing old operation as
+    ambiguous and must not blindly redispatch it.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_operations: int = 100_000,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if max_operations < 1:
+            raise ValueError("max_operations must be positive")
+        self._max_operations = max_operations
+        self._clock = clock
+        self._records: dict[str, RunnerTurnOperation] = {}
+
+    @staticmethod
+    def validate_operation_id(operation_id: str) -> None:
+        if not _OPERATION_ID_RE.fullmatch(operation_id):
+            raise InvalidTurnOperation("operation_id must be 32 lowercase hexadecimal characters")
+
+    def reserve(
+        self,
+        *,
+        operation_id: str,
+        session_id: str,
+        request: Mapping[str, Any],
+    ) -> tuple[RunnerTurnOperation, bool]:
+        """Reserve an operation or return its exact replay record."""
+        self.validate_operation_id(operation_id)
+        request_hash = _canonical_hash(request)
+        existing = self._records.get(operation_id)
+        if existing is not None:
+            if existing.session_id != session_id or existing.request_hash != request_hash:
+                raise TurnOperationConflict(
+                    "operation_id is already bound to another session or request"
+                )
+            return existing, False
+        if len(self._records) >= self._max_operations:
+            raise TurnOperationCapacityError("runner operation replay registry is full")
+        now = self._clock()
+        created = RunnerTurnOperation(
+            operation_id=operation_id,
+            session_id=session_id,
+            request_hash=request_hash,
+            state="accepted",
+            created_at=now,
+            updated_at=now,
+        )
+        self._records[operation_id] = created
+        return created, True
+
+    def get(self, operation_id: str) -> RunnerTurnOperation | None:
+        """Return one operation without changing its lifecycle."""
+        self.validate_operation_id(operation_id)
+        return self._records.get(operation_id)
+
+    def mark_running(self, operation_id: str) -> RunnerTurnOperation:
+        """Advance ``accepted`` to ``running``; exact replay is a no-op."""
+        return self._transition(operation_id, expected=frozenset({"accepted"}), target="running")
+
+    def mark_terminal(self, operation_id: str, state: str) -> RunnerTurnOperation:
+        """Advance ``running`` to an immutable terminal state."""
+        if state not in _TERMINAL_STATES:
+            raise ValueError("runner terminal state is invalid")
+        return self._transition(operation_id, expected=frozenset({"running"}), target=state)
+
+    def _transition(
+        self,
+        operation_id: str,
+        *,
+        expected: frozenset[str],
+        target: str,
+    ) -> RunnerTurnOperation:
+        record = self.get(operation_id)
+        if record is None:
+            raise KeyError(operation_id)
+        if record.state == target:
+            return record
+        if record.state not in expected:
+            raise TurnOperationStateError(
+                f"cannot transition operation {operation_id} from {record.state} to {target}"
+            )
+        advanced = replace(record, state=target, updated_at=self._clock())
+        self._records[operation_id] = advanced
+        return advanced

--- a/tests/runner/test_turn_operation_protocol.py
+++ b/tests/runner/test_turn_operation_protocol.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 
 from omnigent.runner import create_runner_app
+from omnigent.runner.resource_registry import SessionResourceRegistry
 from tests.runner.conftest import _FakeProcessManager, _ScriptedHarnessClient
 from tests.runner.helpers import NullServerClient
 
@@ -25,7 +26,11 @@ def _sse(event: dict[str, Any]) -> str:
     return f"data: {json.dumps(event)}\n\n"
 
 
-def _app(*, frames: list[str] | None = None) -> tuple[FastAPI, _FakeProcessManager]:
+def _app(
+    *,
+    frames: list[str] | None = None,
+    resource_registry: SessionResourceRegistry | None = None,
+) -> tuple[FastAPI, _FakeProcessManager]:
     harness = _ScriptedHarnessClient(
         frames
         or [
@@ -37,6 +42,7 @@ def _app(*, frames: list[str] | None = None) -> tuple[FastAPI, _FakeProcessManag
     app = create_runner_app(
         process_manager=manager,  # type: ignore[arg-type]
         server_client=NullServerClient(),  # type: ignore[arg-type]
+        resource_registry=resource_registry,
     )
     return app, manager
 
@@ -161,6 +167,32 @@ async def test_failed_harness_stream_terminalizes_operation_as_failed() -> None:
         status = await client.get(f"/v1/turn-operations/{operation_id}")
         assert status.status_code == 200
         assert status.json()["state"] == "failed"
+
+
+async def test_failure_after_reservation_does_not_leave_operation_accepted() -> None:
+    class _FailingRegistry(SessionResourceRegistry):
+        def note_session_turn_started(self, session_id: str) -> None:
+            raise RuntimeError(f"turn-state write failed for {session_id}")
+
+    app, manager = _app(resource_registry=_FailingRegistry())
+    operation_id = _id("setup-failure-operation")
+    session_id = _id("setup-failure-session")
+    async with await _client(app) as client:
+        with pytest.raises(RuntimeError, match="turn-state write failed"):
+            await client.post(
+                f"/v1/sessions/{session_id}/events",
+                json={
+                    "content": "fail after reservation",
+                    "harness_override": "codex-native",
+                    "operation_id": operation_id,
+                },
+            )
+        status = await client.get(f"/v1/turn-operations/{operation_id}")
+    assert status.status_code == 200
+    assert status.json()["state"] == "failed"
+    assert session_id not in app.state.active_operation_ids
+    assert session_id not in app.state.active_turns
+    assert manager.get_client_calls == []
 
 
 async def test_deleting_live_session_terminalizes_operation_as_cancelled() -> None:

--- a/tests/runner/test_turn_operation_protocol.py
+++ b/tests/runner/test_turn_operation_protocol.py
@@ -1,0 +1,272 @@
+"""Runner HTTP protocol tests for replay-safe operation IDs and status."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.runner import create_runner_app
+from tests.runner.conftest import _FakeProcessManager, _ScriptedHarnessClient
+from tests.runner.helpers import NullServerClient
+
+
+def _id(seed: str) -> str:
+    return uuid.uuid5(uuid.NAMESPACE_DNS, seed).hex
+
+
+def _sse(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event)}\n\n"
+
+
+def _app(*, frames: list[str] | None = None) -> tuple[FastAPI, _FakeProcessManager]:
+    harness = _ScriptedHarnessClient(
+        frames
+        or [
+            _sse({"type": "response.created", "response": {"id": "resp_operation"}}),
+            _sse({"type": "response.completed", "response": {"status": "completed"}}),
+        ]
+    )
+    manager = _FakeProcessManager(harness)
+    app = create_runner_app(
+        process_manager=manager,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    return app, manager
+
+
+async def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://runner")
+
+
+async def _eventually(predicate: Callable[[], bool]) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition did not become true")
+
+
+async def test_operation_post_exact_replay_and_terminal_status() -> None:
+    app, manager = _app()
+    operation_id = _id("operation")
+    session_id = _id("session")
+    body = {
+        "type": "message",
+        "role": "user",
+        "content": "build it",
+        "harness": "openai-agents",
+        "spawn_env": {},
+        "operation_id": operation_id,
+    }
+
+    async with await _client(app) as client:
+        accepted = await client.post(f"/v1/sessions/{session_id}/events", json=body)
+        assert accepted.status_code == 202
+        assert accepted.json()["operation_id"] == operation_id
+        assert accepted.json()["state"] == "running"
+        incarnation = accepted.json()["runner_incarnation_id"]
+
+        replay = await client.post(f"/v1/sessions/{session_id}/events", json=dict(body))
+        assert replay.status_code == 202
+        assert replay.json()["operation_id"] == operation_id
+        assert "no new turn" in replay.json()["detail"]
+
+        await _eventually(
+            lambda: app.state.turn_operation_registry.get(operation_id).state == "succeeded"
+        )
+        status = await client.get(f"/v1/turn-operations/{operation_id}")
+        assert status.status_code == 200
+        assert status.json()["state"] == "succeeded"
+        assert status.json()["runner_incarnation_id"] == incarnation
+
+    assert len(manager.get_client_calls) == 1
+
+
+async def test_exact_replay_does_not_repeat_forwarded_content_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import omnigent.runner.app as runner_app
+
+    app, manager = _app()
+    operation_id = _id("resolve-once")
+    session_id = _id("resolve-once-session")
+    resolutions = 0
+
+    async def _resolve_once(
+        content: list[dict[str, Any]],
+        *,
+        session_id: str,
+        server_client: Any,
+    ) -> list[dict[str, Any]]:
+        del session_id, server_client
+        nonlocal resolutions
+        resolutions += 1
+        return content
+
+    monkeypatch.setattr(runner_app, "_resolve_forwarded_message_content", _resolve_once)
+    body = {
+        "content": [{"type": "input_text", "text": "same"}],
+        "harness": "openai-agents",
+        "spawn_env": {},
+        "operation_id": operation_id,
+    }
+    async with await _client(app) as client:
+        first = await client.post(f"/v1/sessions/{session_id}/events", json=body)
+        replay = await client.post(f"/v1/sessions/{session_id}/events", json=body)
+        await _eventually(
+            lambda: app.state.turn_operation_registry.get(operation_id).state == "succeeded"
+        )
+    assert first.status_code == 202
+    assert replay.status_code == 202
+    assert resolutions == 1
+    assert len(manager.get_client_calls) == 1
+
+
+async def test_failed_harness_stream_terminalizes_operation_as_failed() -> None:
+    app, _manager = _app(
+        frames=[
+            _sse({"type": "response.created", "response": {"id": "resp_failed"}}),
+            _sse(
+                {
+                    "type": "response.failed",
+                    "response": {"status": "failed"},
+                    "error": {"message": "executor failed", "code": "executor_error"},
+                }
+            ),
+        ]
+    )
+    operation_id = _id("failed-operation")
+    session_id = _id("failed-session")
+    async with await _client(app) as client:
+        accepted = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "content": "fail",
+                "harness": "openai-agents",
+                "spawn_env": {},
+                "operation_id": operation_id,
+            },
+        )
+        assert accepted.status_code == 202
+        await _eventually(
+            lambda: app.state.turn_operation_registry.get(operation_id).state == "failed"
+        )
+        status = await client.get(f"/v1/turn-operations/{operation_id}")
+        assert status.status_code == 200
+        assert status.json()["state"] == "failed"
+
+
+async def test_deleting_live_session_terminalizes_operation_as_cancelled() -> None:
+    app, _manager = _app()
+    operation_id = _id("deleted-operation")
+    session_id = _id("deleted-session")
+    registry = app.state.turn_operation_registry
+    registry.reserve(
+        operation_id=operation_id,
+        session_id=session_id,
+        request={"content": "delete me", "conversation_id": session_id},
+    )
+    registry.mark_running(operation_id)
+    app.state.active_operation_ids[session_id] = operation_id
+    app.state.active_turns[session_id] = None
+
+    async with await _client(app) as client:
+        deleted = await client.delete(f"/v1/sessions/{session_id}")
+        assert deleted.status_code == 200
+        status = await client.get(f"/v1/turn-operations/{operation_id}")
+        assert status.status_code == 200
+        assert status.json()["state"] == "cancelled"
+    assert session_id not in app.state.active_operation_ids
+
+
+async def test_operation_replay_with_changed_body_or_session_conflicts() -> None:
+    app, _manager = _app()
+    operation_id = _id("operation")
+    session_id = _id("session")
+    body = {
+        "content": "first",
+        "harness": "openai-agents",
+        "spawn_env": {},
+        "operation_id": operation_id,
+    }
+    async with await _client(app) as client:
+        assert (
+            await client.post(f"/v1/sessions/{session_id}/events", json=body)
+        ).status_code == 202
+        changed = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={**body, "content": "changed"},
+        )
+        assert changed.status_code == 409
+        assert changed.json()["error"] == "operation_conflict"
+        rebound = await client.post(f"/v1/sessions/{_id('other')}/events", json=body)
+        assert rebound.status_code == 409
+        assert rebound.json()["error"] == "operation_conflict"
+
+
+async def test_new_operation_is_rejected_not_buffered_while_session_busy() -> None:
+    app, _manager = _app()
+    operation_id = _id("operation")
+    session_id = _id("session")
+    app.state.active_turns[session_id] = None
+
+    async with await _client(app) as client:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"content": "next", "operation_id": operation_id},
+        )
+        assert response.status_code == 409
+        assert response.json()["error"] == "session_busy"
+        assert app.state.turn_operation_registry.get(operation_id) is None
+        assert not app.state.session_message_buffers.get(session_id)
+
+        legacy = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"content": "legacy follow-up"},
+        )
+        assert legacy.status_code == 202
+        assert legacy.json()["status"] == "buffered"
+        assert len(app.state.session_message_buffers[session_id]) == 1
+
+
+async def test_invalid_or_control_operation_request_fails_before_side_effects() -> None:
+    app, manager = _app()
+    session_id = _id("session")
+    async with await _client(app) as client:
+        invalid = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"content": "x", "operation_id": "BAD"},
+        )
+        assert invalid.status_code == 400
+        control = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"type": "interrupt", "operation_id": _id("operation")},
+        )
+        assert control.status_code == 400
+        assert control.json()["error"] == "invalid_operation_request"
+    assert manager.get_client_calls == []
+
+
+async def test_unknown_status_is_ambiguous_and_incarnation_scoped() -> None:
+    app, _manager = _app()
+    operation_id = _id("unknown")
+    async with await _client(app) as client:
+        response = await client.get(f"/v1/turn-operations/{operation_id}")
+        assert response.status_code == 404
+        payload = response.json()
+        assert payload["error"] == "operation_not_found"
+        assert "do not infer" in payload["detail"]
+        assert payload["runner_incarnation_id"] == app.state.runner_incarnation_id
+
+        invalid = await client.get("/v1/turn-operations/not-an-operation")
+        assert invalid.status_code == 400
+
+    replacement, _replacement_manager = _app()
+    assert replacement.state.runner_incarnation_id != app.state.runner_incarnation_id

--- a/tests/runner/test_turn_operations.py
+++ b/tests/runner/test_turn_operations.py
@@ -1,0 +1,144 @@
+"""Unit tests for runner-local turn-operation deduplication."""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import pytest
+
+from omnigent.runner.turn_operations import (
+    InvalidTurnOperation,
+    RunnerTurnOperationRegistry,
+    TurnOperationCapacityError,
+    TurnOperationConflict,
+    TurnOperationStateError,
+)
+
+
+def _op(seed: str) -> str:
+    return uuid.uuid5(uuid.NAMESPACE_DNS, seed).hex
+
+
+def test_exact_replay_returns_same_record_without_advancing() -> None:
+    ticks = iter([10.0, 20.0, 30.0])
+    registry = RunnerTurnOperationRegistry(clock=lambda: next(ticks))
+    request = {"operation_id": _op("one"), "content": [{"text": "build"}]}
+    first, created = registry.reserve(
+        operation_id=_op("one"), session_id=_op("session"), request=request
+    )
+    running = registry.mark_running(first.operation_id)
+    replay, replay_created = registry.reserve(
+        operation_id=_op("one"), session_id=_op("session"), request=dict(request)
+    )
+    assert created is True
+    assert replay_created is False
+    assert replay == running
+    assert replay.state == "running"
+
+
+def test_operation_id_is_not_part_of_request_fingerprint() -> None:
+    registry = RunnerTurnOperationRegistry()
+    operation_id = _op("one")
+    first, _ = registry.reserve(
+        operation_id=operation_id,
+        session_id=_op("session"),
+        request={"operation_id": operation_id, "content": "same"},
+    )
+    replay, created = registry.reserve(
+        operation_id=operation_id,
+        session_id=_op("session"),
+        request={"content": "same"},
+    )
+    assert created is False
+    assert replay == first
+
+
+@pytest.mark.parametrize("operation_id", ["", "ABC", "g" * 32, "a" * 31, "a" * 33])
+def test_invalid_operation_id_fails_closed(operation_id: str) -> None:
+    registry = RunnerTurnOperationRegistry()
+    with pytest.raises(InvalidTurnOperation, match="32 lowercase"):
+        registry.reserve(operation_id=operation_id, session_id=_op("session"), request={})
+
+
+def test_changed_request_or_session_conflicts() -> None:
+    registry = RunnerTurnOperationRegistry()
+    operation_id = _op("one")
+    registry.reserve(operation_id=operation_id, session_id=_op("session"), request={"x": 1})
+    with pytest.raises(TurnOperationConflict):
+        registry.reserve(operation_id=operation_id, session_id=_op("session"), request={"x": 2})
+    with pytest.raises(TurnOperationConflict):
+        registry.reserve(operation_id=operation_id, session_id=_op("other"), request={"x": 1})
+
+
+def test_nonfinite_or_nonjson_request_is_rejected() -> None:
+    registry = RunnerTurnOperationRegistry()
+    with pytest.raises(InvalidTurnOperation, match="canonical JSON"):
+        registry.reserve(
+            operation_id=_op("nan"),
+            session_id=_op("session"),
+            request={"value": math.nan},
+        )
+    with pytest.raises(InvalidTurnOperation, match="canonical JSON"):
+        registry.reserve(
+            operation_id=_op("object"),
+            session_id=_op("session"),
+            request={"value": object()},
+        )
+
+
+def test_lifecycle_is_strict_terminal_and_idempotent() -> None:
+    ticks = iter([10.0, 20.0, 30.0])
+    registry = RunnerTurnOperationRegistry(clock=lambda: next(ticks))
+    operation, _ = registry.reserve(operation_id=_op("one"), session_id=_op("session"), request={})
+    with pytest.raises(TurnOperationStateError, match="accepted to succeeded"):
+        registry.mark_terminal(operation.operation_id, "succeeded")
+    running = registry.mark_running(operation.operation_id)
+    assert running.updated_at == 20.0
+    assert registry.mark_running(operation.operation_id) == running
+    terminal = registry.mark_terminal(operation.operation_id, "succeeded")
+    assert terminal.updated_at == 30.0
+    assert registry.mark_terminal(operation.operation_id, "succeeded") == terminal
+    with pytest.raises(TurnOperationStateError, match="succeeded to failed"):
+        registry.mark_terminal(operation.operation_id, "failed")
+
+
+def test_capacity_never_evicts_old_replay_records() -> None:
+    registry = RunnerTurnOperationRegistry(max_operations=1)
+    first, _ = registry.reserve(
+        operation_id=_op("one"), session_id=_op("session"), request={"x": 1}
+    )
+    registry.mark_running(first.operation_id)
+    registry.mark_terminal(first.operation_id, "succeeded")
+    with pytest.raises(TurnOperationCapacityError, match="registry is full"):
+        registry.reserve(operation_id=_op("two"), session_id=_op("session"), request={"x": 2})
+    replay, created = registry.reserve(
+        operation_id=first.operation_id, session_id=_op("session"), request={"x": 1}
+    )
+    assert created is False
+    assert replay.state == "succeeded"
+
+
+def test_status_shape_omits_request_hash() -> None:
+    registry = RunnerTurnOperationRegistry(clock=lambda: 10.0)
+    operation, _ = registry.reserve(
+        operation_id=_op("one"), session_id=_op("session"), request={"secret": "value"}
+    )
+    status = operation.public_dict(runner_incarnation_id="runner-incarnation")
+    assert status == {
+        "operation_id": _op("one"),
+        "session_id": _op("session"),
+        "state": "accepted",
+        "created_at": 10.0,
+        "updated_at": 10.0,
+        "runner_incarnation_id": "runner-incarnation",
+    }
+    assert "request_hash" not in status
+
+
+def test_unknown_operation_is_none_and_mutation_raises() -> None:
+    registry = RunnerTurnOperationRegistry()
+    operation_id = _op("unknown")
+    assert registry.get(operation_id) is None
+    with pytest.raises(KeyError, match=operation_id):
+        registry.mark_running(operation_id)


### PR DESCRIPTION
## Summary

- add a runner-local operation registry keyed by a server-owned 32-character operation ID
- make exact POST replays return the existing lifecycle without starting a second turn
- reject changed-request or changed-session reuse, busy-session operation buffering, and unsafe operation shapes
- expose GET /v1/turn-operations/{operation_id} with a per-process runner incarnation ID
- terminalize operations on success, failure, cancellation, deletion, harness desynchronization, and post-reservation setup failure

## Safety model

- request equality uses a canonical SHA-256 digest; the digest is never returned
- operation records are immutable after a terminal state
- records are never evicted during an incarnation; the bounded registry fails closed at capacity
- a 404 in a new incarnation explicitly remains ambiguous and must not be treated as proof that dispatch did not occur
- exact replay is recognized before forwarded-content resolution, so retrying cannot repeat attachment resolution work
- first-turn harness overrides are recorded before native lifecycle bookkeeping

## Validation

- 22 focused registry and HTTP protocol tests pass
- new registry coverage: 97 percent
- existing dispatch and recovery matrix: 189 passed, 1 existing skip
- existing delete, interrupt, cancel, and desync selection: 13 passed
- Ruff, changed-file Pyrefly, diff check, and policy hooks pass

## Boundary

This is runner protocol and in-incarnation replay protection only. It does not wire the server coordinator or claim exactly-once execution across runner restarts. PR #4868 is the complementary durable server journal foundation; the coordinator must bind its dispatch record to the runner incarnation before enabling blind retries.

Relates to #4861.