### PR TITLE
fix(db): diagnose a database newer than the client instead of stale

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9915,11 +9915,24 @@ def debug_db_upgrade(url: str) -> None:
     """
     from sqlalchemy import create_engine
 
-    from omnigent.db.utils import _run_migrations
+    from omnigent.db.utils import (
+        _database_ahead_of_build_message,
+        _get_current_db_revision,
+        _get_head_db_revision,
+        _revision_is_known,
+        _run_migrations,
+    )
 
     click.echo(f"Upgrading {url} ...")
     engine = create_engine(url)
     try:
+        # A database written by a newer omnigent has no upgrade path
+        # here; Alembic would raise an unresolvable-revision error.
+        current = _get_current_db_revision(engine)
+        if current is not None and not _revision_is_known(url, current):
+            raise click.ClickException(
+                _database_ahead_of_build_message(current, _get_head_db_revision(url))
+            )
         _run_migrations(engine, url)
     finally:
         engine.dispose()

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -475,16 +475,67 @@ def _get_head_db_revision(db_uri: str) -> str:
     return head
 
 
+def _revision_is_known(db_uri: str, revision: str) -> bool:
+    """
+    Report whether *revision* exists in our migrations directory.
+
+    A revision recorded in ``alembic_version`` that this build has
+    never heard of means the database was migrated by a newer
+    omnigent, which Alembic cannot upgrade from — it has no path to
+    start walking.
+
+    :param db_uri: Database URL — only used to build an Alembic
+        ``Config`` pointing at our scripts directory.
+    :param revision: Revision hash read from the database.
+    :returns: ``True`` if the revision resolves against our scripts.
+    """
+    from alembic.script import ScriptDirectory
+    from alembic.script.revision import RevisionError
+    from alembic.util.exc import CommandError
+
+    script = ScriptDirectory.from_config(_build_alembic_config(db_uri))
+    try:
+        # get_revision re-raises resolution failures as CommandError.
+        script.get_revision(revision)
+    except (RevisionError, CommandError):
+        return False
+    return True
+
+
+def _database_ahead_of_build_message(current: str, head: str) -> str:
+    """
+    Explain that the database was written by a newer omnigent.
+
+    Deliberately does not suggest ``omnigent debug db-upgrade``: that
+    command cannot resolve *current* either, so it would fail the same
+    way and send the operator in a circle.
+
+    :param current: Revision recorded in the database.
+    :param head: Head revision this build ships.
+    :returns: The operator-facing error message.
+    """
+    return (
+        f"Omnigent database is at revision {current!r}, which this build does not "
+        f"recognize (its latest revision is {head!r}). The database was created by "
+        f"a newer omnigent and cannot be migrated backwards to match this build. "
+        f"Upgrade omnigent to a version that includes revision {current!r}, or "
+        f"point this one at a different database."
+    )
+
+
 def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     """
     Bring a fresh or stale database to head before the server starts.
 
-    Three cases:
+    Four cases:
 
     - **Fresh DB** (no ``alembic_version`` table) — run migrations to
       head. This covers brand-new SQLite files and freshly created
       Postgres schemas.
     - **At head** — no-op.
+    - **Ahead of head** — the database records a revision this build
+      does not ship, so it was written by a newer omnigent. Fail with
+      that diagnosis; no migration can help.
     - **Behind head** — log a warning, attempt an automatic Alembic
       upgrade to head, then verify that the database reached head.
       If the migration fails, re-raise with context so the server
@@ -494,8 +545,8 @@ def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     :param engine: SQLAlchemy engine bound to the target database.
     :param db_uri: Database URL, used both for Alembic config and in
         any migration-failure error message.
-    :raises RuntimeError: If automatic schema migration fails or does
-        not bring the database to head.
+    :raises RuntimeError: If the database is ahead of this build, or if
+        automatic schema migration fails or does not reach head.
     """
     head = _get_head_db_revision(db_uri)
     current = _get_current_db_revision(engine)
@@ -503,6 +554,9 @@ def _initialize_or_verify_schema(engine: Engine, db_uri: str) -> None:
     if current is None:
         _run_migrations(engine, db_uri)
         return
+
+    if current != head and not _revision_is_known(db_uri, current):
+        raise RuntimeError(_database_ahead_of_build_message(current, head))
 
     if current != head:
         _logger.warning(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -325,6 +325,43 @@ def test_debug_logs_host_daemon_alias_reads_host_destination(
     assert "host log" in result.output
 
 
+def test_debug_db_upgrade_explains_database_written_by_newer_build(
+    tmp_path: Path,
+) -> None:
+    """
+    ``debug db-upgrade`` on a database ahead of this build exits with an
+    explanation rather than an Alembic traceback.
+
+    Alembic cannot resolve a revision it does not ship, so the upgrade
+    used to abort with an uncaught ``CommandError`` that reached the
+    crash reporter.
+    """
+    from alembic import command
+    from sqlalchemy import create_engine, text
+
+    from omnigent.db.utils import _build_alembic_config
+
+    uri = f"sqlite:///{tmp_path / 'ahead.db'}"
+    engine = create_engine(uri)
+    try:
+        config = _build_alembic_config(uri)
+        with engine.begin() as conn:
+            config.attributes["connection"] = conn
+            command.upgrade(config, "head")
+        # Stands in for a revision from a future release.
+        with engine.begin() as conn:
+            conn.execute(text("UPDATE alembic_version SET version_num = 'ffffffffffff'"))
+    finally:
+        engine.dispose()
+
+    result = CliRunner().invoke(cli, ["debug", "db-upgrade", uri])
+
+    assert result.exit_code == 1, result.output
+    assert "ffffffffffff" in result.output, result.output
+    assert "newer omnigent" in result.output, result.output
+    assert "Traceback" not in result.output, result.output
+
+
 def _fake_run_claude_native_capture(
     captured: dict[str, object],
 ) -> Callable[..., None]:

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -475,6 +475,7 @@ def test_revision_is_known_distinguishes_shipped_and_unknown_revisions(
 
 def test_initialize_or_verify_schema_rejects_db_ahead_of_build(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     A database stamped with a revision this build does not ship is
@@ -483,6 +484,8 @@ def test_initialize_or_verify_schema_rejects_db_ahead_of_build(
     Alembic cannot upgrade from an unknown revision — it has no path to
     start walking — so the stale-schema wording used to send operators
     to ``omnigent debug db-upgrade``, which then failed the same way.
+    Also guards that no migration is attempted: trying one and failing
+    is what produced the original crash.
     """
     db_path = tmp_path / "ahead.db"
     uri = _make_db_at_revision(db_path, "head")
@@ -495,6 +498,11 @@ def test_initialize_or_verify_schema_rejects_db_ahead_of_build(
         f"Fixture revision {future_revision!r} now exists in the "
         f"migrations directory; pick another absent revision."
     )
+
+    def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("no migration may be attempted for an unknown revision")
+
+    monkeypatch.setattr("omnigent.db.utils._run_migrations", _fail_if_called)
 
     engine = create_engine(uri)
     try:

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from alembic import command
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from omnigent.db.utils import (
     _LAKEBASE_POOL_RECYCLE_SECONDS,
@@ -20,6 +20,7 @@ from omnigent.db.utils import (
     _initialize_or_verify_schema,
     _install_lakebase_token_refresh,
     _resolve_lakebase_token_provider,
+    _revision_is_known,
     build_search_snippet,
     builtin_agent_id,
     clear_engine_cache,
@@ -456,6 +457,68 @@ def test_initialize_or_verify_schema_reports_manual_retry_when_auto_migration_fa
     assert uri in msg, (
         f"Error message must include the database URL so the "
         f"command is copy-pastable. Got: {msg!r}"
+    )
+
+
+def test_revision_is_known_distinguishes_shipped_and_unknown_revisions(
+    tmp_path: Path,
+) -> None:
+    """
+    ``_revision_is_known`` resolves against the scripts directory, not
+    the database, so it answers for a URL that has no file behind it.
+    """
+    uri = f"sqlite:///{tmp_path / 'probe.db'}"
+
+    assert _revision_is_known(uri, _get_head_db_revision(uri))
+    assert not _revision_is_known(uri, "ffffffffffff")
+
+
+def test_initialize_or_verify_schema_rejects_db_ahead_of_build(
+    tmp_path: Path,
+) -> None:
+    """
+    A database stamped with a revision this build does not ship is
+    diagnosed as newer than the client, not as stale.
+
+    Alembic cannot upgrade from an unknown revision — it has no path to
+    start walking — so the stale-schema wording used to send operators
+    to ``omnigent debug db-upgrade``, which then failed the same way.
+    """
+    db_path = tmp_path / "ahead.db"
+    uri = _make_db_at_revision(db_path, "head")
+    head = _get_head_db_revision(uri)
+    # Stands in for a revision from a future release. It has to be
+    # written straight into alembic_version: _make_db_at_revision can
+    # only reach revisions that already exist on disk.
+    future_revision = "ffffffffffff"
+    assert not _revision_is_known(uri, future_revision), (
+        f"Fixture revision {future_revision!r} now exists in the "
+        f"migrations directory; pick another absent revision."
+    )
+
+    engine = create_engine(uri)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE alembic_version SET version_num = :rev"),
+                {"rev": future_revision},
+            )
+        with pytest.raises(RuntimeError) as exc_info:
+            _initialize_or_verify_schema(engine, uri)
+    finally:
+        engine.dispose()
+
+    msg = str(exc_info.value)
+    assert future_revision in msg, (
+        f"Error must name the unrecognized revision so the operator can "
+        f"tell which build wrote the database. Got: {msg!r}"
+    )
+    assert head in msg, (
+        f"Error must name this build's head so the operator sees the gap. Got: {msg!r}"
+    )
+    assert "omnigent debug db-upgrade" not in msg, (
+        f"Error must not suggest db-upgrade: it cannot resolve the "
+        f"database's revision either, so the operator would loop. Got: {msg!r}"
     )
 
 


### PR DESCRIPTION
## Related issue

Closes #4963

## Summary

An older omnigent opening a database a newer one has migrated reported the
schema as "out of date" and pointed at `omnigent debug db-upgrade`. The database
is actually *newer*, and that command cannot resolve its revision either, so it
crashed with an uncaught Alembic `CommandError`.

`_initialize_or_verify_schema` had three cases, so `current != head` always meant
"stale". This adds a fourth: a revision absent from this build's scripts
directory means a newer omnigent wrote the database, and no migration helps.

| DB revision | Behaviour |
| --- | --- |
| none | migrate to head (unchanged) |
| head | no-op (unchanged) |
| unknown to this build | **"created by a newer omnigent"** (new) |
| behind head | auto-upgrade, else retry hint (unchanged) |

`debug db-upgrade` checks the same thing up front and exits via `ClickException`.
The new message omits the `db-upgrade` hint that caused the loop.

You get into this state by running a newer checkout against the default
`~/.omnigent`: it migrates the shared database, and the released build can no
longer read it. Giving the dev server its own port doesn't help, since the data
dir is what's shared.

## Test Plan

Three new tests, two in `tests/db/test_utils.py` and one in `tests/cli/test_cli.py`:

- `_revision_is_known` resolves shipped revisions and rejects absent ones
- startup raises naming the unknown revision and head, and *not* `db-upgrade`
- `debug db-upgrade` exits 1 with the explanation and no traceback

Confirmed non-vacuous: stubbing `_revision_is_known` to `True` restores the old
message and fails the startup assertion.

`pytest tests/db/test_utils.py tests/cli/test_cli.py` passes. The three
`psycopg` failures in the db file are pre-existing without the Postgres extra,
and identical on a clean checkout. `pre-commit` passes on all four files.

## Demo

N/A — no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests write an unknown revision into `alembic_version` directly, since
`_make_db_at_revision` can only reach revisions that exist on disk.

## Changelog

An older omnigent now tells you your database was written by a newer version, instead of reporting the schema as out of date
