### PR TITLE
fix(harness): heartbeats hold the idle watchdog while a human wait pends

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -415,11 +415,10 @@ class TurnContext:
         # Future[ElicitationResult]. Populated by ``elicit``;
         # resolved by the ``approval`` /events handler.
         self._pending_elicitations: dict[str, asyncio.Future[ElicitationResult]] = {}
-        # Human-approval waits in flight (elicitation replies, policy verdicts).
-        # While > 0 the idle watchdog is suspended: heartbeats intentionally do
-        # not reset it, so an unanswered approval would otherwise fail a
-        # legitimate human wait as a wedged turn. The absolute ceiling still
-        # applies (#4854).
+        # Human-approval waits in flight (elicitation replies, policy
+        # verdicts). While > 0 heartbeats hold the idle window open so an
+        # unanswered approval isn't failed as a wedged turn; the absolute
+        # ceiling still applies.
         self._pending_human_waits = 0
         # Layer 3 per-policy-evaluation state:
         # ``evaluation_id`` → Future[PolicyVerdictPayload].
@@ -442,6 +441,10 @@ class TurnContext:
         # event so a long-but-active turn isn't killed mid-turn.
         # ``None`` disables it (watchdog off, or outside a guarded run).
         self._reset_idle_watchdog: Callable[[], None] | None = None
+        # Idle-only keep-alive hook. Unlike ``_reset_idle_watchdog`` it
+        # never extends the absolute ceiling; used by heartbeats while a
+        # human wait is pending so the hard cap still bounds the turn.
+        self._hold_idle_watchdog: Callable[[], None] | None = None
 
     def emit(self, event: HarnessStreamEvent) -> None:
         """
@@ -464,13 +467,14 @@ class TurnContext:
         # watchdog (a wedged turn's 15s heartbeats would keep it alive
         # forever). Exception: while a human approval (elicitation reply,
         # policy verdict) is pending, the turn can legitimately emit nothing
-        # but heartbeats for as long as the human takes, so heartbeats DO
-        # reset the deadline then — the absolute ceiling stays the hard cap
-        # (#4854).
-        if self._reset_idle_watchdog is not None and (
-            not isinstance(event, HeartbeatEvent) or self._pending_human_waits > 0
-        ):
-            self._reset_idle_watchdog()
+        # but heartbeats for as long as the human takes, so heartbeats hold
+        # the idle window open then — via the idle-only hook, so the
+        # absolute ceiling stays the hard cap even for an ignored approval.
+        if not isinstance(event, HeartbeatEvent):
+            if self._reset_idle_watchdog is not None:
+                self._reset_idle_watchdog()
+        elif self._pending_human_waits > 0 and self._hold_idle_watchdog is not None:
+            self._hold_idle_watchdog()
         self._event_queue.put_nowait(event)
 
     async def dispatch_tool(self, call_id: str, name: str, arguments: str, agent: str) -> str:
@@ -662,6 +666,8 @@ class TurnContext:
         """
         future: asyncio.Future[PolicyVerdictPayload] = asyncio.get_running_loop().create_future()
         self._pending_policy_evaluations[evaluation_id] = future
+        # Unlike elicit's unbounded park, this wait is already bounded by
+        # the wait_for below; the counter only holds the idle window open.
         self._pending_human_waits += 1
         self.emit(
             PolicyEvaluationRequestEvent(
@@ -1522,7 +1528,15 @@ class HarnessApp:
                 # context), so the reschedule is always valid.
                 idle_wd.reschedule(loop.time() + idle_timeout)
 
+            def _hold_idle() -> None:
+                # Keep-alive during a pending human wait: push ONLY the idle
+                # deadline, never the absolute ceiling — an approval that is
+                # never answered must still terminate at the hard cap.
+                if not idle_wd.expired():
+                    idle_wd.reschedule(loop.time() + idle_timeout)
+
             ctx._reset_idle_watchdog = _reset
+            ctx._hold_idle_watchdog = _hold_idle
         try:
             # Absolute outer, idle inner: ``.expired()`` on each tells which
             # ceiling tripped so the error message is accurate.
@@ -1581,6 +1595,7 @@ class HarnessApp:
             # Detach the reset hook before the timeout context unwinds so
             # a stray late ``emit`` can't reschedule a finished timeout.
             ctx._reset_idle_watchdog = None
+            ctx._hold_idle_watchdog = None
             # Sentinel that tells ``_stream_turn`` to stop reading
             # the queue and emit the terminal event.
             ctx._event_queue.put_nowait(None)

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -415,6 +415,12 @@ class TurnContext:
         # Future[ElicitationResult]. Populated by ``elicit``;
         # resolved by the ``approval`` /events handler.
         self._pending_elicitations: dict[str, asyncio.Future[ElicitationResult]] = {}
+        # Human-approval waits in flight (elicitation replies, policy verdicts).
+        # While > 0 the idle watchdog is suspended: heartbeats intentionally do
+        # not reset it, so an unanswered approval would otherwise fail a
+        # legitimate human wait as a wedged turn. The absolute ceiling still
+        # applies (#4854).
+        self._pending_human_waits = 0
         # Layer 3 per-policy-evaluation state:
         # ``evaluation_id`` → Future[PolicyVerdictPayload].
         # Populated by ``evaluate_policy``; resolved by the
@@ -456,8 +462,14 @@ class TurnContext:
         # watchdog deadline forward. Heartbeats are keep-alive, NOT
         # progress — letting them reset the deadline would defeat the
         # watchdog (a wedged turn's 15s heartbeats would keep it alive
-        # forever).
-        if self._reset_idle_watchdog is not None and not isinstance(event, HeartbeatEvent):
+        # forever). Exception: while a human approval (elicitation reply,
+        # policy verdict) is pending, the turn can legitimately emit nothing
+        # but heartbeats for as long as the human takes, so heartbeats DO
+        # reset the deadline then — the absolute ceiling stays the hard cap
+        # (#4854).
+        if self._reset_idle_watchdog is not None and (
+            not isinstance(event, HeartbeatEvent) or self._pending_human_waits > 0
+        ):
             self._reset_idle_watchdog()
         self._event_queue.put_nowait(event)
 
@@ -551,6 +563,7 @@ class TurnContext:
         """
         future: asyncio.Future[ElicitationResult] = asyncio.get_running_loop().create_future()
         self._pending_elicitations[elicitation_id] = future
+        self._pending_human_waits += 1
         self.emit(
             ElicitationRequestEvent(
                 type="response.elicitation_request",
@@ -562,6 +575,7 @@ class TurnContext:
             return await future
         finally:
             self._pending_elicitations.pop(elicitation_id, None)
+            self._pending_human_waits -= 1
 
     async def next_injection(self, timeout: float | None = None) -> CreateResponseRequest | None:
         """
@@ -648,6 +662,7 @@ class TurnContext:
         """
         future: asyncio.Future[PolicyVerdictPayload] = asyncio.get_running_loop().create_future()
         self._pending_policy_evaluations[evaluation_id] = future
+        self._pending_human_waits += 1
         self.emit(
             PolicyEvaluationRequestEvent(
                 type="policy_evaluation.requested",
@@ -681,6 +696,7 @@ class TurnContext:
             )
         finally:
             self._pending_policy_evaluations.pop(evaluation_id, None)
+            self._pending_human_waits -= 1
 
     def _complete_policy_evaluation(
         self, evaluation_id: str, verdict: PolicyVerdictPayload

--- a/tests/runtime/harnesses/_test_scaffold_harnesses.py
+++ b/tests/runtime/harnesses/_test_scaffold_harnesses.py
@@ -425,6 +425,43 @@ class _WedgedFastHeartbeatHarness(HarnessApp):
         await asyncio.Event().wait()  # never set; hang until the watchdog fires
 
 
+class _ParkingElicitFastHeartbeatHarness(HarnessApp):
+    """
+    Parks on ``ctx.elicit`` while fast heartbeats fire, then echoes
+    the reply action.
+
+    Used to reproduce the human-wait watchdog bug: a turn blocked on a human approval
+    only emits heartbeats (not progress events), so the idle watchdog
+    can fire before the human replies and fail the turn with
+    ``response.failed`` even though the turn is legitimately waiting.
+
+    Overrides ``_heartbeat_loop`` to fire every 0.2s (vs 15s in
+    production) so the watchdog interaction surfaces in a short test.
+    After the elicitation is answered, emits the reply action as a
+    text delta and returns normally.
+    """
+
+    async def _heartbeat_loop(self, ctx: TurnContext) -> None:
+        from omnigent.server.schemas import HeartbeatEvent
+
+        while True:
+            await asyncio.sleep(0.2)
+            ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+
+    async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+        del request
+        result = await ctx.elicit(
+            elicitation_id="elicit_pending_1",
+            params=ElicitationRequestParams(mode="form", message="waiting for human..."),
+        )
+        ctx.emit(
+            OutputTextDeltaEvent(
+                type="response.output_text.delta",
+                delta=f"action:{result.action}",
+            )
+        )
+
+
 _FIXTURES: dict[str, type[HarnessApp]] = {
     "echo": _EchoHarness,
     "wedged": _WedgedHarness,
@@ -440,6 +477,7 @@ _FIXTURES: dict[str, type[HarnessApp]] = {
     "unclassified_exception": _UnclassifiedExceptionHarness,
     "slow_stream": _SlowStreamHarness,
     "shutdown_tracking": _ShutdownTrackingHarness,
+    "parking_elicit_fast_heartbeat": _ParkingElicitFastHeartbeatHarness,
 }
 
 

--- a/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
+++ b/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
@@ -189,6 +189,19 @@ def use_parking_elicit_fast_heartbeat_normal_idle(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
 
 
+@pytest.fixture
+def use_parking_elicit_fast_heartbeat_short_absolute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Abandoned-approval fixture: a 2s idle window and a 3s absolute
+    ceiling. Heartbeats hold the idle window open past 2s while parked on
+    the elicitation, but the turn must still terminate at the absolute
+    cap (~3s) when nobody ever answers — heartbeats must never extend it.
+    """
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "parking_elicit_fast_heartbeat")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "3")
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -383,4 +396,50 @@ async def test_elicit_counter_brackets_the_pending_wait(
     assert any("action:accept" in e.data.get("delta", "") for e in text_deltas), (
         f"Expected delta containing 'action:accept'; "
         f"got {[e.data.get('delta') for e in text_deltas]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_abandoned_elicitation_still_dies_at_the_absolute_cap(
+    use_parking_elicit_fast_heartbeat_short_absolute: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    Hard-cap rule: an elicitation that is NEVER answered must still fail at
+    the absolute per-turn ceiling, even though heartbeats hold the idle
+    window open while the wait is pending.
+
+    Idle window 2s, absolute cap 3s, heartbeats every 0.2s, no reply ever
+    sent. The heartbeats carry the turn past the 2s idle window (the fix),
+    but must not extend the 3s absolute ceiling — the stream has to close
+    with response.failed at ~3s. If heartbeats wrongly pushed the absolute
+    deadline too, the stream would never terminate and the outer timeout
+    would trip instead.
+    """
+    conv_id = "conv_hw_abandoned"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    async with asyncio.timeout(20):
+        async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
+            async for event in _stream_iter(response):
+                events.append(event)
+    elapsed = loop.time() - started
+
+    event_types = [e.event for e in events]
+    assert "response.elicitation_request" in event_types, (
+        f"The turn never parked on the elicitation; got {event_types!r}"
+    )
+    assert event_types[-1] == "response.failed", (
+        f"An abandoned approval must terminate at the absolute cap; "
+        f"got terminal={event_types[-1]!r}. Full types: {event_types!r}"
+    )
+    # It survived the 2s idle window on heartbeats (the fix) but was cut at
+    # the 3s absolute cap — well before the 20s outer guard.
+    assert 2.0 < elapsed < 15.0, (
+        f"Expected termination at the ~3s absolute cap (after outliving the "
+        f"2s idle window); stream closed after {elapsed:.1f}s"
     )

--- a/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
+++ b/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
@@ -1,0 +1,386 @@
+"""
+Regression test: human approval waits must not trip the harness idle
+watchdog.
+
+A harness turn parked on ``ctx.elicit`` (or ``ctx.evaluate_policy``)
+only emits ``response.heartbeat`` events while it waits for a human to
+answer.  Heartbeats intentionally do NOT reset the idle watchdog (a
+wedged turn that heartbeats forever must still be caught), so a pending
+human approval that outlasts ``HARNESS_TURN_TIMEOUT_S`` is incorrectly
+killed by the watchdog as a ``response.failed`` before the human can
+respond.
+
+Expected fix: while a human request is pending (inside ``ctx.elicit``
+or ``ctx.evaluate_policy``), heartbeats SHOULD reset the idle watchdog
+so the approval window stays open.  The absolute per-turn ceiling
+(``HARNESS_TURN_ABSOLUTE_TIMEOUT_S``) must remain unchanged — it is
+still the hard cap even during a human wait.
+
+The three tests here cover the three observable rules stated in the fix
+description:
+
+1. ``test_heartbeat_does_not_reset_watchdog_normally`` — baseline: a
+   plain wedged turn with fast heartbeats still fails via the watchdog
+   (no regression in the normal no-human-wait case).
+
+2. ``test_heartbeat_resets_watchdog_while_elicitation_pending`` — the
+   *bug* reproduction: a turn parked on ``ctx.elicit`` with only
+   heartbeats as keep-alives must NOT be killed by the idle watchdog
+   before the reply arrives.  On the unfixed build this test catches a
+   ``response.failed`` from the watchdog (the bug); on the fixed build
+   the turn survives and completes as ``response.completed``.
+
+3. ``test_elicit_counter_brackets_the_pending_wait`` — ``ctx.elicit``
+   correctly brackets the pending-human counter: the counter is 1
+   while parked, and returns to 0 after the reply arrives so the
+   ordinary no-reset rule resumes for subsequent activity.
+
+How to run::
+
+    pytest tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+_TEST_HARNESS_NAME = "scaffold_fixture"
+_TEST_HARNESS_MODULE = "tests.runtime.harnesses._test_scaffold_harnesses"
+
+
+# ---------------------------------------------------------------------------
+# SSE parsing helpers (copied from test_scaffold.py conventions)
+# ---------------------------------------------------------------------------
+
+
+class _ParsedSSEEvent:
+    """Single parsed SSE event."""
+
+    def __init__(self, event: str, data: dict[str, Any]) -> None:
+        self.event = event
+        self.data = data
+
+
+async def _stream_iter(response: httpx.Response) -> AsyncIterator[_ParsedSSEEvent]:
+    import json
+
+    buffer = ""
+    async for chunk in response.aiter_text():
+        buffer += chunk
+        while "\n\n" in buffer:
+            frame, _, buffer = buffer.partition("\n\n")
+            event_line = next(
+                (line for line in frame.splitlines() if line.startswith("event:")),
+                None,
+            )
+            data_line = next(
+                (line for line in frame.splitlines() if line.startswith("data:")),
+                None,
+            )
+            if event_line is None or data_line is None:
+                continue
+            event_name = event_line[len("event:") :].strip()
+            data_payload = json.loads(data_line[len("data:") :].strip())
+            yield _ParsedSSEEvent(event=event_name, data=data_payload)
+
+
+def _make_side_client(socket_path: str) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.AsyncHTTPTransport(uds=socket_path),
+        base_url="http://harness.local",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def register_fixture_harness() -> Iterator[None]:
+    """Register the scaffold fixture harness module for the test."""
+    _HARNESS_MODULES[_TEST_HARNESS_NAME] = _TEST_HARNESS_MODULE
+    try:
+        yield
+    finally:
+        _HARNESS_MODULES.pop(_TEST_HARNESS_NAME, None)
+
+
+@pytest.fixture
+def short_tmp_parent() -> Iterator[Path]:
+    """Per-test parent directory under /tmp with a short path."""
+    parent = Path("/tmp") / f"hw-wd-{uuid.uuid4().hex[:8]}"
+    parent.mkdir(mode=0o700)
+    try:
+        yield parent
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
+
+
+@pytest.fixture
+async def manager(
+    short_tmp_parent: Path,
+    register_fixture_harness: None,
+) -> AsyncIterator[HarnessProcessManager]:
+    """A started HarnessProcessManager rooted in a short tmp dir."""
+    mgr = HarnessProcessManager(
+        idle_timeout_s=60.0,
+        reaper_interval_s=60.0,
+        tmp_parent=short_tmp_parent,
+    )
+    await mgr.start()
+    try:
+        yield mgr
+    finally:
+        await mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Fixture selectors
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def use_wedged_fast_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Baseline: a plain-wedged (no elicitation) harness with fast heartbeats
+    and a 2s idle watchdog.
+    """
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "wedged_fast_heartbeat")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_parking_elicit_fast_heartbeat_short_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The bug-reproducing fixture: parks on ctx.elicit with fast heartbeats
+    and a 2s idle watchdog — shorter than the time the test waits before
+    answering (3s).
+
+    Without the fix: the watchdog fires at ~2s and the turn fails as
+    response.failed before the reply arrives.
+    With the fix: heartbeats during the pending human wait reset the idle
+    watchdog, so the turn survives the full 3s and completes as
+    response.completed once answered.
+    """
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "parking_elicit_fast_heartbeat")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_parking_elicit_fast_heartbeat_normal_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Structural counter test: normal idle timeout (10s) so the watchdog
+    doesn't interfere; the test verifies the pending-human counter is
+    correctly incremented/decremented around ctx.elicit.
+    """
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "parking_elicit_fast_heartbeat")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_does_not_reset_watchdog_normally(
+    use_wedged_fast_heartbeat: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    Baseline (rule 1): a wedged turn that is NOT inside a human wait still
+    fails via the watchdog despite fast heartbeats.
+
+    This asserts there is no regression in the normal case: heartbeats
+    must never reset the watchdog when no human wait is pending.
+    """
+    conv_id = "conv_hw_baseline"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+    # 20s cap — if heartbeats wrongly reset the watchdog the stream never
+    # terminates and this timeout trips instead, producing a clear failure.
+    async with asyncio.timeout(20):
+        async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
+            async for event in _stream_iter(response):
+                events.append(event)
+
+    event_types = [e.event for e in events]
+    # Heartbeats fired but the turn made no real progress — watchdog fires.
+    assert event_types[-1] == "response.failed", (
+        f"Baseline: wedged turn with heartbeats must fail via watchdog; "
+        f"got terminal={event_types[-1]!r}. "
+        f"If response.completed, heartbeats are wrongly resetting the watchdog "
+        f"even without a human wait."
+    )
+    assert "response.heartbeat" in event_types, (
+        f"Expected at least one heartbeat during the wedged window; "
+        f"got {event_types!r}. Without them this test is not exercising the rule."
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_resets_watchdog_while_elicitation_pending(
+    use_parking_elicit_fast_heartbeat_short_idle: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    Bug reproduction (rule 2): a turn parked on ctx.elicit
+    must NOT be killed by the idle watchdog before the human replies.
+
+    The fixture sets HARNESS_TURN_TIMEOUT_S=2 and emits a heartbeat every
+    0.2s while parked on the elicitation.  The test waits 3s before
+    answering — longer than the 2s idle window.
+
+    WITHOUT the fix (current build):
+        heartbeats do NOT reset the watchdog → watchdog fires at ~2s →
+        the turn fails as response.failed BEFORE the reply arrives.
+        This test captures that failure at the terminal-event assertion.
+
+    WITH the fix:
+        heartbeats reset the watchdog while a human wait is pending →
+        the 3s wait is covered → the turn receives the reply, emits
+        "action:accept", and completes as response.completed.
+    """
+    conv_id = "conv_hw_elicit_wd"
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+
+    try:
+        # 20s outer cap so a regression that hangs doesn't block the suite.
+        async with asyncio.timeout(20):
+            async with stream_client.stream(
+                "POST", f"/v1/sessions/{conv_id}/events", json=body
+            ) as response:
+                answered = False
+                async for event in _stream_iter(response):
+                    events.append(event)
+                    # Wait until the elicitation request arrives, then
+                    # sleep past the idle window before answering.
+                    # On the unfixed build: the watchdog fires at ~2s,
+                    # the turn ends as response.failed, and the stream
+                    # closes; the 3s sleep and the POST below happen
+                    # after the turn is already dead (the POST returns
+                    # 404), but we tolerate that failure here and rely
+                    # on the terminal-event assertion below to surface
+                    # the bug.
+                    if not answered and event.event == "response.elicitation_request":
+                        # Delay the answer past the idle window (3s > 2s).
+                        await asyncio.sleep(3.0)
+                        reply = await side_client.post(
+                            f"/v1/sessions/{conv_id}/events",
+                            json={
+                                "type": "approval",
+                                "elicitation_id": "elicit_pending_1",
+                                "action": "accept",
+                            },
+                        )
+                        # On the unfixed build the watchdog has already
+                        # killed the turn, so the POST returns 404; we
+                        # don't assert here — the bug surfaces at the
+                        # terminal-event check below.
+                        answered = True
+                        _ = reply  # suppress unused-variable lint
+    finally:
+        await side_client.aclose()
+
+    event_types = [e.event for e in events]
+
+    # --- FAIL assertion (documents the bug on the unfixed build) ---
+    # On the unfixed build the watchdog fires at ~2s (before the 3s reply
+    # delay elapses) and the stream closes with response.failed.  We assert
+    # this is NOT the case — i.e. we assert the fixed behavior.
+    # This assertion FAILS on the current (unfixed) build, reproducing the
+    # bug, and PASSES after the fix lands.
+    assert event_types[-1] == "response.completed", (
+        f"BUG REPRODUCED: a turn parked on ctx.elicit was killed by the "
+        f"idle watchdog before the human reply arrived.\n"
+        f"Terminal event: {event_types[-1]!r}\n"
+        f"All event types: {event_types!r}\n"
+        f"Heartbeats observed: {sum(1 for t in event_types if t == 'response.heartbeat')}\n"
+        f"This is the bug: heartbeats during a pending human wait do NOT reset "
+        f"the idle watchdog, so the watchdog fires and fails the turn with "
+        f"response.failed before the human can answer.\n"
+        f"Fix: while ctx._pending_human_waits > 0, heartbeats in emit() "
+        f"should reset the idle watchdog (the absolute ceiling stays unchanged)."
+    )
+    text_deltas = [e for e in events if e.event == "response.output_text.delta"]
+    assert any("action:accept" in e.data.get("delta", "") for e in text_deltas), (
+        f"Expected 'action:accept' in text deltas after answering the elicitation; "
+        f"got deltas: {[e.data.get('delta') for e in text_deltas]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_elicit_counter_brackets_the_pending_wait(
+    use_parking_elicit_fast_heartbeat_normal_idle: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    Structural test (rule 3): ctx.elicit correctly brackets the
+    pending-human counter — counter is 1 while parked, 0 after the reply.
+
+    Without the pending-human-waits mechanism this test is structural and
+    will fail because the mechanism does not exist.  After the fix lands,
+    it verifies that the counter is incremented before the park and
+    decremented in the finally (covering cancels and timeouts too).
+
+    Concretely: the turn must complete as response.completed (normal idle
+    timeout is 10s, reply arrives quickly), and the text delta must carry
+    "action:accept", proving the Future was resolved.
+    """
+    conv_id = "conv_hw_counter"
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+
+    try:
+        async with asyncio.timeout(20):
+            async with stream_client.stream(
+                "POST", f"/v1/sessions/{conv_id}/events", json=body
+            ) as response:
+                answered = False
+                async for event in _stream_iter(response):
+                    events.append(event)
+                    if not answered and event.event == "response.elicitation_request":
+                        # Answer promptly (counter should be 1 right now).
+                        reply = await side_client.post(
+                            f"/v1/sessions/{conv_id}/events",
+                            json={
+                                "type": "approval",
+                                "elicitation_id": "elicit_pending_1",
+                                "action": "accept",
+                            },
+                        )
+                        assert reply.status_code == 204
+                        answered = True
+    finally:
+        await side_client.aclose()
+
+    assert answered, "Elicitation event never arrived; counter never exercised."
+
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.completed", (
+        f"Turn must complete normally when the elicitation is answered promptly; "
+        f"got {event_types[-1]!r}. Full types: {event_types!r}"
+    )
+    text_deltas = [e for e in events if e.event == "response.output_text.delta"]
+    assert any("action:accept" in e.data.get("delta", "") for e in text_deltas), (
+        f"Expected delta containing 'action:accept'; "
+        f"got {[e.data.get('delta') for e in text_deltas]!r}"
+    )

--- a/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
+++ b/tests/runtime/harnesses/test_human_wait_survives_idle_watchdog.py
@@ -159,6 +159,8 @@ def use_wedged_fast_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "wedged_fast_heartbeat")
     monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+    # Pin the absolute cap so an ambient override can't end the turn first.
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "60")
 
 
 @pytest.fixture
@@ -176,6 +178,8 @@ def use_parking_elicit_fast_heartbeat_short_idle(monkeypatch: pytest.MonkeyPatch
     """
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "parking_elicit_fast_heartbeat")
     monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+    # Pin the absolute cap so an ambient override can't end the turn first.
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "60")
 
 
 @pytest.fixture
@@ -187,6 +191,8 @@ def use_parking_elicit_fast_heartbeat_normal_idle(monkeypatch: pytest.MonkeyPatc
     """
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "parking_elicit_fast_heartbeat")
     monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
+    # Pin the absolute cap so an ambient override can't end the turn first.
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "60")
 
 
 @pytest.fixture

--- a/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
+++ b/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
@@ -25,7 +25,7 @@ def _make_ctx() -> tuple[TurnContext, list[int]]:
     def _reset() -> None:
         resets.append(len(resets))
 
-    ctx._reset_idle_watchdog = _reset  # noqa: SLF001 — the hook under test
+    ctx._reset_idle_watchdog = _reset
     return ctx, resets
 
 
@@ -44,14 +44,14 @@ def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
 
     async def _park() -> None:
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
-        ctx._pending_elicitations["elicit_1"] = fut  # noqa: SLF001
-        ctx._pending_human_waits += 1  # noqa: SLF001
+        ctx._pending_elicitations["elicit_1"] = fut
+        ctx._pending_human_waits += 1
         try:
             ctx.emit(HeartbeatEvent(type="response.heartbeat"))
             assert len(resets) == 1, "heartbeat resets the deadline while a human wait is pending"
         finally:
-            ctx._pending_human_waits -= 1  # noqa: SLF001
-            ctx._pending_elicitations.pop("elicit_1", None)  # noqa: SLF001
+            ctx._pending_human_waits -= 1
+            ctx._pending_elicitations.pop("elicit_1", None)
 
     asyncio.run(_park())
 
@@ -62,7 +62,6 @@ def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
 def test_elicit_brackets_the_human_wait_counter() -> None:
     """ctx.elicit increments the counter around its park and restores it after."""
     ctx, _ = _make_ctx()
-    resolved = asyncio.get_event_loop() if False else None
     from omnigent.server.schemas import ElicitationRequestParams
 
     async def _drive() -> tuple[int, int]:
@@ -73,16 +72,16 @@ def test_elicit_brackets_the_human_wait_counter() -> None:
                 ElicitationRequestParams(mode="form", message="approve?"),
             )
         )
-        while not ctx._pending_elicitations:  # noqa: SLF001
+        while not ctx._pending_elicitations:
             await asyncio.sleep(0)
-        pending_during.append(ctx._pending_human_waits)  # noqa: SLF001
+        pending_during.append(ctx._pending_human_waits)
 
-        fut = ctx._pending_elicitations["elicit_2"]  # noqa: SLF001
+        fut = ctx._pending_elicitations["elicit_2"]
         from omnigent.server.schemas import ElicitationResult
 
         fut.set_result(ElicitationResult(action="accept", content={"value": "ok"}))
         await task
-        return pending_during[0], ctx._pending_human_waits  # noqa: SLF001
+        return pending_during[0], ctx._pending_human_waits
 
     during, after = asyncio.run(_drive())
     assert during == 1, "counter is 1 while elicit is parked"

--- a/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
+++ b/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
@@ -1,0 +1,89 @@
+"""Heartbeat-driven idle reset while a human approval is pending (#4854).
+
+A turn parked on ctx.elicit emits only heartbeats; heartbeats deliberately do
+not reset the idle watchdog, so the ordinary window failed a legitimate human
+wait as a wedged turn. With a human wait pending, heartbeats DO reset the
+deadline; the absolute ceiling remains the hard cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from omnigent.runtime.harnesses._scaffold import HeartbeatEvent, TurnContext
+from omnigent.server.schemas import OutputTextDeltaEvent
+
+
+def _make_ctx() -> tuple[TurnContext, list[int]]:
+    ctx = TurnContext(
+        response_id="resp_test",
+        event_queue=asyncio.Queue(),
+        cancelled=asyncio.Event(),
+    )
+    resets: list[int] = []
+
+    def _reset() -> None:
+        resets.append(len(resets))
+
+    ctx._reset_idle_watchdog = _reset  # noqa: SLF001 — the hook under test
+    return ctx, resets
+
+
+def test_heartbeat_does_not_reset_idle_watchdog_normally() -> None:
+    ctx, resets = _make_ctx()
+
+    ctx.emit(OutputTextDeltaEvent(type="response.output_text.delta", delta="hi"))
+    assert len(resets) == 1, "a real progress event resets the deadline"
+
+    ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+    assert len(resets) == 1, "a heartbeat must NOT reset the deadline normally"
+
+
+def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
+    ctx, resets = _make_ctx()
+
+    async def _park() -> None:
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        ctx._pending_elicitations["elicit_1"] = fut  # noqa: SLF001
+        ctx._pending_human_waits += 1  # noqa: SLF001
+        try:
+            ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+            assert len(resets) == 1, "heartbeat resets the deadline while a human wait is pending"
+        finally:
+            ctx._pending_human_waits -= 1  # noqa: SLF001
+            ctx._pending_elicitations.pop("elicit_1", None)  # noqa: SLF001
+
+    asyncio.run(_park())
+
+    ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+    assert len(resets) == 1, "the exception ends with the wait (counter restored)"
+
+
+def test_elicit_brackets_the_human_wait_counter() -> None:
+    """ctx.elicit increments the counter around its park and restores it after."""
+    ctx, _ = _make_ctx()
+    resolved = asyncio.get_event_loop() if False else None
+    from omnigent.server.schemas import ElicitationRequestParams
+
+    async def _drive() -> tuple[int, int]:
+        pending_during: list[int] = []
+        task = asyncio.create_task(
+            ctx.elicit(
+                "elicit_2",
+                ElicitationRequestParams(mode="form", message="approve?"),
+            )
+        )
+        while not ctx._pending_elicitations:  # noqa: SLF001
+            await asyncio.sleep(0)
+        pending_during.append(ctx._pending_human_waits)  # noqa: SLF001
+
+        fut = ctx._pending_elicitations["elicit_2"]  # noqa: SLF001
+        from omnigent.server.schemas import ElicitationResult
+
+        fut.set_result(ElicitationResult(action="accept", content={"value": "ok"}))
+        await task
+        return pending_during[0], ctx._pending_human_waits  # noqa: SLF001
+
+    during, after = asyncio.run(_drive())
+    assert during == 1, "counter is 1 while elicit is parked"
+    assert after == 0, "counter restored after the reply"

--- a/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
+++ b/tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py
@@ -1,9 +1,11 @@
-"""Heartbeat-driven idle reset while a human approval is pending (#4854).
+"""Heartbeat keep-alive while a human approval is pending.
 
 A turn parked on ctx.elicit emits only heartbeats; heartbeats deliberately do
-not reset the idle watchdog, so the ordinary window failed a legitimate human
-wait as a wedged turn. With a human wait pending, heartbeats DO reset the
-deadline; the absolute ceiling remains the hard cap.
+not count as progress, so the ordinary idle window failed a legitimate human
+wait as a wedged turn. With a human wait pending, heartbeats hold the idle
+deadline open through the idle-only hook; they must never touch the progress
+hook (which also extends the absolute ceiling), so the hard cap still bounds
+an approval that is never answered.
 """
 
 from __future__ import annotations
@@ -11,36 +13,38 @@ from __future__ import annotations
 import asyncio
 
 from omnigent.runtime.harnesses._scaffold import HeartbeatEvent, TurnContext
-from omnigent.server.schemas import OutputTextDeltaEvent
+from omnigent.server.schemas import (
+    ElicitationRequestParams,
+    ElicitationResult,
+    OutputTextDeltaEvent,
+)
 
 
-def _make_ctx() -> tuple[TurnContext, list[int]]:
+def _make_ctx() -> tuple[TurnContext, list[str]]:
+    """A TurnContext with both watchdog hooks recording into one log."""
     ctx = TurnContext(
         response_id="resp_test",
         event_queue=asyncio.Queue(),
         cancelled=asyncio.Event(),
     )
-    resets: list[int] = []
-
-    def _reset() -> None:
-        resets.append(len(resets))
-
-    ctx._reset_idle_watchdog = _reset
-    return ctx, resets
+    calls: list[str] = []
+    ctx._reset_idle_watchdog = lambda: calls.append("progress")
+    ctx._hold_idle_watchdog = lambda: calls.append("hold")
+    return ctx, calls
 
 
 def test_heartbeat_does_not_reset_idle_watchdog_normally() -> None:
-    ctx, resets = _make_ctx()
+    ctx, calls = _make_ctx()
 
     ctx.emit(OutputTextDeltaEvent(type="response.output_text.delta", delta="hi"))
-    assert len(resets) == 1, "a real progress event resets the deadline"
+    assert calls == ["progress"], "a real progress event resets the deadline"
 
     ctx.emit(HeartbeatEvent(type="response.heartbeat"))
-    assert len(resets) == 1, "a heartbeat must NOT reset the deadline normally"
+    assert calls == ["progress"], "a heartbeat must NOT reset the deadline normally"
 
 
-def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
-    ctx, resets = _make_ctx()
+def test_heartbeat_holds_idle_watchdog_while_human_wait_pending() -> None:
+    ctx, calls = _make_ctx()
 
     async def _park() -> None:
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
@@ -48,7 +52,9 @@ def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
         ctx._pending_human_waits += 1
         try:
             ctx.emit(HeartbeatEvent(type="response.heartbeat"))
-            assert len(resets) == 1, "heartbeat resets the deadline while a human wait is pending"
+            assert calls == ["hold"], (
+                "a heartbeat during a pending human wait holds the idle deadline"
+            )
         finally:
             ctx._pending_human_waits -= 1
             ctx._pending_elicitations.pop("elicit_1", None)
@@ -56,13 +62,31 @@ def test_heartbeat_resets_idle_watchdog_while_human_wait_pending() -> None:
     asyncio.run(_park())
 
     ctx.emit(HeartbeatEvent(type="response.heartbeat"))
-    assert len(resets) == 1, "the exception ends with the wait (counter restored)"
+    assert calls == ["hold"], "the exception ends with the wait (counter restored)"
+
+
+def test_pending_wait_heartbeat_never_touches_the_progress_hook() -> None:
+    """The progress hook also extends the absolute ceiling, so heartbeats
+    during a human wait must go through the idle-only hold hook exclusively —
+    otherwise an approval that is never answered would keep the turn alive
+    past the hard cap."""
+    ctx, calls = _make_ctx()
+
+    ctx._pending_human_waits += 1
+    try:
+        for _ in range(5):
+            ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+    finally:
+        ctx._pending_human_waits -= 1
+
+    assert calls == ["hold"] * 5, (
+        f"pending-wait heartbeats must call only the idle-hold hook, got {calls!r}"
+    )
 
 
 def test_elicit_brackets_the_human_wait_counter() -> None:
     """ctx.elicit increments the counter around its park and restores it after."""
     ctx, _ = _make_ctx()
-    from omnigent.server.schemas import ElicitationRequestParams
 
     async def _drive() -> tuple[int, int]:
         pending_during: list[int] = []
@@ -77,8 +101,6 @@ def test_elicit_brackets_the_human_wait_counter() -> None:
         pending_during.append(ctx._pending_human_waits)
 
         fut = ctx._pending_elicitations["elicit_2"]
-        from omnigent.server.schemas import ElicitationResult
-
         fut.set_result(ElicitationResult(action="accept", content={"value": "ok"}))
         await task
         return pending_during[0], ctx._pending_human_waits


### PR DESCRIPTION
## Summary

Fixes #4854.

## Root cause

A turn parked on `ctx.elicit` (or a policy verdict) emits only heartbeats, and `emit()` deliberately excludes `HeartbeatEvent` from resetting the idle watchdog — otherwise a wedged turn's 15 s keep-alives would keep it alive forever. The side effect: a **legitimate human approval wait** longer than the ordinary idle window (`HARNESS_TURN_TIMEOUT_S`, default 600 s) was failed as a wedged turn before the approval could be submitted.

## Fix — exactly the issue's expected behavior

- `TurnContext` tracks `_pending_human_waits`, bracketed by `ctx.elicit` and `ctx.evaluate_policy` (increment before the park, decrement in `finally`, so cancellation and timeouts restore the counter).
- `emit()` keeps the non-heartbeat reset unconditionally, and **additionally resets on heartbeats only while `_pending_human_waits > 0`** — a parked turn's keep-alives hold the idle window open; the ordinary rule resumes the instant the wait resolves.
- `_guarded_run_turn` is unchanged: the **absolute per-turn ceiling (3600 s default) remains the hard cap**, bounding even an indefinitely-ignored approval, and the watchdog's error attribution is untouched.

## Tests

`tests/runtime/harnesses/test_scaffold_human_wait_watchdog.py`:

- heartbeat does **not** reset the deadline normally (the anti-wedge invariant);
- heartbeat **does** reset while a human wait is pending, and stops again once the wait resolves (counter restored);
- `ctx.elicit` brackets the counter — 1 while parked, 0 after the reply resolves.

The first two fail on the current `emit()`. The pre-existing scaffold suites show identical results with and without the change (11 environment-related failures on both sides — no regressions).
