### PR TITLE
feat(web): resume imported / host-less sessions from the web

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5734,6 +5734,7 @@ def import_session_command(
     import httpx
 
     from omnigent.chat import _remote_headers
+    from omnigent.conversation_browser import conversation_url
     from omnigent.session_import import (
         ImportSource,
         SessionImportNotFoundError,
@@ -5839,13 +5840,17 @@ def import_session_command(
             )
             continue
         imported_count += 1
+        # Surface the browser URL, not the bare id, so the user can open the
+        # imported session straight into the web (where it offers the resume
+        # picker). Maps a Databricks API base to its workspace SPA link.
+        session_link = conversation_url(base_url, session_id)
         if is_batch:
             click.echo(
                 f"Imported {item_count} item(s) from {current_source_session_id} "
-                f"into {session_id}."
+                f"into {session_link}"
             )
         else:
-            click.echo(f"Imported {item_count} item(s) into {session_id}.")
+            click.echo(f"Imported {item_count} item(s) into {session_link}")
 
     if is_batch:
         click.echo(f"\nImported: {imported_count}")

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1785,12 +1785,13 @@ def create_app(
                 host_version = host_versions.get(conn.host_id)
             if conn.runner_id is None:
                 # No runner binding: an in-process executor (or a session
-                # not yet dispatched) is reachable — EXCEPT an unbound fork
-                # of a session that had a working directory, which must
-                # rebind a host + directory first. Reporting it offline
-                # routes the first message into the directory picker instead
-                # of dropping it against a runner that can't start.
-                runner_online = not conn.needs_workspace
+                # not yet dispatched) is reachable — EXCEPT sessions that have
+                # no executor to reach and must launch a runner on a host
+                # first: an unbound fork (needs a workspace) or an imported
+                # transcript (no live executor anywhere). Reporting those
+                # offline routes the first message into the resume picker
+                # instead of dropping it against a runner that can't start.
+                runner_online = not (conn.needs_workspace or conn.imported)
             else:
                 # Strict: reachable only if the runner tunnel is up. No
                 # host-relaunch optimism — host state lives in host_online.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -210,6 +210,12 @@ class SessionConnectivity:
         dot off while ``runner_id``/``host_id`` are still ``None`` so
         the UI prompts for a host + directory before the clone can run,
         rather than treating it as an in-process session.
+    :param imported: ``True`` when this session was imported from a local
+        harness transcript (the ``omnigent.import.source`` label is set).
+        Like ``needs_workspace``, forces the online dot off while unbound:
+        an imported transcript has no live executor anywhere, so it must
+        launch a runner on a host before it can run — reporting it offline
+        routes the first message into the resume picker.
     :param runner_last_seen: Epoch seconds the bound runner's tunnel was
         last observed alive, written by the replica holding the tunnel.
         ``None`` when never observed (or cleared on graceful disconnect).
@@ -221,6 +227,7 @@ class SessionConnectivity:
     runner_id: str | None
     host_id: str | None
     needs_workspace: bool
+    imported: bool = False
     runner_last_seen: int | None = None
 
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1136,10 +1136,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationMetadata.id.in_(unique_ids),
                 )
             ).all()
-        # Fork-source label is in the AP DB.
+        # Connectivity markers are in the AP DB. Both signal on presence:
+        # the fork-source label forces an unbound clone to pick a workspace;
+        # the import-source label marks a transcript with no live executor.
         with self._conv_session("get_session_connectivity") as ap_sess:
-            # One pass over the fork-source connectivity marker, which
-            # signals on presence (its value is the source id).
             label_rows = ap_sess.execute(
                 select(
                     SqlConversationLabel.conversation_id,
@@ -1148,17 +1148,21 @@ class SqlAlchemyConversationStore(ConversationStore):
                 ).where(
                     SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversationLabel.conversation_id.in_(unique_ids),
-                    SqlConversationLabel.key.in_([FORK_SOURCE_LABEL_KEY]),
+                    SqlConversationLabel.key.in_([FORK_SOURCE_LABEL_KEY, IMPORT_SOURCE_LABEL_KEY]),
                 )
             ).all()
         needs_workspace_ids = {
             row.conversation_id for row in label_rows if row.key == FORK_SOURCE_LABEL_KEY
+        }
+        imported_ids = {
+            row.conversation_id for row in label_rows if row.key == IMPORT_SOURCE_LABEL_KEY
         }
         return {
             row.id: SessionConnectivity(
                 runner_id=row.runner_id,
                 host_id=row.host_id,
                 needs_workspace=row.id in needs_workspace_ids,
+                imported=row.id in imported_ids,
                 runner_last_seen=row.runner_last_seen,
             )
             for row in meta_rows

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -66,7 +66,9 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
 
     assert result.exit_code == 0, result.output
     assert "import" in _CLICK_SUBCOMMANDS
-    assert "conv_imported" in result.output
+    # The output surfaces the session's browser URL, not the bare id, so the
+    # user can open the import straight into the web (resume picker).
+    assert f"{_BASE}/c/conv_imported" in result.output
     request = route.calls.last.request
     payload = json.loads(request.content)
     assert payload == {

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -302,7 +302,8 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
         env=env,
     )
 
-    match = re.search(r"Imported \d+ item\(s\) into (\S+)\.", result.stdout)
+    # Output is the session's browser URL (…/c/<id>); pull the id back out.
+    match = re.search(r"Imported \d+ item\(s\) into \S+/c/(\S+)", result.stdout)
     assert match is not None, result.stdout
     session_id = match.group(1)
     session = httpx.get(
@@ -374,7 +375,7 @@ def test_cli_imports_recent_claude_chats_as_batch(live_server: str, tmp_path: Pa
     )
 
     imported = re.findall(
-        r"Imported \d+ item\(s\) from (\S+) into (\S+)\.",
+        r"Imported \d+ item\(s\) from (\S+) into \S+/c/(\S+)",
         result.stdout,
     )
     assert [source_id for source_id, _ in imported] == list(source_session_ids[1:])
@@ -464,7 +465,7 @@ def test_cli_imports_recent_codex_chats_as_batch(live_server: str, tmp_path: Pat
     )
 
     imported = re.findall(
-        r"Imported \d+ item\(s\) from (\S+) into (\S+)\.",
+        r"Imported \d+ item\(s\) from (\S+) into \S+/c/(\S+)",
         result.stdout,
     )
     assert [source_id for source_id, _ in imported] == list(source_session_ids[1:])
@@ -516,7 +517,7 @@ def test_cli_force_replaces_imported_chat(
         timeout=30,
         env=env,
     )
-    first_match = re.search(r"into (\S+)\.", first.stdout)
+    first_match = re.search(r"into \S+/c/(\S+)", first.stdout)
     assert first_match is not None, first.stdout
 
     _write_force_import_fixture(tmp_path, harness, "new prompt")
@@ -528,7 +529,7 @@ def test_cli_force_replaces_imported_chat(
         timeout=30,
         env=env,
     )
-    replaced_match = re.search(r"into (\S+)\.", replaced.stdout)
+    replaced_match = re.search(r"into \S+/c/(\S+)", replaced.stdout)
     assert replaced_match is not None, replaced.stdout
     assert replaced_match.group(1) == first_match.group(1)
 
@@ -586,7 +587,7 @@ def test_cli_imports_jsonl_harness_chat_end_to_end(
     )
 
     match = re.search(
-        rf"Imported 2 item\(s\) from {re.escape(source_session_id)} into (\S+)\.",
+        rf"Imported 2 item\(s\) from {re.escape(source_session_id)} into \S+/c/(\S+)",
         result.stdout,
     )
     assert match is not None, result.stdout
@@ -653,7 +654,7 @@ def test_cli_imports_opencode_export_end_to_end(
     )
 
     match = re.search(
-        rf"Imported 4 item\(s\) from {source_session_id} into (\S+)\.",
+        rf"Imported 4 item\(s\) from {source_session_id} into \S+/c/(\S+)",
         result.stdout,
     )
     assert match is not None, result.stdout

--- a/tests/e2e_ui/sessions/test_imported_session_resume.py
+++ b/tests/e2e_ui/sessions/test_imported_session_resume.py
@@ -1,0 +1,147 @@
+"""E2E: resume a real imported / host-less session onto a chosen online host.
+
+An imported session has no host binding (``host_id`` null) and no runner, so it
+used to read as a normal reachable session (or, with no executor, a terminal
+reconnect dead-end). Now the server reports an unbound imported transcript as
+``runner_online: false`` (it has no live executor anywhere), and the open view
+routes to the in-app "Resume on a machine" picker — the same bind + launch path
+(``POST /v1/hosts/{id}/runners``) the fork-resume dialog uses.
+
+This drives the REAL liveness path: it imports a genuine transcript through the
+public ``POST /v1/imports`` API and never stubs ``/health`` or the session
+snapshot. The only stubs are the host-side wire the harness can't provide (it
+spawns no ``omnigent host`` daemon): the hosts list reports one online host, the
+filesystem pre-flight lists empty, and the runner launch records its body.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+_HOST_ID = "host_imported_e2e"
+_WS_DIR = "/home/e2e/imported-repo"
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_imported_session_resumes_onto_chosen_local_host(
+    page: Page,
+    live_server: str,
+) -> None:
+    """A real imported session offers the resume picker and launches a runner.
+
+    Failure modes this guards:
+
+    - The server stops reporting an unbound import as ``runner_online: false``
+      (the ``imported`` connectivity marker), so it reads as reachable and the
+      picker never appears.
+    - The client re-applies the cold-boot startup grace to imports, so the
+      picker is masked behind "Connecting…" instead of showing at once.
+    - The offline routing regresses to the terminal reconnect dead-end instead
+      of the picker.
+    - The bind wire shape drifts (wrong session_id / workspace on the launch).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param live_server: Base URL of the spawned server.
+    """
+    base_url = live_server
+
+    runner_bodies: list[dict[str, Any]] = []
+
+    def handle_hosts(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "hosts": [
+                        {
+                            "host_id": _HOST_ID,
+                            "name": "e2e-laptop",
+                            "owner": "e2e",
+                            "status": "online",
+                            "sandbox_provider": None,
+                            "configured_harnesses": {},
+                        }
+                    ]
+                }
+            ),
+        )
+
+    def handle_filesystem(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"object": "list", "data": [], "has_more": False}),
+        )
+
+    def handle_runners(route: Route) -> None:
+        runner_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"runner_id": "runner_imported_e2e", "status": "launching"}),
+        )
+
+    page.route("**/v1/hosts", handle_hosts)
+    page.route(f"**/v1/hosts/{_HOST_ID}/filesystem/**", handle_filesystem)
+    page.route(f"**/v1/hosts/{_HOST_ID}/runners", handle_runners)
+
+    # Import a genuine transcript through the public API. The route stamps the
+    # ``omnigent.import.source`` label and leaves the session host-less — the
+    # exact state a real ``omnigent import`` produces.
+    resp = httpx.post(
+        f"{base_url}/v1/imports",
+        json={
+            "source": "claude",
+            "external_session_id": f"e2e-import-{uuid4().hex}",
+            "workspace": _WS_DIR,
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "resp_1",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hello from an import"}],
+                    },
+                }
+            ],
+        },
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    session_id = resp.json()["session_id"]
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Real liveness resolves the import to local_stranded (server reports
+    # runner_online=false; the client skips the cold-boot grace for imports),
+    # so the disconnected banner shows. Clicking it must open the resume
+    # picker, NOT the terminal reconnect dialog.
+    indicator = page.get_by_test_id("disconnected-indicator")
+    expect(indicator).to_be_visible(timeout=30_000)
+    indicator.click()
+
+    dialog = page.get_by_test_id("resume-dir-dialog")
+    expect(dialog).to_be_visible()
+    expect(page.get_by_test_id("reconnect-session-dialog")).not_to_be_visible()
+
+    # Prefill: the session's own workspace, host defaulted to the sole online
+    # machine → the bind button is enabled without any further input.
+    bind = page.get_by_test_id("resume-dir-bind-button")
+    expect(bind).to_be_enabled(timeout=10_000)
+    bind.click()
+
+    deadline = time.monotonic() + 30.0
+    while not runner_bodies and time.monotonic() < deadline:
+        time.sleep(0.2)
+    assert len(runner_bodies) == 1, "expected exactly one runner launch"
+    launch = runner_bodies[0]
+    assert launch["session_id"] == session_id, launch
+    assert launch["workspace"] == _WS_DIR, launch

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -803,6 +803,61 @@ async def test_health_unbound_fork_of_coding_session_reads_offline(
     assert sessions[chat_fork.id]["runner_online"] is True
 
 
+@pytest.mark.asyncio
+async def test_health_unbound_imported_session_reads_offline(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    """
+    An unbound imported transcript reads offline; a plain session online.
+
+    Both are unbound (no runner, no host). The ``omnigent.import.source``
+    label is the difference: an import has no live executor anywhere, so it
+    must launch a runner on a host first and reads ``runner_online: false``
+    (routing the open view to the resume picker). A plain unbound session
+    resumes in-process and stays online. Regression guard for the
+    ``imported`` branch of ``_bulk_session_liveness``.
+    """
+    from omnigent.server.app import create_app
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.host_store import HostStore
+
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+    host_store = HostStore(db_uri)
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+
+    imported = conversation_store.create_conversation()
+    conversation_store.set_labels(imported.id, {"omnigent.import.source": "claude"})
+    plain = conversation_store.create_conversation()
+
+    app = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=conversation_store,
+        artifact_store=artifact_store,
+        host_store=host_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+    )
+    ids = f"{imported.id},{plain.id}"
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get(f"/health?session_ids={ids}")
+
+    assert resp.status_code == 200
+    sessions = resp.json()["sessions"]
+    # Imported → offline (needs a host). A True here means the unbound branch
+    # ignored the import marker (the pre-fix behavior).
+    assert sessions[imported.id]["runner_online"] is False
+    # Plain unbound session → reachable in-process.
+    assert sessions[plain.id]["runner_online"] is True
+
+
 @dataclass(frozen=True)
 class _SeedStores:
     """

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4475,6 +4475,28 @@ def test_get_session_connectivity_reports_needs_workspace_for_fork(
     assert result[plain.id].needs_workspace is False
 
 
+def test_get_session_connectivity_reports_imported(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    The import-source label surfaces as ``imported=True``.
+
+    An imported transcript carries the ``omnigent.import.source`` label and
+    has no live executor, so ``get_session_connectivity`` must report
+    ``imported=True`` — the flag that makes ``_bulk_session_liveness`` mark
+    the unbound import offline so the open view offers the resume picker
+    instead of treating it as a reachable in-process session.
+    """
+    imported = conversation_store.create_conversation()
+    conversation_store.set_labels(imported.id, {"omnigent.import.source": "claude"})
+    plain = conversation_store.create_conversation()
+
+    result = conversation_store.get_session_connectivity([imported.id, plain.id])
+
+    assert result[imported.id].imported is True
+    assert result[plain.id].imported is False
+
+
 def test_get_session_connectivity_empty_input_skips_query(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/hooks/useSessionLiveness.test.ts
+++ b/web/src/hooks/useSessionLiveness.test.ts
@@ -234,6 +234,16 @@ describe("useSessionLiveness — derivation truth table", () => {
       });
     });
 
+    it("imported session skips the grace → local_stranded even when fresh", () => {
+      // An import has no runner booting, so the cold-boot grace must not apply:
+      // a fresh import reads local_stranded at once (offering the resume
+      // picker) instead of "Connecting…" for the whole grace window. Same
+      // inputs as the just-created case above, which is `starting`.
+      expect(
+        derive(false, null, conv({ host_id: null, created_at: freshCreatedAt(), imported: true })),
+      ).toEqual({ kind: "local_stranded" });
+    });
+
     it("starting wins over host_offline for a fresh host-bound session", () => {
       // The grace precedes the host_offline check: a new host-bound session
       // whose host hasn't registered yet must not flash "host offline" either.
@@ -339,6 +349,7 @@ describe("useSessionLiveness — derivation truth table", () => {
         created_at: 123,
         host_resumable: false,
         kind: undefined,
+        imported: false,
       });
       // hostResumable flows through so an off-sidebar resumable host can
       // classify host_asleep rather than dead-ending on host_offline.

--- a/web/src/hooks/useSessionLiveness.ts
+++ b/web/src/hooks/useSessionLiveness.ts
@@ -47,7 +47,18 @@ export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "c
    * reconnect modal). Absent ⇒ treated as ``"default"``.
    */
   kind?: "default" | "sub_agent";
+  /**
+   * Whether this session was imported from a local harness transcript (the
+   * `omnigent.import.source` label). An import has no runner booting, so it
+   * must skip the cold-boot startup grace — otherwise it shows "Connecting…"
+   * for {@link STARTING_GRACE_S} before settling to `local_stranded`, when it
+   * should offer the resume picker immediately. Absent ⇒ treated `false`.
+   */
+  imported?: boolean;
 };
+
+/** Label marking a session imported from a local harness transcript. */
+export const IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source";
 
 /**
  * Build a {@link LivenessRow} from the single-session snapshot
@@ -61,7 +72,10 @@ export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "c
  */
 export function livenessRowFromSession(
   session:
-    | Pick<Session, "hostId" | "permissionLevel" | "createdAt" | "hostResumable" | "kind">
+    | Pick<
+        Session,
+        "hostId" | "permissionLevel" | "createdAt" | "hostResumable" | "kind" | "labels"
+      >
     | null
     | undefined,
 ): LivenessRow | null {
@@ -72,6 +86,7 @@ export function livenessRowFromSession(
     created_at: session.createdAt,
     host_resumable: session.hostResumable ?? false,
     kind: session.kind,
+    imported: Boolean(session.labels?.[IMPORT_SOURCE_LABEL_KEY]),
   };
 }
 
@@ -241,6 +256,7 @@ export function useSessionLiveness(
   const createdAt = conv?.created_at;
   if (
     !runnerEverOnline &&
+    !conv?.imported &&
     typeof createdAt === "number" &&
     createdAt > 0 &&
     Date.now() / 1000 - createdAt < STARTING_GRACE_S

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -39,6 +39,7 @@ import {
   stripGatedSubagentRoutingChips,
   stripPendingElicitations,
   subAgentComposerLabel,
+  unboundSessionResumableInApp,
   WORKING_MESSAGES,
   workingIndicatorLabel,
 } from "./ChatPage";
@@ -1637,6 +1638,40 @@ describe("isUnboundCodingFork", () => {
     // needs_workspace is workspace IS NULL, and "" never satisfies the
     // workspace-required-for-host constraint — treat it as unbound.
     expect(isUnboundCodingFork({ forkSourceId: "conv_src", workspace: "" })).toBe(true);
+  });
+});
+
+describe("unboundSessionResumableInApp", () => {
+  const owner = { unbound: true, isOwner: true, importSource: null };
+
+  it("is false unless the session is unbound", () => {
+    expect(unboundSessionResumableInApp({ ...owner, unbound: false })).toBe(false);
+  });
+
+  it("is false for a non-owner (launch_runner would 404)", () => {
+    // Regression: a shared viewer must not get a picker that always fails.
+    expect(unboundSessionResumableInApp({ ...owner, isOwner: false })).toBe(false);
+    expect(unboundSessionResumableInApp({ ...owner, isOwner: false, importSource: "claude" })).toBe(
+      false,
+    );
+  });
+
+  it("allows a non-import unbound session (e.g. an unbound fork)", () => {
+    expect(unboundSessionResumableInApp(owner)).toBe(true);
+  });
+
+  it("allows host-portable import sources", () => {
+    for (const src of ["claude", "codex", "pi", "opencode"]) {
+      expect(unboundSessionResumableInApp({ ...owner, importSource: src })).toBe(true);
+    }
+  });
+
+  it("blocks imports whose context does not carry to a chosen host", () => {
+    // kimi has no resume path; kiro/qwen resume only from a local file on the
+    // original machine — a chosen host would launch with no context.
+    for (const src of ["kimi", "kiro", "qwen"]) {
+      expect(unboundSessionResumableInApp({ ...owner, importSource: src })).toBe(false);
+    }
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -146,6 +146,7 @@ import { useRefreshSessionStateOnRunnerOnline } from "@/hooks/useSessionOnlineRe
 import {
   type LivenessRow,
   type SessionLiveness,
+  IMPORT_SOURCE_LABEL_KEY,
   livenessRowFromSession,
   useSessionLiveness,
 } from "@/hooks/useSessionLiveness";
@@ -1069,6 +1070,28 @@ export function ChatPage() {
     forkSourceId,
     workspace: activeSession?.workspace ?? activeConv?.workspace ?? null,
   });
+  // An unbound session (no host, no runner — e.g. an imported one) routes the
+  // offline guard to the directory picker (bind + launch a runner on a chosen
+  // machine) instead of the terminal reconnect dead-end — but only when that
+  // resume would actually work. The picker calls launch_runner, which requires
+  // the caller to OWN the session (a shared non-owner 404s), and — for imports —
+  // only harnesses that reconstruct context from the omnigent transcript carry
+  // onto a chosen host (kimi can't resume at all; kiro/qwen resume from a local
+  // file that lives on the original machine). Everything else falls through to
+  // the reconnect path rather than a picker that would fail or start blank.
+  // See unboundSessionResumableInApp. The picker itself handles the no-online-
+  // host case, so we don't gate on host availability here.
+  const importSource =
+    activeSession?.labels?.[IMPORT_SOURCE_LABEL_KEY] ??
+    activeConv?.labels?.[IMPORT_SOURCE_LABEL_KEY] ??
+    null;
+  const canResumeOnLocalHost = unboundSessionResumableInApp({
+    unbound:
+      (activeSession?.hostId ?? activeConv?.host_id ?? null) === null &&
+      (activeSession?.runnerId ?? activeConv?.runner_id ?? null) === null,
+    isOwner: isOwnerLevel(activeSession?.permissionLevel ?? activeConv?.permission_level ?? null),
+    importSource,
+  });
 
   // Author labels show only once a session is shared. A non-owner viewer
   // already implies a share; the owner needs the grant list (manage-only,
@@ -1116,6 +1139,10 @@ export function ChatPage() {
         permission_level: activeSession?.permissionLevel ?? activeConv.permission_level,
         host_resumable: activeSession?.hostResumable ?? false,
         kind: activeSession?.kind,
+        // Skip the cold-boot grace for imports (nothing is booting) so the
+        // resume picker shows at once. Snapshot labels win; sidebar row is the
+        // fallback for an off-page session.
+        imported: Boolean((activeSession?.labels ?? activeConv.labels)?.[IMPORT_SOURCE_LABEL_KEY]),
       }
     : livenessRowFromSession(activeSession);
   // Host-switch launch marker; see the store field. Keeps this surface's
@@ -1175,7 +1202,7 @@ export function ChatPage() {
     // the bind. Pin the prompt to THIS session so it replays here, never
     // into a session the user may switch to first; carry any attachments
     // so the replay sends the same payload.
-    if (urlConvId && runnerOnline === false && isUnboundFork) {
+    if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
       setPendingResumePrompt({ sessionId: urlConvId, text, files: files ?? [] });
       setResumeDirDialogOpen(true);
       return;
@@ -1211,7 +1238,7 @@ export function ChatPage() {
     if (!agentId) return;
     // Slash commands aren't replayed (an edge), but still route an unbound
     // coding clone to the directory picker so it isn't a dead end.
-    if (urlConvId && runnerOnline === false && isUnboundFork) {
+    if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
       setResumeDirDialogOpen(true);
       return;
     }
@@ -1285,9 +1312,10 @@ export function ChatPage() {
       onStop={onStop}
       onShowReconnectHelp={() => {
         // Route the banner to the SAME dialog typing a message would: an
-        // unbound coding clone opens the directory picker (bind + launch),
-        // everything else gets the reconnect dialog.
-        if (isUnboundFork) setResumeDirDialogOpen(true);
+        // unbound coding clone or a host-less session the caller can resume
+        // in-app opens the directory picker (bind + launch), everything else
+        // gets the reconnect dialog.
+        if (isUnboundFork || canResumeOnLocalHost) setResumeDirDialogOpen(true);
         else setReconnectDialogOpen(true);
       }}
       agents={visibleAgents}
@@ -1348,12 +1376,19 @@ export function ChatPage() {
         sourceHostId={activeSession?.hostId}
         sourceGitBranch={activeSession?.gitBranch}
       />
-      {isUnboundFork && forkSourceId && (
+      {((isUnboundFork && forkSourceId) || canResumeOnLocalHost) && (
         <ResumeWithDirectoryDialog
           open={resumeDirDialogOpen}
           onOpenChange={setResumeDirDialogOpen}
           sessionId={urlConvId}
-          sourceSessionId={forkSourceId}
+          // Fork clone prefills from its source; a host-less session has none
+          // and prefills from its own recorded host/workspace/branch instead.
+          sourceSessionId={isUnboundFork ? forkSourceId : null}
+          prefill={{
+            hostId: activeSession?.hostId ?? null,
+            workspace: activeSession?.workspace ?? null,
+            gitBranch: activeSession?.gitBranch ?? null,
+          }}
           serverUrl={getCliServerUrl()}
           wrapper={activeConv?.labels?.["omnigent.wrapper"]}
         />
@@ -5958,6 +5993,35 @@ export function isUnboundCodingFork(params: {
   workspace: string | null | undefined;
 }): boolean {
   return params.forkSourceId !== null && !params.workspace;
+}
+
+// Import sources whose resume reconstructs conversation context from the
+// omnigent-stored transcript, so it carries onto any chosen host. Kimi has no
+// resume path (blank context regardless of host); kiro/qwen resume only from a
+// local recording file that exists on the original machine, so a different host
+// starts blank. The in-app resume picker is restricted to this portable set.
+const HOST_PORTABLE_IMPORT_SOURCES = new Set(["claude", "codex", "pi", "opencode"]);
+
+/**
+ * Whether an unbound session may be resumed in-app via the "Resume on a machine"
+ * picker. The picker calls `launch_runner`, which requires the caller to OWN the
+ * session, and — for imported sessions — only reconstructs context for
+ * host-portable harnesses. Non-owners (who would 404) and kimi/kiro/qwen imports
+ * (which would launch with no context) are excluded so they route to the
+ * terminal reconnect path instead of a picker that fails or starts blank.
+ *
+ * @param unbound - Session has no host and no runner.
+ * @param isOwner - Caller holds owner level on the session.
+ * @param importSource - `omnigent.import.source` label, or null for non-imports
+ *   (e.g. an unbound fork, which is host-portable and owned by its creator).
+ */
+export function unboundSessionResumableInApp(params: {
+  unbound: boolean;
+  isOwner: boolean;
+  importSource: string | null | undefined;
+}): boolean {
+  if (!params.unbound || !params.isOwner) return false;
+  return params.importSource == null || HOST_PORTABLE_IMPORT_SOURCES.has(params.importSource);
 }
 
 const EFFORT_LEVELS = ["low", "medium", "high"] as const;

--- a/web/src/shell/ResumeWithDirectoryDialog.test.tsx
+++ b/web/src/shell/ResumeWithDirectoryDialog.test.tsx
@@ -249,3 +249,100 @@ describe("ResumeWithDirectoryDialog", () => {
     expect(screen.queryByTestId("resume-dir-bind-button")).toBeNull();
   });
 });
+
+function renderHostless(prefill?: {
+  hostId?: string | null;
+  workspace?: string | null;
+  gitBranch?: string | null;
+}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ResumeWithDirectoryDialog
+        open
+        onOpenChange={() => {}}
+        sessionId="conv_imported"
+        // Host-less: no fork source.
+        sourceSessionId={null}
+        prefill={prefill}
+        serverUrl="http://localhost:5173"
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ResumeWithDirectoryDialog (host-less session)", () => {
+  it("prefills from the session's own fields and binds without fetching a source", async () => {
+    useHostsMock.mockReturnValue({
+      data: [
+        { host_id: "host_a", name: "laptop", owner: "me", status: "online" },
+        { host_id: "host_b", name: "desktop", owner: "me", status: "online" },
+      ],
+    } as unknown as ReturnType<typeof useHosts>);
+
+    // Prefer the session's recorded host when it's online; prefill the dir.
+    renderHostless({ hostId: "host_b", workspace: "/Users/alice/imported" });
+
+    const bindBtn = await screen.findByTestId("resume-dir-bind-button");
+    await waitFor(() => expect((bindBtn as HTMLButtonElement).disabled).toBe(false));
+    await waitFor(() =>
+      expect((screen.getByTestId("mock-workspace-input") as HTMLInputElement).value).toBe(
+        "/Users/alice/imported",
+      ),
+    );
+    fireEvent.click(bindBtn);
+
+    await waitFor(() =>
+      expect(launchRunnerMock).toHaveBeenCalledWith(
+        "host_b",
+        "conv_imported",
+        "/Users/alice/imported",
+        undefined,
+      ),
+    );
+    // No fork source → the source session is never fetched.
+    expect(getSessionMock).not.toHaveBeenCalled();
+    // No source means no mismatch/CLI-fallback machinery.
+    expect(screen.queryByTestId("resume-dir-mismatch-warning")).toBeNull();
+    expect(screen.queryByTestId("resume-dir-cli-fallback")).toBeNull();
+  });
+
+  it("defaults the host to the caller's current online machine when the recorded host is gone", async () => {
+    // Recorded host offline (or absent from the list) → fall back to the
+    // most-recent online machine (first in the list).
+    useHostsMock.mockReturnValue({
+      data: [
+        { host_id: "host_current", name: "laptop", owner: "me", status: "online" },
+        { host_id: "host_old", name: "old", owner: "me", status: "offline" },
+      ],
+    } as unknown as ReturnType<typeof useHosts>);
+
+    renderHostless({ hostId: "host_old", workspace: "/repo" });
+
+    const bindBtn = await screen.findByTestId("resume-dir-bind-button");
+    await waitFor(() => expect((bindBtn as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(bindBtn);
+
+    await waitFor(() =>
+      expect(launchRunnerMock).toHaveBeenCalledWith(
+        "host_current",
+        "conv_imported",
+        "/repo",
+        undefined,
+      ),
+    );
+  });
+
+  it("shows the no-online-hosts message (no CLI fallback) when none are online", async () => {
+    useHostsMock.mockReturnValue({
+      data: [{ host_id: "host_old", name: "old", owner: "me", status: "offline" }],
+    } as unknown as ReturnType<typeof useHosts>);
+
+    renderHostless({ workspace: "/repo" });
+
+    expect(await screen.findByTestId("resume-dir-no-hosts")).toBeTruthy();
+    expect(screen.queryByTestId("resume-dir-cli-fallback")).toBeNull();
+    expect(screen.queryByTestId("resume-dir-host-select")).toBeNull();
+    expect(launchRunnerMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/ResumeWithDirectoryDialog.tsx
+++ b/web/src/shell/ResumeWithDirectoryDialog.tsx
@@ -34,31 +34,34 @@ import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { getSessionSlim, launchRunner } from "@/lib/sessionsApi";
 
 /**
- * Dialog surfaced when the user tries to chat with an unbound *coding*
- * clone (a fork of a session that had a working directory — it carries
- * the ``omnigent.fork.source_id`` label). Unlike ``ResumeChatDialog``
- * (which only prints a CLI command), this binds the clone to a host +
- * directory in-app via ``POST /v1/hosts/{id}/runners`` (``launchRunner``)
- * and lets the runner start, after which ChatPage replays the queued
- * message.
+ * Dialog that binds an *unbound* session to a host + directory in-app via
+ * ``POST /v1/hosts/{id}/runners`` (``launchRunner``) and lets the runner
+ * start, after which ChatPage replays any queued message. Unlike
+ * ``ResumeChatDialog`` (which only prints a CLI command), this resumes the
+ * session from the browser. Serves two unbound cases:
  *
- * The picker prefills from the *source* session (same-user CUJ 1):
- * the source's host is the default, its workspace the default directory,
- * and — when the source used a git worktree — a branch is suggested so
- * the clone diverges onto its own worktree rather than fighting the
- * original over the same files.
+ * - **Fork clone** (``sourceSessionId`` set): a fork of a session that had a
+ *   working directory (``omnigent.fork.source_id`` label). Prefills from the
+ *   *source* session — its host is the default, its workspace the default
+ *   directory, and when it used a git worktree a branch is suggested so the
+ *   clone diverges onto its own worktree. When the source's host is offline
+ *   there's nothing to launch on, so it falls back to the CLI reconnect
+ *   command — the escape hatch ``ResumeChatDialog`` shows.
  *
- * When the source's host is offline there is no runner to launch, so the
- * dialog falls back to the CLI reconnect command (``omnigent connect``)
- * — the same escape hatch ``ResumeChatDialog`` shows.
+ * - **Host-less session** (no ``sourceSessionId``): an imported session with
+ *   no host/runner of its own. Prefills from ``prefill`` (the session's own
+ *   recorded workspace/host) and defaults the host to the caller's current
+ *   online machine, so the common case is one click.
  *
  * @param open - Whether the dialog is visible.
  * @param onOpenChange - Radix-controlled visibility setter.
- * @param sessionId - The unbound clone to bind, e.g. ``"conv_clone"``.
- * @param sourceSessionId - The source the clone was forked from
- *   (``omnigent.fork.source_id``); read for host/dir/branch prefill.
+ * @param sessionId - The unbound session to bind, e.g. ``"conv_abc"``.
+ * @param sourceSessionId - Fork source (``omnigent.fork.source_id``) read for
+ *   host/dir/branch prefill; ``null``/absent for a host-less session.
+ * @param prefill - Defaults for the host-less case (the session's own
+ *   host/workspace/branch). Ignored when ``sourceSessionId`` is set.
  * @param serverUrl - Origin for the CLI fallback command.
- * @param wrapper - The clone's ``omnigent.wrapper`` label (CLI fallback).
+ * @param wrapper - The session's ``omnigent.wrapper`` label (CLI fallback).
  * @param onBound - Called after a successful bind so the caller can
  *   replay the message the user was trying to send.
  */
@@ -67,6 +70,7 @@ export function ResumeWithDirectoryDialog({
   onOpenChange,
   sessionId,
   sourceSessionId,
+  prefill,
   serverUrl,
   wrapper,
   onBound,
@@ -74,19 +78,24 @@ export function ResumeWithDirectoryDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   sessionId: string;
-  sourceSessionId: string;
+  sourceSessionId?: string | null;
+  prefill?: { hostId?: string | null; workspace?: string | null; gitBranch?: string | null };
   serverUrl: string;
   wrapper?: string | null;
   onBound?: () => void;
 }) {
   const queryClient = useQueryClient();
 
+  // A fork clone prefills from its source session; a host-less session has no
+  // source and prefills from its own recorded fields instead.
+  const hasSource = sourceSessionId != null && sourceSessionId !== "";
+
   // Source session prefill (host/workspace/git_branch). Only fetch while
-  // the dialog is open.
+  // the dialog is open and we actually have a source.
   const { data: source, isLoading: sourceLoading } = useQuery({
     queryKey: ["session", sourceSessionId],
-    queryFn: () => getSessionSlim(sourceSessionId),
-    enabled: open,
+    queryFn: () => getSessionSlim(sourceSessionId as string),
+    enabled: open && hasSource,
   });
   const { data: hosts } = useHosts({ enabled: open });
 
@@ -97,6 +106,19 @@ export function ResumeWithDirectoryDialog({
   );
   const sourceHostOnline = sourceHost?.status === "online";
   const onlineHosts = useMemo(() => (hosts ?? []).filter((h) => h.status === "online"), [hosts]);
+
+  // Unified prefill: a fork reads its source session; a host-less session
+  // reads the ``prefill`` its own snapshot supplied.
+  const prefillWorkspace = hasSource ? source?.workspace : prefill?.workspace;
+  const prefillBranch = hasSource ? source?.gitBranch : prefill?.gitBranch;
+  // Default host: the source's host (fork, only if online — otherwise the CLI
+  // fallback fires) or, for a host-less session, its own recorded host when
+  // still online, else the caller's current (most-recent) online machine.
+  const defaultHostId = useMemo(() => {
+    if (hasSource) return sourceHostOnline ? sourceHostId : null;
+    const preferred = onlineHosts.find((h) => h.host_id === prefill?.hostId);
+    return (preferred ?? onlineHosts[0])?.host_id ?? null;
+  }, [hasSource, sourceHostOnline, sourceHostId, onlineHosts, prefill?.hostId]);
 
   const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
   const [workspace, setWorkspace] = useState("");
@@ -109,27 +131,27 @@ export function ResumeWithDirectoryDialog({
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
 
-  // Prefill host = source host (when it is online) once both load.
+  // Prefill the host selection once the hosts (and source, if any) load.
   useEffect(() => {
-    if (open && selectedHostId === null && sourceHostId && sourceHostOnline) {
-      setSelectedHostId(sourceHostId);
+    if (open && selectedHostId === null && defaultHostId) {
+      setSelectedHostId(defaultHostId);
     }
-  }, [open, selectedHostId, sourceHostId, sourceHostOnline]);
+  }, [open, selectedHostId, defaultHostId]);
 
-  // Prefill the directory with the source's workspace.
+  // Prefill the directory with the session's recorded workspace.
   useEffect(() => {
-    if (open && workspace === "" && source?.workspace) {
-      setWorkspace(source.workspace);
+    if (open && workspace === "" && prefillWorkspace) {
+      setWorkspace(prefillWorkspace);
     }
-  }, [open, workspace, source?.workspace]);
+  }, [open, workspace, prefillWorkspace]);
 
   // When the source used a worktree, default the base ref to that branch
   // so the clone branches off where the original left work.
   useEffect(() => {
-    if (open && baseBranch === "" && source?.gitBranch) {
-      setBaseBranch(source.gitBranch);
+    if (open && baseBranch === "" && prefillBranch) {
+      setBaseBranch(prefillBranch);
     }
-  }, [open, baseBranch, source?.gitBranch]);
+  }, [open, baseBranch, prefillBranch]);
 
   // Reset transient state when the dialog closes.
   function handleOpenChange(next: boolean): void {
@@ -227,21 +249,32 @@ export function ResumeWithDirectoryDialog({
   // flashing the CLI fallback for an online source host would be wrong.
   const hostsLoaded = hosts !== undefined;
   const showCliFallback = !sourceLoading && hostsLoaded && source != null && !sourceHostOnline;
+  const loading = (hasSource && sourceLoading) || !hostsLoaded;
+  // Host-less sessions have no source host to reconnect, so there's no CLI
+  // fallback: when the caller owns no online machine, say so plainly.
+  const noOnlineHosts = !hasSource && hostsLoaded && onlineHosts.length === 0;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent data-testid="resume-dir-dialog" className="flex flex-col gap-4 sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Resume this session</DialogTitle>
+          <DialogTitle>{hasSource ? "Resume this session" : "Resume on a machine"}</DialogTitle>
           <DialogDescription>
-            This clone hasn't picked a working directory yet. Choose a host and directory to
-            continue the conversation against your files.
+            {hasSource
+              ? "This clone hasn't picked a working directory yet. Choose a host and directory to continue the conversation against your files."
+              : "This session isn't running on any machine. Pick one of your machines and a directory to continue the conversation against your files."}
           </DialogDescription>
         </DialogHeader>
 
-        {sourceLoading || !hostsLoaded ? (
+        {loading ? (
           <p className="text-sm text-muted-foreground" data-testid="resume-dir-loading">
-            Loading the original session's directory…
+            {hasSource ? "Loading the original session's directory…" : "Loading your machines…"}
+          </p>
+        ) : noOnlineHosts ? (
+          <p className="text-sm text-muted-foreground" data-testid="resume-dir-no-hosts">
+            None of your machines are online. Start one with{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono">omnigent host</code> from your
+            terminal, then reopen this dialog.
           </p>
         ) : showCliFallback ? (
           <div className="flex flex-col gap-2" data-testid="resume-dir-cli-fallback">


### PR DESCRIPTION
## Related issue

None — new capability.

## Summary

Imported / unbound sessions (no host, no runner) couldn't run from the web — they read as reachable (first message dropped) or dead-ended on the terminal reconnect path. Now the server reports an unbound import as `runner_online: false` (a new `imported` connectivity marker, keyed on the `omnigent.import.source` label, sibling of the fork `needs_workspace` marker), so the open view routes to the **existing** host picker instead. The picker binds the session to an online host + workspace (defaulting to the current host) and launches a runner via the existing `POST /v1/hosts/{id}/runners` path — no new host-selection UI, no new launch route. Imports also skip the cold-boot grace so the picker shows at once, and `omnigent import` prints the session URL.

The picker is offered only when resume will actually work: owner-only (launch_runner requires owner), and for imports only host-portable harnesses (claude/codex/pi/opencode). Kimi (no resume) and kiro/qwen (resume from a local file on the original machine) route to the terminal reconnect path instead of a picker that would fail or start blank.

## Test Plan

- Server: `pytest tests/stores/test_conversation_store.py -k get_session_connectivity`, `tests/server/test_app.py -k "imported or unbound_fork"`, `tests/cli/test_import.py`
- Web: `vitest run src/hooks/useSessionLiveness.test.ts src/shell/ResumeWithDirectoryDialog.test.tsx src/pages/`
- E2E: `pytest tests/e2e_ui/sessions/test_imported_session_resume.py` — real import via `POST /v1/imports`, real liveness (no stubs).
- Manual: local server + host + `omnigent import claude` → picker prefilled → Start session launched the runner.

## Demo

UI change. Verified live on a real import; picker prefills the recorded workspace + online host. Screenshot to attach.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: imported a real transcript, confirmed the disconnected banner opens the resume picker (not the reconnect dead-end), prefilled with the recorded workspace + online host, and that Start session binds + launches the runner.

## Changelog

Imported sessions can be resumed from the web via the host picker (defaulted to your current online machine)
