### PR TITLE
fix(web): make the Working… status pin opaque in dark mode

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2326,15 +2326,21 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           tab's left edge lines up with the inline shimmer's. */}
       <div className={cn("mx-auto w-full px-4", CHAT_COLUMN_WIDTH)}>
         {showShimmer && (
-          // Tab shape (rounded top, no bottom border, composer-matching bg) so
-          // its flat bottom edge merges into the chat box. aria-hidden: the
-          // sr-only span above owns the announcement, so the rotating label
-          // here stays silent to screen readers. Collapses to sr-only when at
-          // the bottom (`!visible`) — the inline shimmer paints there instead.
+          // Tab shape (rounded top, no bottom border) so its flat bottom edge
+          // merges into the composer. bg-card-solid, not bg-card: in dark mode
+          // bg-card is a translucent glass surface (the `.dark .bg-card` frosted
+          // backdrop-blur), so the tab read as a see-through pill floating over
+          // the transcript. The opaque solid keeps it readable and, by not
+          // matching the glass rule, lets `border-b-0` actually merge — that
+          // rule's `border` shorthand would otherwise re-add a bottom edge.
+          // aria-hidden: the sr-only span above owns the announcement, so the
+          // rotating label here stays silent to screen readers. Collapses to
+          // sr-only when at the bottom (`!visible`) — the inline shimmer paints
+          // there instead.
           <div
             aria-hidden="true"
             className={cn(
-              "flex w-fit items-center gap-1.5 rounded-t-lg border border-b-0 border-border bg-card px-3 pt-1 pb-1.5",
+              "flex w-fit items-center gap-1.5 rounded-t-lg border border-b-0 border-border bg-card-solid px-3 pt-1 pb-1.5",
               !visible && "sr-only",
             )}
           >


### PR DESCRIPTION
## What

The mobile dark-mode "Tinkering…" / "Working…" pop-up — the pinned `WorkingStatusPin` tab that appears above the composer while the agent is working — rendered as a **translucent** pill, so the transcript showed through it. Reported in Slack; design confirmed it must be opaque.

## Before / after (dark mode)

![WorkingStatusPin over the transcript — before (bg-card, translucent, text shows through) vs after (bg-card-solid, opaque)](https://raw.githubusercontent.com/omnigent-ai/omnigent/pr-4962-assets/working-pin-before-after-v3.png)

The real pin (`BrandLogo` + `Shimmer`) laid over real assistant text. **Left (`bg-card`, current):** the transcript text is visible **through** the chip. **Right (`bg-card-solid`, this fix):** opaque — the text behind it is hidden.

## Why

The tab used `bg-card`. In dark mode that is a glass surface:
- `--card` is `rgba(31, 39, 45, 0.6)` (60% opacity), and
- the global `.dark .bg-card` rule adds `backdrop-filter: blur(32px) saturate(180%)`.

So the tab let the content behind it show through. The composer directly below it deliberately opts out with `dark:bg-card-solid` (opaque `#181f25`); the pin's own comment claimed "composer-matching bg" but it didn't match — that mismatch was the bug.

## Fix

Swap the tab's surface from `bg-card` to `bg-card-solid` — the token documented as the opaque form of `--card`, "for card surfaces that must fully hide" what's behind. This:
- makes the pill opaque in dark mode (all viewports), and
- by not matching the `.dark .bg-card` glass rule, lets the tab's `border-b-0` actually merge flush into the composer (that rule's `border` shorthand was otherwise re-adding a bottom edge).

Light mode is unchanged — `--card` and `--card-solid` are both `#fff`.

Per design, the sticky/floating behavior is intentionally left as-is; this PR only addresses the translucency.

## Verification

Rendered the real pin (`BrandLogo` + `Shimmer`, exact tab markup) over real assistant prose in dark mode (see above): with `bg-card` the text is visible through the chip; with `bg-card-solid` it's opaque. No test asserts on the pin's background token (`ChatPage.indicators.test.tsx` and siblings are unaffected).

This pull request and its description were written by Isaac.
