### PR TITLE
fix(qwen): complete ACP event handling

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -40,21 +40,17 @@ Tracks pending work and known limitations for the Qwen Code harness
   catalog, so without it they fell back to the wrong 128K default
   (qwen3-coder-plus is 1M). A spec's `executor.context_window` still overrides;
   unrecognized qwen models keep the 128K fallback.
-- **In-session model selection (`/model`).** Switching models mid-session
-  works. The model is fixed in the `qwen --acp` subprocess env
-  (`HARNESS_QWEN_MODEL`) at spawn, so on a `/model` change the runner's
-  `HarnessProcessManager` respawns the harness with the new value — a fresh
-  `QwenExecutor` then opens a new `session/new` carrying the new model. Context
-  survives the respawn because the first turn of the new session replays the
-  prior conversation (see History replay below).
+- **In-session model selection (`/model`).** The requested model is applied to
+  the live ACP session with the standard `session/set_config_option` method and
+  Qwen's advertised `model` config option. The transcript stays in the existing
+  session; `session/new.model` is not used.
 - **History replay on a fresh ACP session.** When the `qwen --acp` subprocess
-  is (re)spawned — first turn, a `/model` switch, or a `Session not found`
+  is (re)spawned — first turn, a process restart, or a `Session not found`
   reset — qwen holds none of the earlier conversation (it lived in the dead
   process). `run_turn` normally sends only the latest user turn, so the first
   turn of any fresh session folds the prior transcript into the prompt as a
   labeled `Conversation so far:` block (`_history_prefix`), mirroring
-  `ClaudeSDKExecutor._build_prompt`. Keeps a mid-conversation model switch from
-  dropping the thread. (Same fix applied to the goose ACP harness.)
+  `ClaudeSDKExecutor._build_prompt`. (Same fix applied to the goose ACP harness.)
 - **OS sandbox.** When the spec's `os_env.sandbox` is not `none`, the whole
   `qwen` process tree is wrapped in the platform sandbox (bwrap / seatbelt) at
   spawn (`_sandbox_launch_path`), confining qwen's own file/shell tools to the
@@ -304,8 +300,10 @@ comments; this is the *what*, not the *how*.)
 
 - [ ] **More attachment types.** Text files and images now reach the agent;
   still unsupported are binary documents (PDF, etc.) and audio input.
-- [ ] **Session resilience:** cancel a turn mid-flight, recover when the `qwen`
-  subprocess crashes, and resume a session across separate runs.
+- [ ] **Session resilience:** recover when the `qwen` subprocess crashes and
+  resume an ACP session across separate runs. Mid-turn cancellation now sends
+  Qwen's ACP `session/cancel` notification after session setup, with SIGTERM as
+  the fallback before setup or when the notification cannot be sent.
   - *Done in this pass:* dead qwen-native terminals now recreate on attach
     instead of failing 4404, so the embedded pane recovers after a crash or
     deferred-start failure.
@@ -348,7 +346,9 @@ leaves `login_args` / `logout_args` / `status_args` unset so
 
 ### ACP constraints
 
-- Qwen runs its own tools internally (not yet bridged — see Pending work).
+- Qwen runs its own tools internally. ACP `tool_call` / `tool_call_update`
+  notifications are forwarded as informational tool request/completion events,
+  and `agent_thought_chunk` is forwarded as reasoning output.
 - Qwen assigns its own `sessionId`; ours is a hint.
 - ACP has no system-prompt field, so the spec `prompt:` is folded into the
   first user turn.

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -41,6 +41,7 @@ from omnigent.inner.executor import (
     ExecutorError,
     ExecutorEvent,
     Message,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -110,14 +111,21 @@ def _looks_like_missing_file(message: str) -> bool:
 _AGENT_METHOD_INITIALIZE = "initialize"
 _AGENT_METHOD_SESSION_NEW = "session/new"
 _AGENT_METHOD_SESSION_PROMPT = "session/prompt"
+_AGENT_METHOD_SESSION_CANCEL = "session/cancel"
+_AGENT_METHOD_SET_CONFIG_OPTION = "session/set_config_option"
 
 # Notifications sent *from* the agent to the client
 _CLIENT_NOTIFICATION_SESSION_UPDATE = "session/update"
 
 # session/update.update.sessionUpdate values we care about
 _UPDATE_AGENT_MESSAGE_CHUNK = "agent_message_chunk"
+_UPDATE_AGENT_THOUGHT_CHUNK = "agent_thought_chunk"
 _UPDATE_TOOL_CALL = "tool_call"
 _UPDATE_TOOL_CALL_UPDATE = "tool_call_update"
+
+_CONFIG_OPTION_MODEL = "model"
+_TOOL_STATUS_COMPLETED = "completed"
+_TOOL_STATUS_FAILED = "failed"
 
 # How long (seconds) to wait for qwen to respond to a JSON-RPC request
 # before treating the turn as timed out.
@@ -275,6 +283,11 @@ class QwenExecutor(Executor):
         # first user turn only (subsequent turns reuse the same session and
         # qwen retains the earlier context).
         self._system_prompt_sent: bool = False
+
+        self._config_option_ids: set[str] = set()
+        self._active_model: str | None = None
+        self._model_switch_supported: bool = True
+        self._tool_names: dict[str, str] = {}
 
         # Bridges the ExecutorAdapter installs (best-effort, via
         # ``getattr(..., None) is None``) so qwen's mid-turn
@@ -640,9 +653,6 @@ class QwenExecutor(Executor):
             "cwd": self._cwd,
             "mcpServers": mcp_servers,
         }
-        if self._model:
-            params["model"] = self._model
-
         resp = await self._rpc(
             _AGENT_METHOD_SESSION_NEW,
             params,
@@ -656,6 +666,7 @@ class QwenExecutor(Executor):
         # Qwen assigns (possibly remaps) the session id — always use what
         # the server returns, not what we sent.
         result = resp.get("result", {})
+        self._note_config_options(result.get("configOptions"))
         server_session_id = result.get("sessionId")
         if not server_session_id:
             raise RuntimeError(
@@ -663,6 +674,53 @@ class QwenExecutor(Executor):
             )
         self._session_id = server_session_id
         return self._session_id
+
+    def _note_config_options(self, options: object) -> str | None:
+        """Record advertised session options and the active model."""
+        if not isinstance(options, list):
+            return None
+        model_value: str | None = None
+        for option in options:
+            if not isinstance(option, dict):
+                continue
+            option_id = option.get("id")
+            if not isinstance(option_id, str):
+                continue
+            self._config_option_ids.add(option_id)
+            if option_id == _CONFIG_OPTION_MODEL:
+                current = option.get("currentValue")
+                if isinstance(current, str) and current:
+                    self._active_model = current
+                    model_value = current
+        return model_value
+
+    async def _apply_model_override(self, session_id: str, model: str | None) -> None:
+        """Apply a model through ACP's standard session config option."""
+        if not model or model == self._active_model or not self._model_switch_supported:
+            return
+        if self._config_option_ids and _CONFIG_OPTION_MODEL not in self._config_option_ids:
+            self._model_switch_supported = False
+            return
+        response = await self._rpc(
+            _AGENT_METHOD_SET_CONFIG_OPTION,
+            {"sessionId": session_id, "configId": _CONFIG_OPTION_MODEL, "value": model},
+        )
+        if "error" in response:
+            self._model_switch_supported = False
+            logger.warning(
+                "qwen model switch to %s rejected (%s); continuing on the current model",
+                model,
+                response["error"].get("message", response["error"]),
+            )
+            return
+        result = response.get("result")
+        echoed = (
+            self._note_config_options(result.get("configOptions"))
+            if isinstance(result, dict)
+            else None
+        )
+        if echoed is None:
+            self._active_model = model
 
     # ------------------------------------------------------------------
     # Server-initiated requests (agent → client)
@@ -1210,12 +1268,32 @@ class QwenExecutor(Executor):
     # Executor interface
     # ------------------------------------------------------------------
 
+    def handles_tools_internally(self) -> bool:
+        """Qwen executes the tool calls represented by ACP updates."""
+        return True
+
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002
+        """Cancel the active Qwen prompt, falling back to process termination."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return False
+        if self._session_id is not None:
+            try:
+                await self._notify(_AGENT_METHOD_SESSION_CANCEL, {"sessionId": self._session_id})
+                return True
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("qwen session/cancel failed; falling back to SIGTERM: %s", exc)
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+            return True
+        return False
+
     async def run_turn(
         self,
         messages: list[Message],
         tools: list[ToolSpec],
         system_prompt: str,
-        config: ExecutorConfig | None = None,  # noqa: ARG002 — unused; required by the Executor interface
+        config: ExecutorConfig | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         """Run one turn of the Qwen agent loop via ACP.
 
@@ -1242,6 +1320,13 @@ class QwenExecutor(Executor):
         except Exception as exc:  # noqa: BLE001
             yield ExecutorError(message=describe_exception(exc), retryable=False)
             return
+
+        requested_model = config.model if config is not None else self._model
+        try:
+            await self._apply_model_override(session_id, requested_model)
+        except Exception as exc:  # noqa: BLE001
+            self._model_switch_supported = False
+            logger.warning("qwen model switch failed: %s", exc)
 
         # A fresh ACP session (first turn of a new/respawned process, or after
         # a reset) holds no prior context. Captured before we flip the latch
@@ -1410,14 +1495,41 @@ class QwenExecutor(Executor):
                         accumulated_text.append(text)
                         yield TextChunk(text=text)
 
+                elif update_type == _UPDATE_AGENT_THOUGHT_CHUNK:
+                    content = update.get("content", {})
+                    text = content.get("text", "") if isinstance(content, dict) else ""
+                    if text:
+                        yield ReasoningChunk(delta=text, event_type="reasoning_text")
+
                 elif update_type == _UPDATE_TOOL_CALL:
-                    # Qwen is executing a built-in tool — surface it as info.
-                    tool_title = update.get("title", "tool_call")
-                    logger.debug("qwen tool_call: %s", tool_title)
+                    call_id = update.get("toolCallId")
+                    name = str(update.get("title") or update.get("kind") or "tool")
+                    raw_input = update.get("rawInput")
+                    if isinstance(call_id, str) and call_id:
+                        self._tool_names[call_id] = name
+                        yield ToolCallRequest(
+                            name=name,
+                            args=raw_input if isinstance(raw_input, dict) else {},
+                            metadata={"call_id": call_id},
+                        )
 
                 elif update_type == _UPDATE_TOOL_CALL_UPDATE:
-                    # Status update on an in-progress tool call — skip.
-                    pass
+                    call_id = update.get("toolCallId")
+                    status = update.get("status")
+                    if isinstance(call_id, str) and status in (
+                        _TOOL_STATUS_COMPLETED,
+                        _TOOL_STATUS_FAILED,
+                    ):
+                        yield ToolCallComplete(
+                            name=self._tool_names.pop(call_id, "tool"),
+                            status=(
+                                ToolCallStatus.SUCCESS
+                                if status == _TOOL_STATUS_COMPLETED
+                                else ToolCallStatus.ERROR
+                            ),
+                            result=update.get("content") or update.get("rawOutput"),
+                            metadata={"call_id": call_id},
+                        )
 
             elif notification.get("id") is not None and notification.get("method"):
                 # Server-initiated request (e.g. session/request_permission):

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -1321,7 +1321,7 @@ class QwenExecutor(Executor):
             yield ExecutorError(message=describe_exception(exc), retryable=False)
             return
 
-        requested_model = config.model if config is not None else self._model
+        requested_model = config.model if config is not None and config.model else self._model
         try:
             await self._apply_model_override(session_id, requested_model)
         except Exception as exc:  # noqa: BLE001

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -455,12 +455,12 @@ class _SubprocessEntry:
     :param last_used_at: Monotonic timestamp of the most recent
         ``get_client`` call for this conversation. Used by the
         idle reaper to detect abandoned entries.
-    :param model: The ``HARNESS_<H>_MODEL`` value this subprocess
+        :param model: The ``HARNESS_<H>_MODEL`` value this subprocess
         was spawned with (or ``None`` when the spawn env set no
-        model). The model is fixed at spawn time (it's a process
-        env var), so :meth:`HarnessProcessManager.get_client`
-        re-spawns when a later turn requests a different model —
-        e.g. after the user runs ``/model``.
+        model). Most harnesses fix the model at spawn, so
+        :meth:`HarnessProcessManager.get_client` re-spawns on a
+        later model change. Harnesses in
+        :data:`_LIVE_MODEL_CONFIG_HARNESSES` apply it in-process.
     """
 
     def __init__(
@@ -493,6 +493,9 @@ def _model_env_key(harness: str) -> str:
         ``"claude-sdk"`` or ``"HARNESS_CODEX_MODEL"`` for ``"codex"``.
     """
     return f"HARNESS_{harness.upper().replace('-', '_')}_MODEL"
+
+
+_LIVE_MODEL_CONFIG_HARNESSES = frozenset({"qwen"})
 
 
 def _build_harness_spawn_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -800,13 +803,10 @@ class HarnessProcessManager:
                 await self._close_entry(entry)
                 entry = None
                 respawn_reason = "harness_respawn_agent_switch"
-            if entry is not None:
-                # The model is baked into the subprocess env at spawn time;
-                # a later turn requesting a different model (e.g. after the
-                # user runs ``/model``) must respawn, otherwise the cached
-                # process keeps serving the old model. Only respawn when a
-                # concrete different model is requested — a turn that sets no
-                # model env (``None``) keeps the running process.
+            if entry is not None and harness not in _LIVE_MODEL_CONFIG_HARNESSES:
+                # Most harnesses bake the model into the subprocess env. A
+                # later concrete model change must respawn them; ACP harnesses
+                # in the live-config set instead apply the request in-session.
                 requested_model = (env or {}).get(_model_env_key(harness))
                 if requested_model is not None and requested_model != entry.model:
                     _logger.info(

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -22,7 +22,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from omnigent.inner.executor import (
+    ExecutorConfig,
     ExecutorError,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -430,6 +432,46 @@ async def test_ensure_session_uses_server_assigned_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ensure_session_records_config_options_without_legacy_model_param() -> None:
+    """Qwen model selection uses session config, not session/new.model."""
+    executor = QwenExecutor(model="qwen-plus")
+    captured: dict = {}
+
+    async def fake_rpc(method: str, params: dict, timeout: float = 30.0) -> dict:
+        captured.update(params)
+        return {
+            "result": {
+                "sessionId": "s1",
+                "configOptions": [{"id": "model", "currentValue": "qwen-turbo"}],
+            }
+        }
+
+    executor._rpc = fake_rpc  # type: ignore[method-assign]
+    await executor._ensure_session()
+
+    assert "model" not in captured
+    assert executor._active_model == "qwen-turbo"
+
+
+@pytest.mark.asyncio
+async def test_model_override_uses_standard_session_config() -> None:
+    executor = QwenExecutor()
+    executor._config_option_ids.add("model")
+    executor._active_model = "qwen-turbo"
+    executor._rpc = AsyncMock(
+        return_value={"result": {"configOptions": [{"id": "model", "currentValue": "qwen-plus"}]}}
+    )  # type: ignore[method-assign]
+
+    await executor._apply_model_override("s1", "qwen-plus")
+
+    executor._rpc.assert_awaited_once_with(
+        "session/set_config_option",
+        {"sessionId": "s1", "configId": "model", "value": "qwen-plus"},
+    )
+    assert executor._active_model == "qwen-plus"
+
+
+@pytest.mark.asyncio
 async def test_ensure_session_cached_after_first_call() -> None:
     """_ensure_session does not make a second RPC call once session is set."""
     executor = QwenExecutor()
@@ -521,6 +563,117 @@ async def test_run_turn_yields_text_chunks_and_turn_complete() -> None:
     assert text_chunks[0].text == "Hello!"
     assert len(turn_completes) == 1
     assert turn_completes[0].response == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_forwards_reasoning_and_structured_tool_updates() -> None:
+    executor = QwenExecutor()
+    executor._initialized = True
+    executor._session_id = "sess-events"
+    executor._system_prompt_sent = True
+    executor._proc = MagicMock(returncode=None)
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") != "session/prompt":
+            return
+        for update in (
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "checking"},
+            },
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc1",
+                "title": "shell",
+                "rawInput": {"command": "pwd"},
+            },
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc1",
+                "status": "completed",
+                "rawOutput": "ok",
+            },
+        ):
+            await executor._queue.put(
+                {
+                    "method": "session/update",
+                    "params": {"sessionId": "sess-events", "update": update},
+                }
+            )
+        executor._pending[msg["id"]].set_result(
+            {"id": msg["id"], "result": {"stopReason": "end_turn"}}
+        )
+
+    executor._send = fake_send  # type: ignore[method-assign]
+    events = [
+        event
+        async for event in executor.run_turn(
+            [{"role": "user", "content": "inspect"}],
+            [],
+            "",
+            ExecutorConfig(),
+        )
+    ]
+
+    assert executor.handles_tools_internally() is True
+    assert [(e.delta, e.event_type) for e in events if isinstance(e, ReasoningChunk)] == [
+        ("checking", "reasoning_text")
+    ]
+    requests = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert requests == [
+        ToolCallRequest(name="shell", args={"command": "pwd"}, metadata={"call_id": "tc1"})
+    ]
+    completes = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert completes[0].name == "shell"
+    assert completes[0].status is ToolCallStatus.SUCCESS
+    assert completes[0].result == "ok"
+    assert completes[0].metadata == {"call_id": "tc1"}
+
+
+@pytest.mark.asyncio
+async def test_interrupt_sends_session_cancel_notification() -> None:
+    executor = QwenExecutor()
+    executor._session_id = "s1"
+    proc = MagicMock(returncode=None)
+    executor._proc = proc
+    executor._notify = AsyncMock()  # type: ignore[method-assign]
+
+    assert await executor.interrupt_session("ignored") is True
+    executor._notify.assert_awaited_once_with("session/cancel", {"sessionId": "s1"})
+    proc.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_terminates_before_session_setup() -> None:
+    executor = QwenExecutor()
+    proc = MagicMock(returncode=None)
+    executor._proc = proc
+
+    assert await executor.interrupt_session("ignored") is True
+    proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_terminates_when_session_cancel_fails() -> None:
+    executor = QwenExecutor()
+    executor._session_id = "s1"
+    proc = MagicMock(returncode=None)
+    executor._proc = proc
+    executor._notify = AsyncMock(side_effect=OSError("closed"))  # type: ignore[method-assign]
+
+    assert await executor.interrupt_session("ignored") is True
+    proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_noops_without_live_process() -> None:
+    executor = QwenExecutor()
+    assert await executor.interrupt_session("ignored") is False
+
+    proc = MagicMock(returncode=0)
+    executor._proc = proc
+    assert await executor.interrupt_session("ignored") is False
+    proc.terminate.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -472,6 +472,38 @@ async def test_model_override_uses_standard_session_config() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_turn_applies_configured_model_without_per_turn_override() -> None:
+    """An empty per-turn config must not discard HARNESS_QWEN_MODEL."""
+    executor = QwenExecutor(model="qwen-plus")
+    executor._initialized = True
+    executor._session_id = "s1"
+    executor._system_prompt_sent = True
+    executor._proc = MagicMock(returncode=None)
+    executor._apply_model_override = AsyncMock()  # type: ignore[method-assign]
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            executor._pending[msg["id"]].set_result(
+                {"id": msg["id"], "result": {"stopReason": "end_turn"}}
+            )
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [
+        event
+        async for event in executor.run_turn(
+            [{"role": "user", "content": "hello"}],
+            [],
+            "",
+            ExecutorConfig(model=None),
+        )
+    ]
+
+    executor._apply_model_override.assert_awaited_once_with("s1", "qwen-plus")
+    assert any(isinstance(event, TurnComplete) for event in events)
+
+
+@pytest.mark.asyncio
 async def test_ensure_session_cached_after_first_call() -> None:
     """_ensure_session does not make a second RPC call once session is set."""
     executor = QwenExecutor()

--- a/tests/runtime/test_process_manager.py
+++ b/tests/runtime/test_process_manager.py
@@ -98,6 +98,38 @@ async def test_get_client_respawns_only_when_model_changes(
         await final.client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_qwen_model_change_keeps_live_acp_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Qwen applies model changes through ACP session config without respawning."""
+    pm = HarnessProcessManager()
+    pm._started = True
+    spawns: list[str | None] = []
+
+    async def _fake_spawn(conv: str, harness: str, env: dict[str, str] | None) -> _SubprocessEntry:
+        model = (env or {}).get(_model_env_key(harness))
+        spawns.append(model)
+        return _SubprocessEntry(
+            process=_AliveProc(),  # type: ignore[arg-type]
+            client=httpx.AsyncClient(),
+            endpoint=_HarnessEndpoint(socket_path=Path("/tmp/fake-qwen.sock")),
+            harness=harness,
+            model=model,
+        )
+
+    monkeypatch.setattr(pm, "_spawn_entry", _fake_spawn)
+    key = _model_env_key("qwen")
+
+    await pm.get_client("conv_qwen", "qwen", env={key: "qwen-turbo"})
+    await pm.get_client("conv_qwen", "qwen", env={key: "qwen-plus"})
+
+    assert spawns == ["qwen-turbo"]
+    entry = pm._entries.get("conv_qwen")
+    if entry is not None:
+        await entry.client.aclose()
+
+
 def test_build_harness_spawn_env_strips_binding_token_with_overrides(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #4876

Related: #1638 (Qwen Stop button only; Hermes stays on that issue / #1643).

## Summary

Qwen already runs through ACP, but several protocol surfaces never made it
into Omnigent.

This keeps the existing `QwenExecutor` and wires the missing events and
the standard model-config method.

- Stop sends ACP `session/cancel` after the session exists. SIGTERM is
  only the fallback before setup or when the notification fails.
- `agent_thought_chunk` becomes `ReasoningChunk`.
- `tool_call` / `tool_call_update` become `ToolCallRequest` /
  `ToolCallComplete`.
- `/model` uses `session/set_config_option` on the live session.
  `session/new.model` is no longer sent.
- The process manager no longer respawns Qwen when the model changes.
- An empty per-turn `ExecutorConfig` no longer drops `HARNESS_QWEN_MODEL`.

Hermes interrupt is out of scope. #1643 still covers that half of #1638.

## Test Plan

- `uv run --python 3.12 --group test --extra databricks --frozen pytest tests/inner/test_qwen_executor.py tests/runtime/test_process_manager.py -q` → 97 passed
- New coverage for cancel, thought/tool events, `session/set_config_option`,
  configured-model fallback, and Qwen live-process `/model`.
- `pre-commit` on the changed files: ruff, format, pyrefly clean.

## Demo

N/A. Backend harness event and lifecycle wiring. The existing Qwen ACP
session UI is unchanged except that Stop, reasoning, tools, and `/model`
now have something to show.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests drive the ACP notification and RPC paths. A live signed-in
Qwen turn is the best human check: Stop mid-turn, watch reasoning and
tool cards, then `/model` without losing the session.

## Changelog

Qwen Stop, reasoning, tool cards, and `/model` now follow the ACP session
instead of being dropped
