### PR TITLE
fix(forwarder): clamp the retry backoff exponent, not just the delay

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -699,8 +699,15 @@ class _PostRetryTracker:
                 exhausted=True,
                 permanent=permanent,
             )
+        # Clamp the EXPONENT, not the result: transient failures retry with no
+        # give-up budget, so attempts is unbounded and 2 ** attempts eventually
+        # overflows float conversion (min() evaluates both operands, so a cap on
+        # the result cannot protect the exponentiation). The exponent cap only
+        # needs to be large enough that base * 2**cap >= max for any base > 0 —
+        # 64 covers every realistic configuration (#4885).
+        exponent = min(max(0, entry.attempts - 1), 64)
         delay_s = min(
-            self._base_delay_s * (2 ** max(0, entry.attempts - 1)),
+            self._base_delay_s * (2 ** exponent),
             self._max_delay_s,
         )
         entry.next_attempt_at = time.monotonic() + delay_s

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -7996,3 +7996,20 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+def test_post_retry_tracker_survives_unbounded_transient_attempts() -> None:
+    """Transient failures retry with no give-up budget, so attempts is
+    unbounded; the backoff exponent must not overflow float conversion at
+    ~1025 attempts (#4885)."""
+    import httpx
+
+    tracker = forwarder._PostRetryTracker(base_delay_s=1.0, max_delay_s=30.0)
+    exc = httpx.RequestError("Databricks token refresh returned no token")
+    last = None
+    for _ in range(3000):
+        last = tracker.record_failure("k", exc)
+    assert last is not None
+    assert last.attempts == 3000
+    assert last.delay_s == 30.0  # capped, and still returned instead of raising
+    assert last.exhausted is False


### PR DESCRIPTION
## Summary

Fixes #4885.

## Root cause (as diagnosed in the issue, verified)

`_PostRetryTracker.record_failure` computed its backoff as:

```python
delay_s = min(self._base_delay_s * (2 ** max(0, entry.attempts - 1)), self._max_delay_s)
```

`min()` evaluates **both** operands, so the delay cap cannot protect the exponentiation feeding it. Transient/transport failures retry with no give-up budget (by design — the class docstring says so), so `attempts` is unbounded; past ~1025 the int `2 ** attempts` no longer converts to `float` and `record_failure` raises `OverflowError` instead of returning a decision. One real Databricks-mint outage produced a **106 MB runner log** of the resulting retry storm, per the issue.

## Fix

Clamp the **exponent** to 64 — large enough that `base * 2**64 ≥ max` for any positive base, so the exponential shape is fully preserved while the overflow becomes structurally impossible no matter how unbounded attempts grows:

```python
exponent = min(max(0, entry.attempts - 1), 64)
delay_s = min(self._base_delay_s * (2 ** exponent), self._max_delay_s)
```

The give-up-budget question for transport failures (the mint path's `RequestError` class) is a separate policy decision, deliberately untouched.

## Test

The issue's exact reproduction as a regression test: 3000 `record_failure` calls with a transient `httpx.RequestError` — the decision comes back with `attempts=3000`, the capped `delay_s=30.0`, `exhausted=False`. **Fails on the current code** (raises at attempt 1025). The other pre-existing failures in this suite on the local Windows checkout are unchanged between baseline and this patch (environment-related, same 7 before and after).
