### PR TITLE
feat(web): restyle chat error banner as a centered pill

### DIFF
--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -240,11 +240,11 @@ def test_failed_upload_restores_the_message(
     composer.fill("look at this file")
     composer.press("Enter")
 
-    # The compact banner keeps the reason one expansion away instead of
+    # The compact pill keeps the reason one expansion away instead of
     # dropping it or replacing it with a bare status line.
-    alert = page.get_by_role("alert")
-    expect(alert).to_be_visible(timeout=30_000)
-    headline = alert.get_by_role("button", name="Something went wrong", exact=False)
+    pill = page.get_by_test_id("error-pill")
+    expect(pill).to_be_visible(timeout=30_000)
+    headline = pill.get_by_role("button", name="Something went wrong", exact=False)
     expect(headline).to_have_attribute("aria-expanded", "false")
     headline.click()
     expect(page.get_by_text("Unsupported attachment type", exact=False)).to_be_visible()

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -1,11 +1,12 @@
-"""Failure error cards render as clear English, not a raw code + log blob.
+"""Failure error pills render as clear English, not a raw code + log blob.
 
 A harness launch/turn failure persists an ``error`` transcript item. Before,
 the chat rendered it as ``Error · <code>`` over the raw message. Now the
-banner leads with a human headline: a classified failure shows its friendly
-title, and an unclassified one still maps its ``code`` to a plain-English
-sentence (mirror of ``describe_failure_code`` /
-``FAILURE_CODE_DESCRIPTIONS``) rather than exposing the enum.
+failure renders as a centered pill leading with a human headline: a
+classified failure shows its friendly title, and an unclassified one still
+maps its ``code`` to a plain-English sentence (mirror of
+``describe_failure_code`` / ``FAILURE_CODE_DESCRIPTIONS``) rather than
+exposing the enum. The pill expands in place to the message and diagnostics.
 
 Seeds the error item straight into the store (like ``seed_committed_turn``)
 so the assertion is on transcript hydration + rendering, deterministic and
@@ -75,11 +76,11 @@ def test_unclassified_failure_renders_english_headline_not_raw_code(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    alert = page.get_by_role("alert")
+    pill = page.get_by_test_id("error-pill")
     # The friendly, code-derived headline is shown...
-    expect(alert).to_contain_text("The agent's terminal exited unexpectedly", timeout=15_000)
+    expect(pill).to_contain_text("The agent's terminal exited unexpectedly", timeout=15_000)
     # ...and the raw enum is not surfaced as the headline.
-    expect(alert).not_to_contain_text("Error · required_terminal_exited", timeout=15_000)
+    expect(pill).not_to_contain_text("Error · required_terminal_exited", timeout=15_000)
 
 
 def test_persisted_failure_expands_retries_and_dismisses_locally(
@@ -125,39 +126,50 @@ def test_persisted_failure_expands_retries_and_dismisses_locally(
     page.route(f"**/v1/sessions/{session_id}/events", _recover)
     page.goto(f"{base_url}/c/{session_id}")
 
-    alert = page.get_by_role("alert")
-    expect(alert).to_be_visible(timeout=15_000)
-    headline = alert.get_by_role(
+    pill = page.get_by_test_id("error-pill")
+    expect(pill).to_be_visible(timeout=15_000)
+    headline = pill.get_by_role(
         "button", name="The agent's terminal exited unexpectedly", exact=False
     )
     expect(headline).to_have_attribute("aria-expanded", "false")
-    expect(alert.get_by_test_id("error-message-content")).to_have_count(0)
+    expect(pill.get_by_test_id("error-message-content")).to_have_count(0)
 
     headline.focus()
     page.keyboard.press("Enter")
     expect(headline).to_have_attribute("aria-expanded", "true")
-    expect(alert.get_by_role("heading", name="Message")).to_be_visible()
-    expect(alert.get_by_test_id("error-message-content")).to_contain_text(
+    expect(pill.get_by_role("heading", name="Message")).to_be_visible()
+    expect(pill.get_by_test_id("error-message-content")).to_contain_text(
         "Required terminal exited unexpectedly"
     )
 
-    alert.get_by_role("button", name="View diagnostics").click()
-    tabs = alert.get_by_role("tablist", name="Diagnostic sections")
+    # Clicking inside the expanded message body must not collapse the pill.
+    pill.get_by_test_id("error-message-content").click()
+    expect(headline).to_have_attribute("aria-expanded", "true")
+
+    # Clicking pill padding (outside any button) toggles expansion.
+    pill.click(position={"x": 3, "y": 3})
+    expect(headline).to_have_attribute("aria-expanded", "false")
+    pill.click(position={"x": 3, "y": 3})
+    expect(headline).to_have_attribute("aria-expanded", "true")
+
+    pill.get_by_role("button", name="View diagnostics").click()
+    tabs = pill.get_by_role("tablist", name="Diagnostic sections")
     expect(tabs).to_be_visible()
     terminal_tab = tabs.get_by_role("tab", name="Terminal")
     expect(terminal_tab).to_have_attribute("aria-selected", "true")
-    expect(alert.get_by_test_id("error-diagnostics-content")).to_contain_text("exit_code: 1")
+    expect(pill.get_by_test_id("error-diagnostics-content")).to_contain_text("exit_code: 1")
     tabs.get_by_role("tab", name="Last captured output").click()
-    expect(alert.get_by_test_id("error-diagnostics-content")).to_contain_text(
+    expect(pill.get_by_test_id("error-diagnostics-content")).to_contain_text(
         "fatal: runner unavailable"
     )
 
-    alert.get_by_role("button", name="Retry").click()
-    expect(alert).to_have_count(0)
+    # Retry triggers recovery and removes the pill rather than expanding it.
+    pill.get_by_role("button", name="Retry").click()
+    expect(pill).to_have_count(0)
     assert retry_payloads == [{"type": "retry_session", "data": {}}]
 
     page.reload()
-    alert = page.get_by_role("alert")
-    expect(alert).to_be_visible(timeout=15_000)
-    alert.get_by_role("button", name="Dismiss error").click()
-    expect(alert).to_have_count(0)
+    pill = page.get_by_test_id("error-pill")
+    expect(pill).to_be_visible(timeout=15_000)
+    pill.get_by_role("button", name="Dismiss error message").click()
+    expect(pill).to_have_count(0)

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -132,17 +132,18 @@ describe("BlockRenderer dispatch", () => {
       },
     ];
 
-    const { container } = render(<BlockRenderer items={items} sessionStatus="idle" />);
+    render(<BlockRenderer items={items} sessionStatus="idle" />);
 
-    const alert = screen.getByRole("alert");
-    expect(alert).toHaveClass("min-w-0");
-    expect(alert).toHaveClass("overflow-hidden");
+    const pill = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    expect(pill).toHaveClass("w-[560px]", "max-w-full");
 
-    fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
-    const description = container.querySelector('[data-slot="alert-description"]');
-    expect(description).not.toBeNull();
-    expect(description).toHaveClass("min-w-0");
-    expect(description).toHaveClass("overflow-hidden");
+    fireEvent.click(pill);
+    const expandedRegion = screen
+      .getByTestId("error-message-content")
+      .closest("section")?.parentElement;
+    expect(expandedRegion).not.toBeNull();
+    expect(expandedRegion).toHaveClass("min-w-0");
+    expect(expandedRegion).toHaveClass("overflow-hidden");
 
     const messageNode = screen.getByTestId("error-message-content");
     expect(messageNode).toHaveClass("whitespace-pre-wrap");

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -134,10 +134,11 @@ describe("BlockRenderer dispatch", () => {
 
     render(<BlockRenderer items={items} sessionStatus="idle" />);
 
-    const pill = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    const toggle = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    const pill = toggle.parentElement!.parentElement as HTMLElement;
     expect(pill).toHaveClass("w-[560px]", "max-w-full");
 
-    fireEvent.click(pill);
+    fireEvent.click(toggle);
     const expandedRegion = screen
       .getByTestId("error-message-content")
       .closest("section")?.parentElement;

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -197,6 +197,7 @@ describe("ErrorBanner", () => {
     expect(toggle).toHaveAttribute("type", "button");
     expect(toggle).toHaveClass("min-w-0", "flex-1", "bg-transparent", "text-left");
     const pill = toggle.parentElement!.parentElement as HTMLElement;
+    expect(pill).toHaveAttribute("data-testid", "error-pill");
     expect(pill).not.toHaveAttribute("role");
     expect(pill).not.toHaveAttribute("tabindex");
     expect(pill).toHaveClass("rounded-[12px]", "p-[8px]", "w-[560px]", "group/error");

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -42,11 +42,12 @@ describe("ErrorBanner", () => {
     expect(messageToggle).toHaveAttribute("aria-expanded", "false");
     expect(messageToggle).not.toHaveAttribute("aria-controls");
     expect(screen.getByTestId("error-headline")).toHaveClass("truncate");
+    expect(screen.getByTestId("error-headline")).not.toHaveTextContent("execution");
     expect(screen.queryByText("Message")).toBeNull();
     fireEvent.click(messageToggle);
     expect(messageToggle).toHaveAttribute("aria-expanded", "true");
     expect(messageToggle).toHaveAttribute("aria-controls");
-    expect(screen.getByTestId("error-headline")).not.toHaveClass("truncate");
+    expect(screen.getByTestId("error-headline")).toHaveClass("truncate");
     expect(screen.getByText("Message")).toBeInTheDocument();
     const message = screen.getByTestId("error-message-content");
     expect(message).toHaveClass("whitespace-pre-wrap");
@@ -61,13 +62,16 @@ describe("ErrorBanner", () => {
     );
 
     const messageToggle = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
-    expect(screen.getByTestId("error-leading-slot")).toHaveClass("size-5");
+    expect(screen.getByTestId("error-leading-slot")).toHaveClass("h-[18px]", "w-[18px]");
     expect(screen.getByTestId("error-status-icon")).toBeInTheDocument();
     expect(screen.queryByTestId("error-disclosure-icon")).toBeNull();
 
     fireEvent.mouseEnter(messageToggle);
     expect(screen.queryByTestId("error-status-icon")).toBeNull();
-    expect(screen.getByTestId("error-disclosure-icon")).toHaveClass("text-foreground");
+    expect(screen.getByTestId("error-disclosure-icon")).toHaveClass(
+      "text-muted-foreground",
+      "group-hover/error:text-foreground",
+    );
     expect(screen.getByTestId("error-disclosure-icon")).not.toHaveClass("rotate-90");
 
     fireEvent.mouseLeave(messageToggle);
@@ -127,12 +131,9 @@ describe("ErrorBanner", () => {
 
       fireEvent.keyDown(messageToggle, { key });
       expect(screen.queryByTestId("error-status-icon")).toBeNull();
-      expect(screen.getByTestId("error-disclosure-icon")).not.toHaveClass("rotate-90");
-      fireEvent.click(messageToggle);
       expect(screen.getByTestId("error-disclosure-icon")).toHaveClass("rotate-90");
 
       fireEvent.keyDown(messageToggle, { key });
-      fireEvent.click(messageToggle);
       expect(screen.queryByTestId("error-status-icon")).toBeNull();
       expect(screen.getByTestId("error-disclosure-icon")).not.toHaveClass("rotate-90");
 
@@ -162,43 +163,65 @@ describe("ErrorBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     const reconnecting = screen.getByTestId("error-reconnecting");
     const status = screen.getByRole("status");
-    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByTestId("error-headline")).toBeNull();
     expect(reconnecting).toHaveClass("justify-center", "min-h-14");
     expect(status).toHaveTextContent(/^Reconnecting$/);
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveAttribute("aria-atomic", "true");
     expect(status).toHaveClass("rounded-xl", "border-border", "bg-background");
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Dismiss error" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss error message" })).toBeNull();
     expect(screen.queryByText("Message")).toBeNull();
     expect(screen.queryByRole("button", { name: "View diagnostics" })).toBeNull();
     expect(screen.queryByTestId("error-status-icon")).toBeNull();
-    expect(screen.queryByTestId("error-headline")).toBeNull();
 
     await act(async () => rejectRetry?.(new Error("Host is still offline")));
-    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByTestId("error-headline")).toBeInTheDocument();
     expect(screen.queryByTestId("error-reconnecting")).toBeNull();
     expect(screen.getByRole("status")).toHaveTextContent("Retry failed: Host is still offline");
     expect(screen.getByTestId("error-status-icon")).toBeInTheDocument();
   });
 
-  it("matches the reference diagnostics hierarchy and surface treatment", () => {
+  it("matches the prototype pill structure and diagnostics treatment", () => {
     render(
       <ErrorBanner message={TERMINAL_ERROR} source="execution" code="required_terminal_exited" />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
-    expect(screen.getByRole("alert")).toHaveClass("rounded-2xl", "p-4");
+    const pill = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    expect(pill).toHaveClass("rounded-[12px]", "p-[8px]", "w-[560px]", "group/error");
+    expect(pill.style.background).toContain("color-mix");
+    expect(pill.style.border).toContain("color-mix");
+    expect(pill.parentElement).toHaveClass("items-center", "px-[16px]", "mb-[24px]");
+    const dashedRule = pill.parentElement!.querySelector('[aria-hidden="true"]');
+    expect(dashedRule).toHaveClass("pointer-events-none", "top-[20px]", "h-px");
+    expect((dashedRule as HTMLElement).style.background).toContain("repeating-linear-gradient");
+    expect(screen.getByTestId("error-headline")).toHaveClass(
+      "truncate",
+      "whitespace-nowrap",
+      "leading-6",
+      "text-destructive",
+    );
+
+    fireEvent.click(pill);
     const message = screen.getByTestId("error-message-content");
-    const copyMessage = screen.getByRole("button", { name: "Copy message" });
-    expect(message).toHaveClass("font-mono", "text-sm", "pr-10");
-    expect(copyMessage.parentElement).toBe(message.parentElement);
-    expect(copyMessage).toHaveClass("absolute", "top-0", "right-0");
-    expect(screen.getByText("Message").nextElementSibling).toBe(message.parentElement);
+    const copyMessage = screen.getByRole("button", { name: "Copy error message" });
+    expect(message).toHaveClass("font-mono", "text-sm", "whitespace-pre-wrap");
+    expect(copyMessage).toHaveClass("size-6");
+    expect(screen.getByText("Message")).toHaveClass(
+      "text-sm",
+      "font-medium",
+      "leading-4",
+      "text-muted-foreground",
+    );
 
     const diagnosticsToggle = screen.getByRole("button", { name: "View diagnostics" });
-    expect(diagnosticsToggle).toHaveClass("justify-between");
-    expect(diagnosticsToggle.closest('[data-slot="collapsible"]')).toHaveClass("border-t", "pt-4");
+    expect(diagnosticsToggle).toHaveClass("justify-between", "px-[12px]", "py-[8px]");
+    expect(diagnosticsToggle.closest('[data-slot="collapsible"]')).toHaveClass(
+      "border-t",
+      "-mx-[8px]",
+      "-mb-[8px]",
+      "w-[calc(100%+16px)]",
+    );
     fireEvent.click(diagnosticsToggle);
 
     expect(screen.getByRole("tablist", { name: "Diagnostic sections" })).toHaveAttribute(
@@ -243,6 +266,9 @@ describe("ErrorBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
     fireEvent.click(screen.getByRole("button", { name: "View diagnostics" }));
     expect(screen.getByRole("tab", { name: "Terminal" })).toHaveAttribute("aria-selected", "true");
+    // Clicks inside the expanded body must not collapse the pill.
+    fireEvent.click(screen.getByTestId("error-message-content"));
+    expect(screen.getByText("Message")).toBeInTheDocument();
     const terminal = screen.getByTestId("error-diagnostics-content");
     expect(terminal).toHaveTextContent("terminal: claude:main");
     expect(terminal).toHaveTextContent("termination_reason: terminal pane no longer available");
@@ -262,9 +288,9 @@ describe("ErrorBanner", () => {
       <ErrorBanner message={TERMINAL_ERROR} source="execution" code="required_terminal_exited" />,
     );
     fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy error message" }));
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Message copied" })).toBeTruthy(),
+      expect(screen.getByRole("button", { name: "Error message copied" })).toBeTruthy(),
     );
     expect(copyText).toHaveBeenCalledWith(
       "Required terminal exited unexpectedly; the session runtime is no longer available.",
@@ -280,7 +306,7 @@ describe("ErrorBanner", () => {
 
   it("falls back to a non-empty message without diagnostics controls", () => {
     render(<ErrorBanner message="" source="" code="mystery_failure" />);
-    fireEvent.click(screen.getByRole("button", { name: "Something went wrong" }));
+    fireEvent.click(screen.getByRole("button", { name: /Something went wrong/ }));
     expect(screen.getByTestId("error-message-content")).toHaveTextContent("mystery_failure");
     expect(screen.queryByRole("button", { name: "View diagnostics" })).toBeNull();
   });
@@ -292,8 +318,8 @@ describe("ErrorBanner", () => {
         <ErrorBanner message="boom" source="execution" code="executor_error" />
       </div>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss error" }));
-    expect(screen.queryByRole("alert")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss error message" }));
+    expect(screen.queryByTestId("error-headline")).toBeNull();
     expect(screen.getByText("Unrelated transcript content")).toBeInTheDocument();
   });
 
@@ -321,13 +347,13 @@ describe("ErrorBanner", () => {
       retry.click();
     });
     expect(onRetry).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByTestId("error-headline")).toBeNull();
     expect(screen.getByRole("status")).toHaveTextContent(/^Reconnecting$/);
     expect(screen.queryByText("Message")).toBeNull();
     resolveRetry?.();
     await waitFor(() => {
       expect(screen.queryByRole("status")).toBeNull();
-      expect(screen.queryByRole("alert")).toBeNull();
+      expect(screen.queryByTestId("error-headline")).toBeNull();
     });
   });
 
@@ -346,7 +372,7 @@ describe("ErrorBanner", () => {
       expect(screen.getByRole("status")).toHaveTextContent("Retry failed: Host is still offline"),
     );
     expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Dismiss error" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Dismiss error message" })).toHaveFocus();
     fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
     expect(screen.getByRole("button", { name: "View diagnostics" })).toBeInTheDocument();
   });

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -131,9 +131,12 @@ describe("ErrorBanner", () => {
 
       fireEvent.keyDown(messageToggle, { key });
       expect(screen.queryByTestId("error-status-icon")).toBeNull();
+      expect(screen.getByTestId("error-disclosure-icon")).not.toHaveClass("rotate-90");
+      fireEvent.click(messageToggle);
       expect(screen.getByTestId("error-disclosure-icon")).toHaveClass("rotate-90");
 
       fireEvent.keyDown(messageToggle, { key });
+      fireEvent.click(messageToggle);
       expect(screen.queryByTestId("error-status-icon")).toBeNull();
       expect(screen.getByTestId("error-disclosure-icon")).not.toHaveClass("rotate-90");
 
@@ -187,7 +190,15 @@ describe("ErrorBanner", () => {
       <ErrorBanner message={TERMINAL_ERROR} source="execution" code="required_terminal_exited" />,
     );
 
-    const pill = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    const toggle = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    // The expand/collapse control is a real button wrapping icon + headline;
+    // the pill container is a plain div so no interactive elements nest.
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle).toHaveAttribute("type", "button");
+    expect(toggle).toHaveClass("min-w-0", "flex-1", "bg-transparent", "text-left");
+    const pill = toggle.parentElement!.parentElement as HTMLElement;
+    expect(pill).not.toHaveAttribute("role");
+    expect(pill).not.toHaveAttribute("tabindex");
     expect(pill).toHaveClass("rounded-[12px]", "p-[8px]", "w-[560px]", "group/error");
     expect(pill.style.background).toContain("color-mix");
     expect(pill.style.border).toContain("color-mix");
@@ -201,9 +212,17 @@ describe("ErrorBanner", () => {
       "leading-6",
       "text-destructive",
     );
+    expect(screen.getByTestId("error-headline")).toHaveAttribute(
+      "title",
+      "The agent's terminal exited unexpectedly, so the session can't continue.",
+    );
+    expect(screen.getByRole("button", { name: "Dismiss error message" })).toHaveClass(
+      "hover:text-foreground",
+    );
 
-    fireEvent.click(pill);
+    fireEvent.click(toggle);
     const message = screen.getByTestId("error-message-content");
+    expect(message.closest("section")!.parentElement).toHaveClass("cursor-auto");
     const copyMessage = screen.getByRole("button", { name: "Copy error message" });
     expect(message).toHaveClass("font-mono", "text-sm", "whitespace-pre-wrap");
     expect(copyMessage).toHaveClass("size-6");
@@ -323,6 +342,39 @@ describe("ErrorBanner", () => {
     expect(screen.getByText("Unrelated transcript content")).toBeInTheDocument();
   });
 
+  it("toggles from the pill body but not from nested action buttons", async () => {
+    let resolveRetry: (() => void) | undefined;
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    render(
+      <ErrorBanner
+        message={TERMINAL_ERROR}
+        source="execution"
+        code="required_terminal_exited"
+        onRetry={onRetry}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /terminal exited unexpectedly/i });
+    const pill = toggle.parentElement!.parentElement as HTMLElement;
+    // Clicks on pill padding (outside the headline button) toggle expansion.
+    fireEvent.click(pill);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(pill);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Retry starts recovery instead of toggling; dismiss removes the banner.
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("error-reconnecting")).toBeInTheDocument();
+    await act(async () => resolveRetry?.());
+    expect(screen.queryByTestId("error-headline")).toBeNull();
+  });
+
   it("prevents duplicate retries and removes the replacement pill on success", async () => {
     let resolveRetry: (() => void) | undefined;
     const onRetry = vi.fn(
@@ -373,6 +425,9 @@ describe("ErrorBanner", () => {
     );
     expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Dismiss error message" })).toHaveFocus();
+    // The retry-error status row must not toggle the pill when clicked.
+    fireEvent.click(screen.getByRole("status"));
+    expect(screen.queryByText("Message")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /terminal exited unexpectedly/i }));
     expect(screen.getByRole("button", { name: "View diagnostics" })).toBeInTheDocument();
   });

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -255,19 +255,7 @@ export function ErrorBanner({
         }}
       />
       <div
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded}
-        aria-controls={expanded ? messageId : undefined}
         onClick={() => setExpanded((value) => !value)}
-        onKeyDown={(event) => {
-          if (event.target !== event.currentTarget) return;
-          setHeaderFocusVisible(event.currentTarget.matches(":focus-visible"));
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            setExpanded((value) => !value);
-          }
-        }}
         onMouseEnter={() => setHeaderHovered(true)}
         onMouseLeave={() => setHeaderHovered(false)}
         onPointerDown={() => {
@@ -280,18 +268,7 @@ export function ErrorBanner({
         onPointerCancel={() => {
           headerPointerDownRef.current = false;
         }}
-        onFocus={(event) => {
-          if (event.target !== event.currentTarget) return;
-          setHeaderFocusVisible(
-            !headerPointerDownRef.current && event.currentTarget.matches(":focus-visible"),
-          );
-        }}
-        onBlur={(event) => {
-          if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-          headerPointerDownRef.current = false;
-          setHeaderFocusVisible(false);
-        }}
-        className="group/error relative z-10 w-[560px] max-w-full cursor-pointer rounded-[12px] p-[8px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        className="group/error relative z-10 w-[560px] max-w-full cursor-pointer rounded-[12px] p-[8px] text-foreground"
         style={{
           background:
             "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
@@ -299,33 +276,57 @@ export function ErrorBanner({
         }}
       >
         <div className="flex w-full min-w-0 items-start gap-[4px]">
-          <span
-            data-testid="error-leading-slot"
-            className="mt-[4px] mr-[4px] flex h-[18px] w-[18px] shrink-0 items-center justify-center"
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-controls={expanded ? messageId : undefined}
+            onClick={(event) => {
+              event.stopPropagation();
+              setExpanded((value) => !value);
+            }}
+            onKeyDown={(event) => {
+              setHeaderFocusVisible(event.currentTarget.matches(":focus-visible"));
+            }}
+            onFocus={(event) => {
+              setHeaderFocusVisible(
+                !headerPointerDownRef.current && event.currentTarget.matches(":focus-visible"),
+              );
+            }}
+            onBlur={() => {
+              headerPointerDownRef.current = false;
+              setHeaderFocusVisible(false);
+            }}
+            className="flex min-w-0 flex-1 cursor-pointer items-start rounded-lg bg-transparent text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           >
-            {showDisclosureIcon ? (
-              <ChevronRightIcon
-                data-testid="error-disclosure-icon"
-                className={cn(
-                  "size-4 text-muted-foreground transition-transform duration-150 animate-in fade-in group-hover/error:text-foreground",
-                  expanded && "rotate-90",
-                )}
-                aria-hidden="true"
-              />
-            ) : (
-              <AlertCircleIcon
-                data-testid="error-status-icon"
-                className="size-[18px] text-destructive duration-150 animate-in fade-in"
-                aria-hidden="true"
-              />
-            )}
-          </span>
-          <span
-            data-testid="error-headline"
-            className="mr-[4px] min-w-0 flex-1 truncate whitespace-nowrap leading-6 text-destructive"
-          >
-            {headline}
-          </span>
+            <span
+              data-testid="error-leading-slot"
+              className="mt-[4px] mr-[4px] flex h-[18px] w-[18px] shrink-0 items-center justify-center"
+            >
+              {showDisclosureIcon ? (
+                <ChevronRightIcon
+                  data-testid="error-disclosure-icon"
+                  className={cn(
+                    "size-4 text-muted-foreground transition-transform duration-150 animate-in fade-in group-hover/error:text-foreground",
+                    expanded && "rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+              ) : (
+                <AlertCircleIcon
+                  data-testid="error-status-icon"
+                  className="size-[18px] text-destructive duration-150 animate-in fade-in"
+                  aria-hidden="true"
+                />
+              )}
+            </span>
+            <span
+              data-testid="error-headline"
+              title={headline}
+              className="mr-[4px] min-w-0 flex-1 truncate whitespace-nowrap leading-6 text-destructive"
+            >
+              {headline}
+            </span>
+          </button>
           {retryable ? (
             <Button
               type="button"
@@ -352,7 +353,7 @@ export function ErrorBanner({
               event.stopPropagation();
               setDismissed(true);
             }}
-            className="size-6 shrink-0 rounded-[var(--control-radius,var(--radius-lg))] text-muted-foreground hover:bg-muted hover:text-[var(--button-icon-hover-color)]"
+            className="size-6 shrink-0 rounded-[var(--control-radius,var(--radius-lg))] text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             <XIcon className="size-4" aria-hidden="true" />
           </Button>
@@ -362,6 +363,7 @@ export function ErrorBanner({
             role="status"
             aria-live="assertive"
             aria-atomic="true"
+            onClick={(event) => event.stopPropagation()}
             className="mx-[4px] mt-[8px] text-sm leading-5 break-words text-destructive [overflow-wrap:anywhere]"
           >
             {retryError}
@@ -371,7 +373,7 @@ export function ErrorBanner({
           <div
             id={messageId}
             onClick={(event) => event.stopPropagation()}
-            className="mt-[12px] min-w-0 max-w-full overflow-hidden text-foreground [text-wrap:wrap]"
+            className="mt-[12px] min-w-0 max-w-full cursor-auto overflow-hidden text-foreground [text-wrap:wrap]"
           >
             <section aria-labelledby={`${messageId}-label`} className="min-w-0">
               <div className="mx-[4px] flex items-center justify-between gap-2">

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -255,6 +255,7 @@ export function ErrorBanner({
         }}
       />
       <div
+        data-testid="error-pill"
         onClick={() => setExpanded((value) => !value)}
         onMouseEnter={() => setHeaderHovered(true)}
         onMouseLeave={() => setHeaderHovered(false)}

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -1,7 +1,7 @@
 // Inline status indicators for non-tool, non-text, non-reasoning blocks.
 // Each is small enough to live in one file.
 //
-// - ErrorBanner: destructive Alert with `[source]` + code + message.
+// - ErrorBanner: centered destructive pill with an expandable message body.
 // - RetryIndicator: muted one-liner about an in-flight retry.
 // - CompactionMarker: permanent marker shown after compaction completes.
 //   The in-progress state renders as a Shimmer in ChatPage, mirroring
@@ -14,6 +14,7 @@ import {
   ChevronRightIcon,
   CopyIcon,
   RotateCcwIcon,
+  RotateCwIcon,
   ShieldXIcon,
   ShrinkIcon,
   XIcon,
@@ -127,18 +128,18 @@ function parseErrorMessage(rawMessage: string): ParsedErrorMessage {
 }
 
 /**
- * Loud destructive banner for `error` blocks.
+ * Centered destructive pill for `error` blocks: a truncated headline row over
+ * a dashed rule; the whole pill toggles the expanded message body.
  *
  * When the runner classified the failure it passes `title` / `cause` /
- * `remediation`, and the banner renders a clear card: headline, plain-English
- * cause, a "Try this" remediation line, and the raw diagnostics folded into a
+ * `remediation`, and the expanded body shows the plain-English cause, a
+ * "Try this" remediation line, and the raw diagnostics folded into a
  * collapsible. Otherwise it falls back to a code→sentence map (so even an
  * unclassified failure reads as English) and finally to the raw message/code —
  * never a blank panel.
  */
 export function ErrorBanner({
   message,
-  source,
   code,
   title,
   cause,
@@ -244,91 +245,99 @@ export function ErrorBanner({
   };
 
   return (
-    <Alert
-      variant="destructive"
-      className={cn(
-        TOOL_SURFACE_WIDTH_CLASS,
-        "block overflow-hidden rounded-2xl border-destructive/30 bg-destructive/[0.045] p-4 text-destructive sm:p-5",
-      )}
-    >
-      <div className="min-w-0 max-w-full">
-        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-start gap-x-2">
-          <button
-            type="button"
-            aria-expanded={expanded}
-            aria-controls={expanded ? messageId : undefined}
-            onClick={() => setExpanded((value) => !value)}
-            onMouseEnter={() => setHeaderHovered(true)}
-            onMouseLeave={() => setHeaderHovered(false)}
-            onPointerDown={() => {
-              headerPointerDownRef.current = true;
-              setHeaderFocusVisible(false);
-            }}
-            onPointerUp={() => {
-              headerPointerDownRef.current = false;
-            }}
-            onPointerCancel={() => {
-              headerPointerDownRef.current = false;
-            }}
-            onFocus={(event) => {
-              setHeaderFocusVisible(
-                !headerPointerDownRef.current && event.currentTarget.matches(":focus-visible"),
-              );
-            }}
-            onKeyDown={(event) => {
-              setHeaderFocusVisible(event.currentTarget.matches(":focus-visible"));
-            }}
-            onBlur={() => {
-              headerPointerDownRef.current = false;
-              setHeaderFocusVisible(false);
-            }}
-            className="group/header -m-1 grid min-w-0 cursor-pointer grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-x-3 rounded-lg p-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    <div className="relative mb-[24px] flex w-full flex-col items-center px-[16px]">
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-[20px] right-0 left-0 h-px"
+        style={{
+          background:
+            "repeating-linear-gradient(to right, color-mix(in srgb, var(--destructive) 32%, transparent) 0 2px, transparent 2px 6px)",
+        }}
+      />
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-controls={expanded ? messageId : undefined}
+        onClick={() => setExpanded((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return;
+          setHeaderFocusVisible(event.currentTarget.matches(":focus-visible"));
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setExpanded((value) => !value);
+          }
+        }}
+        onMouseEnter={() => setHeaderHovered(true)}
+        onMouseLeave={() => setHeaderHovered(false)}
+        onPointerDown={() => {
+          headerPointerDownRef.current = true;
+          setHeaderFocusVisible(false);
+        }}
+        onPointerUp={() => {
+          headerPointerDownRef.current = false;
+        }}
+        onPointerCancel={() => {
+          headerPointerDownRef.current = false;
+        }}
+        onFocus={(event) => {
+          if (event.target !== event.currentTarget) return;
+          setHeaderFocusVisible(
+            !headerPointerDownRef.current && event.currentTarget.matches(":focus-visible"),
+          );
+        }}
+        onBlur={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+          headerPointerDownRef.current = false;
+          setHeaderFocusVisible(false);
+        }}
+        className="group/error relative z-10 w-[560px] max-w-full cursor-pointer rounded-[12px] p-[8px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        style={{
+          background:
+            "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
+          border: "1px solid color-mix(in srgb, var(--destructive) 32%, transparent)",
+        }}
+      >
+        <div className="flex w-full min-w-0 items-start gap-[4px]">
+          <span
+            data-testid="error-leading-slot"
+            className="mt-[4px] mr-[4px] flex h-[18px] w-[18px] shrink-0 items-center justify-center"
           >
-            <span
-              data-testid="error-leading-slot"
-              className="mt-0.5 flex size-5 shrink-0 items-center justify-center"
-            >
-              {showDisclosureIcon ? (
-                <ChevronRightIcon
-                  data-testid="error-disclosure-icon"
-                  className={cn(
-                    "size-4 text-foreground transition-transform duration-150 animate-in fade-in",
-                    expanded && "rotate-90",
-                  )}
-                  aria-hidden="true"
-                />
-              ) : (
-                <AlertCircleIcon
-                  data-testid="error-status-icon"
-                  className="size-4 animate-in fade-in duration-150"
-                  aria-hidden="true"
-                />
-              )}
-            </span>
-            <AlertTitle className="min-w-0 pr-1 text-sm font-semibold leading-6 text-destructive sm:text-base">
-              <span
-                data-testid="error-headline"
+            {showDisclosureIcon ? (
+              <ChevronRightIcon
+                data-testid="error-disclosure-icon"
                 className={cn(
-                  "block min-w-0",
-                  expanded ? "break-words [overflow-wrap:anywhere]" : "truncate",
+                  "size-4 text-muted-foreground transition-transform duration-150 animate-in fade-in group-hover/error:text-foreground",
+                  expanded && "rotate-90",
                 )}
-              >
-                {headline}
-                {source ? (
-                  <span className="font-normal text-destructive/75"> · {source}</span>
-                ) : null}
-              </span>
-            </AlertTitle>
-          </button>
+                aria-hidden="true"
+              />
+            ) : (
+              <AlertCircleIcon
+                data-testid="error-status-icon"
+                className="size-[18px] text-destructive duration-150 animate-in fade-in"
+                aria-hidden="true"
+              />
+            )}
+          </span>
+          <span
+            data-testid="error-headline"
+            className="mr-[4px] min-w-0 flex-1 truncate whitespace-nowrap leading-6 text-destructive"
+          >
+            {headline}
+          </span>
           {retryable ? (
             <Button
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() => void retry()}
-              className="mt-0.5 shrink-0 text-muted-foreground hover:text-foreground"
+              onClick={(event) => {
+                event.stopPropagation();
+                void retry();
+              }}
+              className="h-6 shrink-0 gap-1 rounded-[var(--control-radius,var(--radius-lg))] px-2 text-[var(--text-13,13px)] leading-5 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
-              <RotateCcwIcon aria-hidden="true" />
+              <RotateCwIcon className="size-3.5" aria-hidden="true" />
               Retry
             </Button>
           ) : null}
@@ -337,11 +346,14 @@ export function ErrorBanner({
             type="button"
             variant="ghost"
             size="icon-xs"
-            aria-label="Dismiss error"
-            onClick={() => setDismissed(true)}
-            className="mt-0.5 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss error message"
+            onClick={(event) => {
+              event.stopPropagation();
+              setDismissed(true);
+            }}
+            className="size-6 shrink-0 rounded-[var(--control-radius,var(--radius-lg))] text-muted-foreground hover:bg-muted hover:text-[var(--button-icon-hover-color)]"
           >
-            <XIcon aria-hidden="true" />
+            <XIcon className="size-4" aria-hidden="true" />
           </Button>
         </div>
         {retryError ? (
@@ -349,54 +361,61 @@ export function ErrorBanner({
             role="status"
             aria-live="assertive"
             aria-atomic="true"
-            className="mt-2 break-words pl-8 text-sm text-destructive [overflow-wrap:anywhere]"
+            className="mx-[4px] mt-[8px] text-sm leading-5 break-words text-destructive [overflow-wrap:anywhere]"
           >
             {retryError}
           </div>
         ) : null}
         {expanded ? (
-          <AlertDescription
+          <div
             id={messageId}
-            className="mt-6 min-w-0 max-w-full overflow-hidden text-foreground [text-wrap:wrap]"
+            onClick={(event) => event.stopPropagation()}
+            className="mt-[12px] min-w-0 max-w-full overflow-hidden text-foreground [text-wrap:wrap]"
           >
-            <section aria-labelledby={`${messageId}-label`} className="min-w-0 space-y-2">
-              <h4 id={`${messageId}-label`} className="text-sm font-medium text-muted-foreground">
-                Message
-              </h4>
-              <div className="relative min-w-0">
-                <div
-                  data-testid="error-message-content"
-                  className="max-w-full min-w-0 whitespace-pre-wrap break-words pr-10 font-mono text-sm leading-6 text-foreground [overflow-wrap:anywhere] [text-wrap:wrap]"
+            <section aria-labelledby={`${messageId}-label`} className="min-w-0">
+              <div className="mx-[4px] flex items-center justify-between gap-2">
+                <h4
+                  id={`${messageId}-label`}
+                  className="text-sm leading-4 font-medium text-muted-foreground"
                 >
-                  {messageText}
-                </div>
+                  Message
+                </h4>
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon-xs"
-                  className="absolute top-0 right-0 text-muted-foreground hover:text-foreground"
-                  aria-label={copiedTarget === "message" ? "Message copied" : "Copy message"}
+                  className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  aria-label={
+                    copiedTarget === "message" ? "Error message copied" : "Copy error message"
+                  }
                   onClick={() => void copy("message", messageText)}
                 >
                   {copiedTarget === "message" ? (
-                    <CheckIcon aria-hidden="true" />
+                    <CheckIcon className="size-3.5" aria-hidden="true" />
                   ) : (
-                    <CopyIcon aria-hidden="true" />
+                    <CopyIcon className="size-3.5" aria-hidden="true" />
                   )}
                 </Button>
+              </div>
+              <div
+                data-testid="error-message-content"
+                className="mx-[4px] mt-[4px] max-w-full min-w-0 font-mono text-sm leading-6 break-words whitespace-pre-wrap text-foreground [overflow-wrap:anywhere] [text-wrap:wrap]"
+              >
+                {messageText}
               </div>
             </section>
             {diagnostics.length > 0 ? (
               <Collapsible
                 open={diagnosticsOpen}
                 onOpenChange={setDiagnosticsOpen}
-                className="mt-6 border-t border-destructive/15 pt-4"
+                className="-mx-[8px] -mb-[8px] mt-[12px] w-[calc(100%+16px)] border-t"
+                style={{ borderColor: "var(--sidebar-edge-border, var(--border))" }}
               >
                 <CollapsibleTrigger asChild>
                   <button
                     type="button"
                     aria-controls={diagnosticsOpen ? diagnosticsId : undefined}
-                    className="flex w-full cursor-pointer items-center justify-between gap-3 rounded-md py-1 text-left text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                    className="flex w-full cursor-pointer items-center justify-between gap-3 px-[12px] py-[8px] text-left text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                   >
                     <span>View diagnostics</span>
                     <ChevronRightIcon
@@ -408,7 +427,7 @@ export function ErrorBanner({
                     />
                   </button>
                 </CollapsibleTrigger>
-                <CollapsibleContent id={diagnosticsId} className="min-w-0 pt-4">
+                <CollapsibleContent id={diagnosticsId} className="min-w-0 px-[12px] pb-[12px]">
                   <Tabs value={activeDiagnostics} onValueChange={setActiveDiagnostics}>
                     {diagnostics.length > 1 ? (
                       <TabsList
@@ -461,10 +480,10 @@ export function ErrorBanner({
                 </CollapsibleContent>
               </Collapsible>
             ) : null}
-          </AlertDescription>
+          </div>
         ) : null}
       </div>
-    </Alert>
+    </div>
   );
 }
 

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -335,7 +335,8 @@ export function ErrorBanner({
                 event.stopPropagation();
                 void retry();
               }}
-              className="h-6 shrink-0 gap-1 rounded-[var(--control-radius,var(--radius-lg))] px-2 text-[var(--text-13,13px)] leading-5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              style={{ fontSize: "var(--text-13, 13px)" }}
+              className="h-6 shrink-0 gap-1 rounded-[var(--control-radius,var(--radius-lg))] px-2 leading-5 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
               <RotateCwIcon className="size-3.5" aria-hidden="true" />
               Retry


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; visual alignment with the published UX prototype (`agentic-ux-2026-omnigent.vercel.app/s/sso-enterprise`).

## Summary

The chat error banner (`ErrorBanner`, rendered for `error` blocks) was a full-width destructive `Alert` card and had drifted from the UX prototype. This restyles it to match the prototype exactly:

- Full-width card → compact, horizontally centered **560px pill** sitting over a full-width dashed destructive rule (32% destructive, 2px/4px dash).
- Collapsed row is a single truncated destructive headline (with a native tooltip for the full text); the alert icon swaps to a chevron on hover/focus (chevron rotates when expanded).
- Clicking anywhere on the pill toggles expansion for mouse users; the icon+headline region is a real `<button>` (aria-expanded, keyboard, focus ring) so the accessibility tree has no nested-interactive violation.
- Retry button uses the correct **clockwise** `rotate-cw` icon at the prototype's 13px size (previously counter-clockwise); dismiss X stays top-right with a theme-safe hover color.
- The message body and diagnostics now expand **inside** the pill: mono "Message" section with a copy button, and a full-bleed "View diagnostics" footer separated by a hairline.

ELI5: the error box in chat looked nothing like the design; now it's the small red pill from the prototype, and clicking it still unfolds the details.

```
before:  [====== full-width rounded card, big headline, padding 20px ======]
after:   ······· [ == 560px pill: (!) headline…  ⟳ Retry  ✕ == ] ·······
                       └ click to expand: Message (mono, copy) ▸ View diagnostics
```

Behavior is unchanged: same props, same retryable-error gating, same retry/dismiss/expand/focus flows, same `data-testid`s. Missing prototype CSS vars fall back to existing theme tokens (`--background`, `--border`, `--radius-lg`), so no global CSS was added.

## Test Plan

- `npx vitest run src/components/blocks/StatusBlocks.test.tsx src/components/blocks/BlockRenderer.test.tsx` — 108/108 pass (assertions updated to the new DOM; coverage kept for retryable vs non-retryable, dismiss, expand/collapse, retry flow, retry-error focus, diagnostics tabs/parsing; new tests: clicking the pill body toggles but nested action buttons don't, and clicking the retry-error row doesn't expand).
- `uv run --no-sync pytest tests/e2e_ui/chat/test_failure_error_card.py -v` — 2/2 pass (Playwright against a spawned server; covers pill rendering, keyboard expansion, pill-padding toggle, message-body click stability, diagnostics tabs, retry interception, reload + dismiss).
- `oxlint --deny-warnings` on touched files: clean. `tsc -b`: no new errors.
- Manual: ran the dev stack (`omnigent server`, `omnigent host`, `web` dev server), opened a session containing real error blocks, and compared computed styles against the prototype DOM in both light and dark themes (pill geometry, dashed rule, truncated headline, 13px Retry label, dismiss hover contrast, expanded Message/diagnostics footer, and the un-nested toggle button structure).

## Demo

Collapsed pills (light theme):

![error pills — light](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-retry-ux/tmp-screenshots/error-pill-light.png)

Collapsed pills (dark theme):

![error pills — dark](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-retry-ux/tmp-screenshots/error-pill-dark.png)

Expanded pill with Message + View diagnostics (dark theme):

![error pill expanded — dark](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-retry-ux/tmp-screenshots/error-pill-expanded-dark.png)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the visual contract that unit tests can't: computed pill geometry/colors, the dashed rule, icon swap, dark-theme dismiss hover contrast, and the expanded layout were compared against the live prototype DOM in both themes on a session with real error blocks. Behavior (retry/dismiss/expand/focus/keyboard) is covered by the updated unit tests.

## Changelog

Chat error banners are now a compact centered pill with inline Retry, matching the design prototype
