### PR TITLE
fix(claude-native): preserve nested subagent parents

### DIFF
--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -1404,9 +1404,10 @@ def _subagent_parents_by_tool_use(
     """Correlate Claude spawn tool ids to their immediate transcript owner.
 
     Reads the root transcript and every ``agent-*.jsonl`` in full. The caller
-    only invokes this while new sub-agent meta files are appearing (a bounded,
-    transient window), so the re-read cost is paid during spawn bursts, not on
-    every idle poll.
+    only invokes this when unregistered meta files exist, so idle sessions pay
+    nothing. The common case is a transient spawn burst; the exception is an
+    orphan meta whose spawn record never lands, which keeps the transcripts
+    re-read on every poll until it appears (or the process restarts).
     """
     owners: dict[str, str | None] = {}
     ambiguous: set[str] = set()
@@ -1533,6 +1534,31 @@ async def _forward_available_subagents(
                     deferred.append((meta_path, meta, parent_subagent_id))
                     continue
                 if not parent_entry.child_conversation_id:
+                    # The parent was parked (registration exhausted its retries),
+                    # so its conversation will never exist and this child can never
+                    # attach. Park the child too rather than re-resolving it every
+                    # tick; the empty child id filters it out of the tail loops.
+                    if subagent_id not in updated.subagents:
+                        _logger.warning(
+                            "Parking claude-native sub-agent whose parent was "
+                            "dropped; parent_session=%s subagent_id=%s "
+                            "parent_subagent_id=%s",
+                            parent_session_id,
+                            subagent_id,
+                            parent_subagent_id,
+                        )
+                        updated = SubagentForwardState(
+                            subagents={
+                                **updated.subagents,
+                                subagent_id: SubagentEntry(
+                                    subagent_id=subagent_id,
+                                    child_conversation_id="",
+                                    parent_subagent_id=parent_subagent_id,
+                                ),
+                            }
+                        )
+                        await _write_subagent_forward_state_async(bridge_dir, updated)
+                        made_progress = True
                     continue
                 immediate_parent_session_id = parent_entry.child_conversation_id
             try:

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -1550,6 +1550,10 @@ async def _forward_available_subagents(
                     # attach. Park the child too rather than re-resolving it every
                     # tick; the empty child id filters it out of the tail loops.
                     if subagent_id not in updated.subagents:
+                        # No dead letter: the child can't be replayed anywhere
+                        # correct — its parent conversation never existed, and a
+                        # replay would re-post it under the root session and
+                        # flatten the hierarchy. The WARNING is the recovery signal.
                         _logger.warning(
                             "Parking claude-native sub-agent whose parent was "
                             "dropped; parent_session=%s subagent_id=%s "
@@ -1557,23 +1561,6 @@ async def _forward_available_subagents(
                             parent_session_id,
                             subagent_id,
                             parent_subagent_id,
-                        )
-                        # The parent's own dead letter can't carry descendant
-                        # info, so record the child's start payload too or its
-                        # metadata is unrecoverable on replay.
-                        append_dead_letter(
-                            bridge_dir,
-                            session_id=parent_session_id,
-                            event_type="external_subagent_start",
-                            payload={
-                                "subagent_id": subagent_id,
-                                "agent_type": meta["agentType"],
-                                "description": meta["description"],
-                                "tool_use_id": meta["toolUseId"],
-                                "parent_subagent_id": parent_subagent_id,
-                            },
-                            reason="parent sub-agent was dropped",
-                            delivered_ambiguous=False,
                         )
                         updated = SubagentForwardState(
                             subagents={

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import httpx
@@ -1495,11 +1495,8 @@ async def _forward_available_subagents(
     candidate_meta_paths = [
         path
         for path in meta_paths
-        if _subagent_id_from_meta_path(path) not in updated.subagents
-        and start_retry_tracker.retry_delay_s(
-            f"subagent_start:{_subagent_id_from_meta_path(path)}"
-        )
-        is None
+        if (sid := _subagent_id_from_meta_path(path)) not in updated.subagents
+        and start_retry_tracker.retry_delay_s(f"subagent_start:{sid}") is None
     ]
     parents_by_tool_use = (
         await asyncio.to_thread(
@@ -1744,14 +1741,10 @@ async def _forward_available_subagents(
                     # someone needs to recover it.
                     seen.add(item.source_id)
                     seen_source_ids.append(item.source_id)
-                    new_entry = SubagentEntry(
-                        subagent_id=entry.subagent_id,
-                        child_conversation_id=entry.child_conversation_id,
-                        parent_subagent_id=entry.parent_subagent_id,
+                    new_entry = replace(
+                        new_entry,
                         byte_offset=entry.byte_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                        last_activity_ts=new_entry.last_activity_ts,
-                        last_status=new_entry.last_status,
                     )
                     updated = SubagentForwardState(
                         subagents={**updated.subagents, subagent_id: new_entry}
@@ -1774,14 +1767,10 @@ async def _forward_available_subagents(
                     item_retry_tracker.clear(retry_key)
                     seen.add(item.source_id)
                     seen_source_ids.append(item.source_id)
-                    new_entry = SubagentEntry(
-                        subagent_id=entry.subagent_id,
-                        child_conversation_id=entry.child_conversation_id,
-                        parent_subagent_id=entry.parent_subagent_id,
+                    new_entry = replace(
+                        new_entry,
                         byte_offset=entry.byte_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
-                        last_activity_ts=new_entry.last_activity_ts,
-                        last_status=new_entry.last_status,
                     )
                     updated = SubagentForwardState(
                         subagents={**updated.subagents, subagent_id: new_entry}
@@ -1811,14 +1800,11 @@ async def _forward_available_subagents(
             had_item = True
             seen.add(item.source_id)
             seen_source_ids.append(item.source_id)
-            new_entry = SubagentEntry(
-                subagent_id=entry.subagent_id,
-                child_conversation_id=entry.child_conversation_id,
-                parent_subagent_id=entry.parent_subagent_id,
+            new_entry = replace(
+                new_entry,
                 byte_offset=entry.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now,
-                last_status=new_entry.last_status,
             )
             updated = SubagentForwardState(subagents={**updated.subagents, subagent_id: new_entry})
             await _write_subagent_forward_state_async(bridge_dir, updated)
@@ -1826,28 +1812,21 @@ async def _forward_available_subagents(
         # posted successfully (or there were no items at all).
         # Advancing past a failed item permanently skips it.
         if not items_failed and (result.byte_offset != entry.byte_offset or had_item):
-            new_entry = SubagentEntry(
-                subagent_id=entry.subagent_id,
-                child_conversation_id=entry.child_conversation_id,
-                parent_subagent_id=entry.parent_subagent_id,
+            new_entry = replace(
+                entry,
                 byte_offset=result.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now if had_item else entry.last_activity_ts,
-                last_status=entry.last_status,
             )
         elif had_item:
             # Items DID flow but a later post failed — still record
             # the activity timestamp so the status badge advances,
             # but leave byte_offset at the previous tick's value so
             # the failed items get retried.
-            new_entry = SubagentEntry(
-                subagent_id=entry.subagent_id,
-                child_conversation_id=entry.child_conversation_id,
-                parent_subagent_id=entry.parent_subagent_id,
-                byte_offset=entry.byte_offset,
+            new_entry = replace(
+                entry,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now,
-                last_status=entry.last_status,
             )
 
         # Quiescence-based status. Sub-agent transcripts don't carry
@@ -1888,15 +1867,7 @@ async def _forward_available_subagents(
                     )
                 else:
                     status_retry_tracker.clear(retry_key)
-                    new_entry = SubagentEntry(
-                        subagent_id=new_entry.subagent_id,
-                        child_conversation_id=new_entry.child_conversation_id,
-                        parent_subagent_id=new_entry.parent_subagent_id,
-                        byte_offset=new_entry.byte_offset,
-                        seen_source_ids=new_entry.seen_source_ids,
-                        last_activity_ts=new_entry.last_activity_ts,
-                        last_status=desired_status,
-                    )
+                    new_entry = replace(new_entry, last_status=desired_status)
 
         if new_entry is not entry:
             updated = SubagentForwardState(subagents={**updated.subagents, subagent_id: new_entry})

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -83,6 +83,9 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 # One per Claude Task-tool subagent; appears alongside the matching
 # ``agent-<id>.jsonl`` transcript.
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
+# Claude's built-in sub-agent spawn tool; its tool-use id is the ``toolUseId``
+# stamped into each ``agent-<id>.meta.json``.
+_SUBAGENT_SPAWN_TOOL_NAME = "Agent"
 
 
 def _subagent_id_from_meta_path(meta_path: Path) -> str:
@@ -1394,6 +1397,11 @@ def _tool_use_ids_in_transcript(
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "tool_use":
                 continue
+            # Only the sub-agent spawn tool mints the ids in ``.meta.json``.
+            # Restricting to it keeps an unrelated tool-use id collision from
+            # making a legitimate spawn look ambiguous.
+            if block.get("name") != _SUBAGENT_SPAWN_TOOL_NAME:
+                continue
             tool_use_id = block.get("id")
             if isinstance(tool_use_id, str) and tool_use_id:
                 tool_use_ids.add(tool_use_id)
@@ -1610,6 +1618,7 @@ async def _forward_available_subagents(
                             "agent_type": meta["agentType"],
                             "description": meta["description"],
                             "tool_use_id": meta["toolUseId"],
+                            "parent_subagent_id": parent_subagent_id,
                         },
                         reason="permanent HTTP failure after retries",
                         delivered_ambiguous=False,

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -1369,7 +1369,10 @@ def _tool_use_ids_in_transcript(
     :returns: Tool-use ids owned by this transcript.
     """
     try:
-        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+        # ``errors="replace"`` tolerates a snapshot that ends mid-multibyte char
+        # while Claude is writing; the mangled tail line fails JSON parse below
+        # and is skipped, and the completed record is read on the next poll.
+        lines = transcript_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return set()
     tool_use_ids: set[str] = set()
@@ -1546,6 +1549,23 @@ async def _forward_available_subagents(
                             parent_session_id,
                             subagent_id,
                             parent_subagent_id,
+                        )
+                        # The parent's own dead letter can't carry descendant
+                        # info, so record the child's start payload too or its
+                        # metadata is unrecoverable on replay.
+                        append_dead_letter(
+                            bridge_dir,
+                            session_id=parent_session_id,
+                            event_type="external_subagent_start",
+                            payload={
+                                "subagent_id": subagent_id,
+                                "agent_type": meta["agentType"],
+                                "description": meta["description"],
+                                "tool_use_id": meta["toolUseId"],
+                                "parent_subagent_id": parent_subagent_id,
+                            },
+                            reason="parent sub-agent was dropped",
+                            delivered_ambiguous=False,
                         )
                         updated = SubagentForwardState(
                             subagents={

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -43,6 +43,7 @@ from omnigent.harnesses.claude_native.bridge import (
 )
 from omnigent.harnesses.claude_native.message_display_hook import MESSAGE_DELTAS_FILE
 from omnigent.harnesses.claude_native.status import sync_raw_status_context
+from omnigent.inner.hook_scripts.subagent_router import AGENT_TOOL_NAMES
 from omnigent.models.model_metadata import concrete_reported_model
 from omnigent.native._native_post_delivery import (
     append_dead_letter,
@@ -84,8 +85,9 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 # ``agent-<id>.jsonl`` transcript.
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
 # Claude's built-in sub-agent spawn tool; its tool-use id is the ``toolUseId``
-# stamped into each ``agent-<id>.meta.json``.
-_SUBAGENT_SPAWN_TOOL_NAME = "Agent"
+# stamped into each ``agent-<id>.meta.json``. Reuse the router's canonical set so
+# both the current ``Agent`` name and the still-supported ``Task`` alias match.
+_SUBAGENT_SPAWN_TOOL_NAMES = frozenset(AGENT_TOOL_NAMES)
 
 
 def _subagent_id_from_meta_path(meta_path: Path) -> str:
@@ -1400,7 +1402,7 @@ def _tool_use_ids_in_transcript(
             # Only the sub-agent spawn tool mints the ids in ``.meta.json``.
             # Restricting to it keeps an unrelated tool-use id collision from
             # making a legitimate spawn look ambiguous.
-            if block.get("name") != _SUBAGENT_SPAWN_TOOL_NAME:
+            if block.get("name") not in _SUBAGENT_SPAWN_TOOL_NAMES:
                 continue
             tool_use_id = block.get("id")
             if isinstance(tool_use_id, str) and tool_use_id:

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -381,6 +381,9 @@ class SubagentEntry:
     :param child_conversation_id: Omnigent child Conversation id minted
         by the server's ``external_subagent_start`` handler,
         e.g. ``"conv_child456"``.
+    :param parent_subagent_id: Claude-side id of the immediate parent
+        sub-agent, or ``None`` when the top-level session spawned this
+        agent.
     :param byte_offset: Bytes already forwarded from the sub-agent's
         ``.jsonl``. ``0`` means we haven't read anything yet (the
         common case when the sub-agent has just been created).
@@ -403,6 +406,7 @@ class SubagentEntry:
 
     subagent_id: str
     child_conversation_id: str
+    parent_subagent_id: str | None = None
     byte_offset: int = 0
     seen_source_ids: tuple[str, ...] = ()
     last_activity_ts: float | None = None
@@ -1142,6 +1146,7 @@ def _read_subagent_forward_state(bridge_dir: Path) -> SubagentForwardState:
         if not isinstance(subagent_id, str) or not isinstance(row, dict):
             continue
         child_id = row.get("child_conversation_id")
+        parent_subagent_id = row.get("parent_subagent_id")
         byte_offset = row.get("byte_offset", 0)
         seen_source_ids = row.get("seen_source_ids", [])
         last_activity_ts = row.get("last_activity_ts")
@@ -1152,6 +1157,8 @@ def _read_subagent_forward_state(bridge_dir: Path) -> SubagentForwardState:
         # what keeps the parked sub-agent from being retried.
         if not isinstance(child_id, str):
             continue
+        if parent_subagent_id is not None and not isinstance(parent_subagent_id, str):
+            parent_subagent_id = None
         if not isinstance(byte_offset, int) or byte_offset < 0:
             byte_offset = 0
         if not isinstance(seen_source_ids, list) or not all(
@@ -1165,6 +1172,7 @@ def _read_subagent_forward_state(bridge_dir: Path) -> SubagentForwardState:
         entries[subagent_id] = SubagentEntry(
             subagent_id=subagent_id,
             child_conversation_id=child_id,
+            parent_subagent_id=parent_subagent_id,
             byte_offset=byte_offset,
             seen_source_ids=tuple(seen_source_ids),
             last_activity_ts=last_activity_ts,
@@ -1186,6 +1194,7 @@ def _write_subagent_forward_state(bridge_dir: Path, state: SubagentForwardState)
         "subagents": {
             entry.subagent_id: {
                 "child_conversation_id": entry.child_conversation_id,
+                "parent_subagent_id": entry.parent_subagent_id,
                 "byte_offset": entry.byte_offset,
                 "seen_source_ids": list(entry.seen_source_ids),
                 "last_activity_ts": entry.last_activity_ts,
@@ -1337,6 +1346,79 @@ def _read_subagent_meta(meta_path: Path) -> dict[str, str] | None:
     }
 
 
+def _tool_use_ids_in_transcript(
+    transcript_path: Path,
+    *,
+    include_sidechains: bool,
+) -> set[str]:
+    """Return assistant tool-use ids from a Claude transcript.
+
+    A partial trailing record is ignored because Claude may still be writing it;
+    the next watcher poll reads the completed record.
+
+    :param transcript_path: Claude JSONL transcript to inspect.
+    :param include_sidechains: Whether records mirrored from child agents
+        belong to this transcript owner.
+    :returns: Tool-use ids owned by this transcript.
+    """
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return set()
+    tool_use_ids: set[str] = set()
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        if record.get("isSidechain") is True and not include_sidechains:
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            tool_use_id = block.get("id")
+            if isinstance(tool_use_id, str) and tool_use_id:
+                tool_use_ids.add(tool_use_id)
+    return tool_use_ids
+
+
+def _subagent_parents_by_tool_use(
+    transcript_path: Path,
+    subagents_dir: Path,
+) -> dict[str, str | None]:
+    """Correlate Claude spawn tool ids to their immediate transcript owner."""
+    owners: dict[str, str | None] = {}
+    ambiguous: set[str] = set()
+    transcript_owners: list[tuple[Path, str | None]] = [(transcript_path, None)]
+    transcript_owners.extend(
+        (
+            path,
+            path.stem.removeprefix("agent-"),
+        )
+        for path in sorted(subagents_dir.glob("agent-*.jsonl"))
+    )
+    for path, owner_id in transcript_owners:
+        for tool_use_id in _tool_use_ids_in_transcript(
+            path,
+            include_sidechains=owner_id is not None,
+        ):
+            if tool_use_id in owners and owners[tool_use_id] != owner_id:
+                ambiguous.add(tool_use_id)
+            else:
+                owners[tool_use_id] = owner_id
+    for tool_use_id in ambiguous:
+        owners.pop(tool_use_id, None)
+    return owners
+
+
 async def _forward_available_subagents(
     *,
     client: httpx.AsyncClient,
@@ -1388,96 +1470,127 @@ async def _forward_available_subagents(
     # filesystem on the event loop.
     meta_paths = await asyncio.to_thread(lambda: sorted(subagents_dir.glob(_SUBAGENT_META_GLOB)))
     updated = state
-    for meta_path in meta_paths:
-        # ``agent-<id>.meta.json`` → ``<id>``
-        subagent_id = meta_path.stem.removeprefix("agent-").removesuffix(".meta")
-        if subagent_id in updated.subagents:
-            continue
-        retry_key = f"subagent_start:{subagent_id}"
-        if start_retry_tracker.retry_delay_s(retry_key) is not None:
-            continue
+    candidate_meta_paths = [
+        path
+        for path in meta_paths
+        if path.stem.removeprefix("agent-").removesuffix(".meta") not in updated.subagents
+        and start_retry_tracker.retry_delay_s(
+            "subagent_start:" + path.stem.removeprefix("agent-").removesuffix(".meta")
+        )
+        is None
+    ]
+    parents_by_tool_use = (
+        await asyncio.to_thread(
+            _subagent_parents_by_tool_use,
+            transcript_path,
+            subagents_dir,
+        )
+        if candidate_meta_paths
+        else {}
+    )
+    pending: list[tuple[Path, dict[str, str], str | None]] = []
+    for meta_path in candidate_meta_paths:
         meta = await asyncio.to_thread(_read_subagent_meta, meta_path)
         if meta is None:
-            # File may be mid-write; try again on the next tick.
             continue
-        try:
-            child_id = await _post_external_subagent_start(
-                client,
-                parent_session_id=parent_session_id,
-                subagent_id=subagent_id,
-                agent_type=meta["agentType"],
-                description=meta["description"],
-                tool_use_id=meta["toolUseId"],
-            )
-        except httpx.HTTPError as exc:
-            decision = start_retry_tracker.record_failure(retry_key, exc)
-            if decision.exhausted:
-                _logger.error(
-                    "Dropping claude-native sub-agent after permanent HTTP failures; "
-                    "parent_session=%s subagent_id=%s attempts=%s http_status=%s",
-                    parent_session_id,
+        tool_use_id = meta["toolUseId"]
+        if tool_use_id not in parents_by_tool_use:
+            # The spawning transcript record may still be mid-write.
+            continue
+        pending.append((meta_path, meta, parents_by_tool_use[tool_use_id]))
+
+    while pending:
+        deferred: list[tuple[Path, dict[str, str], str | None]] = []
+        made_progress = False
+        for meta_path, meta, parent_subagent_id in pending:
+            subagent_id = meta_path.stem.removeprefix("agent-").removesuffix(".meta")
+            retry_key = f"subagent_start:{subagent_id}"
+            if parent_subagent_id is None:
+                immediate_parent_session_id = parent_session_id
+            else:
+                parent_entry = updated.subagents.get(parent_subagent_id)
+                if parent_entry is None:
+                    deferred.append((meta_path, meta, parent_subagent_id))
+                    continue
+                if not parent_entry.child_conversation_id:
+                    continue
+                immediate_parent_session_id = parent_entry.child_conversation_id
+            try:
+                child_id = await _post_external_subagent_start(
+                    client,
+                    parent_session_id=immediate_parent_session_id,
+                    subagent_id=subagent_id,
+                    agent_type=meta["agentType"],
+                    description=meta["description"],
+                    tool_use_id=meta["toolUseId"],
+                )
+            except httpx.HTTPError as exc:
+                decision = start_retry_tracker.record_failure(retry_key, exc)
+                if decision.exhausted:
+                    _logger.error(
+                        "Dropping claude-native sub-agent after permanent HTTP failures; "
+                        "parent_session=%s subagent_id=%s attempts=%s http_status=%s",
+                        immediate_parent_session_id,
+                        subagent_id,
+                        decision.attempts,
+                        _http_status_for_log(exc),
+                    )
+                    append_dead_letter(
+                        bridge_dir,
+                        session_id=immediate_parent_session_id,
+                        event_type="external_subagent_start",
+                        payload={
+                            "subagent_id": subagent_id,
+                            "agent_type": meta["agentType"],
+                            "description": meta["description"],
+                            "tool_use_id": meta["toolUseId"],
+                        },
+                        reason="permanent HTTP failure after retries",
+                        delivered_ambiguous=False,
+                        http_status=_http_status_for_log(exc),
+                    )
+                    updated = SubagentForwardState(
+                        subagents={
+                            **updated.subagents,
+                            subagent_id: SubagentEntry(
+                                subagent_id=subagent_id,
+                                child_conversation_id="",
+                                parent_subagent_id=parent_subagent_id,
+                            ),
+                        }
+                    )
+                    await _write_subagent_forward_state_async(bridge_dir, updated)
+                    continue
+                _logger.warning(
+                    "Failed to register claude-native sub-agent; parent_session=%s "
+                    "subagent_id=%s attempt=%s permanent=%s next_retry_s=%.3f "
+                    "http_status=%s",
+                    immediate_parent_session_id,
                     subagent_id,
                     decision.attempts,
+                    decision.permanent,
+                    decision.delay_s,
                     _http_status_for_log(exc),
-                    extra={"session_id": parent_session_id},
+                    exc_info=True,
+                    extra={"session_id": immediate_parent_session_id},
                 )
-                # Dead-letter the dropped payload for recovery (#1120; replay #1579).
-                append_dead_letter(
-                    bridge_dir,
-                    session_id=parent_session_id,
-                    event_type="external_subagent_start",
-                    payload={
-                        "subagent_id": subagent_id,
-                        "agent_type": meta["agentType"],
-                        "description": meta["description"],
-                        "tool_use_id": meta["toolUseId"],
-                    },
-                    reason="permanent HTTP failure after retries",
-                    # Claude only dead-letters permanent 4xx (it retries
-                    # transient failures forever), so the server proved it
-                    # rejected the item: never ambiguous, never replayable (#1579).
-                    delivered_ambiguous=False,
-                    http_status=_http_status_for_log(exc),
-                )
-                # Park this sub-agent: insert a sentinel entry so we
-                # don't keep retrying. ``child_conversation_id=""``
-                # is filtered out by the tail / status loops below.
-                updated = SubagentForwardState(
-                    subagents={
-                        **updated.subagents,
-                        subagent_id: SubagentEntry(
-                            subagent_id=subagent_id,
-                            child_conversation_id="",
-                        ),
-                    }
-                )
-                await _write_subagent_forward_state_async(bridge_dir, updated)
                 continue
-            _logger.warning(
-                "Failed to register claude-native sub-agent; parent_session=%s "
-                "subagent_id=%s attempt=%s permanent=%s next_retry_s=%.3f "
-                "http_status=%s",
-                parent_session_id,
-                subagent_id,
-                decision.attempts,
-                decision.permanent,
-                decision.delay_s,
-                _http_status_for_log(exc),
-                exc_info=True,
-                extra={"session_id": parent_session_id},
+            start_retry_tracker.clear(retry_key)
+            updated = SubagentForwardState(
+                subagents={
+                    **updated.subagents,
+                    subagent_id: SubagentEntry(
+                        subagent_id=subagent_id,
+                        child_conversation_id=child_id,
+                        parent_subagent_id=parent_subagent_id,
+                    ),
+                }
             )
-            continue
-        start_retry_tracker.clear(retry_key)
-        updated = SubagentForwardState(
-            subagents={
-                **updated.subagents,
-                subagent_id: SubagentEntry(
-                    subagent_id=subagent_id,
-                    child_conversation_id=child_id,
-                ),
-            }
-        )
-        await _write_subagent_forward_state_async(bridge_dir, updated)
+            await _write_subagent_forward_state_async(bridge_dir, updated)
+            made_progress = True
+        if not made_progress:
+            break
+        pending = deferred
 
     # ── Tail each tracked sub-agent's transcript ────────
     now = time.time()
@@ -1562,6 +1675,7 @@ async def _forward_available_subagents(
                     new_entry = SubagentEntry(
                         subagent_id=entry.subagent_id,
                         child_conversation_id=entry.child_conversation_id,
+                        parent_subagent_id=entry.parent_subagent_id,
                         byte_offset=entry.byte_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                         last_activity_ts=new_entry.last_activity_ts,
@@ -1591,6 +1705,7 @@ async def _forward_available_subagents(
                     new_entry = SubagentEntry(
                         subagent_id=entry.subagent_id,
                         child_conversation_id=entry.child_conversation_id,
+                        parent_subagent_id=entry.parent_subagent_id,
                         byte_offset=entry.byte_offset,
                         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                         last_activity_ts=new_entry.last_activity_ts,
@@ -1627,6 +1742,7 @@ async def _forward_available_subagents(
             new_entry = SubagentEntry(
                 subagent_id=entry.subagent_id,
                 child_conversation_id=entry.child_conversation_id,
+                parent_subagent_id=entry.parent_subagent_id,
                 byte_offset=entry.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now,
@@ -1641,6 +1757,7 @@ async def _forward_available_subagents(
             new_entry = SubagentEntry(
                 subagent_id=entry.subagent_id,
                 child_conversation_id=entry.child_conversation_id,
+                parent_subagent_id=entry.parent_subagent_id,
                 byte_offset=result.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now if had_item else entry.last_activity_ts,
@@ -1654,6 +1771,7 @@ async def _forward_available_subagents(
             new_entry = SubagentEntry(
                 subagent_id=entry.subagent_id,
                 child_conversation_id=entry.child_conversation_id,
+                parent_subagent_id=entry.parent_subagent_id,
                 byte_offset=entry.byte_offset,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 last_activity_ts=now,
@@ -1701,6 +1819,7 @@ async def _forward_available_subagents(
                     new_entry = SubagentEntry(
                         subagent_id=new_entry.subagent_id,
                         child_conversation_id=new_entry.child_conversation_id,
+                        parent_subagent_id=new_entry.parent_subagent_id,
                         byte_offset=new_entry.byte_offset,
                         seen_source_ids=new_entry.seen_source_ids,
                         last_activity_ts=new_entry.last_activity_ts,

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -83,6 +83,13 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 # One per Claude Task-tool subagent; appears alongside the matching
 # ``agent-<id>.jsonl`` transcript.
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
+
+
+def _subagent_id_from_meta_path(meta_path: Path) -> str:
+    """``agent-<id>.meta.json`` / ``agent-<id>.jsonl`` → ``<id>``."""
+    return meta_path.stem.removeprefix("agent-").removesuffix(".meta")
+
+
 _DEFAULT_POLL_INTERVAL_S = 0.25
 # Minimum spacing between permission-mode pane reads. Unlike the model mirror
 # (which reads a JSON file), this spawns a ``tmux capture-pane`` subprocess, so
@@ -1394,15 +1401,18 @@ def _subagent_parents_by_tool_use(
     transcript_path: Path,
     subagents_dir: Path,
 ) -> dict[str, str | None]:
-    """Correlate Claude spawn tool ids to their immediate transcript owner."""
+    """Correlate Claude spawn tool ids to their immediate transcript owner.
+
+    Reads the root transcript and every ``agent-*.jsonl`` in full. The caller
+    only invokes this while new sub-agent meta files are appearing (a bounded,
+    transient window), so the re-read cost is paid during spawn bursts, not on
+    every idle poll.
+    """
     owners: dict[str, str | None] = {}
     ambiguous: set[str] = set()
     transcript_owners: list[tuple[Path, str | None]] = [(transcript_path, None)]
     transcript_owners.extend(
-        (
-            path,
-            path.stem.removeprefix("agent-"),
-        )
+        (path, _subagent_id_from_meta_path(path))
         for path in sorted(subagents_dir.glob("agent-*.jsonl"))
     )
     for path, owner_id in transcript_owners:
@@ -1473,9 +1483,9 @@ async def _forward_available_subagents(
     candidate_meta_paths = [
         path
         for path in meta_paths
-        if path.stem.removeprefix("agent-").removesuffix(".meta") not in updated.subagents
+        if _subagent_id_from_meta_path(path) not in updated.subagents
         and start_retry_tracker.retry_delay_s(
-            "subagent_start:" + path.stem.removeprefix("agent-").removesuffix(".meta")
+            f"subagent_start:{_subagent_id_from_meta_path(path)}"
         )
         is None
     ]
@@ -1495,7 +1505,17 @@ async def _forward_available_subagents(
             continue
         tool_use_id = meta["toolUseId"]
         if tool_use_id not in parents_by_tool_use:
-            # The spawning transcript record may still be mid-write.
+            # No transcript owns this spawn yet: the record is still mid-write, or
+            # it resolved to two owners and was dropped as ambiguous. Either way we
+            # retry next tick; log so a persistent miss (e.g. a transcript-format
+            # drift) is diagnosable rather than silent.
+            _logger.debug(
+                "Deferring claude-native sub-agent with no resolved parent; "
+                "parent_session=%s subagent_id=%s tool_use_id=%s",
+                parent_session_id,
+                _subagent_id_from_meta_path(meta_path),
+                tool_use_id,
+            )
             continue
         pending.append((meta_path, meta, parents_by_tool_use[tool_use_id]))
 
@@ -1503,7 +1523,7 @@ async def _forward_available_subagents(
         deferred: list[tuple[Path, dict[str, str], str | None]] = []
         made_progress = False
         for meta_path, meta, parent_subagent_id in pending:
-            subagent_id = meta_path.stem.removeprefix("agent-").removesuffix(".meta")
+            subagent_id = _subagent_id_from_meta_path(meta_path)
             retry_key = f"subagent_start:{subagent_id}"
             if parent_subagent_id is None:
                 immediate_parent_session_id = parent_session_id
@@ -1589,6 +1609,16 @@ async def _forward_available_subagents(
             await _write_subagent_forward_state_async(bridge_dir, updated)
             made_progress = True
         if not made_progress:
+            # A full pass registered nothing: every deferred child is waiting on a
+            # parent we haven't seen on disk yet. Retry next tick; log the stuck
+            # set so a parent that never arrives doesn't strand children silently.
+            if deferred:
+                _logger.debug(
+                    "Deferring claude-native sub-agents whose parent is not yet "
+                    "registered; parent_session=%s pending=%s",
+                    parent_session_id,
+                    [_subagent_id_from_meta_path(path) for path, _, _ in deferred],
+                )
             break
         pending = deferred
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5329,6 +5329,82 @@ async def test_subagent_watcher_preserves_nested_parent_graph_across_restart(
     assert restarted.subagents["b-grandchild"].parent_subagent_id == "a-child"
 
 
+async def test_subagent_watcher_parks_child_of_a_parked_parent(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A child whose parent was parked is parked too, not retried forever.
+
+    When a parent's registration exhausts its retries it is parked with an empty
+    ``child_conversation_id`` — its Omnigent conversation will never exist. A
+    child that resolves to that parent can therefore never attach; it must be
+    parked (and logged) rather than silently re-resolved on every poll.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    parent_transcript = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="z-parent",
+        agent_type="general-purpose",
+        description="parent worker",
+        tool_use_id="toolu_parent",
+    )
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="a-child",
+        agent_type="general-purpose",
+        description="nested child",
+        tool_use_id="toolu_child",
+        spawn_transcript_path=parent_transcript,
+    )
+    # The parent is already parked on disk (empty child id): its registration
+    # exhausted retries on an earlier tick.
+    parked = forwarder.SubagentForwardState(
+        subagents={
+            "z-parent": forwarder.SubagentEntry(
+                subagent_id="z-parent",
+                child_conversation_id="",
+                parent_subagent_id=None,
+            )
+        }
+    )
+
+    starts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal starts
+        if json.loads(request.content).get("type") == "external_subagent_start":
+            starts += 1
+        return httpx.Response(202, json={})
+
+    caplog.set_level(logging.WARNING, logger="omnigent.claude_native_forwarder")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=parked,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    # The child was parked, not registered: no start POST, empty child id,
+    # and the parked entry survives a state round-trip.
+    assert starts == 0
+    assert state.subagents["a-child"].child_conversation_id == ""
+    assert state.subagents["a-child"].parent_subagent_id == "z-parent"
+    assert forwarder._read_subagent_forward_state(bridge_dir) == state
+    assert "whose parent was dropped" in caplog.text
+
+
 async def test_subagent_watcher_defers_and_logs_when_no_transcript_owns_the_spawn(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5404,6 +5404,87 @@ async def test_subagent_watcher_parks_child_of_a_parked_parent(
     assert forwarder._read_subagent_forward_state(bridge_dir) == state
     assert "whose parent was dropped" in caplog.text
 
+    # The child's start payload is dead-lettered for replay parity: the parent's
+    # own dead letter can't carry descendant info.
+    dead_letter = (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
+    assert len(dead_letter) == 1
+    record = json.loads(dead_letter[0])
+    assert record["event_type"] == "external_subagent_start"
+    assert record["payload"]["subagent_id"] == "a-child"
+    assert record["payload"]["parent_subagent_id"] == "z-parent"
+
+
+async def test_subagent_watcher_defers_a_spawn_owned_by_two_transcripts(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A spawn id claimed by two agent transcripts is dropped as ambiguous.
+
+    Attribution is trustworthy only when a spawn `tool_use` id has a single
+    owner. If the same id appears in two `agent-*.jsonl` transcripts, the owner
+    can't be resolved, so it must be dropped (not guessed) and the agent
+    deferred rather than mis-attributed.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    # Seed a normal agent (spawn lands in the root transcript, owner=None); then
+    # write the SAME spawn tool-use id into an agent transcript too, so the id
+    # resolves to two conflicting owners (root and that agent) and is dropped.
+    jsonl_path = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="a-worker",
+        agent_type="Explore",
+        description="ambiguous spawn",
+        tool_use_id="toolu_dup",
+    )
+    other_owner = jsonl_path.parent / "agent-owner-two.jsonl"
+    other_owner.write_text(
+        json.dumps(
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "dup-spawn",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "toolu_dup", "name": "Agent"}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    starts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal starts
+        if json.loads(request.content).get("type") == "external_subagent_start":
+            starts += 1
+        return httpx.Response(202, json={})
+
+    caplog.set_level(logging.DEBUG, logger="omnigent.claude_native_forwarder")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert starts == 0
+    assert "a-worker" not in state.subagents
+    assert "no resolved parent" in caplog.text
+
 
 async def test_subagent_watcher_defers_and_logs_when_no_transcript_owns_the_spawn(
     tmp_path: Path,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5055,6 +5055,7 @@ def _seed_subagent_on_disk(
     description: str,
     tool_use_id: str,
     transcript_records: list[dict[str, Any]] | None = None,
+    spawn_transcript_path: Path | None = None,
 ) -> Path:
     """
     Create the ``.meta.json`` + ``.jsonl`` pair Claude Code would
@@ -5075,9 +5076,34 @@ def _seed_subagent_on_disk(
         rows to seed into the sub-agent's ``.jsonl``. ``None`` /
         empty leaves the transcript empty (the common case when a
         sub-agent has just been spawned).
+    :param spawn_transcript_path: Transcript containing the spawning
+        tool call. Defaults to the top-level transcript.
     :returns: Path to the sub-agent's ``.jsonl`` (handy for tests
         that append rows after the fact).
     """
+    spawn_path = spawn_transcript_path or transcript_path
+    with spawn_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "isSidechain": spawn_path != transcript_path,
+                    "type": "assistant",
+                    "uuid": f"spawn-{subagent_id}",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": tool_use_id,
+                                "name": "Agent",
+                                "input": {"description": description},
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
     subagents_dir = transcript_path.parent / transcript_path.stem / "subagents"
     subagents_dir.mkdir(parents=True, exist_ok=True)
     meta_path = subagents_dir / f"agent-{subagent_id}.meta.json"
@@ -5185,6 +5211,122 @@ async def test_subagent_watcher_posts_external_subagent_start_for_new_meta(
             await task
         server.shutdown()
         server.server_close()
+
+
+async def test_subagent_watcher_preserves_nested_parent_graph_across_restart(
+    tmp_path: Path,
+) -> None:
+    """Nested Claude agents register under their immediate Omnigent parent."""
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    parent_transcript = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="z-parent",
+        agent_type="general-purpose",
+        description="parent worker",
+        tool_use_id="toolu_parent",
+    )
+    child_transcript = _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="a-child",
+        agent_type="general-purpose",
+        description="nested child",
+        tool_use_id="toolu_child",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "nested-child-output",
+                "message": {"role": "assistant", "content": "working"},
+            }
+        ],
+        spawn_transcript_path=parent_transcript,
+    )
+    with transcript_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "isSidechain": True,
+                    "type": "assistant",
+                    "uuid": "mirrored-nested-spawn",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_child",
+                                "name": "Agent",
+                                "input": {"description": "nested child"},
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
+    start_paths: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body.get("type") != "external_subagent_start":
+            return httpx.Response(202, json={})
+        subagent_id = body["data"]["subagent_id"]
+        start_paths[subagent_id] = request.url.path
+        return httpx.Response(
+            202,
+            json={"queued": False, "child_session_id": f"conv_{subagent_id}"},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+        assert start_paths == {
+            "z-parent": "/v1/sessions/conv_root/events",
+            "a-child": "/v1/sessions/conv_z-parent/events",
+        }
+        assert state.subagents["z-parent"].parent_subagent_id is None
+        assert state.subagents["a-child"].parent_subagent_id == "z-parent"
+
+        reconstructed = forwarder._read_subagent_forward_state(bridge_dir)
+        assert reconstructed == state
+
+        _seed_subagent_on_disk(
+            transcript_path=transcript_path,
+            subagent_id="b-grandchild",
+            agent_type="Explore",
+            description="second nested level",
+            tool_use_id="toolu_grandchild",
+            spawn_transcript_path=child_transcript,
+        )
+        restarted = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=reconstructed,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert start_paths["b-grandchild"] == "/v1/sessions/conv_a-child/events"
+    assert restarted.subagents["b-grandchild"].parent_subagent_id == "a-child"
 
 
 async def test_subagent_watcher_forwards_transcript_items_to_child_session(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5329,6 +5329,65 @@ async def test_subagent_watcher_preserves_nested_parent_graph_across_restart(
     assert restarted.subagents["b-grandchild"].parent_subagent_id == "a-child"
 
 
+async def test_subagent_watcher_defers_and_logs_when_no_transcript_owns_the_spawn(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A meta whose spawn record no transcript owns is deferred, not registered.
+
+    Claude can flush ``agent-<id>.meta.json`` before the spawning ``tool_use``
+    record lands in a transcript. The watcher must skip such an agent (retry next
+    tick) and log the miss so a spawn record that never arrives is diagnosable.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    subagents_dir = transcript_path.parent / transcript_path.stem / "subagents"
+    subagents_dir.mkdir(parents=True, exist_ok=True)
+    (subagents_dir / "agent-orphan.meta.json").write_text(
+        json.dumps(
+            {
+                "agentType": "Explore",
+                "description": "spawn record not flushed yet",
+                "toolUseId": "toolu_missing",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (subagents_dir / "agent-orphan.jsonl").write_text("", encoding="utf-8")
+
+    starts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal starts
+        if json.loads(request.content).get("type") == "external_subagent_start":
+            starts += 1
+        return httpx.Response(202, json={})
+
+    caplog.set_level(logging.DEBUG, logger="omnigent.claude_native_forwarder")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert starts == 0
+    assert "orphan" not in state.subagents
+    assert "no resolved parent" in caplog.text
+    assert "toolu_missing" in caplog.text
+
+
 async def test_subagent_watcher_forwards_transcript_items_to_child_session(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5379,7 +5379,7 @@ async def test_subagent_watcher_parks_child_of_a_parked_parent(
             starts += 1
         return httpx.Response(202, json={})
 
-    caplog.set_level(logging.WARNING, logger="omnigent.claude_native_forwarder")
+    caplog.set_level(logging.WARNING, logger="omnigent.harnesses.claude_native.forwarder")
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://ap",
@@ -5464,7 +5464,7 @@ async def test_subagent_watcher_defers_a_spawn_owned_by_two_transcripts(
             starts += 1
         return httpx.Response(202, json={})
 
-    caplog.set_level(logging.DEBUG, logger="omnigent.claude_native_forwarder")
+    caplog.set_level(logging.DEBUG, logger="omnigent.harnesses.claude_native.forwarder")
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://ap",
@@ -5522,7 +5522,7 @@ async def test_subagent_watcher_defers_and_logs_when_no_transcript_owns_the_spaw
             starts += 1
         return httpx.Response(202, json={})
 
-    caplog.set_level(logging.DEBUG, logger="omnigent.claude_native_forwarder")
+    caplog.set_level(logging.DEBUG, logger="omnigent.harnesses.claude_native.forwarder")
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://ap",

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5404,14 +5404,10 @@ async def test_subagent_watcher_parks_child_of_a_parked_parent(
     assert forwarder._read_subagent_forward_state(bridge_dir) == state
     assert "whose parent was dropped" in caplog.text
 
-    # The child's start payload is dead-lettered for replay parity: the parent's
-    # own dead letter can't carry descendant info.
-    dead_letter = (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
-    assert len(dead_letter) == 1
-    record = json.loads(dead_letter[0])
-    assert record["event_type"] == "external_subagent_start"
-    assert record["payload"]["subagent_id"] == "a-child"
-    assert record["payload"]["parent_subagent_id"] == "z-parent"
+    # No dead letter: a replay would re-post the child under the root session and
+    # flatten the hierarchy, so the child is parked (WARNING only), not recorded
+    # for replay.
+    assert not (bridge_dir / "dead_letter.jsonl").exists()
 
 
 async def test_subagent_watcher_defers_a_spawn_owned_by_two_transcripts(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5056,6 +5056,7 @@ def _seed_subagent_on_disk(
     tool_use_id: str,
     transcript_records: list[dict[str, Any]] | None = None,
     spawn_transcript_path: Path | None = None,
+    spawn_tool_name: str = "Agent",
 ) -> Path:
     """
     Create the ``.meta.json`` + ``.jsonl`` pair Claude Code would
@@ -5078,6 +5079,8 @@ def _seed_subagent_on_disk(
         sub-agent has just been spawned).
     :param spawn_transcript_path: Transcript containing the spawning
         tool call. Defaults to the top-level transcript.
+    :param spawn_tool_name: Name on the spawning ``tool_use`` block.
+        Defaults to ``"Agent"``; pass ``"Task"`` to exercise the alias.
     :returns: Path to the sub-agent's ``.jsonl`` (handy for tests
         that append rows after the fact).
     """
@@ -5095,7 +5098,7 @@ def _seed_subagent_on_disk(
                             {
                                 "type": "tool_use",
                                 "id": tool_use_id,
-                                "name": "Agent",
+                                "name": spawn_tool_name,
                                 "input": {"description": description},
                             }
                         ],
@@ -5126,6 +5129,62 @@ def _seed_subagent_on_disk(
     else:
         jsonl_path.write_text("", encoding="utf-8")
     return jsonl_path
+
+
+async def test_subagent_watcher_registers_a_task_named_spawn(
+    tmp_path: Path,
+) -> None:
+    """A spawn recorded under the legacy ``Task`` name still registers.
+
+    ``Task`` was renamed to ``Agent`` in CLI 2.1.63 but remains a supported
+    alias, so a transcript may carry either name. Correlation gates all
+    registration, so missing the alias would strand every such sub-agent.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="a-worker",
+        agent_type="Explore",
+        description="spawned via the Task alias",
+        tool_use_id="toolu_task",
+        spawn_tool_name="Task",
+    )
+
+    start_paths: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body.get("type") != "external_subagent_start":
+            return httpx.Response(202, json={})
+        subagent_id = body["data"]["subagent_id"]
+        start_paths[subagent_id] = request.url.path
+        return httpx.Response(
+            202,
+            json={"queued": False, "child_session_id": f"conv_{subagent_id}"},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_root",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert start_paths == {"a-worker": "/v1/sessions/conv_root/events"}
+    assert state.subagents["a-worker"].child_conversation_id == "conv_a-worker"
+    assert state.subagents["a-worker"].parent_subagent_id is None
 
 
 async def test_subagent_watcher_posts_external_subagent_start_for_new_meta(


### PR DESCRIPTION
## Related issue

Closes #4497

## Summary

- Correlate each Claude Code subagent's `toolUseId` with the root or subagent transcript that owns the spawning tool call.
- Register nested sessions against the immediate Omnigent parent, including child-before-parent discovery and cursor reconstruction after restart.
- Ignore mirrored sidechain records in the root transcript so they cannot flatten or ambiguously attribute nested agents.

**ELI5:** Claude stores every nested agent in one shared folder. Omnigent now checks which agent actually made each spawn call before drawing the family tree.

```text
root session
└── parent agent
    └── nested child
        └── post-restart grandchild
```

## Test Plan

- `uv run --no-sync pytest tests/test_claude_native_forwarder.py -q` → 147 passed.
- `uv run --no-sync pre-commit run --all-files` → all repository hooks passed.

## Demo

Live Omnigent UI driven from an isolated headless Chrome-for-Testing session. The full session shows the issue #4497 fixture in the real Subagents panel.

![Full Omnigent session showing the nested Claude subagent hierarchy](https://github.com/user-attachments/assets/52f2757d-6716-44fb-a3a3-2eb49cc990cb)

Close-up: each level is attached to its immediate parent — `Claude Code → z-parent → a-child → b-grandchild` — and the rendered details identify the delegation at every hop.

![Subagents hierarchy showing parent, child, and grandchild nested under their immediate parents](https://github.com/user-attachments/assets/643ab846-866d-4725-9aba-775e0a087e6e)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test exercises root, child, nested child, and a grandchild discovered after durable state is reloaded. It also covers child-before-parent file ordering, transcript activity after registration, and mirrored root sidechain records.

## Changelog

Nested Claude Code subagents now appear under the agent that actually spawned them.