### PR TITLE
fix(approvals): keep the turn alive when an approval is declined

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7020,7 +7020,15 @@ def create_runner_app(
             pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
             if _session_harness_name(conversation_id) == "claude-native":
                 await _apply_claude_native_plan_verdict(conversation_id, _data)
-            if _elicit_action == "decline":
+            _declined_harness = _session_harness_name(conversation_id)
+            if _elicit_action == "decline" and (
+                _declined_harness is None or is_native_harness(_declined_harness)
+            ):
+                # A native harness runs a vendor TUI that only stops on an
+                # abort signal. Every other harness reads the deny off its
+                # policy hook and keeps the turn. An UNRESOLVED harness keeps
+                # the abort too: at an approval boundary, uncertainty must
+                # cost the turn, never risk running work the user refused.
                 try:
                     _int_client = await process_manager.get_client(conversation_id, "any")
                     await _int_client.post(

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response
 from omnigent.codex_native_elicitation import codex_elicitation_id
 from omnigent.entities import Conversation
 from omnigent.errors import ElicitationDeclinedError, ErrorCode, OmnigentError
+from omnigent.harness_aliases import is_native_harness
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     get_agent_cache,
@@ -76,6 +77,7 @@ from omnigent.server.routes._sessions.helpers import (
     _get_runner_client,
     _native_ask_gate_lock,
     _publish_policy_denied,
+    _resolve_harness,
     _structured_ask_user_question,
 )
 from omnigent.server.routes._sessions.orchestration import (
@@ -871,17 +873,16 @@ def register_hooks_routes(
                                 elicitation_id=hook_elicitation_id,
                             )
                         except ElicitationDeclinedError as exc:
-                            # Explicit user decline: interrupt the native
-                            # harness BEFORE returning the hook deny so the
-                            # Escape key reaches Claude Code's tmux pane first.
-                            # By the time the DENY response reaches the hook
-                            # subprocess, the abort signal is already queued.
-                            # Best-effort: forwarding failures are swallowed.
-                            await _forward_session_change_to_runner(
-                                session_id,
-                                get_server_runner_router(),
-                                {"type": "interrupt"},
-                            )
+                            # A native harness drives a vendor TUI that stops
+                            # only on an abort signal, sent before the deny.
+                            # Every other harness keeps the turn on the deny.
+                            _declined_harness = _resolve_harness(conv)
+                            if _declined_harness is None or is_native_harness(_declined_harness):
+                                await _forward_session_change_to_runner(
+                                    session_id,
+                                    get_server_runner_router(),
+                                    {"type": "interrupt"},
+                                )
                             decline_body = {
                                 "result": "POLICY_ACTION_DENY",
                                 "reason": exc.args[0] or "Approval was declined.",

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7438,6 +7438,111 @@ async def test_approval_event_without_content_flattened() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("harness", "expected_event_types"),
+    [("hermes", ["approval"]), ("claude-native", ["interrupt", "approval"])],
+)
+async def test_approval_decline_interrupts_only_native_harness(
+    harness: str,
+    expected_event_types: list[str],
+) -> None:
+    """
+    A declined approval interrupts a native harness only.
+
+    A native harness runs a vendor TUI that has to be told to stop. Every
+    other harness reads the deny off its policy hook and keeps the turn,
+    so interrupting it discards work the user did not cancel.
+
+    :param harness: Harness the session's agent spec declares.
+    :param expected_event_types: Event types the harness must receive, in
+        order.
+    """
+    captured: list[dict[str, Any]] = []
+
+    class _CapturingHarnessClient:
+        async def post(
+            self, url: str, *, json: dict[str, Any], timeout: float | None = None
+        ) -> httpx.Response:
+            del url, timeout
+            captured.append(json)
+            return httpx.Response(204)
+
+    async def _spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """
+        Resolve a minimal spec on the parametrized harness.
+
+        :param agent_id: Agent id (unused).
+        :param session_id: Session id (unused).
+        :returns: A minimal spec whose harness is ``harness``.
+        """
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="approval-decline-agent",
+            executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+        )
+
+    mgr = _FakeProcessManager(harness_client=cast(Any, _CapturingHarnessClient()))
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, mgr),
+        spec_resolver=_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        # POST /v1/sessions seeds _session_spec_cache, which is what the
+        # approval path reads the session's harness back from.
+        create = await http.post(
+            "/v1/sessions",
+            json={"session_id": "conv_decline", "agent_id": "agent_decline"},
+        )
+        assert create.status_code == 201, create.text
+        resp = await http.post(
+            "/v1/sessions/conv_decline/events",
+            json={"type": "approval", "data": {"elicitation_id": "e2", "action": "decline"}},
+        )
+
+    assert resp.status_code == 204
+    assert [event["type"] for event in captured] == expected_event_types
+
+
+@pytest.mark.asyncio
+async def test_approval_decline_unresolved_harness_keeps_interrupt() -> None:
+    """
+    A decline whose session harness cannot be resolved keeps the interrupt.
+
+    The spec cache has no entry for the session, so harness resolution
+    returns ``None``. At an approval boundary that uncertainty must fail
+    closed: sacrifice the turn rather than risk a native TUI continuing
+    work the user refused.
+    """
+    captured: list[dict[str, Any]] = []
+
+    class _CapturingHarnessClient:
+        async def post(
+            self, url: str, *, json: dict[str, Any], timeout: float | None = None
+        ) -> httpx.Response:
+            del url, timeout
+            captured.append(json)
+            return httpx.Response(204)
+
+    mgr = _FakeProcessManager(harness_client=cast(Any, _CapturingHarnessClient()))
+    app = create_runner_app(
+        process_manager=cast(HarnessProcessManager, mgr),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_test_client(app) as http:
+        # Deliberately no POST /v1/sessions first: the spec cache stays
+        # empty, so _session_harness_name returns None for this id.
+        resp = await http.post(
+            "/v1/sessions/conv_unresolved/events",
+            json={"type": "approval", "data": {"elicitation_id": "e3", "action": "decline"}},
+        )
+
+    assert resp.status_code == 204
+    assert [event["type"] for event in captured] == ["interrupt", "approval"]
+
+
+@pytest.mark.asyncio
 async def test_spawn_handle_round_trips_to_sys_cancel_async(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -768,18 +768,40 @@ async def test_tool_call_ask_holds_gate_and_returns_allow_on_accept(
     assert resp.json()["result"] == "POLICY_ACTION_ALLOW"
 
 
+@pytest.mark.parametrize(
+    ("harness", "expects_interrupt"),
+    [("hermes", False), ("claude-native", True)],
+)
 async def test_tool_call_ask_returns_deny_on_decline(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+    expects_interrupt: bool,
 ) -> None:
     """
     A declined TOOL_CALL ASK collapses to ``POLICY_ACTION_DENY`` —
     fail-closed. If the human refuses at the approve URL, the native
     tool must not run.
+
+    A native harness also gets an ``interrupt`` so the vendor TUI stops.
+    Every other harness continues the turn from the deny response.
+
+    :param harness: Harness the agent under test runs.
+    :param expects_interrupt: Whether the runner must receive an
+        ``interrupt`` event alongside the deny.
     """
     _patch_default_policies(monkeypatch, f"{__name__}._ask_for_bash")
-    agent = await create_test_agent(client)
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": harness}},
+    )
     session_id = await _create_session(client, agent["id"])
+
+    # Installed after session creation, which itself touches the runner
+    # snapshot path; the forward falls back to the global runner client
+    # when no runner is bound for the session.
+    capturing = CapturingRunnerClient()
+    monkeypatch.setattr("omnigent.runtime._globals._runner_client", capturing)
 
     drain = asyncio.create_task(_drain_elicitation_id(session_id))
     await asyncio.sleep(0.05)
@@ -800,6 +822,56 @@ async def test_tool_call_ask_returns_deny_on_decline(
     resp = await evaluate
     assert resp.status_code == 200, resp.text
     assert resp.json()["result"] == "POLICY_ACTION_DENY"
+    event_types = [post["json"].get("type") for post in capturing.posted]
+    assert ("interrupt" in event_types) is expects_interrupt
+
+
+async def test_tool_call_ask_decline_interrupts_when_harness_unresolved(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A decline whose harness resolution fails keeps the interrupt.
+
+    ``_resolve_harness`` returns ``None`` for missing state and caught
+    resolution errors. The decline boundary fails closed on that
+    uncertainty: the interrupt is kept, sacrificing the turn rather than
+    risking a native TUI continuing refused work.
+    """
+    _patch_default_policies(monkeypatch, f"{__name__}._ask_for_bash")
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "hermes"}},
+    )
+    session_id = await _create_session(client, agent["id"])
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.routes_hooks._resolve_harness",
+        lambda *a, **kw: None,
+    )
+    capturing = CapturingRunnerClient()
+    monkeypatch.setattr("omnigent.runtime._globals._runner_client", capturing)
+
+    drain = asyncio.create_task(_drain_elicitation_id(session_id))
+    await asyncio.sleep(0.05)
+    evaluate = asyncio.create_task(
+        client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json=_tool_call_request("Bash"),
+        )
+    )
+    elicitation_id = await drain
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "decline"},
+    )
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await evaluate
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["result"] == "POLICY_ACTION_DENY"
+    event_types = [post["json"].get("type") for post in capturing.posted]
+    assert "interrupt" in event_types
 
 
 async def test_tool_call_ask_forwards_popup_event_to_runner(


### PR DESCRIPTION
## Related issue

Closes #4894

## Summary

Declining one approval cancels the agent's whole turn on every harness, and #1839 made that
deliberate. This change keeps the abort for native and unresolved harnesses and lets known
non-native harnesses continue after the DENY. `docs/POLICIES.md` still says DENY-and-continue,
which is the conflict this raises.

```
decline arrives
  |-- native CLI harness ----> interrupt + DENY   (existing turn abort retained)
  |-- unresolved harness ----> interrupt + DENY   (uncertainty fails closed)
  `-- non-native harness ----> DENY only, turn continues
```

Two sites posted `{"type": "interrupt"}` on every decline without checking the session's harness:
the `ElicitationDeclinedError` handler in `omnigent/server/routes/sessions/routes_hooks.py`, and the
`approval` event handler in `omnigent/runner/app.py`. Both now gate on the session's resolved
harness, using resolution helpers already in the tree. A harness that resolves as native keeps the
interrupt, and so does one that cannot be resolved at all: at an approval boundary, uncertainty
costs the turn rather than risking work the user refused. Two imports are the only other production
change; no new API surface.

If operation-scoped denial is chosen, the agent may retry and ask again. A declined ASK
currently records no checkpoint, so a uniform implementation would need to address repeated
approval attempts.

**Reviewer decision:** Should explicit Decline block one operation or stop the whole turn? #1839
chose turn-scoped behavior. This patch's harness-specific split is not proposed for merge until
that contract is settled.

## Test Plan

- `tests/runner/test_runner_dispatch.py::test_approval_decline_interrupts_only_native_harness` and
  `tests/server/integration/test_sessions_policy_evaluate.py::test_tool_call_ask_returns_deny_on_decline`:
  fail on pristine `main` with only the tests applied (`2 failed, 2 passed`; the two passing cases
  are the `claude-native` parametrizations, so the native abort is unchanged by construction), pass
  with the fix (`4 passed`), and fail again when only the production edits are reverted.
- `test_approval_decline_unresolved_harness_keeps_interrupt` and
  `test_tool_call_ask_decline_interrupts_when_harness_unresolved`: fail against the fix without its
  fail-closed guard (`2 failed`), pass with it.
- Both touched suites in full: `216 passed, 1 skipped`.
- Static checks: `ruff check` and `ruff format --check` clean on the four changed files, `pyrefly`
  0 errors, `pre-commit` all hooks except a `vscode-tsc` baseline reproduced identically on
  pristine `main`.
- A composed manual run with a deterministic scripted ACP process on the generic ACP harness
  against `main` at `fc0e2e99` drove the full decline path: unpatched, the turn ended
  `response.cancelled` with the permission request never answered; patched, zero interrupts and the
  turn continued to `response.completed`. That run predates the unresolved-harness guard, which the
  two fail-closed tests cover.
- Not verified by automation: no automated test drives a complete turn through a decline; the
  composed manual run above is the only full-turn evidence. No e2e test, per `CONTRIBUTING.md`'s
  scope for bug fixes.

## Demo

Deterministic text output, not a visual capture. The event sequence the runner posts to the harness
on a decline, from the passing tests:

```
  harness=hermes         ->  ['approval']                  interrupt withheld
  harness=claude-native  ->  ['interrupt', 'approval']     interrupt kept
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One new runner test and one parametrization of the existing server decline test cover both harness
kinds; two further tests prove the fail-closed boundary for an unresolvable harness on each path.
No e2e test: the change alters an existing decline path rather than adding user-facing
functionality.

## Changelog

Explicit declines continue the turn on known non-native harnesses; native and unresolved harnesses retain the existing turn abort.

