### PR TITLE
fix(terminal): close() kills the tmux server after the inner process exits

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -975,6 +975,10 @@ class TerminalInstance:
     # the tmux server itself is launched.
     terminal_transport: str | None = None
     running: bool = False
+    # Set on first successful launch and never cleared: close() must be able
+    # to kill the private tmux server even after the inner process exited and
+    # is_alive() flipped `running` off (see close()).
+    _launched: bool = field(default=False, repr=False, compare=False)
     launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
     # carries no ``egress_rules`` or the backend doesn't need a
@@ -1252,6 +1256,7 @@ class TerminalInstance:
             )
 
         self.running = True
+        self._launched = True
         self.launch_cwd = effective_cwd
 
     async def send(
@@ -1403,7 +1408,15 @@ class TerminalInstance:
         await self._stop_idle_watcher()
         self._stop_idle_watcher_thread()
 
-        if self.running:
+        # Kill the private tmux server whenever this terminal was launched,
+        # not only while `running` still holds: with keep_alive_after_exit the
+        # inner process exits first, is_alive() flips `running` off as its
+        # documented side effect, and the remain-on-exit session + server would
+        # otherwise outlive the terminal (one leaked tmux server per closed
+        # terminal). Callers previously had to "restore running before close()"
+        # to work around exactly this; kill-server against an already-dead
+        # socket is an ignored error, so an unconditional attempt is safe.
+        if self.running or getattr(self, "_launched", False):
             with contextlib.suppress(RuntimeError):
                 await self._tmux("kill-server")
             self.running = False

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -1102,3 +1102,58 @@ async def test_dead_registered_pane_close_restores_running_for_kill_server(
     assert registry.get(sid, "claude", "main") is None, (
         "Stale entry must be removed from the registry"
     )
+
+
+@pytest.mark.asyncio
+async def test_close_kills_server_after_inner_process_exit(tmp_path: Path) -> None:
+    """close() must kill the private tmux server after the inner process has
+    exited (keep_alive_after_exit): is_alive() flips ``running`` off as its
+    documented side effect, and the old ``if self.running`` guard then skipped
+    kill-server -- one leaked tmux server per closed terminal (#4880)."""
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "k.sock",
+        private_dir=tmp_path / "k_private",
+    )
+    (tmp_path / "k_private").mkdir(exist_ok=True)
+    instance.running = True
+    instance._launched = True  # noqa: SLF001 — simulating a successful launch
+    # The pane died; is_alive's documented side effect already flipped running.
+    instance.running = False  # noqa: SLF001
+
+    kill_calls: list[tuple[str, ...]] = []
+
+    async def _fake_tmux(*args: str) -> None:
+        kill_calls.append(args)
+
+    instance._tmux = _fake_tmux  # type: ignore[assignment]
+
+    await instance.close()
+
+    assert any("kill-server" in call for call in kill_calls), (
+        "close() skipped kill-server because the inner process already exited"
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_never_launched_does_not_kill(tmp_path: Path) -> None:
+    """A terminal that was never launched owns no server to kill."""
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "n.sock",
+        private_dir=tmp_path / "n_private",
+    )
+    (tmp_path / "n_private").mkdir(exist_ok=True)
+
+    kill_calls: list[tuple[str, ...]] = []
+
+    async def _fake_tmux(*args: str) -> None:
+        kill_calls.append(args)
+
+    instance._tmux = _fake_tmux  # type: ignore[assignment]
+
+    await instance.close()
+
+    assert not any("kill-server" in call for call in kill_calls)


### PR DESCRIPTION
## Summary

Fixes #4880.

## Root cause (as diagnosed in the issue, verified)

`TerminalInstance.close()` guarded the tmux server teardown with `if self.running:`. With `keep_alive_after_exit=True` the inner process exits **before** the owner closes the terminal, and `is_alive()` flips `running = False` as its **documented side effect** — so `close()` skipped `kill-server` and every such terminal leaked its private tmux server for the process lifetime.

The codebase already contains a caller-side workaround acknowledging this exact defect: `test_dead_registered_pane_close_restores_running_for_kill_server` documents *"running must be restored before close() so kill-server runs"* — the self-heal path sets `running = True` back before closing, purely so the guard fires. The defect itself lived in `close()`.

## Fix

A `_launched` flag (dataclass field, set on first successful launch, never cleared) drives the guard:

```python
if self.running or self._launched:
    with contextlib.suppress(RuntimeError):
        await self._tmux("kill-server")
    self.running = False
```

- the issue's lifecycle (launched → pane dead → `running` already False → close) now kills the server;
- `kill-server` against an already-dead socket stays an ignored error, so attempting whenever launched is safe;
- a never-launched terminal still kills nothing;
- the existing "restore running before close" workaround stays valid but is no longer load-bearing.

## Tests

- the issue's exact lifecycle as a regression test — **fails on current `main`** (close skips kill-server when `running` was flipped off);
- never-launched terminal issues no kill-server.

Verified locally: with the fix, these suites go from 4 pre-existing failures on baseline to 3 (the fix incidentally repairs one of them), no regressions.
