### PR TITLE
feat(web): add default session view preference

### DIFF
--- a/tests/e2e_ui/sessions/test_default_session_view.py
+++ b/tests/e2e_ui/sessions/test_default_session_view.py
@@ -1,0 +1,133 @@
+"""E2E: Settings → Appearance default Chat / Terminal session view.
+
+The browser flow uses two real server-backed sessions and patches only their
+browser-visible session/terminal snapshots. This keeps the test deterministic
+without launching a native CLI while exercising the production Settings and
+AppShell code paths end to end.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+STORAGE_KEY = "omnigent:default-session-view"
+
+
+def _patch_terminal_first_snapshots(
+    page: Page,
+    *,
+    terminal_session_id: str,
+    no_terminal_session_id: str,
+) -> None:
+    """Present two sessions as terminal-first, with a terminal only on one."""
+    session_ids = {terminal_session_id, no_terminal_session_id}
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        path = urlparse(request.url).path
+
+        for session_id in session_ids:
+            if path == f"/v1/sessions/{session_id}/resources/terminals":
+                data = []
+                if session_id == terminal_session_id:
+                    data.append(
+                        {
+                            "id": "terminal_claude_main",
+                            "type": "terminal",
+                            "name": "claude",
+                            "metadata": {
+                                "terminal_name": "claude",
+                                "session_key": "main",
+                                "running": True,
+                                "terminal_transport": "pty",
+                            },
+                        }
+                    )
+                route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": data}),
+                )
+                return
+
+            if path == f"/v1/sessions/{session_id}" and request.method == "GET":
+                response = route.fetch()
+                payload = response.json()
+                payload["labels"] = {
+                    **payload.get("labels", {}),
+                    "omnigent.ui": "terminal",
+                    "omnigent.wrapper": "claude-code-native-ui",
+                }
+                route.fulfill(
+                    status=response.status,
+                    headers=response.headers,
+                    content_type="application/json",
+                    body=json.dumps(payload),
+                )
+                return
+
+        route.continue_()
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def _expect_view(page: Page, view: str) -> None:
+    """Wait for the terminal-first switcher and assert its active segment."""
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id(f"view-mode-{view}")).to_have_attribute(
+        "aria-pressed", "true", timeout=30_000
+    )
+
+
+def test_default_session_view_persists_and_respects_session_eligibility(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Terminal persists, explicit Chat wins, and no-terminal sessions stay Chat."""
+    base_url, terminal_session_id, no_terminal_session_id = seeded_session_pair
+    _patch_terminal_first_snapshots(
+        page,
+        terminal_session_id=terminal_session_id,
+        no_terminal_session_id=no_terminal_session_id,
+    )
+
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("radiogroup", name="Default session view")).to_be_visible(
+        timeout=30_000
+    )
+    chat_card = page.get_by_test_id("default-session-view-chat")
+    terminal_card = page.get_by_test_id("default-session-view-terminal")
+    expect(chat_card).to_have_attribute("aria-checked", "true")
+    assert page.evaluate(f"() => localStorage.getItem('{STORAGE_KEY}')") is None
+
+    terminal_card.click()
+    expect(terminal_card).to_have_attribute("aria-checked", "true")
+    assert page.evaluate(f"() => localStorage.getItem('{STORAGE_KEY}')") == "terminal"
+
+    page.reload()
+    expect(page.get_by_test_id("default-session-view-terminal")).to_have_attribute(
+        "aria-checked", "true", timeout=30_000
+    )
+
+    page.goto(f"{base_url}/c/{terminal_session_id}")
+    _expect_view(page, "terminal")
+
+    page.get_by_test_id("view-mode-chat").click()
+    _expect_view(page, "chat")
+    assert (
+        page.evaluate(
+            f"() => sessionStorage.getItem('omnigent.web.panel-key:{terminal_session_id}')"
+        )
+        == "chat"
+    )
+
+    page.goto(f"{base_url}/settings/appearance")
+    page.goto(f"{base_url}/c/{terminal_session_id}")
+    _expect_view(page, "chat")
+
+    page.goto(f"{base_url}/c/{no_terminal_session_id}")
+    _expect_view(page, "chat")
+    expect(page.get_by_test_id("view-mode-terminal")).to_be_disabled()

--- a/tests/e2e_ui/sessions/test_default_session_view.py
+++ b/tests/e2e_ui/sessions/test_default_session_view.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from urllib.parse import urlparse
 
+import httpx
 from playwright.sync_api import Page, Route, expect
 
 STORAGE_KEY = "omnigent:default-session-view"
@@ -21,6 +22,7 @@ def _patch_terminal_first_snapshots(
     *,
     terminal_session_id: str,
     no_terminal_session_id: str,
+    session_payload: dict[str, object],
 ) -> None:
     """Present two sessions as terminal-first, with a terminal only on one."""
     session_ids = {terminal_session_id, no_terminal_session_id}
@@ -54,16 +56,15 @@ def _patch_terminal_first_snapshots(
                 return
 
             if path == f"/v1/sessions/{session_id}" and request.method == "GET":
-                response = route.fetch()
-                payload = response.json()
+                payload = dict(session_payload)
+                payload["id"] = session_id
                 payload["labels"] = {
                     **payload.get("labels", {}),
                     "omnigent.ui": "terminal",
                     "omnigent.wrapper": "claude-code-native-ui",
                 }
                 route.fulfill(
-                    status=response.status,
-                    headers=response.headers,
+                    status=200,
                     content_type="application/json",
                     body=json.dumps(payload),
                 )
@@ -84,14 +85,18 @@ def _expect_view(page: Page, view: str) -> None:
 
 def test_default_session_view_persists_and_respects_session_eligibility(
     page: Page,
-    seeded_session_pair: tuple[str, str, str],
+    seeded_session: tuple[str, str],
 ) -> None:
     """Terminal persists, explicit Chat wins, and no-terminal sessions stay Chat."""
-    base_url, terminal_session_id, no_terminal_session_id = seeded_session_pair
+    base_url, terminal_session_id = seeded_session
+    no_terminal_session_id = "conv_no_terminal_default_view"
+    snapshot = httpx.get(f"{base_url}/v1/sessions/{terminal_session_id}", timeout=10.0)
+    snapshot.raise_for_status()
     _patch_terminal_first_snapshots(
         page,
         terminal_session_id=terminal_session_id,
         no_terminal_session_id=no_terminal_session_id,
+        session_payload=snapshot.json(),
     )
 
     page.goto(f"{base_url}/settings/appearance")

--- a/web/src/lib/sessionViewPreferences.test.ts
+++ b/web/src/lib/sessionViewPreferences.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeDefaultSessionView,
+  readDefaultSessionView,
+  SESSION_VIEW_DEFAULT,
+  writeDefaultSessionView,
+} from "./sessionViewPreferences";
+
+const STORAGE_KEY = "omnigent:default-session-view";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("sessionViewPreferences — read/write", () => {
+  it("preserves the current chat default when nothing is stored", () => {
+    expect(readDefaultSessionView()).toBe(SESSION_VIEW_DEFAULT);
+    expect(readDefaultSessionView()).toBe("chat");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("persists terminal and clears the key for chat", () => {
+    writeDefaultSessionView("terminal");
+    expect(readDefaultSessionView()).toBe("terminal");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("terminal");
+
+    writeDefaultSessionView("chat");
+    expect(readDefaultSessionView()).toBe("chat");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("normalizeDefaultSessionView", () => {
+  it("passes through supported values", () => {
+    expect(normalizeDefaultSessionView("chat")).toBe("chat");
+    expect(normalizeDefaultSessionView("terminal")).toBe("terminal");
+  });
+
+  it("maps missing and unknown values to chat", () => {
+    expect(normalizeDefaultSessionView(null)).toBe("chat");
+    expect(normalizeDefaultSessionView(undefined)).toBe("chat");
+    expect(normalizeDefaultSessionView("shell")).toBe("chat");
+  });
+});

--- a/web/src/lib/sessionViewPreferences.ts
+++ b/web/src/lib/sessionViewPreferences.ts
@@ -1,0 +1,34 @@
+const STORAGE_KEY = "omnigent:default-session-view";
+
+export const sessionViewDefaults = ["chat", "terminal"] as const;
+export type DefaultSessionView = (typeof sessionViewDefaults)[number];
+
+/** Preserve the existing behavior when no preference has been selected. */
+export const SESSION_VIEW_DEFAULT: DefaultSessionView = "chat";
+
+export function normalizeDefaultSessionView(value: string | null | undefined): DefaultSessionView {
+  return value === "terminal" ? "terminal" : SESSION_VIEW_DEFAULT;
+}
+
+export function readDefaultSessionView(): DefaultSessionView {
+  if (typeof window === "undefined") return SESSION_VIEW_DEFAULT;
+  try {
+    return normalizeDefaultSessionView(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return SESSION_VIEW_DEFAULT;
+  }
+}
+
+export function writeDefaultSessionView(value: DefaultSessionView): void {
+  if (typeof window === "undefined") return;
+  try {
+    const normalized = normalizeDefaultSessionView(value);
+    if (normalized === SESSION_VIEW_DEFAULT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, normalized);
+    }
+  } catch {
+    // localStorage quota or access errors shouldn't break settings.
+  }
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -299,6 +299,24 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "false");
   });
 
+  it("persists the default session view and preserves chat when unset", () => {
+    renderPage("/settings/appearance");
+
+    expect(screen.getByRole("radiogroup", { name: "Default session view" })).toBeInTheDocument();
+    expect(screen.getByTestId("default-session-view-chat")).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("omnigent:default-session-view")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("default-session-view-terminal"));
+    expect(screen.getByTestId("default-session-view-terminal")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(localStorage.getItem("omnigent:default-session-view")).toBe("terminal");
+
+    fireEvent.click(screen.getByTestId("default-session-view-chat"));
+    expect(localStorage.getItem("omnigent:default-session-view")).toBeNull();
+  });
+
   it("reflects a stored light terminal theme on mount", () => {
     localStorage.setItem("omnigent:terminal-theme", "light");
     renderPage("/settings/appearance");
@@ -455,6 +473,7 @@ describe("SettingsPage", () => {
     mocks.theme = "dark";
     fireEvent.click(screen.getByTestId("theme-dark"));
     fireEvent.click(screen.getByTestId("terminal-theme-dark"));
+    fireEvent.click(screen.getByTestId("default-session-view-terminal"));
     fireEvent.change(screen.getByTestId("color-theme-select") as HTMLSelectElement, {
       target: { value: "github" },
     });
@@ -500,6 +519,8 @@ describe("SettingsPage", () => {
 
     // Terminal theme, workspace panel, and harness visibility are restored.
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("default-session-view-chat")).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("omnigent:default-session-view")).toBeNull();
     expect(screen.getByTestId("workspace-panel-default-open")).toHaveAttribute(
       "aria-checked",
       "true",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -10,7 +10,7 @@
  * Sections:
  *
  * - **Appearance** — theme mode (System / Light / Dark), terminal theme,
- *   Workspace panel default for new chats, and UI/code font controls.
+ *   default session view, Workspace panel default, and UI/code font controls.
  * - **Git** — Git behavior, e.g. the default base branch pre-filled when
  *   naming a new worktree branch in the composer.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
@@ -45,6 +45,7 @@ import {
   KeyRoundIcon,
   LaptopMinimalIcon,
   LogOutIcon,
+  MessagesSquareIcon,
   MinusIcon,
   MonitorIcon,
   MoonIcon,
@@ -52,6 +53,7 @@ import {
   PanelRightIcon,
   PlusIcon,
   SunIcon,
+  TerminalIcon,
   Trash2Icon,
   UserCogIcon,
 } from "lucide-react";
@@ -137,6 +139,12 @@ import {
   writeWorkspacePanelDefault,
   type WorkspacePanelDefault,
 } from "@/lib/workspacePanelPreferences";
+import {
+  type DefaultSessionView,
+  readDefaultSessionView,
+  SESSION_VIEW_DEFAULT,
+  writeDefaultSessionView,
+} from "@/lib/sessionViewPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
@@ -283,6 +291,15 @@ const workspacePanelCards: {
 }[] = [
   { value: "open", label: "Open", icon: PanelRightIcon },
   { value: "collapsed", label: "Collapsed", icon: PanelRightCloseIcon },
+];
+
+const sessionViewCards: {
+  value: DefaultSessionView;
+  label: string;
+  icon: typeof TerminalIcon;
+}[] = [
+  { value: "chat", label: "Chat", icon: MessagesSquareIcon },
+  { value: "terminal", label: "Terminal", icon: TerminalIcon },
 ];
 
 /**
@@ -587,6 +604,35 @@ function WorkspacePanelDefaultControl() {
   );
 }
 
+function DefaultSessionViewControl() {
+  const [value, setValue] = useState(() => readDefaultSessionView());
+  const labelId = useId();
+  const choose = useCallback((next: DefaultSessionView) => {
+    setValue(next);
+    writeDefaultSessionView(next);
+  }, []);
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Default session view"
+      helper="Choose whether sessions with a terminal initially open in Chat or Terminal. A session's choice in this tab still takes priority."
+    >
+      <CardRadioGroup<DefaultSessionView>
+        labelledBy={labelId}
+        value={value}
+        onSelect={choose}
+        className="grid grid-cols-2 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={sessionViewCards.map((card) => ({
+          value: card.value,
+          testId: `default-session-view-${card.value}`,
+          body: iconCardBody(card.icon, card.label),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
 function ColorThemeControl() {
   // Render each chip in the currently-resolved mode so it matches the app now.
   const { resolvedTheme } = useTheme();
@@ -864,6 +910,7 @@ function AppearanceSection() {
     applyCustomTheme(DEFAULT_CUSTOM_THEME);
 
     writeWorkspacePanelDefault(WORKSPACE_PANEL_DEFAULT);
+    writeDefaultSessionView(SESSION_VIEW_DEFAULT);
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
 
@@ -888,6 +935,7 @@ function AppearanceSection() {
           "omnigent:ui-theme-palette",
           "omnigent:custom-theme",
           "omnigent:default-workspace-panel",
+          "omnigent:default-session-view",
           "omnigent:hide-unconfigured-harnesses",
         ]) {
           window.localStorage.removeItem(key);
@@ -930,6 +978,8 @@ function AppearanceSection() {
         {!isEmbedded && <ColorThemeControl />}
 
         <WorkspacePanelDefaultControl />
+
+        <DefaultSessionViewControl />
 
         <HideUnconfiguredHarnessesControl />
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -634,6 +634,67 @@ describe("AppShell header", () => {
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
   });
 
+  it("uses the terminal default for an eligible session with a usable terminal", () => {
+    localStorage.setItem("omnigent:default-session-view", "terminal");
+    mockConversations([
+      {
+        id: "conv_terminal",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        {
+          id: "terminal_claude_main",
+          name: "claude",
+          session: "main",
+          running: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_terminal");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+  });
+
+  it("lets an explicit per-session Chat choice override the terminal default", () => {
+    localStorage.setItem("omnigent:default-session-view", "terminal");
+    mockConversations([
+      {
+        id: "conv_terminal",
+        permission_level: null,
+        labels: { "omnigent.ui": "terminal" },
+      },
+    ]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        {
+          id: "terminal_claude_main",
+          name: "claude",
+          session: "main",
+          running: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_terminal");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+    fireEvent.click(screen.getByRole("button", { name: "Chat" }));
+    expect(sessionStorage.getItem("omnigent.web.panel-key:conv_terminal")).toBe("chat");
+
+    cleanup();
+    renderShell("/c/conv_terminal");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
+  });
+
   it("shows the terminal-startup spinner while a terminal-first session is coming up", () => {
     // Baseline for the suppression test below: terminalPending (PTY being
     // created) with no terminals available drives terminalStartingUp true.
@@ -808,11 +869,12 @@ describe("TerminalFirstContext", () => {
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
   });
 
-  it("flips to an empty Terminal view when a terminal-first session has no terminal resource", () => {
-    // The terminal-first pill is still a useful navigation affordance when a
-    // stopped/killed session has no resource rows. `setView("terminal")`
-    // must persist an open-but-empty terminal view instead of refusing to
-    // switch because there is no first terminal key.
+  it("stays Chat-only when the terminal default has no usable terminal resource", () => {
+    localStorage.setItem("omnigent:default-session-view", "terminal");
+    sessionStorage.setItem(
+      "omnigent.web.panel-key:conv_native_empty",
+      "terminal:terminal_claude_main",
+    );
     mockConversations([
       {
         id: "conv_native_empty",
@@ -834,7 +896,7 @@ describe("TerminalFirstContext", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
 
-    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "terminal");
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
     expect(screen.queryByTestId("terminals-panel")).toBeNull();
   });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -38,6 +38,7 @@ import {
   readDefaultWorkspacePanelOpen,
   writeDefaultWorkspacePanelOpen,
 } from "@/lib/workspacePanelPreferences";
+import { readDefaultSessionView } from "@/lib/sessionViewPreferences";
 import {
   Dialog,
   DialogContent,
@@ -59,7 +60,6 @@ import {
   AGENT_TERMINAL_IDS,
   inventoryTerminals,
   isAgentTerminalKey,
-  PANEL_NO_TERMINAL_KEY,
   terminalTabKey,
   useDeleteTerminal,
   useTerminals,
@@ -112,6 +112,8 @@ import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { WorkspacePanel } from "./WorkspacePanel";
 import { SessionRail } from "./SessionRail";
 import type { RightRailTab } from "./railTabs";
+
+const SESSION_CHAT_VIEW_KEY = "chat";
 
 /**
  * Top-level layout. The sidebar and right panels are responsive:
@@ -352,6 +354,8 @@ export function AppShell() {
   const { terminals } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
+  const hadTerminalRef = useRef(false);
+  const terminalConversationRef = useRef(conversationId);
 
   const debugMode = useDebugMode();
   const { data: conversationsData } = useConversations("", true);
@@ -834,24 +838,25 @@ export function AppShell() {
     [changedFilePaths],
   );
 
-  // Persist the Chat/TUI toggle position per-conversation so leaving and
-  // re-entering a native session doesn't drop the user back into chat
-  // view. sessionStorage scope: same tab, cleared on tab close —
-  // a deliberately narrow scope so a stale "terminal view" preference
-  // can't survive across browser sessions, where the user's mental model
-  // may have moved on.
+  // Persist an explicit Chat/TUI choice per conversation. Terminal keys remain
+  // backward-compatible; terminal-first sessions use a Chat sentinel so an
+  // explicit Chat choice can override the app-global Terminal default.
   const setPanelInitialKey = useCallback(
     (key: string | null) => {
       setPanelInitialKeyState(key);
       if (!conversationId) return;
       const storageKey = `omnigent.web.panel-key:${conversationId}`;
       if (key === null) {
-        sessionStorage.removeItem(storageKey);
+        if (terminalFirst) {
+          sessionStorage.setItem(storageKey, SESSION_CHAT_VIEW_KEY);
+        } else {
+          sessionStorage.removeItem(storageKey);
+        }
       } else {
         sessionStorage.setItem(storageKey, key);
       }
     },
-    [conversationId],
+    [conversationId, terminalFirst],
   );
 
   // Restore the per-session workspace state when switching conversations:
@@ -883,9 +888,6 @@ export function AppShell() {
       return;
     }
     const persisted = readSessionWorkspaceState(conversationId);
-
-    const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
-    setPanelInitialKeyState(stored);
 
     // Restore the selected rail tab (the Files vs Changes scope is now the tab
     // itself). ``nextTab`` stays null when there's no persisted tab and no file
@@ -938,6 +940,51 @@ export function AppShell() {
 
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Restore an explicit per-session view first; otherwise seed eligible
+  // terminal-first sessions from the Appearance default. Waiting for a usable
+  // terminal keeps stopped and still-starting sessions in Chat.
+  useEffect(() => {
+    if (terminalConversationRef.current !== conversationId) {
+      terminalConversationRef.current = conversationId;
+      hadTerminalRef.current = false;
+    }
+
+    if (!conversationId) {
+      setPanelInitialKeyState(null);
+      return;
+    }
+
+    const stored = sessionStorage.getItem(`omnigent.web.panel-key:${conversationId}`);
+    if (stored === SESSION_CHAT_VIEW_KEY) {
+      setPanelInitialKeyState(null);
+      return;
+    }
+
+    if (!terminalFirst) {
+      setPanelInitialKeyState(stored);
+      return;
+    }
+
+    if (terminals.length === 0) {
+      if (hadTerminalRef.current) return;
+      setPanelInitialKeyState(null);
+      return;
+    }
+
+    if (stored !== null) {
+      setPanelInitialKeyState(stored);
+      return;
+    }
+
+    if (readDefaultSessionView() === "terminal") {
+      const agentTerminal = terminals.find((terminal) => AGENT_TERMINAL_IDS.has(terminal.id));
+      setPanelInitialKeyState(terminalTabKey(agentTerminal ?? terminals[0]));
+      return;
+    }
+
+    setPanelInitialKeyState(null);
+  }, [conversationId, terminalFirst, terminals]);
 
   // Persist the per-session rail tab + open file tabs whenever they change.
   // Keyed on the state (not conversationId) and targeted at the conversation
@@ -1471,17 +1518,14 @@ export function AppShell() {
         setPanelInitialKey(null);
         return;
       }
-      if (terminals.length === 0) {
-        if (terminalFirst) setPanelInitialKey(PANEL_NO_TERMINAL_KEY);
-        return;
-      }
+      if (terminals.length === 0) return;
       // The pill's Terminal view is the AGENT's terminal: target it
       // explicitly (the SDK REPL or the native vendor pane) so the
       // pill never lands on a user shell.
       const agentTerminal = terminals.find((t) => AGENT_TERMINAL_IDS.has(t.id));
       setPanelInitialKey(terminalTabKey(agentTerminal ?? terminals[0]));
     },
-    [terminalFirst, terminals, setPanelInitialKey],
+    [terminals, setPanelInitialKey],
   );
 
   // `terminals` is already runner-accurate (useTerminals empties it when the
@@ -1517,15 +1561,13 @@ export function AppShell() {
   // own terminal) takes over the main view chrome-free:
   // ConnectionIndicator hides the Chat/Terminal pill while this is
   // true, and MainTerminalView renders the shell with its own close
-  // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
-  // "open with no target" stays a pill view.
+  // affordance.
   const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
 
   // A runner stop/disconnect empties the terminal list; if that lands while the
   // terminal view is open, flip back to chat rather than stranding the user on
   // "No terminals available" (and chat is where the composer resumes it).
   // Edge-triggered + startingUp-guarded so a cold boot / relaunch isn't yanked.
-  const hadTerminalRef = useRef(false);
   useEffect(() => {
     if (
       terminalFirst &&


### PR DESCRIPTION
## Related issue

Closes #4410

## Summary

- Adds a **Default session view: Chat / Terminal** control to Settings → Appearance, persisted in `localStorage` with Chat as the backward-compatible unset default.
- Applies the preference only to terminal-first sessions with an available terminal. Existing per-session choices win, including an explicit Chat choice, and sessions without a usable terminal remain in Chat.
- Extends Appearance reset behavior and adds persistence, shell-level, and browser E2E regression coverage.

**ELI5:** The setting chooses the starting view, but a session remembers when you explicitly choose differently. If no terminal is available, Omnigent safely stays in Chat.

```mermaid
flowchart LR
  A[Appearance default] --> C{Per-session choice?}
  B[Session storage] --> C
  C -->|Yes| D[Use session choice]
  C -->|No| E{Terminal-first and terminal available?}
  E -->|Yes| F[Use Appearance default]
  E -->|No| G[Chat]
```

## Test Plan

- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run src/lib/sessionViewPreferences.test.ts src/pages/SettingsPage.test.tsx src/shell/AppShell.test.tsx` → 3 files passed, 151 tests passed.
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_default_session_view.py -v` → 1 passed in 20.76s.
- `pnpm --filter web run type-check` → passed.
- `pnpm --filter web run lint` → passed with warnings denied.
- `pnpm --filter web run format:check` → passed.
- `pnpm --filter web run build` → production build passed.
- `uv run --no-sync pre-commit run --all-files` → all hooks passed.
- Rendered `/settings/appearance` locally at 1440×1600 and confirmed the new Chat / Terminal cards appear below Workspace panel with Chat selected by default.

## Demo

![Appearance settings showing the Default session view Chat and Terminal cards](https://github.com/user-attachments/assets/9afb85b6-f7cb-49dc-875b-c6ddd088efec)

Local 1440×1600 render confirmed the new **Default session view** control in Appearance, with **Chat** selected by default. The browser E2E test exercises selecting Terminal, applying it to an eligible session, restoring an explicit Chat override, and falling back to Chat without a terminal.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually rendered the local Appearance page and confirmed the new control's placement, labels, icons, and default selection. Automated unit, integration, and Playwright tests cover localStorage persistence and reset, unchanged default behavior, explicit per-session override, terminal-first eligibility, and no-terminal fallback.

## Changelog

Choose whether terminal-enabled sessions initially open in Chat or Terminal from Appearance settings.
