### PR TITLE
fix(runner): never-connected guard on the auth rejection streak

### DIFF
--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -426,7 +426,16 @@ async def serve_tunnel(
                 http_status = _websocket_http_status(exc)
                 if http_status is not None and http_status in _REFRESHABLE_HTTP_STATUSES:
                     http_auth_rejection_streak += 1
-                    if http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS:
+                    # A tunnel that already completed an upgrade proved its
+                    # credentials: a later 401/403 is a network-path artifact
+                    # (VPN drop, intermediary answering before the server) and
+                    # must retry indefinitely rather than exit -- the host
+                    # tunnel gained exactly this ever_connected guard in
+                    # host/connect.py; the runner path is its mirror (#4958).
+                    if (
+                        not ever_connected
+                        and http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
+                    ):
                         login_hint = (
                             f"run `databricks auth login --host {server_url}` to re-authenticate"
                             if server_url

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -1837,3 +1837,67 @@ async def test_serve_tunnel_no_ssl_context_for_ws(
         monkeypatch, "ws://127.0.0.1:6767/v1/runners/runner_test/tunnel"
     )
     assert captured["kwargs"]["ssl"] is None
+
+
+async def test_serve_tunnel_survives_auth_rejection_after_first_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tunnel that already upgraded once must retry 401s forever.
+
+    A once-connected runner proved its credentials; a later 401/403 is a
+    network-path artifact (VPN drop, intermediary answering the upgrade), and
+    exiting would kill every session the runner serves for a blip (#4958).
+    Mirrors the host tunnel's _ever_connected guard in host/connect.py.
+    """
+    from omnigent.runner.transports.ws_tunnel.serve import _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
+
+    attempt = 0
+    shutdown = asyncio.Event()
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+        on_connected: Any = None,
+        **_kwargs: Any,
+    ) -> None:
+        del app, tunnel_url, server_url, runner_id, runner_version, auth_token, tunnel_token
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            # Successful upgrade: report the connection so the loop marks
+            # the runner ever_connected (the real _serve_tunnel_once invokes
+            # this callback once the tunnel is live).
+            if on_connected is not None:
+                on_connected()
+            return
+        raise InvalidStatus(Response(401, "Unauthorized", [], b""))
+
+    async def _sleep(_delay: float) -> None:
+        # Let several streak-caps' worth of rejections land, then stop the loop
+        # to observe that it never exited on its own.
+        if attempt > _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS + 3:
+            shutdown.set()
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    # Returns via the shutdown event, NOT by raising the fatal rejection.
+    await asyncio.wait_for(
+        serve_tunnel(
+            _noop_app,
+            server_url="https://example.databricksapps.com",
+            runner_id="runner_blip_survivor",
+            runner_version="0.1.0",
+            auth_token="tok",
+            shutdown_event=shutdown,
+        ),
+        timeout=10.0,
+    )
+
+    assert attempt > _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS + 3


### PR DESCRIPTION
## Summary

Fixes #4958 — the `ever_connected` half of #3943 that never made it to the runner path.

## Root cause (as traced in the issue, verified)

`serve.py`'s rejection streak exits after `_HTTP_AUTH_REJECTION_FATAL_ATTEMPTS` (3) consecutive 401/403s **regardless of connection history**, and each rejection resets `delay_s` to the initial reconnect delay — so a brief network-path blip (VPN drop; an intermediary answering the WS upgrade with 403 before the request reaches the server) exhausts the streak in seconds. From healthy tunnel to dead process in ~8 seconds, killing every session the runner serves.

The host tunnel got exactly this guard in #4025 (`host/connect.py`: `if status in (401, 403) and self._ever_connected:` → retry indefinitely, with a comment explaining a once-upgraded tunnel proved its credentials). The runner path is its mirror and was left behind.

## Fix

The fatal raise now applies only when `not ever_connected`:

- **once-connected** runner (an upgrade completed → credentials proven): a later 401/403 is a network-path artifact → retry indefinitely, bounded only by shutdown;
- **never-connected** runner: the fast-fail streak is intact (that path is genuinely bad credentials).

## Tests

- New `test_serve_tunnel_survives_auth_rejection_after_first_connect`: one successful upgrade (the fake invokes the real `on_connected` callback so `ever_connected` flips), then nothing but 401s well past the streak cap — the loop keeps retrying and exits only via the shutdown event. **Fails on `main`** (the fatal raise fires at attempt 4).
- The existing `test_serve_tunnel_fails_loud_on_http_auth_rejection` (never connects) passes unchanged — fast-fail semantics preserved. Full file: 39/39.
