### PR TITLE
fix(acp): explicit policy ALLOW short-circuits elicitation

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -821,7 +821,8 @@ class AcpExecutor(Executor):
         1. **TOOL_CALL policy** (:attr:`_policy_evaluator`): a hard
            ``POLICY_ACTION_DENY`` denies; ``POLICY_ACTION_ASK`` defers to
            elicitation (and **fails closed** when no handler is wired);
-           ``ALLOW`` / unspecified falls through.
+           ``POLICY_ACTION_ALLOW`` short-circuits to allow; unspecified falls
+           through.
         2. **Human-consent elicitation** (:attr:`_elicitation_handler`): routes
            to the user via a web approval card and returns their accept/deny.
 
@@ -860,7 +861,15 @@ class AcpExecutor(Executor):
                     tool_name,
                 )
                 return allowed
-            # ALLOW / UNSPECIFIED / unknown → fall through to elicitation.
+            if action == "POLICY_ACTION_ALLOW":
+                # An explicit policy ALLOW must short-circuit elicitation: an
+                # always-ask agent raising session/request_permission for every
+                # tool call would otherwise prompt (and, unattended, refuse) on
+                # calls the policy already permits -- --approval-mode=always-ask
+                # plus server-side policies could never run headless (#4928).
+                logger.info("acp permission allowed by policy: tool=%s", tool_name)
+                return True
+            # UNSPECIFIED / unknown → fall through to elicitation.
 
         if handler is not None:
             allowed = bool(await handler(tool_name, tool_input))

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -1000,3 +1000,32 @@ def test_startup_error_names_the_exception_type_when_str_is_empty() -> None:
     """No stderr and an empty ``str(exc)`` still yields something actionable."""
     ex = AcpExecutor(AcpAgentConfig(command="x", name="A"))
     assert "TimeoutError" in ex._startup_error_message(TimeoutError())
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_allow_short_circuits_elicitation() -> None:
+    """An explicit policy ALLOW must not prompt: always-ask agents would
+    otherwise refuse policy-permitted calls on every unattended run (#4928)."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+
+    class _V:
+        action = "POLICY_ACTION_ALLOW"
+
+    ex._policy_evaluator = AsyncMock(return_value=_V())
+    ex._elicitation_handler = AsyncMock(return_value=False)
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    ex._elicitation_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_unspecified_still_elicits() -> None:
+    """UNSPECIFIED keeps the conservative path: elicitation decides (#4928)."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+
+    class _V:
+        action = None
+
+    ex._policy_evaluator = AsyncMock(return_value=_V())
+    ex._elicitation_handler = AsyncMock(return_value=True)
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    ex._elicitation_handler.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #4928.

## Root cause (as diagnosed in the issue, verified in source)

`_decide_permission` handled the TOOL_CALL policy verdict as DENY → deny, ASK → elicitation, and **ALLOW / UNSPECIFIED / unknown → fall through to elicitation** (the in-source comment said exactly that). So with an always-ask agent (`omp --approval-mode=always-ask`) raising `session/request_permission` for every tool call, the policy engine's explicit ALLOW never short-circuited the prompt — and with no human attached (`omnigent run -p …`, scheduled tasks, CI), every permission request resolved to a refusal. The approval mode blocked everything instead of governing anything, and "always-ask + server-side policies" was unusable as a unification route for ACP-native tool loops.

## Fix

An explicit `POLICY_ACTION_ALLOW` returns allow **before** the elicitation stage (info-level log, consistent with the DENY/ASK logging). Deliberately unchanged:

- **UNSPECIFIED / unknown actions / eval failures** keep the conservative fall-through to elicitation (only an *explicit* allow short-circuits);
- DENY and ASK semantics, including ASK's fail-closed-without-handler.

## Tests

Two regression tests in `tests/inner/test_acp_executor.py`:

- the always-ask shape from the issue — policy ALLOW with a wired elicitation handler that would refuse: the decision is allow and the handler is **never awaited**;
- UNSPECIFIED still elicits (the conservative path is intact).

Verified locally: the new allow test **fails on the current fall-through code**, and the full executor suite passes with the fix (61/61).
