### PR TITLE
fix(server): user-configured acp agents win over same-slug builtins

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -745,7 +745,23 @@ def _ensure_default_acp_agents(
     from omnigent._platform import resolve_cli_binary
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
-    # (1) User-configured acp:<slug> agents — "set up" == present in config.
+    # (1) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
+    # by the catalog id (already a valid slug), not the display label. Seeded FIRST
+    # so a same-slug user configuration below wins: a configured ``acp:`` agent
+    # whose slug equals a builtin id (``Devin`` -> ``devin``) used to be silently
+    # overwritten by the builtin row, discarding the explicit config (#4926).
+    for key, row in ACP_CLI_HARNESSES.items():
+        if resolve_cli_binary(row.binary) is None:
+            continue
+        _ensure_builtin_agent(
+            agent_store,
+            artifact_store,
+            agent_cache,
+            name=key,
+            bundle_bytes=_build_acp_bundle(harness=key, name=key),
+        )
+
+    # (2) User-configured acp:<slug> agents — "set up" == present in config.
     try:
         from omnigent.onboarding.acp_auth import acp_agents
 
@@ -764,19 +780,6 @@ def _ensure_default_acp_agents(
             agent_cache,
             name=agent.slug,
             bundle_bytes=_build_acp_bundle(harness=f"acp:{agent.slug}", name=agent.slug),
-        )
-
-    # (2) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
-    # by the catalog id (already a valid slug), not the display label.
-    for key, row in ACP_CLI_HARNESSES.items():
-        if resolve_cli_binary(row.binary) is None:
-            continue
-        _ensure_builtin_agent(
-            agent_store,
-            artifact_store,
-            agent_cache,
-            name=key,
-            bundle_bytes=_build_acp_bundle(harness=key, name=key),
         )
 
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1651,3 +1651,51 @@ def test_load_debug_routers_collects_entries() -> None:
     _router, prefix, tags = entries[0]
     assert prefix == "/debug"
     assert tags == ["debug"]
+
+
+def test_ensure_default_acp_agents_config_wins_over_same_slug_builtin(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configured ``acp:`` agent whose slug equals a builtin row id keeps its
+    explicit configuration instead of being silently overwritten by the builtin
+    CLI row (#4926).
+
+    **What breaks if this fails**: a user who configures ``Devin`` with
+    ``devin acp --model swe-1-7-medium`` gets the builtin row's account-default
+    harness in the picker — their explicit config is discarded with no warning.
+    """
+    import hashlib
+
+    from omnigent.onboarding.acp_auth import AcpAgentEntry
+
+    # "devin" is a real builtin ACP CLI catalog id; the display label slugifies
+    # to exactly that id.
+    entry = AcpAgentEntry(
+        slug="devin", name="Devin", command="devin acp --model swe-1-7-medium"
+    )
+    monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [entry])
+    # The builtin binary resolves on PATH, so both sources claim the slug.
+    monkeypatch.setattr(
+        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/local/bin/x"
+    )
+
+    server_app._ensure_default_acp_agents(
+        seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
+    )
+
+    seeded = seed_stores.agent_store.get_by_name("devin")
+    assert seeded is not None, "same-slug collision seeded nothing at all"
+
+    # The stored bundle must be the CONFIGURED agent's (harness acp:devin), not
+    # the builtin row's (harness devin). The content-addressed location carries
+    # the bundle's sha256, so compare against both candidate bundles.
+    configured_bundle = server_app._build_acp_bundle(harness="acp:devin", name="devin")
+    builtin_bundle = server_app._build_acp_bundle(harness="devin", name="devin")
+    configured_sha = hashlib.sha256(configured_bundle).hexdigest()
+    builtin_sha = hashlib.sha256(builtin_bundle).hexdigest()
+    assert configured_sha != builtin_sha, "test premise: the two bundles differ"
+
+    assert configured_sha in (seeded.bundle_location or ""), (
+        "the builtin ACP CLI row silently overwrote the user-configured acp:devin agent"
+    )
+    assert builtin_sha not in (seeded.bundle_location or "")

--- a/web/src/hooks/useIsCoarsePointer.ts
+++ b/web/src/hooks/useIsCoarsePointer.ts
@@ -1,0 +1,31 @@
+// Reactive "is the primary pointer coarse?" hook.
+//
+// `(pointer: coarse)` matches touch-primary devices (phones, tablets) and is
+// the standard signal for "there is no practical Shift+Enter": the on-screen
+// keyboard's Enter is the only newline key such devices have. Used to keep
+// Enter an inserting key (rather than a submitting one) in text inputs where
+// submission already has an explicit button.
+
+import { useSyncExternalStore } from "react";
+
+const COARSE_QUERY = "(pointer: coarse)";
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mql = window.matchMedia(COARSE_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(COARSE_QUERY).matches;
+}
+
+/**
+ * True when the device's primary pointer is coarse (touch). Reactive across
+ * pointer changes, SSR-safe (returns `false` on the server).
+ */
+export function useIsCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1597,3 +1597,53 @@ describe("sanitizeInitialPrompt", () => {
     expect(sanitizeInitialPrompt(input)).toBe(expected);
   });
 });
+
+describe("create-session input on touch-primary devices (#4943)", () => {
+  it("Enter inserts a newline instead of submitting when the pointer is coarse", async () => {
+    // Phones have no practical Shift+Enter, so an Enter-submit in the
+    // create-session composer was an unrecoverable accidental send. On
+    // coarse-pointer devices the composer must let Enter fall through to the
+    // textarea's native newline; sending stays an explicit tap.
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query: string) =>
+        query.includes("pointer: coarse")
+          ? ({
+              matches: true,
+              media: query,
+              onchange: null,
+              addListener: () => {},
+              removeListener: () => {},
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            } as MediaQueryList)
+          : ({
+              matches: false,
+              media: query,
+              onchange: null,
+              addListener: () => {},
+              removeListener: () => {},
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            } as MediaQueryList),
+      );
+
+    try {
+      renderLanding();
+      await waitForWorkspaceSeed();
+      const input = screen.getByTestId("new-chat-landing-input");
+      fireEvent.change(input, { target: { value: "first line of a long prompt" } });
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      // No session was created and no navigation happened: Enter was not
+      // intercepted, so the composer still holds the user's draft.
+      expect(authenticatedFetch).not.toHaveBeenCalled();
+      expect(navigateMock).not.toHaveBeenCalled();
+    } finally {
+      matchMediaSpy.mockRestore();
+    }
+  });
+});

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -92,6 +92,7 @@ import {
 } from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { CliCommandBlock } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
@@ -1955,6 +1956,7 @@ export function NewChatLandingScreen() {
   const [message, setMessage] = useState<string>(() => landingDraft?.message ?? "");
   // Composer text captured when voice dictation starts, so Esc can revert to it.
   const voiceSnapshotRef = useRef("");
+  const isCoarsePointer = useIsCoarsePointer();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Declared after textareaRef so dictation can place the caret after the
   // text it inserts (and insert at the caret rather than the draft's end).
@@ -4079,8 +4081,11 @@ export function NewChatLandingScreen() {
                     return;
                   }
                 }
-                // Enter sends; Shift+Enter inserts a newline.
-                if (e.key === "Enter" && !e.shiftKey) {
+                // Enter sends; Shift+Enter inserts a newline. On touch-primary
+                // devices there is no practical Shift+Enter and an accidental
+                // submit is unrecoverable, so Enter only inserts a newline and
+                // sending stays an explicit tap on the send button (#4943).
+                if (e.key === "Enter" && !e.shiftKey && !isCoarsePointer) {
                   e.preventDefault();
                   // The mention menu is briefly closed while its listing loads;
                   // swallow Enter so the in-progress "@dir/" token isn't sent.


### PR DESCRIPTION
## Summary

Fixes #4926 (the picker-shadowing half; see scope note).

## Root cause (as diagnosed in the issue, verified)

`_ensure_default_acp_agents` seeded **configured `acp:` agents first, builtin ACP CLI rows second**. Both key their picker row by slug, and a configured `Devin` slugifies to exactly the builtin row's id — so the builtin `_ensure_builtin_agent` call overwrote the user's row, silently discarding the explicit configuration (`--model swe-1-7-medium` etc.) with no warning. Picking "Devin" in the web picker ran the account-default model.

## Fix

Swap the seeding order: **builtins first, configured agents second** — on a slug collision, the user's explicit configuration wins the shared name and the picker runs `acp:devin` with the configured command. Symmetric and future-proof: any future builtin/id overlap resolves in the user's favor, matching the "never silently discard explicit config" default.

## Test

Regression test reproducing the exact collision — configured `Devin` (slug `devin` = builtin row id) with the binary on PATH — asserting the stored bundle is the **configured** agent's (via its content-addressed sha256; the two bundles differ by harness `acp:devin` vs `devin`). Verified locally: the test **fails on the current ordering** and passes with the swap, and the four existing ACP seeding tests stay green (5/5 passed).

## Scope note

Symptom 2 from the issue — the duplicate "Devin" rows in `omni setup`'s harness list, produced by `cli_config.py` labeling each source verbatim — is a separate display surface left for a follow-up; with the picker now honoring the config, that duplication is cosmetic.
