### PR TITLE
fix(windows): pass Windows process essentials through harness env filters

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -367,6 +367,13 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "REQUESTS_CA_BUNDLE",
         "CURL_CA_BUNDLE",
         "NODE_EXTRA_CA_CERTS",
+        # Force UTF-8 I/O on Windows. Without this, Python on Windows defaults
+        # to the system ANSI code page (e.g. cp1252), causing UnicodeEncodeError
+        # when the host daemon / runner prints Unicode characters such as "✓" or
+        # "↑" in connection status messages — which kills the tunnel in an
+        # infinite reconnect loop. Safe to propagate: a non-secret interpreter
+        # flag. No-op on POSIX where UTF-8 is the default.
+        "PYTHONUTF8",
         # Environment descriptor baked into the sandbox host image
         # (deploy/docker/Dockerfile `host` target), never set on
         # laptops. Claude Code refuses --dangerously-skip-permissions

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 from collections.abc import Iterable, Mapping
 
+from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 
 # Categories every POSIX CLI needs regardless of vendor: where the user's
@@ -64,6 +65,10 @@ BASE_ALLOW_EXACT: frozenset[str] = frozenset(
         # git, not just the one whose bug surfaced it.
         "SSH_AUTH_SOCK",
         OMNIGENT_SESSION_ENV_VAR,
+        # Windows system / profile constants (SYSTEMROOT is mandatory for
+        # Winsock init, USERPROFILE for Path.home(), etc.); no-ops on POSIX
+        # because these names don't exist there. See omnigent._platform.
+        *WINDOWS_ENV_PASSTHROUGH,
     }
 )
 

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -800,7 +800,16 @@ def _harness_cli_version_satisfies(
     try:
         parsed = Version(version)
     except InvalidVersion:
-        return False
+        # Fall back to the leading X.Y.Z segment for pre-release version
+        # strings that packaging rejects (e.g. ``0.146.0-alpha.9.2``).
+        # This avoids mis-classifying a newer pre-release as too old.
+        m = re.match(r"^(\d+\.\d+\.\d+)", version)
+        if not m:
+            return False
+        try:
+            parsed = Version(m.group(1))
+        except InvalidVersion:
+            return False
     if spec.min_version is not None:
         try:
             if parsed < Version(spec.min_version):

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -115,7 +115,9 @@ async def validate_existing_host_workspace(
             "workspace required when host_id is set",
             code=ErrorCode.INVALID_INPUT,
         )
-    if not workspace.startswith("/"):
+    from omnigent.server.routes._workspace_validation import _is_windows_absolute_path
+
+    if not workspace.startswith("/") and not _is_windows_absolute_path(workspace):
         raise OmnigentError(
             "workspace must be an absolute path starting with /",
             code=ErrorCode.INVALID_INPUT,

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import secrets
 from typing import Any
 
@@ -37,6 +38,15 @@ _logger = logging.getLogger(__name__)
 # Treat these spec cwd values as "relative" — the agent doesn't pin
 # a specific directory and the workspace is unconstrained.
 _RELATIVE_CWD_PLACEHOLDERS: frozenset[str] = frozenset({"", ".", "./"})
+
+# Matches a Windows drive-letter absolute path such as ``C:\`` or ``C:/``.
+_WINDOWS_ABS_PATH_RE = re.compile(r"^[A-Za-z]:[/\\]")
+
+
+def _is_windows_absolute_path(path: str) -> bool:
+    """Return True for Windows drive-letter absolute paths (``C:\\…`` / ``C:/…``)."""
+    return bool(_WINDOWS_ABS_PATH_RE.match(path))
+
 
 # How long to wait for a host.stat round-trip before giving up. Stat
 # is a single syscall on the host side and a single WS round trip;
@@ -214,7 +224,7 @@ async def validate_workspace(
         The exception message is suitable for surfacing to the
         API caller verbatim.
     """
-    if not workspace.startswith("/"):
+    if not workspace.startswith("/") and not _is_windows_absolute_path(workspace):
         # Belt-and-suspenders. The Pydantic schema layer also
         # rejects this; pin it here so direct callers (tests,
         # other server-internal paths) can't bypass.


### PR DESCRIPTION
## Related issue

Closes #4851

## Summary

On native Windows, every harness CLI spawned via `clean_agent_env` (codex, pi, claude-sdk, antigravity, …) died instantly on spawn because the shared deny-by-default env filter `agent_env.BASE_ALLOW_EXACT` stripped `SYSTEMROOT`, `COMSPEC`, `USERPROFILE`, and other Windows-mandatory constants. Without `SYSTEMROOT`, Winsock/crypto cannot initialise — the subprocess exits before reading stdin, and the executor idles to the 600s watchdog.

The constant set already existed as `WINDOWS_ENV_PASSTHROUGH` in `_platform.py` and was already wired into `os_env._DEFAULT_ENV_PASSTHROUGH` and `connect._RUNNER_ENV_ALLOWLIST`. This PR adds it to `BASE_ALLOW_EXACT` so every harness executor inherits it automatically, matching the pattern used by the rest of the codebase.

Three related Windows issues fixed in the same pass:

- `PYTHONUTF8` was not in `_RUNNER_ENV_ALLOWLIST`, so the host daemon and runner subprocesses printed Unicode status characters (✓ ↑) on the Windows ANSI code page (cp1252), raising `UnicodeEncodeError` and killing the host tunnel in an infinite reconnect loop.
- `validate_existing_host_workspace` and `validate_workspace` required `workspace.startswith("/")`, rejecting every Windows drive-letter path (`C:\…`) from a connected Windows host. Windows absolute paths matching `^[A-Za-z]:[/\\]` are now accepted.
- `_harness_cli_version_satisfies` returned `False` on `packaging.version.InvalidVersion`, so pre-release versions like `0.146.0-alpha.9.2` (newer than the declared floor) were mis-classified as too-old and the harness was refused at the version gate. The fix falls back to the leading `X.Y.Z` segment for non-PEP-440 strings.

## Test Plan

- [x] Reproduced the root cause with the isolation script from the issue: with `env=None` (full inherited env) codex responds normally; with `_clean_codex_env()` as-was, `ConnectionResetError` on the first write.
- [x] Verified fix with `_clean_codex_env()` after adding `WINDOWS_ENV_PASSTHROUGH` to `BASE_ALLOW_EXACT` — codex app-server responds to `initialize`.
- [x] ruff format and ruff check pass on all changed files.
- [ ] Full Windows E2E — needs a Windows runner; the issue author confirmed the local fix works.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The core fix (adding `WINDOWS_ENV_PASSTHROUGH` to `BASE_ALLOW_EXACT`) is mechanically identical to how `os_env.py` and `connect.py` already include the same constants — the pattern is already tested in those modules. Full Windows E2E requires a Windows CI runner that isn't available in the current matrix; the issue author verified the fix locally.

## Changelog

Native Windows: harness CLIs (codex, pi, claude-sdk, antigravity) no longer hang on spawn due to missing `SYSTEMROOT`/`COMSPEC`; Windows drive-letter workspace paths (`C:\…`) are now accepted; pre-release harness CLI versions (e.g. `0.146.0-alpha.9.2`) no longer fail the version gate.