### PR TITLE
Allow Copilot SDK readiness with CLI OAuth

### DIFF
--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -249,19 +249,12 @@ def _harness_availability_core(harness: str) -> HarnessAvailability:
     if canonical == COPILOT_KEY:
         # Copilot runs in-process via the ``github-copilot-sdk`` package (the
         # SDK bundles the CLI binary it drives, so there is no separate binary to
-        # gate on) and authenticates against GitHub's Copilot backend with a
-        # GitHub token. So, like cursor, readiness is whether a token is
-        # resolvable — one stored by ``omnigent setup`` (the ``copilot:`` config
-        # block — see :mod:`omnigent.onboarding.copilot_auth`) or inherited from
-        # the environment. A bad / Copilot-less token surfaces at run time.
-        from omnigent.onboarding.copilot_auth import (
-            COPILOT_TOKEN_ENV_VARS,
-            copilot_github_token_configured,
-        )
-
-        return copilot_github_token_configured() or any(
-            os.environ.get(var) for var in COPILOT_TOKEN_ENV_VARS
-        )
+        # gate on). The backing CLI can authenticate through its own persisted
+        # OAuth login when no explicit token is configured, and that credential
+        # store is intentionally not read by Omnigent. Keep readiness ungated,
+        # like the other SDK harnesses, and surface missing/invalid auth from the
+        # executor's first turn.
+        return True
     if (
         canonical not in _HARNESS_FAMILY
         and canonical not in _PI_HARNESSES

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -19,14 +19,12 @@ from omnigent.onboarding.harness_readiness import (
 
 @pytest.fixture(autouse=True)
 def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Isolate cursor + copilot credential sources so their readiness is deterministic.
+    """Isolate credential sources so readiness tests are deterministic.
 
-    Cursor readiness keys off a configured ``CURSOR_API_KEY`` and copilot off a
-    GitHub token (the ``cursor:`` / ``copilot:`` config blocks or the
-    environment), so point the config home at an empty tmp dir and clear any
-    ambient ``CURSOR_API_KEY`` / ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
-    ``GITHUB_TOKEN`` — otherwise a developer's real key would flip their verdict
-    under these tests.
+    Point the config home at an empty tmp dir and clear ambient provider
+    credentials so a developer's real configuration cannot change verdicts.
+    Copilot SDK readiness is intentionally independent of these values because
+    the backing CLI may use its own persisted OAuth login.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("CURSOR_API_KEY", raising=False)
@@ -381,6 +379,8 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "openai-agents",
         "openai-agents-sdk",
         "agents_sdk",
+        "copilot",
+        "github-copilot",
     ):
         assert result[sdk] is True, f"{sdk} should never be gated"
     # CLI-wrapping spellings — gated, so False when the binary is absent.
@@ -427,15 +427,14 @@ def test_configured_harness_map_gates_only_cli_harnesses(
 def test_configured_harness_map_all_true_with_clis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Every spelling reads True once the CLIs are installed and the key/token-
-    gated harnesses are satisfied.
+    """Every spelling reads True once CLIs and gated credentials are available.
 
     The CLI harnesses pass their binary check, the SDK harnesses are ungated,
-    cursor (key-gated) is satisfied by a ``CURSOR_API_KEY``, copilot
-    (token-gated) by a ``GH_TOKEN``, antigravity-native (binary + credential
-    gated) by a detected Gemini OAuth credential, kimi (binary + credential
-    gated) by a detected ``kimi login`` credential, and the generic ACP harness
-    (config-gated) by a registered agent — so nothing is reported unconfigured.
+    cursor (key-gated) is satisfied by a ``CURSOR_API_KEY``,
+    antigravity-native (binary + credential gated) by a detected Gemini OAuth
+    credential, kimi (binary + credential gated) by a detected ``kimi login``
+    credential, and the generic ACP harness (config-gated) by a registered
+    agent — so nothing is reported unconfigured.
     """
     import omnigent.onboarding.gemini_auth as _ga
     import omnigent.onboarding.kimi_auth as _ka


### PR DESCRIPTION
## Summary
- treat the native Copilot SDK harness as launchable without a separately registered GitHub token
- allow the bundled Copilot CLI to use its persisted OAuth login
- keep missing or invalid authentication errors at the first executor turn, where they are actionable
- classify `copilot` and `github-copilot` with the other ungated SDK harness spellings

## Root cause
The readiness gate only checked Omnigent token configuration and ambient GitHub token variables. The GitHub Copilot SDK defaults to the logged-in Copilot CLI user, whose credential store is intentionally not read by Omnigent, so valid SDK sessions were rejected with HTTP 412 before provider launch.

## Validation
- regression test verified red before the production change and green afterward
- `54 passed, 1 deselected` across readiness and Copilot auth tests; the deselected Claude/Gemini probing test also fails unchanged on the base commit
- Ruff check and format validation passed
- live AI Harness -> Omnigent host -> Copilot SDK turn completed using CLI OAuth and returned the exact marker `HARNESS-SDK-FULL-E2E-20260818-1330`
