### PR TITLE
feat(server): seed configured ACP agents into the New Chat picker

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -519,6 +519,7 @@ def _ensure_default_agents(
     :param agent_cache: Cache for loaded agent specs.
     """
     _ensure_default_native_agents(agent_store, artifact_store, agent_cache)
+    _ensure_default_acp_agents(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
@@ -662,6 +663,120 @@ def _ensure_default_native_agents(
             agent_cache,
             name=agent.agent_name,
             bundle_bytes=_build_native_bundle(provider),
+        )
+
+
+# Light framing for a seeded ACP picker agent. ACP agents run their own tool
+# loop, so the vendor CLI supplies the real behavior; this is just enough to
+# name the role.
+_ACP_AGENT_PROMPT = (
+    "You are a coding agent running inside Omnigent through the Agent Client "
+    "Protocol. Help the user with software engineering tasks in their workspace: "
+    "read and edit files, run commands, investigate, and implement changes. Work "
+    "within the current repository, explain what you are doing, and when you finish "
+    "a task tell the user how to verify it."
+)
+
+
+def _build_acp_bundle(*, harness: str, name: str) -> bytes:
+    """
+    Materialize a one-file ACP picker agent and tar it.
+
+    ACP agents have no provider row (unlike :func:`_build_native_bundle`), so the
+    spec is a generated single YAML on the debby-style directory path: just the
+    ``acp:<slug>`` (or builtin ACP CLI) harness id. The launch command is resolved
+    from the host's own ``acp:`` config (user agents) or PATH (builtin CLI rows)
+    at spawn time, so nothing host-specific is baked into the bundle.
+
+    :param harness: The harness id, e.g. ``"acp:devin"`` or ``"grok"``.
+    :param name: The agent name / stable-id seed — a valid ``[a-zA-Z0-9_-]+``
+        slug (e.g. ``"devin"``, ``"grok"``), never a display label with spaces.
+    :returns: Gzipped tarball bytes suitable for the artifact store.
+    """
+    import tempfile
+
+    import yaml
+
+    from omnigent.spec import materialize_bundle
+
+    raw = {
+        "spec_version": 1,
+        "name": name,
+        "prompt": _ACP_AGENT_PROMPT,
+        "executor": {"type": "omnigent", "config": {"harness": harness}},
+        "os_env": {"type": "caller_process", "cwd": ".", "sandbox": {"type": "none"}},
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source = Path(tmpdir) / "src"
+        source.mkdir()
+        (source / "config.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+        bundle_dir = materialize_bundle(source, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_acp_agents(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """
+    Seed a picker agent for each ACP harness set up on THIS server's host.
+
+    Native harnesses seed a fixed ``<harness>-ui`` agent each
+    (:func:`_ensure_default_native_agents`). ACP agents are host config rather
+    than a fixed catalog, so seed one agent per user-configured ``acp:<slug>``
+    agent (``harness_is_configured("acp:...")`` treats "in config" as set up) and
+    per builtin ACP CLI harness whose binary is on PATH (its readiness gate). On a
+    host with no ACP setup — the common remote-server case, where the server holds
+    no ``acp:`` config — this seeds nothing.
+
+    Purely additive: it only adds picker rows and never touches native seeding.
+    A malformed ``acp:`` block is logged and skipped, never fatal to startup
+    (mirrors the dynamic ``acp:*`` catalog rows in ``harness_plugins``).
+
+    Note: a seeded row is keyed by the agent's display name, so renaming a
+    configured ACP agent leaves the old picker row behind until the store is
+    reseeded — acceptable since native names are fixed and never rename.
+
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for agent bundles.
+    :param agent_cache: Cache for loaded agent specs.
+    """
+    from omnigent._platform import resolve_cli_binary
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+    # (1) User-configured acp:<slug> agents — "set up" == present in config.
+    try:
+        from omnigent.onboarding.acp_auth import acp_agents
+
+        configured = list(acp_agents())
+    except Exception:  # noqa: BLE001 — a malformed acp: block must never break startup
+        _logger.debug("acp agent seeding skipped (config unreadable)", exc_info=True)
+        configured = []
+    for agent in configured:
+        # Key the built-in by the slug, not the display label: agent names must be
+        # ``[a-zA-Z0-9_-]+`` (the spec validator rejects spaces/dots), and a label
+        # like "Gemini CLI" would fail to load. The web picker capitalizes the slug
+        # for display (e.g. ``devin`` -> "Devin").
+        _ensure_builtin_agent(
+            agent_store,
+            artifact_store,
+            agent_cache,
+            name=agent.slug,
+            bundle_bytes=_build_acp_bundle(harness=f"acp:{agent.slug}", name=agent.slug),
+        )
+
+    # (2) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
+    # by the catalog id (already a valid slug), not the display label.
+    for key, row in ACP_CLI_HARNESSES.items():
+        if resolve_cli_binary(row.binary) is None:
+            continue
+        _ensure_builtin_agent(
+            agent_store,
+            artifact_store,
+            agent_cache,
+            name=key,
+            bundle_bytes=_build_acp_bundle(harness=key, name=key),
         )
 
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -984,6 +984,126 @@ def test_ensure_default_native_agents_seeds_every_native_agent(
         assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
 
+def test_ensure_default_acp_agents_seeds_configured_agent(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configured ``acp:<slug>`` agent becomes a picker-renderable built-in.
+
+    This is the ACP analogue of the native seeding: the New-Session picker reads
+    built-ins from ``GET /v1/agents``, so a configured ACP agent must seed to
+    appear — the same way ``opencode-native-ui`` etc. do.
+
+    **What breaks if this fails**: a user with Devin (or any ``acp:`` agent) set
+    up on their machine never sees it in the web picker.
+    """
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.onboarding.acp_auth import AcpAgentEntry
+
+    # A display label with a space ("Gemini CLI") must not become the agent name
+    # (spec names are [a-zA-Z0-9_-]+); the slug is used instead.
+    entry = AcpAgentEntry(
+        slug="gemini-cli", name="Gemini CLI", command="gemini --experimental-acp"
+    )
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [entry])
+    # No builtin ACP CLI installed, so only the configured agent seeds.
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _b, **k: None)
+
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+
+    # Keyed by the slug, not the label.
+    seeded = seed_stores.agent_store.get_by_name("gemini-cli")
+    assert seeded is not None, "configured acp:<slug> agent was not seeded into the picker"
+    assert seed_stores.agent_store.get_by_name("Gemini CLI") is None, (
+        "the invalid space-bearing label must not be used as the agent name"
+    )
+    assert seeded.id == builtin_agent_id("gemini-cli")
+    assert seeded.session_id is None, "built-ins must be session-scope NULL"
+    assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
+
+
+def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A builtin ACP CLI harness whose binary is on PATH seeds a picker built-in."""
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [])
+    # Every builtin ACP CLI resolves on PATH in this test.
+    monkeypatch.setattr(
+        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/local/bin/x"
+    )
+
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+    # Keyed by the catalog id (a valid slug), not the display label.
+    for key in ACP_CLI_HARNESSES:
+        assert seed_stores.agent_store.get_by_name(key) is not None, (
+            f"installed builtin ACP CLI {key!r} was not seeded"
+        )
+
+
+def test_ensure_default_acp_agents_noop_when_nothing_set_up(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No configured agents + no installed builtin CLI → nothing seeded.
+
+    **What breaks if this fails**: a remote server (no ``acp:`` config, ACP CLIs
+    absent) shows phantom ACP picker rows that can't launch there.
+    """
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [])
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _b, **k: None)
+
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+    assert seed_stores.agent_store.get_by_name("devin") is None
+    for key in ACP_CLI_HARNESSES:
+        assert seed_stores.agent_store.get_by_name(key) is None
+
+
+def test_ensure_default_acp_agents_survives_unreadable_config(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed ``acp:`` block is skipped, never fatal to server startup."""
+
+    def _boom(*_a: object, **_k: object) -> list[object]:
+        raise ValueError("bad acp: block")
+
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", _boom)
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _b, **k: None)
+
+    # Must not raise — startup calls this and a bad user config can't take the
+    # whole server down.
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+
+
+def test_build_acp_bundle_carries_the_harness_id(tmp_path: Path) -> None:
+    """The seeded bundle's spec runs on ``acp:<slug>`` — resolved at spawn.
+
+    **What breaks if this fails**: the picker row exists but launches the wrong
+    (or no) ACP agent because the harness id didn't reach the bundle.
+    """
+    import io
+    import tarfile
+
+    from omnigent.spec import load
+
+    data = server_app._build_acp_bundle(harness="acp:devin", name="devin")
+    dest = tmp_path / "bundle"
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        tf.extractall(dest, filter="data")
+    spec = load(dest)
+    assert spec.name == "devin"
+    assert spec.executor.config["harness"] == "acp:devin"
+
+
 def test_ensure_default_native_agents_raises_when_provider_missing(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/web/src/lib/agentGrouping.test.ts
+++ b/web/src/lib/agentGrouping.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
+import { partitionAgentsByKind } from "@/lib/agentGrouping";
+
+function agent(overrides: Partial<AvailableAgent> & Pick<AvailableAgent, "name">): AvailableAgent {
+  return {
+    id: `id-${overrides.name}`,
+    display_name: overrides.name,
+    description: null,
+    harness: null,
+    skills: [],
+    ...overrides,
+  };
+}
+
+describe("partitionAgentsByKind", () => {
+  it("groups a server-marked built-in with harnesses even when its name isn't in the static allowlist", () => {
+    // A seeded ACP agent (Devin) — name not in BUILTIN_AGENTS, but the server
+    // set builtin=true. Without grouping by that flag it would fall to customs.
+    const { builtins, customs } = partitionAgentsByKind([
+      agent({ name: "devin", harness: "acp:devin", builtin: true }),
+      agent({ name: "grok", harness: "grok", builtin: true }),
+    ]);
+    expect(builtins.map((a) => a.name)).toEqual(expect.arrayContaining(["devin", "grok"]));
+    expect(customs).toHaveLength(0);
+  });
+
+  it("keeps a server-marked non-built-in in customs", () => {
+    const { builtins, customs } = partitionAgentsByKind([
+      agent({ name: "my-uploaded-agent", builtin: false }),
+    ]);
+    expect(builtins).toHaveLength(0);
+    expect(customs.map((a) => a.name)).toEqual(["my-uploaded-agent"]);
+  });
+
+  it("falls back to the name allowlist when the server omits the builtin field", () => {
+    // Older server: no builtin field. The allowlist still classifies the shipped
+    // native, and an unknown name is custom.
+    const { builtins, customs } = partitionAgentsByKind([
+      agent({ name: "claude-native-ui", harness: "claude-native" }),
+      agent({ name: "some-custom", harness: "claude-sdk" }),
+    ]);
+    expect(builtins.map((a) => a.name)).toEqual(["claude-native-ui"]);
+    expect(customs.map((a) => a.name)).toEqual(["some-custom"]);
+  });
+});

--- a/web/src/lib/agentGrouping.test.ts
+++ b/web/src/lib/agentGrouping.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
-import { partitionAgentsByKind } from "@/lib/agentGrouping";
+import { isAcpHarnessAgent, partitionAgentsByKind } from "@/lib/agentGrouping";
 
 function agent(overrides: Partial<AvailableAgent> & Pick<AvailableAgent, "name">): AvailableAgent {
   return {
@@ -43,5 +43,22 @@ describe("partitionAgentsByKind", () => {
     ]);
     expect(builtins.map((a) => a.name)).toEqual(["claude-native-ui"]);
     expect(customs.map((a) => a.name)).toEqual(["some-custom"]);
+  });
+});
+
+describe("isAcpHarnessAgent", () => {
+  it("recognizes configured acp:<slug> agents and builtin ACP CLI harnesses", () => {
+    // NewChatDialog routes these into the "Harnesses" group (beside the native
+    // CLIs), not "Agents" — they select a harness to run, not a composed agent.
+    expect(isAcpHarnessAgent({ harness: "acp:devin" })).toBe(true);
+    expect(isAcpHarnessAgent({ harness: "acp:kilocode" })).toBe(true);
+    expect(isAcpHarnessAgent({ harness: "grok" })).toBe(true);
+  });
+
+  it("does not misclassify composed agents, native harnesses, or missing harness", () => {
+    expect(isAcpHarnessAgent({ harness: "claude-sdk" })).toBe(false); // Polly / Debby
+    expect(isAcpHarnessAgent({ harness: "claude-native" })).toBe(false); // native harness
+    expect(isAcpHarnessAgent({ harness: null })).toBe(false);
+    expect(isAcpHarnessAgent(null)).toBe(false);
   });
 });

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -26,6 +26,29 @@ export const BUILTIN_AGENTS = new Set([
   "debby",
 ]);
 
+// Builtin ACP CLI harness ids (mirrors ACP_CLI_HARNESSES on the server). Like
+// the native harnesses, these are harness-backed picks — not composed agents —
+// so the picker groups them under "Harnesses ▸ More", beside OpenCode/Cursor.
+// User-configured ACP agents carry an `acp:<slug>` harness; a builtin ACP CLI
+// harness carries a bare id.
+export const ACP_CLI_HARNESS_IDS = new Set<string>(["grok"]);
+
+/**
+ * Whether an agent is backed by the generic ACP harness — a configured
+ * `acp:<slug>` agent (e.g. Devin, Kilocode) or a builtin ACP CLI harness
+ * (e.g. Grok). These belong in the picker's "Harnesses" group with the native
+ * CLIs: selecting one runs a harness, not a composed agent.
+ *
+ * @param agent - Agent to classify (only its `harness` is read).
+ */
+export function isAcpHarnessAgent(
+  agent: Pick<AvailableAgent, "harness"> | null | undefined,
+): boolean {
+  const harness = agent?.harness;
+  if (harness == null) return false;
+  return harness.startsWith("acp:") || ACP_CLI_HARNESS_IDS.has(harness);
+}
+
 // Preferred display order for the built-in group. The server returns
 // agents newest-registered first (agent_store.list sorts by created_at
 // desc), so pin the order users expect; any agent not listed here falls

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -77,8 +77,15 @@ export function partitionAgentsByKind<T extends AvailableAgent>(
   agents: readonly T[],
 ): { builtins: T[]; customs: T[] } {
   const sorted = sortAgentsForDisplay(agents);
+  // Prefer the server's ``builtin`` signal — GET /v1/agents now sets it
+  // (session-scope-NULL row with a deterministic name-derived id). This groups
+  // dynamically-seeded built-ins with the harnesses instead of under custom
+  // agents; the {@link BUILTIN_AGENTS} allowlist is only a fallback for older
+  // servers that don't send the field. Without this, seeded ACP agents (Devin,
+  // grok, …) — whose names aren't in the static allowlist — fall to "custom".
+  const isBuiltin = (a: T): boolean => a.builtin ?? BUILTIN_AGENTS.has(a.name);
   return {
-    builtins: sorted.filter((a) => BUILTIN_AGENTS.has(a.name)),
-    customs: sorted.filter((a) => !BUILTIN_AGENTS.has(a.name)),
+    builtins: sorted.filter(isBuiltin),
+    customs: sorted.filter((a) => !isBuiltin(a)),
   };
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -133,7 +133,11 @@ import {
   type SmartRoutingUnavailableCause,
 } from "@/lib/smartRoutingAvailability";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
-import { partitionAgentsByKind, sortAgentsForDisplay } from "@/lib/agentGrouping";
+import {
+  isAcpHarnessAgent,
+  partitionAgentsByKind,
+  sortAgentsForDisplay,
+} from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import {
@@ -1917,16 +1921,20 @@ export function NewChatLandingScreen() {
     [agents],
   );
 
-  // Split the picker into "Harnesses" (the native terminal CLIs) and
-  // "Agents" (SDK / bundle agents like Polly & Debby plus any custom
-  // user-registered agents). This is the isNativeCodingAgent split, NOT the
-  // builtins/customs split: Polly & Debby are built-ins but belong under
-  // "Agents", not "Harnesses".
+  // Split the picker into "Harnesses" (harness-backed picks — the native
+  // terminal CLIs plus generic-ACP harness agents like Grok / Devin / Kilocode)
+  // and "Agents" (composed SDK / bundle agents like Polly & Debby plus custom
+  // user-registered agents). Harness-backed vs composed, NOT the builtins/customs
+  // split: Polly & Debby are built-ins but are composed agents, so they stay
+  // under "Agents". ACP agents aren't native, so they fold into "More".
   const harnessEntries = useMemo(
-    () => agentList.filter((a) => isNativeCodingAgent(a)),
+    () => agentList.filter((a) => isNativeCodingAgent(a) || isAcpHarnessAgent(a)),
     [agentList],
   );
-  const agentEntries = useMemo(() => agentList.filter((a) => !isNativeCodingAgent(a)), [agentList]);
+  const agentEntries = useMemo(
+    () => agentList.filter((a) => !isNativeCodingAgent(a) && !isAcpHarnessAgent(a)),
+    [agentList],
+  );
 
   // "Create custom agent" dialog state and pending bundle. When the user
   // creates a custom agent via the dialog, the bundle input is stored


### PR DESCRIPTION
## Related issue

No filed issue — this is the web-picker sibling of the `omni setup` ACP discovery
gap (shipped in #4700). Happy to file one retroactively if the queue wants it.

## Summary

The web **New Chat picker lists agents** (`GET /v1/agents`), not harnesses. Native
harnesses appear only because `_ensure_default_native_agents` seeds a
`<harness>-ui` agent for each at server startup. **Nothing seeded ACP agents**, so
a user with Devin (or any `acp:<slug>` agent) configured — or an installed builtin
ACP CLI harness like Grok Build — never saw it in the picker, even though it was a
first-class harness everywhere else.

This seeds a picker built-in per ACP harness **set up on the server's host**,
mirroring how the natives are seeded:

- one per user-configured `acp:<slug>` agent — "in config" is the set-up signal,
  matching `harness_is_configured("acp:...")`;
- one per builtin ACP CLI harness whose binary is on `PATH` — its readiness gate.

On a host with no ACP setup — the common remote-server case, where the server holds
no `acp:` config — this seeds **nothing**.

```
GET /v1/agents  (New Chat picker)
  before                    after (on a host with Devin/kilocode + grok set up)
  claude-native-ui          claude-native-ui
  codex-native-ui           codex-native-ui
  …                    ->   …
  polly                     polly
                            Devin          ← acp:devin   (from acp: config)
                            kilocode       ← acp:kilocode
                            Grok Build     ← grok        (binary on PATH)
```

Purely additive: it only adds picker rows and never touches native seeding. A
malformed `acp:` block is logged and skipped, never fatal to startup (mirrors the
dynamic `acp:*` catalog rows in `harness_plugins`).

## Test Plan

- New unit tests in `tests/server/test_app.py` (mirroring the native seeding tests):
  a configured `acp:<slug>` agent seeds (stable id, session-scope NULL, retrievable
  bundle); an installed builtin ACP CLI seeds; **nothing** seeds when no config +
  no on-PATH CLI (the remote-server no-op); a malformed `acp:` block is survived,
  not fatal; and `_build_acp_bundle` carries the `acp:<slug>` harness into the
  loadable spec.
- `pytest tests/server/test_app.py` → **54 passed** (5 new + 49 existing).
- `ruff format` / `ruff check` clean; `pyrefly check` (CI's `--extra all`) → **0
  errors**.

**Manual verification against a real machine config:** ran
`_ensure_default_acp_agents` against a copy of a real `~/.omnigent/config.yaml` with
a Devin + kilocode `acp:` block, `grok` on PATH → **Devin, kilocode, and Grok Build**
all seeded as picker agents with stable ids.

## Demo

Server-side change; the user-visible effect is new rows in the New Chat picker,
shown above and proven by the manual run (the three ACP agents seeded from a real
host config). No `web/src` changes — the picker renders whatever `/v1/agents`
returns.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered what a unit test can't: that a *real* host's `acp:`
config + on-PATH CLIs produce the expected picker agents end to end (the SPA picker
itself isn't exercised in unit tests). Automated tests pin the store seeding, the
no-op-when-nothing-set-up remote case, the malformed-config survival, and that the
bundle carries the right harness id.

Two known limitations, documented in the code and worth stating:
- Seeded rows are keyed by the agent's display name, so **renaming** a configured
  ACP agent leaves the old picker row behind until the store is reseeded (native
  names are fixed and never rename, so they don't hit this).
- Seeding reads the **server's** host config, so it only populates ACP agents for a
  local server. Making a remote server's picker reflect the *runner* host's ACP
  agents is host-aware seeding — a separate follow-up (it needs the host to
  advertise its configured ACP agents up to the server).

## Changelog

Configured ACP agents (e.g. Devin) and installed ACP CLI harnesses (e.g. Grok Build) now appear in the web New Chat picker, like the native harnesses
