### PR TITLE
Log headless hosts in with GitHub App tokens

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9504,7 +9504,12 @@ def _remember_default_server(server: str) -> None:
 
 @cli.command("login")
 @click.argument("server_url")
-def login(server_url: str) -> None:
+@click.option(
+    "--github-token",
+    is_flag=True,
+    help="Exchange GH_TOKEN for a session without opening a browser.",
+)
+def login(server_url: str, github_token: bool) -> None:
     """Authenticate with a remote Omnigent server.
 
     Probes the server's auth mode and runs the matching flow:
@@ -9600,6 +9605,38 @@ def login(server_url: str) -> None:
     import webbrowser
 
     from omnigent.cli_auth import store_token
+
+    if github_token:
+        ambient_token = os.environ.get("GH_TOKEN", "").strip()
+        if not ambient_token:
+            raise click.ClickException("--github-token requires GH_TOKEN in the environment.")
+        try:
+            token_resp = _httpx.post(
+                f"{server}/auth/github-token",
+                headers={"Authorization": f"Bearer {ambient_token}"},
+                timeout=10.0,
+            )
+        except _httpx.HTTPError as exc:
+            raise click.ClickException(
+                f"Could not exchange GH_TOKEN with {server}: {exc}"
+            ) from exc
+        if not token_resp.is_success:
+            raise click.ClickException(
+                f"GitHub token login failed ({token_resp.status_code}): {token_resp.text[:200]}"
+            )
+        result = token_resp.json()
+        expires_in = result.get("expires_in", 8 * 3600)
+        import time as _time
+
+        store_token(
+            server_url=server,
+            token=result["token"],
+            user_id=result["user_id"],
+            expires_at=_time.time() + expires_in,
+        )
+        click.echo(f"Logged in as {result['user_id']}")
+        _remember_default_server(server)
+        return
 
     # Step 1: Request a CLI login ticket.
     try:

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -21,7 +21,7 @@ from urllib.parse import urlencode
 import httpx
 import jwt
 from fastapi import APIRouter, Query, Request
-from starlette.responses import RedirectResponse, Response
+from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from omnigent.server.accounts_store import SqlAlchemyAccountStore
 from omnigent.server.admin_list import AdminList, promote_if_listed
@@ -128,6 +128,31 @@ def create_auth_router(
     # (5 min) and single-use. Keyed by ticket ID.
     _cli_tickets: dict[str, _CliTicket] = {}
 
+    def _issue_session(email: str) -> tuple[str, str] | JSONResponse:
+        """Apply admission policy and mint an Omnigent session."""
+        email = email.lower()
+        if not admission.is_admitted(email):
+            domain = email.rsplit("@", 1)[-1] if "@" in email else ""
+            return JSONResponse(
+                status_code=403,
+                content={"error": f"Email domain {domain!r} is not permitted on this server"},
+            )
+        if email in _RESERVED_USERS:
+            return JSONResponse(
+                status_code=403,
+                content={"error": f"Reserved user name {email!r}"},
+            )
+        if permission_store is not None:
+            permission_store.ensure_user(email)
+            promote_if_listed(admin_list, permission_store, email)
+        token = mint_session_cookie(
+            user_id=email,
+            cookie_secret=config.cookie_secret,
+            ttl_hours=config.session_ttl_hours,
+            provider=config.provider_type,
+        )
+        return email, token
+
     @router.get("/login")
     async def login(request: Request) -> Response:
         """Redirect to the IdP's authorization endpoint.
@@ -208,8 +233,6 @@ def create_auth_router(
         :returns: 302 redirect to the app with session cookie set,
             or 400/403 on validation failure.
         """
-        from fastapi.responses import JSONResponse
-
         code = request.query_params.get("code")
         state = request.query_params.get("state")
         if not code or not state:
@@ -293,9 +316,6 @@ def create_auth_router(
                 content={"error": "Could not determine user email from IdP"},
             )
 
-        # Normalize email to lowercase.
-        email = email.lower()
-
         # Redeem an OIDC invite (if one rode along in the signed state)
         # BEFORE the admission check, so the just-bound email passes the
         # domain gate via the invite bypass. Single-use: the token is
@@ -310,39 +330,10 @@ def create_auth_router(
                     str(invite_token), email, now_epoch_seconds=int(time.time())
                 )
 
-        # Admission control: domain allowlist (env ∪ file) plus the
-        # admin-list / invite bypasses. An empty effective allowlist
-        # means "no restriction" (admit any IdP user) — the OSS default.
-        if not admission.is_admitted(email):
-            domain = email.rsplit("@", 1)[-1] if "@" in email else ""
-            return JSONResponse(
-                status_code=403,
-                content={"error": f"Email domain {domain!r} is not permitted on this server"},
-            )
-
-        # Reject reserved user names.
-        if email in _RESERVED_USERS:
-            return JSONResponse(
-                status_code=403,
-                content={"error": f"Reserved user name {email!r}"},
-            )
-
-        # Ensure user exists in the permission store, then apply the
-        # file-backed admin list. Promotion is additive (never demotes)
-        # and is OIDC's only path to admin — the IdP doesn't tell us
-        # who is an operator. ensure_user must run first so the
-        # set_admin UPDATE inside promote_if_listed matches a row.
-        if permission_store is not None:
-            permission_store.ensure_user(email)
-            promote_if_listed(admin_list, permission_store, email)
-
-        # Mint session cookie.
-        session_jwt = mint_session_cookie(
-            user_id=email,
-            cookie_secret=config.cookie_secret,
-            ttl_hours=config.session_ttl_hours,
-            provider=config.provider_type,
-        )
+        issued = _issue_session(email)
+        if isinstance(issued, JSONResponse):
+            return issued
+        email, session_jwt = issued
 
         # Check if this callback fulfills a CLI login ticket.
         ticket_id = state_payload.get("ticket")
@@ -406,6 +397,56 @@ def create_auth_router(
             samesite="lax",
         )
         return response
+
+    if config.provider_type == "github":
+
+        @router.post("/github-token")
+        async def github_token_login(request: Request) -> Response:
+            """Exchange this GitHub App's user token for an Omnigent session."""
+            authorization = request.headers.get("Authorization", "")
+            scheme, _, access_token = authorization.partition(" ")
+            if scheme.lower() != "bearer" or not access_token:
+                return JSONResponse(
+                    status_code=401,
+                    content={"error": "GitHub bearer token required"},
+                )
+
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2026-03-10",
+            }
+            async with httpx.AsyncClient() as client:
+                check = await client.post(
+                    f"https://api.github.com/applications/{config.client_id}/token",
+                    auth=(config.client_id, config.client_secret),
+                    headers=headers,
+                    json={"access_token": access_token},
+                    timeout=10.0,
+                )
+                if check.status_code != 200:
+                    return JSONResponse(
+                        status_code=401,
+                        content={"error": "Token was not issued to this GitHub App"},
+                    )
+                email = await _resolve_github_email(client, access_token)
+
+            if not email:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Could not determine user email from GitHub"},
+                )
+            issued = _issue_session(email)
+            if isinstance(issued, JSONResponse):
+                return issued
+            user_id, session_jwt = issued
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "token": session_jwt,
+                    "user_id": user_id,
+                    "expires_in": config.session_ttl_hours * 3600,
+                },
+            )
 
     if _invites_enabled:
 

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -554,6 +554,30 @@ def test_login_oidc_mode_sets_default_server(
     assert cli_mod._load_global_config().get("server") == server
 
 
+def test_login_oidc_with_github_token_skips_browser(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """An explicit GH_TOKEN exchange stores the returned Omnigent session."""
+    server = "http://omni-oidc.internal:6767"
+    fake = _FakeHttpx(responses=[_response(401, body={"login_url": "/auth/login"})])
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+    monkeypatch.setenv("GH_TOKEN", "ghu_test_token")
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, **kw: _response(
+            200,
+            body={"token": "omni-jwt", "user_id": "alice@example.com", "expires_in": 3600},
+        ),
+    )
+
+    result = CliRunner().invoke(cli_group, ["login", "--github-token", server])
+
+    assert result.exit_code == 0, result.output
+    assert "Logged in as alice@example.com" in result.output
+    assert cli_mod._load_global_config().get("server") == server
+
+
 def test_login_failure_leaves_default_server_unchanged(
     monkeypatch: pytest.MonkeyPatch, token_dir: Path
 ) -> None:

--- a/tests/server/integration/test_oidc_auth_e2e.py
+++ b/tests/server/integration/test_oidc_auth_e2e.py
@@ -288,6 +288,42 @@ async def test_callback_returns_400_on_token_exchange_failure() -> None:
     assert "Token exchange failed" in resp.json()["error"]
 
 
+async def test_github_token_exchange_mints_omnigent_session() -> None:
+    """A user token from this GitHub App can bootstrap CLI auth."""
+    mock_cm = _mock_httpx_client_for_github()
+    transport = _build_oidc_app()
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with patch("omnigent.server.routes.auth.httpx.AsyncClient", return_value=mock_cm):
+            resp = await client.post(
+                "/auth/github-token",
+                headers={"Authorization": "Bearer ghu_test_token"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == "alice@example.com"
+    payload = jwt.decode(body["token"], _TEST_SECRET, algorithms=["HS256"])
+    assert payload["sub"] == "alice@example.com"
+    assert body["expires_in"] == 8 * 3600
+
+
+async def test_github_token_exchange_rejects_token_from_another_app() -> None:
+    """GitHub's check-token endpoint binds the bearer to this client ID."""
+    mock_cm = _mock_httpx_client_for_github(token_status=404)
+    transport = _build_oidc_app()
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with patch("omnigent.server.routes.auth.httpx.AsyncClient", return_value=mock_cm):
+            resp = await client.post(
+                "/auth/github-token",
+                headers={"Authorization": "Bearer ghu_foreign_token"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.json()["error"] == "Token was not issued to this GitHub App"
+
+
 # ── 5. Logout ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Headless hosts currently have to open a second browser login even when their environment already has a user OAuth token from the same GitHub App. Add `POST /auth/github-token` to validate that token against the configured App, resolve the user's verified primary email, and apply the existing admission policy before issuing a normal Omnigent session.

`omni login --github-token SERVER_URL` reads `GH_TOKEN` from the environment and stores the returned Omnigent token through the existing credential path. The GitHub token never appears in CLI arguments or persisted config. Tokens issued to another GitHub App are rejected.

## Test Plan

- Run the auth integration tests for token acceptance, foreign-App rejection, and existing admission rules.
- Run the CLI login tests for ambient token exchange and credential persistence.
- Start a host with an injected GitHub App token, then stop and restart it without another browser login.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A fresh remote host exchanged its ambient GitHub token, registered with the server, and reconnected with the same host ID after a stop/start cycle.

## Changelog

Log into Omnigent non-interactively with an OAuth token from the configured GitHub App.
