### PR TITLE
docs(acp): correct the env-var claim on builtin ACP CLI rows

### DIFF
--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -24,6 +24,14 @@ spawn-env builder. Rows own their auth and model selection (``OWN_AUTH``): no
 Omnigent credential or model override is wired, so a ``/model`` pick is
 rejected up front rather than silently dropped.
 
+One consequence worth knowing before adding a row: the generic ACP spawn env is
+deny-by-default and a row has no ``env_passthrough`` of its own (only a
+user-configured ``acp:<slug>`` agent can declare one), so a row's CLI reaches the
+agent with the base environment only. A vendor that configures or authenticates
+*solely* from an environment variable therefore needs a user-configured agent
+rather than a row here; a vendor that reads stored credentials from disk (Devin,
+Grok's OAuth login) works as a row.
+
 This module stays import-light (stdlib + :mod:`omnigent.harness_install_spec`)
 so the registry, onboarding, and runner layers can all read it without cycles.
 """
@@ -75,10 +83,11 @@ class AcpCliHarness:
 ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
     # Devin (Cognition's ``devin`` CLI) drives ``devin acp`` — its ACP stdio
     # server. Ships via a curl installer (not npm) and authenticates through its
-    # own ``devin auth login`` (or a Devin API key); Omnigent stores no
-    # credential. The row runs Devin's account-default model; a builtin row can't
-    # carry a per-user model, so set ``DEVIN_MODEL`` to pin one (or use an
-    # ``acp:`` config entry with ``--model``).
+    # own ``devin auth login``, which writes a credential file it reads back at
+    # spawn; Omnigent stores nothing. The row runs Devin's account-default model:
+    # a row carries no per-user model, and ``DEVIN_MODEL`` cannot reach the agent
+    # (see the env note above), so pinning a model needs a user-configured
+    # ``acp:<slug>`` agent whose command passes ``--model``.
     "devin": AcpCliHarness(
         install=HarnessInstallSpec(
             "Devin",
@@ -86,7 +95,7 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
             None,
             login_args=("auth", "login"),
             install_hint="curl -fsSL https://cli.devin.ai/install.sh | bash",
-            auth_hint="run `devin auth login` (or set a Devin API key)",
+            auth_hint="run `devin auth login` (Omnigent stores no Devin credential)",
         ),
         args=("acp",),
     ),


### PR DESCRIPTION
## Related issue

No filed issue — a correctness fix to documentation I added in #4920 (merged).

## Summary

The Devin row's comment and auth hint both implied an environment variable can
configure or authenticate a builtin ACP CLI harness:

- comment: *"set `DEVIN_MODEL` to pin one"*
- `auth_hint`: *"run `devin auth login` (or set a Devin API key)"*

Neither works. The generic ACP spawn env is **deny-by-default** —
`AcpExecutor._build_spawn_env` calls `clean_agent_env(allow_prefixes=(), …)` and
adds only the names the agent's own config declares — and a catalog row has no
`env_passthrough` of its own. Only a user-configured `acp:<slug>` agent can
declare one (`workflow.py` sets `HARNESS_ACP_ENV_PASSTHROUGH` from
`agent.env_passthrough`; `_build_acp_cli_spawn_env`, the row path, never does).

Verified against the real builder rather than inferred from the docstring:

```
DEVIN_MODEL in parent env: swe-1-7-medium
builtin row              -> DEVIN_MODEL forwarded: False
acp: agent declaring it  -> DEVIN_MODEL forwarded: True   value=swe-1-7-medium
```

So this corrects the row to describe what actually happens — `devin auth login`
writes a credential file the agent reads back at spawn, which is why Devin works
as a row at all — and points a per-model setup at an `acp:<slug>` agent whose
command carries `--model`.

It also records the constraint once in the module docstring, because it decides
whether a future vendor can be a row at all: a vendor that configures or
authenticates *solely* from an environment variable needs a user-configured
agent, while a vendor that reads stored credentials from disk works as a row.

Worth flagging for a follow-up (deliberately **not** changed here): the
pre-existing `grok` row advertises *"or set `XAI_API_KEY`"*, which is unreachable
for the same reason. Its OAuth login path (`grok login --device-auth`) does work,
so the row is functional — but that half of the hint is misleading. Left alone
rather than quietly editing another vendor's row; happy to fix it in a follow-up
or extend `AcpCliHarness` with an `env_passthrough` field if we want env-var
vendors to be rows.

## Test Plan

- `pytest tests/test_acp_cli_harnesses.py` → **11 passed** (the suite is
  parametrized over the real catalog, so it covers the edited row).
- `ruff format` / `ruff check` clean.
- The empirical check above, run against the real `AcpExecutor._build_spawn_env`
  with `DEVIN_MODEL` exported, for both a row-shaped config and one declaring
  passthrough.

Comment/metadata only — no behaviour change, so no new test. The `auth_hint`
string is rendered into the setup checklist; the catalog suite asserts the row's
install/auth wiring and still passes.

## Demo

N/A — comments and one setup-hint string.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the point here: the claim being corrected is about the
spawn environment, which no unit test asserted. I drove the real
`_build_spawn_env` for both shapes (row vs. declared passthrough) with the
variable actually exported, rather than reading the docstring and trusting it —
the docstring was right, the row comment was not.

## Changelog

N/A — internal comments and a setup hint.
