### PR TITLE
fix(web): Enter inserts a newline on touch-primary devices

### DIFF
--- a/web/src/hooks/useIsCoarsePointer.ts
+++ b/web/src/hooks/useIsCoarsePointer.ts
@@ -1,0 +1,31 @@
+// Reactive "is the primary pointer coarse?" hook.
+//
+// `(pointer: coarse)` matches touch-primary devices (phones, tablets) and is
+// the standard signal for "there is no practical Shift+Enter": the on-screen
+// keyboard's Enter is the only newline key such devices have. Used to keep
+// Enter an inserting key (rather than a submitting one) in text inputs where
+// submission already has an explicit button.
+
+import { useSyncExternalStore } from "react";
+
+const COARSE_QUERY = "(pointer: coarse)";
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mql = window.matchMedia(COARSE_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(COARSE_QUERY).matches;
+}
+
+/**
+ * True when the device's primary pointer is coarse (touch). Reactive across
+ * pointer changes, SSR-safe (returns `false` on the server).
+ */
+export function useIsCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1597,3 +1597,53 @@ describe("sanitizeInitialPrompt", () => {
     expect(sanitizeInitialPrompt(input)).toBe(expected);
   });
 });
+
+describe("create-session input on touch-primary devices (#4943)", () => {
+  it("Enter inserts a newline instead of submitting when the pointer is coarse", async () => {
+    // Phones have no practical Shift+Enter, so an Enter-submit in the
+    // create-session composer was an unrecoverable accidental send. On
+    // coarse-pointer devices the composer must let Enter fall through to the
+    // textarea's native newline; sending stays an explicit tap.
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query: string) =>
+        query.includes("pointer: coarse")
+          ? ({
+              matches: true,
+              media: query,
+              onchange: null,
+              addListener: () => {},
+              removeListener: () => {},
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            } as MediaQueryList)
+          : ({
+              matches: false,
+              media: query,
+              onchange: null,
+              addListener: () => {},
+              removeListener: () => {},
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            } as MediaQueryList),
+      );
+
+    try {
+      renderLanding();
+      await waitForWorkspaceSeed();
+      const input = screen.getByTestId("new-chat-landing-input");
+      fireEvent.change(input, { target: { value: "first line of a long prompt" } });
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      // No session was created and no navigation happened: Enter was not
+      // intercepted, so the composer still holds the user's draft.
+      expect(authenticatedFetch).not.toHaveBeenCalled();
+      expect(navigateMock).not.toHaveBeenCalled();
+    } finally {
+      matchMediaSpy.mockRestore();
+    }
+  });
+});

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -92,6 +92,7 @@ import {
 } from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { CliCommandBlock } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
@@ -1955,6 +1956,7 @@ export function NewChatLandingScreen() {
   const [message, setMessage] = useState<string>(() => landingDraft?.message ?? "");
   // Composer text captured when voice dictation starts, so Esc can revert to it.
   const voiceSnapshotRef = useRef("");
+  const isCoarsePointer = useIsCoarsePointer();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Declared after textareaRef so dictation can place the caret after the
   // text it inserts (and insert at the caret rather than the draft's end).
@@ -4079,8 +4081,11 @@ export function NewChatLandingScreen() {
                     return;
                   }
                 }
-                // Enter sends; Shift+Enter inserts a newline.
-                if (e.key === "Enter" && !e.shiftKey) {
+                // Enter sends; Shift+Enter inserts a newline. On touch-primary
+                // devices there is no practical Shift+Enter and an accidental
+                // submit is unrecoverable, so Enter only inserts a newline and
+                // sending stays an explicit tap on the send button (#4943).
+                if (e.key === "Enter" && !e.shiftKey && !isCoarsePointer) {
                   e.preventDefault();
                   // The mention menu is briefly closed while its listing loads;
                   // swallow Enter so the in-progress "@dir/" token isn't sent.


### PR DESCRIPTION
## Summary

Fixes #4943.

## The bug

The create-session composer's keydown handler implemented "Enter sends; Shift+Enter inserts a newline" — desktop convention with no touch equivalent. On a phone, the on-screen keyboard's Enter is the **only** newline key, so typing a multi-line prompt submitted the session with a half-written draft (unrecoverable: the session is created). The behavior also **varied by agent** (`polly` submitted, `claude_code` inserted), because the handler's effect differed across the agents' configuration paths.

## Fix

- New **`useIsCoarsePointer`** hook — the same reactive `useSyncExternalStore` shape as the existing `useIsMobileViewport`, exposing `(pointer: coarse)` (SSR-safe).
- The "Enter sends" branch in `NewChatDialog` is gated on `!isCoarsePointer`: on touch-primary devices Enter falls through to the textarea's **native newline**, identically for every agent, and sending stays an explicit tap on the send button (which already mirrors `canSubmit`).

Deliberately untouched:

- the slash/mention menu's Enter-to-select (list selection, not submission),
- the desktop Shift+Enter convention,
- the IME-composition guard on Enter.

Making Enter a pure insert on coarse pointers also resolves the inconsistency: the semantics are now determined by the device, not by the selected agent.

## Test

A regression test in the flow suite (`NewChatDialog.flow.test.tsx`) drives a coarse-pointer render (spying `matchMedia` for the pointer query) and asserts that Enter with a drafted message neither POSTs a session nor navigates — the draft stays with the user.

(Couldn't run the vitest suite locally on this Windows checkout without node_modules; relying on CI.)
