### PR TITLE
fix(db): report database-ahead-of-client instead of a bogus upgrade path

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -475,6 +475,22 @@ def _get_head_db_revision(db_uri: str) -> str:
     return head
 
 
+def _revision_unknown_to_this_client(revision: str, db_uri: str) -> bool:
+    """
+    Whether *revision* exists in this build's migrations at all.
+
+    A revision recorded by a newer omnigent build is absent from this
+    build's script map; detecting that distinguishes "database ahead of
+    the client" (fix: upgrade the client) from "database behind" (fix:
+    migrate), which share only the ``current != head`` observable.
+    """
+    from alembic.script import ScriptDirectory
+
+    config = _build_alembic_config(db_uri)
+    script = ScriptDirectory.from_config(config)
+    return revision not in {rev.revision for rev in script.walk_revisions()}
+
+
 def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     """
     Bring a fresh or stale database to head before the server starts.
@@ -503,6 +519,22 @@ def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     if current is None:
         _run_migrations(engine, db_uri)
         return
+
+    if current != head and _revision_unknown_to_this_client(current, db_uri):
+        # A database written by a NEWER omnigent contains revisions this
+        # build's migrations cannot name, so the automatic upgrade below
+        # cannot resolve it -- Alembic fails with "Can't locate revision"
+        # and the generic handler misreports that as a stale schema with
+        # retry advice that can never work. Say what actually happened
+        # (#4963).
+        raise RuntimeError(
+            f"Omnigent database schema was written by a newer omnigent "
+            f"(found revision {current!r}, this build only knows up to {head!r}). "
+            f"Upgrade omnigent to a version at or beyond the one that wrote "
+            f"this database, then try again. (Running an older omnigent against "
+            f"a newer database is unsupported; the suggested db-upgrade cannot "
+            f"resolve revisions this build does not contain.)"
+        )
 
     if current != head:
         _logger.warning(

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,47 @@
+
+def test_schema_ahead_of_client_reports_upgrade_client() -> None:
+    """A database written by a NEWER omnigent (revision absent from this
+    build) must not be misreported as stale with retry advice that cannot
+    run — Alembic cannot resolve the unknown revision (#4963)."""
+    from omnigent.db import utils as db_utils
+
+    # Drive _initialize_or_verify_schema with stubs: current revision is
+    # unknown to the script map (written by a newer build).
+    calls = {"migrated": False}
+
+    def _fake_head(uri):
+        return "f7a8b9c0d1e2"
+
+    def _fake_current(eng):
+        return "za2b3c4d5e6f"
+
+    def _fake_unknown(rev, uri):
+        return True
+
+    def _fail_migrate(*a, **k):
+        calls["migrated"] = True
+        raise AssertionError("upgrade must not be attempted for an unknown revision")
+
+    orig_head, orig_cur = db_utils._get_head_db_revision, db_utils._get_current_db_revision
+    orig_unknown = getattr(db_utils, "_revision_unknown_to_this_client", None)
+    orig_migrate = db_utils._run_migrations
+    db_utils._get_head_db_revision = _fake_head
+    db_utils._get_current_db_revision = _fake_current
+    if orig_unknown is not None:
+        db_utils._revision_unknown_to_this_client = _fake_unknown
+    db_utils._run_migrations = _fail_migrate
+    try:
+        import pytest
+
+        with pytest.raises(RuntimeError) as excinfo:
+            db_utils._initialize_or_verify_schema(None, "sqlite:///:memory:")
+        msg = str(excinfo.value)
+        assert "newer omnigent" in msg
+        assert "Upgrade omnigent" in msg
+        assert calls["migrated"] is False, "no migration may be attempted"
+    finally:
+        db_utils._get_head_db_revision = orig_head
+        db_utils._get_current_db_revision = orig_cur
+        if orig_unknown is not None:
+            db_utils._revision_unknown_to_this_client = orig_unknown
+        db_utils._run_migrations = orig_migrate


### PR DESCRIPTION
## Summary

Fixes #4963.

## Root cause (as diagnosed in the issue, verified)

`_initialize_or_verify_schema` handles three cases — fresh DB, at head, behind head — but not **ahead**: a database already migrated by a newer omnigent falls into the behind-head branch, the automatic upgrade crashes with `Can't locate revision 'za2b3c4d5e6f'` (that revision doesn't exist in this build), and the generic handler misreports *"schema is out of date"* with `db-upgrade` advice that re-runs the same impossible upgrade and crashes again with the Alembic `CommandError` escaping to the crash reporter.

## Fix — the missing fourth case

A new `_revision_unknown_to_this_client(revision, db_uri)` check (membership against `ScriptDirectory.walk_revisions()`) distinguishes "database ahead of the client" from "database behind" — they share only the `current != head` observable. When the current revision is unknown to this build:

- raise **immediately** with the truthful diagnosis — the database was written by a newer omnigent; upgrade the client — explicitly noting the `db-upgrade` suggestion cannot resolve revisions this build doesn't contain;
- **no migration is attempted** (the old path would have run the impossible upgrade).

The behind-head, at-head, and fresh-DB paths are byte-for-byte unchanged.

## Test

`test_schema_ahead_of_client_reports_upgrade_client` drives the exact scenario with stubs (current = unknown revision, script head earlier) and asserts the new message and that the stubbed `_run_migrations` is **never invoked** — on `main`, that stub fires (the bug) and the test errors. Behind-head behavior is covered by the existing migration suite.
