### PR TITLE
fix(ci): grant pull-requests write so /rerun can post its result

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -34,8 +34,12 @@ jobs:
     name: Re-run failed CI for the PR head
     permissions:
       actions: write        # gh run rerun
-      pull-requests: read   # resolve the PR head SHA
-      issues: write         # react to the comment + post the result
+      # `write`, not `read`: besides resolving the PR head SHA, the final
+      # `gh pr comment` posts via the GraphQL `addComment` mutation, which is
+      # authorised by the pull-requests scope -- `issues: write` does NOT cover
+      # it, and the step dies with "Resource not accessible by integration".
+      pull-requests: write  # resolve the PR head SHA + post the result comment
+      issues: write         # react to the triggering comment
     # PR comment, body starts with `/rerun`, not a bot, in this repo, AND the
     # commenter is the PR author or has write access. `issue.user.login` is the
     # PR author; `comment.user.login` is the commenter.


### PR DESCRIPTION
## Related issue

Closes #4898

## Summary

`/rerun` re-runs the failed CI runs correctly and then **fails on its own result comment**, so the workflow goes red even though the recovery worked and the contributor never learns which runs restarted.

```
• Re-running failed jobs in 'E2E UI Tests' (run 32014464458)
GraphQL: Resource not accessible by integration (addComment)
##[error]Process completed with exit code 1.
```

`gh pr comment` posts through the GraphQL `addComment` mutation, which is authorised by the **pull-requests** scope. `issues: write` only covers the REST reaction call — which is why the 👀 reaction lands but the comment does not. This bumps `pull-requests: read` → `write` and re-words the two permission comments to say which call needs which scope.

Every other workflow here that calls `gh pr comment` already has `pull-requests: write`; `rerun-ci.yml` was the lone outlier:

| workflow | `gh pr comment` | pull-requests scope |
|---|---|---|
| `oss-regen-on-comment.yml` | yes | `write` |
| `ui-preview.yml` | yes | `write` |
| `ui-snapshot-update.yml` | yes | `write` |
| `rerun-ci.yml` (before) | yes | **`read`** |

Worth fixing because the failure teaches the wrong lesson: `/rerun` looks broken, so contributors fall back to pushing an empty commit — exactly what this workflow's own header warns against, since a push event dismisses stale reviews.

## Test Plan

Not unit-testable — repo has no actionlint or workflow-permission tests, and the bug only manifests against GitHub's real token scoping. Verified by:

1. **Live reproduction** — commented `/rerun` on #4613. Run [32025561263](https://github.com/omnigent-ai/omnigent/actions/runs/32025561263) shows the re-run succeeding (E2E UI shard 1/3 restarted, run `32014464458`) and then the job dying on `addComment`. Reproduced a second time earlier in the same PR, so it is deterministic, not flaky.
2. **Scope audit** — grepped every workflow calling `gh pr comment` and compared declared permissions (table above); `rerun-ci.yml` is the only one with `read`.
3. **YAML validity** — `yaml.safe_load` parses the file and the job resolves to `{'actions': 'write', 'pull-requests': 'write', 'issues': 'write'}`.
4. `issues: write` retained — still required for the REST reaction call.

No behaviour change beyond the permission: the trigger, authorization `if`, and command validation are untouched, so this does not widen who can invoke `/rerun`.

## Demo

N/A — CI-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-permission changes cannot be exercised by the test suite — the repo has no actionlint or workflow-lint step, and `GITHUB_TOKEN` scoping only exists inside a real Actions run. Verified manually as described in the Test Plan: live failure reproduced twice with logs, YAML parsed and asserted, and the permission set cross-checked against the three other workflows that make the same call. The fix will self-verify the next time anyone comments `/rerun` — the job should post its summary and go green.

