### PR TITLE
Invoke explicit skills in Codex-native chat

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -445,8 +445,9 @@ def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
     ``$CODEX_HOME/skills/``) and the slash-command menu's ``codex_host_skills``
     provider — so the linked set and the menu cannot drift on which roots
     are scanned. Priority order: the agent's own ``<bundle>/skills/`` before
-    host-installed ``<home>/.codex/skills/`` (a bundled skill shadows a host
-    skill of the same name). Only existing directories are returned.
+    legacy ``<home>/.codex/skills/``, then shared
+    ``<home>/.agents/skills/``. Earlier sources shadow later sources with the
+    same skill name. Only existing directories are returned.
 
     :param bundle_dir: Materialized agent-bundle root, or ``None``.
     :param home: The user home directory (``Path.home()``); injected so
@@ -456,9 +457,9 @@ def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
     sources: list[Path] = []
     if bundle_dir is not None and (bundle_dir / "skills").is_dir():
         sources.append(bundle_dir / "skills")
-    host = home / ".codex" / "skills"
-    if host.is_dir():
-        sources.append(host)
+    for host in (home / ".codex" / "skills", home / ".agents" / "skills"):
+        if host.is_dir():
+            sources.append(host)
     return sources
 
 

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 from typing import cast
 
-from omnigent.codex_native_app_server import client_for_transport
+from omnigent.codex_native_app_server import CodexAppServerClient, client_for_transport
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
@@ -105,6 +105,7 @@ class CodexNativeExecutor(Executor):
             )
             await client.connect()
             try:
+                input_items = await _expand_explicit_skill_command(client, input_items)
                 response = await client.request(
                     "turn/steer",
                     {
@@ -264,6 +265,7 @@ class CodexNativeExecutor(Executor):
                 )
                 await client.connect()
                 try:
+                    input_items = await _expand_explicit_skill_command(client, input_items)
                     if goal_objective is not None:
                         await client.request(
                             "thread/goal/set",
@@ -482,6 +484,54 @@ def _content_to_input_items(content: object, bridge_dir: Path) -> list[dict[str,
     if content is None:
         return []
     return [{"type": "text", "text": json.dumps(content, ensure_ascii=True)}]
+
+
+async def _expand_explicit_skill_command(
+    client: CodexAppServerClient,
+    items: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Resolve a leading ``/skill`` through Codex's skill registry."""
+    if not items:
+        return items
+    first = items[0]
+    text = first.get("text") if first.get("type") == "text" else None
+    if not isinstance(text, str):
+        return items
+    parts = text.split(maxsplit=1)
+    command = parts[0]
+    if not command.startswith("/") or len(command) == 1:
+        return items
+    name = command[1:]
+    try:
+        response = await client.request("skills/list", {"cwds": []})
+    except Exception:  # noqa: BLE001 - unsupported lookup leaves input literal.
+        _logger.warning("Codex native skills/list failed", exc_info=True)
+        return items
+    result = _json_object(response.get("result"))
+    data = result.get("data") if result is not None else None
+    if not isinstance(data, list):
+        return items
+    for entry in data:
+        entry_obj = _json_object(entry)
+        skills = entry_obj.get("skills") if entry_obj is not None else None
+        if not isinstance(skills, list):
+            continue
+        for skill in skills:
+            skill_obj = _json_object(skill)
+            if (
+                skill_obj is None
+                or skill_obj.get("name") != name
+                or skill_obj.get("enabled") is not True
+            ):
+                continue
+            path = skill_obj.get("path")
+            if not isinstance(path, str) or not path:
+                return items
+            expanded: list[dict[str, object]] = [{"type": "skill", "name": name, "path": path}]
+            if len(parts) == 2:
+                expanded.append({"type": "text", "text": parts[1]})
+            return [*expanded, *items[1:]]
+    return items
 
 
 def _file_block_to_input_item(

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3276,16 +3276,18 @@ def test_select_codex_skill_dirs_none_and_list(tmp_path: Path) -> None:
 
 
 def test_codex_skill_sources_order_bundle_then_host(tmp_path: Path) -> None:
-    """codex_skill_sources lists <bundle>/skills before <home>/.codex/skills."""
+    """Codex sources prefer bundle, then legacy and shared user skills."""
     from omnigent.inner.codex_executor import codex_skill_sources
 
     bundle = tmp_path / "bundle"
     (bundle / "skills").mkdir(parents=True)
     home = tmp_path / "home"
     (home / ".codex" / "skills").mkdir(parents=True)
+    (home / ".agents" / "skills").mkdir(parents=True)
     assert codex_skill_sources(bundle, home) == [
         bundle / "skills",
         home / ".codex" / "skills",
+        home / ".agents" / "skills",
     ]
 
 

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -48,6 +48,7 @@ class _FakeCodexNativeClient:
 
     requests: list[tuple[str, dict[str, Any]]] = []
     created: list[tuple[Path | None, str | None, str]] = []
+    skill_entries: list[dict[str, Any]] = []
     next_turn = 1
 
     def __init__(
@@ -102,6 +103,18 @@ class _FakeCodexNativeClient:
             return {"result": {"turn": {"id": turn_id}}}
         if method == "turn/steer":
             return {"result": {"turnId": "turn_steered"}}
+        if method == "skills/list":
+            return {
+                "result": {
+                    "data": [
+                        {
+                            "cwd": "/workspace",
+                            "skills": type(self).skill_entries,
+                            "errors": [],
+                        }
+                    ]
+                }
+            }
         return {"result": {}}
 
     async def iter_events(self) -> Any:
@@ -191,6 +204,62 @@ def test_web_started_codex_turn_returns_without_waiting_for_terminal_event(
                 "input": [{"type": "text", "text": "first"}],
             },
         )
+    ]
+
+
+def test_explicit_slash_skill_uses_structured_codex_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A slash-invoked skill stays outside ambient context but reaches Codex."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    skill_path = tmp_path / "skills" / "ask-matt" / "SKILL.md"
+    monkeypatch.setattr(
+        _FakeCodexNativeClient,
+        "skill_entries",
+        [
+            {
+                "name": "ask-matt",
+                "path": str(skill_path),
+                "enabled": True,
+                "description": "Find the right skill or workflow",
+                "scope": "user",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "/ask-matt verify this service")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        ("skills/list", {"cwds": []}),
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [
+                    {"type": "skill", "name": "ask-matt", "path": str(skill_path)},
+                    {"type": "text", "text": "verify this service"},
+                ],
+            },
+        ),
     ]
 
 

--- a/tests/spec/test_skill_sources.py
+++ b/tests/spec/test_skill_sources.py
@@ -293,6 +293,16 @@ def test_codex_provider_surfaces_home_codex_skills(tmp_path: Path) -> None:
     assert "using-superpowers" in [s.name for s in out]
 
 
+def test_codex_provider_surfaces_shared_agent_skills(tmp_path: Path) -> None:
+    """Codex slash menu includes skills from its shared Agent Skills root."""
+    home = tmp_path / "home"
+    _write_skill(home / ".agents" / "skills", "ask-matt")
+
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "codex-native")
+
+    assert "ask-matt" in [s.name for s in out]
+
+
 def test_codex_provider_respects_none_filter(tmp_path: Path) -> None:
     home = tmp_path / "home"
     _write_skill(home / ".codex" / "skills", "using-superpowers")


### PR DESCRIPTION
## Related issue

Closes #4935

## Summary

- Resolve a leading `/skill` through Codex's own `skills/list` registry and send structured skill input from chat view.
- Discover shared Agent Skills under `~/.agents/skills` after bundle and legacy Codex skill roots.
- Leave unknown, disabled, or unsupported commands unchanged.

ELI5: chat view now hands Codex the same labeled skill card that terminal view uses, instead of a plain sentence beginning with `/`.

```text
/skill arguments -> skills/list -> structured skill + argument text -> Codex turn
```

## Test Plan

- `uv run --no-sync pytest tests/inner/test_codex_executor.py tests/inner/test_codex_native_executor.py tests/spec/test_skill_sources.py -q --tb=short`
- Result: 190 passed.

## Demo

N/A — no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover fresh turns, steering, enabled-skill lookup, structured arguments, and shared skill-source discovery.

## Changelog

Codex-native chat now invokes explicit slash skills and discovers shared Agent Skills.
