### PR TITLE
fix(mcp): classify Session terminated (32600) as a connection error

### DIFF
--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -1221,14 +1221,27 @@ _CONNECTION_ERROR_TYPES = (
 )
 
 
+# The streamable-HTTP transport reports a dead server-side session as
+# ``ErrorData(code=32600, message="Session terminated")`` (mcp 1.29.0,
+# mcp/client/streamable_http.py). The code is an upstream typo of JSON-RPC's
+# invalid-request ``-32600`` -- positive 32600 is not in the specification --
+# so match on both the code and the message: the SDK could fix the sign of the
+# code at any time, and the message is what the session-lost path emits.
+_SESSION_TERMINATED_CODE = 32600
+_SESSION_TERMINATED_MESSAGE = "session terminated"
+
+
 def _is_connection_error(exc: BaseException) -> bool:
     """
     Determine if an exception indicates a dead MCP connection.
 
     Returns ``True`` for transport-level failures (broken pipe,
     EOF, connection reset) and MCP-level connection-closed
-    errors. Returns ``False`` for tool-level errors (invalid
-    args, tool not found) which should not trigger a reconnect.
+    errors, including the streamable-HTTP transport's
+    ``Session terminated`` (32600) raised when the server no longer
+    knows the session id (e.g. it restarted). Returns ``False`` for
+    tool-level errors (invalid args, tool not found) which should not
+    trigger a reconnect.
 
     :param exc: The exception to classify.
     :returns: ``True`` if the error is connection-related.
@@ -1236,7 +1249,12 @@ def _is_connection_error(exc: BaseException) -> bool:
     if isinstance(exc, _CONNECTION_ERROR_TYPES):
         return True
     if isinstance(exc, McpError):
-        return exc.error.code == CONNECTION_CLOSED
+        if exc.error.code == CONNECTION_CLOSED:
+            return True
+        return exc.error.code == _SESSION_TERMINATED_CODE or (
+            isinstance(exc.error.message, str)
+            and exc.error.message.strip().lower() == _SESSION_TERMINATED_MESSAGE
+        )
     return False
 
 

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -2425,3 +2425,46 @@ async def test_open_http_transport_uses_streamable_for_non_sse_url() -> None:
         await conn._open_http_transport(stack)
 
     assert calls == ["streamable"], "plain URL must try Streamable HTTP first"
+
+
+def test_is_connection_error_mcp_session_terminated_code() -> None:
+    """
+    The streamable-HTTP transport's Session terminated (positive 32600,
+    raised when the server restarted and lost the session id) must be
+    classified as a connection error so the reconnect path runs (#4939).
+    """
+    exc = McpError(
+        ErrorData(
+            code=32600,
+            message="Session terminated",
+        )
+    )
+    assert _is_connection_error(exc) is True
+
+
+def test_is_connection_error_mcp_session_terminated_message_only() -> None:
+    """
+    The message match keeps classification correct if the SDK fixes the
+    sign of the code (32600 is a typo of JSON-RPC's -32600).
+    """
+    exc = McpError(
+        ErrorData(
+            code=-32600,
+            message="Session terminated",
+        )
+    )
+    assert _is_connection_error(exc) is True
+
+
+def test_is_connection_error_mcp_real_invalid_request_not_connection() -> None:
+    """
+    A genuine -32600 invalid-request error with different message text is
+    NOT a connection error.
+    """
+    exc = McpError(
+        ErrorData(
+            code=-32600,
+            message="Invalid Request",
+        )
+    )
+    assert _is_connection_error(exc) is False


### PR DESCRIPTION
## Summary

Fixes #4939.

## Root cause (as diagnosed in the issue, verified against the installed SDK's behavior)

A restarted streamable-HTTP MCP server no longer knows the session id, and the transport surfaces that as:

```python
McpError(ErrorData(code=32600, message="Session terminated"))
```

`_is_connection_error` only matched `CONNECTION_CLOSED` (-32000), so `_call_tool_with_reconnect` took the `if not _is_connection_error(exc): raise` branch — the retry loop, backoff, and reconnect never ran. One server restart permanently broke every conversation holding a session with it, with the same failure repeating identically 40 minutes later (per the issue's log).

## Fix — the issue's suggested belt-and-suspenders

`32600` is an upstream typo of JSON-RPC's `-32600` (positive values aren't in the spec), so the classifier now matches an `McpError` as a connection error when **either**:

- the code equals the SDK's literal `32600`, or
- the message is exactly `Session terminated` (case-insensitive, trimmed),

keeping classification correct whether or not the SDK ever fixes the sign. A genuine invalid-request `-32600` with different message text remains a tool-level error. The reconnect machinery itself is untouched — with the classifier fixed, it finally runs.

## Tests

Three new tests alongside the existing classifier suite:

- literal `32600` + `Session terminated` → connection error;
- `-32600` + `Session terminated` (the SDK-fixed-sign future) → connection error;
- `-32600` + `Invalid Request` (a real invalid-request error) → **not** a connection error.

Verified locally: the two positive tests fail on the current classifier, and the full `tests/tools/test_mcp.py` suite passes with the fix (87/87).
