### PR TITLE
[OMNI-2843 fix] Fix overlaying toolbar icons

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -746,6 +746,15 @@ aside[aria-label="Workspace"][data-maximized] {
   align-self: flex-start;
   margin-top: 1rem;
 }
+/* A maximized workspace rail breaks out to inset-0 (the left sidebar collapses
+ * on entry), so its tab strip starts at the window's top-left corner — where
+ * the traffic lights float (0–5rem) and the title-bar cluster sits (5rem–10rem,
+ * z above the rail). Pad the strip past both so its leftmost tab icon clears
+ * them. Only the maximized rail reaches this corner; the docked rail sits right
+ * of the sidebar and is untouched. */
+[data-electron-mac] aside[aria-label="Workspace"][data-maximized] .workspace-tab-strip {
+  padding-left: 10.5rem;
+}
 /* Drag regions are geometric, not z-ordered: anything that overlaps the
  * strip (e.g. the mobile full-screen sidebar overlay) would lose clicks
  * without an explicit counter-region on interactive elements. */

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -716,7 +716,7 @@ export function WorkspacePanel({
           horizontal scroller — see below). The outer row never scrolls
           (overflow-x-hidden), so the divider is a fixed boundary that doesn't
           drift when the tabs scroll. */}
-      <div className="shrink-0 flex items-center overflow-x-hidden border-b border-border px-2 py-2">
+      <div className="workspace-tab-strip shrink-0 flex items-center overflow-x-hidden border-b border-border px-2 py-2">
         <Tabs
           // Static group — never compresses (shrink-0) and stays anchored on
           // the LEFT whether or not tabs are open. The open tabs render to its


### PR DESCRIPTION
## Related issue

Related to OMNI-2843 (additional fix)

## Summary

On the macOS Electron desktop shell, maximizing the workspace rail (right
sidebar) made its tab-strip icons collide with the window's traffic-light
controls in the top-left corner.

- When maximized, the rail breaks out to `absolute inset-0` and the left
  sidebar collapses, so the rail's tab strip starts at the window's top-left —
  exactly where macOS floats the close/minimize/maximize buttons (the shell
  uses `titleBarStyle: "hiddenInset"`), and where the title-bar cluster
  (Search / Settings / sidebar-toggle) sits at `left: 5rem`.
- Fix: on the mac shell, pad the maximized rail's tab strip left so the first
  icon clears both the traffic lights (0–5rem) and the cluster (5rem–10rem).
  Scoped to `[data-electron-mac] … [data-maximized]`, so the docked rail and
  every other platform/browser are untouched.

```
Before (maximized rail, macOS Electron):     After:
┌───────────────────────────────┐            ┌───────────────────────────────┐
│ ●●● [Files][Changes][Agents]…  │            │ ●●●  ⌕ ⚙ ⬅   [Files][Changes]… │
│  ↑ traffic lights overlap tabs │            │  ↑ tabs padded clear of both   │
└───────────────────────────────┘            └───────────────────────────────┘
```

## Test Plan

Manual, on macOS in the Electron shell (`just electron-dev`):

1. Open a session with a workspace (Files / Agents / Shells tabs present).
2. Maximize the right workspace rail.
3. Confirm the leftmost tab icon no longer sits under the traffic lights or the
   Search/Settings/toggle cluster, and all tabs stay clickable.
4. Un-maximize → docked rail toolbar unchanged (icons flush left). In a browser
   and on Windows/Linux Electron, maximize → also unchanged (the rule is scoped
   to `[data-electron-mac]`).

## Demo

**Before:**

<img width="891" height="955" alt="Screenshot 2026-08-17 at 12 54 29" src="https://github.com/user-attachments/assets/29f5ea53-4078-4921-8acb-4dc3eeb0317a" />

**After:**

<img width="891" height="958" alt="Screenshot 2026-08-17 at 12 52 37" src="https://github.com/user-attachments/assets/5d1311f1-4b56-447e-bbea-0d7c445b25d4" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Presentational CSS change (a scoped `padding-left` plus a class hook) with no
logic to unit-test. Verified manually on the macOS Electron shell per the Test
Plan; behaviour on other platforms/browsers is unchanged because the rule is
scoped to `[data-electron-mac]`.

## Changelog

Maximizing the workspace panel in the desktop app no longer tucks its tab icons under the macOS window controls.
