### PR TITLE
fix(web): keep the Working shimmer lit while background tasks run

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3743,13 +3743,18 @@ def _publish_status(
     # an explicit ``0`` clears it so a finished background shell drops the
     # indicator on the next turn end. ``None`` means "no information" (the
     # trailing PTY-activity ``idle`` carries none) and must NOT wipe the
-    # count the Stop hook just published. A new turn or a failure clears it.
+    # count the Stop hook just published. A new ``running`` turn does NOT clear
+    # it either — background shells outlive turn boundaries, so the tally
+    # persists across the turn (the composer pill stays lit alongside the
+    # working shimmer) until the next authoritative count. Only a failure
+    # clears it: a dead session may never post another count to drop a stale
+    # tally.
     if background_task_count is not None:
         if background_task_count > 0:
             _session_background_task_count_cache[session_id] = background_task_count
         else:
             _session_background_task_count_cache.pop(session_id, None)
-    elif status in ("running", "failed"):
+    elif status == "failed":
         _session_background_task_count_cache.pop(session_id, None)
     event = SessionStatusEvent(
         type="session.status",

--- a/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
+++ b/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
@@ -1,14 +1,17 @@
 """Working indicator behavior when background tasks run alongside a turn.
 
 The "Working…" shimmer and the ``background-task-pill`` are independent
-surfaces:
+surfaces, and the background-shell tally is sticky across turn boundaries
+(shells outlive the turn that launched them):
 
-* While the turn is still active (``running``/``waiting`` — the parent parked
-  on its async-work drain of sub-agents / background shells), BOTH show: the
-  shimmer reports the live turn and the pill counts the tasks.
-* Once the turn has genuinely ended (``idle``) but a background shell outlives
-  it, only the pill shows — a "Working…" shimmer there would misread as the
-  agent still thinking.
+* Turn actively ``running`` with a lingering shell → BOTH show: the shimmer
+  reports the live turn and the pill counts the shell.
+* Turn genuinely ended (``idle``) with a shell still running → only the pill
+  shows; a "Working…" shimmer there would misread as the agent still thinking.
+
+(A claude-native turn-end ``waiting`` is normalized to ``idle`` server-side —
+see ``_background_task_delivery_status`` — so the client's "working + shell"
+state is the ``running`` case above, not ``waiting``.)
 
 All tests drive the real status edges through the Sessions events route
 (the same path the claude-native forwarder posts to), so they are
@@ -97,30 +100,32 @@ def test_background_task_indicator_label_lifecycle(
     expect(working).to_have_count(0)
 
     # 2. A new turn starts (the `running` edge a composer send produces): the
-    #    fresh turn supersedes the tally, so the pill gives way to the rotating
-    #    working shimmer (e.g. "Working…", "Cooking…"). Accept any label in the
-    #    pool — which one shows depends on the wall-clock bucket the turn lands
-    #    on.
+    #    background shell outlives the turn boundary, so the pill STAYS lit and
+    #    the rotating "Working…" shimmer lights up beside it — both surfaces at
+    #    once. Accept any label in the pool — which one shows depends on the
+    #    wall-clock bucket the turn lands on.
     _publish_status(base_url, session_id, "running")
     expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
-    expect(pill).to_have_count(0)
+    expect(pill).to_contain_text("2 background tasks")
 
     # 3. The turn ends with the background shell finished: an authoritative
-    #    Stop-hook `0` clears the tally, so the indicator goes out.
+    #    Stop-hook `0` clears the tally, so both surfaces go out.
     _publish_status(base_url, session_id, "idle", background_task_count=0)
     expect(working).to_have_count(0, timeout=15_000)
+    expect(pill).to_have_count(0)
 
 
-def test_working_shimmer_and_pill_coexist_while_waiting(
+def test_working_shimmer_and_pill_coexist_while_running(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """A ``waiting`` turn shows the working shimmer AND the pill together.
+    """A ``running`` turn with a lingering shell shows the shimmer AND the pill.
 
-    ``waiting`` is the parent turn parked on its async-work drain — sub-agents
-    or background shells it spawned are still running. The turn is live, so the
-    "Working…" shimmer stays lit; the shells are running, so the pill tallies
-    them. The two are independent surfaces and must show side by side.
+    Background shells outlive turn boundaries, so when a new turn goes
+    ``running`` the tally persists: the "Working…" shimmer lights for the live
+    turn and the pill keeps counting the shell. The two are independent
+    surfaces and must show side by side — the regression this guards is the
+    pill blinking off the moment the working shimmer appears.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` from the local server
@@ -132,10 +137,17 @@ def test_working_shimmer_and_pill_coexist_while_waiting(
     pill = page.locator(_PILL)
     page.goto(f"{base_url}/c/{session_id}")
 
-    _publish_status(base_url, session_id, "waiting", background_task_count=2)
-    # Both surfaces light: the shimmer for the live turn, the pill for the tally.
+    # A prior turn ended with a background shell: idle + a positive count lights
+    # the pill (turn over, no shimmer yet).
+    _publish_status(base_url, session_id, "idle", background_task_count=2)
     expect(pill).to_contain_text("2 background tasks", timeout=15_000)
+    expect(working).to_have_count(0)
+
+    # A new turn starts: the shell outlives the boundary, so both light up —
+    # the shimmer for the live turn, the pill for the still-running shell.
+    _publish_status(base_url, session_id, "running")
     expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
+    expect(pill).to_contain_text("2 background tasks")
 
 
 def test_sidebar_spinner_ignores_background_tasks(

--- a/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
+++ b/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
@@ -1,12 +1,16 @@
-"""Working indicator behavior when background shells outlive a turn.
+"""Working indicator behavior when background tasks run alongside a turn.
 
-A claude-native turn can settle to ``idle`` while background shells keep
-running. The forwarder reports that as ``external_session_status: idle``
-carrying a positive ``background_task_count``. The turn has ended, so the
-composer's ``background-task-pill`` names the shells instead of the
-"Working…" shimmer (which would misread as the agent still thinking).
+The "Working…" shimmer and the ``background-task-pill`` are independent
+surfaces:
 
-Both tests drive the real status edges through the Sessions events route
+* While the turn is still active (``running``/``waiting`` — the parent parked
+  on its async-work drain of sub-agents / background shells), BOTH show: the
+  shimmer reports the live turn and the pill counts the tasks.
+* Once the turn has genuinely ended (``idle``) but a background shell outlives
+  it, only the pill shows — a "Working…" shimmer there would misread as the
+  agent still thinking.
+
+All tests drive the real status edges through the Sessions events route
 (the same path the claude-native forwarder posts to), so they are
 deterministic — no live LLM turn, whose timing and the openai-agents
 executor's handling of a blocked mock would make the assertions flaky.
@@ -105,6 +109,33 @@ def test_background_task_indicator_label_lifecycle(
     #    Stop-hook `0` clears the tally, so the indicator goes out.
     _publish_status(base_url, session_id, "idle", background_task_count=0)
     expect(working).to_have_count(0, timeout=15_000)
+
+
+def test_working_shimmer_and_pill_coexist_while_waiting(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A ``waiting`` turn shows the working shimmer AND the pill together.
+
+    ``waiting`` is the parent turn parked on its async-work drain — sub-agents
+    or background shells it spawned are still running. The turn is live, so the
+    "Working…" shimmer stays lit; the shells are running, so the pill tallies
+    them. The two are independent surfaces and must show side by side.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    working = page.locator(_WORKING)
+    pill = page.locator(_PILL)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    _publish_status(base_url, session_id, "waiting", background_task_count=2)
+    # Both surfaces light: the shimmer for the live turn, the pill for the tally.
+    expect(pill).to_contain_text("2 background tasks", timeout=15_000)
+    expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
 
 
 def test_sidebar_spinner_ignores_background_tasks(

--- a/tests/server/routes/test_sessions_background_task_status.py
+++ b/tests/server/routes/test_sessions_background_task_status.py
@@ -6,8 +6,10 @@ in-chat "N background tasks still running" indicator survives the trailing
 PTY-activity ``idle`` (which carries no count) and a reload.
 
 The tally must clear on an authoritative ``Stop``-hook ``0`` (the shell
-finished), on a new turn (``running``), and on a failure — but NOT on the
-countless trailing ``idle`` edges that carry no count. It must never make
+finished) and on a failure — but NOT on the countless trailing ``idle`` edges
+that carry no count, and NOT on a new ``running`` turn (background shells
+outlive turn boundaries, so the composer pill stays lit alongside the working
+shimmer until the next authoritative count). It must never make
 ``_session_status_with_child_rollup`` report ``running``: the turn is over
 and the session takes a new message immediately.
 """
@@ -85,10 +87,14 @@ def test_authoritative_zero_clears_tally_and_list_drops_to_idle() -> None:
     assert _session_status_with_child_rollup(_SID, []) == "idle"
 
 
-def test_new_turn_running_clears_tally() -> None:
+def test_new_turn_running_keeps_tally() -> None:
+    # A new ``running`` turn does NOT clear the tally: background shells outlive
+    # turn boundaries, so the composer pill stays lit alongside the working
+    # shimmer until the next authoritative count (the trailing ``running`` edge
+    # carries none).
     _publish_status(_SID, "idle", background_task_count=2)
     _publish_status(_SID, "running")
-    assert _SID not in _sessions_mod._session_background_task_count_cache
+    assert _sessions_mod._session_background_task_count_cache.get(_SID) == 2
 
 
 def test_failure_clears_tally_and_wins_over_count() -> None:

--- a/web/src/hooks/useWorkingLabelTick.ts
+++ b/web/src/hooks/useWorkingLabelTick.ts
@@ -46,7 +46,7 @@ function getSnapshot(): number {
 
 /**
  * Monotonic wall-clock bucket that advances once every `ROTATE_MS`. Feed it
- * into `workingIndicatorLabel(bgCount, tick)` to rotate the label. SSR-safe
+ * into `workingIndicatorLabel(tick)` to rotate the label. SSR-safe
  * (returns 0 on the server, matching `useIsMobileViewport`).
  */
 export function useWorkingLabelTick(): number {

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -848,7 +848,7 @@ describe("computeShowsWorking", () => {
 
   it("parent idle stays idle in the main chat", () => {
     // Busy children are surfaced by the sidebar/Agents rail, not by the
-    // main chat's shimmer or pinned "Working…" pill.
+    // main chat's "Working…" shimmer.
     expect(computeShowsWorking("idle", opts())).toBe(false);
   });
 

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -1020,75 +1020,69 @@ describe("shouldShowWorkingIndicator", () => {
 
 describe("workingIndicatorLabel — parked on a dialog", () => {
   it("names what the agent is waiting on", () => {
-    expect(workingIndicatorLabel(0, 0, "permission prompt")).toBe("Blocked on: permission prompt");
+    expect(workingIndicatorLabel(0, "permission prompt")).toBe("Blocked on: permission prompt");
   });
 
-  it("outranks the background tally and the rotation", () => {
+  it("outranks the rotation", () => {
     // Being blocked on the user is the one state that needs an action, and the
     // dialog may exist only in the terminal tab — so it must not be buried
-    // under a rotating "Cooking…" or a background-shell count.
-    expect(workingIndicatorLabel(3, 2, "dialog open")).toBe("Blocked on: dialog open");
+    // under a rotating "Cooking…".
+    expect(workingIndicatorLabel(2, "dialog open")).toBe("Blocked on: dialog open");
   });
 
   it("falls back to the normal label when not parked", () => {
-    expect(workingIndicatorLabel(0, 0, null)).toBe("Working…");
-    expect(workingIndicatorLabel(1, 0, null)).toBe("1 background task still running");
+    expect(workingIndicatorLabel(0, null)).toBe("Working…");
   });
 });
 
 describe("workingIndicatorLabel", () => {
-  it("shows the plain Working label when no background tasks remain", () => {
+  it("shows the plain Working label at the first tick", () => {
     expect(workingIndicatorLabel(0)).toBe("Working…");
   });
 
-  it("treats a negative count as no background tasks", () => {
-    // Defensive: the store seeds 0, but a stale/negative tally must never
-    // produce a nonsensical "-1 background tasks" label.
-    expect(workingIndicatorLabel(-1)).toBe("Working…");
-  });
-
-  it("uses the singular noun for exactly one background task", () => {
-    expect(workingIndicatorLabel(1)).toBe("1 background task still running");
-  });
-
-  it("pluralizes the noun for more than one background task", () => {
-    expect(workingIndicatorLabel(3)).toBe("3 background tasks still running");
+  it("does not report background tasks — the pill owns that count", () => {
+    // The shimmer is the working indicator; the background-task tally lives in
+    // BackgroundTaskPill, so the label never mentions it regardless of tick.
+    expect(workingIndicatorLabel(0)).toBe("Working…");
+    expect(workingIndicatorLabel(5)).toBe(WORKING_MESSAGES[5 % WORKING_MESSAGES.length]);
   });
 
   it("pins the first rotation message to 'Working…'", () => {
     // A fresh tick and the default arg both land on index 0, so this label
-    // must stay "Working…" — the invariant the (0) / (-1) cases rely on.
+    // must stay "Working…".
     expect(WORKING_MESSAGES[0]).toBe("Working…");
-    expect(workingIndicatorLabel(0, 0)).toBe("Working…");
+    expect(workingIndicatorLabel(0)).toBe("Working…");
   });
 
   it("rotates through the message pool by tick", () => {
-    expect(workingIndicatorLabel(0, 1)).toBe(WORKING_MESSAGES[1]);
-    expect(workingIndicatorLabel(0, 2)).toBe(WORKING_MESSAGES[2]);
+    expect(workingIndicatorLabel(1)).toBe(WORKING_MESSAGES[1]);
+    expect(workingIndicatorLabel(2)).toBe(WORKING_MESSAGES[2]);
   });
 
   it("wraps the rotation modulo the pool length", () => {
-    expect(workingIndicatorLabel(0, WORKING_MESSAGES.length)).toBe("Working…");
-    expect(workingIndicatorLabel(0, WORKING_MESSAGES.length + 1)).toBe(WORKING_MESSAGES[1]);
-  });
-
-  it("ignores the tick while background tasks remain", () => {
-    // The count is information, not decoration — it must not rotate away.
-    expect(workingIndicatorLabel(2, 5)).toBe("2 background tasks still running");
+    expect(workingIndicatorLabel(WORKING_MESSAGES.length)).toBe("Working…");
+    expect(workingIndicatorLabel(WORKING_MESSAGES.length + 1)).toBe(WORKING_MESSAGES[1]);
   });
 });
 
 // ── isBackgroundTasksOnly ───────────────────────────────────────────────────
 
 describe("isBackgroundTasksOnly", () => {
-  it("is true only when background tasks remain and nothing is blocked", () => {
-    expect(isBackgroundTasksOnly(2, null)).toBe(true);
-    expect(isBackgroundTasksOnly(0, null)).toBe(false);
+  it("is true only once the turn ends with background tasks and nothing blocked", () => {
+    // Turn over (not working) + shells linger → the pill owns the state.
+    expect(isBackgroundTasksOnly(2, null, false)).toBe(true);
+    expect(isBackgroundTasksOnly(0, null, false)).toBe(false);
+  });
+
+  it("yields while the turn is still active so the shimmer shows too", () => {
+    // running/waiting or a local send in flight: the agent's turn is live, so
+    // the "Working…" shimmer wins and the pill sits alongside it.
+    expect(isBackgroundTasksOnly(2, null, true)).toBe(false);
   });
 
   it("yields to a parked dialog so the shimmer still shouts", () => {
     // blockedOn needs an action; it must never sit as a quiet pill.
-    expect(isBackgroundTasksOnly(2, "permission prompt")).toBe(false);
+    expect(isBackgroundTasksOnly(2, "permission prompt", false)).toBe(false);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2299,10 +2299,12 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
   const { isAtBottom } = useStickToBottomContext();
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
   const blockedOn = useChatStore((s) => s.blockedOn);
+  const agentWorking = useAgentTurnActive();
   const tick = useWorkingLabelTick();
-  // BackgroundTaskPill owns the background-tasks-only case; the pinned tab and
-  // its announcement yield to it.
-  const showShimmer = show && !isBackgroundTasksOnly(bgCount, blockedOn);
+  // Once the turn ends but background shells outlive it, BackgroundTaskPill owns
+  // the state; the pinned tab and its announcement yield. While the turn is
+  // active the tab still shows.
+  const showShimmer = show && !isBackgroundTasksOnly(bgCount, blockedOn, agentWorking);
   const visible = showShimmer && !isAtBottom && !suppress;
   return (
     <div
@@ -2346,7 +2348,7 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           >
             <BrandLogo variant="icon" className="otto-working h-4 w-auto shrink-0" />
             <Shimmer className="text-sm font-mono" duration={1.5}>
-              {workingIndicatorLabel(bgCount, tick, blockedOn)}
+              {workingIndicatorLabel(tick, blockedOn)}
             </Shimmer>
           </div>
         )}
@@ -2987,35 +2989,44 @@ export const WORKING_MESSAGES = [
 ] as const;
 
 /**
- * Busy only because background tasks outlive the turn (a dev server, a
- * background shell) — the agent isn't thinking and nothing's blocked. The
- * composer's `BackgroundTaskPill` owns this; the "Working…" shimmer yields.
+ * Busy only because background tasks outlive a FINISHED turn (a dev server, a
+ * background shell) — the agent's own turn has ended and nothing's blocked. The
+ * composer's `BackgroundTaskPill` reports the count and the "Working…" shimmer
+ * stays off (it would misread as the agent still thinking). While the turn is
+ * still active (`agentWorking`) the shimmer wins, and the pill shows the count
+ * alongside it.
  */
-export function isBackgroundTasksOnly(bgCount: number, blockedOn: string | null): boolean {
-  return !blockedOn && bgCount > 0;
+export function isBackgroundTasksOnly(
+  bgCount: number,
+  blockedOn: string | null,
+  agentWorking: boolean,
+): boolean {
+  return !agentWorking && !blockedOn && bgCount > 0;
 }
 
 /**
- * The label shown next to the working spinner. When the agent is parked on a
- * dialog (`blockedOn`) it says so — that outranks everything else, because it
- * is the one case where the session needs the user rather than time, and the
- * dialog may live only in the terminal tab. Otherwise, when background shells
- * outlive the turn (`bgCount > 0`) it names how many are still running (the
- * tick is ignored — that count is information, not decoration). Failing both
- * it rotates through `WORKING_MESSAGES` by wall-clock `tick`.
+ * Whether the agent's own turn is in progress — server `running`/`waiting`, or
+ * a local send in flight — as opposed to being busy only because background
+ * tasks outlive a finished turn. Separates the shimmer's "working" state from
+ * the pill's "background-tasks-only" state.
  */
-export function workingIndicatorLabel(
-  bgCount: number,
-  tick = 0,
-  blockedOn: string | null = null,
-): string {
+function useAgentTurnActive(): boolean {
+  const sessionStatus = useChatStore((s) => s.sessionStatus);
+  const localSending = useChatStore((s) => s.status === "streaming");
+  return computeIsWorking(sessionStatus) || localSending;
+}
+
+/**
+ * The label shown next to the working shimmer. When the agent is parked on a
+ * dialog (`blockedOn`) it says so — that outranks the rotation, because it is
+ * the one case where the session needs the user rather than time, and the
+ * dialog may live only in the terminal tab. Otherwise it rotates through
+ * `WORKING_MESSAGES` by wall-clock `tick`. Background-task counts belong to
+ * `BackgroundTaskPill`, not this shimmer.
+ */
+export function workingIndicatorLabel(tick = 0, blockedOn: string | null = null): string {
   if (blockedOn) {
     return `Blocked on: ${blockedOn}`;
-  }
-  if (bgCount > 0) {
-    return bgCount === 1
-      ? "1 background task still running"
-      : `${bgCount} background tasks still running`;
   }
   return WORKING_MESSAGES[tick % WORKING_MESSAGES.length]!;
 }
@@ -3023,11 +3034,13 @@ export function workingIndicatorLabel(
 function WorkingIndicator() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
   const blockedOn = useChatStore((s) => s.blockedOn);
+  const agentWorking = useAgentTurnActive();
   const tick = useWorkingLabelTick();
-  // BackgroundTaskPill owns this case; the shimmer would misread as the agent
-  // still thinking.
-  if (isBackgroundTasksOnly(bgCount, blockedOn)) return null;
-  const label = workingIndicatorLabel(bgCount, tick, blockedOn);
+  // Once the turn ends but background shells outlive it, BackgroundTaskPill owns
+  // the state and the shimmer stays off (it would misread as the agent still
+  // thinking). While the turn is active the shimmer shows, with the pill beside it.
+  if (isBackgroundTasksOnly(bgCount, blockedOn, agentWorking)) return null;
+  const label = workingIndicatorLabel(tick, blockedOn);
   return (
     <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
       <MessageContent>
@@ -4426,15 +4439,16 @@ function SubagentComposerTray({ label }: { label: string }) {
 }
 
 /**
- * Pill above the composer tallying background tasks that outlive the turn (a
- * dev server, a background shell), shown in place of the "Working…" shimmer —
- * which would misread as the agent still thinking. Label-only: the count spans
- * shells, sub-agents, and tools, so there's no single terminal to open.
+ * Pill above the composer tallying background tasks that are running (a dev
+ * server, a background shell, a sub-agent). Independent of the "Working…"
+ * shimmer: while the turn is active both show — the shimmer for the turn, the
+ * pill for the tally — and once the turn ends the pill carries on alone.
+ * Label-only: the count spans shells, sub-agents, and tools, so there's no
+ * single terminal to open.
  */
 function BackgroundTaskPill() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
-  const blockedOn = useChatStore((s) => s.blockedOn);
-  if (!isBackgroundTasksOnly(bgCount, blockedOn)) return null;
+  if (bgCount <= 0) return null;
   return (
     <div className={cn("mx-auto flex w-full px-1 pb-1.5", CHAT_COLUMN_WIDTH)}>
       <div

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2090,8 +2090,9 @@ function MainAgentSurface({
                     {/* Working… shimmer, lit for the whole busy turn so the user
                     always sees the session is still going. Suppressed when the
                     last bubble is a compaction spinner — that bubble already
-                    owns the "in-progress" slot. aria-hidden: the pinned pill
-                    owns the single aria-live region (see WorkingStatusPin). */}
+                    owns the "in-progress" slot. Owns the sole aria-live region
+                    announcing the working state (its visible label is
+                    aria-hidden, so the rotating text never re-announces). */}
                     {showWorkingIndicator && <WorkingIndicator />}
                     {/* Terminal-first spin-up cue beneath the just-sent first
                     message: the prompt bubble renders immediately (no
@@ -2117,9 +2118,6 @@ function MainAgentSurface({
                 <LatestTurnSpacer scrollElement={scroller?.el ?? null} />
               </ConversationContent>
               <ConversationScrollButton />
-              {/* Outside ConversationContent so it's pinned to the viewport, not the scroll. See WorkingStatusPin.
-              Suppressed in a sub-agent session: the composer's "Chatting with sub-agent …" tray owns this slot. */}
-              <WorkingStatusPin show={showWorkingIndicator} suppress={subAgentLabel != null} />
               <UserMessageNavConnected
                 goPrev={nav.goPrev}
                 goNext={nav.goNext}
@@ -2281,79 +2279,6 @@ function UserMessageNavConnected(props: React.ComponentProps<typeof UserMessageN
       // sizes regardless of the buttons.
       className={cn(props.className, "md:hidden", isAtBottom && "max-md:hidden")}
     />
-  );
-}
-
-/**
- * Scroll-pinned "Working…" pill — sole aria-live region (inline shimmer is
- * aria-hidden).
- *
- * @param show - True while the main session is working; gates both the
- *   aria-live announcement and the painted tab.
- * @param suppress - Hides the painted tab without silencing the aria-live
- *   region (still gated on ``show``). Set in a sub-agent session, where the
- *   composer's "Chatting with sub-agent …" tray rises in this same slot and
- *   the "Working…" tab would otherwise stack on top of it.
- */
-function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?: boolean }) {
-  const { isAtBottom } = useStickToBottomContext();
-  const bgCount = useChatStore((s) => s.backgroundTaskCount);
-  const blockedOn = useChatStore((s) => s.blockedOn);
-  const agentWorking = useAgentTurnActive();
-  const tick = useWorkingLabelTick();
-  // Once the turn ends but background shells outlive it, BackgroundTaskPill owns
-  // the state; the pinned tab and its announcement yield. While the turn is
-  // active the tab still shows.
-  const showShimmer = show && !isBackgroundTasksOnly(bgCount, blockedOn, agentWorking);
-  const visible = showShimmer && !isAtBottom && !suppress;
-  return (
-    <div
-      // Always mounted (the aria-live region announces on show); bottom-0 sits
-      // it flush on the composer so the tab reads as rising from behind it.
-      role="status"
-      aria-live="polite"
-      data-testid="working-indicator-pin"
-      className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 z-20 transition-opacity duration-200",
-        visible ? "opacity-100" : "opacity-0",
-      )}
-    >
-      {/* The single announced string. Held stable at "Working…" so the rotating
-          tab text below never re-announces every few seconds. Present whenever
-          the agent is working, so it announces whether the tab is painted
-          (scrolled up) or collapsed (at the bottom, where the inline shimmer
-          owns the visuals). */}
-      {showShimmer && <span className="sr-only">Working…</span>}
-      {/* Mirror the conversation content column (mx-auto + px-4 + width) so the
-          tab's left edge lines up with the inline shimmer's. */}
-      <div className={cn("mx-auto w-full px-4", CHAT_COLUMN_WIDTH)}>
-        {showShimmer && (
-          // Tab shape (rounded top, no bottom border) so its flat bottom edge
-          // merges into the composer. bg-card-solid, not bg-card: in dark mode
-          // bg-card is a translucent glass surface (the `.dark .bg-card` frosted
-          // backdrop-blur), so the tab read as a see-through pill floating over
-          // the transcript. The opaque solid keeps it readable and, by not
-          // matching the glass rule, lets `border-b-0` actually merge — that
-          // rule's `border` shorthand would otherwise re-add a bottom edge.
-          // aria-hidden: the sr-only span above owns the announcement, so the
-          // rotating label here stays silent to screen readers. Collapses to
-          // sr-only when at the bottom (`!visible`) — the inline shimmer paints
-          // there instead.
-          <div
-            aria-hidden="true"
-            className={cn(
-              "flex w-fit items-center gap-1.5 rounded-t-lg border border-b-0 border-border bg-card-solid px-3 pt-1 pb-1.5",
-              !visible && "sr-only",
-            )}
-          >
-            <BrandLogo variant="icon" className="otto-working h-4 w-auto shrink-0" />
-            <Shimmer className="text-sm font-mono" duration={1.5}>
-              {workingIndicatorLabel(tick, blockedOn)}
-            </Shimmer>
-          </div>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -3042,16 +2967,25 @@ function WorkingIndicator() {
   if (isBackgroundTasksOnly(bgCount, blockedOn, agentWorking)) return null;
   const label = workingIndicatorLabel(tick, blockedOn);
   return (
-    <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
-      <MessageContent>
-        <div className="flex items-center gap-1.5 py-0.5">
-          <BrandLogo variant="icon" className="otto-working h-4 w-auto shrink-0" />
-          <Shimmer className="text-sm font-mono" duration={1.5}>
-            {label}
-          </Shimmer>
-        </div>
-      </MessageContent>
-    </Message>
+    <>
+      {/* Sole aria-live region for the working state. A stable "Working…" (not
+          the rotating label) so screen readers announce the turn once, without
+          re-announcing every few seconds; the visible shimmer below stays
+          aria-hidden. */}
+      <span role="status" aria-live="polite" className="sr-only">
+        Working…
+      </span>
+      <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
+        <MessageContent>
+          <div className="flex items-center gap-1.5 py-0.5">
+            <BrandLogo variant="icon" className="otto-working h-4 w-auto shrink-0" />
+            <Shimmer className="text-sm font-mono" duration={1.5}>
+              {label}
+            </Shimmer>
+          </div>
+        </MessageContent>
+      </Message>
+    </>
   );
 }
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2969,10 +2969,12 @@ describe("chatStore — background-shell tally (claude-native)", () => {
     expect(state.activeResponse?.state).toBe("completed");
   });
 
-  it("clears the shell count when a new turn starts (running edge)", () => {
-    // A `running` edge with no count means a fresh turn began; the prior
-    // turn's tally is stale and must clear, mirroring the server's
-    // `_publish_status`. (The PTY `running` carries no count.)
+  it("keeps the sticky shell count when a new turn starts (running edge)", () => {
+    // A `running` edge with no count means a fresh turn began, but shells
+    // launched earlier keep running across the turn boundary — so the tally
+    // persists and the composer pill stays lit alongside the "Working…"
+    // shimmer. (The PTY `running` carries no count; the next Stop hook
+    // re-reports authoritatively.) Mirrors the server's `_publish_status`.
     useChatStore.setState({
       conversationId: "conv_abc",
       sessionStatus: "idle",
@@ -2984,23 +2986,31 @@ describe("chatStore — background-shell tally (claude-native)", () => {
       conversationId: "conv_abc",
       status: "running",
     });
-    expect(useChatStore.getState().backgroundTaskCount).toBe(0);
+    const state = useChatStore.getState();
+    expect(state.sessionStatus).toBe("running");
+    expect(state.backgroundTaskCount).toBe(2);
   });
 
-  it("clears the sticky shell count when the user sends a new turn", async () => {
-    // Asking another question while shells run supersedes the prior turn's
-    // tally: the label must flip from "N background tasks still running" to "Working…"
-    // immediately, not linger until the next status edge.
+  it("keeps the sticky shell count when the user sends a new turn", async () => {
+    // Asking another question while shells run must not blink the pill off: the
+    // shells keep running across the new turn, so the tally persists and the
+    // pill stays up alongside the "Working…" shimmer. The next Stop hook
+    // re-reports it authoritatively.
     seedSession("conv_abc");
+    useChatStore.setState({ conversationId: "conv_abc", status: "idle" });
+    // Bind the stream first (a real, open session the user is looking at) so the
+    // follow-up send below takes the already-bound path and does NOT re-hydrate
+    // the count from the snapshot.
+    await useChatStore.getState().send("first question", "agent_xyz");
+    // A prior turn ended with a background shell still running.
     useChatStore.setState({
-      conversationId: "conv_abc",
       sessionStatus: "waiting",
       backgroundTaskCount: 2,
       status: "idle",
       activeResponse: null,
     });
     await useChatStore.getState().send("another question", "agent_xyz");
-    expect(useChatStore.getState().backgroundTaskCount).toBe(0);
+    expect(useChatStore.getState().backgroundTaskCount).toBe(2);
   });
 });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1569,12 +1569,13 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           ...(selfAuthor !== null ? { author: selfAuthor } : {}),
         },
       ],
-      // A new turn supersedes the prior turn's background-shell tally: the
-      // "N background tasks still running" label must give way to "Working…" the
-      // moment the user sends, not linger until the next status edge. The
-      // count is sticky (see the `session_status` handler) precisely so a
-      // trailing idle can't wipe it, so it has to be cleared explicitly here.
-      backgroundTaskCount: 0,
+      // A new turn does NOT supersede the background-shell tally: shells
+      // launched in an earlier turn keep running across the turn boundary, so
+      // the composer pill must stay lit alongside the "Working…" shimmer rather
+      // than blink off the moment the user sends. The count is sticky (see the
+      // `session_status` handler) and the next Stop hook re-reports it
+      // authoritatively. Only the parked-dialog reason clears — a fresh send is
+      // not parked on a dialog.
       blockedOn: null,
     }));
 
@@ -5308,11 +5309,14 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
         // after it appeared. So: an explicit count is authoritative (a Stop
         // hook's `0` clears it, so a finished shell drops the indicator on the
         // next turn end; a positive count sets it); `undefined` leaves it
-        // untouched; and a new turn (`running`) or a failure clears it —
-        // mirroring the server's `_publish_status`.
+        // untouched. A new `running` turn does NOT clear it — background shells
+        // outlive turn boundaries, so the pill stays lit alongside the "Working…"
+        // shimmer and the next Stop hook re-reports authoritatively. Only a
+        // failure clears it (a dead session may never post another count to drop
+        // a stale tally). Mirrors the server's `_publish_status`.
         if (event.backgroundTaskCount !== undefined) {
           patch.backgroundTaskCount = event.backgroundTaskCount;
-        } else if (event.status === "running" || event.status === "failed") {
+        } else if (event.status === "failed") {
           patch.backgroundTaskCount = 0;
         }
         if (event.responseId !== undefined && event.status === "running") {


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Before (background task pill unrenders and rerenders):


https://github.com/user-attachments/assets/0d8ee117-89ba-470f-98ac-f4569e54cd7b



After (background task stays active as long as there are background tasks):



https://github.com/user-attachments/assets/42f2d565-0993-438f-be69-88b55fc39716




When Claude has background tasks running (a `run_in_background` shell, `npm run dev &`,
a sub-agent), the "Working…" shimmer and the background-task pill should be able to
show **at the same time** — the shimmer answers "is the agent busy?", the pill answers
"how many background tasks are running?". They're different questions, so one must not
hide the other. #4893 (the pill) accidentally made them mutually exclusive; this PR
makes them independent. Three commits:

**1. Decouple the two surfaces.** #4893 added a shared `isBackgroundTasksOnly` predicate
that gated **all three** busy surfaces (inline shimmer, pinned tab shimmer, pill) off
`bgCount > 0` alone, without checking whether the agent's turn was still active. So any
live turn coinciding with a background task suppressed the shimmer and showed the pill
only — misreading an active turn as finished. Now:
- `isBackgroundTasksOnly(bgCount, blockedOn, agentWorking)` also requires `!agentWorking`
  (`running`/`waiting` or a local send in flight), so the shimmer yields **only** once the
  turn has genuinely ended.
- `BackgroundTaskPill` shows on `bgCount > 0` alone, decoupled from the shimmer.
- `workingIndicatorLabel` no longer emits the background count (the pill owns it).

**2. Keep the tally lit across the turn.** After (1) the pill still blinked off the moment
the shimmer appeared, because the background-shell tally was **zeroed on every new turn** in
three places — the server's `_publish_status` popped its cache on a `running` edge, the
client's `session_status` reducer zeroed it on `running`, and the optimistic send path
cleared it synchronously. All three date from the single-surface design, where the count was
a *label on the shimmer* ("N background tasks still running") that a new turn should replace
with "Working…". Background shells outlive turn boundaries, so with the pill as its own
surface the tally must persist across the turn. Stop clearing on `running` in all three
places; keep clearing only on an authoritative Stop-hook `0` (shell finished) and on `failed`
(a dead session may never post another count). The next Stop hook re-reports the count
authoritatively, so restore and clear share one signal and can't disagree.

**3. Remove the scroll-pinned "Working…" tab.** The pinned tab (shown while scrolled up) was
designed to merge its flat bottom edge into the composer — but with the pill now sitting
between them, it read as a stray rounded card floating above the pill. Removed
`WorkingStatusPin` entirely; the inline shimmer at the end of the thread is the working cue.
Its one non-visual job — the sole `aria-live` region announcing the working state — moved
onto the inline `WorkingIndicator` (a stable "Working…" in a `role=status` region, with the
rotating visible label kept `aria-hidden` so it never re-announces). Trade-off: while
scrolled up mid-turn there is no longer a persistent on-screen "Working…" cue (the scroll-to-
bottom button remains); screen-reader announcement is preserved.

**ELI5:** "Working…" means the agent is busy; the pill counts background tasks. They answer
different questions, so they shouldn't hide each other — and a background shell that keeps
running into the next turn should keep its pill lit the whole time.

### Behavior

| State | Shimmer | Pill |
|---|---|---|
| Working, no background tasks | ✅ | — |
| Working (`running`), background shell still running | ✅ **(fixed)** | ✅ **(fixed)** |
| Turn ended (`idle`), shell lingers | — | ✅ (unchanged) |
| Blocked on a dialog | ✅ "Blocked on: …" | ✅ if tasks |

The scroll-pinned "Working…" tab is gone in every state.

### Signal model (background-shell tally)

The tally is a turn-end snapshot recomputed by the claude-native **Stop hook**
(`claude_native_bridge.py` counts only non-terminal `background_tasks`):

- **explicit count (>0 or 0)** → authoritative, always wins (Stop hook). `0` is the "no
  tasks left" signal — it clears both surfaces.
- **`undefined`** (bare PTY `idle`, `running`) → "no info", leave the tally sticky.
- **`failed`** → clear (a dead session may never post another count).

Note the server normalizes a claude-native turn-end `waiting`+count to `idle`
(`_background_task_delivery_status`), so the client's real "working + shell" state is
`running` with a preserved count — not `waiting`. Known limitation (pre-existing): a shell
that finishes *mid-turn* over-reports until the next turn end re-reports; the tally is a
turn-boundary snapshot, not a live per-shell subscription.

## Test Plan

- `pnpm exec vitest run src/pages/ChatPage.test.ts src/store/chatStore.test.ts` — 685 pass.
  Updated `isBackgroundTasksOnly` / `workingIndicatorLabel` for the new signatures; reworked
  the two "clears the tally on a new turn / send" reducer tests to assert the tally now
  **persists** (the send test binds a live stream first so it mirrors an open session rather
  than a cold re-hydrate).
- `uv run --no-sync pytest tests/server/routes/test_sessions_background_task_status.py` —
  12 pass, incl. `test_new_turn_running_keeps_tally` (was `_clears_tally`).
- `pnpm exec tsc -b`, `pnpm exec oxlint`, `pnpm exec prettier --check`, `ruff@0.15.16
  format/check` — clean.
- E2E: reworked `test_working_indicator_background_tasks.py` — the lifecycle test now asserts
  the pill **persists** on the `running` edge alongside the shimmer; added
  `test_working_shimmer_and_pill_coexist_while_running` (idle+count lights the pill, then a
  `running` edge lights the shimmer beside it).
- Manual: drove a `running` turn with a lingering background shell and confirmed shimmer +
  pill show together, then dropped to pill-only once the turn settled to `idle`, both cleared
  on a Stop-hook `0`, and no scroll-pinned tab appears when scrolled up mid-turn.

## Demo

<!-- Screen recording to be attached: shimmer + pill visible together during a `running`
turn with a background shell, then pill-only after the turn ends, then both clear when the
shell finishes; and no floating "Working…" tab while scrolled up. -->
Before: a background task suppressed the "Working…" shimmer, the pill blinked off the moment
a turn went active, and a stray rounded "Working…" tab floated above the pill while scrolled
up. After: see the behavior table above — both surfaces coexist while the turn is working,
and the pinned tab is gone.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the two pure UI helpers (`isBackgroundTasksOnly`, `workingIndicatorLabel`)
and the store reducer's sticky-tally behavior across `running`/send/`failed`/Stop-hook-`0`.
Server tests cover `_publish_status` cache stickiness (running now keeps the tally, failure
and explicit `0` clear it). E2E covers the `running` coexistence path and the full
pill→shimmer+pill→cleared lifecycle via the Sessions events route. The scroll-pinned tab
removal is a deletion with no dedicated test (no test asserted on it); its `aria-live`
announcement moved to the inline indicator. Manual verification as described in the Test Plan.

## Changelog

The "Working…" indicator and the background-tasks pill now show together while the agent works with background tasks running

---
This pull request and its description were written by Isaac.
