### PR TITLE
fix(web): honour IME composition in the terminal pane

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -147,6 +147,19 @@ describe("shouldEchoSynchronously", () => {
     expect(shouldEchoSynchronously(SYNC_ECHO_MAX_BYTES + 1, 10)).toBe(false);
     expect(shouldEchoSynchronously(SYNC_ECHO_MAX_BYTES, 10)).toBe(true);
   });
+
+  it("stays async while an IME composition is in flight", () => {
+    // A same-task repaint over an uncommitted preedit is a paint xterm's
+    // composition handling never sees from stock `write`. The chunk here is
+    // otherwise a perfect fast-path candidate, so only `composing` can hold
+    // it back.
+    expect(shouldEchoSynchronously(64, 10, true)).toBe(false);
+    expect(shouldEchoSynchronously(64, 10, false)).toBe(true);
+  });
+
+  it("defaults to not composing so existing callers are unaffected", () => {
+    expect(shouldEchoSynchronously(64, 10)).toBe(true);
+  });
 });
 
 describe("loadWebglRenderer", () => {
@@ -222,6 +235,31 @@ describe("terminalKeyEventPayload", () => {
     expect(
       terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, altKey: true })),
     ).toBeNull();
+  });
+
+  it("claims nothing while an IME composition is in flight", () => {
+    // xterm consults the custom handler BEFORE its own composition check and
+    // returns early when the handler returns false
+    // (`CoreBrowserTerminal._keyDown`), so claiming this key here is the last
+    // word: the IME never sees it and a CSI-u sequence reaches the PTY
+    // mid-conversion.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, isComposing: true })),
+    ).toBeNull();
+  });
+
+  it("claims nothing for the keyCode 229 composition fallback", () => {
+    // Browsers/IMEs that report the composition only via the legacy keyCode.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, keyCode: 229 })),
+    ).toBeNull();
+  });
+
+  it("still encodes Shift+Enter once the composition has ended", () => {
+    // The guard must not cost the feature outside composition.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, isComposing: false })),
+    ).toBe(SHIFT_ENTER_CSI_U);
   });
 });
 
@@ -627,5 +665,145 @@ describe("TerminalSession", () => {
     const observer = FakeResizeObserver.instances[0];
     expect(observer.observed).toContain(container);
     session.dispose();
+  });
+
+  // IME composition, driven through the real wiring rather than the pure
+  // helpers: these dispatch composition and key events at the textarea xterm
+  // actually listens on, so they also fail if xterm stops routing keydown
+  // through the custom handler, or stops handing us a textarea at all.
+  describe("IME composition", () => {
+    const DECODER = new TextDecoder();
+
+    /** The hidden textarea xterm created for keyboard input. */
+    function textareaOf(container: HTMLElement): HTMLTextAreaElement {
+      const textarea = container.querySelector("textarea");
+      // Not a soft assertion: without it the composition listeners are never
+      // registered and every test below would pass for the wrong reason.
+      expect(textarea).not.toBeNull();
+      return textarea as HTMLTextAreaElement;
+    }
+
+    /**
+     * Binary frames the session sent, decoded back to strings.
+     *
+     * Frames are selected by *not* being a string rather than by `instanceof
+     * Uint8Array`: `TextEncoder` here yields a `Uint8Array` from a different
+     * realm than jsdom's, so `instanceof` is `false` for every keystroke frame
+     * and an `instanceof` filter silently returns nothing at all.
+     */
+    function sentText(socket: { sent: (string | Uint8Array)[] }): string[] {
+      return socket.sent
+        .filter((frame): frame is Uint8Array => typeof frame !== "string")
+        .map((frame) => DECODER.decode(frame));
+    }
+
+    function keydown(init: KeyboardEventInit): KeyboardEvent {
+      return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+    }
+
+    it("does not claim Shift+Enter while a composition is in flight", () => {
+      // WHY: xterm consults this handler before its own CompositionHelper and
+      // returns early when we claim the key, so claiming it here skips the
+      // commit that CompositionHelper.keydown would have performed — the
+      // converted text is dropped and CSI-u goes out in its place. Driven
+      // through the real textarea so the test also fails if xterm stops
+      // routing keydown through the custom handler.
+      const { container, socket, session } = makeSession();
+      socket.open();
+      const textarea = textareaOf(container);
+
+      textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+      textarea.dispatchEvent(
+        keydown({ key: "Enter", shiftKey: true, keyCode: 13, isComposing: true }),
+      );
+
+      expect(sentText(socket)).not.toContain(SHIFT_ENTER_CSI_U);
+      session.dispose();
+    });
+
+    it("claims Shift+Enter again once the composition has ended", () => {
+      // WHY: the guard must cost nothing outside composition, and the flag has
+      // to actually clear on compositionend.
+      const { container, socket, session } = makeSession();
+      socket.open();
+      const textarea = textareaOf(container);
+
+      textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+      textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "日本語" }));
+      textarea.dispatchEvent(keydown({ key: "Enter", shiftKey: true, keyCode: 13 }));
+
+      expect(sentText(socket)).toContain(SHIFT_ENTER_CSI_U);
+      session.dispose();
+    });
+
+    /** xterm's private synchronous write, reached the same way the code does. */
+    function writeSyncOf(session: TerminalSession) {
+      const withCore = session as unknown as {
+        term: { _core: { writeSync: (b: Uint8Array) => void } };
+      };
+      // eslint-disable-next-line no-underscore-dangle
+      return withCore.term._core;
+    }
+
+    it("keeps inbound output on the async write path while composing", () => {
+      // WHY: the fast path is a same-task repaint through xterm's private
+      // writeSync, which its composition handling never sees. The chunk is
+      // small and lands right after a keystroke, so only the composition can
+      // hold it back.
+      const { container, socket, session } = makeSession();
+      socket.open();
+      const textarea = textareaOf(container);
+      const writeSpy = vi.spyOn(Terminal.prototype, "write");
+      const syncSpy = vi.spyOn(writeSyncOf(session), "writeSync");
+
+      // Arm the echo window the way a keystroke does, then start composing.
+      // keyCode matters: without it xterm produces no data for the key, onData
+      // never fires, and the window this test depends on is never opened.
+      textarea.dispatchEvent(keydown({ key: "a", keyCode: 65 }));
+      textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+      // Only the inbound frame below should count towards either spy.
+      writeSpy.mockClear();
+      syncSpy.mockClear();
+      socket.emit("message", { data: new Uint8Array([0x61]).buffer });
+
+      expect(syncSpy).not.toHaveBeenCalled();
+      expect(writeSpy).toHaveBeenCalled();
+      session.dispose();
+    });
+
+    it("still takes the fast path for an echo when not composing", () => {
+      // WHY: pins that the test above measures composition rather than a build
+      // where writeSync is simply unavailable — the identical chunk must go
+      // the fast way with no composition in flight.
+      const { container, socket, session } = makeSession();
+      socket.open();
+      const textarea = textareaOf(container);
+      const syncSpy = vi.spyOn(writeSyncOf(session), "writeSync");
+
+      textarea.dispatchEvent(keydown({ key: "a", keyCode: 65 }));
+      syncSpy.mockClear();
+      socket.emit("message", { data: new Uint8Array([0x61]).buffer });
+
+      expect(syncSpy).toHaveBeenCalled();
+      session.dispose();
+    });
+
+    it("stops tracking composition after dispose", () => {
+      // WHY: the listeners share the session's AbortController, so a remount
+      // must not leave a disposed session mutating state from a live textarea.
+      const { container, socket, session } = makeSession();
+      socket.open();
+      const textarea = textareaOf(container);
+      const state = session as unknown as { composing: boolean };
+
+      textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+      expect(state.composing).toBe(true); // listener is live before dispose
+      textarea.dispatchEvent(new CompositionEvent("compositionend"));
+
+      session.dispose();
+      textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+
+      expect(state.composing).toBe(false); // the abort signal removed it
+    });
   });
 });

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -15,6 +15,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { codeFontFamilyForEditor, readCodeFont } from "@/lib/codeFontPreferences";
+import { isImeCompositionNativeKeyEvent } from "@/lib/ime";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -171,11 +172,34 @@ export const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
  * CSI-u while keeping plain Enter and modified Enter variants on xterm's
  * default path.
  *
+ * An event the IME is composing on is never claimed. xterm consults this
+ * handler *before* its own composition handling and returns early when it
+ * claims the event (``CoreBrowserTerminal._keyDown``), so claiming here is the
+ * last word: the key never reaches ``CompositionHelper.keydown``, which would
+ * otherwise have swallowed it or committed the pending text first. The
+ * composed text is dropped and a stray CSI-u sequence reaches the PTY instead.
+ *
+ * The check reads the event's own flags and nothing else, deliberately.
+ * xterm's ``CompositionHelper`` gates on two private fields —
+ * ``_isComposing`` and an ``_isSendingComposition`` that stays set for one
+ * macrotask after ``compositionend`` while the committed text is dispatched —
+ * and mirroring that state machine from the outside gets it wrong in both
+ * directions: a keystroke inside the sending window would be claimed too
+ * eagerly, and a composition that xterm finalizes *without* a
+ * ``compositionend`` (``CompositionHelper.keydown`` does exactly that when a
+ * non-composition key interrupts) would leave a mirrored flag stuck, silently
+ * disabling Shift+Enter. Reading the event only is monotonic: strictly fewer
+ * wrong claims than before, never more, and no state to desynchronise. Keys
+ * that arrive without the flags set — the commit key can report ``keyCode``
+ * 13 — are therefore still claimed; closing that needs xterm's own state and
+ * is left to a follow-up.
+ *
  * :param event: Browser keyboard event from xterm's custom key handler.
  * :returns: CSI-u bytes for Shift+Enter, or ``null`` to let xterm handle
  *     the event normally.
  */
 export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
+  if (isImeCompositionNativeKeyEvent(event)) return null;
   if (
     event.key === "Enter" &&
     event.shiftKey &&
@@ -212,13 +236,35 @@ export const SYNC_ECHO_MAX_BYTES = 2048;
  * can't monopolize the main thread. Mirrors openui's terminal input fast
  * path.
  *
+ * An in-flight IME composition takes the fast path out of play. This is a
+ * same-task repaint that stock xterm never performs, so xterm's composition
+ * handling — which keeps the uncommitted preedit in a ``.composition-view``
+ * overlay repositioned from ``onRender`` — has never been exercised against
+ * it. That is the argument for standing down here, not a claim that the
+ * overlay is provably torn: reported IME corruption in this pane tracks
+ * exactly the window this function gates, and the async queue is the only
+ * write path xterm itself uses. Deferring while composing costs a frame of
+ * echo latency on a keystroke that has not been committed yet.
+ *
+ * Note that composition state cannot be derived from *msSinceLastInput*:
+ * ``onData`` stays silent for the whole composition and fires once on commit,
+ * so the timestamp still refers to the keystroke *before* the composition
+ * began — which is exactly why a fast typist stays inside the window and a
+ * slow one falls out of it.
+ *
  * Pure helper — exported for direct unit testing.
  *
  * :param byteLength: Size of the inbound chunk in bytes.
  * :param msSinceLastInput: Milliseconds since the last user keystroke.
+ * :param composing: Whether an IME composition is currently in flight.
  * :returns: ``true`` to take the synchronous echo path.
  */
-export function shouldEchoSynchronously(byteLength: number, msSinceLastInput: number): boolean {
+export function shouldEchoSynchronously(
+  byteLength: number,
+  msSinceLastInput: number,
+  composing = false,
+): boolean {
+  if (composing) return false;
   return msSinceLastInput < SYNC_ECHO_WINDOW_MS && byteLength <= SYNC_ECHO_MAX_BYTES;
 }
 
@@ -444,6 +490,8 @@ export class TerminalSession {
   private readonly dataDispose: { dispose: () => void };
   /** ``performance.now()`` of the last keystroke; gates the echo fast path. */
   private lastUserInputAt = 0;
+  /** Whether an IME composition is in flight; disables the echo fast path. */
+  private composing = false;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
   private disposed = false;
   /**
@@ -541,6 +589,30 @@ export class TerminalSession {
     // closed" overlay on top of the freshly-connecting terminal.
     this.listenerCtl = new AbortController();
     const { signal } = this.listenerCtl;
+
+    // Follow IME composition to gate the echo fast path (see
+    // {@link writeOutput}) — and only that path, never the key handler, whose
+    // reasoning for reading the event instead is in
+    // {@link terminalKeyEventPayload}. These events fire on the hidden textarea
+    // xterm keeps for keyboard input; subscribing alongside xterm's own
+    // listeners is fine, they are independent. `textarea` is typed optional (it
+    // does not exist before `open()`, called above), so an absent one simply
+    // leaves the fast path as it was.
+    //
+    // This flag is an imperfect mirror of xterm's private composition state,
+    // and it is used only where being wrong is cheap. It can over-report:
+    // xterm also finalizes a composition without emitting `compositionend`
+    // (`CompositionHelper.keydown`, when a non-composition key interrupts),
+    // leaving this `true` until the next one. That costs a frame of echo
+    // latency and nothing else. `blur` is deliberately *not* followed, which
+    // would be the other direction: xterm's blur handler does not finalize the
+    // composition (`CoreBrowserTerminal._handleTextAreaBlur`), so clearing
+    // there would re-arm the fast path under a live preedit.
+    const { textarea } = this.term;
+    if (textarea) {
+      textarea.addEventListener("compositionstart", () => (this.composing = true), { signal });
+      textarea.addEventListener("compositionend", () => (this.composing = false), { signal });
+    }
 
     // Make the browser copy gesture (right-click → Copy and Edit → Copy on
     // every platform, ⌘C on macOS) yield the terminal selection as text.
@@ -733,9 +805,19 @@ export class TerminalSession {
    * future xterm that drops it — falls back to the async public ``write``.
    * Correctness never depends on the private API; it only shaves a frame
    * off the echo when present.
+   *
+   * The same reasoning applies to an IME composition, which also takes the
+   * fast path out of play: correctness should not rest on a private
+   * same-task write that xterm's own composition handling never sees.
    */
   private writeOutput(bytes: Uint8Array): void {
-    if (shouldEchoSynchronously(bytes.length, performance.now() - this.lastUserInputAt)) {
+    if (
+      shouldEchoSynchronously(
+        bytes.length,
+        performance.now() - this.lastUserInputAt,
+        this.composing,
+      )
+    ) {
       // eslint-disable-next-line no-underscore-dangle
       const core = (this.term as unknown as TerminalCore)._core;
       if (typeof core?.writeSync === "function") {

--- a/web/src/lib/ime.test.ts
+++ b/web/src/lib/ime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isImeCompositionKeyEvent } from "./ime";
+import { isImeCompositionKeyEvent, isImeCompositionNativeKeyEvent } from "./ime";
 
 function keyEvent(nativeEvent: { isComposing?: boolean; keyCode?: number }) {
   return { nativeEvent };
@@ -20,5 +20,42 @@ describe("isImeCompositionKeyEvent", () => {
 
   it("returns false for ordinary key events", () => {
     expect(isImeCompositionKeyEvent(keyEvent({ isComposing: false, keyCode: 13 }))).toBe(false);
+  });
+});
+
+describe("isImeCompositionNativeKeyEvent", () => {
+  it("reads the IME flags straight off a native KeyboardEvent", () => {
+    // The React-shaped sibling cannot be used from a DOM listener: there is
+    // no `nativeEvent` to unwrap.
+    expect(
+      isImeCompositionNativeKeyEvent(new KeyboardEvent("keydown", { isComposing: true })),
+    ).toBe(true);
+    expect(isImeCompositionNativeKeyEvent(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps the keyCode 229 fallback for browsers that leave isComposing unset", () => {
+    expect(isImeCompositionNativeKeyEvent({ keyCode: 229 })).toBe(true);
+  });
+
+  it("honours a caller-tracked composition flag", () => {
+    // For callers that follow compositionstart/end themselves and see a key
+    // event whose own flags say nothing.
+    expect(isImeCompositionNativeKeyEvent({}, true)).toBe(true);
+  });
+
+  it("agrees with the React-shaped check on the same flags", () => {
+    // One predicate, two shapes: the two must never drift apart.
+    for (const flags of [
+      {},
+      { isComposing: true },
+      { keyCode: 229 },
+      { isComposing: false, keyCode: 13 },
+    ]) {
+      expect(isImeCompositionNativeKeyEvent(flags)).toBe(
+        isImeCompositionKeyEvent({ nativeEvent: flags }),
+      );
+    }
   });
 });

--- a/web/src/lib/ime.ts
+++ b/web/src/lib/ime.ts
@@ -1,16 +1,36 @@
 const IME_PROCESSING_KEY_CODE = 229;
 
+interface ImeKeyFlags {
+  isComposing?: boolean;
+  keyCode?: number;
+}
+
 interface ImeKeyboardEvent {
-  nativeEvent: {
-    isComposing?: boolean;
-    keyCode?: number;
-  };
+  nativeEvent: ImeKeyFlags;
+}
+
+function hasImeCompositionFlags(flags: ImeKeyFlags): boolean {
+  return flags.isComposing === true || flags.keyCode === IME_PROCESSING_KEY_CODE;
 }
 
 export function isImeCompositionKeyEvent(event: ImeKeyboardEvent, isComposing = false): boolean {
-  return (
-    isComposing ||
-    event.nativeEvent.isComposing === true ||
-    event.nativeEvent.keyCode === IME_PROCESSING_KEY_CODE
-  );
+  return isComposing || hasImeCompositionFlags(event.nativeEvent);
+}
+
+/**
+ * The same check for a native ``KeyboardEvent`` instead of React's wrapper.
+ *
+ * xterm's custom key handler is a plain DOM listener, so it receives the
+ * native event and cannot call {@link isImeCompositionKeyEvent}, whose
+ * parameter is React-shaped (``event.nativeEvent``). Both entry points share
+ * one predicate so the ``keyCode === 229`` fallback — still needed for IMEs
+ * and browsers that leave ``isComposing`` unset on keydown — is defined once.
+ *
+ * :param event: A native ``KeyboardEvent`` (only the IME flags are read).
+ * :param isComposing: Caller-tracked composition state, for callers that
+ *     follow ``compositionstart`` / ``compositionend`` themselves.
+ * :returns: ``true`` when the keystroke belongs to an in-flight composition.
+ */
+export function isImeCompositionNativeKeyEvent(event: ImeKeyFlags, isComposing = false): boolean {
+  return isComposing || hasImeCompositionFlags(event);
 }


### PR DESCRIPTION
## Related issue

Closes #4964

## Summary

The Terminal view's xterm pane never looked at IME composition state — `grep -iE 'composition|isComposing|ime'` over `TerminalSession.ts` returned nothing, while three React inputs in the same app already guard for it. Two things went wrong as a result, and this fixes both.

- **Shift+Enter was claimed out from under an active composition, dropping the composed text.** `terminalKeyEventPayload` now returns `null` when the event says a composition is in flight, so the key stays with the IME.
- **The synchronous echo path repainted while a preedit was uncommitted.** `shouldEchoSynchronously` now refuses the same-task `writeSync` fast path while composing and falls back to the async queue.

**ELI5.** Typing Japanese in the Terminal pane garbles the input — characters run together or double up — but only when you type quickly. Two causes: a key the IME needed was being stolen, and the terminal was repainting itself in the middle of an unconfirmed conversion. Both now stand down until the composition commits.

Why claiming that key loses text rather than merely being rude: xterm consults the custom key handler **before** its own composition handling and returns early when it returns `false` (`@xterm/xterm@6.0.0`, `src/browser/CoreBrowserTerminal.ts`, `_keyDown`):

```ts
if (this._customKeyEventHandler && this._customKeyEventHandler(event) === false) {
  return false;                                    // ← we win here
}
// …
if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
  return false;                                    // ← never reached
}
```

and the `CompositionHelper.keydown` that gets skipped is what **commits the pending text** before a non-composition key is processed:

```ts
if (this._isComposing || this._isSendingComposition) {
  if (ev.keyCode === 20 || ev.keyCode === 229) { return false; }
  if (ev.keyCode === 16 || ev.keyCode === 17 || ev.keyCode === 18) { return false; }
  // Finish composition immediately. This is mainly here for the case where enter is
  // pressed and the handler needs to be triggered before the command is executed.
  this._finalizeComposition(false);
}
```

So the converted text is never sent at all, and a CSI-u sequence goes out in its place.

And why the timing gate matters for the second one:

```mermaid
flowchart TD
    A[keystroke commits] --> B[onData fires<br/>lastUserInputAt = now]
    B --> C[composition starts<br/>onData stays silent until commit]
    C --> D{inbound chunk:<br/>within 750 ms of<br/>lastUserInputAt?}
    D -->|fast typist: yes| E[BEFORE: same-task writeSync<br/>repaints over the live preedit]
    D -->|slow typist: no| F[async write — the path xterm's<br/>composition handling expects]
    E --> G[AFTER: composing short-circuits<br/>the fast path, so both go to F]
```

`onData` is silent for the whole composition and fires once on commit, so `lastUserInputAt` still refers to the keystroke *before* the composition began. That is why the window is open for a fast typist and expired for a slow one — and why composition state cannot be inferred from the timestamp.

### The two decisions use different signals, on purpose

The session tracks `compositionstart` / `compositionend` on `term.textarea`, and that tracked flag feeds **only** the echo decision. The key decision reads the event's own flags instead. The asymmetry is deliberate, because the cost of being wrong is not symmetric:

|  | over-reports composition | under-reports composition |
|---|---|---|
| echo fast path | one frame of extra echo latency | the bug this PR fixes |
| Shift+Enter guard | the feature silently stops working | a key is stolen from the IME |

A mirror built from the two public events gets the key decision wrong in *both* directions. xterm's `CompositionHelper` gates on two private fields: `_isComposing`, and an `_isSendingComposition` that stays set for one macrotask after `compositionend` while the committed text is dispatched from a `setTimeout(…, 0)`. It also finalizes a composition **without** emitting `compositionend` at all — the `keydown` path quoted above does exactly that. So a mirror under-reports inside the sending window and sticks `true` after an interrupted composition, at which point Shift+Enter quietly stops working until the next clean `compositionend`.

Reading the event's own flags for the key decision is monotonic instead: strictly fewer wrong claims than today, never more, and no state that can desynchronise. The residual case is a commit key that arrives with the flags unset (an Enter reported as `keyCode` 13) — still claimed, as today. Closing that needs xterm's own composition state, so I have left it rather than guess; if you would rather expose that state, or consult the custom key handler *after* `CompositionHelper.keydown`, that is the cleaner fix and I am happy to follow up.

Notes on the shape:

- `web/src/lib/ime.ts` already owned this predicate, including the `keyCode === 229` fallback, but its parameter is React-shaped (`event.nativeEvent`) and xterm's handler is a plain DOM listener. Rather than duplicate the `229` constant, the inner predicate is factored out and a native-shaped sibling added. `isImeCompositionKeyEvent` keeps its exact signature and behaviour, so `ChatPage.tsx`, `NewChatDialog.tsx`, and `Sidebar.tsx` are untouched — a test asserts the two shapes never drift apart.
- `shouldEchoSynchronously`'s new `composing` parameter defaults to `false`, so every existing call site and test reads the same.
- `term.textarea` is public API (`xterm.d.ts`: `readonly textarea: HTMLTextAreaElement | undefined`) and typed optional, so the guard around it is required rather than merely defensive. Listeners share the existing `AbortController` signal, so `dispose()` removes them for free.
- **No `blur` listener, deliberately.** xterm's blur handler does not finalize the composition (`_handleTextAreaBlur`), so clearing the flag there would claim "not composing" while xterm still says it is, re-arming the fast path under a live preedit.
- Only the private `writeSync` bypass is suppressed. The async `write()` path is unchanged, which is the point: it is the write path xterm itself uses.

Users who never touch an IME see no change: both guards are no-ops unless a composition is in flight, and the fast path stays exactly as tuned.

## Test Plan

```bash
cd web
pnpm vitest run src/lib/ime.test.ts src/components/blocks/TerminalSession.test.ts
#  Test Files  2 passed (2)
#       Tests  53 passed (53)

pnpm type-check                                        # clean
pnpm lint                                              # oxlint, clean
./node_modules/.bin/prettier --check <changed files>   # clean
```

Five of the new tests are integration tests rather than pure-function ones: they reuse the existing `makeSession()` harness and dispatch real `CompositionEvent`s and `KeyboardEvent`s at the textarea xterm actually listens on, so they also fail if xterm stops routing keydown through the custom handler or stops handing us a textarea. They cover: Shift+Enter not being claimed mid-composition, being claimed again after `compositionend`, inbound output staying on the async path while composing, the identical chunk still taking the fast path when *not* composing, and the listeners going away on `dispose()`.

**Both guards were mutation-tested**, because a test that cannot fail is worse than none:

| mutation | tests that fail |
|---|---|
| drop the composition guard in `terminalKeyEventPayload` | *claims nothing while an IME composition is in flight*, *claims nothing for the keyCode 229 composition fallback*, and the integration test *does not claim Shift+Enter while a composition is in flight* — the CSI-u frame appears on the socket |
| `writeOutput`'s `this.composing` → `false` | *keeps inbound output on the async write path while composing* — `writeSync` is called once |

Pure-function tests cover the remaining branches: both composition signals (`isComposing` and the legacy `keyCode === 229`), Shift+Enter still encoding outside composition, the `composing` default keeping existing callers unaffected, the native predicate reading flags straight off a `KeyboardEvent`, and an equivalence test pinning the React-shaped and native-shaped predicates to the same answer.

Full-suite note, stated plainly: `pnpm vitest run` reports 46 failed files / 912 failed tests on this machine both **with and without** this change (verified by stashing it and re-running: 912 failed either way, only the passed count moving by the tests added here). They are environmental — this checkout is on Node 25, where a built-in `localStorage` shadows jsdom's and every affected test dies on `window.localStorage.removeItem is not a function`; CONTRIBUTING asks for Node 22 LTS. Nothing in that set is touched by these files.

Everything asserted about xterm above was read out of `@xterm/xterm@6.0.0` in `node_modules` rather than assumed: the evaluation order, `CompositionHelper`'s commit-on-interrupt behaviour, the `_isSendingComposition` window and its `setTimeout`, the `.composition-view` overlay, and `textarea` being public API.

## Demo

This change has no visual surface — no pixels move; it changes which keystrokes reach the PTY and which write path paints. A recording would show Japanese text being typed into the Terminal pane cleanly instead of garbling, which needs a Japanese IME to produce; happy to attach a screen recording if a reviewer wants it. The mechanical half is demonstrable without an IME and is what the integration tests above assert.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the garbling in the Terminal pane on 0.9.0 (Chrome / macOS, Japanese IME) and confirmed the fast-vs-slow split that the 750 ms gate predicts. Both fixes are additionally pinned by the integration tests and the mutation checks above, so the manual pass is corroboration rather than the only evidence.

One incidental finding worth flagging for future tests in this file: `FakeWebSocket.sent` is typed `(string | Uint8Array)[]`, but `TextEncoder` here yields a `Uint8Array` from a different realm than jsdom's, so `frame instanceof Uint8Array` is `false` for every keystroke frame. An `instanceof` filter silently returns nothing and makes such a test pass for the wrong reason — I hit exactly that while writing these, which is how the mutation checks earned their place. The helper selects frames by *not* being a string and says why.

## Changelog

Typing with a Japanese or Chinese IME in the Terminal view no longer garbles input mid-conversion.
