### PR TITLE
fix(electron): trigger sign-in from "Run on this machine" instead of looping on "No hosts"

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2521,7 +2521,7 @@ function registerIpc() {
       // Ensure the CLI is authenticated for a remote server first (local needs
       // none) — otherwise the host connect would just fail on a 401.
       const auth = await serverManager.ensureServerAuth(cliPath, serverUrl);
-      if (!auth.ok) result = { ok: false, error: auth.error };
+      if (!auth.ok) result = { ok: false, error: auth.error, authError: auth.authError };
       else if (action === "start")
         result = await serverManager.ensureHostConnected(cliPath, serverUrl);
       else result = await serverManager.restartHost(cliPath, serverUrl);

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -432,14 +432,17 @@ function serverAuthed(serverUrl) {
  * Run `omnigent login <serverUrl>` to authenticate the CLI to a server. It's a
  * no-op when the server needs no auth (header mode), opens the system browser
  * for OIDC / Databricks, and fails fast for password (TTY) modes when run
- * without a terminal. Long timeout to allow the interactive browser flow.
+ * without a terminal. The default timeout is generous (~300s) so a human
+ * completing the browser sign-in isn't SIGKILLed mid-flow — the CLI's own OIDC
+ * ticket deadline (300s, `_CLI_LOGIN_TIMEOUT_SECONDS` in omnigent/cli.py)
+ * governs first.
  *
  * @param {string} cliPath
  * @param {string} serverUrl
  * @param {{ timeoutMs?: number }} [opts]
  * @returns {Promise<{ ok: boolean, output: string }>}
  */
-async function loginServer(cliPath, serverUrl, { timeoutMs = 180000 } = {}) {
+async function loginServer(cliPath, serverUrl, { timeoutMs = 305000 } = {}) {
   const res = await runCli(cliPath, ["login", serverUrl], { timeoutMs });
   return { ok: res.code === 0, output: (res.stdout || res.stderr).trim() };
 }
@@ -779,6 +782,53 @@ async function probeHostTunnel(serverUrl, hostId, { timeoutMs = 2000 } = {}) {
 }
 
 /**
+ * Whether the CLI is authenticated to `serverUrl` right now, decided by the same
+ * signal the Python side trusts to gate a connect: a single `GET
+ * {serverUrl}/v1/me`. A 200 means authed; anything else (a 401, or a
+ * Databricks-edge 302 to the workspace OAuth page) means a login is needed —
+ * mirroring `_ensure_databricks_server_auth()` and the `login` command in
+ * omnigent/cli.py, so the desktop and CLI agree on "is auth needed?".
+ *
+ * Sends a stored session token ({@link bearerTokenFor}) when one exists, so an
+ * already-authed OIDC/accounts server answers 200 and we skip a needless
+ * `omnigent login`. A Databricks-pointer login stores no in-process token (the
+ * SDK mints one per request), so the probe is unauthenticated and returns
+ * not-authed — which correctly defers to `omnigent login`, itself browserless
+ * while the workspace grant is still live and refreshable.
+ *
+ * `redirect: "manual"` so a Databricks 302 is never followed into a 200 login
+ * page — an opaque redirect surfaces as a non-200 status, which is the answer we
+ * want. `reachable:false` (a thrown fetch) lets the caller skip a doomed login
+ * and let the connect attempt raise its own, clearer error. Never throws.
+ *
+ * @param {string} serverUrl
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<{ authed: boolean, reachable: boolean }>}
+ */
+async function probeServerAuth(serverUrl, { timeoutMs = 10000 } = {}) {
+  if (typeof serverUrl !== "string" || serverUrl === "") {
+    return { authed: false, reachable: false };
+  }
+  const headers = {};
+  const token = bearerTokenFor(serverUrl);
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const base = serverUrl.replace(/\/+$/, "");
+  try {
+    const resp = await fetch(`${base}/v1/me`, {
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { authed: resp.status === 200, reachable: true };
+  } catch {
+    // Unreachable / timed out — can't confirm auth. Report unreachable so the
+    // caller lets the connect attempt surface its own error rather than forcing
+    // a login that can't complete against a dead server.
+    return { authed: false, reachable: false };
+  }
+}
+
+/**
  * This machine's connection to `serverUrl`, resolved WITHOUT the slow `omnigent
  * host status` subprocess: daemon metadata + process state come from the
  * on-disk registry ({@link readDaemonRecords}), and tunnel health from one
@@ -899,6 +949,7 @@ module.exports = {
   stopLocalServer,
   stopHost,
   serverAuthed,
+  probeServerAuth,
   loginServer,
   matchesServer,
   daemonRegistryDir,

--- a/web/electron/src/server_manager.js
+++ b/web/electron/src/server_manager.js
@@ -131,7 +131,13 @@ function spawnHostChild(cliPath, serverUrl) {
     const holder = { text: "" };
     let child;
     try {
-      child = spawn(cliPath, ["host", "--server", serverUrl], {
+      // `--non-interactive`: the desktop owns the sign-in step (ensureServerAuth
+      // runs `omnigent login` first), so the host daemon must never try its own
+      // interactive login. Without the flag, an unauthed connect relies on the
+      // spawned child's stdin not being a TTY to bail — with it, the CLI raises a
+      // deterministic "run `omnigent login`" error that `isAuthError` classifies,
+      // so any residual auth gap becomes a fast, surfaced authError, not a hang.
+      child = spawn(cliPath, ["host", "--server", serverUrl, "--non-interactive"], {
         stdio: ["ignore", "pipe", "pipe"],
       });
     } catch (err) {
@@ -295,23 +301,41 @@ async function disconnectHost(cliPath, serverUrl) {
 
 /**
  * Ensure the CLI is authenticated for a server before connecting a host to it.
- * Local (loopback) servers need no auth. For a remote server with no valid
- * stored credentials, runs `omnigent login <url>` (browser/OIDC/Databricks; a
- * no-op when the server needs no auth). Returns ok when already authed, after a
- * successful login, or for a no-auth server; an error (pointing at `omnigent
- * login`) when login fails — e.g. a password/TTY mode that can't run headless.
+ * Local (loopback) servers need no auth. For a remote server, this asks the
+ * server itself (a `GET /v1/me` probe via {@link module:omnigent_cli.probeServerAuth})
+ * rather than trusting the on-disk token file — a Databricks pointer record has
+ * no readable expiry, so a stale file would otherwise falsely report "authed"
+ * and skip the login that should open the browser. When not authed it runs
+ * `omnigent login <url>` (browser/OIDC/Databricks), which is idempotent: a
+ * live-but-expired Databricks access token refreshes silently with no browser,
+ * and only a dead grant opens the sign-in browser.
+ *
+ * Returns ok when already authed, when the server is unreachable (so the connect
+ * attempt can raise its own, clearer error), or after a successful login. On
+ * login failure returns `{ ok:false, authError:true, error }` so the UI can
+ * offer a sign-in/retry affordance instead of a generic failure.
  *
  * @param {string} cliPath
  * @param {string} serverUrl
- * @returns {Promise<{ ok: boolean, error?: string }>}
+ * @returns {Promise<{ ok: boolean, authError?: boolean, error?: string }>}
  */
 async function ensureServerAuth(cliPath, serverUrl) {
-  if (cli.isLoopbackServer(serverUrl) || cli.serverAuthed(serverUrl)) return { ok: true };
+  if (cli.isLoopbackServer(serverUrl)) return { ok: true };
+  const probe = await cli.probeServerAuth(serverUrl);
+  // Already authed, or unreachable — in the unreachable case skip a doomed login
+  // and let the connect attempt surface the real (connectivity) error.
+  if (probe.authed || !probe.reachable) return { ok: true };
   const res = await cli.loginServer(cliPath, serverUrl);
   if (res.ok) return { ok: true };
+  // Deliberately a fixed, generic message — NOT `res.output`. `omnigent login`
+  // stdout on the OIDC path contains the login-ticket URL
+  // (`…/auth/login?ticket=…`), which is auth material; threading it to the
+  // renderer would leak it. The server URL alone is safe (the renderer already
+  // knows it).
   return {
     ok: false,
-    error: `Sign-in required — run \`omnigent login ${serverUrl}\` in a terminal, then try again.`,
+    authError: true,
+    error: `Sign-in to ${serverUrl} didn't complete. A browser window should have opened — finish signing in and try again (or run \`omnigent login ${serverUrl}\` in a terminal).`,
   };
 }
 

--- a/web/electron/test/omnigent_cli.test.js
+++ b/web/electron/test/omnigent_cli.test.js
@@ -20,6 +20,7 @@ const {
   parseDaemonRecord,
   daemonServerUrl,
   getHostConnectionFast,
+  probeServerAuth,
   localHostId,
 } = require("../src/omnigent_cli");
 
@@ -311,6 +312,99 @@ describe("getHostConnectionFast — probe destination & token handling (S1)", ()
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].headers.Authorization, undefined);
+  });
+});
+
+describe("probeServerAuth — /v1/me auth gate", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it("returns authed for a 200 and targets {server}/v1/me with redirect:manual", async () => {
+    mock.method(fs, "readFileSync", () => "{}"); // no stored token
+    const calls = [];
+    mock.method(globalThis, "fetch", async (target, init) => {
+      calls.push({ target, init });
+      return { status: 200 };
+    });
+
+    const res = await probeServerAuth("https://app.example.com");
+
+    assert.deepEqual(res, { authed: true, reachable: true });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].target, "https://app.example.com/v1/me");
+    assert.equal(calls[0].init.redirect, "manual");
+  });
+
+  it("returns not-authed for non-200 statuses (Databricks 302, opaque-redirect 0, 401)", async () => {
+    mock.method(fs, "readFileSync", () => "{}");
+    const url = "https://app.example.com";
+
+    // Databricks-edge 302 to the workspace OAuth page.
+    mock.method(globalThis, "fetch", async () => ({ status: 302 }));
+    assert.deepEqual(await probeServerAuth(url), { authed: false, reachable: true });
+
+    // undici opaque-redirect (redirect:"manual") surfaces as status 0.
+    mock.method(globalThis, "fetch", async () => ({ status: 0 }));
+    assert.deepEqual(await probeServerAuth(url), { authed: false, reachable: true });
+
+    // Plain unauthenticated.
+    mock.method(globalThis, "fetch", async () => ({ status: 401 }));
+    assert.deepEqual(await probeServerAuth(url), { authed: false, reachable: true });
+  });
+
+  it("returns unreachable (never authed) when fetch throws", async () => {
+    mock.method(fs, "readFileSync", () => "{}");
+    mock.method(globalThis, "fetch", async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    const res = await probeServerAuth("https://app.example.com");
+
+    assert.deepEqual(res, { authed: false, reachable: false });
+  });
+
+  it("attaches a stored session token, but none for a Databricks pointer", async () => {
+    const url = "https://app.example.com";
+
+    // Session-token record → Authorization attached, so an authed OIDC/accounts
+    // server can answer 200 and skip a needless login.
+    mock.method(fs, "readFileSync", () =>
+      JSON.stringify({ [url]: { token: "sess-123", expires_at: Date.now() / 1000 + 3600 } }),
+    );
+    let seen;
+    mock.method(globalThis, "fetch", async (_target, init) => {
+      seen = init.headers;
+      return { status: 200 };
+    });
+    await probeServerAuth(url);
+    assert.equal(seen.Authorization, "Bearer sess-123");
+
+    // Databricks pointer → no in-process token → no Authorization header (the
+    // unauthenticated probe correctly yields not-authed and defers to login).
+    mock.method(fs, "readFileSync", () =>
+      JSON.stringify({ [url]: { auth_type: "databricks", workspace_host: "https://ws" } }),
+    );
+    seen = undefined;
+    mock.method(globalThis, "fetch", async (_target, init) => {
+      seen = init.headers;
+      return { status: 302 };
+    });
+    await probeServerAuth(url);
+    assert.equal(seen.Authorization, undefined);
+  });
+
+  it("returns unreachable without fetching for an empty server URL", async () => {
+    const calls = [];
+    mock.method(globalThis, "fetch", async (target) => {
+      calls.push(target);
+      return { status: 200 };
+    });
+
+    const res = await probeServerAuth("");
+
+    assert.deepEqual(res, { authed: false, reachable: false });
+    assert.equal(calls.length, 0);
   });
 });
 

--- a/web/electron/test/server_manager.test.js
+++ b/web/electron/test/server_manager.test.js
@@ -1,0 +1,102 @@
+// Tests for the auth gate in src/server_manager.js (`ensureServerAuth`), run
+// with `node --test`. The spawning functions need a real binary + live server
+// and are covered by the manual verification flow; here we test the pure
+// decision logic: loopback skip → /v1/me probe → (idempotent) login → error.
+//
+// `server_manager` captures the `omnigent_cli` module object once at require
+// time, so mocking methods on that same shared object (via `mock.method`) is
+// seen by the code under test.
+
+const { describe, it, mock, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+const cli = require("../src/omnigent_cli");
+const { ensureServerAuth } = require("../src/server_manager");
+
+const SERVER = "https://app.example.com";
+const CLI_PATH = "/bin/omnigent";
+
+describe("ensureServerAuth", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it("skips auth entirely for a loopback server (no probe, no login)", async () => {
+    mock.method(cli, "isLoopbackServer", () => true);
+    const probe = mock.method(cli, "probeServerAuth", async () => ({
+      authed: false,
+      reachable: true,
+    }));
+    const login = mock.method(cli, "loginServer", async () => ({ ok: false, output: "" }));
+
+    const res = await ensureServerAuth(CLI_PATH, "http://localhost:6767");
+
+    assert.deepEqual(res, { ok: true });
+    assert.equal(probe.mock.callCount(), 0);
+    assert.equal(login.mock.callCount(), 0);
+  });
+
+  it("skips login when the probe reports already authed", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: true, reachable: true }));
+    const login = mock.method(cli, "loginServer", async () => ({ ok: false, output: "" }));
+
+    const res = await ensureServerAuth(CLI_PATH, SERVER);
+
+    assert.deepEqual(res, { ok: true });
+    assert.equal(login.mock.callCount(), 0);
+  });
+
+  it("skips login (defers to the connect attempt) when the server is unreachable", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: false }));
+    const login = mock.method(cli, "loginServer", async () => ({ ok: false, output: "" }));
+
+    const res = await ensureServerAuth(CLI_PATH, SERVER);
+
+    assert.deepEqual(res, { ok: true });
+    assert.equal(login.mock.callCount(), 0);
+  });
+
+  it("runs login when not authed, and returns ok on success", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: true }));
+    const login = mock.method(cli, "loginServer", async () => ({ ok: true, output: "Logged in." }));
+
+    const res = await ensureServerAuth(CLI_PATH, SERVER);
+
+    assert.deepEqual(res, { ok: true });
+    assert.equal(login.mock.callCount(), 1);
+    assert.deepEqual(login.mock.calls[0].arguments, [CLI_PATH, SERVER]);
+  });
+
+  it("returns an authError with a generic message and does NOT surface raw login output", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: true }));
+    // `omnigent login` stdout on the OIDC path can carry the login-ticket URL
+    // (auth material); it must never reach the renderer via the error string.
+    mock.method(cli, "loginServer", async () => ({
+      ok: false,
+      output: "Opening browser for login: https://app.example.com/auth/login?ticket=SECRET123",
+    }));
+
+    const res = await ensureServerAuth(CLI_PATH, SERVER);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.authError, true);
+    assert.doesNotMatch(res.error, /ticket=|SECRET123/);
+    assert.match(res.error, /omnigent login https:\/\/app\.example\.com/);
+  });
+
+  it("uses the same generic message when login fails with no output", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: true }));
+    mock.method(cli, "loginServer", async () => ({ ok: false, output: "" }));
+
+    const res = await ensureServerAuth(CLI_PATH, SERVER);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.authError, true);
+    assert.match(res.error, /omnigent login https:\/\/app\.example\.com/);
+  });
+});

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -223,6 +223,13 @@ export interface HostIdentity {
 export interface HostActionResult {
   ok: boolean;
   error?: string;
+  /**
+   * True when the failure was an authentication/sign-in problem — e.g. the
+   * server needs a Databricks/OIDC login the desktop couldn't complete
+   * headlessly — so the UI can offer a sign-in/retry affordance rather than a
+   * generic error. Set by the desktop's `omnigent:host-control` handler.
+   */
+  authError?: boolean;
 }
 
 export type UpdateMode = "none" | "manual" | "start" | "default";

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2,6 +2,7 @@ import type * as IdentityModule from "@/lib/identity";
 import type * as UseConversationsModule from "@/hooks/useConversations";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
 import type * as ChatStoreModule from "@/store/chatStore";
+import type * as NativeBridgeModule from "@/lib/nativeBridge";
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,6 +44,12 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
+import {
+  controlHost,
+  getHostIdentity,
+  isElectronShell,
+  onHostStatusChanged,
+} from "@/lib/nativeBridge";
 import { writeHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -52,6 +59,16 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 vi.mock("@/lib/identity", async (importOriginal) => ({
   ...(await importOriginal<typeof IdentityModule>()),
   authenticatedFetch: vi.fn(),
+}));
+// Desktop bridge: default to the browser/jsdom world (isElectronShell → false),
+// so existing tests are unaffected; the "Run on this machine" suite opts into
+// the desktop shell by overriding these per-test.
+vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof NativeBridgeModule>()),
+  isElectronShell: vi.fn(() => false),
+  getHostIdentity: vi.fn(async () => null),
+  onHostStatusChanged: vi.fn(() => () => {}),
+  controlHost: vi.fn(async () => ({ ok: false })),
 }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
@@ -868,6 +885,71 @@ function closeMenu(): void {
 function saveConfig(): void {
   fireEvent.click(screen.getByTestId("new-chat-landing-config-save"));
 }
+
+describe("Run on this machine (desktop host enrollment)", () => {
+  beforeEach(() => {
+    setupLandingMocks();
+    // No hosts connected yet → the picker offers the one-click connect.
+    mockHosts([]);
+    // Pretend we're in the desktop shell with the CLI installed, so
+    // `showConnectThisMachine` is true and the affordance renders.
+    vi.mocked(isElectronShell).mockReturnValue(true);
+    vi.mocked(getHostIdentity).mockResolvedValue({ cliInstalled: true, hostId: "this-machine" });
+    vi.mocked(onHostStatusChanged).mockReturnValue(() => {});
+    // Call history persists across tests in this file (no global clearMocks), so
+    // reset controlHost so per-test call-count assertions start from zero.
+    vi.mocked(controlHost).mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    // Restore the browser default so these overrides don't leak into the other
+    // describe blocks (which assume no desktop shell).
+    vi.mocked(isElectronShell).mockReturnValue(false);
+  });
+
+  // Open the host chip menu and click "Run on this machine". Selecting the item
+  // arms `pendingConnectRef`; the menu closing then runs `connectThisMachine`.
+  async function clickRunOnThisMachine() {
+    const chip = await screen.findByTestId("new-chat-landing-host-chip");
+    fireEvent.pointerDown(chip, { button: 0 });
+    fireEvent.click(chip);
+    const item = await screen.findByTestId("new-chat-landing-run-on-this-machine");
+    fireEvent.click(item);
+  }
+
+  it("surfaces an auth failure (with a retry) instead of silently returning to No hosts", async () => {
+    vi.mocked(controlHost).mockResolvedValue({
+      ok: false,
+      authError: true,
+      error:
+        "Sign-in required — run `omnigent login https://app.example.com` in a terminal, then try again.",
+    });
+    renderLanding();
+    await clickRunOnThisMachine();
+
+    const err = await screen.findByTestId("new-chat-landing-connect-error");
+    expect(err.textContent).toContain("Sign-in required");
+    expect(screen.getByTestId("new-chat-landing-connect-error-retry")).toBeTruthy();
+    expect(vi.mocked(controlHost)).toHaveBeenCalledWith("start");
+  });
+
+  it("re-invokes the connect when Try again is clicked", async () => {
+    vi.mocked(controlHost).mockResolvedValue({
+      ok: false,
+      authError: true,
+      error: "Sign-in required.",
+    });
+    renderLanding();
+    await clickRunOnThisMachine();
+    await screen.findByTestId("new-chat-landing-connect-error");
+
+    // Clear the initial connect's call, then assert the retry re-invokes it.
+    vi.mocked(controlHost).mockClear();
+    fireEvent.click(screen.getByTestId("new-chat-landing-connect-error-retry"));
+    await waitFor(() => expect(vi.mocked(controlHost)).toHaveBeenCalledWith("start"));
+  });
+});
 
 describe("NewChatLandingScreen", () => {
   beforeEach(setupLandingMocks);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2128,6 +2128,11 @@ export function NewChatLandingScreen() {
   // picker can tag the current machine and offer to auto-connect it.
   const [desktopHost, setDesktopHost] = useState<HostIdentity | null>(null);
   const [connectingThisMachine, setConnectingThisMachine] = useState(false);
+  // Error surfaced when "Run on this machine" fails (sign-in needed, enrollment
+  // declined, server unreachable). Rendered in the composer body with a retry,
+  // so the failure isn't silently swallowed and the user isn't stranded on the
+  // "No hosts" state.
+  const [connectError, setConnectError] = useState<string | null>(null);
   // Defer the connect until the dropdown has actually closed (set on select,
   // consumed in the menu's onOpenChange) — connecting while the menu is open
   // looks janky. A ref so the close handler sees it synchronously.
@@ -3551,9 +3556,24 @@ export function NewChatLandingScreen() {
   async function connectThisMachine() {
     if (connectingThisMachine) return;
     setConnectingThisMachine(true);
+    setConnectError(null);
     try {
+      // A single controlHost("start") blocks through the whole enrollment →
+      // sign-in (browser OAuth) → connect sequence, so on success the machine is
+      // already authed and connected — no separate retry needed. On failure we
+      // MUST surface it: this used to `return` silently, dropping the user back
+      // on "No hosts" with no clue why. An auth failure gets sign-in-flavored
+      // copy; the rendered error carries a "Try again" affordance.
       const res = await controlHost("start");
-      if (!res.ok) return;
+      if (!res.ok) {
+        setConnectError(
+          res.authError
+            ? (res.error ??
+                "Sign-in didn't complete. A browser should have opened — finish signing in, then try again.")
+            : (res.error ?? "Couldn't run on this machine."),
+        );
+        return;
+      }
       const identity = await getHostIdentity();
       setDesktopHost(identity);
       await queryClient.invalidateQueries({ queryKey: ["hosts"] });
@@ -4920,6 +4940,24 @@ export function NewChatLandingScreen() {
           {createError && (
             <p className="text-sm text-destructive" data-testid="new-chat-landing-error">
               {createError}
+            </p>
+          )}
+
+          {connectError && (
+            <p
+              className="flex flex-wrap items-center gap-x-1.5 text-sm text-destructive"
+              data-testid="new-chat-landing-connect-error"
+            >
+              <span>{connectError}</span>
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:no-underline disabled:opacity-60"
+                onClick={() => void connectThisMachine()}
+                disabled={connectingThisMachine}
+                data-testid="new-chat-landing-connect-error-retry"
+              >
+                Try again
+              </button>
             </p>
           )}
         </div>


### PR DESCRIPTION
## Problem

Clicking **"Run on this machine"** in the desktop app could loop back to a **"No hosts"** error with no explanation. Getting unblocked required completing a browser (Databricks/Okta) sign-in by running `omni` in a terminal first — which defeats the purpose of the one-click affordance.

## Root cause

`connectThisMachine()` → `controlHost("start")` → `ensureServerAuth` → spawn `omnigent host`. When the desktop's stored Databricks OAuth grant had expired:

1. `serverAuthed()` treated **any** Databricks pointer record in `auth_tokens.json` as authed (it only checked that `workspace_host` was set, never token freshness), so `ensureServerAuth` **skipped `omnigent login`**.
2. The spawned `omnigent host` (stdin not a TTY) hit the non-interactive Databricks-auth guard and exited before connecting.
3. `connectThisMachine` saw `!res.ok` and **returned silently** — leaving the user on "No hosts". Repeated clicks kept skipping login (the stale pointer persisted), producing the loop.

## Fix (contained to the desktop shell + web UI; no shared Python CLI change)

- **`ensureServerAuth`** now decides "is auth needed?" with a `GET /v1/me` probe (`probeServerAuth`) — the same signal the CLI's own pre-flight uses — instead of trusting the on-disk token file. When not authed it runs the **idempotent** `omnigent login`, which silently refreshes a live grant (no browser) and only opens the browser for a genuine re-auth. It also now catches revoked-but-unexpired session tokens.
- **Spawn `omnigent host --non-interactive`** so any residual auth gap fails *loudly* with a classifiable `authError` rather than hanging on a missing TTY. (No Python change — the flag already exists.)
- **Surface the failure** in the New Chat dialog with a **Try again** affordance instead of returning silently; auth failures get sign-in-flavored copy. `authError` is threaded through the `omnigent:host-control` IPC result and `HostActionResult`.
- **Raise the login timeout 180s → 305s** so a human completing the browser sign-in isn't SIGKILLed mid-flow (the CLI's own OIDC ticket deadline governs).

Because a single `controlHost("start")` blocks through the whole enrollment → sign-in → connect sequence, the browser opens and the host connects within one action — no terminal.

## Tests

- **`probeServerAuth`**: 200 → authed; 302 / opaque-redirect-0 / 401 → not authed; thrown fetch → unreachable; sends a stored session token but not for a Databricks pointer; empty URL short-circuits.
- **`ensureServerAuth`**: loopback skip; probe-authed skip; unreachable skip; login-success; login-failure → `authError`.
- **New Chat dialog**: surfaces the error with a retry on auth failure, and the retry re-invokes the connect.

`tsc -b`, oxlint, and prettier are clean; the full Electron suite passes (252 tests + the new auth tests).

## Notes / follow-ups

- The Databricks OAuth end-to-end path (expired grant → click → browser → connect) should be verified on a real Databricks-fronted setup; everything short of that is unit-covered. The one behavior to confirm on-device is that `databricks auth login` doesn't prompt on stdin under the non-TTY spawn.
- Routing omnigent's links/redirects into the app's own in-app browser is a **separate follow-up**: page-driven OAuth popups already stay in-app, and the Databricks host-connect flow is a system-browser flow owned by the `databricks` CLI.

This pull request and its description were written by Isaac.
