### PR TITLE
fix(tools): paginate agent and session discovery

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -604,9 +604,110 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
 # sys_os_write, e.g. following the ``build-omnigent`` skill).
 _AGENT_CONFIG_SUBDIR = ".omnigent/agent-configs"
 
-# Broad page size for the sys_agent_list fan-out reads. Orchestrators want
-# the full launchable surface in one call, not a 20-row default page.
+# Broad internal page size for discovery fan-out reads.
 _AGENT_LIST_PAGE_LIMIT = 1000
+
+_DISCOVERY_LIST_MAX_LIMIT = 100
+# Match the existing default ceiling for ``sys_os_shell`` output. Discovery
+# tools stay below the same Omnigent-owned budget instead of guessing a
+# harness-specific limit.
+_DISCOVERY_LIST_OUTPUT_MAX_CHARS = 100_000
+
+
+def _discovery_list_window(args: _JsonObject, tool_name: str) -> tuple[int | None, int] | str:
+    """Validate the shared pagination window for discovery list tools."""
+    limit = args.get("limit")
+    offset = args.get("offset", 0)
+    if "limit" in args and (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or not 1 <= limit <= _DISCOVERY_LIST_MAX_LIMIT
+    ):
+        return json.dumps(
+            {
+                "error": (
+                    f"{tool_name}: 'limit' must be an integer between 1 and "
+                    f"{_DISCOVERY_LIST_MAX_LIMIT}"
+                )
+            }
+        )
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        return json.dumps({"error": f"{tool_name}: 'offset' must be a non-negative integer"})
+    return cast(int | None, limit), offset
+
+
+def _page_rows(rows: list[_JsonObject], limit: int, offset: int) -> tuple[list[_JsonObject], bool]:
+    """Return one page and whether another row exists in the fetched window."""
+    end = offset + limit
+    return rows[offset:end], len(rows) > end
+
+
+def _bounded_discovery_result(
+    sections: dict[str, list[_JsonObject]],
+    *,
+    limit: int | None,
+    offset: int,
+    page_sections: tuple[str, ...] | None = None,
+) -> str:
+    """Keep a small legacy result intact, otherwise return a fitting page."""
+    complete = json.dumps(sections)
+    if limit is None and offset == 0 and len(complete) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
+        return complete
+
+    requested_limit = limit or _DISCOVERY_LIST_MAX_LIMIT
+    paged = page_sections or tuple(sections)
+
+    def _candidate(candidate_limit: int) -> str:
+        page = dict(sections)
+        has_more: dict[str, bool] = {}
+        for name in paged:
+            rows = sections[name]
+            page[name], has_more[name] = _page_rows(rows, candidate_limit, offset)
+        return json.dumps(
+            {
+                **page,
+                "page": {
+                    "limit": candidate_limit,
+                    "offset": offset,
+                    "has_more": has_more,
+                },
+            }
+        )
+
+    low = 1
+    high = requested_limit
+    best: str | None = None
+    while low <= high:
+        candidate_limit = (low + high) // 2
+        candidate = _candidate(candidate_limit)
+        if len(candidate) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
+            best = candidate
+            low = candidate_limit + 1
+        else:
+            high = candidate_limit - 1
+    if best is not None:
+        return best
+
+    empty_page = _candidate(0)
+    if len(empty_page) > _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
+        kind = "fixed_section"
+        oversized_sections = [
+            name for name, rows in sections.items() if name not in paged and rows
+        ]
+    else:
+        kind = "paginated_row"
+        oversized_sections = [name for name in paged if offset < len(sections[name])]
+    return json.dumps(
+        {
+            "error": (
+                f"Discovery result exceeds the {_DISCOVERY_LIST_OUTPUT_MAX_CHARS}-character "
+                "output limit even at the smallest page."
+            ),
+            "page": {"offset": offset},
+            "oversized": {"kind": kind, "sections": oversized_sections},
+        }
+    )
+
 
 # Union of all locally-dispatched tools.
 _ALL_LOCAL_TOOLS = (
@@ -3738,7 +3839,17 @@ async def _execute_session_query_tool(
         return json.dumps({"error": f"{tool_name}: malformed JSON arguments"})
 
     if tool_name == "sys_session_list":
-        return await _session_list_via_rest(conversation_id, server_client, args.get("agent_name"))
+        window = _discovery_list_window(args, tool_name)
+        if isinstance(window, str):
+            return window
+        limit, offset = window
+        return await _session_list_via_rest(
+            conversation_id,
+            server_client,
+            args.get("agent_name"),
+            limit=limit,
+            offset=offset,
+        )
     if tool_name == "sys_session_get_history":
         return await _session_get_history_via_rest(args, server_client)
     if tool_name == "sys_session_get_info":
@@ -4051,11 +4162,17 @@ async def _execute_agent_tool(
     if server_client is None:
         return json.dumps({"error": f"{tool_name} requires server access"})
     if tool_name == "sys_agent_list":
+        window = _discovery_list_window(args, tool_name)
+        if isinstance(window, str):
+            return window
+        limit, offset = window
         return await _agent_list_via_rest(
             server_client,
             agent_spec=agent_spec,
             conversation_id=conversation_id,
             runner_workspace=runner_workspace,
+            limit=limit,
+            offset=offset,
         )
     session_id = args.get("session_id")
     if not isinstance(session_id, str) or not session_id:
@@ -4419,6 +4536,8 @@ async def _agent_list_via_rest(
     agent_spec: AgentSpec | None,
     conversation_id: str | None,
     runner_workspace: Path | None,
+    limit: int | None,
+    offset: int,
 ) -> str:
     """
     List launchable agents across built-ins, session-bound, and local.
@@ -4448,7 +4567,11 @@ async def _agent_list_via_rest(
         resolution of the local-config scan.
     :param conversation_id: The caller's session id, for os_env cwd.
     :param runner_workspace: The runner workspace, authoritative cwd.
-    :returns: JSON ``{builtins, session_agents, local_configs}``.
+    :param limit: Optional maximum rows returned from each source. When
+        omitted, the complete legacy result is preserved while it fits.
+    :param offset: Zero-based offset applied to each source.
+    :returns: The legacy complete JSON result while it fits, otherwise a
+        bounded page with continuation metadata.
     """
     builtins_raw = await _agent_list_fetch("/v1/agents", server_client)
     sessions_raw = await _agent_list_fetch("/v1/sessions", server_client)
@@ -4460,7 +4583,7 @@ async def _agent_list_via_rest(
     listing["builtins"] = _in_spawn_family(
         listing["builtins"], await _spawn_family(server_client, conversation_id)
     )
-    return json.dumps(listing)
+    return _bounded_discovery_result(listing, limit=limit, offset=offset)
 
 
 def _project_agent_list(
@@ -4511,6 +4634,9 @@ async def _session_list_via_rest(
     conversation_id: str,
     server_client: httpx.AsyncClient,
     agent_name: object = None,
+    *,
+    limit: int | None,
+    offset: int,
 ) -> str:
     """
     Return the two-view session list: ``sub_agents`` + global ``sessions``.
@@ -4528,11 +4654,20 @@ async def _session_list_via_rest(
     :param server_client: HTTP client pointed at the Omnigent server.
     :param agent_name: Optional agent-name filter for the global
         ``sessions`` view; ignored for ``sub_agents``.
-    :returns: JSON ``{"sub_agents": [...], "sessions": [...]}``.
+    :param limit: Optional maximum rows returned from the global sessions view. When
+        omitted, the complete legacy result is preserved while it fits.
+    :param offset: Zero-based offset into the global sessions view.
+    :returns: The legacy complete JSON result while it fits, otherwise a
+        bounded page with continuation metadata.
     """
     sub_agents = await _collect_sub_agents(conversation_id, server_client)
     sessions = await _collect_global_sessions(server_client, agent_name)
-    return json.dumps({"sub_agents": sub_agents, "sessions": sessions})
+    return _bounded_discovery_result(
+        {"sub_agents": cast(list[_JsonObject], sub_agents), "sessions": sessions},
+        limit=limit,
+        offset=offset,
+        page_sections=("sessions",),
+    )
 
 
 async def _rename_current_session_via_rest(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -20,6 +20,7 @@ Tool categories:
 from __future__ import annotations
 
 import asyncio
+import base64
 import dataclasses
 import json
 import logging
@@ -614,10 +615,13 @@ _DISCOVERY_LIST_MAX_LIMIT = 100
 _DISCOVERY_LIST_OUTPUT_MAX_CHARS = 100_000
 
 
-def _discovery_list_window(args: _JsonObject, tool_name: str) -> tuple[int | None, int] | str:
-    """Validate the shared pagination window for discovery list tools."""
+def _discovery_list_window(
+    args: _JsonObject,
+    tool_name: str,
+    page_sections: tuple[str, ...],
+) -> tuple[int | None, dict[str, str | int | None]] | str:
+    """Validate discovery pagination and decode its opaque continuation cursor."""
     limit = args.get("limit")
-    offset = args.get("offset", 0)
     if "limit" in args and (
         not isinstance(limit, int)
         or isinstance(limit, bool)
@@ -631,27 +635,63 @@ def _discovery_list_window(args: _JsonObject, tool_name: str) -> tuple[int | Non
                 )
             }
         )
-    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
-        return json.dumps({"error": f"{tool_name}: 'offset' must be a non-negative integer"})
-    return cast(int | None, limit), offset
+    cursor = args.get("cursor")
+    state: dict[str, str | int | None] = {
+        name: 0 if name == "local_configs" else None for name in page_sections
+    }
+    if cursor is None:
+        return cast(int | None, limit), state
+    if not isinstance(cursor, str) or not cursor:
+        return json.dumps({"error": f"{tool_name}: 'cursor' must be a non-empty string"})
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(cursor + padding).decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+    if not isinstance(payload, dict) or payload.get("v") != 1:
+        return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+    for name, default in state.items():
+        value = payload.get(name, default)
+        if name == "local_configs":
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+        elif value is not None and not isinstance(value, str):
+            return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+        state[name] = value
+    return cast(int | None, limit), state
 
 
-def _page_rows(rows: list[_JsonObject], limit: int, offset: int) -> tuple[list[_JsonObject], bool]:
-    """Return one page and whether another row exists in the fetched window."""
-    end = offset + limit
-    return rows[offset:end], len(rows) > end
+def _encode_discovery_cursor(state: dict[str, str | int | None]) -> str:
+    """Serialize a discovery continuation cursor without exposing its shape."""
+    payload = json.dumps({"v": 1, **state}, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+@dataclass(frozen=True)
+class _DiscoveryPage:
+    """Rows and continuation state from one discovery source."""
+
+    rows: list[_JsonObject]
+    has_more: bool
+    next_after: str | None = None
 
 
 def _bounded_discovery_result(
     sections: dict[str, list[_JsonObject]],
     *,
     limit: int | None,
-    offset: int,
+    cursor_state: dict[str, str | int | None],
+    source_pages: dict[str, _DiscoveryPage],
     page_sections: tuple[str, ...] | None = None,
 ) -> str:
     """Keep a small legacy result intact, otherwise return a fitting page."""
     complete = json.dumps(sections)
-    if limit is None and offset == 0 and len(complete) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
+    if (
+        limit is None
+        and not any(cursor_state.values())
+        and not any(page.has_more for page in source_pages.values())
+        and len(complete) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS
+    ):
         return complete
 
     requested_limit = limit or _DISCOVERY_LIST_MAX_LIMIT
@@ -660,19 +700,28 @@ def _bounded_discovery_result(
     def _candidate(candidate_limit: int) -> str:
         page = dict(sections)
         has_more: dict[str, bool] = {}
+        next_state = dict(cursor_state)
         for name in paged:
             rows = sections[name]
-            page[name], has_more[name] = _page_rows(rows, candidate_limit, offset)
-        return json.dumps(
-            {
-                **page,
-                "page": {
-                    "limit": candidate_limit,
-                    "offset": offset,
-                    "has_more": has_more,
-                },
-            }
-        )
+            page_rows = rows[:candidate_limit]
+            page[name] = page_rows
+            source_page = source_pages[name]
+            has_more[name] = len(rows) > candidate_limit or source_page.has_more
+            if name == "local_configs":
+                start = cast(int, cursor_state[name])
+                next_state[name] = start + len(page_rows)
+            elif page_rows:
+                identifier = "agent_id" if name == "builtins" else "session_id"
+                next_state[name] = _optional_string(page_rows[-1].get(identifier))
+            elif source_page.has_more:
+                next_state[name] = source_page.next_after
+        metadata: dict[str, object] = {
+            "limit": candidate_limit,
+            "has_more": has_more,
+        }
+        if any(has_more.values()):
+            metadata["next_cursor"] = _encode_discovery_cursor(next_state)
+        return json.dumps({**page, "page": metadata})
 
     low = 1
     high = requested_limit
@@ -696,14 +745,14 @@ def _bounded_discovery_result(
         ]
     else:
         kind = "paginated_row"
-        oversized_sections = [name for name in paged if offset < len(sections[name])]
+        oversized_sections = [name for name in paged if sections[name]]
     return json.dumps(
         {
             "error": (
                 f"Discovery result exceeds the {_DISCOVERY_LIST_OUTPUT_MAX_CHARS}-character "
                 "output limit even at the smallest page."
             ),
-            "page": {"offset": offset},
+            "page": {"has_more": {name: source_pages[name].has_more for name in paged}},
             "oversized": {"kind": kind, "sections": oversized_sections},
         }
     )
@@ -3839,16 +3888,16 @@ async def _execute_session_query_tool(
         return json.dumps({"error": f"{tool_name}: malformed JSON arguments"})
 
     if tool_name == "sys_session_list":
-        window = _discovery_list_window(args, tool_name)
+        window = _discovery_list_window(args, tool_name, ("sessions",))
         if isinstance(window, str):
             return window
-        limit, offset = window
+        limit, cursor_state = window
         return await _session_list_via_rest(
             conversation_id,
             server_client,
             args.get("agent_name"),
             limit=limit,
-            offset=offset,
+            cursor_state=cursor_state,
         )
     if tool_name == "sys_session_get_history":
         return await _session_get_history_via_rest(args, server_client)
@@ -4162,17 +4211,21 @@ async def _execute_agent_tool(
     if server_client is None:
         return json.dumps({"error": f"{tool_name} requires server access"})
     if tool_name == "sys_agent_list":
-        window = _discovery_list_window(args, tool_name)
+        window = _discovery_list_window(
+            args,
+            tool_name,
+            ("builtins", "session_agents", "local_configs"),
+        )
         if isinstance(window, str):
             return window
-        limit, offset = window
+        limit, cursor_state = window
         return await _agent_list_via_rest(
             server_client,
             agent_spec=agent_spec,
             conversation_id=conversation_id,
             runner_workspace=runner_workspace,
             limit=limit,
-            offset=offset,
+            cursor_state=cursor_state,
         )
     session_id = args.get("session_id")
     if not isinstance(session_id, str) or not session_id:
@@ -4349,9 +4402,12 @@ async def _agent_download_via_rest(
 async def _agent_list_fetch(
     path: str,
     server_client: httpx.AsyncClient,
-) -> list[_JsonObject]:
+    *,
+    after: str | None,
+    limit: int,
+) -> _DiscoveryPage:
     """
-    Fetch one page of a paginated list endpoint, returning its ``data``.
+    Fetch one cursor page of a paginated list endpoint.
 
     Best-effort: returns ``[]`` on transport error or non-200 so a single
     failing source degrades ``sys_agent_list`` to "that section is empty"
@@ -4360,21 +4416,27 @@ async def _agent_list_fetch(
     :param path: The list endpoint path, e.g. ``"/v1/agents"`` or
         ``"/v1/sessions"``.
     :param server_client: HTTP client pointed at the Omnigent server.
-    :returns: The ``data`` list from the paginated response (possibly
-        empty).
+    :param after: Server cursor from the previous page, if any.
+    :param limit: Maximum number of source rows to fetch.
+    :returns: Rows and server continuation metadata.
     """
     try:
-        resp = await server_client.get(
-            path,
-            params={"limit": _AGENT_LIST_PAGE_LIMIT, "order": "desc"},
-            timeout=30.0,
-        )
+        params: dict[str, str | int] = {"limit": limit, "order": "desc"}
+        if after is not None:
+            params["after"] = after
+        resp = await server_client.get(path, params=params, timeout=30.0)
     except Exception:  # noqa: BLE001
-        return []
+        return _DiscoveryPage([], False)
     if resp.status_code != 200:
-        return []
+        return _DiscoveryPage([], False)
     body = _string_object_dict(resp.json())
-    return _json_object_list(body.get("data")) if body is not None else []
+    if body is None:
+        return _DiscoveryPage([], False)
+    return _DiscoveryPage(
+        _json_object_list(body.get("data")),
+        body.get("has_more") is True,
+        _optional_string(body.get("last_id")),
+    )
 
 
 def _scan_local_agent_configs(configs_dir: Path) -> list[_JsonObject]:
@@ -4537,7 +4599,7 @@ async def _agent_list_via_rest(
     conversation_id: str | None,
     runner_workspace: Path | None,
     limit: int | None,
-    offset: int,
+    cursor_state: dict[str, str | int | None],
 ) -> str:
     """
     List launchable agents across built-ins, session-bound, and local.
@@ -4569,21 +4631,49 @@ async def _agent_list_via_rest(
     :param runner_workspace: The runner workspace, authoritative cwd.
     :param limit: Optional maximum rows returned from each source. When
         omitted, the complete legacy result is preserved while it fits.
-    :param offset: Zero-based offset applied to each source.
+    :param cursor_state: Opaque continuation positions for each source.
     :returns: The legacy complete JSON result while it fits, otherwise a
         bounded page with continuation metadata.
     """
-    builtins_raw = await _agent_list_fetch("/v1/agents", server_client)
-    sessions_raw = await _agent_list_fetch("/v1/sessions", server_client)
+    source_limit = limit or _AGENT_LIST_PAGE_LIMIT
+    builtins_page = await _agent_list_fetch(
+        "/v1/agents",
+        server_client,
+        after=cast(str | None, cursor_state["builtins"]),
+        limit=source_limit,
+    )
+    sessions_page = await _agent_list_fetch(
+        "/v1/sessions",
+        server_client,
+        after=cast(str | None, cursor_state["session_agents"]),
+        limit=source_limit,
+    )
     spec = _effective_runner_os_env_spec(agent_spec, conversation_id, runner_workspace)
     assert spec.cwd is not None
     configs_dir = Path(spec.cwd) / _AGENT_CONFIG_SUBDIR
     local_configs = await asyncio.to_thread(_scan_local_agent_configs, configs_dir)
-    listing = _project_agent_list(builtins_raw, sessions_raw, local_configs)
+    local_start = cast(int, cursor_state["local_configs"])
+    listing = _project_agent_list(
+        builtins_page.rows,
+        sessions_page.rows,
+        local_configs[local_start : local_start + source_limit],
+    )
     listing["builtins"] = _in_spawn_family(
         listing["builtins"], await _spawn_family(server_client, conversation_id)
     )
-    return _bounded_discovery_result(listing, limit=limit, offset=offset)
+    return _bounded_discovery_result(
+        listing,
+        limit=limit,
+        cursor_state=cursor_state,
+        source_pages={
+            "builtins": builtins_page,
+            "session_agents": sessions_page,
+            "local_configs": _DiscoveryPage(
+                listing["local_configs"],
+                local_start + len(listing["local_configs"]) < len(local_configs),
+            ),
+        },
+    )
 
 
 def _project_agent_list(
@@ -4636,7 +4726,7 @@ async def _session_list_via_rest(
     agent_name: object = None,
     *,
     limit: int | None,
-    offset: int,
+    cursor_state: dict[str, str | int | None],
 ) -> str:
     """
     Return the two-view session list: ``sub_agents`` + global ``sessions``.
@@ -4656,16 +4746,22 @@ async def _session_list_via_rest(
         ``sessions`` view; ignored for ``sub_agents``.
     :param limit: Optional maximum rows returned from the global sessions view. When
         omitted, the complete legacy result is preserved while it fits.
-    :param offset: Zero-based offset into the global sessions view.
+    :param cursor_state: Opaque continuation position for the global sessions view.
     :returns: The legacy complete JSON result while it fits, otherwise a
         bounded page with continuation metadata.
     """
     sub_agents = await _collect_sub_agents(conversation_id, server_client)
-    sessions = await _collect_global_sessions(server_client, agent_name)
+    sessions_page = await _collect_global_sessions(
+        server_client,
+        agent_name,
+        after=cast(str | None, cursor_state["sessions"]),
+        limit=limit or _AGENT_LIST_PAGE_LIMIT,
+    )
     return _bounded_discovery_result(
-        {"sub_agents": cast(list[_JsonObject], sub_agents), "sessions": sessions},
+        {"sub_agents": cast(list[_JsonObject], sub_agents), "sessions": sessions_page.rows},
         limit=limit,
-        offset=offset,
+        cursor_state=cursor_state,
+        source_pages={"sessions": sessions_page},
         page_sections=("sessions",),
     )
 
@@ -4803,7 +4899,10 @@ async def _resolve_runner_online_map(
 async def _collect_global_sessions(
     server_client: httpx.AsyncClient,
     agent_name: object,
-) -> list[_JsonObject]:
+    *,
+    after: str | None,
+    limit: int,
+) -> _DiscoveryPage:
     """
     Fetch the global session list via ``GET /v1/sessions``, with connectivity.
 
@@ -4818,38 +4917,46 @@ async def _collect_global_sessions(
     :param server_client: HTTP client pointed at the Omnigent server.
     :param agent_name: Optional agent-name filter; applied only when a
         non-empty string.
-    :returns: The projected global session entries.
+    :param after: Server cursor from the previous page, if any.
+    :param limit: Maximum number of source rows to fetch.
+    :returns: Projected global session entries and continuation metadata.
     """
-    params: dict[str, str | int] = {"limit": _AGENT_LIST_PAGE_LIMIT, "order": "desc"}
+    params: dict[str, str | int] = {"limit": limit, "order": "desc"}
     if isinstance(agent_name, str) and agent_name:
         params["agent_name"] = agent_name
+    if after is not None:
+        params["after"] = after
     try:
         resp = await server_client.get("/v1/sessions", params=params, timeout=30.0)
     except Exception:  # noqa: BLE001
-        return []
+        return _DiscoveryPage([], False)
     if resp.status_code != 200:
-        return []
+        return _DiscoveryPage([], False)
     body = _string_object_dict(resp.json())
     if body is None:
-        return []
+        return _DiscoveryPage([], False)
     rows = _json_object_list(body.get("data"))
     online = await _resolve_runner_online_map(rows, server_client)
-    return [
-        {
-            "session_id": r.get("id"),
-            # Hide the internal ``-native-ui`` wrapper name (e.g.
-            # ``pi-native-ui`` -> ``Pi``) in the global listing too, matching
-            # ``sys_session_get_info``. The server-side ``agent_name`` filter
-            # above still receives the caller's raw argument unchanged.
-            "agent_name": public_agent_name(_optional_string(r.get("agent_name"))),
-            "title": r.get("title"),
-            "status": r.get("status"),
-            "runner_id": r.get("runner_id"),
-            "runner_online": online.get(_optional_string(r.get("runner_id")) or ""),
-            "parent_session_id": r.get("parent_session_id"),
-        }
-        for r in rows
-    ]
+    return _DiscoveryPage(
+        [
+            {
+                "session_id": r.get("id"),
+                # Hide the internal ``-native-ui`` wrapper name (e.g.
+                # ``pi-native-ui`` -> ``Pi``) in the global listing too, matching
+                # ``sys_session_get_info``. The server-side ``agent_name`` filter
+                # above still receives the caller's raw argument unchanged.
+                "agent_name": public_agent_name(_optional_string(r.get("agent_name"))),
+                "title": r.get("title"),
+                "status": r.get("status"),
+                "runner_id": r.get("runner_id"),
+                "runner_online": online.get(_optional_string(r.get("runner_id")) or ""),
+                "parent_session_id": r.get("parent_session_id"),
+            }
+            for r in rows
+        ],
+        body.get("has_more") is True,
+        _optional_string(body.get("last_id")),
+    )
 
 
 def _child_rows_to_entries(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -613,13 +613,19 @@ _DISCOVERY_LIST_MAX_LIMIT = 100
 # tools stay below the same Omnigent-owned budget instead of guessing a
 # harness-specific limit.
 _DISCOVERY_LIST_OUTPUT_MAX_CHARS = 100_000
+_DISCOVERY_CURSOR_MAX_CHARS = 40_000
+_DISCOVERY_START = "start"
+_DISCOVERY_AT = "at"
+_DISCOVERY_END = "end"
+_DiscoveryState = tuple[str, str | None]
 
 
 def _discovery_list_window(
     args: _JsonObject,
     tool_name: str,
     page_sections: tuple[str, ...],
-) -> tuple[int | None, dict[str, str | int | None]] | str:
+    filters: _JsonObject,
+) -> tuple[int | None, dict[str, _DiscoveryState], bool] | str:
     """Validate discovery pagination and decode its opaque continuation cursor."""
     limit = args.get("limit")
     if "limit" in args and (
@@ -636,35 +642,65 @@ def _discovery_list_window(
             }
         )
     cursor = args.get("cursor")
-    state: dict[str, str | int | None] = {
-        name: 0 if name == "local_configs" else None for name in page_sections
-    }
+    state: dict[str, _DiscoveryState] = dict.fromkeys(page_sections, (_DISCOVERY_START, None))
     if cursor is None:
-        return cast(int | None, limit), state
+        return cast(int | None, limit), state, False
     if not isinstance(cursor, str) or not cursor:
         return json.dumps({"error": f"{tool_name}: 'cursor' must be a non-empty string"})
+    if len(cursor) > _DISCOVERY_CURSOR_MAX_CHARS:
+        return json.dumps({"error": f"{tool_name}: pagination cursor is too long"})
     try:
         padding = "=" * (-len(cursor) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(cursor + padding).decode("utf-8"))
+        raw = base64.b64decode(cursor + padding, altchars=b"-_", validate=True)
+        payload = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
         return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
-    if not isinstance(payload, dict) or payload.get("v") != 1:
+    if not isinstance(payload, dict) or set(payload) != {"v", "tool", "filters", "sections"}:
         return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
-    for name, default in state.items():
-        value = payload.get(name, default)
-        if name == "local_configs":
-            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-                return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
-        elif value is not None and not isinstance(value, str):
+    if payload.get("v") != 1:
+        return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+    if payload.get("tool") != tool_name:
+        return json.dumps({"error": f"{tool_name}: cursor was minted by a different tool"})
+    if payload.get("filters") != filters:
+        return json.dumps({"error": f"{tool_name}: cursor uses different filter arguments"})
+    sections = payload.get("sections")
+    if not isinstance(sections, dict) or set(sections) != set(page_sections):
+        return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+    for name in state:
+        value = sections.get(name)
+        if not isinstance(value, list) or len(value) != 2:
             return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
-        state[name] = value
-    return cast(int | None, limit), state
+        tag, position = value
+        if tag in {_DISCOVERY_START, _DISCOVERY_END}:
+            if position is not None:
+                return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+        elif tag == _DISCOVERY_AT:
+            if not isinstance(position, str) or not position:
+                return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+        else:
+            return json.dumps({"error": f"{tool_name}: invalid pagination cursor"})
+        state[name] = (tag, cast(str | None, position))
+    return cast(int | None, limit), state, True
 
 
-def _encode_discovery_cursor(state: dict[str, str | int | None]) -> str:
+def _encode_discovery_cursor(
+    tool_name: str,
+    filters: _JsonObject,
+    state: dict[str, _DiscoveryState],
+) -> str | None:
     """Serialize a discovery continuation cursor without exposing its shape."""
-    payload = json.dumps({"v": 1, **state}, separators=(",", ":")).encode("utf-8")
-    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    payload = json.dumps(
+        {
+            "v": 1,
+            "tool": tool_name,
+            "filters": filters,
+            "sections": {name: list(value) for name, value in state.items()},
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    cursor = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return cursor if len(cursor) <= _DISCOVERY_CURSOR_MAX_CHARS else None
 
 
 @dataclass(frozen=True)
@@ -674,21 +710,52 @@ class _DiscoveryPage:
     rows: list[_JsonObject]
     has_more: bool
     next_after: str | None = None
+    failed: bool = False
+
+
+def _parse_discovery_page(body: object) -> _DiscoveryPage:
+    """Validate the server envelope before trusting its continuation state."""
+    if not isinstance(body, dict):
+        return _DiscoveryPage([], False, failed=True)
+    data = body.get("data")
+    if not isinstance(data, list):
+        return _DiscoveryPage([], False, failed=True)
+    rows: list[_JsonObject] = []
+    for row in data:
+        if not isinstance(row, dict):
+            return _DiscoveryPage([], False, failed=True)
+        row_id = row.get("id")
+        if not isinstance(row_id, str) or not row_id:
+            return _DiscoveryPage([], False, failed=True)
+        rows.append(row)
+    has_more = body.get("has_more", False)
+    last_id = body.get("last_id")
+    if not isinstance(has_more, bool):
+        return _DiscoveryPage([], False, failed=True)
+    if last_id is not None and (not isinstance(last_id, str) or not last_id):
+        return _DiscoveryPage([], False, failed=True)
+    if has_more and last_id is None:
+        return _DiscoveryPage([], False, failed=True)
+    return _DiscoveryPage(rows, has_more, cast(str | None, last_id))
 
 
 def _bounded_discovery_result(
     sections: dict[str, list[_JsonObject]],
     *,
     limit: int | None,
-    cursor_state: dict[str, str | int | None],
+    cursor_state: dict[str, _DiscoveryState],
+    continued: bool,
     source_pages: dict[str, _DiscoveryPage],
     page_sections: tuple[str, ...] | None = None,
+    tool_name: str,
+    filters: _JsonObject,
 ) -> str:
     """Keep a small legacy result intact, otherwise return a fitting page."""
     complete = json.dumps(sections)
     if (
         limit is None
-        and not any(cursor_state.values())
+        and not continued
+        and not any(page.failed for page in source_pages.values())
         and not any(page.has_more for page in source_pages.values())
         and len(complete) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS
     ):
@@ -697,7 +764,7 @@ def _bounded_discovery_result(
     requested_limit = limit or _DISCOVERY_LIST_MAX_LIMIT
     paged = page_sections or tuple(sections)
 
-    def _candidate(candidate_limit: int) -> str:
+    def _candidate(candidate_limit: int) -> str | None:
         page = dict(sections)
         has_more: dict[str, bool] = {}
         next_state = dict(cursor_state)
@@ -706,38 +773,52 @@ def _bounded_discovery_result(
             page_rows = rows[:candidate_limit]
             page[name] = page_rows
             source_page = source_pages[name]
+            if source_page.failed:
+                # A failed read proves neither progress nor exhaustion. Keep
+                # the incoming position so the continuation retries it.
+                has_more[name] = True
+                continue
             has_more[name] = len(rows) > candidate_limit or source_page.has_more
-            if name == "local_configs":
-                start = cast(int, cursor_state[name])
-                next_state[name] = start + len(page_rows)
+            if not has_more[name]:
+                next_state[name] = (_DISCOVERY_END, None)
             elif page_rows:
-                identifier = "agent_id" if name == "builtins" else "session_id"
-                next_state[name] = _optional_string(page_rows[-1].get(identifier))
-            elif source_page.has_more:
-                next_state[name] = source_page.next_after
+                if name == "local_configs":
+                    position = _optional_string(page_rows[-1].get("path"))
+                else:
+                    identifier = "agent_id" if name == "builtins" else "session_id"
+                    position = _optional_string(page_rows[-1].get(identifier))
+                if position is not None:
+                    next_state[name] = (_DISCOVERY_AT, position)
+            elif source_page.has_more and source_page.next_after is not None:
+                next_state[name] = (_DISCOVERY_AT, source_page.next_after)
         metadata: dict[str, object] = {
             "limit": candidate_limit,
             "has_more": has_more,
         }
         if any(has_more.values()):
-            metadata["next_cursor"] = _encode_discovery_cursor(next_state)
+            cursor = _encode_discovery_cursor(tool_name, filters, next_state)
+            if cursor is None:
+                return None
+            metadata["next_cursor"] = cursor
         return json.dumps({**page, "page": metadata})
 
-    low = 1
-    high = requested_limit
-    best: str | None = None
-    while low <= high:
-        candidate_limit = (low + high) // 2
+    # Cursor size depends on the last returned row, so serialized page size is
+    # not monotonic in the row limit. Check the bounded public range directly.
+    for candidate_limit in range(requested_limit, 0, -1):
         candidate = _candidate(candidate_limit)
-        if len(candidate) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
-            best = candidate
-            low = candidate_limit + 1
-        else:
-            high = candidate_limit - 1
-    if best is not None:
-        return best
+        if candidate is not None and len(candidate) <= _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
+            return candidate
 
     empty_page = _candidate(0)
+    if empty_page is None:
+        return json.dumps(
+            {
+                "error": (
+                    f"Discovery continuation exceeds the {_DISCOVERY_CURSOR_MAX_CHARS}-character "
+                    "cursor limit."
+                )
+            }
+        )
     if len(empty_page) > _DISCOVERY_LIST_OUTPUT_MAX_CHARS:
         kind = "fixed_section"
         oversized_sections = [
@@ -3888,16 +3969,23 @@ async def _execute_session_query_tool(
         return json.dumps({"error": f"{tool_name}: malformed JSON arguments"})
 
     if tool_name == "sys_session_list":
-        window = _discovery_list_window(args, tool_name, ("sessions",))
+        agent_name = args.get("agent_name")
+        window = _discovery_list_window(
+            args,
+            tool_name,
+            ("sessions",),
+            {"agent_name": agent_name if isinstance(agent_name, str) and agent_name else None},
+        )
         if isinstance(window, str):
             return window
-        limit, cursor_state = window
+        limit, cursor_state, continued = window
         return await _session_list_via_rest(
             conversation_id,
             server_client,
-            args.get("agent_name"),
+            agent_name,
             limit=limit,
             cursor_state=cursor_state,
+            continued=continued,
         )
     if tool_name == "sys_session_get_history":
         return await _session_get_history_via_rest(args, server_client)
@@ -4215,10 +4303,11 @@ async def _execute_agent_tool(
             args,
             tool_name,
             ("builtins", "session_agents", "local_configs"),
+            {},
         )
         if isinstance(window, str):
             return window
-        limit, cursor_state = window
+        limit, cursor_state, continued = window
         return await _agent_list_via_rest(
             server_client,
             agent_spec=agent_spec,
@@ -4226,6 +4315,7 @@ async def _execute_agent_tool(
             runner_workspace=runner_workspace,
             limit=limit,
             cursor_state=cursor_state,
+            continued=continued,
         )
     session_id = args.get("session_id")
     if not isinstance(session_id, str) or not session_id:
@@ -4426,17 +4516,14 @@ async def _agent_list_fetch(
             params["after"] = after
         resp = await server_client.get(path, params=params, timeout=30.0)
     except Exception:  # noqa: BLE001
-        return _DiscoveryPage([], False)
+        return _DiscoveryPage([], False, failed=True)
     if resp.status_code != 200:
-        return _DiscoveryPage([], False)
-    body = _string_object_dict(resp.json())
-    if body is None:
-        return _DiscoveryPage([], False)
-    return _DiscoveryPage(
-        _json_object_list(body.get("data")),
-        body.get("has_more") is True,
-        _optional_string(body.get("last_id")),
-    )
+        return _DiscoveryPage([], False, failed=True)
+    try:
+        body = resp.json()
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return _DiscoveryPage([], False, failed=True)
+    return _parse_discovery_page(body)
 
 
 def _scan_local_agent_configs(configs_dir: Path) -> list[_JsonObject]:
@@ -4599,7 +4686,8 @@ async def _agent_list_via_rest(
     conversation_id: str | None,
     runner_workspace: Path | None,
     limit: int | None,
-    cursor_state: dict[str, str | int | None],
+    cursor_state: dict[str, _DiscoveryState],
+    continued: bool,
 ) -> str:
     """
     List launchable agents across built-ins, session-bound, and local.
@@ -4636,27 +4724,43 @@ async def _agent_list_via_rest(
         bounded page with continuation metadata.
     """
     source_limit = limit or _AGENT_LIST_PAGE_LIMIT
-    builtins_page = await _agent_list_fetch(
-        "/v1/agents",
-        server_client,
-        after=cast(str | None, cursor_state["builtins"]),
-        limit=source_limit,
+    builtins_page = (
+        _DiscoveryPage([], False)
+        if cursor_state["builtins"][0] == _DISCOVERY_END
+        else await _agent_list_fetch(
+            "/v1/agents",
+            server_client,
+            after=cursor_state["builtins"][1],
+            limit=source_limit,
+        )
     )
-    sessions_page = await _agent_list_fetch(
-        "/v1/sessions",
-        server_client,
-        after=cast(str | None, cursor_state["session_agents"]),
-        limit=source_limit,
+    sessions_page = (
+        _DiscoveryPage([], False)
+        if cursor_state["session_agents"][0] == _DISCOVERY_END
+        else await _agent_list_fetch(
+            "/v1/sessions",
+            server_client,
+            after=cursor_state["session_agents"][1],
+            limit=source_limit,
+        )
     )
     spec = _effective_runner_os_env_spec(agent_spec, conversation_id, runner_workspace)
     assert spec.cwd is not None
     configs_dir = Path(spec.cwd) / _AGENT_CONFIG_SUBDIR
     local_configs = await asyncio.to_thread(_scan_local_agent_configs, configs_dir)
-    local_start = cast(int, cursor_state["local_configs"])
+    local_state, local_after = cursor_state["local_configs"]
+    if local_state == _DISCOVERY_END:
+        remaining_configs = []
+    elif local_after is not None:
+        remaining_configs = [
+            row for row in local_configs if str(row.get("path", "")) > local_after
+        ]
+    else:
+        remaining_configs = local_configs
     listing = _project_agent_list(
         builtins_page.rows,
         sessions_page.rows,
-        local_configs[local_start : local_start + source_limit],
+        remaining_configs[:source_limit],
     )
     listing["builtins"] = _in_spawn_family(
         listing["builtins"], await _spawn_family(server_client, conversation_id)
@@ -4665,12 +4769,15 @@ async def _agent_list_via_rest(
         listing,
         limit=limit,
         cursor_state=cursor_state,
+        continued=continued,
+        tool_name="sys_agent_list",
+        filters={},
         source_pages={
             "builtins": builtins_page,
             "session_agents": sessions_page,
             "local_configs": _DiscoveryPage(
                 listing["local_configs"],
-                local_start + len(listing["local_configs"]) < len(local_configs),
+                len(listing["local_configs"]) < len(remaining_configs),
             ),
         },
     )
@@ -4726,7 +4833,8 @@ async def _session_list_via_rest(
     agent_name: object = None,
     *,
     limit: int | None,
-    cursor_state: dict[str, str | int | None],
+    cursor_state: dict[str, _DiscoveryState],
+    continued: bool,
 ) -> str:
     """
     Return the two-view session list: ``sub_agents`` + global ``sessions``.
@@ -4751,16 +4859,23 @@ async def _session_list_via_rest(
         bounded page with continuation metadata.
     """
     sub_agents = await _collect_sub_agents(conversation_id, server_client)
-    sessions_page = await _collect_global_sessions(
-        server_client,
-        agent_name,
-        after=cast(str | None, cursor_state["sessions"]),
-        limit=limit or _AGENT_LIST_PAGE_LIMIT,
+    sessions_page = (
+        _DiscoveryPage([], False)
+        if cursor_state["sessions"][0] == _DISCOVERY_END
+        else await _collect_global_sessions(
+            server_client,
+            agent_name,
+            after=cursor_state["sessions"][1],
+            limit=limit or _AGENT_LIST_PAGE_LIMIT,
+        )
     )
     return _bounded_discovery_result(
         {"sub_agents": cast(list[_JsonObject], sub_agents), "sessions": sessions_page.rows},
         limit=limit,
         cursor_state=cursor_state,
+        continued=continued,
+        tool_name="sys_session_list",
+        filters={"agent_name": agent_name if isinstance(agent_name, str) and agent_name else None},
         source_pages={"sessions": sessions_page},
         page_sections=("sessions",),
     )
@@ -4929,13 +5044,17 @@ async def _collect_global_sessions(
     try:
         resp = await server_client.get("/v1/sessions", params=params, timeout=30.0)
     except Exception:  # noqa: BLE001
-        return _DiscoveryPage([], False)
+        return _DiscoveryPage([], False, failed=True)
     if resp.status_code != 200:
-        return _DiscoveryPage([], False)
-    body = _string_object_dict(resp.json())
-    if body is None:
-        return _DiscoveryPage([], False)
-    rows = _json_object_list(body.get("data"))
+        return _DiscoveryPage([], False, failed=True)
+    try:
+        body = resp.json()
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return _DiscoveryPage([], False, failed=True)
+    page = _parse_discovery_page(body)
+    if page.failed:
+        return page
+    rows = page.rows
     online = await _resolve_runner_online_map(rows, server_client)
     return _DiscoveryPage(
         [
@@ -4954,8 +5073,8 @@ async def _collect_global_sessions(
             }
             for r in rows
         ],
-        body.get("has_more") is True,
-        _optional_string(body.get("last_id")),
+        page.has_more,
+        page.next_after,
     )
 
 

--- a/omnigent/tools/builtins/agents.py
+++ b/omnigent/tools/builtins/agents.py
@@ -188,8 +188,8 @@ class SysAgentListTool(Tool):
     """
     List launchable agents across three sources.
 
-    A **global read** that surfaces, in one call, every agent the caller
-    could launch a session from:
+    A **global read** that pages agents the caller could launch a session
+    from across three sources:
 
     - **built-ins**: template agents registered on the server
       (``GET /v1/agents``);
@@ -230,7 +230,10 @@ class SysAgentListTool(Tool):
             "agent never needs its bundle downloaded or re-uploaded. "
             "Use sys_agent_get / sys_agent_download (with a "
             "session_agents row's session_id) only to inspect or fork "
-            "an agent's config. Global read — no parameters."
+            "an agent's config. Calls without pagination keep the complete "
+            "result while it fits the tool-output budget; larger results "
+            "return a page with has_more metadata. Pass limit and offset "
+            "to continue."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -238,7 +241,7 @@ class SysAgentListTool(Tool):
         Return the OpenAI-format tool schema.
 
         :returns: Dict with ``"type": "function"`` and a
-            ``"function"`` sub-dict; no parameters.
+            ``"function"`` sub-dict; optional pagination parameters.
         """
         return {
             "type": "function",
@@ -247,7 +250,23 @@ class SysAgentListTool(Tool):
                 "description": SysAgentListTool.description(),
                 "parameters": {
                     "type": "object",
-                    "properties": {},
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": (
+                                "Optional maximum rows returned from each source. "
+                                "Omit it to keep the complete result while it fits."
+                            ),
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "description": "Zero-based offset applied to each source.",
+                        },
+                    },
                     "additionalProperties": False,
                 },
             },

--- a/omnigent/tools/builtins/agents.py
+++ b/omnigent/tools/builtins/agents.py
@@ -262,6 +262,7 @@ class SysAgentListTool(Tool):
                         },
                         "cursor": {
                             "type": "string",
+                            "maxLength": 40000,
                             "description": (
                                 "Opaque continuation cursor from a prior "
                                 "sys_agent_list result's page.next_cursor."

--- a/omnigent/tools/builtins/agents.py
+++ b/omnigent/tools/builtins/agents.py
@@ -232,8 +232,8 @@ class SysAgentListTool(Tool):
             "session_agents row's session_id) only to inspect or fork "
             "an agent's config. Calls without pagination keep the complete "
             "result while it fits the tool-output budget; larger results "
-            "return a page with has_more metadata. Pass limit and offset "
-            "to continue."
+            "return a page with has_more metadata and an opaque "
+            "next_cursor. Pass that cursor to continue."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -260,11 +260,12 @@ class SysAgentListTool(Tool):
                                 "Omit it to keep the complete result while it fits."
                             ),
                         },
-                        "offset": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "default": 0,
-                            "description": "Zero-based offset applied to each source.",
+                        "cursor": {
+                            "type": "string",
+                            "description": (
+                                "Opaque continuation cursor from a prior "
+                                "sys_agent_list result's page.next_cursor."
+                            ),
                         },
                     },
                     "additionalProperties": False,

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -502,7 +502,7 @@ class SysSessionListTool(Tool):
             "sessions running that agent. Calls without pagination keep "
             "the complete result while it fits the tool-output budget; "
             "larger global session lists return a page with has_more "
-            "metadata. Pass limit and offset to continue; sub_agents stays "
+            "metadata and an opaque next_cursor. Pass that cursor to continue; sub_agents stays "
             "complete."
         )
 
@@ -540,11 +540,12 @@ class SysSessionListTool(Tool):
                                 "Omit it to keep the complete result while it fits."
                             ),
                         },
-                        "offset": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "default": 0,
-                            "description": "Zero-based offset into 'sessions'.",
+                        "cursor": {
+                            "type": "string",
+                            "description": (
+                                "Opaque continuation cursor from a prior "
+                                "sys_session_list result's page.next_cursor."
+                            ),
                         },
                     },
                     "required": [],

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -499,7 +499,11 @@ class SysSessionListTool(Tool):
             "for orchestration (inspect via sys_agent_get / "
             "sys_session_get_info, or drive via sys_session_send by "
             "session_id). Pass agent_name to filter the global list to "
-            "sessions running that agent."
+            "sessions running that agent. Calls without pagination keep "
+            "the complete result while it fits the tool-output budget; "
+            "larger global session lists return a page with has_more "
+            "metadata. Pass limit and offset to continue; sub_agents stays "
+            "complete."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -507,7 +511,8 @@ class SysSessionListTool(Tool):
         Return the OpenAI-format tool schema.
 
         :returns: Dict with ``"type": "function"`` and a
-            ``"function"`` sub-dict; an optional ``agent_name`` filter.
+            ``"function"`` sub-dict; an optional ``agent_name`` filter
+            and pagination parameters.
         """
         return {
             "type": "function",
@@ -525,6 +530,21 @@ class SysSessionListTool(Tool):
                                 "this name, e.g. 'researcher'. Does not "
                                 "affect the 'sub_agents' view."
                             ),
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": (
+                                "Optional maximum rows returned from 'sessions'. "
+                                "Omit it to keep the complete result while it fits."
+                            ),
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "description": "Zero-based offset into 'sessions'.",
                         },
                     },
                     "required": [],

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -542,6 +542,7 @@ class SysSessionListTool(Tool):
                         },
                         "cursor": {
                             "type": "string",
+                            "maxLength": 40000,
                             "description": (
                                 "Opaque continuation cursor from a prior "
                                 "sys_session_list result's page.next_cursor."

--- a/tests/e2e/test_discovery_cursor_compat_e2e.py
+++ b/tests/e2e/test_discovery_cursor_compat_e2e.py
@@ -1,0 +1,131 @@
+"""E2E compatibility coverage for discovery-tool cursor continuations."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    send_user_message_to_session,
+)
+
+
+@pytest.mark.compat_smoke
+def test_session_list_cursor_round_trips_through_runner_and_old_server(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """A returned cursor drives a distinct second page through the live runner.
+
+    The fast compatibility gate runs this against a new runner and the latest
+    released server. It is intentionally skipped with a pinned old runner:
+    cursor pagination is a new runner-owned tool contract, so that direction
+    is covered by the old runner's pre-existing schema instead.
+    """
+    if os.environ.get("OMNIGENT_COMPAT_RUNNER_VERSION"):
+        pytest.skip("cursor pagination requires the checked-out runner")
+
+    suffix = uuid.uuid4().hex[:8]
+    model = f"discovery-cursor-{suffix}"
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"discovery-cursor-{suffix}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="Follow the scripted tool calls exactly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    session_id = create_runner_bound_session(
+        http_client,
+        agent_name=agent_name,
+        runner_id=live_runner_id,
+    )
+    # Ensure the permission-bounded global list has another entry to continue to.
+    create_runner_bound_session(
+        http_client,
+        agent_name=agent_name,
+        runner_id=live_runner_id,
+    )
+
+    def tool_call(arguments: dict[str, object]) -> dict[str, object]:
+        return {
+            "tool_calls": [
+                {
+                    "call_id": f"call_{uuid.uuid4().hex[:8]}",
+                    "name": "sys_session_list",
+                    "arguments": json.dumps(arguments),
+                }
+            ]
+        }
+
+    configure_mock_llm(
+        mock_llm_server_url,
+        [tool_call({"limit": 1}), {"text": "first page complete"}],
+        key=model,
+    )
+    first_response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="List one session.",
+    )
+    first_turn = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=first_response_id,
+        timeout=120,
+    )
+    assert first_turn["status"] == "completed", first_turn
+
+    def list_outputs() -> list[str]:
+        response = http_client.get(f"/v1/sessions/{session_id}/items", params={"limit": 1000})
+        response.raise_for_status()
+        flattened = [
+            {**item, **item["data"]} if isinstance(item.get("data"), dict) else item
+            for item in response.json()["data"]
+        ]
+        call_ids = {
+            item.get("call_id")
+            for item in flattened
+            if item.get("type") == "function_call" and item.get("name") == "sys_session_list"
+        }
+        return [
+            str(item.get("output") or "")
+            for item in flattened
+            if item.get("type") == "function_call_output" and item.get("call_id") in call_ids
+        ]
+
+    first_page = json.loads(list_outputs()[-1])
+    cursor = first_page["page"].get("next_cursor")
+    assert isinstance(cursor, str) and cursor
+    assert first_page["page"]["has_more"] == {"sessions": True}
+
+    configure_mock_llm(
+        mock_llm_server_url,
+        [tool_call({"limit": 1, "cursor": cursor}), {"text": "second page complete"}],
+        key=model,
+    )
+    second_response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Continue the list with the cursor.",
+    )
+    second_turn = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=second_response_id,
+        timeout=120,
+    )
+    assert second_turn["status"] == "completed", second_turn
+
+    second_page = json.loads(list_outputs()[-1])
+    assert second_page["sessions"][0]["session_id"] != first_page["sessions"][0]["session_id"]

--- a/tests/runner/test_discovery_list_pagination.py
+++ b/tests/runner/test_discovery_list_pagination.py
@@ -1,0 +1,351 @@
+"""Compatibility and pagination contracts for discovery tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.runner.tool_dispatch import execute_tool
+
+_ROW_COUNT = 12
+
+
+def _agent_rows(*, large: bool) -> list[dict[str, object]]:
+    return [
+        {
+            "id": f"ag_{index:02d}",
+            "name": f"agent-{index:02d}",
+            "description": "x" * 10_000 if large else f"Agent {index}",
+            "harness": "claude-sdk",
+        }
+        for index in range(_ROW_COUNT)
+    ]
+
+
+def _session_rows(*, large: bool) -> list[dict[str, object]]:
+    return [
+        {
+            "id": f"conv_{index:02d}",
+            "agent_id": f"ag_{index:02d}",
+            "agent_name": "researcher",
+            "title": f"{'x' * 10_000}{index:02d}" if large else f"Session {index}",
+            "status": "idle",
+            "runner_id": None,
+            "parent_session_id": None,
+        }
+        for index in range(_ROW_COUNT)
+    ]
+
+
+async def _agent_list_with_empty_server(
+    tmp_path: Path, arguments: dict[str, object] | None = None
+) -> str:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path in {"/v1/agents", "/v1/sessions"}:
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        return await execute_tool(
+            tool_name="sys_agent_list",
+            arguments=json.dumps(arguments or {}),
+            server_client=client,
+            conversation_id="conv_caller",
+            runner_workspace=tmp_path,
+        )
+
+
+async def _session_list_with_rows(
+    *, sessions: list[dict[str, object]], children: list[dict[str, object]]
+) -> str:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_caller/child_sessions":
+            return httpx.Response(200, json={"data": children})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(200, json={"id": "conv_caller", "parent_session_id": None})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": sessions})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        return await execute_tool(
+            tool_name="sys_session_list",
+            arguments="{}",
+            server_client=client,
+            conversation_id="conv_caller",
+        )
+
+
+@pytest.mark.asyncio
+async def test_sys_agent_list_preserves_small_default_then_pages(tmp_path: Path) -> None:
+    """Only a result above the output budget changes the parameterless response."""
+    configs_dir = tmp_path / ".omnigent" / "agent-configs"
+    configs_dir.mkdir(parents=True)
+    for index in range(_ROW_COUNT):
+        (configs_dir / f"local-{index:02d}.yaml").write_text(
+            f"name: local-{index:02d}\ndescription: Local agent {index}\n",
+            encoding="utf-8",
+        )
+
+    state = {"large": False}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            return httpx.Response(200, json={"data": _agent_rows(large=state["large"])})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": _session_rows(large=False)})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        complete = json.loads(
+            await execute_tool(
+                tool_name="sys_agent_list",
+                arguments="{}",
+                server_client=client,
+                conversation_id="conv_caller",
+                runner_workspace=tmp_path,
+            )
+        )
+        later = json.loads(
+            await execute_tool(
+                tool_name="sys_agent_list",
+                arguments=json.dumps({"limit": 5, "offset": 5}),
+                server_client=client,
+                conversation_id="conv_caller",
+                runner_workspace=tmp_path,
+            )
+        )
+        state["large"] = True
+        large_raw = await execute_tool(
+            tool_name="sys_agent_list",
+            arguments="{}",
+            server_client=client,
+            conversation_id="conv_caller",
+            runner_workspace=tmp_path,
+        )
+
+    assert len(complete["builtins"]) == _ROW_COUNT
+    assert len(complete["session_agents"]) == _ROW_COUNT
+    assert len(complete["local_configs"]) == _ROW_COUNT
+    assert "page" not in complete
+    assert [row["agent_id"] for row in later["builtins"]] == [
+        f"ag_{index:02d}" for index in range(5, 10)
+    ]
+    assert later["page"] == {
+        "limit": 5,
+        "offset": 5,
+        "has_more": {"builtins": True, "session_agents": True, "local_configs": True},
+    }
+
+    large = json.loads(large_raw)
+    assert len(large_raw) <= 100_000
+    assert 0 < len(large["builtins"]) < _ROW_COUNT
+    assert large["page"]["limit"] == len(large["builtins"])
+    assert large["page"]["has_more"]["builtins"] is True
+
+
+@pytest.mark.asyncio
+async def test_sys_session_list_preserves_small_default_then_pages() -> None:
+    """A large global view pages without hiding the caller's direct children."""
+    state = {"large": False}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_caller/child_sessions":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "conv_child",
+                            "title": "researcher:catalog",
+                            "tool": "researcher",
+                            "session_name": "catalog",
+                        }
+                    ]
+                },
+            )
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(200, json={"id": "conv_caller", "parent_session_id": None})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": _session_rows(large=state["large"])})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        complete = json.loads(
+            await execute_tool(
+                tool_name="sys_session_list",
+                arguments="{}",
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
+        later = json.loads(
+            await execute_tool(
+                tool_name="sys_session_list",
+                arguments=json.dumps({"limit": 5, "offset": 5}),
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
+        state["large"] = True
+        large_raw = await execute_tool(
+            tool_name="sys_session_list",
+            arguments="{}",
+            server_client=client,
+            conversation_id="conv_caller",
+        )
+
+    child = {"agent": "researcher", "title": "catalog", "conversation_id": "conv_child"}
+    assert len(complete["sessions"]) == _ROW_COUNT
+    assert complete["sub_agents"] == [child]
+    assert "page" not in complete
+    assert [row["session_id"] for row in later["sessions"]] == [
+        f"conv_{index:02d}" for index in range(5, 10)
+    ]
+    assert later["sub_agents"] == [child]
+    assert later["page"] == {
+        "limit": 5,
+        "offset": 5,
+        "has_more": {"sessions": True},
+    }
+
+    large = json.loads(large_raw)
+    assert len(large_raw) <= 100_000
+    assert large["sub_agents"] == [child]
+    assert 0 < len(large["sessions"]) < _ROW_COUNT
+    assert large["page"]["limit"] == len(large["sessions"])
+    assert large["page"]["has_more"] == {"sessions": True}
+
+
+@pytest.mark.asyncio
+async def test_sys_agent_list_reports_oversized_local_config_row(tmp_path: Path) -> None:
+    """A single local row cannot escape the discovery output budget."""
+    configs_dir = tmp_path / ".omnigent" / "agent-configs"
+    configs_dir.mkdir(parents=True)
+    (configs_dir / "oversized.yaml").write_text(
+        f"name: oversized\ndescription: {'x' * 110_000}\n",
+        encoding="utf-8",
+    )
+
+    raw = await _agent_list_with_empty_server(tmp_path)
+
+    result = json.loads(raw)
+    assert len(raw) <= 100_000
+    assert result["oversized"] == {
+        "kind": "paginated_row",
+        "sections": ["local_configs"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_session_list_reports_oversized_session_row() -> None:
+    """A single session row cannot escape the discovery output budget."""
+
+    row = _session_rows(large=False)[0]
+    row["title"] = "x" * 110_000
+    raw = await _session_list_with_rows(sessions=[row], children=[])
+
+    result = json.loads(raw)
+    assert len(raw) <= 100_000
+    assert result["oversized"] == {
+        "kind": "paginated_row",
+        "sections": ["sessions"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_session_list_reports_oversized_fixed_sub_agents() -> None:
+    """An unpaged child view cannot escape the discovery output budget."""
+
+    raw = await _session_list_with_rows(
+        sessions=[],
+        children=[
+            {
+                "id": "conv_child",
+                "title": f"researcher:{'x' * 110_000}",
+                "tool": "researcher",
+                "session_name": "x" * 110_000,
+            }
+        ],
+    )
+
+    result = json.loads(raw)
+    assert len(raw) <= 100_000
+    assert result["oversized"] == {
+        "kind": "fixed_section",
+        "sections": ["sub_agents"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_agent_list_pages_local_configs_beyond_server_fetch_limit(
+    tmp_path: Path,
+) -> None:
+    """The server fetch size does not cap local-config pagination."""
+    configs_dir = tmp_path / ".omnigent" / "agent-configs"
+    configs_dir.mkdir(parents=True)
+    for index in range(1_001):
+        (configs_dir / f"local-{index:04d}.yaml").write_text(
+            f"name: local-{index:04d}\n",
+            encoding="utf-8",
+        )
+
+    result = json.loads(
+        await _agent_list_with_empty_server(tmp_path, {"limit": 100, "offset": 1_000})
+    )
+
+    assert [row["name"] for row in result["local_configs"]] == ["local-1000"]
+    assert result["page"] == {
+        "limit": 100,
+        "offset": 1_000,
+        "has_more": {"builtins": False, "session_agents": False, "local_configs": False},
+    }
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "error"),
+    [
+        ("sys_agent_list", {"limit": 0}, "'limit' must be an integer between 1 and 100"),
+        ("sys_agent_list", {"limit": None}, "'limit' must be an integer between 1 and 100"),
+        ("sys_session_list", {"offset": -1}, "'offset' must be a non-negative integer"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_discovery_list_rejects_invalid_windows(
+    tool_name: str,
+    arguments: dict[str, object],
+    error: str,
+) -> None:
+    """Invalid windows fail before a server request."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"unexpected request {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        result = json.loads(
+            await execute_tool(
+                tool_name=tool_name,
+                arguments=json.dumps(arguments),
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
+
+    assert error in result["error"]

--- a/tests/runner/test_discovery_list_pagination.py
+++ b/tests/runner/test_discovery_list_pagination.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 
 import httpx
 import pytest
 
+from omnigent.runner import tool_dispatch
 from omnigent.runner.tool_dispatch import execute_tool
 
 _ROW_COUNT = 12
@@ -104,6 +106,167 @@ async def _session_list_with_rows(
             server_client=client,
             conversation_id="conv_caller",
         )
+
+
+async def _call_agent(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    arguments: dict[str, object],
+) -> dict[str, object]:
+    return json.loads(
+        await execute_tool(
+            tool_name="sys_agent_list",
+            arguments=json.dumps(arguments),
+            server_client=client,
+            conversation_id="conv_caller",
+            runner_workspace=tmp_path,
+        )
+    )
+
+
+async def _call_session(
+    client: httpx.AsyncClient,
+    arguments: dict[str, object],
+) -> dict[str, object]:
+    return json.loads(
+        await execute_tool(
+            tool_name="sys_session_list",
+            arguments=json.dumps(arguments),
+            server_client=client,
+            conversation_id="conv_caller",
+        )
+    )
+
+
+def _encode_cursor_payload(payload: object) -> str:
+    return (
+        base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+@pytest.mark.asyncio
+async def test_size_fitter_checks_larger_page_after_smaller_cursor_does_not_fit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A long intermediate cursor must not hide a larger page that fits."""
+    monkeypatch.setattr(
+        tool_dispatch,
+        "_scan_local_agent_configs",
+        lambda _path: [
+            {
+                "name": "large",
+                "path": "/workspace/a.yaml",
+                "description": "d" * 96_000,
+            },
+            {"name": "small", "path": "/workspace/z.yaml", "description": "small"},
+        ],
+    )
+    monkeypatch.setattr(
+        tool_dispatch,
+        "_encode_discovery_cursor",
+        lambda *args: (
+            "x" * 5_000 if args[-1]["local_configs"] in {1, ("at", "/workspace/a.yaml")} else "x"
+        ),
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            return _server_page(
+                request,
+                [
+                    {
+                        "id": "ag_fixed",
+                        "name": "fixed",
+                        "description": "f" * 1_000,
+                        "harness": "claude-sdk",
+                    }
+                ],
+            )
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        payload = await _call_agent(client, tmp_path, {"limit": 2})
+
+    assert "error" not in payload
+    assert payload["page"]["limit"] == 2
+    assert [row["name"] for row in payload["local_configs"]] == ["large", "small"]
+    assert len(json.dumps(payload)) <= 100_000
+
+
+@pytest.mark.asyncio
+async def test_failed_first_source_read_remains_retryable(tmp_path: Path) -> None:
+    """A source that did not answer is pending, not exhausted."""
+    agents_status = 503
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            if agents_status != 200:
+                return httpx.Response(agents_status)
+            return _server_page(request, _agent_rows(large=False))
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        first = await _call_agent(client, tmp_path, {"limit": 3})
+        agents_status = 200
+        second = await _call_agent(
+            client,
+            tmp_path,
+            {"limit": 3, "cursor": first["page"]["next_cursor"]},
+        )
+
+    assert first["builtins"] == []
+    assert first["page"]["has_more"]["builtins"] is True
+    assert [row["agent_id"] for row in second["builtins"]] == [
+        "ag_00",
+        "ag_01",
+        "ag_02",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_source_is_not_refetched_while_other_source_continues(
+    tmp_path: Path,
+) -> None:
+    """An exhausted section stays distinct from an unread failed section."""
+    agent_reads = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal agent_reads
+        if request.url.path == "/v1/agents":
+            agent_reads += 1
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions":
+            return _server_page(request, _session_rows(large=False))
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        first = await _call_agent(client, tmp_path, {"limit": 3})
+        await _call_agent(
+            client,
+            tmp_path,
+            {"limit": 3, "cursor": first["page"]["next_cursor"]},
+        )
+
+    assert agent_reads == 1
 
 
 @pytest.mark.asyncio
@@ -410,6 +573,172 @@ async def test_sys_agent_list_pages_local_configs_beyond_server_fetch_limit(
         "limit": 100,
         "has_more": {"builtins": False, "session_agents": False, "local_configs": False},
     }
+
+
+@pytest.mark.asyncio
+async def test_local_config_continuation_uses_last_returned_path(tmp_path: Path) -> None:
+    """Edits before the resume path do not skip or repeat later configs."""
+    configs_dir = tmp_path / ".omnigent" / "agent-configs"
+    configs_dir.mkdir(parents=True)
+    for index in range(6):
+        (configs_dir / f"cfg-{index}.yaml").write_text(
+            f"name: cfg-{index}\n",
+            encoding="utf-8",
+        )
+
+    first = json.loads(await _agent_list_with_empty_server(tmp_path, {"limit": 3}))
+    (configs_dir / "cfg-0.yaml").unlink()
+    second = json.loads(
+        await _agent_list_with_empty_server(
+            tmp_path,
+            {"limit": 3, "cursor": first["page"]["next_cursor"]},
+        )
+    )
+
+    assert [row["name"] for row in first["local_configs"]] == ["cfg-0", "cfg-1", "cfg-2"]
+    assert [row["name"] for row in second["local_configs"]] == ["cfg-3", "cfg-4", "cfg-5"]
+
+
+@pytest.mark.asyncio
+async def test_cursor_is_bound_to_tool_sections_and_filters(tmp_path: Path) -> None:
+    """A cursor cannot be replayed under a different listing contract."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            return _server_page(request, _agent_rows(large=False))
+        if request.url.path == "/v1/sessions":
+            return _server_page(request, _session_rows(large=False))
+        if request.url.path == "/v1/sessions/conv_caller/child_sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(200, json={"id": "conv_caller", "parent_session_id": None})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        agent_page = await _call_agent(client, tmp_path, {"limit": 3})
+        wrong_tool = await _call_session(
+            client,
+            {"limit": 3, "cursor": agent_page["page"]["next_cursor"]},
+        )
+        session_page = await _call_session(
+            client,
+            {"limit": 3, "agent_name": "researcher"},
+        )
+        wrong_filter = await _call_session(
+            client,
+            {
+                "limit": 3,
+                "agent_name": "planner",
+                "cursor": session_page["page"]["next_cursor"],
+            },
+        )
+
+    assert "different tool" in wrong_tool["error"]
+    assert "different filter" in wrong_filter["error"]
+
+
+@pytest.mark.asyncio
+async def test_cursor_envelope_is_strict_and_bounded(tmp_path: Path) -> None:
+    """Unknown fields, malformed state, and oversized cursors are rejected."""
+    payload = {
+        "v": 1,
+        "tool": "sys_agent_list",
+        "filters": {},
+        "sections": {
+            "builtins": ["start", None],
+            "session_agents": ["start", None],
+            "local_configs": ["start", None],
+        },
+    }
+
+    payload["unknown"] = True
+    unknown = _encode_cursor_payload(payload)
+    payload.pop("unknown")
+    payload["sections"].pop("session_agents")
+    missing_section = _encode_cursor_payload(payload)
+    malformed = _encode_cursor_payload(
+        {
+            "v": 1,
+            "tool": "sys_agent_list",
+            "filters": {},
+            "sections": {
+                "builtins": [],
+                "session_agents": None,
+                "local_configs": None,
+            },
+        }
+    )
+
+    unknown_result = json.loads(await _agent_list_with_empty_server(tmp_path, {"cursor": unknown}))
+    malformed_result = json.loads(
+        await _agent_list_with_empty_server(tmp_path, {"cursor": malformed})
+    )
+    missing_section_result = json.loads(
+        await _agent_list_with_empty_server(tmp_path, {"cursor": missing_section})
+    )
+    oversized_result = json.loads(
+        await _agent_list_with_empty_server(tmp_path, {"cursor": "a" * 40_001})
+    )
+
+    assert "invalid pagination cursor" in unknown_result["error"]
+    assert "invalid pagination cursor" in missing_section_result["error"]
+    assert "invalid pagination cursor" in malformed_result["error"]
+    assert "too long" in oversized_result["error"]
+
+
+@pytest.mark.parametrize(
+    "broken_response",
+    [
+        pytest.param(httpx.Response(503), id="failed-status"),
+        pytest.param(httpx.Response(200, text="not json"), id="malformed-json"),
+        pytest.param(
+            httpx.Response(
+                200,
+                json={"data": [], "has_more": "false", "last_id": None},
+            ),
+            id="invalid-envelope",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_unusable_server_envelope_remains_retryable(
+    tmp_path: Path,
+    broken_response: httpx.Response,
+) -> None:
+    """An unusable 200 response does not falsely exhaust its source."""
+    broken = False
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            return broken_response if broken else _server_page(request, _agent_rows(large=False))
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(404)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        first = await _call_agent(client, tmp_path, {"limit": 3})
+        broken = True
+        failed = await _call_agent(
+            client,
+            tmp_path,
+            {"limit": 3, "cursor": first["page"]["next_cursor"]},
+        )
+        broken = False
+        retried = await _call_agent(
+            client,
+            tmp_path,
+            {"limit": 3, "cursor": failed["page"]["next_cursor"]},
+        )
+
+    assert failed["builtins"] == []
+    assert failed["page"]["has_more"]["builtins"] is True
+    assert [row["agent_id"] for row in retried["builtins"]] == ["ag_03", "ag_04", "ag_05"]
 
 
 @pytest.mark.parametrize(

--- a/tests/runner/test_discovery_list_pagination.py
+++ b/tests/runner/test_discovery_list_pagination.py
@@ -40,6 +40,27 @@ def _session_rows(*, large: bool) -> list[dict[str, object]]:
     ]
 
 
+def _server_page(
+    request: httpx.Request,
+    rows: list[dict[str, object]],
+) -> httpx.Response:
+    """Return a cursor page from *rows*, honoring the server's ``after`` contract."""
+    after = request.url.params.get("after")
+    if after is not None:
+        start = next(index + 1 for index, row in enumerate(rows) if row["id"] == after)
+        rows = rows[start:]
+    limit = int(request.url.params["limit"])
+    page = rows[:limit]
+    return httpx.Response(
+        200,
+        json={
+            "data": page,
+            "has_more": len(rows) > len(page),
+            "last_id": page[-1]["id"] if page else None,
+        },
+    )
+
+
 async def _agent_list_with_empty_server(
     tmp_path: Path, arguments: dict[str, object] | None = None
 ) -> str:
@@ -100,9 +121,9 @@ async def test_sys_agent_list_preserves_small_default_then_pages(tmp_path: Path)
 
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/v1/agents":
-            return httpx.Response(200, json={"data": _agent_rows(large=state["large"])})
+            return _server_page(request, _agent_rows(large=state["large"]))
         if request.url.path == "/v1/sessions":
-            return httpx.Response(200, json={"data": _session_rows(large=False)})
+            return _server_page(request, _session_rows(large=False))
         if request.url.path == "/v1/sessions/conv_caller":
             return httpx.Response(404)
         raise AssertionError(f"unexpected path {request.url.path}")
@@ -119,10 +140,19 @@ async def test_sys_agent_list_preserves_small_default_then_pages(tmp_path: Path)
                 runner_workspace=tmp_path,
             )
         )
+        first_page = json.loads(
+            await execute_tool(
+                tool_name="sys_agent_list",
+                arguments=json.dumps({"limit": 5}),
+                server_client=client,
+                conversation_id="conv_caller",
+                runner_workspace=tmp_path,
+            )
+        )
         later = json.loads(
             await execute_tool(
                 tool_name="sys_agent_list",
-                arguments=json.dumps({"limit": 5, "offset": 5}),
+                arguments=json.dumps({"limit": 5, "cursor": first_page["page"]["next_cursor"]}),
                 server_client=client,
                 conversation_id="conv_caller",
                 runner_workspace=tmp_path,
@@ -144,11 +174,13 @@ async def test_sys_agent_list_preserves_small_default_then_pages(tmp_path: Path)
     assert [row["agent_id"] for row in later["builtins"]] == [
         f"ag_{index:02d}" for index in range(5, 10)
     ]
-    assert later["page"] == {
-        "limit": 5,
-        "offset": 5,
-        "has_more": {"builtins": True, "session_agents": True, "local_configs": True},
+    assert later["page"]["limit"] == 5
+    assert later["page"]["has_more"] == {
+        "builtins": True,
+        "session_agents": True,
+        "local_configs": True,
     }
+    assert "next_cursor" in later["page"]
 
     large = json.loads(large_raw)
     assert len(large_raw) <= 100_000
@@ -180,7 +212,7 @@ async def test_sys_session_list_preserves_small_default_then_pages() -> None:
         if request.url.path == "/v1/sessions/conv_caller":
             return httpx.Response(200, json={"id": "conv_caller", "parent_session_id": None})
         if request.url.path == "/v1/sessions":
-            return httpx.Response(200, json={"data": _session_rows(large=state["large"])})
+            return _server_page(request, _session_rows(large=state["large"]))
         raise AssertionError(f"unexpected path {request.url.path}")
 
     async with httpx.AsyncClient(
@@ -194,10 +226,18 @@ async def test_sys_session_list_preserves_small_default_then_pages() -> None:
                 conversation_id="conv_caller",
             )
         )
+        first_page = json.loads(
+            await execute_tool(
+                tool_name="sys_session_list",
+                arguments=json.dumps({"limit": 5}),
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
         later = json.loads(
             await execute_tool(
                 tool_name="sys_session_list",
-                arguments=json.dumps({"limit": 5, "offset": 5}),
+                arguments=json.dumps({"limit": 5, "cursor": first_page["page"]["next_cursor"]}),
                 server_client=client,
                 conversation_id="conv_caller",
             )
@@ -218,11 +258,9 @@ async def test_sys_session_list_preserves_small_default_then_pages() -> None:
         f"conv_{index:02d}" for index in range(5, 10)
     ]
     assert later["sub_agents"] == [child]
-    assert later["page"] == {
-        "limit": 5,
-        "offset": 5,
-        "has_more": {"sessions": True},
-    }
+    assert later["page"]["limit"] == 5
+    assert later["page"]["has_more"] == {"sessions": True}
+    assert "next_cursor" in later["page"]
 
     large = json.loads(large_raw)
     assert len(large_raw) <= 100_000
@@ -230,6 +268,58 @@ async def test_sys_session_list_preserves_small_default_then_pages() -> None:
     assert 0 < len(large["sessions"]) < _ROW_COUNT
     assert large["page"]["limit"] == len(large["sessions"])
     assert large["page"]["has_more"] == {"sessions": True}
+
+
+@pytest.mark.asyncio
+async def test_sys_session_list_continues_server_catalog_with_cursor() -> None:
+    """The tool forwards the opaque continuation into the server's cursor API."""
+    rows = [
+        {
+            "id": f"conv_{index:04d}",
+            "agent_id": f"ag_{index:04d}",
+            "agent_name": "researcher",
+            "title": f"Session {index}",
+            "status": "idle",
+            "runner_id": None,
+            "parent_session_id": None,
+        }
+        for index in range(1_001)
+    ]
+    received_afters: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_caller/child_sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(200, json={"id": "conv_caller", "parent_session_id": None})
+        if request.url.path == "/v1/sessions":
+            received_afters.append(request.url.params.get("after"))
+            return _server_page(request, rows)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        first = json.loads(
+            await execute_tool(
+                tool_name="sys_session_list",
+                arguments=json.dumps({"limit": 100}),
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
+        second = json.loads(
+            await execute_tool(
+                tool_name="sys_session_list",
+                arguments=json.dumps({"limit": 100, "cursor": first["page"]["next_cursor"]}),
+                server_client=client,
+                conversation_id="conv_caller",
+            )
+        )
+
+    assert first["sessions"][0]["session_id"] == "conv_0000"
+    assert second["sessions"][0]["session_id"] == "conv_0100"
+    assert received_afters == [None, "conv_0099"]
 
 
 @pytest.mark.asyncio
@@ -305,14 +395,19 @@ async def test_sys_agent_list_pages_local_configs_beyond_server_fetch_limit(
             encoding="utf-8",
         )
 
-    result = json.loads(
-        await _agent_list_with_empty_server(tmp_path, {"limit": 100, "offset": 1_000})
-    )
+    cursor: str | None = None
+    for _ in range(11):
+        arguments: dict[str, object] = {"limit": 100}
+        if cursor is not None:
+            arguments["cursor"] = cursor
+        result = json.loads(await _agent_list_with_empty_server(tmp_path, arguments))
+        cursor = result["page"].get("next_cursor")
+        if cursor is None:
+            break
 
     assert [row["name"] for row in result["local_configs"]] == ["local-1000"]
     assert result["page"] == {
         "limit": 100,
-        "offset": 1_000,
         "has_more": {"builtins": False, "session_agents": False, "local_configs": False},
     }
 
@@ -322,7 +417,7 @@ async def test_sys_agent_list_pages_local_configs_beyond_server_fetch_limit(
     [
         ("sys_agent_list", {"limit": 0}, "'limit' must be an integer between 1 and 100"),
         ("sys_agent_list", {"limit": None}, "'limit' must be an integer between 1 and 100"),
-        ("sys_session_list", {"offset": -1}, "'offset' must be a non-negative integer"),
+        ("sys_session_list", {"cursor": "not-a-cursor"}, "invalid pagination cursor"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6115,7 +6115,11 @@ async def test_sys_agent_list_degrades_when_sources_fail(tmp_path: Path) -> None
         )
 
     info = json.loads(output)
-    assert info == {"builtins": [], "session_agents": [], "local_configs": []}
+    assert info == {
+        "builtins": [],
+        "session_agents": [],
+        "local_configs": [],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6089,11 +6089,9 @@ async def test_sys_agent_get_projects_agent_metadata() -> None:
 @pytest.mark.asyncio
 async def test_sys_agent_list_degrades_when_sources_fail(tmp_path: Path) -> None:
     """
-    A failing source degrades to an empty section rather than failing the
-    whole call. Here the server 500s both list endpoints and no local
-    config dir exists, so all three sections come back empty — but the
-    tool still returns a well-formed result. If a source error
-    propagated, the tool would return an ``error`` instead.
+    A failing source degrades to an empty, retryable section rather than
+    failing the whole call or claiming that the source is exhausted. Here
+    the server 500s both list endpoints and no local config dir exists.
 
     :param tmp_path: Workspace dir with no agent-config subdir.
     """
@@ -6115,11 +6113,15 @@ async def test_sys_agent_list_degrades_when_sources_fail(tmp_path: Path) -> None
         )
 
     info = json.loads(output)
-    assert info == {
-        "builtins": [],
-        "session_agents": [],
-        "local_configs": [],
+    assert info["builtins"] == []
+    assert info["session_agents"] == []
+    assert info["local_configs"] == []
+    assert info["page"]["has_more"] == {
+        "builtins": True,
+        "session_agents": True,
+        "local_configs": False,
     }
+    assert isinstance(info["page"]["next_cursor"], str)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/builtins/test_agents.py
+++ b/tests/tools/builtins/test_agents.py
@@ -94,7 +94,9 @@ class TestSysAgentListTool:
         func = schema["function"]
         assert func["name"] == "sys_agent_list"
         params = func["parameters"]
-        assert params["properties"] == {}
+        assert "default" not in params["properties"]["limit"]
+        assert params["properties"]["offset"]["default"] == 0
+        assert "maximum" not in params["properties"]["offset"]
         assert params.get("additionalProperties") is False
 
     def test_invoke_raises(self) -> None:

--- a/tests/tools/builtins/test_agents.py
+++ b/tests/tools/builtins/test_agents.py
@@ -95,8 +95,7 @@ class TestSysAgentListTool:
         assert func["name"] == "sys_agent_list"
         params = func["parameters"]
         assert "default" not in params["properties"]["limit"]
-        assert params["properties"]["offset"]["default"] == 0
-        assert "maximum" not in params["properties"]["offset"]
+        assert params["properties"]["cursor"]["type"] == "string"
         assert params.get("additionalProperties") is False
 
     def test_invoke_raises(self) -> None:

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -810,8 +810,7 @@ def test_session_list_schema_exposes_bounded_pagination() -> None:
 
     assert "default" not in properties["limit"]
     assert properties["limit"]["maximum"] == 100
-    assert properties["offset"]["default"] == 0
-    assert "maximum" not in properties["offset"]
+    assert properties["cursor"]["type"] == "string"
 
 
 def test_close_unknown_conversation_id_returns_not_found(

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -803,6 +803,17 @@ def test_session_list_skips_label_closed_child_with_original_title(
     assert payload["sub_agents"] == []
 
 
+def test_session_list_schema_exposes_bounded_pagination() -> None:
+    """The harness can discover the same pagination inputs the runner accepts."""
+
+    properties = SysSessionListTool().get_schema()["function"]["parameters"]["properties"]
+
+    assert "default" not in properties["limit"]
+    assert properties["limit"]["maximum"] == 100
+    assert properties["offset"]["default"] == 0
+    assert "maximum" not in properties["offset"]
+
+
 def test_close_unknown_conversation_id_returns_not_found(
     session_fixture: _Fixture,
 ) -> None:

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -668,7 +668,7 @@ def test_agent_read_tools_registered_for_every_agent() -> None:
     list_schema = next(
         s for s in mgr.get_tool_schemas() if s["function"]["name"] == "sys_agent_list"
     )
-    assert set(list_schema["function"]["parameters"]["properties"]) == {"limit", "offset"}
+    assert set(list_schema["function"]["parameters"]["properties"]) == {"limit", "cursor"}
 
 
 # ── MCP integration ──────────────────────────────────────

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -661,14 +661,14 @@ def test_agent_read_tools_registered_for_every_agent() -> None:
     assert "sys_agent_download" in names
     assert "sys_agent_list" in names
     # get/download require a session_id (an agent is only inspectable
-    # while running in some session); list takes no parameters.
+    # while running in some session); list exposes optional pagination.
     for tool_name in ("sys_agent_get", "sys_agent_download"):
         schema = next(s for s in mgr.get_tool_schemas() if s["function"]["name"] == tool_name)
         assert "session_id" in schema["function"]["parameters"]["required"]
     list_schema = next(
         s for s in mgr.get_tool_schemas() if s["function"]["name"] == "sys_agent_list"
     )
-    assert list_schema["function"]["parameters"]["properties"] == {}
+    assert set(list_schema["function"]["parameters"]["properties"]) == {"limit", "offset"}
 
 
 # ── MCP integration ──────────────────────────────────────


### PR DESCRIPTION
## Related issue

Closes #4891

## Summary

Small lists still return in one response. Large lists return in pages, so the caller receives usable data instead of a rejected result.

- Add optional `limit` and opaque `cursor` inputs to `sys_agent_list` and `sys_session_list`.
- Keep the existing JSON response when a parameterless result fits within 100,000 characters, every source answers, and every server-backed source is complete.
- Otherwise return the largest page that fits, plus `page: {limit, has_more, next_cursor}`. If the smallest page cannot fit, return a short structured error naming the contributing sections.

```
list result
  parameterless + fits + all sources answered and complete -> existing JSON response
  otherwise
    page fits                -> page + has_more + next_cursor
    smallest page cannot fit -> short error naming contributing sections
```

The cursor keeps a separate position for each paginated source:

- Server-backed sections resume from the server's own cursor and preserve its `has_more` result.
- A source that fails to answer stays pending. The caller can retry the same cursor instead of receiving a false terminal page.
- Local configs resume after the sorted path of the last returned row, so inserts and deletes do not shift a numeric position.
- Each cursor is bound to its minting tool, exact section set, and relevant filters. Malformed, oversized, cross-tool, and mismatched-filter cursors are rejected before use.
- Malformed JSON and unusable server envelopes are treated as failed best-effort reads rather than exceptions or exhaustion.
- Candidate page sizes are checked from largest to smallest because the serialized cursor size makes output size non-monotonic.
- `sub_agents` remains unpaged and is repeated unchanged on each session page. If that fixed section cannot fit, the tool returns a bounded diagnostic.

```
source page -> validate envelope -> project rows -> fit page -> next_cursor
failed read -> preserve source position -> retry with the same cursor
```

Values are never truncated, and callers treat the cursor as opaque.

## Test Plan

- `uv run --extra all pytest -p no:rerunfailures tests/runner/test_discovery_list_pagination.py -q --tb=short` (`19 passed`)
- `uv run --extra all pytest -p no:rerunfailures tests/runner/test_runner_dispatch.py -k 'session_list or sys_agent_list' -q --tb=short` (`5 passed`, `183 deselected`)
- `uv run --extra all pytest -p no:rerunfailures tests/e2e/test_discovery_cursor_compat_e2e.py tests/runner/test_discovery_list_pagination.py tests/tools/builtins/test_agents.py tests/tools/builtins/test_sys_session.py tests/tools/test_manager.py::test_agent_read_tools_registered_for_every_agent -q --tb=short` (`58 passed`)
- The nine follow-up regressions fail on exact head `1a77172a` before the correction and pass on the corrected head. They cover non-monotonic output fitting, retryable source failures, local-config mutation, tool and filter binding, strict cursor validation, malformed JSON, and unusable server envelopes.
- Applicable pre-commit hooks passed for all touched files, including Ruff and Pyrefly.
- An isolated server and host completed a seven-page direct traversal with 20 distinct rows, no repeats, terminal `has_more: false`, and the parameterless legacy response shape intact.
- An isolated Claude agent then completed seven `sys_agent_list` calls with `limit: 2`, copied every cursor unchanged, returned 14 unique built-ins with no duplicates or omissions, and reached terminal `has_more: false`. Its `sys_session_list` call was correctly terminal on the first page.

## Demo

![Discovery cursor traversal across seven pages](https://raw.githubusercontent.com/dosenr/omnigent/7732fcc2560d6751475589e78eb5bb84de81dfc3/4892-pagination-demo.png)

Recorded output from the corrected head. Each response token fingerprint matches the next request, every page returns different rows, and page 7 ends with `has_more: false` and no continuation cursor.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The runner tests exercise the real tool-dispatch boundary with `httpx.MockTransport` and an isolated local-config directory. They cover the unchanged small response, server-backed traversal beyond 1,000 rows, independent source progress, output-size fitting, mutable local configs, failed reads, malformed envelopes, cursor binding and validation, bounded diagnostics, the unchanged unpaged child-session section, and argument validation. The existing E2E compatibility test proves that a live runner accepts a returned cursor and relays the distinct next page against an older server.

## Changelog

Agent and session discovery tools now page large catalogs through an opaque cursor, or return a bounded diagnostic when the smallest page cannot fit.
