### PR TITLE
fix(web): replace worktree name spaces with dashes

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import sys
 import threading
 from collections.abc import Coroutine
 from typing import Any
@@ -3025,6 +3026,9 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
         try:
+            await page.context.grant_permissions(
+                ["clipboard-read", "clipboard-write"], origin=base_url
+            )
             create_bodies: list[dict[str, Any]] = []
             await _register_common_routes(
                 page, created_session_id=session_id, create_bodies=create_bodies
@@ -3041,16 +3045,30 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
                 state="visible", timeout=30_000
             )
 
-            # Open the worktree chip and name a branch + base branch.
+            # Typed spaces become dashes as soon as the input event lands.
             await page.get_by_test_id("new-chat-landing-branch-chip").click()
-            await page.get_by_test_id("new-chat-landing-branch-input").fill("feature/login")
+            branch_input = page.get_by_test_id("new-chat-landing-branch-input")
+            await branch_input.press_sequentially("feature login")
+            await expect(branch_input).to_have_value("feature-login")
+
+            # A real clipboard paste normalizes every space through the same
+            # mobile-safe input path, and the transformed value is submitted.
+            select_all = "Meta+A" if sys.platform == "darwin" else "Control+A"
+            paste = "Meta+V" if sys.platform == "darwin" else "Control+V"
+            await branch_input.press(select_all)
+            await page.evaluate(
+                "(text) => navigator.clipboard.writeText(text)", "release candidate"
+            )
+            await branch_input.press(paste)
+            await expect(branch_input).to_have_value("release-candidate")
+
             # The base-branch input only appears once a branch name is set.
             await expect(page.get_by_test_id("new-chat-landing-base-branch-input")).to_be_visible()
             await page.get_by_test_id("new-chat-landing-base-branch-input").fill("main")
 
             # The chip label follows the branch name.
             await expect(page.get_by_test_id("new-chat-landing-branch-chip")).to_contain_text(
-                "feature/login"
+                "release-candidate"
             )
 
             # Filling the message closes the popover, then send.
@@ -3061,7 +3079,10 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
             body = create_bodies[0]
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
-            assert body.get("git") == {"branch_name": "feature/login", "base_branch": "main"}, body
+            assert body.get("git") == {
+                "branch_name": "release-candidate",
+                "base_branch": "main",
+            }, body
         finally:
             await browser.close()
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2134,6 +2134,58 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-worktree-option")).toBeNull();
   });
 
+  it("replaces a typed space with a dash immediately", async () => {
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    const branchInput = screen.getByTestId("new-chat-landing-branch-input") as HTMLInputElement;
+    for (const character of "feature new~name") {
+      fireEvent.input(branchInput, {
+        target: { value: `${branchInput.value}${character}` },
+      });
+      if (character === " ") {
+        expect(branchInput.value).toBe("feature-");
+      }
+    }
+
+    // Other invalid characters remain available to the existing branch-name validation.
+    expect(branchInput.value).toBe("feature-new~name");
+  });
+
+  it("replaces pasted spaces with dashes immediately and submits the transformed value", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    const branchInput = screen.getByTestId("new-chat-landing-branch-input") as HTMLInputElement;
+    fireEvent.paste(branchInput, {
+      clipboardData: { getData: () => "fix pasted branch" },
+    });
+    fireEvent.input(branchInput, { target: { value: "fix pasted branch" } });
+    expect(branchInput.value).toBe("fix-pasted-branch");
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "use the normalized branch" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      git?: { branch_name: string };
+    };
+    expect(body.git?.branch_name).toBe("fix-pasted-branch");
+  });
+
   it("generates a unique worktree branch name and sends it on create", async () => {
     authenticatedFetchMock.mockResolvedValue({
       ok: true,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -5117,7 +5117,7 @@ export function NewChatLandingScreen() {
                           id="landing-branch-name"
                           type="text"
                           value={branchName}
-                          onChange={(e) => setBranchName(e.target.value)}
+                          onChange={(e) => setBranchName(e.target.value.replaceAll(" ", "-"))}
                           onFocus={() => setBranchInputFocused(true)}
                           // Delay so a click on a dropdown option registers
                           // before the list unmounts on blur.


### PR DESCRIPTION
## Related issue

Closes #4901

## Summary

Replace every typed or pasted ASCII space in the worktree-name input with a dash immediately. The controlled input keeps existing branch-name validation unchanged for all other invalid characters and submits the displayed normalized value.

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/shell/NewChatDialog.test.tsx -t 'replaces (a typed|pasted) space'` — 2 passed
- `uv run pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_add_worktree -v` — 1 passed; verified sequential typing, clipboard paste, immediate display, and submitted `branch_name`
- `cd web && pnpm run lint && pnpm run type-check && pnpm run build` — passed
- `uv run --frozen pre-commit run --from-ref upstream/main --to-ref HEAD` — all applicable checks passed

## Demo

**Typing:** entering `feature login` immediately displays `feature-login` in the worktree-name input.

![Worktree name after typing spaces](https://github.com/user-attachments/assets/aa84f47b-030f-49e8-9062-db271612fbae)

**Pasting:** pasting `release candidate` immediately displays `release-candidate` in the same input.

![Worktree name after pasting spaces](https://github.com/user-attachments/assets/d8d0f3b3-90cd-4b40-bad8-e353127aef8d)
## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Vitest covers typed and pasted input events, preservation of another invalid character for existing validation, and the submitted payload. Playwright covers real sequential typing and an actual clipboard paste through Chromium.

## Changelog

Spaces in worktree names now turn into dashes as you type or paste