### PR TITLE
feat(acp): Devin as a builtin harness + catalog-derived picker identity

### DIFF
--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -73,6 +73,23 @@ class AcpCliHarness:
 # Keyed by canonical harness id. Keep keys sorted; each row's registrations
 # derive from here (see the module docstring for the full list).
 ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
+    # Devin (Cognition's ``devin`` CLI) drives ``devin acp`` — its ACP stdio
+    # server. Ships via a curl installer (not npm) and authenticates through its
+    # own ``devin auth login`` (or a Devin API key); Omnigent stores no
+    # credential. The row runs Devin's account-default model; a builtin row can't
+    # carry a per-user model, so set ``DEVIN_MODEL`` to pin one (or use an
+    # ``acp:`` config entry with ``--model``).
+    "devin": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "Devin",
+            "devin",
+            None,
+            login_args=("auth", "login"),
+            install_hint="curl -fsSL https://cli.devin.ai/install.sh | bash",
+            auth_hint="run `devin auth login` (or set a Devin API key)",
+        ),
+        args=("acp",),
+    ),
     # Grok Build (xAI's ``grok`` CLI) drives ``grok agent stdio``. Ships via a
     # curl installer (not npm) and authenticates through its own ``grok login``
     # (xAI OAuth, device-code capable) or ``XAI_API_KEY``; Omnigent stores no

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1699,7 +1699,8 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "Qwen Code",
         "Goose",
         # Builtin ACP CLI rows (ACP_CLI_HARNESSES) render after Goose, the other
-        # ACP-family builtin, and before the non-ACP harnesses.
+        # ACP-family builtin, sorted by id, before the non-ACP harnesses.
+        "Devin",
         "Grok Build",
         "Copilot",
         "Kiro",
@@ -1828,7 +1829,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["14", "", "", "q"]) + "\n"
+    stdin = "\n".join(["15", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1850,7 +1851,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["14", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1867,7 +1868,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["14", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2058,13 +2059,14 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10 is the builtin ACP CLI row (Grok Build); every row after it shifted
-        # down by one when that block landed.
+        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
+        # every row after them shifted down by two when that block landed.
         ("10", "_show_acp_cli_harness"),
-        ("11", "_manage_copilot_harness"),
-        ("12", "_manage_kiro_harness"),
-        ("13", "_manage_kimi_harness"),
-        ("15", "_add_acp_agent"),
+        ("11", "_show_acp_cli_harness"),
+        ("12", "_manage_copilot_harness"),
+        ("13", "_manage_kiro_harness"),
+        ("14", "_manage_kimi_harness"),
+        ("16", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -26,6 +26,7 @@ const fetchMock = vi.fn();
 
 const BUILTINS_URL = "/v1/agents";
 const SCAN_URL = "/v1/sessions?limit=100&kind=any";
+const HARNESSES_URL = "/v1/harnesses";
 
 /**
  * Stub the global fetch with per-URL responses. Unrouted URLs reject
@@ -88,6 +89,47 @@ describe("useAvailableAgents", () => {
     const urls = fetchMock.mock.calls.map((c) => c[0] as string);
     expect(urls).toContain(BUILTINS_URL);
     expect(urls).toContain(SCAN_URL);
+  });
+
+  it("labels and flags generic-ACP agents from the server harness catalog", async () => {
+    // A seeded ACP agent's name is a slug, so without the catalog the picker
+    // renders Grok Build as "Grok" and — lacking `acpHarness` — groups it under
+    // "Agents" instead of "Harnesses". Both come from the server so a new
+    // builtin ACP row needs no frontend change.
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          { id: "ag_grok", name: "grok", harness: "grok", builtin: true },
+          { id: "ag_polly", name: "polly", harness: "claude-sdk", builtin: true },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: EMPTY_SCAN,
+      [HARNESSES_URL]: mockResponse({
+        data: [
+          { id: "grok", label: "Grok Build", capabilities: { integration_mode: "acp-subprocess" } },
+          {
+            id: "claude-sdk",
+            label: "Claude SDK",
+            capabilities: { integration_mode: "sdk-in-process" },
+          },
+        ],
+      }),
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    // The catalog is a second query, so wait for the enrichment specifically.
+    await waitFor(() =>
+      expect(result.current.data?.find((a) => a.name === "grok")?.acpHarness).toBe(true),
+    );
+    expect(result.current.data?.find((a) => a.name === "grok")?.display_name).toBe("Grok Build");
+
+    // A composed agent on a non-ACP harness keeps its own name: it must not
+    // inherit the harness label ("Claude SDK") nor move into the Harnesses group.
+    const polly = result.current.data?.find((a) => a.name === "polly");
+    expect(polly?.display_name).toBe("Polly");
+    expect(polly?.acpHarness).toBeUndefined();
   });
 
   it("paginates built-ins so defaults pushed past fork rows are still listed", async () => {

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -1,7 +1,8 @@
 import { useQuery, type QueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { authenticatedFetch } from "@/lib/identity";
 import { agentRootName } from "@/lib/forkHarness";
-import { capitalizeAgentName } from "@/lib/agentLabels";
+import { capitalizeAgentName, useAcpHarnessIds, useHarnessLabels } from "@/lib/agentLabels";
 import {
   nativeCodingAgentForAvailableAgent,
   nativeCodingAgentForAgentName,
@@ -31,6 +32,13 @@ export interface AvailableAgent {
   // same-named `omnigent run` upload, but lets a newer upload supersede a
   // user-registered template (builtin === false).
   builtin?: boolean;
+  // True when the server declares this agent's harness generic-ACP (harness
+  // catalog ``integration_mode === "acp-subprocess"``) — a builtin ACP CLI row
+  // (devin / grok) or a user-configured ``acp:<slug>`` agent. Stamped on by
+  // {@link useAvailableAgents}; absent until the catalog loads and on servers
+  // that don't report capabilities, where grouping falls back to the id
+  // heuristic in ``agentGrouping``.
+  acpHarness?: boolean;
   // Creation epoch of a catalog agent — recency signal for same-name
   // supersession. Deliberately NOT updated_at: `--agent` re-registration
   // rewrites a template's bundle on every server restart (non-reproducible
@@ -380,11 +388,53 @@ interface UseAvailableAgentsOptions {
   enabled?: boolean;
 }
 
+/**
+ * Stamp the server's generic-ACP identity onto fetched agents.
+ *
+ * The fetchers above can't read the harness catalog (it's a hook), so the ACP
+ * flag and the vendor label are applied here instead. The label matters: a
+ * seeded ACP agent's ``name`` is a slug, so the capitalization fallback renders
+ * Grok Build as "Grok" and a user's "My Devin Agent" as "My-devin-agent". The
+ * catalog carries the real label for both — the vendor's for a builtin row, the
+ * user's own for a configured ``acp:<slug>`` agent.
+ *
+ * Returns the input array untouched when the catalog hasn't loaded, so a
+ * consumer's ``useMemo`` doesn't churn on an equivalent copy.
+ */
+function applyAcpHarnessCatalog(
+  agents: AvailableAgent[],
+  acpHarnessIds: ReadonlySet<string>,
+  harnessLabels: Record<string, string>,
+): AvailableAgent[] {
+  if (acpHarnessIds.size === 0) return agents;
+  return agents.map((agent) => {
+    const harness = agent.harness;
+    if (harness == null || !acpHarnessIds.has(harness)) return agent;
+    return {
+      ...agent,
+      acpHarness: true,
+      display_name: harnessLabels[harness] ?? agent.display_name,
+    };
+  });
+}
+
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
+  const enabled = options.enabled ?? true;
+  // Read the catalog under the same gate: a disabled picker must not provoke a
+  // request. Both values are cached references, so the memoized select keeps a
+  // stable identity and TanStack doesn't hand consumers a fresh array per render.
+  const acpHarnessIds = useAcpHarnessIds(enabled);
+  const harnessLabels = useHarnessLabels(enabled);
+  const select = useMemo(
+    () => (agents: AvailableAgent[]) =>
+      applyAcpHarnessCatalog(agents, acpHarnessIds, harnessLabels),
+    [acpHarnessIds, harnessLabels],
+  );
   return useQuery({
     queryKey: ["available-agents"],
     queryFn: fetchAvailableAgents,
-    enabled: options.enabled ?? true,
+    enabled,
     staleTime: 30_000,
+    select,
   });
 }

--- a/web/src/lib/agentGrouping.test.ts
+++ b/web/src/lib/agentGrouping.test.ts
@@ -47,14 +47,24 @@ describe("partitionAgentsByKind", () => {
 });
 
 describe("isAcpHarnessAgent", () => {
+  it("trusts the server's acpHarness flag, so an unknown ACP harness still groups right", () => {
+    // The whole point of the catalog-derived flag: a builtin ACP row added to
+    // ACP_CLI_HARNESSES with an id this frontend has never seen must land under
+    // "Harnesses" without any frontend change.
+    expect(isAcpHarnessAgent({ harness: "some-future-acp-cli", acpHarness: true })).toBe(true);
+    // And the server's "no" wins over the id heuristic.
+    expect(isAcpHarnessAgent({ harness: "acp:legacy", acpHarness: false })).toBe(false);
+  });
+
   it("recognizes configured acp:<slug> agents and builtin ACP CLI harnesses", () => {
     // NewChatDialog routes these into the "Harnesses" group (beside the native
     // CLIs), not "Agents" — they select a harness to run, not a composed agent.
     expect(isAcpHarnessAgent({ harness: "acp:devin" })).toBe(true);
     expect(isAcpHarnessAgent({ harness: "acp:kilocode" })).toBe(true);
     expect(isAcpHarnessAgent({ harness: "grok" })).toBe(true);
-    // Bare builtin ACP CLI harness ids (ACP_CLI_HARNESSES): a seeded `devin`
-    // agent carries `harness: "devin"`, not `acp:devin`, so it must be in the id set.
+    // Bare builtin ACP CLI ids: a seeded `devin` agent carries
+    // `harness: "devin"`, not `acp:devin`. This is the older-server fallback
+    // path (no `acpHarness` flag), which the legacy id set still covers.
     expect(isAcpHarnessAgent({ harness: "devin" })).toBe(true);
   });
 

--- a/web/src/lib/agentGrouping.test.ts
+++ b/web/src/lib/agentGrouping.test.ts
@@ -53,6 +53,9 @@ describe("isAcpHarnessAgent", () => {
     expect(isAcpHarnessAgent({ harness: "acp:devin" })).toBe(true);
     expect(isAcpHarnessAgent({ harness: "acp:kilocode" })).toBe(true);
     expect(isAcpHarnessAgent({ harness: "grok" })).toBe(true);
+    // Bare builtin ACP CLI harness ids (ACP_CLI_HARNESSES): a seeded `devin`
+    // agent carries `harness: "devin"`, not `acp:devin`, so it must be in the id set.
+    expect(isAcpHarnessAgent({ harness: "devin" })).toBe(true);
   });
 
   it("does not misclassify composed agents, native harnesses, or missing harness", () => {

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -26,27 +26,33 @@ export const BUILTIN_AGENTS = new Set([
   "debby",
 ]);
 
-// Builtin ACP CLI harness ids (mirrors ACP_CLI_HARNESSES on the server). Like
-// the native harnesses, these are harness-backed picks — not composed agents —
-// so the picker groups them under "Harnesses ▸ More", beside OpenCode/Cursor.
-// User-configured ACP agents carry an `acp:<slug>` harness; a builtin ACP CLI
-// harness carries a bare id.
-export const ACP_CLI_HARNESS_IDS = new Set<string>(["devin", "grok"]);
+// Fallback only: builtin ACP CLI harness ids for servers whose harness catalog
+// doesn't report `capabilities.integration_mode`. NOT the source of truth — a
+// new builtin ACP row needs no entry here, because `useAvailableAgents` stamps
+// `acpHarness` from the server catalog (see {@link isAcpHarnessAgent}).
+const LEGACY_ACP_CLI_HARNESS_IDS = new Set<string>(["devin", "grok"]);
 
 /**
- * Whether an agent is backed by the generic ACP harness — a configured
- * `acp:<slug>` agent (e.g. Devin, Kilocode) or a builtin ACP CLI harness
- * (e.g. Grok). These belong in the picker's "Harnesses" group with the native
+ * Whether an agent is backed by the generic ACP harness — a user-configured
+ * `acp:<slug>` agent (e.g. Kilocode) or a builtin ACP CLI harness (e.g. Devin,
+ * Grok Build). These belong in the picker's "Harnesses" group with the native
  * CLIs: selecting one runs a harness, not a composed agent.
  *
- * @param agent - Agent to classify (only its `harness` is read).
+ * Prefers the server's own answer (`acpHarness`, derived from the harness
+ * catalog's `integration_mode`) so this frontend recognizes ACP harnesses it
+ * has never heard of; the `acp:` prefix and the legacy id set are the
+ * older-server fallback.
+ *
+ * @param agent - Agent to classify (only `harness` / `acpHarness` are read).
  */
 export function isAcpHarnessAgent(
-  agent: Pick<AvailableAgent, "harness"> | null | undefined,
+  agent: Pick<AvailableAgent, "harness" | "acpHarness"> | null | undefined,
 ): boolean {
-  const harness = agent?.harness;
+  if (agent == null) return false;
+  if (agent.acpHarness !== undefined) return agent.acpHarness;
+  const harness = agent.harness;
   if (harness == null) return false;
-  return harness.startsWith("acp:") || ACP_CLI_HARNESS_IDS.has(harness);
+  return harness.startsWith("acp:") || LEGACY_ACP_CLI_HARNESS_IDS.has(harness);
 }
 
 // Preferred display order for the built-in group. The server returns

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -31,7 +31,7 @@ export const BUILTIN_AGENTS = new Set([
 // so the picker groups them under "Harnesses ▸ More", beside OpenCode/Cursor.
 // User-configured ACP agents carry an `acp:<slug>` harness; a builtin ACP CLI
 // harness carries a bare id.
-export const ACP_CLI_HARNESS_IDS = new Set<string>(["grok"]);
+export const ACP_CLI_HARNESS_IDS = new Set<string>(["devin", "grok"]);
 
 /**
  * Whether an agent is backed by the generic ACP harness — a configured

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -40,7 +40,13 @@ export interface SetupStepWire {
 interface HarnessCatalogRow {
   id?: string;
   label?: string;
+  // Declared capability profile. Only ``integration_mode`` is read here, to
+  // recognize the generic-ACP family without hardcoding vendor ids.
+  capabilities?: { integration_mode?: string | null } | null;
 }
+
+/** ``capabilities.integration_mode`` of every generic-ACP harness. */
+const ACP_INTEGRATION_MODE = "acp-subprocess";
 
 interface HarnessCatalogWire {
   data?: HarnessCatalogRow[];
@@ -54,6 +60,8 @@ interface HarnessCatalog {
   labels: Record<string, string>;
   /** harness spelling → ordered setup steps (install/auth) the server describes. */
   setupSteps: Record<string, SetupStepWire[]>;
+  /** ids the server declares generic-ACP — see {@link useAcpHarnessIds}. */
+  acpHarnesses: ReadonlySet<string>;
 }
 
 async function fetchHarnessCatalog(): Promise<HarnessCatalog> {
@@ -61,24 +69,28 @@ async function fetchHarnessCatalog(): Promise<HarnessCatalog> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as HarnessCatalogWire;
   const labels: Record<string, string> = { ...BRAIN_HARNESS_LABELS };
+  const acpHarnesses = new Set<string>();
   for (const row of body.data ?? []) {
-    if (typeof row.id === "string" && typeof row.label === "string") {
-      labels[row.id] = row.label;
-    }
+    if (typeof row.id !== "string") continue;
+    if (typeof row.label === "string") labels[row.id] = row.label;
+    if (row.capabilities?.integration_mode === ACP_INTEGRATION_MODE) acpHarnesses.add(row.id);
   }
   // The server keys setup_steps by every spelling (codex-native, opencode, …)
   // so the dialog resolves whatever harness the session declares.
   const setupSteps =
     body.setup_steps && typeof body.setup_steps === "object" ? body.setup_steps : {};
-  return { labels, setupSteps };
+  return { labels, setupSteps, acpHarnesses };
 }
 
-// Both hooks share one request + cache entry, each selecting its own slice.
-function useHarnessCatalog<T>(select: (c: HarnessCatalog) => T, fallback: T): T {
+// Every hook below shares one request + cache entry, each selecting its own
+// slice. ``enabled`` lets a caller that is itself disabled avoid provoking the
+// request (the agent picker keeps its catalog read in step with its own fetch).
+function useHarnessCatalog<T>(select: (c: HarnessCatalog) => T, fallback: T, enabled = true): T {
   const { data } = useQuery({
     queryKey: ["harness-labels"],
     queryFn: fetchHarnessCatalog,
     staleTime: 30_000,
+    enabled,
     select,
   });
   return data ?? fallback;
@@ -137,6 +149,28 @@ const NO_SETUP_STEPS: Record<string, SetupStepWire[]> = {};
 /** harness id → the server's ordered setup steps (for the setup dialog). */
 export function useHarnessSetupSteps(): Record<string, SetupStepWire[]> {
   return useHarnessCatalog((c) => c.setupSteps, NO_SETUP_STEPS);
+}
+
+/** harness id → picker label, exactly as the server names it. */
+export function useHarnessLabels(enabled = true): Record<string, string> {
+  return useHarnessCatalog((c) => c.labels, BRAIN_HARNESS_LABELS, enabled);
+}
+
+const NO_ACP_HARNESSES: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Harness ids the server declares generic-ACP (``integration_mode ===
+ * "acp-subprocess"``) — builtin ACP CLI rows (``devin``, ``grok``) and
+ * user-configured ``acp:<slug>`` agents alike.
+ *
+ * Server-derived on purpose: a new builtin ACP row is one data entry in
+ * ``omnigent/acp_cli_harnesses.py``, and the picker recognizes it (grouping +
+ * label) with no frontend change. Empty until the catalog loads, and on a
+ * server too old to report capabilities — callers fall back to the id
+ * heuristic in ``agentGrouping``.
+ */
+export function useAcpHarnessIds(enabled = true): ReadonlySet<string> {
+  return useHarnessCatalog((c) => c.acpHarnesses, NO_ACP_HARNESSES, enabled);
 }
 
 /**


### PR DESCRIPTION
## Related issue

No filed issue — this is the follow-on to #4909 (merged): that PR seeds configured
ACP agents into the New Chat picker, and this one makes Devin one of them and
fixes how the picker recognizes and names them. Happy to file retroactively if
the queue wants the signal.

## Summary

Two halves. The second exists because the first exposed it.

### 1. Devin becomes a builtin ACP harness

`devin acp` speaks the Agent Client Protocol on stdio, so — exactly like Grok
Build — it is **one row** in `ACP_CLI_HARNESSES`, no bespoke module. That row
makes Devin first-class:

- shows in **`omni setup`** (own-auth, with its `devin auth login` step and the
  `curl … cli.devin.ai/install.sh` install hint),
- launches via **`--harness devin`**,
- **seeds into the web New Chat picker** (via #4909) once the `devin` binary is
  on `PATH`,
- needs **no user `acp:` config** — an agent or sub-agent can just say
  `harness: devin`.

It runs Devin's account-default model, because a row carries no per-user model.

> **Correction (post-merge, fixed in #4925):** an earlier version of this
> description said `DEVIN_MODEL` could pin the model. It can't — the ACP spawn env
> is deny-by-default and a row has no `env_passthrough`, so the variable never
> reaches the agent (verified: `builtin row -> DEVIN_MODEL forwarded: False`).
> Pinning a model needs a user-configured `acp:<slug>` agent whose command carries
> `--model`. Devin's own auth is unaffected: `devin auth login` writes a credential
> file the agent reads back at spawn.

### 2. The picker derives ACP identity from the harness catalog

Adding that row surfaced a design problem: a new builtin ACP harness required a
**frontend** edit. The picker recognized ACP agents through a hardcoded id set
mirroring `ACP_CLI_HARNESSES`, and rendered their name by capitalizing the agent
slug. So a new row landed under "Agents" instead of "Harnesses" until someone
remembered the mirror — and even a known row showed the wrong name.

Both facts already exist server-side, and the frontend already fetches the
endpoint that carries them (`/v1/harnesses`) — it just dropped them:

| catalog row | `label` | `capabilities.integration_mode` |
|---|---|---|
| `devin` | "Devin" | `acp-subprocess` |
| `grok` | **"Grok Build"** | `acp-subprocess` |
| `acp:kilocode` | **"kilocode"** (the user's own name) | `acp-subprocess` |
| `claude-sdk` | "Claude SDK" | `sdk-in-process` |

So this reads them instead of duplicating them — **no server change**:

- the catalog fetch keeps `capabilities.integration_mode`, exposed as
  `useAcpHarnessIds()` / `useHarnessLabels()`;
- `useAvailableAgents` stamps `acpHarness` and the catalog label onto each agent;
- `isAcpHarnessAgent` prefers that server flag, with the `acp:` prefix and the id
  set demoted to a **fallback** for servers that don't report capabilities.

Display names are fixed as a consequence — the part that was quietly wrong:

| harness | before | after |
|---|---|---|
| `grok` | "Grok" | **"Grok Build"** |
| `acp:my-devin-agent` | "My-devin-agent" | **the user's configured name** |
| `devin` | "Devin" | "Devin" (unchanged) |

**Net invariant:** a new builtin ACP harness is now *one row* in
`acp_cli_harnesses.py` — the picker groups and labels it with no frontend change,
and it recognizes ACP harnesses this frontend has never heard of (which a mirror
list can never do). That is what half 1 should have needed on its own.

## Test Plan

**Python**

- `tests/test_acp_cli_harnesses.py` parametrizes over the **real** catalog, so
  the Devin row is auto-covered end to end (validity, module routing, label,
  capabilities, install spec + keys, setup steps, and that
  `_build_acp_cli_spawn_env` yields a launchable `devin acp`). **11 passed.**
- A second builtin ACP-CLI row shifts the numbered `omni setup` rows (Devin, then
  Grok Build, sorted by id), so the scripted-stdin ordering / dispatch / openclaw
  tests are updated. `pytest tests/cli/test_configure_models.py` → **122 passed**;
  with the catalog tests, **133 passed**.
- `ruff format` / `ruff check` clean; `pyrefly check` (CI's `--extra all`) → **0 errors**.

**Web**

- New: `useAvailableAgents.test.tsx` asserts a seeded `grok` agent gets
  `display_name: "Grok Build"` + `acpHarness: true` from a stubbed
  `/v1/harnesses`, **and** that a composed agent on a non-ACP harness keeps its
  own name (`polly` stays "Polly", does not become "Claude SDK").
- New: `agentGrouping.test.ts` asserts the server flag wins — an ACP harness id
  this frontend has never seen (`some-future-acp-cli`) still groups under
  Harnesses, and a server "no" overrides the id heuristic.
- `vitest` on the two changed files → **27 passed**. Full web suite →
  **5780 passed**.
- `oxlint --deny-warnings`, `prettier --check`, and `pnpm build` (typecheck) clean;
  no lockfile churn.

**Pre-existing failures, not from this PR:** `web/src/shell/NewChatDialog.test.tsx`
has 3 failures (`Unable to find an element with the text: This machine` — the host
chooser, in sandbox-gating tests). Baselined by stashing this PR's working-tree
changes and re-running on clean HEAD: **identical 3 failed / 270 passed**. This
branch's *entire* frontend delta vs `main` before those commits was one `Set`
entry, and the failures are unrelated to ACP or the Harnesses/Agents split.

**Manual verification**

- `--harness devin` resolves in-process to
  `HARNESS_ACP_COMMAND="<devin> acp"` / `HARNESS_ACP_NAME="Devin"`.
- Real `omni setup` run (isolated `OMNIGENT_CONFIG_HOME`, real config copied)
  renders the Devin row; the now-passing
  `test_overview_lists_all_harnesses_in_priority_order` asserts it too.
- The built SPA bundle carries the new logic (`acp-subprocess`, `acpHarness`).

## Demo

`omni setup` — captured from a real run:

```
  Configure harnesses
       Qwen Code               ✗ Not installed
       Goose                   ✓ openrouter
       Devin                   ✓ ACP · own auth
       Grok Build              ✓ ACP · own auth
       Copilot                 ✗ Not installed
```

New Chat picker grouping:

```
  before                          after
  Harnesses                       Harnesses
    Claude Code, Codex, …           Claude Code, Codex, …
    More ▸ OpenCode, Cursor         More ▸ OpenCode, Cursor, Devin, Grok Build, kilocode
  Agents                          Agents
    Polly, Debby                    Polly, Debby          ← unchanged
    Devin, Grok, kilocode  ✗        (ACP agents no longer land here)
```

I was not able to capture a rendered screenshot of the picker in this
environment, so the UI behaviour is pinned by the vitest assertions above rather
than an image. To see it directly: check out this branch, restart the server, then
**New Chat → Harnesses → More** — Devin / Grok Build / any configured
`acp:<slug>` agent appear there with their real labels.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covers what the unit layer can't: that `--harness devin`
resolves to a real launchable command against the installed binary, and that the
setup row renders in the actual TUI. No automated test spawns a live `devin acp`
subprocess.

Two deliberate guards, both with a test:

- The catalog read is gated on the picker's own `enabled`, so a disabled picker
  still issues **no** request (`useAvailableAgents.test.tsx`'s "does not fetch
  while disabled" would otherwise fail).
- The catalog label is applied **only** to ACP-family harnesses, so a composed
  agent keeps its own name — without that gate, Polly and Debby (`claude-sdk`)
  would render as "Claude SDK".

Known limits, stated rather than hidden:

- A builtin row's argv is fixed and a row can pass no environment variable to the
  CLI, so the Devin row runs the account-default model; pinning one needs a
  user-configured `acp:<slug>` agent carrying `--model` (see the correction above
  and #4925).
- For a user-configured `acp:<slug>` agent the label is whatever they named it in
  config, which is the intended behaviour but means a poorly-named entry shows
  that name verbatim.
- Older servers that don't report `capabilities.integration_mode` fall back to the
  `acp:` prefix plus the legacy id set, so builtin ACP rows they don't know about
  would group under "Agents" there. The compat-smoke jobs (new SPA / old server)
  exercise that path.

## Changelog

Devin is now a built-in harness — set it up in `omni setup`, launch it with `--harness devin` or from the New Chat picker, no `acp:` config needed
