### PR TITLE
fix(cursor-native): ignore automated lifecycle prompts

### DIFF
--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -669,17 +669,17 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
     response_id = f"cursor:{blob_id}"[:_RESPONSE_ID_MAX_LEN]
     if role == "user":
         content = obj.get("content")
-        # cursor writes the post-/summarize history rollup as a user blob with a
-        # plain-string content (real user turns are a ``[{type:text}]`` list).
-        # Surface it as a compaction-completed signal, not a chat bubble, so the
-        # forwarder can tell the web UI the compaction actually finished.
-        if isinstance(content, str) and content.startswith(_COMPACTION_SUMMARY_PREFIX):
-            return _MirrorItem(
-                rowid=rowid,
-                item_type="compaction_completed",
-                item_data={},
-                response_id=response_id,
-            )
+        if isinstance(content, str):
+            # Cursor stores lifecycle notifications and compaction rollups as
+            # strings; real user turns use a ``[{type:text}]`` content list.
+            if content.startswith(_COMPACTION_SUMMARY_PREFIX):
+                return _MirrorItem(
+                    rowid=rowid,
+                    item_type="compaction_completed",
+                    item_data={},
+                    response_id=response_id,
+                )
+            return None
         prompt = _unwrap_user_query(_content_text(content))
         if not prompt:
             return None

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -229,6 +229,18 @@ class TestBlobToItem:
         blob = self._blob({"role": "user", "content": "just some unwrapped context"})
         assert fwd._blob_to_item(2, "bid", blob, "a") is None
 
+    def test_automated_notification_with_user_query_is_skipped(self) -> None:
+        content = (
+            "<timestamp>Sunday, Aug 16, 2026, 10:49 AM (UTC-4)</timestamp>\n"
+            "<system_notification>\n"
+            "The following task has finished.\n"
+            "</system_notification>\n"
+            "<user_query>Briefly inform the user about the task result and perform "
+            "any follow-up actions (if needed).</user_query>"
+        )
+        blob = self._blob({"role": "user", "content": content})
+        assert fwd._blob_to_item(2, "bid", blob, "a") is None
+
 
 class TestReadNewItems:
     def test_reads_live_wal_store(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #4882

## Summary

- Stop Cursor-native lifecycle notifications from being mirrored as human-authored user messages.
- Continue forwarding list-form human turns and the dedicated string-form compaction signal.
- Add regression coverage for the exact automated task-notification shape observed in the incident.

## Test Plan

- `uv run --frozen --group dev python -m pytest tests/test_cursor_native.py tests/test_cursor_native_bridge.py tests/test_cursor_native_forwarder.py tests/test_cursor_native_permissions.py tests/test_cursor_native_status.py tests/test_cursor_native_usage.py -q` → 196 passed.
- `uv run --frozen --group dev --extra all pre-commit run --files omnigent/cursor_native_forwarder.py tests/test_cursor_native_forwarder.py` → all hooks passed.
- Replayed the classifier against the incident Cursor store → retained 5 human messages and suppressed all 13 lifecycle notifications.

## Demo

![Before and after: Cursor lifecycle notifications no longer appear as user-authored chat bubbles](https://gist.githubusercontent.com/randypitcherii/c8e2bbda57ffb8fc45392b23c2be0bd8/raw/162981ae72c71518d245fd34855c076d32b07a16/cursor-native-lifecycle-demo.svg)

The incident replay retained every real human turn while removing all 13 repeated lifecycle prompts from the mirrored timeline.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The incident's real Cursor blob store was replayed through the corrected classifier to verify that automated notifications are suppressed without dropping human turns.

## Changelog

Cursor task notifications no longer appear as messages sent by you