### PR TITLE
fix(harnesses): let a configured `acp:` agent win over a same-slug builtin row

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3794,8 +3794,19 @@ def _run_configure_harnesses_interactive() -> None:
         # discoverable than a user's own `acp:` entry.
         from omnigent._platform import resolve_cli_binary
         from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+        from omnigent.onboarding.acp_auth import acp_agents, shadowed_builtin_acp_rows
+
+        # Skip a row a configured `acp:` agent already claims, so the list shows
+        # one "Devin" (the user's, with its command) rather than two identically
+        # labeled rows. A config error is reported by the custom-ACP block below.
+        try:
+            _shadowed_acp_rows: frozenset[str] = shadowed_builtin_acp_rows(acp_agents(config))
+        except ValueError:
+            _shadowed_acp_rows = frozenset()
 
         for _acp_cli_name, _acp_cli_row in sorted(ACP_CLI_HARNESSES.items()):
+            if _acp_cli_name in _shadowed_acp_rows:
+                continue
             _acp_cli_key = _ACP_CLI_PREFIX + _acp_cli_name
             if resolve_cli_binary(_acp_cli_row.binary) is None:
                 rows.append(

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 
 import re
 import shutil
+from collections.abc import Iterable
 from dataclasses import dataclass
 
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.onboarding.provider_config import load_config
 
 # The dedicated top-level config block and the list field inside it.
@@ -183,6 +185,27 @@ def resolve_acp_agent(slug: str, config: dict[str, object] | None = None) -> Acp
         if entry.slug == slug:
             return entry
     return None
+
+
+def shadowed_builtin_acp_rows(entries: Iterable[AcpAgentEntry]) -> frozenset[str]:
+    """Return the builtin ACP CLI row ids claimed by a configured ``acp:`` agent.
+
+    A configured agent named "Devin" slugifies onto ``devin``, which is also a
+    builtin row id (:data:`omnigent.acp_cli_harnesses.ACP_CLI_HARNESSES`), so the
+    two describe the same harness by the same name from different sources. The
+    user's entry is the more specific intent — they wrote the exact command,
+    often with a ``--model`` the fixed row argv cannot carry — so callers that
+    list ACP harnesses skip these rows and keep the configured agent.
+
+    Matches the row id only. An alias-shaped name (``"Grok Build"`` ->
+    ``grok-build``, whose row id is ``grok``) is a genuinely separate harness id
+    with its own command, so it does not shadow the row.
+
+    :param entries: The configured agents, e.g. from :func:`acp_agents`.
+    :returns: Row ids to omit, empty when nothing overlaps.
+    """
+    slugs = {entry.slug for entry in entries}
+    return frozenset(key for key in ACP_CLI_HARNESSES if key in slugs)
 
 
 def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -728,7 +728,8 @@ def _ensure_default_acp_agents(
     agent (``harness_is_configured("acp:...")`` treats "in config" as set up) and
     per builtin ACP CLI harness whose binary is on PATH (its readiness gate). On a
     host with no ACP setup — the common remote-server case, where the server holds
-    no ``acp:`` config — this seeds nothing.
+    no ``acp:`` config — this seeds nothing. When both sources name the same
+    harness, the configured agent wins (see :func:`shadowed_builtin_acp_rows`).
 
     Purely additive: it only adds picker rows and never touches native seeding.
     A malformed ``acp:`` block is logged and skipped, never fatal to startup
@@ -747,12 +748,14 @@ def _ensure_default_acp_agents(
 
     # (1) User-configured acp:<slug> agents — "set up" == present in config.
     try:
-        from omnigent.onboarding.acp_auth import acp_agents
+        from omnigent.onboarding.acp_auth import acp_agents, shadowed_builtin_acp_rows
 
         configured = list(acp_agents())
+        shadowed: frozenset[str] = shadowed_builtin_acp_rows(configured)
     except Exception:  # noqa: BLE001 — a malformed acp: block must never break startup
         _logger.debug("acp agent seeding skipped (config unreadable)", exc_info=True)
         configured = []
+        shadowed = frozenset()
     for agent in configured:
         # Key the built-in by the slug, not the display label: agent names must be
         # ``[a-zA-Z0-9_-]+`` (the spec validator rejects spaces/dots), and a label
@@ -767,9 +770,11 @@ def _ensure_default_acp_agents(
         )
 
     # (2) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
-    # by the catalog id (already a valid slug), not the display label.
+    # by the catalog id (already a valid slug), not the display label. A row a
+    # configured agent already claims is skipped: both seed the same
+    # ``builtin_agent_id``, so the row would overwrite the user's chosen command.
     for key, row in ACP_CLI_HARNESSES.items():
-        if resolve_cli_binary(row.binary) is None:
+        if key in shadowed or resolve_cli_binary(row.binary) is None:
             continue
         _ensure_builtin_agent(
             agent_store,

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1759,6 +1759,42 @@ def test_overview_lists_configured_acp_agents_as_rows(isolated_config, monkeypat
     assert "Custom ACP agent" not in names
 
 
+def test_overview_shows_one_row_when_acp_agent_shadows_builtin(
+    isolated_config, monkeypatch
+) -> None:
+    """A configured agent named after a builtin ACP row replaces it, not doubles it.
+
+    "Devin" slugifies to ``devin``, which is also an ``ACP_CLI_HARNESSES`` id, so
+    both sources want a row. The configured one wins — it names the exact command,
+    which the fixed row argv cannot express — and the builtin is dropped so the
+    list never shows two identically labeled "Devin" rows from different sources.
+    """
+    from rich.text import Text
+
+    config_path = os.path.join(isolated_config, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.safe_dump(
+            {
+                "acp": {
+                    "agents": [{"name": "Devin", "command": "devin acp --model swe-1-7-medium"}]
+                }
+            },
+            f,
+        )
+    options, selectable, _descriptions, _compact, _max_visible = _capture_setup_overview(
+        monkeypatch
+    )
+    names = _overview_row_names(options, selectable)
+    assert names.count("Devin") == 1, f"expected exactly one Devin row, got {names}"
+    # A non-colliding builtin row is untouched.
+    assert "Grok Build" in names
+    # The surviving row is the user's: its status carries the configured command,
+    # not the builtin's "own auth" label.
+    # (the status is width-capped, so match its head rather than the full command)
+    devin_row = next(o for o in options if Text.from_markup(o).plain.startswith("Devin "))
+    assert "ACP · devin acp" in Text.from_markup(devin_row).plain
+
+
 def test_setup_reports_invalid_acp_omnigent_mcp(isolated_config) -> None:
     config_path = os.path.join(isolated_config, "config.yaml")
     with open(config_path, "w") as f:

--- a/tests/onboarding/test_acp_auth.py
+++ b/tests/onboarding/test_acp_auth.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.onboarding.acp_auth import acp_agents, acp_agents_settings
+from omnigent.onboarding.acp_auth import (
+    acp_agents,
+    acp_agents_settings,
+    shadowed_builtin_acp_rows,
+)
 
 
 def test_omnigent_mcp_round_trips_only_when_disabled() -> None:
@@ -123,3 +127,31 @@ def test_env_passthrough_rejects_a_value_instead_of_a_name() -> None:
 def test_env_passthrough_rejects_non_names(value: object) -> None:
     with pytest.raises(ValueError, match="env_passthrough"):
         acp_agents({"acp": {"agents": [{"name": "A", "command": "a", "env_passthrough": value}]}})
+
+
+def test_shadowed_builtin_acp_rows_matches_row_ids_only() -> None:
+    """Only a slug equal to a row id shadows it — an alias-shaped name does not.
+
+    "Devin" slugifies onto the ``devin`` row id, so the two name the same harness
+    and the row is dropped in favor of the user's command. "Grok Build" slugifies
+    to ``grok-build``, which is a *different* harness id from the ``grok`` row
+    (the ``acp:`` prefix survives canonicalization), so both stay addressable.
+    """
+    entries = acp_agents(
+        {
+            "acp": {
+                "agents": [
+                    {"name": "Devin", "command": "devin acp --model swe-1-7-medium"},
+                    {"name": "Grok Build", "command": "grok agent stdio"},
+                    {"name": "Gemini CLI", "command": "gemini --experimental-acp"},
+                ]
+            }
+        }
+    )
+    assert [e.slug for e in entries] == ["devin", "grok-build", "gemini-cli"]
+    assert shadowed_builtin_acp_rows(entries) == {"devin"}
+
+
+def test_shadowed_builtin_acp_rows_empty_without_config() -> None:
+    """No configured agents → no rows suppressed (the common case)."""
+    assert shadowed_builtin_acp_rows([]) == frozenset()

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1045,6 +1045,55 @@ def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
         )
 
 
+def test_ensure_default_acp_agents_configured_agent_beats_same_slug_builtin(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured agent whose slug is a builtin row id keeps its own command.
+
+    ``AcpAgentEntry(name="Devin")`` slugifies to ``devin``, which is also a
+    catalog row id, so both sources seed the same :func:`builtin_agent_id`. The
+    row must be skipped rather than seeded second and overwriting the user's
+    entry — while an unrelated row (``grok``) still seeds alongside.
+
+    **What breaks if this fails**: picking "Devin" in the web picker silently
+    runs the fixed row argv (account-default model) instead of the command the
+    user configured, e.g. ``devin acp --model swe-1-7-medium``.
+    """
+    import io
+    import tarfile
+
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.onboarding.acp_auth import AcpAgentEntry
+    from omnigent.spec import load
+
+    entry = AcpAgentEntry(slug="devin", name="Devin", command="devin acp --model swe-1-7-medium")
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [entry])
+    # Both vendor CLIs are installed, so the devin row would otherwise seed too.
+    monkeypatch.setattr(
+        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/local/bin/x"
+    )
+
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+
+    seeded = seed_stores.agent_store.get_by_name("devin")
+    assert seeded is not None
+    assert seeded.id == builtin_agent_id("devin"), "both sources key the same id"
+    assert seed_stores.agent_store.get_by_name("grok") is not None, (
+        "a non-colliding builtin row must still seed"
+    )
+
+    # Presence is not enough — assert the surviving row launches the *configured*
+    # harness, since the bug was an overwrite that kept the name and lost the spec.
+    bundle = seed_stores.artifact_store.get(seeded.bundle_location)
+    assert bundle is not None
+    dest = tmp_path / "seeded"
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as tf:
+        tf.extractall(dest, filter="data")
+    assert load(dest).executor.config["harness"] == "acp:devin"
+
+
 def test_ensure_default_acp_agents_noop_when_nothing_set_up(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #4926

## Summary

A configured `acp:` agent named "Devin" slugifies onto `devin`, which is also an
`ACP_CLI_HARNESSES` row id. Two sources then describe the same harness by the
same name — and they failed in **opposite directions**, which is why this is one
fix and not two:

| surface | before | after |
|---|---|---|
| Web picker | **one** row, silently the builtin — the user's `--model` dropped | one row, the **configured** agent |
| `omni setup` | **two** identically labeled "Devin" rows | one row, the configured agent |

The picker collapsed because both sources seed the same `builtin_agent_id`, and
the row — seeded second — overwrote the user's entry. `omni setup` doubled
because it appends one row per source.

**The configured agent wins in both.** A user who wrote
`command: devin acp --model swe-1-7-medium` has said "when I say devin, run
this"; a row's fixed argv cannot express that, so the config is the more
specific intent. `shadowed_builtin_acp_rows` states the rule once in
`acp_auth.py` and both surfaces read it, rather than each re-deriving it.

<details>
<summary>ELI5 + the collision, as a diagram</summary>

Two people put a name tag on the same harness: Omnigent ships one that says
"Devin", and you wrote one that says "Devin" with your own model on it. The
picker kept only one tag and threw away yours; the setup list printed both tags
and let you guess. Now yours wins in both places, because you were more specific.

```
                       name: "devin"
  configured acp: agent ──┐
  (devin acp --model X)   │
                          ├──► builtin_agent_id("devin")  ← same id, one row survives
  builtin catalog row  ───┘
  (devin acp)             ▲
                          └── seeded second → overwrote the user's spec

  after: the row is skipped when the slug is already claimed
```
</details>

Matching is on **row ids only**. An alias-shaped name (`"Grok Build"` →
`grok-build`, whose row id is `grok`) is a genuinely separate harness id with its
own command, so it does not shadow the row and both stay listed.

**Scope is listing, deliberately.** Resolution is untouched: `--harness devin`
and a spec saying `harness: devin` still run the builtin row, and removing the
config entry brings the row back on the next repaint — no restart.

## Test Plan

Both new integration tests were confirmed to **fail on `main`** and pass here —
they reproduce the bug, they don't just describe it.

**`tests/server/test_app.py`** — new
`..._configured_agent_beats_same_slug_builtin`: seeds against real stores with a
configured `devin` entry and both CLIs on PATH, then unpacks the surviving
bundle. It asserts the *harness*, not just presence, because the bug kept the
name and lost the spec:

```
# on main
E       AssertionError: assert 'devin' == 'acp:devin'
# on this branch
5 passed
```

It also asserts the non-colliding `grok` row still seeds alongside.

**`tests/cli/test_configure_models.py`** — new
`..._one_row_when_acp_agent_shadows_builtin` drives the real setup overview:

```
# on main
E       AssertionError: expected exactly one Devin row, got [… 'Goose', 'Devin',
        'Grok Build', 'Copilot', 'Kiro', 'Kimi Code', 'Devin', 'Import from OpenClaw', …]
```

**`tests/onboarding/test_acp_auth.py`** — unit coverage for the rule itself,
including the alias case neither integration test reaches (`"Grok Build"` →
`grok-build` must **not** shadow `grok`).

**Suites** — `tests/server/test_app.py`, `tests/cli/test_configure_models.py`,
`tests/onboarding/test_acp_auth.py`, `tests/test_acp_cli_harnesses.py`,
`tests/runtime/test_acp_spawn_env.py` → **222 passed**. Notably
`test_overview_lists_all_harnesses_in_priority_order` (the full row order) and
`test_setup_reports_invalid_acp_omnigent_mcp` (a bad `acp:` block must still
raise a proper `ClickException`, not be swallowed by the new `try`) both still
pass unchanged.

`ruff format` / `ruff check` clean, `pyrefly check --extra all` → **0 errors**,
full `pre-commit` on the changed files → all hooks pass, `uv.lock` untouched.

## Demo

Real `omni setup` capture, isolated `OMNIGENT_CONFIG_HOME`, same config
(`acp.agents: [{name: Devin, command: devin acp --model swe-1-7-medium}]`), the
only difference being this PR's `cli_config.py`:

```
before (main)                                after (this branch)
  10. Devin          ✓ ACP · own auth          10. Grok Build   ✓ ACP · own auth
  11. Grok Build     ✓ ACP · own auth          14. Devin        ✓ ACP · devin acp --model swe-1…
  15. Devin          ✓ ACP · devin acp --model swe-1…
```

The surviving row is the user's — its status carries the command, and its
drill-in header reads `Devin — devin acp --model swe-1-7-medium`.

Picker grouping is unchanged (Harnesses ▸ More); only *which* Devin the row
launches changes, from the builtin `devin` to the configured `acp:devin`. That is
asserted by the bundle unpack above rather than a screenshot, since the visible
row looks identical either way — the bug was invisible, which is what made it
worth fixing.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the real `omni setup` capture in the Demo — the duplicate
row is a rendering-order artifact, so seeing the actual TUI print one row (with
the right status) is worth more than asserting on a row list. The picker half is
covered automatically, against real stores, by unpacking the seeded bundle.

No frontend change is needed: the server stops seeding the shadowing row, so the
picker renders what it is given. The surviving agent still groups under Harnesses
either way — via `capabilities.integration_mode` when the server reports it for
`acp:devin`, or the `acp:` prefix fallback otherwise.

Two trade-offs worth a reviewer's eye, both deliberate:

- **A shadowed row loses its install/sign-in drill-in.** With a Devin entry
  configured, `omni setup` no longer offers the builtin row's `curl … | bash` and
  `devin auth login` hints; the configured row's drill-in shows the command and
  offers removal. Acceptable because a user who wrote the command generally has
  the CLI, configured ACP agents have never been PATH-gated, and removing the
  entry restores the row immediately. The alternative — gating the skip on the
  binary — reintroduces two "Devin" rows with contradictory statuses.
- **Alias-shaped names can still produce two rows with the same label**
  (`"Grok Build"` alongside the `grok` row). Those are distinct harness ids with
  distinct commands and distinct statuses, so listing both is correct; only the
  label coincides. Left as-is rather than widening the match.

## Changelog

`omni setup` and the New Chat picker no longer show a duplicate — or silently
ignore — a built-in ACP harness you configured yourself under the same name;
your own command wins
