### PR TITLE
fix(claude-native): clamp the forwarder retry backoff exponent

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -95,6 +95,15 @@ _FORK_COMMAND_NAMES = frozenset({"/branch", "/fork"})
 _HTTP_POST_MAX_PERMANENT_FAILURES = 3
 _HTTP_POST_RETRY_BASE_DELAY_S = 1.0
 _HTTP_POST_RETRY_MAX_DELAY_S = 30.0
+# Ceiling for the backoff exponent. Transient failures retry with no give-up
+# budget (by design — see _PostRetryTracker), so ``attempts`` is unbounded, and
+# ``min()`` evaluates both operands: without this clamp ``2 ** attempts`` is
+# computed in full before the delay cap can apply, and overflows float once
+# attempts passes ~1025 (OverflowError out of record_failure). Any exponent past
+# the cap is dead weight anyway — with the defaults the cap is already reached at
+# attempt 6 — so 32 leaves the schedule identical while staying far inside float
+# range for any realistic max_delay_s / base_delay_s ratio.
+_HTTP_POST_RETRY_MAX_BACKOFF_EXPONENT = 32
 _HTTP_TRANSIENT_STATUS_CODES = {408, 409, 425, 429}
 # A 503 ``subagent_delivery_not_confirmed`` means the runner could not deliver a
 # terminal sub-agent result to the parent inbox. It is retried (the work entry can
@@ -699,8 +708,9 @@ class _PostRetryTracker:
                 exhausted=True,
                 permanent=permanent,
             )
+        exponent = min(max(0, entry.attempts - 1), _HTTP_POST_RETRY_MAX_BACKOFF_EXPONENT)
         delay_s = min(
-            self._base_delay_s * (2 ** max(0, entry.attempts - 1)),
+            self._base_delay_s * (2**exponent),
             self._max_delay_s,
         )
         entry.next_attempt_at = time.monotonic() + delay_s

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -7920,6 +7920,29 @@ def test_generic_503_without_not_confirmed_body_never_exhausts() -> None:
         assert tracker.record_failure("k", exc).exhausted is False
 
 
+def test_unbounded_transient_retries_keep_delay_capped_without_overflow() -> None:
+    # A transport-level failure is neither permanent nor not-confirmed, so it
+    # retries with no give-up budget and `attempts` grows without bound. The
+    # backoff exponent must be clamped before `2 ** n` is evaluated: min()
+    # computes both operands, so an unclamped exponent overflows float at
+    # attempt ~1025 and raises OverflowError out of record_failure.
+    tracker = forwarder._PostRetryTracker(base_delay_s=1.0, max_delay_s=30.0)
+    exc = httpx.RequestError("Databricks token refresh returned no token")
+    for _ in range(2000):
+        decision = tracker.record_failure("k", exc)
+        assert decision.exhausted is False
+        assert decision.delay_s <= 30.0
+    # The schedule still saturates at the cap instead of decaying.
+    assert decision.delay_s == 30.0
+
+
+def test_backoff_schedule_unchanged_below_the_cap() -> None:
+    tracker = forwarder._PostRetryTracker(base_delay_s=1.0, max_delay_s=30.0)
+    exc = httpx.RequestError("boom")
+    delays = [tracker.record_failure("k", exc).delay_s for _ in range(6)]
+    assert delays == [1.0, 2.0, 4.0, 8.0, 16.0, 30.0]
+
+
 def test_permanent_4xx_still_exhausts_at_three() -> None:
     tracker = forwarder._PostRetryTracker(max_permanent_attempts=3)
     exc = _http_status_error(400, {"error": "bad_request"})


### PR DESCRIPTION
## Related issue

Closes #4885

## Summary

- `_PostRetryTracker.record_failure` clamps the retry delay with `min(...)`, but `min()` evaluates **both** operands — so the cap never protects the `2 ** attempts` that feeds it. Transient/transport failures retry with no give-up budget (by design, per the class docstring), so `attempts` is unbounded and the exponentiation overflows `float` at attempt ~1025, raising `OverflowError` out of `record_failure` instead of returning a decision.
- Clamp the exponent before it is evaluated (`_HTTP_POST_RETRY_MAX_BACKOFF_EXPONENT = 32`). Every exponent past the cap was already dead weight — with the defaults the cap is reached at attempt 6 — so the schedule below the cap is unchanged and the retry **policy** is untouched.

**ELI5.** The backoff says "wait 2ⁿ seconds, but never more than 30". The "never more than 30" part worked, but we still computed 2ⁿ in full first — so after ~1000 retries the number got too big to turn into a delay at all and the calculation itself blew up. Since anything past the cap is discarded anyway, put a lid on the exponent too.

```
attempts:      1     2     4     6         1024        1025
             ┌────────────────────────────────────────────────
before:      1s    2s    8s   30s(cap)     30s(cap)    OverflowError
after:       1s    2s    8s   30s(cap)     30s(cap)    30s(cap)
                          └── identical ──┘            └── fixed
```

## Test Plan

**Automated** — two unit tests next to the existing `_PostRetryTracker` cases:

```
$ uv run pytest tests/test_claude_native_forwarder.py \
    -k "overflow or backoff_schedule or never_exhausts or exhausts_at_three or not_confirmed_503"
6 passed, 146 deselected in 0.11s
```

- `test_unbounded_transient_retries_keep_delay_capped_without_overflow` — feeds an `httpx.RequestError` 2000 times. Verified it actually catches the bug: reverting just the implementation hunk gives
  `E OverflowError: int too large to convert to float` at `omnigent/claude_native_forwarder.py:703` → `1 failed, 1 passed`.
- `test_backoff_schedule_unchanged_below_the_cap` — pins `[1, 2, 4, 8, 16, 30]` so the clamp cannot silently alter the schedule.

**Manual** — driving the real class before/after the change:

```
before (main):  attempts=10 delay=30.0(cap) ... attempts=1024 delay=30.0
                attempts=1025 -> OverflowError: int too large to convert to float
after:          3000 attempts complete, delay stays 30.0, exhausted stays False
                schedule below cap unchanged: [1.0, 2.0, 4.0, 8.0, 16.0, 30.0]
                permanent 4xx still exhausts at 3 -> [False, False, True]
```

Field evidence that motivated it (host CLI 0.8.2, workspace-hosted Omnigent, one session over ~12 h with a broken token mint): 67,624 `httpx.RequestError`, **0** `httpx.HTTPStatusError`, 30,381 `OverflowError` tracebacks, and a **106 MB** runner log. Details in #4885.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two new unit tests cover both halves of the change: the overflow itself (2000 transient failures) and the guarantee that the pre-cap schedule is untouched. Manual verification additionally confirmed the classification paths are unaffected (a permanent 4xx still exhausts at 3 attempts) by exercising the real `_PostRetryTracker`, since that is what the field report exercised.

## Changelog

A stuck event-forward retry no longer crashes with `OverflowError` or floods the runner log
