### PR TITLE
feat(terminal): let terminal.mouse=off disable tmux mouse capture

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -77,6 +77,10 @@ _TRANSPORT_PTY_ALIASES = frozenset({TERMINAL_TRANSPORT_PTY, "0", "false", "no", 
 _CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
 _TERMINAL_CONFIG_TABLE = "terminal"
 _TERMINAL_TRANSPORT_CONFIG_KEY = "transport"
+_TERMINAL_MOUSE_CONFIG_KEY = "mouse"
+# Values under ``terminal.mouse`` that turn tmux mouse mode OFF. Any other
+# value (or an absent key) leaves mouse mode ON, its historical default.
+_MOUSE_OFF_ALIASES = frozenset({"0", "false", "no", "off"})
 
 
 def _global_config_path() -> Path:
@@ -114,25 +118,49 @@ def _global_terminal_transport_default() -> str:
 
     :returns: ``"control"`` or ``"pty"``.
     """
-    raw = _read_terminal_transport_config()
+    raw = _read_terminal_config_value(_TERMINAL_TRANSPORT_CONFIG_KEY)
     if raw is not None and raw.strip().lower() in _TRANSPORT_PTY_ALIASES:
         return TERMINAL_TRANSPORT_PTY
     return TERMINAL_TRANSPORT_CONTROL
 
 
-def _read_terminal_transport_config() -> str | None:
-    """Read ``terminal.transport`` from the global config, or ``None``.
+def _terminal_mouse_enabled() -> bool:
+    """Whether managed tmux servers enable mouse mode (historical default: on).
+
+    Reads ``terminal.mouse`` from ``~/.omnigent/config.yaml`` at call time (like
+    the transport default) so an edit takes effect on the next terminal launch,
+    and tests can point :envvar:`OMNIGENT_CONFIG_HOME` at a scratch config.
+    Mouse mode stays ON unless the key is a falsy value (``off`` / ``false`` /
+    ``no`` / ``0``); a missing/unreadable/typo'd value keeps it ON.
+
+    tmux ``mouse on`` is server-global, so it also applies to the local ``tmux
+    attach`` that ``omnigent claude`` / ``omnigent codex`` make in the user's
+    own terminal, where it captures click-drag selection and modifier-clicks
+    and so breaks native terminal copy-paste and cmd-click on links. Users who
+    attach locally and prefer their terminal's own mouse handling set
+    ``terminal.mouse: off``; under the default ``control`` web transport the
+    browser xterm owns its own scrollback/selection, so this does not cost the
+    web terminal its scroll.
+
+    :returns: ``True`` when tmux mouse mode should be enabled.
+    """
+    raw = _read_terminal_config_value(_TERMINAL_MOUSE_CONFIG_KEY)
+    return not (raw is not None and raw.strip().lower() in _MOUSE_OFF_ALIASES)
+
+
+def _read_terminal_config_value(key: str) -> str | None:
+    """Read ``terminal.<key>`` from the global config, or ``None``.
 
     Best-effort: any failure (missing/unreadable file, non-mapping YAML,
     absent table/key, non-string/bool value) returns ``None`` so the caller
-    uses the control default. Never raises.
+    uses its own default. Never raises.
 
     An unquoted YAML ``true``/``false`` parses as a real bool rather than a
     string, so a bool value is normalized to its lowercase string spelling
-    before returning — ``terminal.transport: false`` still selects the PTY
-    alias in :data:`_TRANSPORT_PTY_ALIASES`.
+    before returning — ``terminal.mouse: false`` still matches a falsy alias.
 
-    :returns: The raw configured transport string, or ``None`` when unset.
+    :param key: Key under the ``terminal:`` table, e.g. ``"transport"``.
+    :returns: The raw configured string value, or ``None`` when unset.
     """
     import yaml
 
@@ -150,7 +178,7 @@ def _read_terminal_transport_config() -> str | None:
     table = raw.get(_TERMINAL_CONFIG_TABLE)
     if not isinstance(table, dict):
         return None
-    value = table.get(_TERMINAL_TRANSPORT_CONFIG_KEY)
+    value = table.get(key)
     if isinstance(value, bool):
         return "true" if value else "false"
     return value if isinstance(value, str) else None
@@ -295,8 +323,9 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
 
     ``history-limit`` is generated per terminal because it comes from
     ``TerminalEnvSpec.scrollback``. ``mouse on`` makes the attached web
-    terminal scrollable. ``focus-events on`` lets interactive programs
-    observe pane focus changes. ``extended-keys`` with CSI-u formatting
+    terminal scrollable and is included unless ``terminal.mouse`` opts out
+    (see :func:`_terminal_mouse_enabled`). ``focus-events on`` lets interactive
+    programs observe pane focus changes. ``extended-keys`` with CSI-u formatting
     lets programs inside tmux receive Kitty Keyboard Protocol keys such
     as Shift+Enter when the attached terminal supports them. Terminals
     without that protocol ignore tmux's request, and the quiet tmux
@@ -307,14 +336,18 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
     :param scrollback: Tmux history limit, e.g. ``10000``.
     :returns: Tmux commands configuring pane input and scrollback.
     """
-    return [
+    commands = [
         ["set-option", "-g", "history-limit", str(scrollback)],
         ["set-option", "-sq", "extended-keys", "on"],
         ["set-option", "-sq", "extended-keys-format", "csi-u"],
-        ["set-option", "-g", "mouse", "on"],
+    ]
+    if _terminal_mouse_enabled():
+        commands.append(["set-option", "-g", "mouse", "on"])
+    commands += [
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],
     ]
+    return commands
 
 
 def _tmux_lockdown_commands() -> list[list[str]]:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -78,6 +78,61 @@ def test_resolve_terminal_transport_precedence(
     )
 
 
+def _write_mouse_config(config_home: Path, value: str | None) -> None:
+    """Write ``terminal.mouse: <value>`` into a scratch config.yaml.
+
+    :param config_home: Directory used as ``OMNIGENT_CONFIG_HOME``.
+    :param value: Mouse value to persist, or ``None`` to write a config with
+        no ``terminal`` table.
+    """
+    body = "" if value is None else f"terminal:\n  mouse: {value}\n"
+    (config_home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+_MOUSE_ON_COMMAND = ["set-option", "-g", "mouse", "on"]
+
+
+def test_terminal_mouse_enabled_reads_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``terminal.mouse`` opts out of tmux mouse mode; anything else keeps it on."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    # No config file, or a config with no terminal table → mouse stays on.
+    assert terminal_mod._terminal_mouse_enabled() is True
+    _write_mouse_config(tmp_path, None)
+    assert terminal_mod._terminal_mouse_enabled() is True
+
+    # Falsy values opt OUT. off/false/no parse as YAML booleans (normalized by
+    # the reader); a quoted "0" exercises the raw-string alias path.
+    for value in ("off", "false", "no", "Off", "FALSE", '"0"'):
+        _write_mouse_config(tmp_path, value)
+        assert terminal_mod._terminal_mouse_enabled() is False, value
+
+    # Truthy / unrecognized values keep mouse mode on, so a typo can't silently
+    # strip mouse-driven scroll from the web terminal.
+    for value in ("on", "true", "yes", "garbage"):
+        _write_mouse_config(tmp_path, value)
+        assert terminal_mod._terminal_mouse_enabled() is True, value
+
+
+def test_tmux_input_option_commands_gate_mouse(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The ``mouse on`` command is emitted only when mouse mode is enabled."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    # Default (no config): mouse mode is on and the command is emitted.
+    assert _MOUSE_ON_COMMAND in terminal_mod._tmux_input_option_commands(10000)
+
+    # Opted out: the mouse command is dropped but the other input options stay.
+    _write_mouse_config(tmp_path, "off")
+    commands = terminal_mod._tmux_input_option_commands(10000)
+    assert _MOUSE_ON_COMMAND not in commands
+    assert ["set-option", "-g", "history-limit", "10000"] in commands
+    assert ["set-option", "-g", "focus-events", "on"] in commands
+
+
 @dataclass
 class _SuccessfulProcess:
     """


### PR DESCRIPTION
Managed terminals run every native harness (claude, codex, ...) inside a private tmux server that sets `mouse on` globally. That option is server-global, so it also applies to the local `tmux attach` that `omnigent claude` / `omnigent codex` make in the user's own terminal, where tmux captures click-drag selection and modifier-clicks — breaking native terminal copy-paste and cmd-click on links (and it's below the harness, so a harness-side TUI setting can't override it).

Add a `terminal.mouse` key to `~/.omnigent/config.yaml` (read the same way as `terminal.transport`): set it to a falsy value to drop the `set-option -g mouse on` command. Default is unchanged (mouse on), and under the default `control` web transport the browser xterm owns its own scrollback/selection, so opting out doesn't cost the web terminal its scroll.

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
