### PR TITLE
feat(web): show background tasks as a composer pill, not the working shimmer

### DIFF
--- a/tests/e2e_ui/chat/test_send_while_background_task.py
+++ b/tests/e2e_ui/chat/test_send_while_background_task.py
@@ -35,7 +35,7 @@ import httpx
 from playwright.sync_api import Page, expect
 
 _QUEUED_STRIP = '[data-testid="composer-queued-strip"]'
-_WORKING = '[data-testid="working-indicator"]'
+_PILL = '[data-testid="background-task-pill"]'
 _COMPOSER_PLACEHOLDER_IDLE = "Ask the agent anything…"
 
 _SEND_MSG = "sentinel-bg-send-2a9c sent while a background task runs"
@@ -103,7 +103,7 @@ def test_message_sends_directly_while_background_task_runs(
 
     # The turn ended but a background shell outlives it: the Stop hook posts
     # `waiting` with the ended turn's response_id and a positive count. The
-    # working indicator stays lit ("1 background task still running").
+    # composer's pill names the shell ("1 background task").
     _publish_status(
         base_url,
         session_id,
@@ -111,9 +111,7 @@ def test_message_sends_directly_while_background_task_runs(
         response_id="resp_bg_1",
         background_task_count=1,
     )
-    expect(page.locator(_WORKING)).to_contain_text(
-        "1 background task still running", timeout=15_000
-    )
+    expect(page.locator(_PILL)).to_contain_text("1 background task", timeout=15_000)
 
     # The composer must be free to send — NOT stuck on the queued follow-up
     # placeholder. This is the exact regression: `waiting`+response_id used
@@ -159,9 +157,7 @@ def test_message_sends_directly_after_reopening_with_background_task(
     composer = page.get_by_label("Message the agent")
     expect(composer).to_be_visible()
     # The shells are still reported (the tally rides the snapshot) …
-    expect(page.locator(_WORKING)).to_contain_text(
-        "1 background task still running", timeout=15_000
-    )
+    expect(page.locator(_PILL)).to_contain_text("1 background task", timeout=15_000)
     # … but the turn is over, so the composer is free.
     expect(composer).to_have_attribute("placeholder", _COMPOSER_PLACEHOLDER_IDLE, timeout=15_000)
 

--- a/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
+++ b/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
@@ -2,10 +2,9 @@
 
 A claude-native turn can settle to ``idle`` while background shells keep
 running. The forwarder reports that as ``external_session_status: idle``
-carrying a positive ``background_task_count``, and the web chat must keep
-the working indicator lit — labelled ``"N background tasks still
-running"`` — instead of falling idle like the TUI's "N shells still
-running" banner.
+carrying a positive ``background_task_count``. The turn has ended, so the
+composer's ``background-task-pill`` names the shells instead of the
+"Working…" shimmer (which would misread as the agent still thinking).
 
 Both tests drive the real status edges through the Sessions events route
 (the same path the claude-native forwarder posts to), so they are
@@ -24,6 +23,7 @@ import httpx
 from playwright.sync_api import Page, expect
 
 _WORKING = '[data-testid="working-indicator"]'
+_PILL = '[data-testid="background-task-pill"]'
 
 # Rotating labels the working indicator cycles through — mirror of
 # WORKING_MESSAGES in web/src/pages/ChatPage.tsx. The running-turn label is
@@ -82,21 +82,24 @@ def test_background_task_indicator_label_lifecycle(
     """
     base_url, session_id = seeded_session
     working = page.locator(_WORKING)
+    pill = page.locator(_PILL)
 
-    # 1. Background shells outlive the turn: idle + a positive count. The
-    #    snapshot caches the count, so a fresh page load hydrates it.
+    # 1. Background shells outlive the turn: idle + a positive count. The turn
+    #    has ended, so the pill (not the shimmer) names them. The snapshot
+    #    caches the count, so a fresh page load hydrates it.
     _publish_status(base_url, session_id, "idle", background_task_count=2)
     page.goto(f"{base_url}/c/{session_id}")
-    expect(working).to_contain_text("2 background tasks still running", timeout=15_000)
+    expect(pill).to_contain_text("2 background tasks", timeout=15_000)
+    expect(working).to_have_count(0)
 
     # 2. A new turn starts (the `running` edge a composer send produces): the
-    #    fresh turn supersedes the tally, so the label flips from the
-    #    background-task count to a rotating working label (e.g. "Working…",
-    #    "Cooking…"). Accept any label in the pool — which one shows depends on
-    #    the wall-clock bucket the turn lands on.
+    #    fresh turn supersedes the tally, so the pill gives way to the rotating
+    #    working shimmer (e.g. "Working…", "Cooking…"). Accept any label in the
+    #    pool — which one shows depends on the wall-clock bucket the turn lands
+    #    on.
     _publish_status(base_url, session_id, "running")
     expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
-    expect(working).not_to_contain_text("background task", timeout=15_000)
+    expect(pill).to_have_count(0)
 
     # 3. The turn ends with the background shell finished: an authoritative
     #    Stop-hook `0` clears the tally, so the indicator goes out.
@@ -123,17 +126,18 @@ def test_sidebar_spinner_ignores_background_tasks(
     :returns: None.
     """
     base_url, session_id = seeded_session
+    pill = page.locator(_PILL)
     working = page.locator(_WORKING)
     # The badge sits in the row's time-marker slot (a sibling of the row link),
     # and `seeded_session` holds exactly one session — so the lone running badge
     # is this session's. Idle rows render no badge at all.
     running_badge = page.locator('[data-testid="session-state-badge"][data-state="running"]')
 
-    # 1. Background shells outlive the turn → the chat indicator lights up, the
+    # 1. Background shells outlive the turn → the chat pill lights up, the
     #    sidebar row does not.
     _publish_status(base_url, session_id, "idle", background_task_count=1)
     page.goto(f"{base_url}/c/{session_id}")
-    expect(working).to_contain_text("1 background task still running", timeout=15_000)
+    expect(pill).to_contain_text("1 background task", timeout=15_000)
     expect(running_badge).to_have_count(0)
 
     # 2. A real turn still lights the row, so the assertion above is about

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -34,6 +34,7 @@ import {
   shouldShowTerminalSurface,
   updateWarmTerminalSurfaces,
   type WarmTerminalEntry,
+  isBackgroundTasksOnly,
   splitSlashCommand,
   stripGatedSubagentRoutingChips,
   stripPendingElicitations,
@@ -1074,6 +1075,20 @@ describe("workingIndicatorLabel", () => {
   it("ignores the tick while background tasks remain", () => {
     // The count is information, not decoration — it must not rotate away.
     expect(workingIndicatorLabel(2, 5)).toBe("2 background tasks still running");
+  });
+});
+
+// ── isBackgroundTasksOnly ───────────────────────────────────────────────────
+
+describe("isBackgroundTasksOnly", () => {
+  it("is true only when background tasks remain and nothing is blocked", () => {
+    expect(isBackgroundTasksOnly(2, null)).toBe(true);
+    expect(isBackgroundTasksOnly(0, null)).toBe(false);
+  });
+
+  it("yields to a parked dialog so the shimmer still shouts", () => {
+    // blockedOn needs an action; it must never sit as a quiet pill.
+    expect(isBackgroundTasksOnly(2, "permission prompt")).toBe(false);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -28,6 +28,7 @@ import {
   PaperclipIcon,
   SettingsIcon,
   SquareIcon,
+  SquareTerminalIcon,
   WifiOffIcon,
   XIcon,
 } from "lucide-react";
@@ -2299,7 +2300,10 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
   const blockedOn = useChatStore((s) => s.blockedOn);
   const tick = useWorkingLabelTick();
-  const visible = show && !isAtBottom && !suppress;
+  // BackgroundTaskPill owns the background-tasks-only case; the pinned tab and
+  // its announcement yield to it.
+  const showShimmer = show && !isBackgroundTasksOnly(bgCount, blockedOn);
+  const visible = showShimmer && !isAtBottom && !suppress;
   return (
     <div
       // Always mounted (the aria-live region announces on show); bottom-0 sits
@@ -2317,11 +2321,11 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           the agent is working, so it announces whether the tab is painted
           (scrolled up) or collapsed (at the bottom, where the inline shimmer
           owns the visuals). */}
-      {show && <span className="sr-only">Working…</span>}
+      {showShimmer && <span className="sr-only">Working…</span>}
       {/* Mirror the conversation content column (mx-auto + px-4 + width) so the
           tab's left edge lines up with the inline shimmer's. */}
       <div className={cn("mx-auto w-full px-4", CHAT_COLUMN_WIDTH)}>
-        {show && (
+        {showShimmer && (
           // Tab shape (rounded top, no bottom border, composer-matching bg) so
           // its flat bottom edge merges into the chat box. aria-hidden: the
           // sr-only span above owns the announcement, so the rotating label
@@ -2977,6 +2981,15 @@ export const WORKING_MESSAGES = [
 ] as const;
 
 /**
+ * Busy only because background tasks outlive the turn (a dev server, a
+ * background shell) — the agent isn't thinking and nothing's blocked. The
+ * composer's `BackgroundTaskPill` owns this; the "Working…" shimmer yields.
+ */
+export function isBackgroundTasksOnly(bgCount: number, blockedOn: string | null): boolean {
+  return !blockedOn && bgCount > 0;
+}
+
+/**
  * The label shown next to the working spinner. When the agent is parked on a
  * dialog (`blockedOn`) it says so — that outranks everything else, because it
  * is the one case where the session needs the user rather than time, and the
@@ -3005,6 +3018,9 @@ function WorkingIndicator() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
   const blockedOn = useChatStore((s) => s.blockedOn);
   const tick = useWorkingLabelTick();
+  // BackgroundTaskPill owns this case; the shimmer would misread as the agent
+  // still thinking.
+  if (isBackgroundTasksOnly(bgCount, blockedOn)) return null;
   const label = workingIndicatorLabel(bgCount, tick, blockedOn);
   return (
     <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
@@ -4404,6 +4420,32 @@ function SubagentComposerTray({ label }: { label: string }) {
 }
 
 /**
+ * Pill above the composer tallying background tasks that outlive the turn (a
+ * dev server, a background shell), shown in place of the "Working…" shimmer —
+ * which would misread as the agent still thinking. Label-only: the count spans
+ * shells, sub-agents, and tools, so there's no single terminal to open.
+ */
+function BackgroundTaskPill() {
+  const bgCount = useChatStore((s) => s.backgroundTaskCount);
+  const blockedOn = useChatStore((s) => s.blockedOn);
+  if (!isBackgroundTasksOnly(bgCount, blockedOn)) return null;
+  return (
+    <div className={cn("mx-auto flex w-full px-1 pb-1.5", CHAT_COLUMN_WIDTH)}>
+      <div
+        role="status"
+        data-testid="background-task-pill"
+        className="flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-sm text-muted-foreground shadow-sm"
+      >
+        <SquareTerminalIcon className="size-3.5 shrink-0" aria-hidden="true" />
+        <span>
+          {bgCount} background task{bgCount === 1 ? "" : "s"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
  * The message-input composer: textarea, attachments, slash-command
  * suggestions menu, and the send/stop controls. Exported for direct
  * unit testing of the slash-command keyboard behavior.
@@ -5308,6 +5350,9 @@ export function Composer({
           Truthy (not just non-null) so an empty label never peeks a
           nameless tray. */}
       {subAgentLabel ? <SubagentComposerTray label={subAgentLabel} /> : null}
+      {/* Background tasks that outlive the turn show as a pill here, not the
+          "Working…" shimmer. Self-gates to null otherwise. */}
+      <BackgroundTaskPill />
       {/* Single rounded container — textarea + action row. No focus-within
           ring; drag-over still lifts an inset ring. dark:bg-card-solid so
           upper trays (queued / sub-agent) don't ghost through glass --card. */}


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-2324/dont-use-shimmerworking-pattern-for-long-running-background-tasks

## Summary

- A claude-native turn settles to `idle` even while background shells/sub-agents
  keep running. The old "Working…" shimmer stayed lit for that state, misreading
  as *the agent is still thinking* when the turn has actually ended.
- Route the background-tasks-only state to a dedicated `BackgroundTaskPill` above
  the composer instead. A shared `isBackgroundTasksOnly` predicate gates both
  shimmer surfaces (`WorkingIndicator` and the scroll-pinned `WorkingStatusPin`)
  off and the pill on, so the two never stack.
- A parked dialog (`blockedOn`) still wins the shimmer — it needs a user action,
  not a quiet pill.

Which indicator shows:

| State | Indicator |
| --- | --- |
| Agent working / streaming | "Working…" shimmer |
| Parked on a dialog (`blockedOn`) | "Blocked on: …" shimmer |
| Turn ended, background tasks remain | `BackgroundTaskPill` |

## Test Plan

- `npm run test` (web) — 194 passing, including a new `isBackgroundTasksOnly`
  unit test and the existing `workingIndicatorLabel` / indicator suites.
- `npm run type-check`, `oxlint`, and `prettier --check` — all clean.
- Manual: force-showed the pill in the dev UI and confirmed it renders above the
  composer for the background-tasks-only state (see Demo).

## Demo

<img width="343" height="175" alt="Screenshot 2026-08-17 at 10 41 31" src="https://github.com/user-attachments/assets/397cabdf-a836-411f-8da1-4ae1f18b98bb" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The priority logic (`isBackgroundTasksOnly`: blocked > background-only > working)
is unit-tested alongside the existing `workingIndicatorLabel` suite. The pill's
render and the shimmer suppression are verified manually — see Demo.

## Changelog

Background tasks that keep running after a turn ends now show as a pill above the composer instead of a "Working…" spinner
