### PR TITLE
fix(databricks): resolve harness launch models from the workspace

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1722,6 +1722,73 @@ def _trust_codex_project(codex_home: Path, cwd: Path) -> None:
     config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
 
 
+# DATABRICKS-PATCH(codex-live-model-discovery)
+def _resolve_databricks_codex_model(host: str, profile: str, requested: str | None) -> str:
+    """Resolve the codex launch model against what the workspace serves.
+
+    Codex used to take its model from the bundled MLflow catalog — a
+    third-party listing whose Databricks ids carry the legacy
+    ``databricks-`` spelling the gateway now answers with ``501
+    NOT_IMPLEMENTED ... Use Unity Catalog model services (v3)`` — so a launch
+    could pin a model the workspace will not serve. Resolve from the workspace
+    instead, as claude-native already does: the live Unity Catalog listing,
+    then ucode's cached copy of it, then the bundled catalog as the documented
+    last resort.
+
+    An explicit model is matched against the servable ids, so a legacy
+    ``model_override`` persisted before this change still launches; one the
+    workspace does not serve passes through untouched, because the gateway's
+    error beats a silent substitution.
+
+    :param host: Workspace origin, e.g. ``"https://example.com"``.
+    :param profile: Databricks CLI profile backing the launch.
+    :param requested: Explicit model id, or ``None`` to take the newest
+        servable one.
+    :returns: The model id to pin on the codex launch.
+    """
+    from omnigent.databricks_model_discovery import (
+        discover_databricks_codex_models,
+        select_servable_model,
+    )
+
+    servable: tuple[str, ...] = ()
+    try:
+        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+        creds = resolve_databricks_workspace(profile)
+        # Discover against the host the launch actually posts to. This resolver
+        # honors ``DATABRICKS_HOST`` while the launch host comes from the
+        # profile section alone (``_databricks_gateway_host``), so using
+        # ``creds.host`` here can pin a model discovered on workspace A onto a
+        # launch targeting workspace B. A token that does not match ``host``
+        # simply fails the listing and drops to the ucode-state fallback below,
+        # which is already keyed by ``host``.
+        servable = discover_databricks_codex_models(host, creds.token)
+    except Exception:  # noqa: BLE001 — cached ucode state is the launch fallback
+        _logger.warning(
+            "native-codex: live Databricks model discovery failed for profile %r; "
+            "falling back to ucode state",
+            profile,
+            exc_info=True,
+        )
+        try:
+            from omnigent.onboarding.ucode_state import read_ucode_state
+
+            workspace_state = read_ucode_state(host)
+            if workspace_state is not None:
+                servable = tuple(workspace_state.codex_models)
+        except Exception:  # noqa: BLE001 — the bundled catalog is the last resort
+            _logger.warning(
+                "native-codex: could not read ucode state for %r", profile, exc_info=True
+            )
+
+    if requested:
+        return select_servable_model(requested, servable) or requested
+    if servable:
+        return servable[0]
+    return model_catalog.resolve_catalog_model("databricks", family="openai").model_id
+
+
 def build_codex_native_server(
     *,
     socket_path: Path,
@@ -1803,8 +1870,7 @@ def build_codex_native_server(
         host = host.rstrip("/")
         config_overrides.extend(
             _databricks_codex_config_overrides(
-                model=model
-                or model_catalog.resolve_catalog_model("databricks", family="openai").model_id,
+                model=_resolve_databricks_codex_model(host, profile, model),
                 base_url=_databricks_codex_base_url(host),
                 auth_command=_databricks_codex_auth_command(host, profile),
             )

--- a/omnigent/databricks_model_discovery.py
+++ b/omnigent/databricks_model_discovery.py
@@ -31,6 +31,11 @@ _HTTP_TIMEOUT_S = 10.0
 #: a model the same way no matter which listing answered.
 _CATALOG_SPELLINGS: tuple[str, ...] = ("databricks-", _SYSTEM_MODEL_PREFIX)
 
+# DATABRICKS-PATCH(codex-live-model-discovery)
+#: ``gpt-5-6-sol`` → ``("gpt", "5", "6", "sol")``. Mirrors
+#: ``codex_model_vocabulary._GPT_ID_RE`` without reaching into its privates.
+_GPT_VERSIONED_ID_RE = re.compile(r"^(gpt|codex)-(\d+)-(\d+)(?:-([a-z0-9]+))?$")
+
 
 def _bare_model_id(model_id: str) -> str:
     """Strip the catalog spelling so ids compare across vocabularies."""
@@ -310,3 +315,86 @@ def discover_databricks_claude_models(
         token,
         transport=transport,
     ).families
+
+
+# DATABRICKS-PATCH(codex-live-model-discovery)
+def discover_databricks_codex_models(
+    workspace_url: str,
+    token: str,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> tuple[str, ...]:
+    """Discover every codex-compatible model a Databricks workspace serves.
+
+    Unity Catalog model services is the only listing that reports what the
+    codex Responses route will serve, so ids are ``system.ai.`` by
+    construction — unlike the Claude catalog above, which also has a legacy
+    gateway listing to merge in.
+
+    :param workspace_url: Workspace origin, e.g. ``"https://example.com"``.
+    :param token: Workspace bearer token.
+    :param transport: Optional HTTP transport used by tests.
+    :returns: Codex-servable model ids, best default first, e.g.
+        ``("system.ai.gpt-5-6-sol", "system.ai.gpt-5-5")``. An empty tuple is
+        authoritative: the listing answered and exposes no codex model.
+    :raises httpx.HTTPError: When the listing cannot be read.
+    :raises ValueError: When the listing is malformed.
+    """
+    from omnigent.model_override import is_codex_compatible_model
+
+    headers = {"Authorization": f"Bearer {token}"}
+    with httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client:
+        model_ids = _list_model_service_ids(client, workspace_url, headers)
+    codex_ids = [model_id for model_id in model_ids if is_codex_compatible_model(model_id)]
+    return tuple(sorted(codex_ids, key=_codex_preference_rank, reverse=True))
+
+
+def _codex_preference_rank(model_id: str) -> tuple[int, int, int, int, str]:
+    """Order codex-servable ids so the best launch default sorts first.
+
+    The listing says what a workspace *can* serve, not which to start on, and a
+    name sort has no opinion either (it ranks ``kimi-k3`` over every GPT).
+    Tiers, highest first: the owned curated codex catalog in its declared
+    cheapest-safe-first order; then versioned ``gpt``/``codex`` ids, newest
+    generation first and untiered ahead of a same-generation tier; then the
+    rest by name, for determinism.
+
+    :param model_id: A servable id, e.g. ``"system.ai.gpt-5-6-sol"``.
+    :returns: A sort key; compare descending.
+    """
+    from omnigent.codex_model_vocabulary import comparable_model_id
+    from omnigent.model_fallbacks import static_model_fallback
+    from omnigent.onboarding.provider_config import SUBSCRIPTION_KIND
+
+    bare = comparable_model_id(model_id)
+    curated = static_model_fallback(SUBSCRIPTION_KIND, "codex")
+    order = [comparable_model_id(m) for m in (curated.model_ids if curated else ())]
+    if bare in order:
+        # Negated so the earliest curated entry sorts highest under reverse=True.
+        return (2, -order.index(bare), 0, 0, "")
+    match = _GPT_VERSIONED_ID_RE.match(bare)
+    if match is None:
+        return (0, 0, 0, 0, bare)
+    _family, major, minor, tier = match.groups()
+    return (1, int(major), int(minor), 0 if tier else 1, tier or "")
+
+
+def select_servable_model(requested: str, servable: Iterable[str]) -> str | None:
+    """Resolve *requested* against the ids a workspace actually serves.
+
+    Compared on the bare id, so a request naming the legacy ``databricks-``
+    spelling resolves to the ``system.ai.`` id serving that same model — only
+    the served spelling is routable.
+
+    :param requested: Model id in either vocabulary, e.g.
+        ``"databricks-gpt-5-6-luna"``.
+    :param servable: Ids the workspace serves, e.g. the result of
+        :func:`discover_databricks_codex_models`.
+    :returns: The servable id for *requested*, or ``None`` when the workspace
+        serves no such model.
+    """
+    wanted = _bare_model_id(requested)
+    for model_id in servable:
+        if _bare_model_id(model_id) == wanted:
+            return model_id
+    return None

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -37,13 +37,14 @@ import sys
 import tempfile
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
-from contextlib import contextmanager, suppress
+from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
+from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
 from omnigent.inner.hook_scripts import subagent_router
@@ -946,6 +947,39 @@ def _find_system_claude() -> str | None:
     return resolve_cli_binary("claude", env_var=_CLAUDE_PATH_ENV)
 
 
+# DATABRICKS-PATCH(claude-sdk-live-model-discovery)
+def _resolve_databricks_claude_model(profile: str | None) -> str:
+    """Resolve the launch model from what the workspace serves.
+
+    The bundled MLflow catalog is a third-party listing whose Databricks ids use
+    the legacy ``databricks-`` spelling the gateway now answers with ``501 … Use
+    Unity Catalog model services (v3)``. Resolve from the live Unity Catalog
+    listing as claude-native does, keeping the catalog as the last resort.
+
+    :param profile: Databricks CLI profile backing the gateway.
+    :returns: The model id to launch on.
+    """
+    try:
+        from omnigent.databricks_model_discovery import discover_databricks_claude_catalog
+        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+        creds = resolve_databricks_workspace(profile)
+        families = discover_databricks_claude_catalog(creds.host, creds.token).families
+        # The precedence claude-native itself falls back to.
+        for tier in ("opus", "sonnet", "haiku", "fable"):
+            servable = families.get(tier)
+            if servable:
+                return servable
+    except Exception:  # noqa: BLE001 — the bundled catalog is the last resort
+        logger.warning(
+            "claude-sdk: live Databricks model discovery failed for profile %r; "
+            "falling back to the bundled catalog",
+            profile,
+            exc_info=True,
+        )
+    return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+
+
 def _resolve_gateway_env(
     profile: str | None = None,
     *,
@@ -1036,15 +1070,28 @@ def _resolve_gateway_env(
         base_url = base_url_override
         auth_command = auth_command_override
 
-    return {
+    gateway_env = {
         "ANTHROPIC_BASE_URL": base_url,
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": str(
             auth_refresh_interval_ms or _GATEWAY_AUTH_REFRESH_MS
         ),
-        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         _ANTHROPIC_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
         _CLAUDE_API_KEY_HELPER_ENV_KEY: auth_command,
     }
+    # DATABRICKS-PATCH(claude-sdk-gateway-betas)
+    # Blanket-disabling betas makes Claude Code strip `interleaved-thinking`,
+    # after which the Databricks gateway rejects the malformed thinking blocks
+    # with `400 messages.N.content.0.type: Expected 'thinking'`. claude-native
+    # already fixed this by negotiating betas with the gateway instead
+    # (`claude_native.py` CLAUDE_CODE_USE_GATEWAY=1); claude-sdk — the harness
+    # behind Polly and Debby — never got that change. Scope it to a real
+    # Databricks AI Gateway base URL so a generic gateway (or a mock server)
+    # that cannot negotiate betas keeps the original workaround.
+    if is_databricks_ai_gateway_url(base_url):
+        gateway_env["CLAUDE_CODE_USE_GATEWAY"] = "1"
+    else:
+        gateway_env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
+    return gateway_env
 
 
 def _databricks_claude_auth_command(host: str, profile: str | None = None) -> str:
@@ -1659,7 +1706,27 @@ class ClaudeSDKExecutor(Executor):
                 # ``options.settings`` explicitly sets apiKeyHelper and
                 # ``options.env`` sets the Databricks base URL, so the
                 # Claude CLI does not need an inherited Anthropic key.
-                with _unset_env_var("CLAUDECODE"), _unset_env_var("ANTHROPIC_API_KEY"):
+                #
+                # DATABRICKS-PATCH(claude-sdk-gateway-betas): on the Databricks
+                # gateway we negotiate betas rather than disabling them, but
+                # *omitting* CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS from
+                # ``options.env`` does not beat an INHERITED one — Databricks
+                # runners export it (devtools/ai/databricks_auth/gateway_env.py
+                # and the arca/isaac runners), and the merge puts os.environ
+                # under options.env. Without this the child still strips
+                # interleaved-thinking and the gateway still answers 400. Scoped
+                # to launches that negotiate (CLAUDE_CODE_USE_GATEWAY): the
+                # non-gateway branch re-adds the key through ``options.env``,
+                # which wins over os.environ, and a non-gateway session keeps
+                # whatever it inherited.
+                sdk_env = getattr(options, "env", None)
+                with ExitStack() as env_stack:
+                    env_stack.enter_context(_unset_env_var("CLAUDECODE"))
+                    env_stack.enter_context(_unset_env_var("ANTHROPIC_API_KEY"))
+                    if isinstance(sdk_env, dict) and "CLAUDE_CODE_USE_GATEWAY" in sdk_env:
+                        env_stack.enter_context(
+                            _unset_env_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS")
+                        )
                     await asyncio.wait_for(client.connect(), timeout=_CONNECT_TIMEOUT_SECONDS)
             except asyncio.TimeoutError as exc:
                 await self._force_close_client(client)
@@ -2256,12 +2323,9 @@ class ClaudeSDKExecutor(Executor):
         # spawning, so no ``databricks-*`` default is injected there.
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            resolution = await run_sync_on_thread(
-                model_catalog.resolve_catalog_model,
-                "databricks",
-                family="claude",
+            model = await run_sync_on_thread(
+                _resolve_databricks_claude_model, self._databricks_profile
             )
-            model = resolution.model_id
 
         # Build env: Databricks gateway settings derived from profile-backed
         # creds. CLAUDECODE removal happens around the subprocess spawn in

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1902,12 +1902,14 @@ class PiExecutor(Executor):
         cfg = config or ExecutorConfig()
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            resolution = await run_sync_on_thread(
-                model_catalog.resolve_catalog_model,
-                "databricks",
-                family="claude",
+            # DATABRICKS-PATCH(pi-live-model-discovery): resolve from the
+            # workspace, not the bundled catalog whose legacy `databricks-` ids
+            # the gateway answers with `501 … Use Unity Catalog model services`.
+            from omnigent.inner.claude_sdk_executor import _resolve_databricks_claude_model
+
+            model_id = await run_sync_on_thread(
+                _resolve_databricks_claude_model, self._databricks_profile
             )
-            model_id = resolution.model_id
             if not isinstance(model_id, str):
                 raise TypeError("Databricks model resolution returned a non-string model id")
             return model_id

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -99,6 +99,15 @@ _LLM_NAME_TOKENS = ("claude", "gpt", "codex", "gemini", "llama", "qwen", "kimi")
 # Chat-capable endpoint tasks ("llm/v1/chat"); embeddings/rerankers don't match.
 _LLM_TASK_TOKENS = ("chat", "completion")
 
+# DATABRICKS-PATCH(model-services-scoped-listing): scope + page the Unity
+# Catalog model-services listing. Mirrors
+# ``databricks_model_discovery._MODEL_SERVICES_PARENT`` /
+# ``_MODEL_SERVICES_MAX_RESULTS`` — including the parameter *name*, so both
+# callers of this endpoint ask for a page size the API actually honors.
+_MODEL_SERVICES_PARENT = "schemas/system.ai"
+_MODEL_SERVICES_MAX_RESULTS = 100
+_MODEL_SERVICES_MAX_PAGES = 100
+
 _ProviderHarness: TypeAlias = Literal[
     "claude-sdk",
     "codex",
@@ -1222,16 +1231,61 @@ def fetch_databricks_model_service_entries(
     :returns: LLM model-service entries with normalized wire metadata.
     :raises httpx.HTTPError: On transport or HTTP failures.
     """
+    # DATABRICKS-PATCH(model-services-scoped-listing)
+    # The listing must be scoped to the `system.ai` schema and paged. Unscoped,
+    # the endpoint walks the WHOLE metastore and returns one page of whatever
+    # schemas sort first — on a busy workspace that is a slice of unrelated user
+    # schemas with a `next_page_token` this call never followed, so a workspace
+    # serving 53 Databricks models reported 2 and zero Claude entries. Same
+    # scoping `databricks_model_discovery._list_model_service_ids` already uses.
+    services: list[object] = []
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
     with httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client:
-        resp = client.get(
-            f"{workspace_url.rstrip('/')}/api/2.1/unity-catalog/model-services",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        resp.raise_for_status()
-        payload = resp.json()
-    services = payload.get("model_services") if isinstance(payload, dict) else None
+        for _ in range(_MODEL_SERVICES_MAX_PAGES):
+            params = {
+                "parent": _MODEL_SERVICES_PARENT,
+                "max_results": str(_MODEL_SERVICES_MAX_RESULTS),
+            }
+            if page_token is not None:
+                params["page_token"] = page_token
+            resp = client.get(
+                f"{workspace_url.rstrip('/')}/api/2.1/unity-catalog/model-services",
+                headers={"Authorization": f"Bearer {token}"},
+                params=params,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            page = payload.get("model_services") if isinstance(payload, dict) else None
+            if isinstance(page, list):
+                services.extend(page)
+            raw_next = payload.get("next_page_token") if isinstance(payload, dict) else None
+            if not isinstance(raw_next, str) or not raw_next:
+                break
+            if raw_next in seen_tokens:
+                # A repeated token means the endpoint is looping. Keep the pages
+                # already collected instead of raising (which is what the
+                # sibling ``_list_model_service_ids`` does): every caller here
+                # treats an exception as "no listing" and falls back to the
+                # bundled catalog's retired ``databricks-`` ids, so failing loud
+                # would reintroduce the 501 this patch exists to remove. A
+                # partial ``system.ai`` list still launches.
+                _logger.warning(
+                    "Databricks model-services pagination repeated a page token; "
+                    "returning the %d entries collected so far",
+                    len(services),
+                )
+                break
+            seen_tokens.add(raw_next)
+            page_token = raw_next
+        else:
+            _logger.warning(
+                "Databricks model-services listing truncated after %d pages; "
+                "the model list may be incomplete",
+                _MODEL_SERVICES_MAX_PAGES,
+            )
     models: list[ModelEntry] = []
-    for service in services if isinstance(services, list) else []:
+    for service in services:
         if not isinstance(service, dict):
             continue
         raw_name = service.get("name")

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -356,6 +356,29 @@ class PiProviderConfig:
         )
 
 
+# DATABRICKS-PATCH(pi-live-model-discovery)
+def _default_claude_model_from(entries: list[_PiModelEntry]) -> str | None:
+    """Pick pi's launch model from the workspace's live Claude entries.
+
+    ``_fetch_pi_model_lists`` reads Unity Catalog model services, so the servable
+    ``system.ai.*`` ids are in hand; without this the launch fell back to the
+    bundled MLflow catalog, whose legacy ``databricks-`` ids the gateway now
+    answers with ``501 … Use Unity Catalog model services (v3)``.
+
+    :param entries: Live Claude entries, e.g. ``[{"id": "system.ai.claude-opus-5"}]``.
+    :returns: The best servable id, or ``None`` when the listing was empty.
+    """
+    from omnigent.databricks_model_discovery import _natural_model_key
+
+    ids = [str(e["id"]) for e in entries if e.get("id")]
+    # The precedence claude-native falls back to; newest within a tier.
+    for tier in ("opus", "sonnet", "haiku", "fable"):
+        matches = [i for i in ids if tier in i.lower()]
+        if matches:
+            return max(matches, key=_natural_model_key)
+    return ids[0] if ids else None
+
+
 def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
     """Resolve a Databricks-profile provider into Pi gateway config.
 
@@ -424,7 +447,11 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
         api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        # DATABRICKS-PATCH(pi-live-model-discovery): prefer what the workspace
+        # actually serves (fetched above) over the bundled catalog.
+        model=model
+        or _default_claude_model_from(claude_models)
+        or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is re-read per request (the auth command attempts a
         # refresh), matching codex-native's refresh semantics.

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -651,6 +651,10 @@ class TestConstructor(unittest.TestCase):
         model falls back to the Databricks default. The neutral
         generic-provider gateway path never does this (see
         ``test_neutral_gateway_no_model_does_not_inject_databricks_default``).
+
+        Live model discovery is stubbed unavailable here so the resolver drops
+        to the bundled catalog — its documented last resort; the discovery-first
+        path is covered by ``test_databricks_profile_uses_discovered_model``.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
         from omnigent.inner.databricks_executor import DatabricksCredentials
@@ -679,6 +683,10 @@ class TestConstructor(unittest.TestCase):
 
             with (
                 patch(
+                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                    side_effect=RuntimeError("live listing unavailable"),
+                ),
+                patch(
                     "omnigent.model_catalog.resolve_catalog_model",
                     side_effect=_resolve_model,
                 ),
@@ -693,6 +701,64 @@ class TestConstructor(unittest.TestCase):
                         pass
 
             self.assertEqual(captured["model"], "catalog-databricks-claude-default")
+
+        _run(_t())
+
+    def test_databricks_profile_uses_discovered_model(self):
+        """gateway=True (profile-derived) + no model → the workspace's live model.
+
+        The resolver prefers the live Unity Catalog listing over the bundled
+        catalog, walking the ``opus > sonnet > haiku > fable`` precedence
+        claude-native falls back to; the bundled ``databricks-*`` catalog is
+        only the last resort (see ``..._default_model_used_when_unset``).
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.inner.databricks_executor import DatabricksCredentials
+
+        async def _t():
+            with patch(
+                "omnigent.inner.databricks_executor._read_databrickscfg",
+                return_value=DatabricksCredentials(
+                    host="https://example.cloud.databricks.com",
+                    token="dapi_test_token",
+                ),
+            ):
+                executor = ClaudeSDKExecutor(gateway=True)
+
+            captured: dict[str, str | None] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["model"] = model
+                raise RuntimeError("stop after model resolution")
+
+            with (
+                patch(
+                    "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+                    return_value=SimpleNamespace(
+                        host="https://example.cloud.databricks.com", token="dapi_test_token"
+                    ),
+                ),
+                patch(
+                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                    return_value=SimpleNamespace(
+                        families={
+                            "sonnet": "system.ai.claude-sonnet-5",
+                            "opus": "system.ai.claude-opus-5",
+                        }
+                    ),
+                ),
+                patch.object(
+                    executor,
+                    "_get_or_create_client",
+                    side_effect=fake_get_or_create_client,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            # opus outranks sonnet in the family precedence.
+            self.assertEqual(captured["model"], "system.ai.claude-opus-5")
 
         _run(_t())
 
@@ -1182,6 +1248,54 @@ class TestResolveGatewayEnv(unittest.TestCase):
                 "x-databricks-use-coding-agent-mode: true",
             )
             self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env)
+
+    def test_databricks_gateway_negotiates_betas(self):
+        """A real Databricks AI Gateway base URL negotiates betas, not disables them.
+
+        Blanket-disabling betas makes Claude Code strip ``interleaved-thinking``,
+        which the Databricks gateway then rejects with a thinking-block 400. On a
+        genuine gateway we set ``CLAUDE_CODE_USE_GATEWAY`` and leave the disable
+        flag off (matching claude-native).
+        """
+        from omnigent.inner.claude_sdk_executor import _resolve_gateway_env
+        from omnigent.inner.databricks_executor import DatabricksCredentials
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "omnigent.inner.databricks_executor._read_databrickscfg",
+                return_value=DatabricksCredentials(
+                    host="https://wkspc.cloud.databricks.com",
+                    token="dapi_abc123",
+                ),
+            ),
+        ):
+            env = _resolve_gateway_env()
+        self.assertEqual(env["CLAUDE_CODE_USE_GATEWAY"], "1")
+        self.assertNotIn("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", env)
+
+    def test_non_databricks_gateway_keeps_beta_disable(self):
+        """A gateway host outside the trusted Databricks domains keeps the workaround.
+
+        A generic gateway (or a mock server) can't negotiate betas, so the
+        original ``CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`` behavior is preserved.
+        """
+        from omnigent.inner.claude_sdk_executor import _resolve_gateway_env
+        from omnigent.inner.databricks_executor import DatabricksCredentials
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "omnigent.inner.databricks_executor._read_databrickscfg",
+                # Not under a trusted Databricks parent domain.
+                return_value=DatabricksCredentials(
+                    host="https://example.databricks.com", token="t"
+                ),
+            ),
+        ):
+            env = _resolve_gateway_env()
+        self.assertEqual(env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"], "1")
+        self.assertNotIn("CLAUDE_CODE_USE_GATEWAY", env)
 
     def test_strips_trailing_slash(self):
         from omnigent.inner.claude_sdk_executor import _resolve_gateway_env

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2989,6 +2989,10 @@ def test_profile_gateway_resolves_databricks_default_model() -> None:
     Failure means pi falls back to its own host default — an
     Anthropic-direct id the Databricks AI gateway rejects, surfacing as a
     model error on the agent's first turn.
+
+    Live discovery is stubbed unavailable so the resolver drops to the bundled
+    catalog (its documented last resort); the discovery-first path is covered
+    by ``test_profile_gateway_uses_discovered_model``.
     """
     with (
         patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
@@ -2998,9 +3002,42 @@ def test_profile_gateway_resolves_databricks_default_model() -> None:
         ),
     ):
         executor = PiExecutor(gateway=True)
-    assert _run(executor._resolve_model(ExecutorConfig(model=None))) == (
-        "catalog-databricks-claude-default"
-    )
+    with patch(
+        "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+        side_effect=RuntimeError("live listing unavailable"),
+    ):
+        assert _run(executor._resolve_model(ExecutorConfig(model=None))) == (
+            "catalog-databricks-claude-default"
+        )
+
+
+def test_profile_gateway_uses_discovered_model() -> None:
+    """Unset model resolves to the workspace's live Claude model, not the catalog.
+
+    ``_resolve_model`` prefers the live Unity Catalog listing (via the shared
+    claude-sdk resolver, walking ``opus > sonnet > haiku > fable``) over the
+    bundled ``databricks-*`` catalog default.
+    """
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+    ):
+        executor = PiExecutor(gateway=True)
+    with (
+        patch(
+            "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+            return_value=SimpleNamespace(host="https://h.example.com", token="tok"),
+        ),
+        patch(
+            "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+            return_value=SimpleNamespace(families={"opus": "system.ai.claude-opus-5"}),
+        ),
+    ):
+        resolved = _run(executor._resolve_model(ExecutorConfig(model=None)))
+    assert resolved == "system.ai.claude-opus-5"
 
 
 def test_catalog_default_is_registered_in_models_json() -> None:
@@ -3011,6 +3048,11 @@ def test_catalog_default_is_registered_in_models_json() -> None:
         patch(
             "omnigent.inner.pi_executor._read_databrickscfg",
             return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+        # Live discovery unavailable → the bundled catalog default is used.
+        patch(
+            "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+            side_effect=RuntimeError("live listing unavailable"),
         ),
         patch(
             "omnigent.model_catalog.resolve_catalog_model",

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -447,6 +447,18 @@ def test_build_codex_native_server_uses_profile_host_without_static_token(
     )
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
 
+    # This test exercises the profile-host base URL + auth command, not model
+    # resolution. Force live codex discovery offline so the build makes no
+    # model-services network call for the profile host; the explicit
+    # ``model="test-model"`` is then used as-is.
+    def _discovery_offline(_profile: str | None) -> object:
+        raise RuntimeError("model discovery is offline in this test")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+        _discovery_offline,
+    )
+
     app_server = build_codex_native_server(
         socket_path=tmp_path / "codex.sock",
         codex_home=tmp_path / "codex-home",

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -1745,3 +1745,43 @@ async def test_codex_native_launch_config_reads_the_auto_harness_flag(
         config = await _codex_native_launch_config(session_id="conv_abc", server_client=client)
 
     assert config.auto_harness is expected
+
+
+def test_resolve_databricks_codex_model_matches_servable_ids() -> None:
+    """The codex launch model resolves against what the workspace serves.
+
+    An unset model takes the newest servable id; a legacy ``databricks-``
+    override resolves to the served ``system.ai.`` id for that same model; and a
+    model the workspace does not serve passes through untouched (the gateway's
+    error beats a silent substitution).
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from omnigent.codex_native_app_server import _resolve_databricks_codex_model
+
+    servable = ("system.ai.gpt-5-6-sol", "system.ai.gpt-5-6-luna")
+    with (
+        patch(
+            "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+            return_value=SimpleNamespace(token="tok"),
+        ),
+        patch(
+            "omnigent.databricks_model_discovery.discover_databricks_codex_models",
+            return_value=servable,
+        ),
+    ):
+        assert (
+            _resolve_databricks_codex_model("https://h.example.com", "prof", None)
+            == "system.ai.gpt-5-6-sol"
+        )
+        assert (
+            _resolve_databricks_codex_model(
+                "https://h.example.com", "prof", "databricks-gpt-5-6-luna"
+            )
+            == "system.ai.gpt-5-6-luna"
+        )
+        assert (
+            _resolve_databricks_codex_model("https://h.example.com", "prof", "databricks-gpt-9-9")
+            == "databricks-gpt-9-9"
+        )

--- a/tests/test_databricks_model_discovery.py
+++ b/tests/test_databricks_model_discovery.py
@@ -310,3 +310,64 @@ def test_family_shim_warns_and_delegates_to_the_catalog() -> None:
             transport=httpx.MockTransport(_handler),
         )
     assert families == {"opus": "system.ai.claude-opus-5"}
+
+
+def _discover_codex(model_services: list[dict[str, str]]) -> tuple[str, ...]:
+    """Run codex discovery against a canned ``system.ai`` model-services page."""
+    from omnigent.databricks_model_discovery import discover_databricks_codex_models
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["parent"] == "schemas/system.ai"
+        return httpx.Response(200, json={"model_services": model_services}, request=request)
+
+    return discover_databricks_codex_models(
+        "https://workspace.example.com",
+        "token",
+        transport=httpx.MockTransport(_handler),
+    )
+
+
+def test_discover_codex_models_filters_non_codex_and_ranks_curated_first() -> None:
+    """Codex discovery keeps only codex-servable ids, curated catalog first.
+
+    The listing says what a workspace *can* serve, not which to launch on:
+    the owned curated codex catalog leads (in its declared order), then
+    versioned GPT ids newest-first, then the rest — and non-codex families
+    (Claude) are dropped entirely.
+    """
+    servable = _discover_codex(
+        [
+            {"name": "model-services/system.ai.gpt-5-5"},
+            {"name": "model-services/system.ai.gpt-5-6-luna"},
+            {"name": "model-services/system.ai.gpt-5-6-sol"},
+            {"name": "model-services/system.ai.gpt-6-1"},
+            {"name": "model-services/system.ai.kimi-k2"},
+            {"name": "model-services/system.ai.claude-opus-5"},
+        ]
+    )
+
+    assert servable == (
+        # Curated (cheapest-safe-first) beats a newer non-curated generation.
+        "system.ai.gpt-5-6-sol",
+        "system.ai.gpt-5-6-luna",
+        "system.ai.gpt-5-5",
+        # Non-curated GPT, newest generation next.
+        "system.ai.gpt-6-1",
+        # Codex-compatible but unversioned, last.
+        "system.ai.kimi-k2",
+    )
+
+
+def test_discover_codex_models_empty_listing_is_authoritative() -> None:
+    """A listing that serves no codex model returns an empty tuple, not an error."""
+    assert _discover_codex([{"name": "model-services/system.ai.claude-opus-5"}]) == ()
+
+
+def test_select_servable_model_matches_legacy_spelling() -> None:
+    """A legacy ``databricks-`` request resolves to the served ``system.ai.`` id."""
+    from omnigent.databricks_model_discovery import select_servable_model
+
+    servable = ("system.ai.gpt-5-6-luna", "system.ai.gpt-5-5")
+    assert select_servable_model("databricks-gpt-5-6-luna", servable) == "system.ai.gpt-5-6-luna"
+    # A model the workspace does not serve is left for the caller to pass through.
+    assert select_servable_model("databricks-gpt-9-9", servable) is None

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1661,3 +1661,96 @@ def test_keychain_credential_ref_degrades_not_crashes(
     assert listing.source == "none"
     assert not listing.models
     assert listing.note, "degraded keychain row must carry an explanatory note"
+
+
+def test_model_services_listing_is_scoped_and_paginated() -> None:
+    """The UC model-services listing is scoped to ``system.ai`` and follows pages.
+
+    Unscoped and unpaged, the endpoint walks the whole metastore and returns one
+    page of whatever schemas sort first, so a workspace serving many models
+    reported a handful of unrelated user schemas with a ``next_page_token`` this
+    call never followed. Scope to ``schemas/system.ai`` and page through.
+    """
+    from omnigent import model_catalog
+
+    requests_seen: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(request)
+        assert request.headers["authorization"] == "Bearer token"
+        page_token = request.url.params.get("page_token")
+        if page_token is None:
+            return httpx.Response(
+                200,
+                json={
+                    "model_services": [
+                        {
+                            "name": "model-services/system.ai.gpt-5-6-sol",
+                            "supported_api_types": ["openai/v1/responses"],
+                        }
+                    ],
+                    "next_page_token": "p2",
+                },
+                request=request,
+            )
+        assert page_token == "p2"
+        return httpx.Response(
+            200,
+            json={
+                "model_services": [
+                    {
+                        "name": "model-services/system.ai.claude-opus-5",
+                        "supported_api_types": ["anthropic/v1/messages"],
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    entries = model_catalog.fetch_databricks_model_service_entries(
+        "https://workspace.example.com/",
+        "token",
+        transport=httpx.MockTransport(_handler),
+    )
+
+    assert [entry.id for entry in entries] == ["system.ai.gpt-5-6-sol", "system.ai.claude-opus-5"]
+    assert len(requests_seen) == 2
+    assert requests_seen[0].url.params["parent"] == "schemas/system.ai"
+    assert requests_seen[0].url.params["max_results"]
+
+
+def test_model_services_listing_stops_on_repeated_page_token(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A looping endpoint returns the pages collected so far instead of raising.
+
+    Every caller treats an exception as "no listing" and falls back to the
+    bundled catalog's retired ``databricks-`` ids, so failing loud would
+    reintroduce the 501 this scoping fix removes; a partial list still launches.
+    """
+    from omnigent import model_catalog
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "model_services": [
+                    {
+                        "name": "model-services/system.ai.gpt-5-6-sol",
+                        "supported_api_types": ["openai/v1/responses"],
+                    }
+                ],
+                "next_page_token": "same",  # never advances
+            },
+            request=request,
+        )
+
+    with caplog.at_level("WARNING", logger="omnigent.model_catalog"):
+        entries = model_catalog.fetch_databricks_model_service_entries(
+            "https://workspace.example.com",
+            "token",
+            transport=httpx.MockTransport(_handler),
+        )
+
+    assert [entry.id for entry in entries]  # partial list kept, not an exception
+    assert any("repeated a page token" in record.message for record in caplog.records)

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1629,3 +1629,18 @@ def test_launch_renders_config_once(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     creds.pi_native_provider_launch(tmp_path / "pi-agent", provider)
 
     assert renders == 1
+
+
+def test_default_claude_model_from_picks_by_tier_then_newest() -> None:
+    """Pi's launch default follows the ``opus > sonnet > …`` precedence, newest first."""
+    from omnigent.pi_native_credentials import _default_claude_model_from
+
+    entries = [
+        {"id": "system.ai.claude-sonnet-5"},
+        {"id": "system.ai.claude-opus-4-8"},
+        {"id": "system.ai.claude-opus-5"},
+    ]
+    # opus outranks sonnet, and opus-5 is the newest opus.
+    assert _default_claude_model_from(entries) == "system.ai.claude-opus-5"
+    # An empty live listing lets the caller fall through to the bundled catalog.
+    assert _default_claude_model_from([]) is None


### PR DESCRIPTION
## Related issue

N/A — no tracked upstream issue. Surfaced by the Databricks AI Gateway retiring
the legacy `databricks-*` model namespace (staging is cut over; prod is not yet),
so every managed gateway turn on the affected harnesses fails today.

## Summary

Every managed harness runs against the workspace **Databricks AI Gateway** with
ucode-minted credentials. The gateway has retired the legacy `databricks-*`
model namespace:

```
501 NOT_IMPLEMENTED  "'databricks-gpt-5-6-luna' is no longer available. Use Unity Catalog model services (v3)."
```

Several harnesses take their launch model from the **bundled MLflow provider
catalog** — a third-party listing with no knowledge of any workspace, whose
Databricks entries carry exactly that retired spelling. `claude-native` was
migrated to live discovery in July and is unaffected; its siblings were left
behind.

| harness | before | after |
|---|---|---|
| **claude-native** | works | unchanged — already resolves via `databricks_model_discovery` |
| **codex-native** | **501 on every turn** | live Unity Catalog listing → ucode state → catalog |
| **claude-sdk** (Polly, Debby) | catalog fallback + thinking-block 400 | live listing + betas negotiated with the gateway |
| **pi-native** | catalog fallback (501) | live listing |

**The Unity Catalog listing itself was broken**, which is why pi's own discovery
never helped it. `model_catalog.fetch_databricks_model_service_entries` queried
the endpoint **unscoped and unpaginated** — no `parent`, no page size, and
`next_page_token` never followed — so it walked the whole metastore and returned
one page of whatever schemas sorted first. On one staging workspace it returned
**2 entries out of 53**, both unrelated user schemas, and bucketed **zero**
Claude models. Scoped to `schemas/system.ai` and paged, the same workspace
returns the full list. This is the shared parser for worker model enumeration
too, so `sys_list_models` gets a correct list as well.

### The fixes

- **codex-native** — `build_codex_native_server` resolves the launch model
  through the live UC listing (`system.ai.` by construction), then ucode's
  cached copy, then the bundled catalog as a documented last resort. An explicit
  legacy `model_override` is matched against the servable ids on the bare id, so
  it recovers instead of failing forever; a model the workspace genuinely doesn't
  serve passes through untouched (the gateway's error beats a silent
  substitution). Ordering is a separate decision from availability: curated codex
  catalog first, then versioned `gpt`/`codex` ids newest-first, then the rest by
  name.
- **claude-sdk** — resolve the launch model from the live listing using the
  family precedence `claude-native` falls back to. And `CLAUDE_CODE_DISABLE_
  EXPERIMENTAL_BETAS: "1"` was set unconditionally, which makes Claude Code strip
  `interleaved-thinking` so the gateway rejects the malformed blocks with `400
  ... Expected 'thinking'`. On a real Databricks AI Gateway base URL we now
  negotiate betas (`CLAUDE_CODE_USE_GATEWAY=1`) as `claude-native` does; a generic
  gateway or mock server keeps the original workaround. Because the SDK builds the
  child env as `{**os.environ, **options.env}`, an *inherited*
  `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` (Databricks runners export it) is also
  unset around the spawn, scoped to gateway launches.
- **pi-native** — resolve the launch model from the live listing
  (`_default_claude_model_from`, family precedence).
- **model_catalog** — scope the model-services listing to `schemas/system.ai`
  and paginate. A repeated page token returns the pages collected so far rather
  than raising, because every caller treats an exception as "no listing" and
  falls back to the retired `databricks-` catalog — failing loud would reintroduce
  the 501.

### Scope / notes

- Only harnesses that pair a Databricks-resolved model with an `/ai-gateway/*`
  route. `opencode` and `inner/databricks_executor` post to `/serving-endpoints`,
  which still accepts legacy ids, and are unaffected.
- The `# DATABRICKS-PATCH(...)` comments tag the Databricks-AI-Gateway-specific
  branches (they also let the downstream Databricks vendored tree track these as
  upstreamed). Happy to drop or reword them if maintainers prefer.
- **Intentionally not included:** a separate pi defect where the managed Pi
  provider must tell the CLI not to eagerly stream per-tool inputs
  (the gateway's Anthropic translator 400s on `eager_input_streaming`). That fix
  depends on a Pi provider `compat` field that doesn't exist in this tree, so it's
  out of scope for this change and left as a follow-up.

## Test Plan

```
uv run pytest tests/test_databricks_model_discovery.py tests/test_model_catalog.py \
  tests/test_pi_native_credentials.py tests/test_codex_native_app_server.py \
  tests/test_codex_native.py tests/inner/test_claude_sdk_executor.py \
  tests/inner/test_pi_executor.py
# 729 passed
```

Added unit tests: codex discovery filtering + curated-first ranking and legacy→
`system.ai.` matching (`discover_databricks_codex_models`, `select_servable_model`);
`model_catalog` listing scoping + pagination + repeated-token truncation;
claude-sdk gateway beta negotiation (on and off a trusted Databricks gateway) and
discovery-first model resolution; pi discovery-first resolution and
`_default_claude_model_from` tier precedence. Existing catalog-fallback tests were
updated to stub live discovery unavailable (the documented last resort).

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change

## Changelog

Managed codex, claude-sdk (Polly/Debby), and pi harnesses resolve their launch model from the workspace's Unity Catalog model services, so they no longer fail against a Databricks AI Gateway that has retired the legacy `databricks-*` model namespace
