### PR TITLE
feat(web): add server URL actions to sidebar picker

### DIFF
--- a/tests/e2e_ui/desktop/test_sidebar_server_picker.py
+++ b/tests/e2e_ui/desktop/test_sidebar_server_picker.py
@@ -62,7 +62,7 @@ def test_server_picker_opens_and_copies_current_url(
     expect(copy_action).to_be_focused()
     copy_action.press("Enter")
 
-    expect(page.get_by_role("status")).to_contain_text("Server URL copied.")
+    expect(page.get_by_test_id("toast")).to_contain_text("Server URL copied.")
     assert page.evaluate("navigator.clipboard.readText()") == _CURRENT_ORIGIN
 
     expect(open_action).to_be_hidden()

--- a/tests/e2e_ui/desktop/test_sidebar_server_picker.py
+++ b/tests/e2e_ui/desktop/test_sidebar_server_picker.py
@@ -1,0 +1,77 @@
+"""E2E coverage for the Electron sidebar server picker URL actions."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+_CURRENT_ORIGIN = "https://connected.example.com:8443"
+_SERVER_PICKER_INIT_SCRIPT = f"""
+window.omnigentDesktop = {{
+  kind: "electron",
+  setBadgeCount: function () {{}},
+  notify: function () {{ return Promise.resolve(false); }},
+  onNotificationActivated: function () {{ return function () {{}}; }},
+  getServerPicker: function () {{
+    return Promise.resolve({{
+      currentOrigin: "{_CURRENT_ORIGIN}",
+      recentServers: [],
+    }});
+  }},
+  switchServer: function () {{ return Promise.resolve(); }},
+  openServerSetup: function () {{}},
+}};
+"""
+
+
+def test_server_picker_opens_and_copies_current_url(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The live menu opens and copies the exact bridge-provided server URL."""
+    base_url, session_id = seeded_session
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"], origin=base_url)
+    page.context.route(
+        f"{_CURRENT_ORIGIN}/**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="text/html",
+            body="<title>Connected Omnigent host</title>",
+        ),
+    )
+    page.add_init_script(_SERVER_PICKER_INIT_SCRIPT)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    trigger = page.get_by_test_id("sidebar-server-picker")
+    expect(trigger).to_be_visible(timeout=30_000)
+    trigger.click()
+
+    open_action = page.get_by_role("menuitem", name="Open server in new tab")
+    copy_action = page.get_by_role("menuitem", name="Copy server URL")
+    expect(open_action).to_have_attribute("href", _CURRENT_ORIGIN)
+    expect(open_action).to_have_attribute("target", "_blank")
+    expect(open_action).to_have_attribute("rel", "noopener noreferrer")
+    assert (copy_action.bounding_box() or {}).get("height", 0) >= 43.5
+
+    page.keyboard.press("Escape")
+    trigger.focus()
+    trigger.press("Enter")
+    open_action = page.get_by_role("menuitem", name="Open server in new tab")
+    copy_action = page.get_by_role("menuitem", name="Copy server URL")
+    expect(open_action).to_be_visible()
+    copy_action.focus()
+    expect(copy_action).to_be_focused()
+    copy_action.press("Enter")
+
+    expect(page.get_by_role("status")).to_contain_text("Server URL copied.")
+    assert page.evaluate("navigator.clipboard.readText()") == _CURRENT_ORIGIN
+
+    expect(open_action).to_be_hidden()
+    trigger.click()
+    open_action = page.get_by_role("menuitem", name="Open server in new tab")
+    expect(open_action).to_be_visible()
+    with page.expect_popup() as popup_info:
+        open_action.click()
+    popup = popup_info.value
+    popup.wait_for_load_state()
+    assert popup.url == f"{_CURRENT_ORIGIN}/"
+    popup.close()

--- a/web/src/shell/SidebarServerPicker.test.tsx
+++ b/web/src/shell/SidebarServerPicker.test.tsx
@@ -9,11 +9,19 @@ import { SidebarServerPicker } from "./SidebarServerPicker";
 const getServerPicker = vi.fn();
 const switchServer = vi.fn();
 const openServerSetup = vi.fn();
+const copyText = vi.fn();
+const showToast = vi.fn();
 
 vi.mock("@/lib/nativeBridge", () => ({
   getServerPicker: () => getServerPicker(),
   switchServer: (url: string) => switchServer(url),
   openServerSetup: () => openServerSetup(),
+}));
+vi.mock("@/lib/clipboard", () => ({
+  copyText: (text: string) => copyText(text),
+}));
+vi.mock("@/components/ui/toast", () => ({
+  showToast: (...args: unknown[]) => showToast(...args),
 }));
 
 function renderPicker() {
@@ -38,9 +46,15 @@ beforeEach(() => {
   getServerPicker.mockReset();
   switchServer.mockReset();
   openServerSetup.mockReset();
+  copyText.mockReset();
+  copyText.mockResolvedValue(undefined);
+  showToast.mockReset();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("SidebarServerPicker", () => {
   it("renders nothing in a plain browser (bridge resolves null)", async () => {
@@ -126,6 +140,89 @@ describe("SidebarServerPicker", () => {
     fireEvent.click(await screen.findByText("other.example.com"));
 
     await waitFor(() => expect(switchServer).toHaveBeenCalledWith("https://other.example.com/"));
+  });
+
+  it("opens with the keyboard and activates the copy action", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://host.example.com:8443",
+      recentServers: [],
+    });
+    renderPicker();
+
+    const trigger = await screen.findByTestId("sidebar-server-picker");
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    const openAction = await screen.findByRole("menuitem", { name: "Open server in new tab" });
+    const copyAction = screen.getByRole("menuitem", { name: "Copy server URL" });
+    expect(openAction).toHaveFocus();
+
+    fireEvent.keyDown(openAction, { key: "ArrowDown" });
+    await waitFor(() => expect(copyAction).toHaveFocus());
+    fireEvent.keyDown(copyAction, { key: "Enter" });
+
+    await waitFor(() => expect(copyText).toHaveBeenCalledWith("https://host.example.com:8443"));
+  });
+
+  it("links the exact connected server URL to a protected new tab", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://host.example.com:8443",
+      recentServers: [],
+    });
+    renderPicker();
+
+    await openMenu();
+    const action = await screen.findByRole("menuitem", { name: "Open server in new tab" });
+
+    expect(action).toHaveAttribute("href", "https://host.example.com:8443");
+    expect(action).toHaveAttribute("target", "_blank");
+    expect(action).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("copies the exact connected server URL and confirms success visibly", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://host.example.com:8443",
+      recentServers: [],
+    });
+    renderPicker();
+
+    await openMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Copy server URL" }));
+
+    await waitFor(() => expect(copyText).toHaveBeenCalledWith("https://host.example.com:8443"));
+    expect(showToast).toHaveBeenCalledWith("Server URL copied.");
+  });
+
+  it("reports clipboard limitations instead of failing silently", async () => {
+    copyText.mockRejectedValue(new Error("Clipboard unavailable"));
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "https://host.example.com",
+      recentServers: [],
+    });
+    renderPicker();
+
+    await openMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Copy server URL" }));
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        "Couldn't copy the server URL. Copy it manually: https://host.example.com",
+        { duration: 0 },
+      ),
+    );
+  });
+
+  it("does not make unsupported server URL schemes openable", async () => {
+    getServerPicker.mockResolvedValue({
+      currentOrigin: "javascript:alert(document.domain)",
+      recentServers: [],
+    });
+    renderPicker();
+
+    await openMenu();
+    const action = await screen.findByRole("menuitem", { name: "Open server in new tab" });
+
+    expect(action).toHaveAttribute("aria-disabled", "true");
+    expect(action).not.toHaveAttribute("href");
   });
 
   it("opens the shell's setup page from 'Connect to new server…'", async () => {

--- a/web/src/shell/SidebarServerPicker.tsx
+++ b/web/src/shell/SidebarServerPicker.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from "react";
-import { CheckIcon, ChevronUpIcon, PlusIcon, ServerIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronUpIcon,
+  CopyIcon,
+  ExternalLinkIcon,
+  PlusIcon,
+  ServerIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { showToast } from "@/components/ui/toast";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,6 +23,7 @@ import {
   switchServer,
   type ServerPickerInfo,
 } from "@/lib/nativeBridge";
+import { copyText } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 import { SIDEBAR_ROW } from "./sidebarStyles";
 
@@ -36,13 +45,30 @@ function originOf(url: string): string | null {
   }
 }
 
+function openableServerUrl(url: string): string | null {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+async function copyServerUrl(url: string): Promise<void> {
+  try {
+    await copyText(url);
+    showToast("Server URL copied.");
+  } catch {
+    showToast(`Couldn't copy the server URL. Copy it manually: ${url}`, { duration: 0 });
+  }
+}
+
 /**
  * Server picker for the Electron desktop shell, pinned to the sidebar's bottom.
  *
  * A sidebar row (server glyph + current host + an upward chevron) that opens a
- * menu of organization-provided and recently-connected servers — selecting one
- * re-points the whole window via the shell — plus "Connect to new server…",
- * which returns the window to the shell's setup page.
+ * menu for visiting or copying the current URL, switching to organization-provided
+ * or recently connected servers, or returning to setup to connect a new server.
  *
  * This deliberately lives at the bottom of the sidebar rather than in the
  * window's title bar. The macOS shell hides the native title bar (titleBarStyle
@@ -87,6 +113,7 @@ export function SidebarServerPicker() {
     return origin !== info.currentOrigin && (origin === null || !managedOrigins.has(origin));
   });
   const currentHost = hostOf(info.currentOrigin);
+  const openUrl = openableServerUrl(info.currentOrigin);
 
   return (
     // shrink-0 keeps the row at its natural height so the scrolling session
@@ -174,6 +201,28 @@ export function SidebarServerPicker() {
               ))}
             </>
           ) : null}
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-muted-foreground">Current server</DropdownMenuLabel>
+          {openUrl ? (
+            <DropdownMenuItem asChild className="min-h-11 gap-2">
+              <a href={openUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLinkIcon className="size-4 shrink-0" />
+                Open server in new tab
+              </a>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem disabled className="min-h-11 gap-2">
+              <ExternalLinkIcon className="size-4 shrink-0" />
+              Open server in new tab
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            className="min-h-11 gap-2"
+            onSelect={() => void copyServerUrl(info.currentOrigin)}
+          >
+            <CopyIcon className="size-4 shrink-0" />
+            Copy server URL
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem className="gap-2" onSelect={() => openServerSetup()}>
             <PlusIcon className="size-4 shrink-0" />


### PR DESCRIPTION
## Related issue

Closes #4902

## Summary

- Add obvious **Open server in new tab** and **Copy server URL** actions to the bottom-left server selector without changing recent-server switching or setup navigation.
- Use a native protected link for reliable keyboard/mobile activation, restrict opening to HTTP(S), and keep copy available for unsupported origins.
- Confirm successful copies visibly and keep a persistent, manually copyable URL message when clipboard access is unavailable.

**ELI5:** The server menu now lets you visit or copy the server address directly instead of finding it elsewhere.

```text
Server selector
├─ Recents (existing switch behavior)
├─ Current server
│  ├─ Open in new tab
│  └─ Copy URL → visible confirmation
└─ Connect to new server… (existing behavior)
```

## Test Plan

- `cd web && pnpm exec vitest run src/shell/SidebarServerPicker.test.tsx` → 11 tests passed.
- `uv run --frozen pytest tests/e2e_ui/desktop/test_sidebar_server_picker.py -v` → 1 Playwright test passed in Chromium.
- `cd web && pnpm run lint` → passed with zero warnings.
- `cd web && pnpm exec tsc -b --force` → passed.
- `cd web && pnpm run build` → production bundle built successfully.
- `uv run --frozen pre-commit run --files web/src/shell/SidebarServerPicker.tsx web/src/shell/SidebarServerPicker.test.tsx tests/e2e_ui/desktop/test_sidebar_server_picker.py` → all applicable repository checks passed.
- Coverage verifies keyboard activation, mobile-sized actions, exact open/copy URL values, protected new-tab behavior, visible success confirmation, clipboard failure fallback, unsafe-scheme rejection, and preserved selector actions.

## Demo

**Server selector actions** — the bottom-left selector shows the connected server with both URL actions.

![Bottom-left server selector open with Open server in new tab and Copy server URL actions](https://github.com/user-attachments/assets/f026fb77-04d6-434b-b03a-a9e0cfa6b7fe)

**Copy confirmation** — the successful copy toast is visible alongside the connected server URL context.

![Server URL copied confirmation visible with the connected server URL context](https://github.com/user-attachments/assets/298ea4aa-1fc2-44f3-b799-8c6f46d2ed38)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The component suite covers failure paths and unsafe URLs; the Playwright test drives the rendered Electron-only selector through its real browser and clipboard behavior.

## Changelog

Open or copy your connected server URL from the sidebar server selector