### PR TITLE
feat(diagnostics): report local auth health, and keep the re-auth reason in fail-closed blocks

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -1046,6 +1046,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         are expressed via the JSON output, not exit codes.
     """
     from omnigent.native_policy_hook import (
+        evaluate_failure_detail,
         evaluation_response_to_hook_output,
         fail_closed_hook_output,
         hook_payload_to_evaluation_request,
@@ -1127,7 +1128,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         reauth=reauth,
     )
     if resp is None:
-        return _fail_closed(api_error or (reauth.failure_reason if reauth else None))
+        return _fail_closed(evaluate_failure_detail(api_error, reauth))
     if not resp.content:
         print("omnigent evaluate-policy hook: empty Omnigent response", file=sys.stderr)
         return _fail_closed()

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4463,6 +4463,47 @@ def diagnose(server: str | None, json_output: bool) -> None:
     click.echo(f"auth    {snap['auth_source']} ({snap['auth_source_origin']})")
     click.echo(f"os      {snap['os']}")
     click.echo(f"python  {snap['python']}")
+    _echo_diagnose_health(snap.get("health") or {})
+
+
+def _echo_diagnose_health(health: dict[str, Any]) -> None:
+    """Print the health section of a diagnostics snapshot.
+
+    One line per section, omitting sections that are absent (no log yet, or a
+    non-Databricks deployment), so the output stays short on a healthy machine
+    and still carries the discriminating counts on a broken one.
+
+    :param health: The ``health`` mapping from
+        :func:`omnigent.diagnostics.collect_snapshot`.
+    """
+    credential = health.get("credential") or {}
+    probe = credential.get("probe")
+    if probe == "ok":
+        # A count, not a verdict: more than one match is not itself a failure.
+        # See omnigent.diagnostics_health._credential_health.
+        click.echo(f"cred    {credential.get('profiles_matching_host')} profile(s) match the host")
+    elif probe == "unavailable":
+        click.echo("cred    profile count unavailable")
+
+    host_log = health.get("host_log")
+    if host_log:
+        parts = [f"idle {host_log.get('idle_seconds', 0)}s"]
+        if host_log.get("stalled_on_connect"):
+            # Not "the tunnel is down": the connect line is logged before the
+            # attempt, so pair this with the idle time above.
+            parts.append("last line is the connect attempt")
+        parts.append(f"{host_log.get('service_restarts', 0)} server-initiated restart(s)")
+        click.echo(f"host    {', '.join(parts)}")
+
+    runner_log = health.get("runner_log")
+    if runner_log:
+        handoff = "bearer from host" if runner_log.get("bearer_handoff") else "no bearer from host"
+        click.echo(
+            f"runner  idle {runner_log.get('idle_seconds', 0)}s, {handoff}, "
+            f"{runner_log.get('sdk_fallback', 0)} self-refresh fallback(s), "
+            f"{runner_log.get('refresh_empty', 0)} empty refresh(es) "
+            f"in the last {runner_log.get('window_bytes', 0) // 1024} KiB"
+        )
 
 
 @cli.command("doctor")

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -24,6 +24,7 @@ from omnigent.codex_native_bridge import (
     read_policy_hook_config,
 )
 from omnigent.native_policy_hook import (
+    evaluate_failure_detail,
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
@@ -177,7 +178,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         reauth=reauth,
     )
     if resp is None:
-        return _fail_closed(api_error or (reauth.failure_reason if reauth else None))
+        return _fail_closed(evaluate_failure_detail(api_error, reauth))
     if not resp.content:
         print("omnigent codex evaluate-policy hook: empty Omnigent response", file=sys.stderr)
         return _fail_closed()

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -13,10 +13,17 @@ server rather than local guesses. When no server is reachable, ``auth_source``
 falls back to what this machine's environment *would* boot a server in, marked
 by ``auth_source_origin`` so the two are never confused.
 
-Invariant: **no secrets.** Only versions, OS, and the coarse auth mode
-(accounts | single_user | oidc | header) are reported — never keys, tokens, or
-config bodies. ``auth_source`` doubles as the OSS-vs-managed signal (there is no
-explicit install marker).
+The ``health`` section comes from :mod:`omnigent.diagnostics_health`: a few
+counts read from ``~/.databrickscfg`` and the newest host/runner logs that
+distinguish the local auth failure modes from a server-side refusal. It lives in
+its own module because it probes the filesystem rather than versions, and
+degrades to ``null`` sections instead of raising.
+
+Invariant: **no secrets.** Only versions, OS, the coarse auth mode
+(accounts | single_user | oidc | header), and the health section's counts and
+fixed classification strings are reported — never keys, tokens, profile names,
+log lines, or config bodies. ``auth_source`` doubles as the OSS-vs-managed
+signal (there is no explicit install marker).
 """
 
 from __future__ import annotations
@@ -147,11 +154,14 @@ def collect_snapshot(*, server_url: str | None = None, timeout: float = 5.0) -> 
               "auth_source": "accounts" | "single_user" | "oidc" | "header" | "unknown",
               "auth_source_origin": "server" | "local-env",
               "os": "macOS-...",
-              "python": "3.12.13"
+              "python": "3.12.13",
+              "health": {...}   # see omnigent.diagnostics_health
             }
 
         Contains no secrets.
     """
+    from omnigent.diagnostics_health import collect_health
+
     server_version: str | None = None
     auth_source = _local_auth_source()
     auth_source_origin = "local-env"
@@ -172,6 +182,7 @@ def collect_snapshot(*, server_url: str | None = None, timeout: float = 5.0) -> 
         "auth_source_origin": auth_source_origin,
         "os": platform.platform(),
         "python": platform.python_version(),
+        "health": collect_health(server_url=server_url),
     }
 
 

--- a/omnigent/diagnostics_health.py
+++ b/omnigent/diagnostics_health.py
@@ -1,0 +1,390 @@
+"""Local health probes for ``omnigent diagnose``.
+
+:mod:`omnigent.diagnostics` answers *what is installed* (CLI/server version,
+OS, auth mode). This module answers *why is it not working* — the three local
+signals that actually discriminate between the auth failure modes a user hits,
+read straight from the artifacts the runtime already writes:
+
+- **credential**: how many ``~/.databrickscfg`` profiles match the workspace
+  host — a count, never a verdict (see :func:`_credential_health` for why a
+  verdict would be wrong). It earns its place because the resolver's final error
+  names the duplicate even when a duplicate is not the cause, so the count tells
+  a reader whether that message is describing the config or the failure.
+- **host log**: whether the host tunnel is stalled mid-connect (a server-side
+  refusal, where restarting locally cannot help) and how often the server
+  restarted the tunnel under it.
+- **runner log**: whether the runner received a bearer from the host, whether
+  it fell back to a self-refreshing credential after that bearer lapsed, and
+  how often a refresh produced nothing. Together these say "recovered by
+  itself" versus "stuck without a credential" — the distinction that decides
+  whether any local action is warranted.
+
+Invariant: **no secrets**, matching :mod:`omnigent.diagnostics`. Only counts,
+booleans, byte sizes, and a fixed vocabulary of classification strings are
+reported — never profile names, hosts, tokens, log lines, or config bodies.
+
+Every probe degrades to ``None`` (section absent) or ``"unknown"`` rather than
+raising: a snapshot for a bug report must survive a half-broken machine, which
+is exactly when it is collected. Logs are read through two bounded windows
+(:data:`_LOG_HEAD_BYTES`, :data:`_LOG_TAIL_BYTES`) rather than whole, because a
+runner log reaches hundreds of megabytes when a transport failure loops.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+# A log is read from both ends, never whole: a runner log reaches hundreds of
+# megabytes when a transport failure loops (#4885), and an unbounded read would
+# defeat the point of a quick snapshot.
+#
+# The two windows answer different questions, and using only one gets the answer
+# wrong. Recurring failures are counted from the TAIL, because a stuck process
+# appends the same line forever and only recent history matters. One-shot
+# startup facts ("was a bearer handed over at launch?") are looked for in the
+# HEAD, because they are written once in the first few lines and scroll out of
+# any tail window on a long-lived session — a tail-only read reports "no bearer"
+# for a runner that was in fact handed one.
+_LOG_TAIL_BYTES = 256 * 1024
+_LOG_HEAD_BYTES = 16 * 1024
+
+# Log markers. These are strings the runtime itself emits, not a third-party
+# library's formatting, so they do not drift when a dependency changes its
+# message layout. The one exception is noted on the field it feeds.
+_MARKER_BEARER_HANDOFF = "using host-provided bearer"
+_MARKER_BEARER_REJECTED = "host bootstrap bearer rejected"
+_MARKER_REFRESH_EMPTY = "Databricks token refresh returned no token"
+# Emitted by databricks-sdk, not by us: the clearest evidence that the runner
+# reached a self-refreshing credential. Counted, never required.
+_MARKER_SDK_AUTH = "Using Databricks CLI authentication"
+_MARKER_TUNNEL_CONNECTING = "Connecting to wss"
+_MARKER_SERVICE_RESTART = "received 1012"
+
+CredentialProbe = Literal["ok", "unavailable", "not-applicable"]
+
+
+def _log_windows(path: Path) -> tuple[str, str]:
+    """Return ``(head, tail)`` text windows of *path*, guaranteed not to overlap.
+
+    A log short enough to read whole comes back entirely as *head*, with *tail*
+    empty. That keeps counting simple: a caller may count a marker across both
+    windows without double-counting a short file, and may test presence in
+    *head* alone for a fact written once at startup.
+
+    :param path: File to read.
+    :returns: ``(head, tail)`` decoded text (errors replaced). ``("", "")`` when
+        the file is unreadable.
+    """
+    head_limit = _LOG_HEAD_BYTES
+    tail_limit = _LOG_TAIL_BYTES
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size <= head_limit + tail_limit:
+                return fh.read(head_limit + tail_limit).decode("utf-8", errors="replace"), ""
+            head = fh.read(head_limit).decode("utf-8", errors="replace")
+            fh.seek(size - tail_limit)
+            tail = fh.read(tail_limit).decode("utf-8", errors="replace")
+            return head, tail
+    except OSError:
+        return "", ""
+
+
+def _log_facts(path: Path, head: str, tail: str) -> dict[str, Any]:
+    """Return the size/window/idle facts every log section reports.
+
+    ``window_bytes`` states how much of the file the counters in that section
+    were computed from, so a count can never be mistaken for a lifetime total.
+    ``idle_seconds`` is how long ago the file was last written, which is what
+    separates "stuck" from "busy": a marker on the last line means something
+    different at 0 seconds (in progress) than at 300 (it stopped there).
+
+    :param path: The log file the windows came from.
+    :param head: Head window text.
+    :param tail: Tail window text.
+    :returns: ``{"size_bytes", "window_bytes", "idle_seconds"}``.
+    """
+    import time
+
+    try:
+        stat = path.stat()
+        size_bytes = stat.st_size
+        idle_seconds = max(0, int(time.time() - stat.st_mtime))
+    except OSError:
+        size_bytes = 0
+        idle_seconds = 0
+    return {
+        "size_bytes": size_bytes,
+        "window_bytes": len(head.encode("utf-8", errors="replace"))
+        + len(tail.encode("utf-8", errors="replace")),
+        "idle_seconds": idle_seconds,
+    }
+
+
+def _newest_log(*destinations: str) -> Path | None:
+    """Return the most recently modified ``*.log`` across log destinations.
+
+    :param destinations: Destination directory names under the logs root, e.g.
+        ``"runner"``, ``"host-runner"``.
+    :returns: The newest log path, or ``None`` when none exists or the logs
+        root is unreadable.
+    """
+    try:
+        from omnigent.process_logging import logs_root
+
+        root = logs_root()
+    except Exception:  # noqa: BLE001 — a snapshot must not fail on import/env
+        return None
+    newest: Path | None = None
+    newest_mtime = -1.0
+    for destination in destinations:
+        directory = root / destination
+        try:
+            candidates = list(directory.glob("*.log"))
+        except OSError:
+            continue
+        for candidate in candidates:
+            try:
+                mtime = candidate.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > newest_mtime:
+                newest, newest_mtime = candidate, mtime
+    return newest
+
+
+def _is_databricks_host(server_url: str | None) -> bool:
+    """Whether *server_url* looks like a Databricks-fronted deployment.
+
+    The credential probe is Databricks-specific, so it is skipped (reported as
+    ``not-applicable``) for OSS/self-hosted servers rather than guessing.
+
+    Covers all three clouds: ``*.cloud.databricks.com`` (AWS, and GCP via
+    ``*.gcp.databricks.com``), ``*.azuredatabricks.net`` (Azure), and
+    ``*.databricksapps.com`` (a Databricks App fronting the server).
+
+    :param server_url: Server URL, or ``None``.
+    :returns: ``True`` when the host looks like a Databricks workspace.
+    """
+    if not server_url:
+        return False
+    return any(
+        suffix in server_url
+        for suffix in (".databricks.com", ".azuredatabricks.net", ".databricksapps.com")
+    )
+
+
+def _workspace_host(server_url: str) -> str:
+    """Return the ``scheme://host`` prefix of *server_url*.
+
+    The Omnigent server sits on a path (``/api/2.0/omnigent``) under the
+    workspace host, but credentials are keyed by the workspace host alone.
+
+    :param server_url: Server URL.
+    :returns: ``scheme://host`` with any path, query, or fragment removed.
+    """
+    match = re.match(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)?(?P<rest>[^/?#]*)", server_url)
+    assert match is not None  # the pattern always matches
+    return f"{match.group('scheme') or ''}{match.group('rest')}"
+
+
+def _profiles_for_host(host: str) -> list[str]:
+    """Return the ``~/.databrickscfg`` profile names whose host is *host*.
+
+    Delegates to the runtime's own matcher so the count reflects what the
+    credential chain actually sees. A separate function (rather than an inline
+    import) keeps it substitutable in tests, the same way
+    :func:`omnigent.diagnostics._fetch_server_info` is.
+
+    :param host: Workspace host, e.g. ``"https://example.cloud.databricks.com"``.
+    :returns: Matching profile names, in config-file order.
+    :raises Exception: When the matcher is unavailable (no ``databricks``
+        extra) or the config cannot be read; the caller classifies that.
+    """
+    from omnigent.inner.databricks_executor import _databrickscfg_profiles_for_host
+
+    return _databrickscfg_profiles_for_host(host)
+
+
+def _credential_health(server_url: str | None) -> dict[str, Any]:
+    """Count the ``~/.databrickscfg`` profiles matching *server_url*'s workspace.
+
+    Reports **only the count**, deliberately. It is tempting to turn the count
+    into a verdict, but every such verdict would be wrong, because
+    ``_resolve_databricks_auth_for_host`` tries each matching profile in turn and
+    falls back to a host-keyed lookup when none authenticates:
+
+    - two or more matches is **not** a failure — the resolver authenticates the
+      candidates one by one and takes the first that works;
+    - exactly one match is **not** success — that profile's credential may be
+      expired;
+    - zero matches is **not** "unauthenticated" — the host-keyed CLI lookup is
+      still tried.
+
+    No authentication is attempted here either: that would shell out to the
+    Databricks CLI once per candidate and can block for seconds.
+
+    The count earns its place for one specific reason. When every matching
+    profile fails to authenticate, the resolver's final error is
+    ``"<a> and <b> match <host> in ~/.databrickscfg. Use --profile"``, which
+    names the duplicate even though the duplicate is not the cause. Seeing
+    "2 profiles match" next to that error tells a reader the message is
+    describing the config, not the failure.
+
+    :param server_url: Server URL, or ``None``.
+    :returns: ``{"backend", "profiles_matching_host", "probe"}``. ``probe`` is
+        ``"ok"`` when the matcher ran, ``"unavailable"`` when it could not (no
+        ``databricks`` extra, unreadable config), and ``"not-applicable"`` for a
+        non-Databricks deployment — it describes **this probe**, never the
+        credential.
+    """
+    if not _is_databricks_host(server_url):
+        return {
+            "backend": "other" if server_url else "unknown",
+            "profiles_matching_host": None,
+            "probe": "not-applicable",
+        }
+    assert server_url is not None  # guarded by _is_databricks_host
+    try:
+        matches = _profiles_for_host(_workspace_host(server_url))
+    except Exception:  # noqa: BLE001 — no databricks extra, unreadable cfg, …
+        return {
+            "backend": "databricks",
+            "profiles_matching_host": None,
+            "probe": "unavailable",
+        }
+    return {
+        "backend": "databricks",
+        "profiles_matching_host": len(matches),
+        "probe": "ok",
+    }
+
+
+def _host_log_health() -> dict[str, Any] | None:
+    """Summarize the newest host log.
+
+    ``stalled_on_connect`` says only that the connect attempt is the last thing
+    in the log — it is not a claim that the tunnel is down. Read it together with
+    ``idle_seconds``: the connect line is written *before* the attempt, so at a
+    low idle time it just means a connect is in flight, while at a high one it is
+    the fingerprint of a server-side refusal, where restarting locally cannot
+    help. Its negation says nothing either — a log can end on any line.
+
+    ``service_restarts`` counts tunnel drops the server initiated (WebSocket close
+    1012), which are normal and self-healing.
+
+    :returns: ``{"size_bytes", "window_bytes", "idle_seconds",
+        "stalled_on_connect", "service_restarts"}``, or ``None`` when no host log
+        exists.
+    """
+    path = _newest_log("host")
+    if path is None:
+        return None
+    head, tail = _log_windows(path)
+    last_lines = [line for line in (tail or head).splitlines() if line.strip()]
+    stalled = bool(last_lines) and _MARKER_TUNNEL_CONNECTING in last_lines[-1]
+    return {
+        **_log_facts(path, head, tail),
+        "stalled_on_connect": stalled,
+        "service_restarts": head.count(_MARKER_SERVICE_RESTART)
+        + tail.count(_MARKER_SERVICE_RESTART),
+    }
+
+
+def _runner_log_health() -> dict[str, Any] | None:
+    """Summarize the newest runner log.
+
+    Read the three counters as a **pair plus a fallback**, not individually:
+
+    ============================  ==================  ==========================
+    ``refresh_empty``             ``sdk_fallback``    reading
+    ============================  ==================  ==========================
+    ``0``                         ``0``               nothing went wrong recently
+    ``> 0``                       ``> 0``             lapsed, then recovered
+    ``> 0``                       ``0``               stuck without a credential
+    ============================  ==================  ==========================
+
+    ``bearer_handoff`` is separate: it says whether the host handed a bearer over
+    at launch. Its absence points at the host rather than the credential.
+
+    The counters describe the **recent window** (the tail), deliberately, not the
+    session's lifetime. A runner that lapsed and recovered hours ago, then went
+    stuck, must not read as healthy because of that old recovery; and one that is
+    quiet now reports zeros either way. ``bearer_handoff`` is looked for in the
+    head instead, because it is logged once at launch and scrolls out of any tail
+    window on a long-lived session.
+
+    The pair stays reliable across the window boundary because a lapse and the
+    fallback that answers it are seconds apart, and therefore adjacent in the
+    file: either both land in the window or neither does. A recovery seen without
+    the lapse that caused it would mean the boundary fell between them, which the
+    two markers being adjacent rules out in practice.
+
+    :returns: ``{"size_bytes", "window_bytes", "idle_seconds",
+        "bearer_handoff", "bearer_rejected", "sdk_fallback", "refresh_empty"}``,
+        or ``None`` when no runner log exists.
+    """
+    path = _newest_log("runner", "host-runner")
+    if path is None:
+        return None
+    head, tail = _log_windows(path)
+    # A file short enough to read whole comes back entirely as ``head``; then the
+    # whole file *is* the recent window.
+    recent = tail or head
+    return {
+        **_log_facts(path, head, tail),
+        "bearer_handoff": _MARKER_BEARER_HANDOFF in head,
+        "bearer_rejected": recent.count(_MARKER_BEARER_REJECTED),
+        "sdk_fallback": recent.count(_MARKER_SDK_AUTH),
+        "refresh_empty": recent.count(_MARKER_REFRESH_EMPTY),
+    }
+
+
+def collect_health(*, server_url: str | None = None) -> dict[str, Any]:
+    """Collect the local health section of the diagnostics snapshot.
+
+    :param server_url: Server URL used to pick the workspace host for the
+        credential probe. When ``None`` the credential section reports
+        ``not-applicable``.
+    :returns: A JSON-serializable dict::
+
+            {
+              "credential": {
+                "backend": "databricks" | "other" | "unknown",
+                "profiles_matching_host": 1 | null,
+                "probe": "ok" | "unavailable" | "not-applicable"
+              } | null,
+              "host_log":   {...} | null,
+              "runner_log": {...} | null
+            }
+
+        Contains no secrets.
+    """
+    return {
+        "credential": _safe(lambda: _credential_health(server_url)),
+        "host_log": _safe(_host_log_health),
+        "runner_log": _safe(_runner_log_health),
+    }
+
+
+def _safe(probe: Callable[[], dict[str, Any] | None]) -> dict[str, Any] | None:
+    """Run *probe*, turning any failure into an absent section.
+
+    The "never raises" guarantee is structural rather than a promise each probe
+    has to keep on its own: a snapshot is collected precisely when the machine
+    is misbehaving, so a probe that trips must cost a ``null`` section and
+    nothing more.
+
+    :param probe: Zero-argument probe returning a section mapping or ``None``.
+    :returns: The probe's result, or ``None`` when it raised.
+    """
+    try:
+        return probe()
+    except Exception:  # noqa: BLE001 — a broken probe must not break the snapshot
+        return None
+
+
+__all__ = ["collect_health"]

--- a/omnigent/kimi_native_hook.py
+++ b/omnigent/kimi_native_hook.py
@@ -52,6 +52,7 @@ from omnigent.kimi_native_bridge import (
     read_hook_config,
 )
 from omnigent.native_policy_hook import (
+    evaluate_failure_detail,
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
@@ -169,7 +170,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         reauth=reauth,
     )
     if resp is None or not resp.content:
-        return _fail_closed(api_error or (reauth.failure_reason if reauth else None))
+        return _fail_closed(evaluate_failure_detail(api_error, reauth))
     try:
         eval_response = resp.json()
     except json.JSONDecodeError:

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -81,6 +81,11 @@ _RELAY_TOKEN_ENV = "_OMNIGENT_RELAY_TOKEN"
 
 _TOOL_RELAY_FILE = "tool_relay.json"
 
+# Cap on each half of the fail-closed detail. ``api_error`` already truncates the
+# server's body to 200 characters; ``failure_reason`` wraps an SDK exception whose
+# text is unbounded, and the detail lands in a harness UI, so bound it the same way.
+_DETAIL_PART_MAX_CHARS = 200
+
 
 class _EvaluationEvent(TypedDict):
     type: str
@@ -453,6 +458,39 @@ def evaluation_response_to_hook_output(
         return None
 
     return None
+
+
+def evaluate_failure_detail(api_error: str | None, reauth: PolicyHookReauth | None) -> str | None:
+    """Combine the evaluate failure with the re-auth failure into one detail.
+
+    Both halves are needed to act on a fail-closed block, and each alone is
+    misleading:
+
+    - ``api_error`` says what the server answered (e.g. ``"server returned
+      401: ..."``) but not why the retry did not rescue it.
+    - :attr:`PolicyHookReauth.failure_reason` says why the re-mint could not
+      produce a fresh bearer (e.g. ``"no credential resolved"``), which is the
+      actionable half — and stderr from a hook subprocess is discarded by the
+      harness, so this string reaching the block reason is its only route to
+      the user.
+
+    Selecting one over the other drops the other permanently. Reporting
+    ``api_error`` alone turns "your local credential is gone" into an opaque
+    ``401``; reporting only the re-auth reason hides whether the server was
+    even reachable. Both are short, so both are surfaced.
+
+    :param api_error: Short error from :func:`post_evaluate_with_retry`, or
+        ``None`` when the POST itself did not fail.
+    :param reauth: The re-auth callable handed to
+        :func:`post_evaluate_with_retry`, or ``None`` when the caller has no
+        re-auth path (the relay route). Its ``failure_reason`` is read after
+        the fact.
+    :returns: The parts joined by ``"; "``, or ``None`` when neither half has
+        anything to say.
+    """
+    reason = getattr(reauth, "failure_reason", None) if reauth is not None else None
+    parts = [part[:_DETAIL_PART_MAX_CHARS] for part in (api_error, reason) if part]
+    return "; ".join(parts) or None
 
 
 def fail_closed_hook_output(

--- a/tests/test_cli_diagnose_health.py
+++ b/tests/test_cli_diagnose_health.py
@@ -1,0 +1,148 @@
+"""Tests for the health lines ``omnigent diagnose`` prints."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from omnigent import cli as cli_module
+
+
+def _invoke(monkeypatch: pytest.MonkeyPatch, health: dict[str, object]) -> str:
+    snap = {
+        "cli_version": "9.9.9",
+        "server_version": None,
+        "server_url": None,
+        "auth_source": "header",
+        "auth_source_origin": "local-env",
+        "os": "test-os",
+        "python": "3.12.0",
+        "health": health,
+    }
+    monkeypatch.setattr("omnigent.diagnostics.collect_snapshot", lambda **_kw: snap)
+    result = CliRunner().invoke(cli_module.cli, ["diagnose"])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_credential_line_reports_a_count_not_a_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _invoke(
+        monkeypatch,
+        {
+            "credential": {
+                "backend": "databricks",
+                "profiles_matching_host": 2,
+                "probe": "ok",
+            },
+            "host_log": None,
+            "runner_log": None,
+        },
+    )
+    assert "cred    2 profile(s) match the host" in out
+    # Two matches is not itself a failure, so no failure word may appear.
+    assert "ambiguous" not in out
+    assert "unauthenticated" not in out
+
+
+def test_credential_line_omitted_for_a_non_databricks_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = _invoke(
+        monkeypatch,
+        {
+            "credential": {
+                "backend": "other",
+                "profiles_matching_host": None,
+                "probe": "not-applicable",
+            },
+            "host_log": None,
+            "runner_log": None,
+        },
+    )
+    assert "cred" not in out
+
+
+def test_host_line_never_claims_the_tunnel_is_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _invoke(
+        monkeypatch,
+        {
+            "credential": None,
+            "host_log": {
+                "size_bytes": 498,
+                "window_bytes": 498,
+                "idle_seconds": 900,
+                "stalled_on_connect": False,
+                "service_restarts": 3,
+            },
+            "runner_log": None,
+        },
+    )
+    assert "host    idle 900s, 3 server-initiated restart(s)" in out
+    # A log that does not end on the connect line proves nothing about the tunnel.
+    assert "connected" not in out
+
+
+def test_host_line_pairs_stalled_with_the_idle_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _invoke(
+        monkeypatch,
+        {
+            "credential": None,
+            "host_log": {
+                "size_bytes": 498,
+                "window_bytes": 498,
+                "idle_seconds": 1200,
+                "stalled_on_connect": True,
+                "service_restarts": 0,
+            },
+            "runner_log": None,
+        },
+    )
+    assert "idle 1200s" in out
+    assert "last line is the connect attempt" in out
+
+
+def test_runner_line_states_the_window_for_its_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _invoke(
+        monkeypatch,
+        {
+            "credential": None,
+            "host_log": None,
+            "runner_log": {
+                "size_bytes": 3_500_000,
+                "window_bytes": 272 * 1024,
+                "idle_seconds": 5,
+                "bearer_handoff": True,
+                "bearer_rejected": 0,
+                "sdk_fallback": 0,
+                "refresh_empty": 216,
+            },
+        },
+    )
+    assert "runner  idle 5s, bearer from host" in out
+    assert "216 empty refresh(es)" in out
+    assert "in the last 272 KiB" in out  # the counts are windowed, not lifetime
+
+
+def test_missing_health_section_prints_nothing_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _invoke(monkeypatch, {})
+    for prefix in ("cred", "host  ", "runner"):
+        assert prefix not in out
+
+
+def test_json_output_carries_the_health_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    snap = {
+        "cli_version": "9.9.9",
+        "server_version": None,
+        "server_url": None,
+        "auth_source": "header",
+        "auth_source_origin": "local-env",
+        "os": "test-os",
+        "python": "3.12.0",
+        "health": {"credential": None, "host_log": None, "runner_log": None},
+    }
+    monkeypatch.setattr("omnigent.diagnostics.collect_snapshot", lambda **_kw: snap)
+    result = CliRunner().invoke(cli_module.cli, ["diagnose", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["health"] == snap["health"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from omnigent import diagnostics
 from omnigent.diagnostics import collect_snapshot
 from omnigent.version import VERSION
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep the health section hermetic: never read the developer's own logs."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
 
 
 def test_snapshot_local_only_has_no_server_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,7 +39,15 @@ def test_snapshot_reports_only_known_keys() -> None:
         "auth_source_origin",
         "os",
         "python",
+        "health",
     }
+
+
+def test_snapshot_embeds_the_health_section() -> None:
+    # The health probes have their own tests; here we only assert the snapshot
+    # carries them, since that is the contract a bug report relies on.
+    health = collect_snapshot(server_url=None)["health"]
+    assert set(health) == {"credential", "host_log", "runner_log"}
 
 
 def test_local_auth_source_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_diagnostics_health.py
+++ b/tests/test_diagnostics_health.py
@@ -1,0 +1,411 @@
+"""Tests for the local health section of the ``omnigent diagnose`` snapshot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent import diagnostics_health
+from omnigent.diagnostics_health import collect_health
+
+_WORKSPACE = "https://example.cloud.databricks.com"
+_SERVER = f"{_WORKSPACE}/api/2.0/omnigent"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the logs root at a scratch dir so probes never read the real one."""
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+
+
+def _write_log(tmp_path: Path, destination: str, name: str, body: str) -> Path:
+    directory = tmp_path / "logs" / destination
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# --- credential ------------------------------------------------------------
+
+
+def test_credential_not_applicable_without_server() -> None:
+    health = collect_health(server_url=None)
+    assert health["credential"]["probe"] == "not-applicable"
+    assert health["credential"]["profiles_matching_host"] is None
+
+
+def test_credential_not_applicable_for_non_databricks_server() -> None:
+    # An OSS/self-hosted server has no workspace profiles to count.
+    health = collect_health(server_url="http://localhost:6767")
+    assert health["credential"] == {
+        "backend": "other",
+        "profiles_matching_host": None,
+        "probe": "not-applicable",
+    }
+
+
+@pytest.mark.parametrize("matches", [[], ["only-one"], ["first", "second"], ["a", "b", "c"]])
+def test_credential_reports_the_match_count(
+    monkeypatch: pytest.MonkeyPatch, matches: list[str]
+) -> None:
+    monkeypatch.setattr(diagnostics_health, "_profiles_for_host", lambda host: matches)
+    credential = collect_health(server_url=_SERVER)["credential"]
+    assert credential["profiles_matching_host"] == len(matches)
+    assert credential["backend"] == "databricks"
+    # ``probe`` describes the probe, never the credential: it stays "ok" for
+    # every count, including 0 and 2+.
+    assert credential["probe"] == "ok"
+
+
+def test_credential_never_turns_the_count_into_a_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A regression guard against re-introducing a verdict field.
+
+    ``_resolve_databricks_auth_for_host`` authenticates each matching profile in
+    turn and falls back to a host-keyed lookup, so no count implies success or
+    failure: 2+ matches is not a failure, 1 match is not success, and 0 matches is
+    not "unauthenticated".
+    """
+    monkeypatch.setattr(diagnostics_health, "_profiles_for_host", lambda host: ["a", "b"])
+    credential = collect_health(server_url=_SERVER)["credential"]
+    assert set(credential) == {"backend", "profiles_matching_host", "probe"}
+    verdicts = {"ambiguous", "unauthenticated", "authenticated", "broken", "ok"}
+    assert not (verdicts - {"ok"}) & set(map(str, credential.values()))
+
+
+def test_credential_probe_uses_the_workspace_host_not_the_api_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Credentials are keyed by the workspace host; the Omnigent server sits on
+    # a path under it, so the path must be stripped before matching.
+    seen: list[str] = []
+
+    def _record(host: str) -> list[str]:
+        seen.append(host)
+        return ["profile"]
+
+    monkeypatch.setattr(diagnostics_health, "_profiles_for_host", _record)
+    collect_health(server_url=f"{_SERVER}?o=123#frag")
+    assert seen == [_WORKSPACE]
+
+
+def test_credential_unavailable_when_matcher_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No databricks extra installed, or an unreadable config: degrade, never raise.
+    def _boom(host: str) -> list[str]:
+        raise RuntimeError("no databricks extra")
+
+    monkeypatch.setattr(diagnostics_health, "_profiles_for_host", _boom)
+    credential = collect_health(server_url=_SERVER)["credential"]
+    assert credential["probe"] == "unavailable"
+    assert credential["profiles_matching_host"] is None
+
+
+# --- host log --------------------------------------------------------------
+
+
+def test_host_log_absent_reports_null() -> None:
+    assert collect_health(server_url=None)["host_log"] is None
+
+
+def test_host_log_stalled_mid_connect(tmp_path: Path) -> None:
+    # The fingerprint of a server-side tunnel refusal: the connect line is the
+    # last thing written and nothing follows it.
+    _write_log(
+        tmp_path,
+        "host",
+        "host-1.log",
+        "INFO host.connect run | Connecting to wss://example/api/2.0/omnigent/v1/host\n",
+    )
+    host_log = collect_health(server_url=None)["host_log"]
+    assert host_log is not None
+    assert host_log["stalled_on_connect"] is True
+    assert host_log["service_restarts"] == 0
+    assert host_log["size_bytes"] > 0
+
+
+def test_host_log_not_stalled_and_counts_service_restarts(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path,
+        "host",
+        "host-1.log",
+        "INFO host.connect run | Connecting to wss://example\n"
+        "WARN host.connect run | Host tunnel disconnected: received 1012 (service restart)\n"
+        "WARN host.connect run | Host tunnel disconnected: received 1012 (service restart)\n"
+        "INFO host.connect _handle_launch | Launched runner\n",
+    )
+    host_log = collect_health(server_url=None)["host_log"]
+    assert host_log is not None
+    # False means only "the log does not end on the connect line" — never
+    # "the tunnel is up".
+    assert host_log["stalled_on_connect"] is False
+    assert host_log["service_restarts"] == 2
+
+
+def test_host_log_picks_the_newest(tmp_path: Path) -> None:
+    old = _write_log(tmp_path, "host", "host-old.log", "Connecting to wss://example\n")
+    new = _write_log(tmp_path, "host", "host-new.log", "INFO settled\n")
+    import os
+
+    os.utime(old, (1, 1))
+    os.utime(new, (2, 2))
+    host_log = collect_health(server_url=None)["host_log"]
+    assert host_log is not None
+    # The newest log is not stalled; picking the older one would say otherwise.
+    assert host_log["stalled_on_connect"] is False
+
+
+# --- runner log ------------------------------------------------------------
+
+
+def test_runner_log_absent_reports_null() -> None:
+    assert collect_health(server_url=None)["runner_log"] is None
+
+
+def test_runner_log_healthy_self_recovery(tmp_path: Path) -> None:
+    # The healthy shape: the launch bearer lapsed, and a self-refreshing
+    # credential took over. No empty refreshes.
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        "INFO __main__ | using host-provided bearer for runner bootstrap\n"
+        "INFO runner._entry invalidate | host bootstrap bearer rejected;"
+        " resolving runner-local auth\n"
+        "INFO databricks.sdk databricks_cli | Using Databricks CLI authentication\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["bearer_handoff"] is True
+    assert runner_log["bearer_rejected"] == 1
+    assert runner_log["sdk_fallback"] == 1
+    assert runner_log["refresh_empty"] == 0
+
+
+def test_runner_log_stuck_without_a_credential(tmp_path: Path) -> None:
+    # The stuck shape: refreshes keep producing nothing and no fallback lands.
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        "INFO __main__ | using host-provided bearer for runner bootstrap\n"
+        + "httpx.RequestError: Databricks token refresh returned no token\n" * 3,
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["refresh_empty"] == 3
+    assert runner_log["sdk_fallback"] == 0
+
+
+def test_runner_log_includes_host_launched_runners(tmp_path: Path) -> None:
+    # Host-launched runners log under a different destination directory.
+    _write_log(
+        tmp_path,
+        "host-runner",
+        "runner-1.log",
+        "INFO __main__ | using host-provided bearer for runner bootstrap\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["bearer_handoff"] is True
+
+
+def test_runner_log_startup_marker_survives_a_long_lived_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A regression guard: the launch marker must not scroll out of view.
+
+    ``using host-provided bearer`` is logged once, in the first few lines. A
+    tail-only read reports "no bearer from host" for every session whose log has
+    since grown past the tail window — which is every long-lived session.
+    """
+    monkeypatch.setattr(diagnostics_health, "_LOG_TAIL_BYTES", 128)
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        "using host-provided bearer for runner bootstrap\n" + ("x" * 8192) + "\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["bearer_handoff"] is True
+    assert runner_log["size_bytes"] > 128  # the true size is still reported
+
+
+def test_runner_log_short_file_is_entirely_the_recent_window(tmp_path: Path) -> None:
+    # A short log has no separate tail; the whole file is the recent window, and
+    # a marker in it must be counted exactly once.
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        "INFO databricks.sdk databricks_cli | Using Databricks CLI authentication\n"
+        "INFO runner.app | ready\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["sdk_fallback"] == 1
+
+
+def test_runner_log_counters_describe_the_recent_window_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An old recovery must not make a currently-stuck runner read as healthy.
+
+    Observed on a real log: a runner lapsed and recovered early in the session,
+    then went stuck hours later. Counting the whole file would pair the old
+    recovery with the current failures and hide the stuck state.
+    """
+    monkeypatch.setattr(diagnostics_health, "_LOG_HEAD_BYTES", 64)
+    monkeypatch.setattr(diagnostics_health, "_LOG_TAIL_BYTES", 64)
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        "using host-provided bearer for runner bootstrap\n"
+        "INFO databricks.sdk databricks_cli | Using Databricks CLI authentication\n"
+        + ("x" * 4096)
+        + "\nDatabricks token refresh returned no token\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["bearer_handoff"] is True  # still found, from the head
+    assert runner_log["sdk_fallback"] == 0  # the old recovery is not recent
+    assert runner_log["refresh_empty"] == 1  # currently failing
+
+
+def test_runner_log_head_read_is_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The head window is bounded too: a marker beyond it is not a startup fact.
+    monkeypatch.setattr(diagnostics_health, "_LOG_HEAD_BYTES", 32)
+    monkeypatch.setattr(diagnostics_health, "_LOG_TAIL_BYTES", 32)
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        ("y" * 4096) + "\nusing host-provided bearer for runner bootstrap\n" + ("z" * 4096) + "\n",
+    )
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["bearer_handoff"] is False
+
+
+# --- shape / secrets -------------------------------------------------------
+
+
+def test_health_reports_only_known_sections() -> None:
+    assert set(collect_health(server_url=None)) == {"credential", "host_log", "runner_log"}
+
+
+def test_health_contains_no_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Profile names and log bodies must not leak into a snapshot meant for a
+    # bug report — only counts, booleans, and fixed classification strings.
+    monkeypatch.setattr(
+        diagnostics_health, "_profiles_for_host", lambda host: ["secret-profile-name"]
+    )
+    _write_log(
+        tmp_path,
+        "runner",
+        "runner-1.log",
+        # A synthetic bearer, assembled so this file carries no JWT-shaped literal.
+        "Authorization: Bearer " + ("ey" + "J-NOT-A-REAL-TOKEN-") * 2 + "\n",
+    )
+    blob = repr(collect_health(server_url=_SERVER))
+    assert "secret-profile-name" not in blob
+    assert "Bearer" not in blob
+    assert "NOT-A-REAL-TOKEN" not in blob
+    assert "example.cloud.databricks.com" not in blob
+
+
+def test_collect_health_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A half-broken machine is exactly when a snapshot is collected.
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", "/nonexistent/path/for/diagnostics/test")
+
+    def _boom(host: str) -> list[str]:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(diagnostics_health, "_profiles_for_host", _boom)
+    health = collect_health(server_url=_SERVER)
+    assert health["credential"]["probe"] == "unavailable"
+    assert health["host_log"] is None
+    assert health["runner_log"] is None
+
+
+# --- facts reported alongside every log section ------------------------------
+
+
+def test_log_sections_report_the_window_and_idle_time(tmp_path: Path) -> None:
+    """``window_bytes`` bounds the counters; ``idle_seconds`` dates them.
+
+    Without the window, a count reads as a lifetime total. Without the idle time,
+    ``stalled_on_connect`` cannot be told apart from a connect in flight.
+    """
+    _write_log(tmp_path, "host", "host-1.log", "Connecting to wss://example\n")
+    _write_log(tmp_path, "runner", "runner-1.log", "using host-provided bearer\n")
+    health = collect_health(server_url=None)
+    for section in (health["host_log"], health["runner_log"]):
+        assert section is not None
+        assert section["window_bytes"] == section["size_bytes"]  # short file: read whole
+        assert section["idle_seconds"] >= 0
+
+
+def test_idle_seconds_grows_with_an_old_log(tmp_path: Path) -> None:
+    import os
+
+    path = _write_log(tmp_path, "host", "host-1.log", "Connecting to wss://example\n")
+    os.utime(path, (1_000_000, 1_000_000))  # long in the past
+    host_log = collect_health(server_url=None)["host_log"]
+    assert host_log is not None
+    # Stalled *and* idle for ages is the conclusive shape; stalled at ~0s is not.
+    assert host_log["stalled_on_connect"] is True
+    assert host_log["idle_seconds"] > 10_000
+
+
+# --- robustness --------------------------------------------------------------
+
+
+def test_credential_section_degrades_when_the_probe_itself_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Not just the matcher: any failure inside the credential probe must cost a
+    # null section rather than the whole snapshot.
+    def _boom(server_url: str | None) -> bool:
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(diagnostics_health, "_is_databricks_host", _boom)
+    health = collect_health(server_url=_SERVER)
+    assert health["credential"] is None
+    assert set(health) == {"credential", "host_log", "runner_log"}
+
+
+def test_log_windows_tolerate_a_split_multibyte_character(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The windows are byte offsets, so a boundary can land inside a UTF-8
+    # sequence. Decoding must replace, not raise, and markers must still match.
+    monkeypatch.setattr(diagnostics_health, "_LOG_HEAD_BYTES", 5)
+    monkeypatch.setattr(diagnostics_health, "_LOG_TAIL_BYTES", 5)
+    path = tmp_path / "logs" / "runner" / "runner-1.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # "あ" is three bytes; the 5-byte windows cut through the sequences.
+    path.write_bytes(("あ" * 40).encode("utf-8") + b"\nno token\n")
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is not None
+    assert runner_log["refresh_empty"] == 0  # the full marker is not in the window
+
+
+def test_log_section_survives_a_file_that_vanishes_mid_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # _newest_log finds it, then it is gone before the read: null, not a crash.
+    path = _write_log(tmp_path, "runner", "runner-1.log", "using host-provided bearer\n")
+    real_windows = diagnostics_health._log_windows
+
+    def _unlink_then_read(p: Path) -> tuple[str, str]:
+        path.unlink(missing_ok=True)
+        return real_windows(p)
+
+    monkeypatch.setattr(diagnostics_health, "_log_windows", _unlink_then_read)
+    runner_log = collect_health(server_url=None)["runner_log"]
+    assert runner_log is None or runner_log["size_bytes"] == 0

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -8,6 +8,7 @@ import pytest
 from omnigent import native_policy_hook
 from omnigent.native_policy_hook import (
     _is_login_redirect_or_unauthorized,
+    evaluate_failure_detail,
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
@@ -727,3 +728,65 @@ def test_policy_hook_reauth_returns_none_without_factory(
         "http://127.0.0.1:6767", {"Content-Type": "application/json"}
     )
     assert reauth() is None
+
+
+def test_evaluate_failure_detail_joins_both_halves() -> None:
+    """Both the server answer and the re-auth reason survive into the detail.
+
+    Reporting only one is what made a dead local credential look like an
+    opaque ``401``: the API error says what the server answered, the re-auth
+    reason says why the retry could not rescue it.
+    """
+    reauth = native_policy_hook.policy_hook_reauth("http://127.0.0.1:6767", {})
+    reauth.failure_reason = "no credential resolved"
+    detail = evaluate_failure_detail("server returned 401: Credential was not sent", reauth)
+    assert detail == "server returned 401: Credential was not sent; no credential resolved"
+
+
+def test_evaluate_failure_detail_keeps_api_error_when_reauth_succeeded() -> None:
+    # A successful re-mint clears failure_reason; the API error is all there is.
+    reauth = native_policy_hook.policy_hook_reauth("http://127.0.0.1:6767", {})
+    reauth.failure_reason = None
+    assert evaluate_failure_detail("server returned 500", reauth) == "server returned 500"
+
+
+def test_evaluate_failure_detail_keeps_reauth_reason_without_api_error() -> None:
+    # The POST never failed, but the re-mint did: that reason must still reach
+    # the user, because hook stderr is discarded by the harness.
+    reauth = native_policy_hook.policy_hook_reauth("http://127.0.0.1:6767", {})
+    reauth.failure_reason = "token mint failed: boom"
+    assert evaluate_failure_detail(None, reauth) == "token mint failed: boom"
+
+
+def test_evaluate_failure_detail_without_reauth_path() -> None:
+    # The relay route has no re-auth callable at all.
+    assert evaluate_failure_detail("server returned 502", None) == "server returned 502"
+
+
+def test_evaluate_failure_detail_returns_none_when_nothing_to_say() -> None:
+    assert evaluate_failure_detail(None, None) is None
+
+
+def test_evaluate_failure_detail_reaches_the_fail_closed_reason() -> None:
+    """The combined detail is what the user actually sees in the block reason."""
+    reauth = native_policy_hook.policy_hook_reauth("http://127.0.0.1:6767", {})
+    reauth.failure_reason = "auth factory returned empty token"
+    detail = evaluate_failure_detail("server returned 403", reauth)
+    output = fail_closed_hook_output("UserPromptSubmit", detail)
+    assert output is not None
+    assert "server returned 403" in str(output)
+    assert "auth factory returned empty token" in str(output)
+
+
+def test_evaluate_failure_detail_bounds_each_half() -> None:
+    """A long SDK exception must not flood the harness UI.
+
+    ``api_error`` already truncates the server body; ``failure_reason`` wraps an
+    exception whose text is unbounded, so both halves are capped the same way.
+    """
+    reauth = native_policy_hook.policy_hook_reauth("http://127.0.0.1:6767", {})
+    reauth.failure_reason = "x" * 5000
+    detail = evaluate_failure_detail("y" * 5000, reauth)
+    assert detail is not None
+    cap = native_policy_hook._DETAIL_PART_MAX_CHARS
+    assert detail == "y" * cap + "; " + "x" * cap


### PR DESCRIPTION
## Related issue

Closes #4954

## Summary

Two changes, one goal: make an auth failure diagnosable from the outside.

- **`omnigent diagnose` gains a `health` section** (new `omnigent/diagnostics_health.py`) with the
  three local signals that discriminate the failure modes: how many `~/.databrickscfg` profiles match
  the workspace host, whether the host log ends on the connect attempt (and how long it has been
  idle), and whether the runner still has a working credential. Read from artifacts the runtime
  already writes; no new auth attempts. Each section reports the window it was computed from, so a
  count can never be mistaken for a lifetime total.
- **The fail-closed block reason stops dropping the actionable half.** The three native hooks selected
  `api_error or reauth.failure_reason`, so `PolicyHookReauth.failure_reason` — which the class
  docstring calls "the only channel that reaches the UI", because hook stderr is discarded — was never
  shown. New `evaluate_failure_detail()` reports both.

**ELI5.** When a session gets blocked, you saw `server returned 401` and nothing else, and
`omnigent host status` said `online` because the process was alive. Now the block also tells you *why
the retry failed*, and `diagnose` tells you whether the runner recovered on its own, is stuck without
a credential, or was refused by the server.

```
                    before                            after
block reason   "server returned 401"          "server returned 401; no credential resolved"
diagnose       cli / server / os / auth       … + cred / host / runner health lines
```

The credential section reports a **count, not a verdict** — deliberately. `_resolve_databricks_auth_for_host`
tries each matching profile in turn and then falls back to a host-keyed lookup, so two matches is not
a failure, one match is not success, and zero matches is not "unauthenticated". The count still earns
its place: when *every* matching profile fails to authenticate, the resolver's final error is
`"<a> and <b> match <host> … Use --profile"`, which names the duplicate even though the duplicate is
not the cause. Seeing "2 profiles match" next to that error tells a reader the message is describing
the config, not the failure. There is a regression test guarding against re-introducing a verdict.

```mermaid
flowchart TD
    A[session blocked] --> B{diagnose health}
    B -->|host log ends on connect + long idle| C[server refused the tunnel<br/>restarting locally cannot help]
    B -->|runner: bearer handed over,<br/>self-refresh fallback > 0| D[recovered on its own<br/>no action needed]
    B -->|runner: empty refreshes > 0,<br/>no fallback| E[stuck without a credential]
    B -->|cred: 2+ profiles match| F[the '...match... Use --profile' error<br/>is about the config, not the cause]
```

Same invariant as `omnigent/diagnostics.py`: **no secrets** — counts, booleans, byte sizes, and a fixed
vocabulary of strings describing *the probe*. Never profile names, hosts, tokens, log lines, or config
bodies. There is a test that asserts exactly that.

Notes on the shape:

- The probes live in their own module because they read the filesystem rather than versions, and
  because `diagnostics.py`'s docstring makes a promise about staying small. `collect_snapshot` just
  composes them.
- Logs are read through two bounded windows (16 KiB head, 256 KiB tail), never whole: a runner log can
  reach hundreds of megabytes when a transport failure loops (#4885). The head is what makes the
  launch-time bearer handoff visible on a long-lived session; the counters come from the tail so a
  stale recovery cannot mask a current failure.
- Every probe degrades to a `null` section rather than raising — a snapshot is collected precisely
  when the machine is misbehaving. `_safe()` makes that structural instead of a per-probe promise.
- The credential probe reuses the runtime's own `_databrickscfg_profiles_for_host`, so the count
  reflects what the credential chain actually sees rather than a re-implementation of the parsing. It
  is skipped (`not-applicable`) for non-Databricks servers.
- `evaluate_failure_detail()` is shared by all three hooks, replacing the same expression triplicated
  in `claude_native_hook.py`, `codex_native_hook.py`, and `kimi_native_hook.py`.

## Review

Reviewed independently by a second model before opening. It blocked the first draft on one issue,
which is fixed here: the credential section had a `resolution` field with values `ok` / `ambiguous` /
`unauthenticated`, which claimed more than the data supports and would have actively misled a reader
(two matches is not a failure). It is now a count plus a `probe` field that describes *the probe*, and
a regression test asserts no verdict creeps back in. Also from that review: the credential probe is
now inside the same `_safe()` wrapper as the log probes so the "never raises" contract is structural
rather than per-probe; the host line no longer prints "connected" for a log that merely does not end
on the connect line; each half of the fail-closed detail is capped at 200 characters so an unbounded
SDK exception cannot flood the harness UI; and tests were added for a probe that raises, a UTF-8
sequence split by a window boundary, a file that vanishes mid-probe, and the human-readable CLI lines.

## Test Plan

```bash
uv run --no-sync pytest tests/test_diagnostics.py tests/test_diagnostics_health.py \
  tests/test_cli_diagnose_health.py tests/test_native_policy_hook.py \
  tests/test_claude_native_hook.py tests/test_codex_native_hook.py \
  tests/test_kimi_native_hook.py tests/host/test_cli_diagnose.py \
  tests/inner/test_hermes_policy_hook.py -q
# 232 passed

.venv/bin/python -m ruff format --check --force-exclude <changed files>
.venv/bin/python -m ruff check --force-exclude <changed files>
# All checks passed
```

New tests cover: the credential count for every match count and that it never becomes a verdict, the
workspace-host-vs-API-path distinction, the connect-attempt fingerprint paired with idle time, the
healthy-recovery and stuck-runner log shapes, host-launched runners logging to a separate destination,
both window bounds, a UTF-8 sequence split by a window boundary, a probe that raises, a file that
vanishes mid-probe, "contains no secrets", the snapshot key set, the human-readable CLI lines and the
`--json` shape, and every branch of `evaluate_failure_detail` including its length cap and that the
combined detail reaches the block reason.

Also verified by hand against four real logs from a workspace-hosted deployment, by pointing
`OMNIGENT_DATA_DIR` at a scratch copy of each:

| real log | reported |
|---|---|
| runner stuck on a pre-fix build | `handoff=True sdk=0 empty=216` → stuck |
| runner that recovered early, then went stuck | `handoff=True sdk=0 empty=256` → stuck (its end state) |
| currently healthy runner | `handoff=True sdk=0 empty=0` → nothing wrong |
| host log left at 498 bytes by a server-side refusal | `stalled_on_connect=True` |

(`sdk=0` in the second row is correct and is the point of the pair reading: that runner's *recent*
window shows failures with no recovery, so its end state was stuck even though it had recovered hours
earlier.)

Two implementation bugs were found this way rather than by the unit tests, and both are now covered by
regression tests:

1. `bearer_handoff` was read from the tail, so it reported "no bearer from host" for every session
   whose log had grown past the tail window — i.e. every long-lived one. It is logged once at launch,
   at byte 79 of the file; the window started at byte 333590.
2. Counting a marker across both windows let an old recovery pair with current failures and hide a
   stuck runner. The counters now describe the recent window only, which is what the pair reading
   needs.

## Demo

N/A — non-visual change (CLI text output and a JSON field).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran `omnigent diagnose` and `omnigent diagnose --json` against a
workspace-hosted server on a machine whose logs contained all four failure modes, and confirmed each
was classified correctly and that no profile name, host, token, or log line appeared in the output.

`collect_snapshot` gains one key (`health`), so `omnigent diagnose --json` consumers see an added
field rather than a changed one. `tests/test_diagnostics.py::test_snapshot_reports_only_known_keys`
is updated to pin the new key set.

## Changelog

`omnigent diagnose` now reports local auth health (credential, host tunnel, runner), and a policy
fail-closed block explains why re-authentication failed instead of only what the server returned.
