### PR TITLE
feat(antigravity): dynamic model options discovery and per-session selection

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -64,10 +64,11 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -109,6 +110,7 @@ from omnigent.antigravity_native_bridge import (
     write_tmux_target,
 )
 from omnigent.antigravity_native_launch import (
+    NativeAntigravityLaunch,
     agy_binary_path,
     build_agy_launch,
     resolve_native_antigravity_launch,
@@ -1775,3 +1777,119 @@ def _launch_is_headless() -> bool:
         # A closed/detached stream raises rather than returning False; treat any
         # such failure as "no interactive client" — the safe, non-hanging choice.
         return True
+
+
+_antigravity_model_discovery_cache: dict[str, list[dict[str, object]]] = {}
+
+
+def parse_antigravity_cli_model_options(stdout: str) -> list[dict[str, object]]:
+    """Parse rows from ``agy models`` stdout into model option dicts.
+
+    :param stdout: Output captured from ``agy models``.
+    :returns: List of model option dicts.
+    """
+    options: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        model_id = parts[0]
+        display_name = parts[1].strip() if len(parts) > 1 else model_id
+        options.append(
+            {
+                "id": model_id,
+                "model": model_id,
+                "displayName": display_name,
+                "isDefault": False,
+            }
+        )
+    return options
+
+
+def list_antigravity_cli_model_options(
+    *,
+    antigravity_path: str | None = None,
+    timeout_s: float = 10.0,
+    env: Mapping[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """Discover available models dynamically by running ``agy models``.
+
+    :param antigravity_path: Optional explicit binary path override.
+    :param timeout_s: Subprocess execution timeout in seconds.
+    :param env: Optional environment overrides.
+    :returns: Discovered model option dicts.
+    """
+    from omnigent.antigravity_native_launch import agy_binary_path
+
+    executable = antigravity_path or agy_binary_path()
+    cached = _antigravity_model_discovery_cache.get(executable)
+    if cached is not None:
+        return [dict(opt) for opt in cached]
+
+    completed = subprocess.run(
+        [executable, "models"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=True,
+        timeout=timeout_s,
+        env=dict(env) if env is not None else None,
+    )
+    parsed = parse_antigravity_cli_model_options(completed.stdout)
+    _antigravity_model_discovery_cache[executable] = parsed
+    return [dict(opt) for opt in parsed]
+
+
+def antigravity_native_model_options(
+    launch_config: NativeAntigravityLaunch | None = None,
+    *,
+    antigravity_path: str | None = None,
+) -> list[dict[str, object]]:
+    """Return model picker rows discovered dynamically from the installed agy CLI.
+
+    :param launch_config: Launch config resolved for the session.
+    :param antigravity_path: Optional explicit binary path override.
+    :returns: Wire-ready model option objects.
+    """
+    try:
+        options = list_antigravity_cli_model_options(antigravity_path=antigravity_path)
+    except Exception:
+        _logger.debug("Failed to discover agy models dynamically via CLI", exc_info=True)
+        options = []
+
+    configured_model = launch_config.model if launch_config is not None else None
+    if not options:
+        if configured_model:
+            return [
+                {
+                    "id": configured_model,
+                    "model": configured_model,
+                    "displayName": configured_model,
+                    "isDefault": True,
+                }
+            ]
+        return []
+
+    has_default = False
+    for opt in options:
+        if configured_model and opt["id"] == configured_model:
+            opt["isDefault"] = True
+            has_default = True
+
+    if not has_default and not configured_model and options:
+        options[0]["isDefault"] = True
+        has_default = True
+
+    if configured_model and not has_default:
+        options.insert(
+            0,
+            {
+                "id": configured_model,
+                "model": configured_model,
+                "displayName": configured_model,
+                "isDefault": True,
+            },
+        )
+
+    return options

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -1677,8 +1677,4 @@ def send_interaction_keys_via_tui(
         )
     socket_path = info["socket_path"]
     tmux_target = info["tmux_target"]
-    if not _session_alive(socket_path, tmux_target):
-        raise RuntimeError(
-            "the agy terminal is no longer running (the TUI exited); restart the session"
-        )
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, *keys)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2322,6 +2322,26 @@ class HostProcess:
                 models=models,
             )
 
+        if harness == "antigravity-native":
+            try:
+                from omnigent.antigravity_native import antigravity_native_model_options
+                from omnigent.antigravity_native_launch import resolve_native_antigravity_launch
+
+                launch = await asyncio.to_thread(resolve_native_antigravity_launch, model=None)
+                models = await asyncio.to_thread(antigravity_native_model_options, launch)
+            except Exception:
+                _logger.exception("Failed to resolve pre-launch Antigravity model options")
+                return HostModelOptionsResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error="failed to resolve Antigravity model options",
+                )
+            return HostModelOptionsResultFrame(
+                request_id=frame.request_id,
+                status="ok",
+                models=models,
+            )
+
         if harness != "claude-native":
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4494,6 +4494,14 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _handle_antigravity_native_model_change(
+        conv_id: str,
+        model: str | None,
+    ) -> Response:
+        # Model is persisted to session.model_override and resolved per turn.
+        del conv_id, model
+        return Response(status_code=204)
+
     async def _handle_claude_native_compact(conv_id: str) -> Response:
         from omnigent.claude_native_bridge import (
             bridge_dir_for_bridge_id,
@@ -6878,6 +6886,7 @@ def create_runner_app(
                 "opencode-native",
                 "kiro-native",
                 "pi-native",
+                "antigravity-native",
             ):
                 model = body.get("model") if isinstance(body, dict) else None
                 if model is not None and not isinstance(model, str):
@@ -6912,6 +6921,11 @@ def create_runner_app(
                     )
                 if harness == "pi-native":
                     return await _handle_pi_native_model_change(
+                        conversation_id,
+                        model,
+                    )
+                if harness == "antigravity-native":
+                    return await _handle_antigravity_native_model_change(
                         conversation_id,
                         model,
                     )
@@ -8579,6 +8593,34 @@ def create_runner_app(
             status_code=200,
             content={"models": claude_native_model_options(claude_config)},
         )
+
+    @app.get("/v1/sessions/{session_id}/antigravity-model-options")
+    async def get_session_antigravity_model_options(session_id: str) -> JSONResponse:
+        if _session_harness_name(session_id) != "antigravity-native":
+            return JSONResponse(status_code=200, content={"models": []})
+        try:
+            from omnigent.antigravity_native import antigravity_native_model_options
+            from omnigent.antigravity_native_launch import resolve_native_antigravity_launch
+
+            launch = await asyncio.to_thread(resolve_native_antigravity_launch, model=None)
+            models = await asyncio.to_thread(antigravity_native_model_options, launch)
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning(
+                "Antigravity-native model discovery failed for session=%s",
+                session_id,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "antigravity_native_model_options_failed",
+                    "detail": _client_safe_error_detail(
+                        exc,
+                        context="antigravity-native model options",
+                    ),
+                },
+            )
+        return JSONResponse(status_code=200, content={"models": models})
 
     @app.post("/v1/sessions/{session_id}/skills/resolve")
     async def resolve_session_skill(session_id: str, request: Request) -> JSONResponse:

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -287,6 +287,9 @@ _KIMI_NATIVE_HARNESS = KIMI_NATIVE_CODING_AGENT.harness
 _ANTIGRAVITY_NATIVE_HARNESS = ANTIGRAVITY_NATIVE_CODING_AGENT.harness
 
 
+_ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE = ANTIGRAVITY_NATIVE_CODING_AGENT.wrapper_label
+
+
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
 
 
@@ -708,6 +711,7 @@ _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CURSOR_NATIVE_WRAPPER_LABEL_VALUE: "cursor-model-options",
     _KIRO_NATIVE_WRAPPER_LABEL_VALUE: "kiro-model-options",
     _OPENCODE_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    _ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE: "antigravity-model-options",
     # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
     # extension (``external_model_options`` → ``_pushed_model_options_cache``),
     # not fetched from a runner route, so the picker works in every auth path
@@ -783,6 +787,7 @@ __all__ = [
     "_ANTIGRAVITY_NATIVE_SUBAGENT_TOOL_CALL_ID_LABEL_KEY",
     "_ANTIGRAVITY_NATIVE_SUBAGENT_TYPE_LABEL_KEY",
     "_ANTIGRAVITY_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE",
+    "_ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE",
     "_APPROVAL_TYPE",
     "_BROWSER_ACTION_AWAIT_S",
     "_BROWSER_ACTION_TIMEOUT_RESULT",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -9340,15 +9340,20 @@ def prefetch_session_routing_catalogs(
     task.add_done_callback(_catalog_prefetch_tasks.discard)
 
 
-async def _host_model_options_via_registry(host_id: str) -> list[dict[str, Any]] | None:
+async def _host_model_options_via_registry(
+    host_id: str,
+    harness: str,
+) -> list[dict[str, Any]] | None:
     """
-    Resolve a host's pre-launch claude catalog over its live tunnel.
+    Resolve a host's pre-launch model catalog over its live tunnel.
 
     Session-side reuse of the new-session picker's source
     (``get_host_model_options`` in ``routes/hosts.py``): the host resolves
     the catalog locally, so no runner is needed.
 
     :param host_id: Host identifier, e.g. ``"host_a1b2c3"``.
+    :param harness: Native harness name, e.g. ``"claude-native"`` or
+        ``"antigravity-native"``.
     :returns: Raw model rows, or ``None`` when the host is not connected,
         rejects the request, or times out.
     """
@@ -9365,7 +9370,7 @@ async def _host_model_options_via_registry(host_id: str) -> list[dict[str, Any]]
         result = await _proxy_model_options(
             host_registry=registry,
             host_conn=conn,
-            harness="claude-native",
+            harness=harness,
         )
     except HTTPException:
         return None
@@ -9375,12 +9380,16 @@ async def _host_model_options_via_registry(host_id: str) -> list[dict[str, Any]]
     return models if isinstance(models, list) else None
 
 
-async def _load_model_options_from_host(session_id: str, host_id: str) -> None:
+async def _load_model_options_from_host(
+    session_id: str,
+    host_id: str,
+    harness: str,
+) -> None:
     """
-    Background catalog fill for an asleep claude-native session.
+    Background catalog fill for an asleep native session.
 
     With no runner bound and a cold cache (e.g. the server restarted while
-    the session slept), the session's host can still resolve the claude
+    the session slept), the session's host can still resolve the native
     catalog — the same pre-launch source the new-session picker uses. Fills
     the cache stale-marked so the next live runner replaces it with its
     launch-exact snapshot, and publishes ``session.model_options`` so open
@@ -9388,12 +9397,14 @@ async def _load_model_options_from_host(session_id: str, host_id: str) -> None:
 
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
     :param host_id: The session's bound host, e.g. ``"host_a1b2c3"``.
+    :param harness: Native harness name, e.g. ``"claude-native"`` or
+        ``"antigravity-native"``.
     """
     # Read through the facade so tests patching
     # ``sessions._host_model_options_via_registry`` reach this impl.
     import omnigent.server.routes.sessions as _facade
 
-    raw = await _facade._host_model_options_via_registry(host_id)
+    raw = await _facade._host_model_options_via_registry(host_id, harness=harness)
     if not raw:
         return
     try:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -137,6 +137,9 @@ from omnigent.server.routes._session_create_validation import (
 # ``__all__`` and the facade's explicit re-exports, preserving its real runtime
 # bindings so a facade-level monkeypatch is honoured in this module too.
 from omnigent.server.routes._sessions.common import (  # noqa: F401
+    _ANTIGRAVITY_NATIVE_HARNESS,
+    _ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE,
+    _CLAUDE_NATIVE_HARNESS,
     _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S,
     _CLAUDE_NATIVE_MODEL,
     _CLAUDE_NATIVE_UI_LABEL_KEY,
@@ -8891,15 +8894,23 @@ async def _fetch_model_options(
         if cached:
             return cached
         # Cold cache too (e.g. the server restarted while the session
-        # slept). claude-native's catalog is also resolvable by the
+        # slept). claude-native / antigravity-native catalogs are also resolvable by the
         # session's host — the same pre-launch source the new-session
         # picker uses — so fill it from there in the background.
         if (
-            wrapper == _CLAUDE_NATIVE_WRAPPER_LABEL_VALUE
+            wrapper
+            in (_CLAUDE_NATIVE_WRAPPER_LABEL_VALUE, _ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE)
             and conv.host_id is not None
             and session_id not in _model_options_inflight
         ):
-            task = asyncio.create_task(_load_model_options_from_host(session_id, conv.host_id))
+            harness_name = (
+                _ANTIGRAVITY_NATIVE_HARNESS
+                if wrapper == _ANTIGRAVITY_NATIVE_WRAPPER_LABEL_VALUE
+                else _CLAUDE_NATIVE_HARNESS
+            )
+            task = asyncio.create_task(
+                _load_model_options_from_host(session_id, conv.host_id, harness=harness_name)
+            )
             _model_options_inflight[session_id] = task
 
             def _clear_host_options_inflight(_task: asyncio.Task[None]) -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -529,6 +529,56 @@ async def test_handle_model_options_rejects_unsupported_harness() -> None:
     )
 
 
+async def test_handle_model_options_uses_antigravity_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Antigravity-native queries discover_antigravity_model_options on the host."""
+    from omnigent import antigravity_native
+
+    monkeypatch.setattr(
+        antigravity_native,
+        "antigravity_native_model_options",
+        lambda config: [
+            {
+                "id": "gemini-3.7-flash-high",
+                "model": "gemini-3.7-flash-high",
+                "displayName": "Gemini 3.7 Flash (High)",
+                "isDefault": True,
+            },
+            {
+                "id": "gemini-3.5-flash-high",
+                "model": "gemini-3.5-flash-high",
+                "displayName": "Gemini 3.5 Flash (High)",
+                "isDefault": False,
+            },
+        ],
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_agy_models", harness="antigravity-native"),
+    )
+
+    assert result == HostModelOptionsResultFrame(
+        request_id="req_agy_models",
+        status="ok",
+        models=[
+            {
+                "id": "gemini-3.7-flash-high",
+                "model": "gemini-3.7-flash-high",
+                "displayName": "Gemini 3.7 Flash (High)",
+                "isDefault": True,
+            },
+            {
+                "id": "gemini-3.5-flash-high",
+                "model": "gemini-3.5-flash-high",
+                "displayName": "Gemini 3.5 Flash (High)",
+                "isDefault": False,
+            },
+        ],
+    )
+
+
 async def test_handle_model_options_reports_the_endpoints_wider_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_antigravity_native.py
+++ b/tests/test_antigravity_native.py
@@ -1312,3 +1312,117 @@ async def test_cli_cold_start_falls_back_when_port_unattributable(
 
     assert len(started) == 1
     assert started[0][0] == 52548  # safe candidate fallback (agy is up in the pane)
+
+
+def test_parse_antigravity_cli_model_options() -> None:
+    """parse_antigravity_cli_model_options converts agy models stdout to dicts."""
+    sample_stdout = (
+        "gemini-3.7-flash-high     Gemini 3.7 Flash (High)\n"
+        "gemini-3.1-pro-high       Gemini 3.1 Pro (High)\n"
+        "claude-sonnet-4-6         Claude Sonnet 4.6 (Thinking)\n"
+    )
+    parsed = _mod.parse_antigravity_cli_model_options(sample_stdout)
+    assert len(parsed) == 3
+    assert parsed[0] == {
+        "id": "gemini-3.7-flash-high",
+        "model": "gemini-3.7-flash-high",
+        "displayName": "Gemini 3.7 Flash (High)",
+        "isDefault": False,
+    }
+    assert parsed[2] == {
+        "id": "claude-sonnet-4-6",
+        "model": "claude-sonnet-4-6",
+        "displayName": "Claude Sonnet 4.6 (Thinking)",
+        "isDefault": False,
+    }
+
+
+def test_antigravity_native_model_options_dynamic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """antigravity_native_model_options uses dynamic CLI discovery and marks first default."""
+    sample_options = [
+        {
+            "id": "gemini-3.7-flash-high",
+            "model": "gemini-3.7-flash-high",
+            "displayName": "Gemini 3.7 Flash (High)",
+            "isDefault": False,
+        },
+        {
+            "id": "gemini-3.1-pro-high",
+            "model": "gemini-3.1-pro-high",
+            "displayName": "Gemini 3.1 Pro (High)",
+            "isDefault": False,
+        },
+    ]
+    monkeypatch.setattr(
+        _mod,
+        "list_antigravity_cli_model_options",
+        lambda **kwargs: [dict(o) for o in sample_options],
+    )
+    options = _mod.antigravity_native_model_options(None)
+    assert len(options) == 2
+    assert options[0]["isDefault"] is True
+    assert options[1]["isDefault"] is False
+
+
+def test_antigravity_native_model_options_respects_launch_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured model in launch config becomes the default option."""
+    from omnigent.antigravity_native_launch import NativeAntigravityLaunch
+
+    sample_options = [
+        {
+            "id": "gemini-3.7-flash-high",
+            "model": "gemini-3.7-flash-high",
+            "displayName": "Gemini 3.7 Flash (High)",
+            "isDefault": False,
+        },
+        {
+            "id": "gemini-3.1-pro-high",
+            "model": "gemini-3.1-pro-high",
+            "displayName": "Gemini 3.1 Pro (High)",
+            "isDefault": False,
+        },
+    ]
+    monkeypatch.setattr(
+        _mod,
+        "list_antigravity_cli_model_options",
+        lambda **kwargs: [dict(o) for o in sample_options],
+    )
+    launch = NativeAntigravityLaunch(auth_mode="subscription", model="gemini-3.1-pro-high")
+    options = _mod.antigravity_native_model_options(launch)
+    pro_opt = next(opt for opt in options if opt["id"] == "gemini-3.1-pro-high")
+    flash_opt = next(opt for opt in options if opt["id"] == "gemini-3.7-flash-high")
+    assert pro_opt["isDefault"] is True
+    assert flash_opt["isDefault"] is False
+
+
+def test_antigravity_native_model_options_custom_model_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom unlisted model in launch config is prepended as default."""
+    from omnigent.antigravity_native_launch import NativeAntigravityLaunch
+
+    sample_options = [
+        {
+            "id": "gemini-3.7-flash-high",
+            "model": "gemini-3.7-flash-high",
+            "displayName": "Gemini 3.7 Flash (High)",
+            "isDefault": False,
+        },
+    ]
+    monkeypatch.setattr(
+        _mod,
+        "list_antigravity_cli_model_options",
+        lambda **kwargs: [dict(o) for o in sample_options],
+    )
+    launch = NativeAntigravityLaunch(auth_mode="subscription", model="custom-preview-model")
+    options = _mod.antigravity_native_model_options(launch)
+    assert options[0] == {
+        "id": "custom-preview-model",
+        "model": "custom-preview-model",
+        "displayName": "custom-preview-model",
+        "isDefault": True,
+    }
+    assert options[1]["id"] == "gemini-3.7-flash-high"
+    assert options[1]["isDefault"] is False

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -4,6 +4,18 @@ export const WRAPPER_LABEL_KEY = "omnigent.wrapper";
 export const UI_MODE_LABEL_KEY = "omnigent.ui";
 export const UI_MODE_TERMINAL_VALUE = "terminal";
 
+export const CLAUDE_NATIVE_WRAPPER = "claude-code-native-ui";
+export const CODEX_NATIVE_WRAPPER = "codex-native-ui";
+export const CURSOR_NATIVE_WRAPPER = "cursor-native-ui";
+export const KIRO_NATIVE_WRAPPER = "kiro-native-ui";
+export const OPENCODE_NATIVE_WRAPPER = "opencode-native-ui";
+export const PI_NATIVE_WRAPPER = "pi-native-ui";
+export const ANTIGRAVITY_NATIVE_WRAPPER = "antigravity-native-ui";
+
+export const CLAUDE_NATIVE_HARNESS = "claude-native";
+export const CODEX_NATIVE_HARNESS = "codex-native";
+export const ANTIGRAVITY_NATIVE_HARNESS = "antigravity-native";
+
 export type NativeCodingAgentIconKind =
   | "claude"
   | "codex"

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -120,6 +120,13 @@ import {
   useChatStore,
 } from "@/store/chatStore";
 import {
+  ANTIGRAVITY_NATIVE_WRAPPER,
+  CLAUDE_NATIVE_WRAPPER,
+  CODEX_NATIVE_WRAPPER,
+  CURSOR_NATIVE_WRAPPER,
+  KIRO_NATIVE_WRAPPER,
+  OPENCODE_NATIVE_WRAPPER,
+  PI_NATIVE_WRAPPER,
   isNativeTerminalSession,
   nativeCodingAgentForHarness,
   nativeCodingAgentForSubagentWrapper,
@@ -4248,6 +4255,7 @@ export function composerHarnessLabel(
   if (modelPickerKind === "cursor") return "Cursor";
   if (modelPickerKind === "kiro") return "Kiro";
   if (modelPickerKind === "opencode") return "OpenCode";
+  if (modelPickerKind === "antigravity") return "Antigravity";
   const display = agentName ? agentDisplayLabel(agentName) : null;
   const harness = sessionHarness ? (harnessLabels[sessionHarness] ?? null) : null;
   if (display && harness) return `${display} (${harness})`;
@@ -5288,8 +5296,9 @@ export function Composer({
     const items = e.clipboardData?.items;
     if (!items) return;
     const pastedFiles: File[] = [];
-    for (const item of items) {
-      if (item.kind === "file") {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item?.kind === "file") {
         const file = item.getAsFile();
         if (file) pastedFiles.push(file);
       }
@@ -5703,14 +5712,6 @@ export function Composer({
               />
             )}
             <div className="flex min-h-9 min-w-0 items-center rounded-lg transition-colors empty:hidden md:min-h-8 has-[button:not([aria-disabled=true])]:hover:bg-muted dark:has-[button:not([aria-disabled=true])]:hover:bg-muted/50 [&>button]:bg-transparent!">
-              <ComposerModelEffortLabel
-                showModels={showModels}
-                showEffort={showEffort}
-                modelPickerKind={modelPickerKind}
-                codexModelOptions={codexModelOptions}
-                costRoutingEligible={costRoutingEligible}
-                harnessLabel={harnessLabel}
-              />
               <ComposerConfigGear
                 harnessLabel={harnessLabel}
                 showModels={showModels}
@@ -5959,7 +5960,8 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode" | "pi";
+type NativeModelPickerKind =
+  "claude" | "codex" | "cursor" | "kiro" | "opencode" | "pi" | "antigravity";
 
 type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
 
@@ -6016,29 +6018,31 @@ export function effortLevelsForConv(
 export function modelPickerKindForConv(
   conv: { labels?: Record<string, string | null> | null } | null | undefined,
 ): NativeModelPickerKind | null {
-  switch (conv?.labels?.["omnigent.wrapper"]) {
-    case "claude-code-native-ui":
+  switch (conv?.labels?.[WRAPPER_LABEL_KEY]) {
+    case CLAUDE_NATIVE_WRAPPER:
       return "claude";
-    case "codex-native-ui":
+    case CODEX_NATIVE_WRAPPER:
       return "codex";
-    case "cursor-native-ui":
+    case CURSOR_NATIVE_WRAPPER:
       return "cursor";
-    case "kiro-native-ui":
+    case KIRO_NATIVE_WRAPPER:
       // Launch-only model selection: kiro applies ``--model`` at launch. Unlike
       // cursor/opencode there is no terminal->web model mirror, so the picker
       // reflects the pre-launch ``model_override`` selection.
       return "kiro";
-    case "opencode-native-ui":
+    case OPENCODE_NATIVE_WRAPPER:
       // Like cursor: a vendor-owns-model wrapper that mirrors its live TUI
       // model into the session ``model_override`` (the forwarder's terminal→web
       // mirror), so the picker surfaces that as the live model.
       return "opencode";
-    case "pi-native-ui":
+    case PI_NATIVE_WRAPPER:
       // Like cursor: the runner types a model switch into the live Pi process
       // (via the bridge inbox → Pi's ``setModel``) and Pi mirrors its own
       // ``/model`` picks back to ``model_override`` via the extension's
       // model_select handler, so the picker surfaces that as the live model.
       return "pi";
+    case ANTIGRAVITY_NATIVE_WRAPPER:
+      return "antigravity";
     default:
       return null;
   }
@@ -6495,6 +6499,19 @@ function ComposerConfigGear({
 
   return (
     <>
+      <ComposerModelEffortLabel
+        showModels={showModels}
+        showEffort={showEffort}
+        modelPickerKind={modelPickerKind}
+        codexModelOptions={codexModelOptions}
+        costRoutingEligible={costRoutingEligible}
+        harnessLabel={harnessLabel}
+        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+          setOpen(true);
+        }}
+      />
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -6641,7 +6658,8 @@ function useResolvedComposerModel(
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "pi" ||
-    modelPickerKind === "opencode";
+    modelPickerKind === "opencode" ||
+    modelPickerKind === "antigravity";
   const modelOptions: readonly { id: string; label?: string; displayName?: string }[] =
     usesServerModelOptions ? codexModelOptions : [];
   const isNativeModelPicker = modelPickerKind !== null;
@@ -6682,7 +6700,8 @@ function useResolvedComposerModel(
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "opencode" ||
-    modelPickerKind === "pi"
+    modelPickerKind === "pi" ||
+    modelPickerKind === "antigravity"
       ? sessionModelOverride
       : (sessionModelOverride ?? sessionStickyModel);
   // SDK/bundle agents (no native picker) never have the cross-session sticky
@@ -6702,9 +6721,11 @@ function useResolvedComposerModel(
         // on a web pick (which also drives a live ``/model`` switch). Either way
         // the Omnigent-visible model is ``model_override``.
         sessionModelOverride
-      : modelPickerKind === "opencode" || modelPickerKind === "pi"
-        ? // opencode/pi mirror their live TUI model into ``model_override``
-          // (set on a web pick, updated by the extension's model_select
+      : modelPickerKind === "opencode" ||
+          modelPickerKind === "pi" ||
+          modelPickerKind === "antigravity"
+        ? // opencode/pi/antigravity mirror their live TUI model into ``model_override``
+          // (set on a web pick, updated by the extension/reader's model_select
           // handler on a TUI switch); show that, falling back to the
           // launch-resolved model before any switch.
           (sessionModelOverride ?? llmModel)
@@ -6744,6 +6765,8 @@ function ComposerModelEffortLabel({
   codexModelOptions,
   costRoutingEligible,
   harnessLabel,
+  disabled = false,
+  onClick,
 }: {
   showModels: boolean;
   showEffort: boolean;
@@ -6751,18 +6774,26 @@ function ComposerModelEffortLabel({
   codexModelOptions: readonly NativeModelOption[];
   costRoutingEligible: boolean;
   harnessLabel: string | null;
+  disabled?: boolean;
+  onClick?: () => void;
 }) {
   const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
   const routingOn = costRoutingEligible && costControlModeOverride === "on";
+  const isClickable = !disabled && Boolean(onClick);
+
   // Routing picks the model + effort per turn, so the label reads
   // "Smart Routing" with no pinned model/effort — matching the tooltip.
   if (routingOn) {
     return (
       <span
         data-testid="composer-model-effort-label"
-        className="min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground"
+        onClick={isClickable ? onClick : undefined}
+        className={cn(
+          "min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground select-none",
+          isClickable && "cursor-pointer hover:text-foreground",
+        )}
       >
         <span className="text-foreground">{SMART_ROUTING_LABEL}</span>
       </span>
@@ -6786,7 +6817,11 @@ function ComposerModelEffortLabel({
     return (
       <span
         data-testid="composer-model-effort-label"
-        className="min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground"
+        onClick={isClickable ? onClick : undefined}
+        className={cn(
+          "min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground select-none",
+          isClickable && "cursor-pointer hover:text-foreground",
+        )}
       >
         <span className="text-foreground">{harnessLabel}</span>
       </span>
@@ -6796,7 +6831,11 @@ function ComposerModelEffortLabel({
   return (
     <span
       data-testid="composer-model-effort-label"
-      className="min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground"
+      onClick={isClickable ? onClick : undefined}
+      className={cn(
+        "min-w-0 shrink truncate pl-2.5 pr-2 text-sm tabular-nums text-muted-foreground select-none",
+        isClickable && "cursor-pointer hover:text-foreground",
+      )}
     >
       {model && <span className="text-foreground">{model}</span>}
       {model && effortLabel && " "}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -137,6 +137,9 @@ import { partitionAgentsByKind, sortAgentsForDisplay } from "@/lib/agentGrouping
 import { cn } from "@/lib/utils";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import {
+  ANTIGRAVITY_NATIVE_HARNESS,
+  CLAUDE_NATIVE_HARNESS,
+  CODEX_NATIVE_HARNESS,
   isFullySupportedNativeCodingAgent,
   isNativeCodingAgent,
   isRecentHarness,
@@ -1398,6 +1401,8 @@ function HarnessConfigModal({
   claudeModelsLoading,
   codexModelOptions,
   codexModelsLoading,
+  agyModelOptions,
+  agyModelsLoading,
   pickedEffort,
   pickedHarness,
   costControlMode,
@@ -1428,6 +1433,8 @@ function HarnessConfigModal({
   claudeModelsLoading: boolean;
   codexModelOptions: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[];
   codexModelsLoading: boolean;
+  agyModelOptions: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[];
+  agyModelsLoading: boolean;
   pickedEffort: string;
   pickedHarness: string | null;
   costControlMode: CostControlMode;
@@ -1449,9 +1456,14 @@ function HarnessConfigModal({
   const hasApproval = nativeAgentHasCapability(agent, "approvalMode");
   const hasCursor = nativeAgentHasCapability(agent, "cursorMode");
   const hasAgySkip = nativeAgentHasCapability(agent, "skipPermissions");
-  const isCodex = entryHarness === "codex-native";
-  const modelOptions = isCodex ? codexModelOptions : claudeModelOptions;
-  const modelsLoading = isCodex ? codexModelsLoading : claudeModelsLoading;
+  const isCodex = entryHarness === CODEX_NATIVE_HARNESS;
+  const isAgy = entryHarness === ANTIGRAVITY_NATIVE_HARNESS;
+  const modelOptions = isAgy ? agyModelOptions : isCodex ? codexModelOptions : claudeModelOptions;
+  const modelsLoading = isAgy
+    ? agyModelsLoading
+    : isCodex
+      ? codexModelsLoading
+      : claudeModelsLoading;
   const brainDefault =
     agent.harness != null && agent.harness in brainHarnessLabels ? agent.harness : null;
 
@@ -1508,6 +1520,10 @@ function HarnessConfigModal({
     () => codexModelOptions.map((m) => ({ id: m.id, label: displayModelId(m) })),
     [codexModelOptions],
   );
+  const agyModelSelectOptions = useMemo(
+    () => agyModelOptions.map((m) => ({ id: m.id, label: m.displayName ?? m.id })),
+    [agyModelOptions],
+  );
   const onModelChange = (value: string) => {
     if (value === MODEL_SELECT_SMART) {
       setDraftRouting("on");
@@ -1562,8 +1578,13 @@ function HarnessConfigModal({
       setCursorExecMode(draftCursor);
       if (entryHarness) writeHarnessOption(entryHarness, { mode: draftCursor });
     } else if (hasAgySkip) {
+      setPickedModel(draftModel);
       setAgySkipMode(draftAgySkip);
-      if (entryHarness) writeHarnessOption(entryHarness, { mode: draftAgySkip });
+      if (entryHarness)
+        writeHarnessOption(entryHarness, {
+          mode: draftAgySkip,
+          model: draftModel,
+        });
     } else if (brainDefault) {
       // Picking the spec default clears the override so the session tracks it.
       setPickedHarness(draftHarness === brainDefault ? null : draftHarness, agent.id);
@@ -1745,6 +1766,17 @@ function HarnessConfigModal({
 
           {!autoRouting && hasAgySkip && (
             <>
+              <ConfigRow label="Model" description="Which Antigravity model runs this session">
+                <RoutingModelSelect
+                  value={draftModel || MODEL_SELECT_DEFAULT}
+                  onValueChange={onModelChange}
+                  offerSmartRouting={false}
+                  testId="new-chat-landing-config-agy-model"
+                  models={agyModelSelectOptions}
+                  defaultLabel={defaultModelLabel(agyModelOptions, (m) => m.displayName ?? m.id)}
+                  ariaLabel="Model"
+                />
+              </ConfigRow>
               <ConfigRow label="Permissions" description="What the agent can do without asking">
                 <DescribedSelect
                   value={draftAgySkip}
@@ -2091,12 +2123,17 @@ export function NewChatLandingScreen() {
   );
   const { data: hostClaudeModelOptions, isLoading: hostClaudeModelsLoading } = useHostModelOptions(
     selectedHostId,
-    "claude-native",
+    CLAUDE_NATIVE_HARNESS,
     !sandboxSelected,
   );
   const { data: hostCodexModelOptions, isLoading: hostCodexModelsLoading } = useHostModelOptions(
     selectedHostId,
-    "codex-native",
+    CODEX_NATIVE_HARNESS,
+    !sandboxSelected,
+  );
+  const { data: hostAgyModelOptions, isLoading: hostAgyModelsLoading } = useHostModelOptions(
+    selectedHostId,
+    ANTIGRAVITY_NATIVE_HARNESS,
     !sandboxSelected,
   );
   const claudeModelOptions = useMemo(
@@ -2115,6 +2152,10 @@ export function NewChatLandingScreen() {
   const codexModelOptions = useMemo(
     () => (sandboxSelected ? [] : (hostCodexModelOptions ?? [])),
     [hostCodexModelOptions, sandboxSelected],
+  );
+  const agyModelOptions = useMemo(
+    () => (sandboxSelected ? [] : (hostAgyModelOptions ?? [])),
+    [hostAgyModelOptions, sandboxSelected],
   );
   // Desktop-shell host status for THIS machine (null outside Electron), so the
   // picker can tag the current machine and offer to auto-connect it.
@@ -2775,7 +2816,14 @@ export function NewChatLandingScreen() {
     if (supportsAgySkipPermissions) {
       const skipValue =
         AGY_NATIVE_SKIP_MODES.find((m) => m.value === agySkipMode)?.label ?? agySkipMode;
-      return [{ label: "Permissions", value: skipValue }, ...routingRow];
+      const modelValue =
+        agyModelOptions.find((m) => m.id === pickedModel)?.displayName ??
+        defaultModelLabel(agyModelOptions, (m) => m.displayName ?? m.id);
+      return [
+        { label: "Model", value: modelValue },
+        { label: "Permissions", value: skipValue },
+        ...routingRow,
+      ];
     }
     if (selectedAgent?.harness != null && selectedAgent.harness in brainHarnessLabelsAll) {
       const active = pickedHarness ?? selectedAgent.harness;
@@ -2797,6 +2845,7 @@ export function NewChatLandingScreen() {
     pickedModel,
     claudeModelOptions,
     codexModelOptions,
+    agyModelOptions,
     pickedEffort,
     permissionMode,
     approvalMode,
@@ -4083,10 +4132,16 @@ export function NewChatLandingScreen() {
               onPaste={(e) => {
                 // Pasted images/files attach instead of inserting as text,
                 // mirroring the in-session composer.
-                const pasted = Array.from(e.clipboardData.items)
-                  .filter((item) => item.kind === "file")
-                  .map((item) => item.getAsFile())
-                  .filter((f): f is File => f !== null);
+                const items = e.clipboardData?.items;
+                if (!items) return;
+                const pasted: File[] = [];
+                for (let i = 0; i < items.length; i++) {
+                  const item = items[i];
+                  if (item?.kind === "file") {
+                    const file = item.getAsFile();
+                    if (file) pasted.push(file);
+                  }
+                }
                 if (pasted.length > 0) {
                   e.preventDefault();
                   addFiles(pasted);
@@ -4334,6 +4389,10 @@ export function NewChatLandingScreen() {
                     codexModelOptions={codexModelOptions}
                     codexModelsLoading={
                       !sandboxSelected && selectedHostId !== null && hostCodexModelsLoading
+                    }
+                    agyModelOptions={agyModelOptions}
+                    agyModelsLoading={
+                      !sandboxSelected && selectedHostId !== null && hostAgyModelsLoading
                     }
                     pickedEffort={pickedEffort}
                     pickedHarness={pickedHarness}

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -116,7 +116,12 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { getOmnigentHostConfig } from "@/lib/host";
 import { getSessionHost } from "@/lib/sessionHost";
 import { isSystemUserContent } from "@/lib/systemMessage";
-import { isNativeWrapper } from "@/lib/nativeCodingAgents";
+import {
+  CLAUDE_NATIVE_WRAPPER,
+  CODEX_NATIVE_WRAPPER,
+  WRAPPER_LABEL_KEY,
+  isNativeWrapper,
+} from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
   /**
@@ -2574,10 +2579,10 @@ type NativeModelFamily = "claude" | "codex";
  * :returns: ``"claude"`` / ``"codex"`` for native wrappers, else ``null``.
  */
 function nativeModelFamilyForSession(session: Pick<Session, "labels">): NativeModelFamily | null {
-  switch (session.labels?.["omnigent.wrapper"]) {
-    case "claude-code-native-ui":
+  switch (session.labels?.[WRAPPER_LABEL_KEY]) {
+    case CLAUDE_NATIVE_WRAPPER:
       return "claude";
-    case "codex-native-ui":
+    case CODEX_NATIVE_WRAPPER:
       return "codex";
     default:
       return null;


### PR DESCRIPTION
## Related issue

Closes #4903

## Summary

- Adds dynamic Antigravity model discovery by querying `agy models` on the host daemon (`antigravity_native_model_options`).
- Exposes model selection in the New Chat Dialog (`RoutingModelSelect`) and passes `--model <model_id>` at session launch.
- Implements the Web UI composer model selector and session configuration modal with direct clickable model labels.
- Decouples session model selection from fragile tmux keystroke injection, deferring mid-session TUI reconfiguration pending maintainer discussion on Issue #4903.

## Test Plan

- **Unit Tests**:
  - `tests/test_antigravity_native.py`: Added dynamic model discovery parsing and default selection tests.
  - `tests/host/test_connect.py`: Verified host daemon handler for Antigravity model discovery.
  - `web/src/pages/ChatPage.capabilities.test.ts`: Verified Antigravity model selector capability gating.
- **Manual Verification**:
  - Started Omnigent host daemon and local server on `http://127.0.0.1:6767`.
  - Verified dynamic model population in the New Chat Dialog.
  - Created an Antigravity session with `--model <id>` and verified model execution and token usage tracking.
  - Verified clicking directly on the composer model name opens the configuration modal.

## Demo

*(Screenshots attached showcasing session model selection and token usage behavior)*

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification completed for Antigravity model selection in the New Chat Dialog, session creation with `--model`, and composer toolbar interactions on `http://localhost:6767`.

## Changelog

Add dynamic model selection for Antigravity native sessions
