### PR TITLE
fix(terminal): release Shift+Enter to xterm during IME composition

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -215,6 +215,27 @@ describe("terminalKeyEventPayload", () => {
     expect(terminalKeyEventPayload(keyEvent({ key: "Enter" }))).toBeNull();
   });
 
+  it("releases Shift+Enter to xterm during an IME composition (#4964)", () => {
+    // xterm consults the custom handler BEFORE its CompositionHelper; claiming
+    // the key mid-conversion skips the helper's finalize path and the composed
+    // text is dropped. The payload must be null so xterm runs composition
+    // handling instead of us sending CSI-u bytes to the PTY.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, isComposing: true })),
+    ).toBeNull();
+    // The 229 keyCode path (Safari/legacy) cannot be set through the
+    // constructor init dict, so exercise it with a stub.
+    expect(
+      terminalKeyEventPayload(
+        { key: "Enter", shiftKey: true, keyCode: 229 } as unknown as KeyboardEvent,
+      ),
+    ).toBeNull();
+    // Without either composition signal the CSI-u payload still applies.
+    expect(terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true }))).toBe(
+      SHIFT_ENTER_CSI_U,
+    );
+  });
+
   it("does not override other modified Enter combinations", () => {
     expect(terminalKeyEventPayload(keyEvent({ key: "Enter", altKey: true }))).toBeNull();
     expect(terminalKeyEventPayload(keyEvent({ key: "Enter", ctrlKey: true }))).toBeNull();

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -176,6 +176,14 @@ export const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
  *     the event normally.
  */
 export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
+  // An in-flight IME composition owns the keyboard: xterm consults this custom
+  // handler BEFORE its CompositionHelper, so claiming Shift+Enter mid-conversion
+  // skips the helper's finalize-on-keydown path and the composed text is never
+  // committed -- it is dropped and a CSI-u sequence reaches the PTY instead
+  // (#4964). Returning null lets xterm run its normal composition handling.
+  if (event.isComposing || event.keyCode === 229) {
+    return null;
+  }
   if (
     event.key === "Enter" &&
     event.shiftKey &&


### PR DESCRIPTION
## Summary

Fixes defect 1 of #4964 (the deterministic input-path bug). Defect 2 (sync-echo repaint over preedit) is explicitly out of scope — see below.

## Root cause (as diagnosed in the issue, verified against xterm's source flow)

xterm consults the custom key handler **before** its `CompositionHelper` and returns early when the handler returns `false`. `terminalKeyEventPayload` unconditionally claimed Shift+Enter, so the helper's finalize-on-keydown path — which commits pending composition text on non-modifier keys — was never reached: the user's converted text was **dropped**, and a CSI-u sequence went to the PTY in its place.

## Fix

`terminalKeyEventPayload` now returns `null` — xterm's default path, which runs composition handling — whenever the event carries an active-composition signal:

- `event.isComposing === true`, or
- the legacy `keyCode === 229` (Safari/older engines).

Plain Shift+Enter outside composition still emits the CSI-u sequence; all other key combinations were already null. Four-case coverage in the existing `terminalKeyEventPayload` vitest describe block (the 229 path via a stub, since constructor init dicts cannot set legacy `keyCode`).

## Why defect 2 is out of scope

The sync-echo repaint-over-preedit interaction can't be verified without a live IME session, and layering an unverified paint-path change onto the input fix risks regressing the echo fast path. If the reporter still sees repaint artifacts once defect 1 is fixed, that deserves its own change with its own repro.

(Couldn't run the vitest suite locally on this Windows checkout without node_modules; the payload logic itself was verified directly in a DOM.)
