### PR TITLE
fix(terminal): stop tmux server after inner process exit

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1403,10 +1403,12 @@ class TerminalInstance:
         await self._stop_idle_watcher()
         self._stop_idle_watcher_thread()
 
-        if self.running:
+        # A launched terminal still owns its private tmux server after the
+        # inner pane exits and ``is_alive`` clears ``running``.
+        if self.launch_cwd is not None:
             with contextlib.suppress(RuntimeError):
                 await self._tmux("kill-server")
-            self.running = False
+        self.running = False
 
         if self.os_env is not None:
             self.os_env.close()

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7565,9 +7565,6 @@ def create_runner_app(
             # same dead instance we just probed.
             current = terminal_registry.get(conv_id, terminal_name, "main")
             if current is instance:
-                # is_alive() set instance.running=False as a side effect;
-                # restore it so close() issues tmux kill-server.
-                instance.running = True
                 try:
                     await terminal_registry.close(conv_id, terminal_name, "main")
                 except asyncio.CancelledError:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -6,11 +6,14 @@ import asyncio
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import psutil
 import pytest
 
 import omnigent.inner.terminal as terminal_mod
@@ -26,6 +29,28 @@ from omnigent.inner.terminal import (
     resolve_terminal_transport,
 )
 from omnigent.runner.identity import RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR
+
+
+def _process_is_gone_or_zombie(process: psutil.Process) -> bool:
+    """Return whether a non-child process has terminated."""
+    try:
+        return not process.is_running() or process.status() == psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return True
+
+
+async def _wait_until_process_terminates(
+    process: psutil.Process,
+    *,
+    timeout: float = 1.0,
+) -> bool:
+    """Poll for process termination without waiting for its parent to reap it."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if _process_is_gone_or_zombie(process):
+            return True
+        await asyncio.sleep(0.02)
+    return _process_is_gone_or_zombie(process)
 
 
 def _write_transport_config(config_home: Path, value: str | None) -> None:
@@ -424,6 +449,130 @@ async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> N
         )
     finally:
         await instance.close()
+
+
+@pytest.mark.asyncio
+async def test_close_stops_launched_server_after_inner_process_exit(
+    tmp_path: Path,
+) -> None:
+    """A launched terminal owns tmux teardown after its pane exits."""
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        launch_cwd=str(tmp_path),
+        running=False,
+    )
+    tmux = AsyncMock()
+    instance._tmux = tmux
+
+    await instance.close()
+
+    tmux.assert_awaited_once_with("kill-server")
+    assert instance.running is False
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux binary")
+@pytest.mark.asyncio
+async def test_close_stops_server_after_inner_process_exit_real_tmux() -> None:
+    """Closing a finished terminal stops its private tmux server."""
+    private_dir = Path(tempfile.mkdtemp(prefix="omnigent-tmux-", dir="/tmp"))
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=private_dir / "tmux.sock",
+        private_dir=private_dir,
+        command="sh",
+        args=["-c", "printf 'terminal-finished\\n'"],
+        keep_alive_after_exit=True,
+    )
+    server_process: psutil.Process | None = None
+    try:
+        await instance.launch(cwd=private_dir)
+
+        server_probe = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(instance.socket_path),
+                "display-message",
+                "-p",
+                "-t",
+                instance.tmux_target,
+                "#{pid}",
+            ],
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+        server_process = psutil.Process(int(server_probe.stdout.decode().strip()))
+
+        for _ in range(250):
+            if not await instance.is_alive():
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - only on a hang/regression
+            raise AssertionError("inner process never reported as exited")
+
+        server_probe = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(instance.socket_path),
+                "has-session",
+                "-t",
+                instance.tmux_target,
+            ],
+            capture_output=True,
+            timeout=5,
+        )
+        assert server_probe.returncode == 0
+        pane = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(instance.socket_path),
+                "capture-pane",
+                "-p",
+                "-S",
+                "-",
+                "-t",
+                instance.tmux_target,
+            ],
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+        assert b"terminal-finished" in pane.stdout
+
+        await instance.close()
+
+        server_probe = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(instance.socket_path),
+                "has-session",
+                "-t",
+                instance.tmux_target,
+            ],
+            capture_output=True,
+            timeout=5,
+        )
+        assert server_probe.returncode != 0
+        assert not instance.socket_path.exists()
+        assert await _wait_until_process_terminates(server_process), (
+            "tmux server remained live after close() once the inner process exited: "
+            f"pid={server_process.pid}"
+        )
+    finally:
+        await instance.close()
+        if server_process is not None and not _process_is_gone_or_zombie(server_process):
+            server_process.terminate()
+            if not await _wait_until_process_terminates(server_process):
+                server_process.kill()
+        shutil.rmtree(private_dir, ignore_errors=True)
 
 
 async def _capture_launch_argv(

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -1037,17 +1037,16 @@ async def test_ensure_terminal_route_recreates_dead_registered_pane(
 
 
 @pytest.mark.asyncio
-async def test_dead_registered_pane_close_restores_running_for_kill_server(
+async def test_dead_registered_pane_close_preserves_finished_state(
     tmp_path: Path,
 ) -> None:
-    """``running`` must be restored before ``close()`` so kill-server runs.
+    """Closing a dead registered pane keeps its finished-process state.
 
     ``is_alive()`` sets ``instance.running = False`` as a side effect when
-    the pane is dead. ``TerminalInstance.close()`` checks ``self.running``
-    before issuing ``tmux kill-server``. The self-heal path in
-    ``_ensure_native_terminal_for_turn`` must restore ``running = True``
-    after detecting a dead pane so the subsequent ``close()`` properly
-    kills the remain-on-exit tmux server instead of leaving it orphaned.
+    the pane is dead. The self-heal path in
+    ``_ensure_native_terminal_for_turn`` must preserve that state when it
+    closes the stale entry; ``TerminalInstance.close()`` uses successful
+    launch state rather than making ``running`` claim the pane is live.
 
     This test exercises the contract directly on ``TerminalRegistry.close``
     with a tracking ``close()`` stub that captures ``running`` at call time.
@@ -1087,17 +1086,13 @@ async def test_dead_registered_pane_close_restores_running_for_kill_server(
     assert alive is False
     assert dead_instance.running is False, "is_alive() should set running=False"
 
-    # This is what _ensure_native_terminal_for_turn does: restore running
-    # before calling registry.close() so close() issues kill-server.
-    dead_instance.running = True
     await registry.close(sid, "claude", "main")
 
     assert len(running_at_close) == 1, (
         f"Expected close() to be called once; got {len(running_at_close)} calls"
     )
-    assert running_at_close[0] is True, (
-        "running must be True when close() is called so tmux kill-server runs; "
-        "was False — is_alive() side-effect was not restored"
+    assert running_at_close[0] is False, (
+        "running must remain False when close() is called for a finished pane"
     )
     assert registry.get(sid, "claude", "main") is None, (
         "Stale entry must be removed from the registry"


### PR DESCRIPTION
## Related issue

Closes #4880

## Summary

- Failure: closing a terminal after its inner process exits leaves the terminal's private tmux server running.
- Cause: `is_alive()` clears `running`, and `close()` used that process-state flag to decide whether it still owned server teardown.
- Boundary: teardown now uses the existing successful-launch marker, and the runner no longer rewrites finished process state before closing a stale terminal.
- Risk: this changes only owner-driven close after a successful launch. It preserves tmux persistence until close and does not cover failures during launch.
- Proof: two focused tests fail on pristine `main` without the production change and pass with this commit.

A terminal can finish its command and still own a tmux server. Closing the terminal now stops that server without marking the finished command as running again.

```text
inner process exits -> running = false
successful launch   -> close() -> tmux kill-server
```

Related history: #849 made the private tmux server survive the inner process exit. #2951 later restored `running=True` at one runner caller before closing a stale terminal. This change moves that ownership rule into `TerminalInstance.close()`.

## Test Plan

- On pristine `main` at `8aaf72c91`, the deterministic ownership test and the real-tmux lifecycle test both failed for the missing teardown (`2 failed`).
- On the candidate, the same focused tests passed (`2 passed`).
- `uv run --no-sync pytest tests/inner/test_terminal.py tests/runner/test_app_sessions_native_terminal_routing.py --basetemp=/tmp/omnigent-terminal-tests-4881 -q` (`60 passed`).
- `uv run --no-sync ruff check tests/inner/test_terminal.py` (passed).
- `uv run --no-sync ruff format --check tests/inner/test_terminal.py` (passed).
- `uv run --no-sync pyrefly check tests/inner/test_terminal.py` (passed with no errors).

## Demo

The terminal is retained after its command exits and removed when its owner closes it:

```text
before close
tmux session exists: true
server process: sleeping
socket exists: true

after close
tmux session exists: false
server process: gone
socket exists: false

exit=0
```

![Tmux teardown after terminal close](https://raw.githubusercontent.com/dosenr/omnigent/b0d4ce033d6988d4557e054395954885511e54fe/4881-tmux-teardown.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deterministic test proves that successful launch state triggers tmux teardown after `running` becomes false. The real-tmux test proves that the retained session remains available until `close()`, then checks that the session and socket disappear and that the server process is gone or terminated as a zombie. A genuine command capture records the same lifecycle outside pytest.

## Changelog

Closing a finished terminal now stops its private tmux server.
