### PR TITLE
test(host): close the cancel race in the midspawn leak test

### DIFF
--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4000,6 +4000,7 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     original_popen = subprocess.Popen
     spawned: list[subprocess.Popen[bytes]] = []
     spawn_started = threading.Event()
+    release_spawn = threading.Event()
 
     def _slow_popen(args: list[str], **kwargs: object) -> subprocess.Popen[bytes]:
         """Spawn a long-lived process, signalling once it exists.
@@ -4015,6 +4016,10 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
         )
         spawned.append(proc)
         spawn_started.set()
+        # Stay inside the shielded spawn until the test has issued its cancel.
+        # Returning here immediately let a loaded machine finish the launch
+        # before the cancel landed, so the cancel missed the leak window.
+        release_spawn.wait(10.0)
         return proc
 
     frame = HostLaunchRunnerFrame(
@@ -4029,6 +4034,7 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
         # so we exercise the real leak window rather than a pre-spawn cancel.
         await asyncio.to_thread(spawn_started.wait, 10.0)
         task.cancel()
+        release_spawn.set()
         with pytest.raises(asyncio.CancelledError):
             await task
 


### PR DESCRIPTION
## Related issue

N/A. This is a `Test / CI` change, which the template exempts from the issue requirement.

Context: it unblocks #4958 / #4957, whose CI is red only because of this flake.

## Summary

`tests/host/test_connect.py::test_launch_cancelled_midspawn_does_not_leak_untracked_runner` is racy and currently red on `main`.

The test sets `spawn_started` *after* `Popen` returns, then cancels the launch task. On a loaded machine the event loop is descheduled in that gap, `_handle_launch` runs to completion, and the cancel arrives after the window it exists to exercise. The test then fails with `DID NOT RAISE CancelledError`, which reads like a leak regression but is only a scheduling artifact.

The fix holds the spawn thread inside the shielded call until the test has issued its cancel, so the cancel lands in the leak window regardless of scheduling. Assertions are unchanged and the test still covers the real post-spawn / pre-register window it was written for.

Not a product bug: `omnigent/host/connect.py` is untouched, and the leak behaviour the test asserts is correct today.

## Test Plan

Currently red on `main`: `Pytest (misc)` fails at `a447db22c` and passed at `ce00d35f0`, with two automatic reruns exhausted. Nothing in that commit is related (it changed `kubernetes.py`, its tests, and a `role.yaml`, and `misc` ignores `tests/onboarding`), so the flake surfaced there rather than being caused by it.

Reproduced deterministically by inserting a scheduling delay where a loaded machine would take one:

```python
await asyncio.to_thread(spawn_started.wait, 10.0)
await asyncio.sleep(0.2)   # stand in for CI load
task.cancel()
```

That fails identically to CI (`DID NOT RAISE <class 'asyncio.exceptions.CancelledError'>`). With this change the same insertion passes.

```
# before (with the 0.2s stand-in): 1 failed
# after  (with the 0.2s stand-in): 1 passed
pytest tests/host/test_connect.py::test_launch_cancelled_midspawn_does_not_leak_untracked_runner
# 20/20 clean in isolation
pytest tests/host/test_connect.py
# 124 passed
```

## Demo

N/A, test-only change with no user-visible behaviour.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is to a test, so the verification is the before/after reproduction above rather than new coverage: the injected delay fails on `main` and passes here, and the test is 20/20 in isolation.

The flake is load-dependent and does not reproduce on an unloaded machine, so the injected delay is how it is demonstrated. It is not left in the committed test.
