### PR TITLE
feat(web): on-screen Esc button for touch devices in the terminal view

### DIFF
--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -805,4 +805,19 @@ export class TerminalSession {
     this.lastSentSize = { cols, rows };
     this.ws.send(JSON.stringify({ type: "resize", cols, rows }));
   }
+
+  /**
+   * Send a bare ESC byte to the terminal, as a physical Escape keypress would.
+   *
+   * Mobile on-screen keyboards have no Escape key, yet ESC is the primary
+   * interrupt/steer control for terminal-driven agents — this method backs the
+   * on-screen ESC control shown on touch devices (#4944). Routes through the
+   * same input path as keystrokes so the WS-open guard and the input-activity
+   * bookkeeping apply unchanged.
+   */
+  sendEscape(): void {
+    this.lastUserInputAt = performance.now();
+    if (this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(INPUT_ENCODER.encode(""));
+  }
 }

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -29,6 +29,7 @@ const terminalSessionMock = vi.hoisted(() => ({
     dispose: ReturnType<typeof vi.fn>;
     setTheme: ReturnType<typeof vi.fn>;
     focus: ReturnType<typeof vi.fn>;
+    sendEscape: ReturnType<typeof vi.fn>;
   }[],
 }));
 
@@ -40,6 +41,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
     dispose = vi.fn();
     setTheme = vi.fn();
     focus = vi.fn();
+    sendEscape = vi.fn();
 
     constructor(
       container: HTMLDivElement,
@@ -58,6 +60,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
         dispose: this.dispose,
         setTheme: this.setTheme,
         focus: this.focus,
+        sendEscape: this.sendEscape,
       });
     }
   },
@@ -544,5 +547,53 @@ describe("selectionHintText", () => {
     expect(hint).toContain("right-click");
     expect(hint).not.toContain("⌘");
     expect(hint.toLowerCase()).not.toContain("ctrl");
+  });
+});
+
+describe("on-screen ESC control (#4944)", () => {
+  function coarseMatchMedia(query: string): MediaQueryList {
+    const matches = query.includes("pointer: coarse");
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as MediaQueryList;
+  }
+
+  it("shows on coarse pointers once connected and sends ESC through the session", async () => {
+    const spy = vi.spyOn(window, "matchMedia").mockImplementation(coarseMatchMedia);
+    try {
+      render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+      await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+      const inst = terminalSessionMock.instances[0];
+      act(() => inst.onState({ kind: "connected" }));
+
+      const esc = await screen.findByTestId("terminal-escape-button");
+      fireEvent.click(esc);
+
+      expect(inst.sendEscape).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("stays hidden on fine-pointer (desktop) devices", async () => {
+    const spy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((q: string) => coarseMatchMedia(q.replace("coarse", "fine")));
+    try {
+      render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+      await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+      act(() => terminalSessionMock.instances[0].onState({ kind: "connected" }));
+
+      expect(screen.queryByTestId("terminal-escape-button")).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -12,6 +12,7 @@ import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
+import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import { resolveInitialAttachUrl, watchDirectUpgrade, withAttachParams } from "@/lib/terminals";
@@ -120,6 +121,12 @@ export function TerminalView({
   // Control mode: xterm owns the buffer + mouse, so plain drag selects and
   // the normal copy gesture works — no forced-selection modifier, no hint bar.
   const controlMode = transport === "control";
+  // Touch-primary devices have no Escape key, yet ESC is how you interrupt a
+  // terminal-driven agent; an on-screen control fills the gap (#4944).
+  const isCoarsePointer = useIsCoarsePointer();
+  const sendEscape = useCallback(() => {
+    sessionRef.current?.sendEscape();
+  }, []);
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
   const [resumeError, setResumeError] = useState<string | null>(null);
@@ -446,6 +453,20 @@ export function TerminalView({
       <div className="min-h-0 flex-1 overflow-hidden p-1">
         <div key={connectAttempt} ref={attachSession} className="h-full w-full overflow-hidden" />
       </div>
+      {isCoarsePointer && !readOnly && state.kind === "connected" && (
+        <div className="flex shrink-0 justify-end px-2 pb-1">
+          <Button
+            type="button"
+            size="xs"
+            variant="secondary"
+            onClick={sendEscape}
+            data-testid="terminal-escape-button"
+            className="font-mono"
+          >
+            Esc
+          </Button>
+        </div>
+      )}
       {/* PTY transport only: the attached tmux session runs with `mouse on`,
           so a plain click-drag is captured by tmux (copy-mode) instead of
           making a browser selection — the user can't select-and-copy without a

--- a/web/src/hooks/useIsCoarsePointer.ts
+++ b/web/src/hooks/useIsCoarsePointer.ts
@@ -1,0 +1,31 @@
+// Reactive "is the primary pointer coarse?" hook.
+//
+// `(pointer: coarse)` matches touch-primary devices (phones, tablets) and is
+// the standard signal for "there is no practical Shift+Enter": the on-screen
+// keyboard's Enter is the only newline key such devices have. Used to keep
+// Enter an inserting key (rather than a submitting one) in text inputs where
+// submission already has an explicit button.
+
+import { useSyncExternalStore } from "react";
+
+const COARSE_QUERY = "(pointer: coarse)";
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mql = window.matchMedia(COARSE_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(COARSE_QUERY).matches;
+}
+
+/**
+ * True when the device's primary pointer is coarse (touch). Reactive across
+ * pointer changes, SSR-safe (returns `false` on the server).
+ */
+export function useIsCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}


### PR DESCRIPTION
## Summary

Implements #4944, scoped to the **terminal session view** — the chat view already has an always-visible Interrupt button in its composer, so the terminal was the actual gap.

## What this does

- **`TerminalSession.sendEscape()`** — sends a bare `\x1b` byte through the same guarded input path as keystrokes (WS-open check, input-activity stamping, `INPUT_ENCODER`), exactly as a physical Escape keypress would.
- **`TerminalView`** renders a small monospace **Esc** button at the bottom of the terminal, shown **only on coarse-pointer devices, when connected and not read-only** — desktop keeps its hardware key and its layout is untouched (the control isn't even mounted on fine pointers).
- Gated by the shared `useIsCoarsePointer` hook, so this and the sibling Enter-inserts-newline fix (#4943) share one detection source. The hook file is carried by both branches; whichever lands first wins and the other drops the duplicate at merge time.

## Tests

Two tests drive the session mock through a coarse-pointer render (spying `matchMedia`):

- the button appears once connected, and clicking it calls `sendEscape` on the session instance exactly once;
- on fine-pointer devices the control stays absent.

(Couldn't run the vitest suite locally on this Windows checkout without node_modules; relying on CI.)
