### PR TITLE
fix(cursor-native): ignore automated lifecycle prompts

### DIFF
--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -669,17 +669,17 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
     response_id = f"cursor:{blob_id}"[:_RESPONSE_ID_MAX_LEN]
     if role == "user":
         content = obj.get("content")
-        # cursor writes the post-/summarize history rollup as a user blob with a
-        # plain-string content (real user turns are a ``[{type:text}]`` list).
-        # Surface it as a compaction-completed signal, not a chat bubble, so the
-        # forwarder can tell the web UI the compaction actually finished.
-        if isinstance(content, str) and content.startswith(_COMPACTION_SUMMARY_PREFIX):
-            return _MirrorItem(
-                rowid=rowid,
-                item_type="compaction_completed",
-                item_data={},
-                response_id=response_id,
-            )
+        if isinstance(content, str):
+            # Cursor stores lifecycle notifications and compaction rollups as
+            # strings; real user turns use a ``[{type:text}]`` content list.
+            if content.startswith(_COMPACTION_SUMMARY_PREFIX):
+                return _MirrorItem(
+                    rowid=rowid,
+                    item_type="compaction_completed",
+                    item_data={},
+                    response_id=response_id,
+                )
+            return None
         prompt = _unwrap_user_query(_content_text(content))
         if not prompt:
             return None

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -229,6 +229,18 @@ class TestBlobToItem:
         blob = self._blob({"role": "user", "content": "just some unwrapped context"})
         assert fwd._blob_to_item(2, "bid", blob, "a") is None
 
+    def test_automated_notification_with_user_query_is_skipped(self) -> None:
+        content = (
+            "<timestamp>Sunday, Aug 16, 2026, 10:49 AM (UTC-4)</timestamp>\n"
+            "<system_notification>\n"
+            "The following task has finished.\n"
+            "</system_notification>\n"
+            "<user_query>Briefly inform the user about the task result and perform "
+            "any follow-up actions (if needed).</user_query>"
+        )
+        blob = self._blob({"role": "user", "content": content})
+        assert fwd._blob_to_item(2, "bid", blob, "a") is None
+
 
 class TestReadNewItems:
     def test_reads_live_wal_store(self, tmp_path: Path) -> None:
@@ -241,6 +253,17 @@ class TestReadNewItems:
             [
                 ("s", {"role": "system", "content": "x"}),
                 ("u", _user("<user_query>\nReply ALPHA\n</user_query>")),
+                (
+                    "notification",
+                    {
+                        "role": "user",
+                        "content": (
+                            "<system_notification>Task finished.</system_notification>"
+                            "<user_query>Briefly inform the user about the task result and "
+                            "perform any follow-up actions (if needed).</user_query>"
+                        ),
+                    },
+                ),
                 ("bin", b"\x00binary"),
                 ("a", _assistant([{"type": "text", "text": "ALPHA"}])),
             ],
@@ -256,8 +279,8 @@ class TestReadNewItems:
         assert [it.item_data["role"] for it in posted] == ["user", "assistant"]
         assert posted[0].item_data["content"][0]["text"] == "Reply ALPHA"
         assert posted[1].item_data["content"][0]["text"] == "ALPHA"
-        # Every row (incl. skipped system/binary) advances the cursor.
-        assert max(it.rowid for it in items) == 4
+        # Every row (incl. skipped system/notification/binary) advances the cursor.
+        assert max(it.rowid for it in items) == 5
 
     def test_rowid_dedup_skips_already_seen(self, tmp_path: Path) -> None:
         store = tmp_path / "store.db"


### PR DESCRIPTION
## Related issue

Closes #4882

## Summary

- Stop the Cursor-native transcript forwarder from turning plain-string lifecycle notifications into human user messages.
- Preserve genuine list-backed Cursor user turns and the existing compaction-completed control event.
- Add unit and SQLite store-path regression coverage for the automated notification shape.

**ELI5:** Cursor stores some automated reminders in the same role it uses for people. Omnigent now uses Cursor's content shape to keep those reminders internal instead of showing them as messages from the signed-in user.

```text
Cursor user blob
├─ list content   → human message
└─ string content → compaction event or skip
```

## Test Plan

- Confirmed the new classifier test fails against the pre-fix implementation because the notification becomes a user message.
- Confirmed the SQLite store-path test fails against the pre-fix implementation with roles `user, user, assistant` instead of `user, assistant`.
- `uv run python -m pytest tests/test_cursor_native_forwarder.py -q` → 63 passed.
- Ruff check and format validation for both changed files → passed.
- `.venv/bin/pre-commit run --all-files` → all hooks passed, including Pyrefly and frontend type checks.
- The repository-wide Python run reached 1,405 passed and 27 skipped before stopping on the checkout's missing optional `psycopg` dependency in `tests/db/test_utils.py`; the focused suite and repository hooks are green.

## Demo

N/A — backend transcript classification fix with automated regression coverage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The store-path test writes both human and automated Cursor blobs through the SQLite reader used by the production forwarder and verifies only the human turn is emitted.

## Changelog

Cursor-native sessions no longer show automated lifecycle notifications as messages authored by me.
