### PR TITLE
feat(web): allow forking from user messages

### DIFF
--- a/tests/e2e_ui/fork_session/test_fork_from_middle.py
+++ b/tests/e2e_ui/fork_session/test_fork_from_middle.py
@@ -1,18 +1,14 @@
 """Browser e2e: forking from the MIDDLE of a conversation truncates history.
 
-The "Fork from here" per-message action passes that response's id as
+The "Fork from here" user-message action passes that prompt's response id as
 ``up_to_response_id``, so the server deep-copies the transcript only up to
-and including the selected turn. This test drives the real chain — two
-marked turns → fork from the FIRST assistant's action → navigate into the
-clone — and asserts truncation two independent ways:
+and including the selected prompt. This test drives the real chain — two
+marked turns → fork from the FIRST user message's action → navigate into the
+clone — and asserts the exact truncation boundary in the rendered history:
 
-1. The rendered fork transcript shows the pre-fork (kept) user turn and
-   NOT the post-fork (dropped) one — the DOM proves the server copied a
-   truncated item list, not the whole conversation.
-2. Asking the clone "what did I ask you" surfaces only the kept code word.
-   The SDK harness replays the copied Omnigent transcript as context, so a
-   reply that recalls the dropped word would mean the truncation point was
-   ignored and the full history leaked into the fork.
+1. The rendered fork transcript shows the selected prompt, but neither its
+   reply nor the later turn — the DOM proves the server honored the user's
+   distinct anchor instead of the assistant response id.
 
 Both source and fork run the seeded ``hello_world`` (openai-agents SDK)
 agent, so this is fully runnable in the e2e_ui harness (no host / native
@@ -23,10 +19,10 @@ from __future__ import annotations
 
 import re
 
-import httpx
 from playwright.sync_api import Page, expect
 
-from tests.e2e_ui.conftest import configure_mock_llm
+from omnigent.entities import MessageData, NewConversationItem
+from tests.e2e_ui.conftest import seed_committed_items
 
 # Two distinct code words with no shared substring, so the kept/dropped
 # assertions can't satisfy each other. Only the KEPT word is part of the
@@ -42,64 +38,91 @@ _USER = '[data-testid="message-bubble"][data-role="user"]'
 def test_fork_from_middle_truncates_history(
     page: Page,
     seeded_session: tuple[str, str],
-    runner_id: str,
-    mock_llm_server_url: str,
 ) -> None:
-    """Fork from the first turn — the clone carries only history up to it.
+    """Fork from the first prompt — its reply and later history are excluded.
 
     Failure modes this catches:
 
     - ``up_to_response_id`` is dropped on the wire or ignored server-side
       (the clone renders the dropped turn too — full-history copy).
-    - The fork action on a non-last message forks the WHOLE session (the
-      per-message action wires the wrong response id).
-    - The truncated transcript hydrates but the SDK replay still feeds the
-      dropped turn to the model (recall surfaces the dropped word).
+    - The user action sends the assistant response id instead of the prompt's
+      own id (the first reply appears in the clone).
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
         runner-bound ``hello_world`` session.
-    :param runner_id: The shared spawned runner's id — the fork is bound to
-        it before the recall turn (the non-coding fork flow creates the
-        clone unbound, so a message would otherwise have no runner).
     """
     base_url, session_id = seeded_session
 
-    # Content-route the recall turn so the mock echoes the kept marker.
-    # Turns 1 & 2 ("reply with just OK") hit the generic fallback ("Mock LLM
-    # response.") which is enough for the fork-point anchor assertions.
-    configure_mock_llm(
-        mock_llm_server_url,
-        [{"text": _KEPT_MARKER}],
-        key="fork-recall",
-        match="What code word did I ask you to remember",
+    # Seed the same distinct turn_*/resp_* shape produced by the live web path.
+    # Direct persistence makes the truncation test deterministic while still
+    # exercising real history hydration, UI state, HTTP, and store slicing.
+    seed_committed_items(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="turn_user_1",
+                data=MessageData(
+                    role="user",
+                    content=[
+                        {
+                            "type": "input_text",
+                            "text": (
+                                f"Remember this code word and reply with just OK: {_KEPT_MARKER}"
+                            ),
+                        }
+                    ],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_assistant_1",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "OK"}],
+                    agent="hello_world",
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="turn_user_2",
+                data=MessageData(
+                    role="user",
+                    content=[
+                        {
+                            "type": "input_text",
+                            "text": (
+                                f"Now also remember this code word and reply with just OK: "
+                                f"{_DROPPED_MARKER}"
+                            ),
+                        }
+                    ],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_assistant_2",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "OK"}],
+                    agent="hello_world",
+                ),
+            ),
+        ],
     )
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    composer = page.get_by_placeholder("Send a message…")
-    expect(composer).to_be_visible()
-
-    # Turn 1 (KEPT): plant the first code word and wait for its reply so the
-    # fork has a committed assistant response to anchor the action on.
-    composer.fill(f"Remember this code word and reply with just OK: {_KEPT_MARKER}")
-    page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator(_ASSISTANT)
-    expect(assistant).to_have_count(1, timeout=60_000)
-
-    # Turn 2 (DROPPED): plant the second code word AFTER the fork point.
-    # Forking from turn 1's response must exclude this turn entirely.
-    composer.fill(f"Now also remember this code word and reply with just OK: {_DROPPED_MARKER}")
-    page.get_by_role("button", name="Send", exact=True).click()
     expect(assistant).to_have_count(2, timeout=60_000)
 
-    # Fork from the FIRST assistant response (the middle of the now
-    # two-turn conversation). The action lives inside that bubble's action
-    # bar (dimmed until hover but clickable); scoping the locator to the
-    # first bubble guarantees we pass turn 1's response id, not turn 2's.
-    first_assistant = assistant.nth(0)
-    first_assistant.hover()
-    first_assistant.get_by_test_id("fork-from-response").click()
+    # Fork from the FIRST user message (the middle of the now two-turn
+    # conversation). Its action must pass the prompt's turn_* id, not the
+    # adjacent assistant bubble's resp_* id.
+    first_user = page.locator(_USER).nth(0)
+    first_user.hover()
+    first_user.get_by_test_id("fork-from-user-message").click()
 
     dialog = page.get_by_test_id("fork-session-dialog")
     expect(dialog).to_be_visible()
@@ -120,35 +143,9 @@ def test_fork_from_middle_truncates_history(
     fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
     assert fork_id != session_id
 
-    # (1) DOM truncation: the kept user turn is present, the dropped one is
-    # absent. to_have_count(0) retries, so this holds even if the dropped
-    # bubble would only ever appear via a (buggy) full-history copy.
+    # DOM truncation: the selected prompt is present, but its assistant
+    # reply and the later turn are absent. A copied first reply means the UI
+    # sent the assistant anchor (or an imported/shared-id cutoff) instead.
     expect(page.locator(_USER).filter(has_text=_KEPT_MARKER).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_ASSISTANT)).to_have_count(0)
     expect(page.locator(_USER).filter(has_text=_DROPPED_MARKER)).to_have_count(0)
-
-    # The non-coding fork is created UNBOUND (the dialog only launches a
-    # runner for a coding source), so a recall turn would have nothing to
-    # dispatch to. Bind it to the shared runner — same PATCH the
-    # ``seeded_session`` fixture uses — then reload so the client picks up
-    # the binding before sending.
-    bind = httpx.patch(
-        f"{base_url}/v1/sessions/{fork_id}",
-        json={"runner_id": runner_id},
-        timeout=10.0,
-    )
-    bind.raise_for_status()
-    page.reload()
-
-    # (2) Recall: ask the clone what it was told to remember. The reply must
-    # echo the kept word and never the dropped one. The copied OK reply is
-    # the only assistant bubble so far; the recall answer is the second.
-    fork_composer = page.get_by_placeholder("Send a message…")
-    expect(fork_composer).to_be_visible()
-    fork_composer.fill("What code word did I ask you to remember? Reply with the code word only.")
-    page.get_by_role("button", name="Send", exact=True).click()
-    fork_assistant = page.locator(_ASSISTANT)
-    expect(fork_assistant).to_have_count(2, timeout=60_000)
-
-    recall = fork_assistant.nth(1)
-    expect(recall).to_contain_text(_KEPT_MARKER, timeout=60_000)
-    expect(recall).not_to_contain_text(_DROPPED_MARKER)

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -62,6 +62,60 @@ function mkExec(name: string, callId: string): ToolExecution {
 }
 
 describe("buildBubbles — bubble grouping", () => {
+  it("preserves a hydrated user message's response id as its fork anchor", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg_user",
+        response_id: "turn_user_123",
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: [{ type: "input_text", text: "Try this approach" }],
+      } as ConversationItem,
+      {
+        id: "msg_assistant",
+        response_id: "resp_assistant_456",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "Here is the result" }],
+      } as ConversationItem,
+    ];
+
+    const user = buildBubbles(itemsToBlocks(items), null)[0] as Extract<Bubble, { kind: "user" }>;
+
+    expect(user.responseId).toBe("turn_user_123");
+  });
+
+  it("preserves a shared imported response id on both user and assistant bubbles", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "imported_user",
+        response_id: "imported_turn_1",
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: [{ type: "input_text", text: "Imported prompt" }],
+      } as ConversationItem,
+      {
+        id: "imported_assistant",
+        response_id: "imported_turn_1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "Imported reply" }],
+      } as ConversationItem,
+    ];
+
+    const [user, assistant] = buildBubbles(itemsToBlocks(items), null) as [
+      Extract<Bubble, { kind: "user" }>,
+      Extract<Bubble, { kind: "assistant" }>,
+    ];
+
+    expect(user.responseId).toBe("imported_turn_1");
+    expect(assistant.responseId).toBe("imported_turn_1");
+  });
+
   it("UserMessageBlock + TextDone in same response → [user, assistant{ items: [text] }]", () => {
     const blocks: AnyBlock[] = [
       {
@@ -2870,11 +2924,25 @@ describe("bubblesEqual — React.memo comparator", () => {
     // a hydrated author would not repaint over an optimistic unattributed
     // bubble of the same itemId/content.
     const content: MessageContentBlock[] = [{ type: "input_text", text: "Hello" }];
-    const alice: Bubble = { kind: "user", itemId: "u1", content, createdBy: "alice@example.com" };
-    const bob: Bubble = { kind: "user", itemId: "u1", content, createdBy: "bob@example.com" };
-    const none: Bubble = { kind: "user", itemId: "u1", content };
+    const alice: Bubble = {
+      kind: "user",
+      itemId: "u1",
+      responseId: "turn_1",
+      content,
+      createdBy: "alice@example.com",
+    };
+    const bob: Bubble = {
+      kind: "user",
+      itemId: "u1",
+      responseId: "turn_1",
+      content,
+      createdBy: "bob@example.com",
+    };
+    const none: Bubble = { kind: "user", itemId: "u1", responseId: "turn_1", content };
+    const otherResponse: Bubble = { ...alice, responseId: "turn_2" };
     expect(bubblesEqual(alice, bob)).toBe(false);
     expect(bubblesEqual(none, alice)).toBe(false);
+    expect(bubblesEqual(alice, otherResponse)).toBe(false);
     expect(bubblesEqual(alice, alice)).toBe(true);
   });
 });

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -146,6 +146,8 @@ export type Bubble =
   | {
       kind: "user";
       itemId: string;
+      /** Server response identifier used as the inclusive fork anchor. */
+      responseId: string;
       content: MessageContentBlock[];
       /** Human author email, when known. */
       createdBy?: string;
@@ -789,6 +791,7 @@ function walkBubbles(
       bubbles.push({
         kind: "user",
         itemId: b.ctx.itemId ?? `user_${i}`,
+        responseId: b.ctx.responseId,
         content: b.content,
         ...(b.ctx.createdBy !== undefined ? { createdBy: b.ctx.createdBy } : {}),
         // Server stamp on cold load, client stamp while live — display
@@ -1705,6 +1708,7 @@ export function bubblesEqual(a: Bubble, b: Bubble): boolean {
   if (a.kind === "user" && b.kind === "user") {
     if (
       a.itemId !== b.itemId ||
+      a.responseId !== b.responseId ||
       a.createdBy !== b.createdBy ||
       a.createdAtS !== b.createdAtS ||
       a.stableKey !== b.stableKey ||

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -347,6 +347,24 @@ describe("forkSession", () => {
     expect(JSON.parse(init.body as string)).toEqual({});
   });
 
+  it("forwards a user-message response id as the server fork anchor", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    await forkSession("conv_src", undefined, undefined, "turn_user_123");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      up_to_response_id: "turn_user_123",
+    });
+  });
+
   it("surfaces a non-ok response as a thrown error (e.g. 403 no access)", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 403 }));
     await expect(forkSession("conv_src")).rejects.toThrow(/403/);

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -187,6 +187,7 @@ describe("BubbleView dispatch", () => {
         bubble={{
           kind: "user",
           itemId: "u1",
+          responseId: "turn_u1",
           content: [{ type: "input_text", text: "hello there" }],
         }}
       />,

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -470,6 +470,7 @@ describe("buildPendingBubbles", () => {
 const userBubble = (id: string): Bubble => ({
   kind: "user",
   itemId: id,
+  responseId: `turn_${id}`,
   content: [{ type: "input_text", text: id }],
 });
 const assistantText = (id: string): Bubble => ({

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -447,6 +447,8 @@ export function buildPendingBubbles(
       kind: "user",
       // No server item id yet; tempId keeps React keys stable until promotion.
       itemId: p.tempId,
+      // The committed item supplies the server anchor after promotion.
+      responseId: "",
       content: p.content,
       ...(author !== null ? { createdBy: author } : {}),
       // Stamped once at send time; absent for snapshot-replayed entries,
@@ -3312,6 +3314,8 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
   const { isCopied, handleCopy } = useCopyMessage(() => text);
   const ts = formatBubbleTimestamp(bubble.createdAtS);
+  const forkDialog = useForkDialog();
+  const canFork = Boolean(forkDialog?.canFork && bubble.responseId);
   // Runtime-injected `[System: ...]` notifications (task completion,
   // timer firings, terminal idle) ride in on role=user. When the content
   // is a pure system marker — no attached images or files — swap the
@@ -3452,11 +3456,11 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
             {text && <FilePathAwareMessageResponse breaks>{text}</FilePathAwareMessageResponse>}
           </MessageContent>
         </div>
-        {/* Skip an empty row when there is neither a timestamp nor a copy
+        {/* Skip an empty row when there is neither a timestamp nor an
             action. 40%-visible on touch (no hover), hover/focus-reveal on
             desktop. py-1 matches the design prototype's 24px action row;
             the timestamp rides inside it instead of adding a new row. */}
-        {(ts || text) && (
+        {(ts || text || canFork) && (
           <div className="flex items-center justify-end gap-3 py-1 opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
             {ts && (
               <span
@@ -3466,16 +3470,31 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                 {ts}
               </span>
             )}
-            {text && (
+            {(text || canFork) && (
               <MessageActions>
-                <MessageAction
-                  tooltip="Copy"
-                  size="icon-xxs"
-                  onClick={handleCopy}
-                  componentId="chat.message.copy_user"
-                >
-                  {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
-                </MessageAction>
+                {text && (
+                  <MessageAction
+                    tooltip="Copy"
+                    size="icon-xxs"
+                    onClick={handleCopy}
+                    componentId="chat.message.copy_user"
+                  >
+                    {isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+                  </MessageAction>
+                )}
+                {canFork && (
+                  <MessageAction
+                    tooltip="Fork from here"
+                    size="icon-xxs"
+                    data-testid="fork-from-user-message"
+                    onClick={() =>
+                      forkDialog?.openForkDialog({ upToResponseId: bubble.responseId })
+                    }
+                    componentId="chat.message.fork"
+                  >
+                    <GitForkIcon size={14} />
+                  </MessageAction>
+                )}
               </MessageActions>
             )}
           </div>

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Bubble } from "@/lib/renderItems";
 import { FileViewerContext } from "@/shell/FileViewerContext";
+import { ForkDialogContextProvider } from "@/shell/ForkDialogContext";
 import { BubbleView } from "./ChatPage";
 
 // UserBubble renders its text through the same markdown renderer as the
@@ -23,6 +24,7 @@ function userBubble(text: string, overrides: Partial<Extract<Bubble, { kind: "us
   return {
     kind: "user" as const,
     itemId: "u1",
+    responseId: "turn_user_1",
     content: [{ type: "input_text" as const, text }],
     ...overrides,
   };
@@ -255,6 +257,53 @@ describe("UserBubble copy button", () => {
       }),
     );
     expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+});
+
+describe("per-message fork actions", () => {
+  function renderForkableBubble(bubble: Bubble, openForkDialog = vi.fn()) {
+    render(
+      <ForkDialogContextProvider value={{ canFork: true, openForkDialog }}>
+        <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+          <BubbleView bubble={bubble} />
+        </FileViewerContext.Provider>
+      </ForkDialogContextProvider>,
+    );
+    return openForkDialog;
+  }
+
+  it("opens a fork from a user message using that message's response id", () => {
+    const openForkDialog = renderForkableBubble(
+      userBubble("fork this prompt", { responseId: "turn_user_distinct" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork from here" }));
+
+    expect(openForkDialog).toHaveBeenCalledWith({ upToResponseId: "turn_user_distinct" });
+  });
+
+  it("passes through an imported response id shared with the assistant reply", () => {
+    const openForkDialog = renderForkableBubble(
+      userBubble("imported prompt", { responseId: "imported_shared_turn" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork from here" }));
+
+    expect(openForkDialog).toHaveBeenCalledWith({ upToResponseId: "imported_shared_turn" });
+  });
+
+  it("does not offer a fork before an optimistic message has a server anchor", () => {
+    renderForkableBubble(userBubble("still pending", { responseId: "" }));
+
+    expect(screen.queryByRole("button", { name: "Fork from here" })).toBeNull();
+  });
+
+  it("still forks an assistant response using the assistant response id", () => {
+    const openForkDialog = renderForkableBubble(assistantBubble("completed"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork from here" }));
+
+    expect(openForkDialog).toHaveBeenCalledWith({ upToResponseId: "codex_turn_123" });
   });
 });
 


### PR DESCRIPTION
## Related issue

Closes #4420

## Summary

- Add **Fork from here** to committed user messages and preserve each message's server `response_id` through bubble state into the existing fork dialog/API.
- Keep optimistic messages hidden until they have a valid server anchor, while preserving assistant-response behavior and current interaction telemetry.
- Cover distinct live IDs and imported histories where the prompt and reply share one ID.

ELI5: a prompt now keeps its own bookmark, so choosing **Fork from here** sends that exact bookmark through the existing fork flow.

```text
user message response_id → Bubble.responseId → fork dialog → up_to_response_id
```

## Test Plan

- `pnpm exec vitest run src/lib/renderItems.test.ts src/pages/ChatPage.userBubble.test.tsx src/pages/ChatPage.test.ts src/pages/ChatPage.indicators.test.tsx src/shell/ForkSessionDialog.test.tsx src/lib/sessionsApi.test.ts` → 453 passed
- `uv run --group test pytest tests/server/routes/test_sessions_fork.py -q` → 25 passed
- `uv run --no-sync pytest tests/e2e_ui/fork_session/test_fork_from_middle.py -q` → real Chromium action-to-server fork passed
- `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check`, and `pnpm run build` → passed
- `uv run --no-sync pre-commit run --all-files` → all hooks passed

## Demo

![Fork from here shown on a user message](https://github.com/user-attachments/assets/e90db7de-a538-4a38-b842-e73d3bfcfc24)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests exercise hydrated history through bubble construction, the per-message action/context boundary, fork-dialog forwarding, the snake_case API payload, and a Playwright action-to-server fork from a distinct user anchor. The existing route suite verifies that a user-role response anchor is accepted and truncated inclusively.

## Changelog

Fork a conversation directly from any committed user message.
