### PR TITLE
Restore prompts after early turn interruption

### DIFF
--- a/tests/e2e_ui/chat/test_interrupted_prompt_recovery.py
+++ b/tests/e2e_ui/chat/test_interrupted_prompt_recovery.py
@@ -1,0 +1,52 @@
+"""Browser e2e: an early interrupt restores the submitted prompt."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm
+
+
+def _wait_for_blocked_turn(mock_url: str) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if httpx.get(f"{mock_url}/gate/pending", timeout=5).json()["pending"]:
+            return
+        time.sleep(0.1)
+    raise AssertionError("LLM request did not reach the blocking gate")
+
+
+def test_escape_during_early_turn_restores_exact_prompt(
+    page: Page,
+    seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """Escape restores and focuses the prompt before assistant output starts."""
+    base_url, session_id = seeded_session
+    prompt = f"adjust this plan\nthen resend it {uuid.uuid4().hex}"
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "This response should be interrupted.", "block": True}],
+        match=prompt,
+    )
+
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+        composer = page.get_by_role("textbox", name="Message the agent")
+        expect(composer).to_be_visible()
+        composer.fill(prompt)
+        page.get_by_role("button", name="Send", exact=True).click()
+
+        expect(page.get_by_role("button", name="Interrupt", exact=True)).to_be_visible()
+        _wait_for_blocked_turn(mock_llm_server_url)
+        composer.press("Escape")
+
+        expect(composer).to_have_value(prompt, timeout=30_000)
+        expect(composer).to_be_focused()
+    finally:
+        # A failed assertion must not leave the shared runner blocked.
+        httpx.post(f"{mock_llm_server_url}/gate/release", timeout=5)

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -4,13 +4,13 @@ import type * as UseHostsModule from "@/hooks/useHosts";
 import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useChatStore } from "@/store/chatStore";
 import { clearSessionDrafts, hasSessionDraft } from "@/lib/sessionDrafts";
 import { setOmnigentHostConfig } from "@/lib/host";
 import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
+import { handleSessionEvent, useChatStore } from "@/store/chatStore";
 
 // Composer reads workspace files via a TanStack query hook (for "@"-file
 // mentions). These slash-command tests don't exercise that, so stub the hook
@@ -157,6 +157,113 @@ describe("Composer session drafts", () => {
 
     fireEvent.submit(textarea().closest("form")!);
     await waitFor(() => expect(hasSessionDraft("conv_draft")).toBe(false));
+  });
+});
+
+describe("Composer interrupted prompt recovery", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("restores and focuses the exact prompt released for the active session", async () => {
+    useChatStore.setState({
+      conversationId: "conv_restore_early",
+      interruptedPromptRecovery: {
+        conversationId: "conv_restore_early",
+        text: "the exact interrupted prompt",
+        tempId: "pend_restore",
+        phase: "ready",
+      },
+    });
+
+    render(<Composer {...composerProps()} />);
+
+    await waitFor(() => expect(textarea().value).toBe("the exact interrupted prompt"));
+    expect(document.activeElement).toBe(textarea());
+    expect(useChatStore.getState().interruptedPromptRecovery).toBeNull();
+  });
+
+  it("preserves a newer draft instead of overwriting it", async () => {
+    useChatStore.setState({
+      conversationId: "conv_restore_newer",
+      interruptedPromptRecovery: null,
+    });
+    render(<Composer {...composerProps()} />);
+    fireEvent.change(textarea(), { target: { value: "newer draft wins" } });
+
+    act(() => {
+      useChatStore.setState({
+        interruptedPromptRecovery: {
+          conversationId: "conv_restore_newer",
+          text: "older interrupted prompt",
+          tempId: "pend_old",
+          phase: "ready",
+        },
+      });
+    });
+
+    await waitFor(() => expect(useChatStore.getState().interruptedPromptRecovery).toBeNull());
+    expect(textarea().value).toBe("newer draft wins");
+  });
+
+  it("does not restore recovery released for another session", async () => {
+    useChatStore.setState({
+      conversationId: "conv_visible",
+      interruptedPromptRecovery: {
+        conversationId: "conv_background",
+        text: "background session prompt",
+        tempId: "pend_background",
+        phase: "ready",
+      },
+    });
+
+    render(<Composer {...composerProps()} />);
+
+    await waitFor(() => expect(textarea().value).toBe(""));
+    expect(useChatStore.getState().interruptedPromptRecovery?.phase).toBe("ready");
+  });
+
+  it("restores the submitted prompt through the Escape interrupt journey", async () => {
+    useChatStore.setState({
+      conversationId: "conv_escape_journey",
+      pendingUserMessages: [
+        {
+          tempId: "pend_escape",
+          content: [{ type: "input_text", text: "adjust and resend me" }],
+        },
+      ],
+      interruptedPromptRecovery: {
+        text: "adjust and resend me",
+        tempId: "pend_escape",
+        phase: "eligible",
+      },
+      status: "streaming",
+      sessionStatus: "running",
+    });
+    const onStop = vi.fn(() => useChatStore.getState().stop());
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true, onStop })} />);
+
+    fireEvent.keyDown(textarea(), { key: "Escape" });
+    expect(onStop).toHaveBeenCalledOnce();
+    handleSessionEvent({
+      type: "session_interrupted",
+      requestedAt: 1704067200,
+    });
+
+    await waitFor(() => expect(textarea().value).toBe("adjust and resend me"));
+  });
+
+  it("dismisses the slash menu before Escape can interrupt", () => {
+    useChatStore.setState({ conversationId: "conv_escape_menu", skills: [] });
+    const onStop = vi.fn();
+    render(<Composer {...composerProps({ status: "streaming", isWorking: true, onStop })} />);
+    fireEvent.change(textarea(), { target: { value: "/" } });
+
+    fireEvent.keyDown(textarea(), { key: "Escape" });
+
+    expect(onStop).not.toHaveBeenCalled();
+    expect(textarea().value).toBe("");
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4335,6 +4335,7 @@ export function Composer({
   // Text + attachments handed back by a send that failed before the server
   // took ownership. Drained below so the message can be retried.
   const failedSendDraft = useChatStore((s) => s.failedSendDraft);
+  const interruptedPromptRecovery = useChatStore((s) => s.interruptedPromptRecovery);
   // The conversation whose draft the composer's value/files currently hold.
   // Trails `conversationId` by one commit across a session switch; see the
   // draft-restore effect.
@@ -4672,6 +4673,24 @@ export function Composer({
     return () => useChatStore.getState().clearPendingComposerAttachments();
     // setMentionedItems is a stable useState setter (from useMentionBrowser).
   }, [pendingComposerAttachments, setMentionedItems]);
+
+  useEffect(() => {
+    if (interruptedPromptRecovery?.phase !== "ready") return;
+    if (interruptedPromptRecovery.conversationId !== conversationId) return;
+    if (settledConversationId !== conversationId) return;
+
+    useChatStore.setState({ interruptedPromptRecovery: null });
+    if (
+      valueRef.current.trim() !== "" ||
+      filesRef.current.length > 0 ||
+      mentionedItems.length > 0
+    ) {
+      return;
+    }
+    setValue(interruptedPromptRecovery.text);
+    dirtyRef.current = true;
+    if (!isMobileRef.current) textareaRef.current?.focus();
+  }, [interruptedPromptRecovery, conversationId, settledConversationId, mentionedItems.length]);
 
   // Restore the text (and attachments) of a send that failed, so the user can
   // fix and resend instead of retyping. The composer is empty in the normal

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3619,6 +3619,91 @@ describe("chatStore — send (file attachments)", () => {
 });
 
 describe("chatStore — stop", () => {
+  it("arms the exact prompt when a new turn is submitted", async () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      abortController: new AbortController(),
+    });
+
+    await useChatStore.getState().send("preserve\nthis prompt", "agent_xyz");
+
+    const pending = useChatStore.getState().pendingUserMessages[0]!;
+    expect(useChatStore.getState().interruptedPromptRecovery).toEqual({
+      text: "preserve\nthis prompt",
+      tempId: pending.tempId,
+      phase: "eligible",
+    });
+  });
+
+  it("arms the submitted prompt and releases it only after an early interrupt is confirmed", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      pendingUserMessages: [
+        {
+          tempId: "pend_1",
+          content: [{ type: "input_text", text: "please keep this exact prompt" }],
+        },
+      ],
+      interruptedPromptRecovery: {
+        text: "please keep this exact prompt",
+        tempId: "pend_1",
+        phase: "eligible",
+      },
+      status: "streaming",
+      sessionStatus: "running",
+    });
+
+    // The input can commit before the user reaches Escape. That does not cross
+    // the recovery boundary; only another user message or agent progress does.
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_1",
+      itemType: "message",
+      data: {
+        role: "user",
+        content: [{ type: "input_text", text: "please keep this exact prompt" }],
+      },
+    });
+    useChatStore.getState().stop();
+
+    expect(useChatStore.getState().interruptedPromptRecovery).toEqual({
+      text: "please keep this exact prompt",
+      tempId: "pend_1",
+      phase: "requested",
+    });
+
+    handleSessionEvent({
+      type: "session_interrupted",
+      requestedAt: 1704067200,
+    });
+
+    expect(useChatStore.getState().interruptedPromptRecovery).toEqual({
+      conversationId: "conv_abc",
+      text: "please keep this exact prompt",
+      tempId: "pend_1",
+      phase: "ready",
+    });
+  });
+
+  it("does not release a prompt after turn progress invalidates recovery", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      interruptedPromptRecovery: {
+        text: "do not restore stale text",
+        tempId: "pend_1",
+        phase: "requested",
+      },
+    });
+
+    useChatStore.setState({ interruptedPromptRecovery: null });
+    handleSessionEvent({
+      type: "session_interrupted",
+      requestedAt: 1704067200,
+    });
+
+    expect(useChatStore.getState().interruptedPromptRecovery).toBeNull();
+  });
+
   it("posts {type: 'interrupt'} to the events endpoint without aborting the local stream", async () => {
     const controller = new AbortController();
     useChatStore.setState({
@@ -5137,6 +5222,11 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       useChatStore.setState({
         blocks: existingBlocks,
         pendingUserMessages: [],
+        interruptedPromptRecovery: {
+          text: "my interrupted prompt",
+          tempId: "pend_mine",
+          phase: "requested",
+        },
       });
 
       handleSessionEvent({
@@ -5157,6 +5247,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(promoted.ctx.itemId).toBe("msg_from_other_client");
       expect(promoted.content).toEqual([{ type: "input_text", text: "from web UI" }]);
       expect(after.pendingUserMessages).toEqual([]);
+      expect(after.interruptedPromptRecovery).toBeNull();
     });
 
     it("threads createdBy onto a cross-client user message for live attribution", () => {
@@ -5571,6 +5662,11 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       bindConversationForTest("conv_bg", {
         activeResponse: { responseId: "resp_bg", state: "streaming", error: null },
         interruptedResponseIds: [],
+        interruptedPromptRecovery: {
+          text: "background prompt",
+          tempId: "pend_bg",
+          phase: "requested",
+        },
       });
       bindConversationForTest("conv_visible");
       useChatStore.setState({
@@ -5590,6 +5686,12 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         error: null,
       });
       expect(bg.get().interruptedResponseIds).toEqual(["resp_bg"]);
+      expect(bg.get().interruptedPromptRecovery).toEqual({
+        conversationId: "conv_bg",
+        text: "background prompt",
+        tempId: "pend_bg",
+        phase: "ready",
+      });
       // The visible turn keeps streaming.
       expect(useChatStore.getState().activeResponse).toEqual({
         responseId: "resp_visible",
@@ -5597,6 +5699,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         error: null,
       });
       expect(useChatStore.getState().interruptedResponseIds).toEqual([]);
+      expect(useChatStore.getState().interruptedPromptRecovery).toBeNull();
     });
 
     it("still applies events delivered by the visible conversation's own stream", () => {
@@ -7501,6 +7604,76 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
 
   const setState = useChatStore.setState as unknown as Parameters<typeof pumpStreamEvents>[3];
   const getState = useChatStore.getState as unknown as Parameters<typeof pumpStreamEvents>[4];
+
+  it("suppresses recovery when assistant output races the interrupt acknowledgement", async () => {
+    useChatStore.setState({
+      conversationId: "conv_interrupt_race",
+      blocks: [],
+      interruptedPromptRecovery: {
+        text: "race-safe prompt",
+        tempId: "pend_race",
+        phase: "requested",
+      },
+    });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_interrupt_race", sink.stream, controller, setState, getState);
+
+    sink.push(sse("response.created", { id: "resp_race", status: "in_progress", output: [] }));
+    sink.push(delta("A"));
+    sink.push(
+      sse("session.interrupted", {
+        type: "session.interrupted",
+        data: { requested_at: 1704067200, response_id: "resp_race" },
+      }),
+    );
+    await tick();
+
+    expect(useChatStore.getState().interruptedPromptRecovery).toBeNull();
+    controller.abort();
+  });
+
+  it("suppresses recovery after tool activity without assistant text", async () => {
+    useChatStore.setState({
+      conversationId: "conv_interrupt_tool",
+      blocks: [],
+      interruptedPromptRecovery: {
+        text: "tool-bound prompt",
+        tempId: "pend_tool",
+        phase: "requested",
+      },
+    });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_interrupt_tool", sink.stream, controller, setState, getState);
+
+    sink.push(
+      sse("response.created", { id: "resp_tool_boundary", status: "in_progress", output: [] }),
+    );
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "tool_boundary",
+          type: "function_call",
+          response_id: "resp_tool_boundary",
+          call_id: "call_boundary",
+          name: "shell",
+          arguments: '{"command":"pwd"}',
+          status: "in_progress",
+        },
+      }),
+    );
+    sink.push(
+      sse("session.interrupted", {
+        type: "session.interrupted",
+        data: { requested_at: 1704067200, response_id: "resp_tool_boundary" },
+      }),
+    );
+    await tick();
+
+    expect(useChatStore.getState().interruptedPromptRecovery).toBeNull();
+    controller.abort();
+  });
 
   it("coalesces multiple buffered blocks into one in-order append per frame", async () => {
     useChatStore.setState({ conversationId: "conv_batch", blocks: [] });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -177,6 +177,19 @@ export interface PendingUserMessage {
   posted?: boolean;
 }
 
+export type InterruptedPromptRecovery =
+  | {
+      text: string;
+      tempId: string;
+      phase: "eligible" | "requested";
+    }
+  | {
+      conversationId: string;
+      text: string;
+      tempId: string;
+      phase: "ready";
+    };
+
 /**
  * A message the user submitted while the agent was busy. It is held
  * client-side — NOT yet POSTed — and shown in the docked queue strip above
@@ -417,6 +430,12 @@ export interface ConversationState {
    * is covered.
    */
   failedSendDraft: { conversationId: string; text: string; files: File[] } | null;
+  /**
+   * Last locally-submitted prompt while it remains safe to recover after an
+   * interrupt. Turn output clears it; the interrupt acknowledgement releases
+   * it to the matching composer.
+   */
+  interruptedPromptRecovery: InterruptedPromptRecovery | null;
   /**
    * When a send last latched THIS conversation's `status` to "streaming", or
    * `null`. Conversation-scoped, not a module global, because `status` is now
@@ -1326,6 +1345,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   streamBudgetExceeded: false,
   streamBudgetBannerDismissed: false,
   failedSendDraft: null,
+  interruptedPromptRecovery: null,
   sendLatchedAt: null,
   llmModel: null,
   pendingModelChange: null,
@@ -1363,6 +1383,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           ...(files && files.length > 0 ? { files } : {}),
         },
       ],
+      interruptedPromptRecovery: null,
     }));
     // A message queued while the agent is idle (a race where the send routed
     // to the queue but the turn had already ended) would otherwise wait for an
@@ -1616,6 +1637,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           ...(selfAuthor !== null ? { author: selfAuthor } : {}),
         },
       ],
+      interruptedPromptRecovery:
+        !alreadyStreaming && text.trim() !== "" ? { text, tempId, phase: "eligible" } : null,
       // A new turn does NOT supersede the background-shell tally: shells
       // launched in an earlier turn keep running across the turn boundary, so
       // the composer pill must stay lit alongside the "Working…" shimmer rather
@@ -1698,6 +1721,9 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           const patch: Partial<ChatState> = {
             pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
           };
+          if (s.interruptedPromptRecovery?.tempId === tempId) {
+            patch.interruptedPromptRecovery = null;
+          }
           if (!alreadyStreaming) {
             patch.status = "idle";
             patch.sessionStatus = "idle";
@@ -1755,6 +1781,9 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // Roll back the optimistic bubble — no server idle will fire.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+        ...(s.interruptedPromptRecovery?.tempId === tempId
+          ? { interruptedPromptRecovery: null }
+          : {}),
       }));
       if (!alreadyStreaming) {
         if (failGet().activeResponse !== null) {
@@ -1823,6 +1852,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
           ...(selfAuthor !== null ? { author: selfAuthor } : {}),
         },
       ],
+      interruptedPromptRecovery: null,
     }));
 
     // Pin the destination at submit time — see `send` above for why a late
@@ -1928,6 +1958,12 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         backgroundTasks: [],
         blockedOn: null,
       };
+      if (s.interruptedPromptRecovery?.phase === "eligible") {
+        patch.interruptedPromptRecovery = {
+          ...s.interruptedPromptRecovery,
+          phase: "requested",
+        };
+      }
       if (s.activeResponse?.state === "streaming") {
         patch.activeResponse = {
           ...s.activeResponse,
@@ -4380,14 +4416,17 @@ function applyLiveDelta(set: Setter, messageId: string, delta: string): void {
     if (at === -1) {
       const live = s.activeResponse;
       const responseId = live?.state === "streaming" ? live.responseId : itemId;
-      return { blocks: [...s.blocks, makeLiveTextBlock(itemId, delta, responseId)] };
+      return {
+        blocks: [...s.blocks, makeLiveTextBlock(itemId, delta, responseId)],
+        interruptedPromptRecovery: null,
+      };
     }
     const existing = s.blocks[at]!;
     if (existing.type !== "text_done") return {};
     const fullText = existing.fullText + delta;
     const next = s.blocks.slice();
     next[at] = { ...existing, fullText, hasCodeBlocks: fullText.includes("```") };
-    return { blocks: next };
+    return { blocks: next, interruptedPromptRecovery: null };
   });
 }
 
@@ -4460,6 +4499,9 @@ async function* tapLiveDeltas(
   get: Getter,
 ): AsyncIterable<StreamEvent> {
   for await (const ev of events) {
+    if (ev.type === "text_delta" && ev.delta !== "") {
+      set((s) => (s.interruptedPromptRecovery === null ? {} : { interruptedPromptRecovery: null }));
+    }
     if (ev.type === "text_delta" && ev.messageId !== undefined) {
       if (!isConversationDisposed(id) && !ignored.has(ev.messageId)) {
         // A scheduled wake streams its first deltas ahead of the batch
@@ -4562,6 +4604,22 @@ function revivePendingElicitationBlock(set: Setter, elicitationId: string): void
     const updated: ElicitationBlock = { ...target, status: "pending", response: null };
     return { blocks: [...s.blocks.slice(0, idx), updated, ...s.blocks.slice(idx + 1)] };
   });
+}
+
+function blockCrossesPromptRecoveryBoundary(block: AnyBlock): boolean {
+  switch (block.type) {
+    case "response_start":
+    case "response_end":
+    case "user_message":
+    case "routing_decision":
+    case "reasoning_start":
+    case "slash_command":
+    case "compaction_loading":
+    case "compaction":
+      return false;
+    default:
+      return true;
+  }
 }
 
 // agent_run / tool_call / create_session telemetry is emitted from this pump's
@@ -4685,6 +4743,12 @@ export async function pumpStreamEvents(
           status: "streaming",
         });
         continue;
+      }
+
+      if (blockCrossesPromptRecoveryBoundary(block)) {
+        set((s) =>
+          s.interruptedPromptRecovery === null ? {} : { interruptedPromptRecovery: null },
+        );
       }
 
       // Native preview cleanup must run before the generic dedup below:
@@ -4909,6 +4973,18 @@ function userContentFromEvent(event: SessionInputConsumedEvent): MessageContentB
       b !== null &&
       "type" in b &&
       (b.type === "input_text" || b.type === "input_image" || b.type === "input_file"),
+  );
+}
+
+function eventMatchesRecoveryPrompt(
+  event: SessionInputConsumedEvent,
+  recovery: InterruptedPromptRecovery | null,
+): boolean {
+  if (recovery === null) return false;
+  return (
+    userContentFromEvent(event)?.some(
+      (block) => block.type === "input_text" && block.text === recovery.text,
+    ) ?? false
   );
 }
 
@@ -5538,6 +5614,9 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
           if (!s.isNativeTerminalSession && s.pendingUserMessages.length > 0) {
             patch.pendingUserMessages = [];
           }
+          if (s.interruptedPromptRecovery?.phase === "eligible") {
+            patch.interruptedPromptRecovery = null;
+          }
         }
         // Surface terminal-native failures carried only by session status.
         // Deduplicate repeated status edges for one response, but preserve the
@@ -5682,7 +5761,11 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
           // steal a real queued message's bubble. Hold the head back for a marker.
           const eventContent = userContentFromEvent(event);
           if (eventContent !== null && isSystemUserContent(eventContent)) return {};
-          if (s.pendingUserMessages.length === 0) return {};
+          if (s.pendingUserMessages.length === 0) {
+            return eventMatchesRecoveryPrompt(event, s.interruptedPromptRecovery)
+              ? {}
+              : { interruptedPromptRecovery: null };
+          }
           return { pendingUserMessages: s.pendingUserMessages.slice(1) };
         }
 
@@ -5756,6 +5839,9 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
             ...s.blocks,
             committedUserBlock(event.itemId, eventContent, undefined, event.createdBy),
           ],
+          interruptedPromptRecovery: eventMatchesRecoveryPrompt(event, s.interruptedPromptRecovery)
+            ? s.interruptedPromptRecovery
+            : null,
         };
       });
       return;
@@ -5788,6 +5874,18 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
           if (s.interruptedResponseIds.includes(interruptedResponseId)) return {};
           return {
             interruptedResponseIds: [...s.interruptedResponseIds, interruptedResponseId],
+          };
+        });
+      }
+      if (sourceConversationId !== null) {
+        applyToConversation((s) => {
+          if (s.interruptedPromptRecovery?.phase !== "requested") return {};
+          return {
+            interruptedPromptRecovery: {
+              ...s.interruptedPromptRecovery,
+              conversationId: sourceConversationId,
+              phase: "ready",
+            },
           };
         });
       }

--- a/web/src/store/conversationState.ts
+++ b/web/src/store/conversationState.ts
@@ -56,6 +56,7 @@ const CONVERSATION_STATE_KEY_MAP: Record<keyof ConversationState, true> = {
   abortController: true,
   runnerLaunchedAt: true,
   failedSendDraft: true,
+  interruptedPromptRecovery: true,
   sendLatchedAt: true,
   historyGeneration: true,
 };
@@ -116,6 +117,7 @@ export function createInitialConversationState(): ConversationState {
     abortController: null,
     runnerLaunchedAt: null,
     failedSendDraft: null,
+    interruptedPromptRecovery: null,
     sendLatchedAt: null,
     historyGeneration: 0,
   };


### PR DESCRIPTION
## Related issue

Closes #4668

## Summary

- Retain the latest locally submitted prompt while a turn has produced no assistant text, reasoning, tool activity, or newer user input.
- Release that prompt only after the existing interrupt path is acknowledged, then restore it into an empty composer for the same session without overwriting a newer draft.
- Cover SDK/native stream boundaries, cross-session routing, input-consumption races, and the real browser Escape journey.

ELI5: pressing Escape immediately after Send now puts the submitted text back in the editor, but only when the agent had not started doing meaningful work and you had not typed something newer.

```mermaid
flowchart LR
  A[Prompt submitted] --> B{Turn progress?}
  B -- Text, reasoning, tool, or newer input --> C[Discard recovery candidate]
  B -- No --> D[Escape uses existing stop path]
  D --> E[Interrupt acknowledged]
  E --> F{Same session and composer empty?}
  F -- Yes --> G[Restore and focus prompt]
  F -- No --> H[Preserve current draft]
```

## Test Plan

- `NODE_OPTIONS="--localstorage-file=/tmp/omnigent-4668-refresh-localstorage" pnpm exec vitest run src/store/chatStore.test.ts src/pages/ChatPage.composer.test.tsx` (from `web/`) — 532 passed.
- `OMNIGENT_CONFIG_HOME=/tmp/omnigent-4668-refresh-e2e-config uv run --no-sync pytest tests/e2e_ui/chat/test_interrupted_prompt_recovery.py -v` (with inherited `OMNIGENT_RUNNER_*` turn variables unset) — 1 passed in Chromium.
- `pnpm run type-check` (from `web/`) — passed.
- `pnpm run lint` (from `web/`) — passed with warnings denied.
- `pnpm run format:check` (from `web/`) — passed.
- `pnpm run build` (from `web/`) — production bundle built successfully.
- `uv run --no-sync pre-commit run --all-files` — every repository hook passed.

## Demo

**1. Early running turn, before Escape.** The submitted prompt is visible in the conversation while the turn is still running; the composer is empty and the interrupt control is active.

![Early running turn before Escape, showing the submitted prompt, running indicator, empty composer, and interrupt control](https://github.com/user-attachments/assets/04412e2f-f6e6-43b8-8214-25f54fa38478)

**2. After Escape.** The exact original two-line prompt is restored in the focused composer, ready to edit or resend.

![Exact original prompt restored and focused in the composer after interruption](https://github.com/user-attachments/assets/a8c6f733-6d3f-4a6b-85d3-7feda29bc5ad)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Playwright test drives the real browser composer through Send and Escape while the mock LLM is blocked before output, then verifies exact multiline restoration and focus. Component/store coverage verifies newer-draft preservation, session isolation, menu precedence, text/tool progress boundaries, and lifecycle races across SDK/native-compatible stream events.

## Changelog

Escape restores a prompt when it interrupts a turn before the agent starts responding