### PR TITLE
Add an opt-in Parallel Search MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Two example agents ship with the repo, and they make good first sessions:
 omnigent run examples/polly/
 omnigent run examples/debby/
 omnigent run examples/deep-research/
+omnigent run examples/parallel_search/
 
 # ...or on a different harness (sub-agents keep their own):
 omnigent run examples/polly/ --harness <harness>
@@ -301,6 +302,12 @@ cross-checked report. It plans sub-queries, searches the live web and reads
 full pages through an MCP search server, and verifies each claim across
 independent sources. It's also the simplest example to copy from: one agent
 plus one `tools/mcp/*.yaml` server, no sub-agents.
+
+**🌐 Parallel Search** is a standalone variant that uses the free, no-account,
+no-API-key Parallel Search MCP server for live web search and URL fetching.
+See [`examples/parallel_search/`](examples/parallel_search/) for the complete
+agent image and research procedure; the existing Deep Research example and
+its provider remain unchanged.
 
 **Prefer the browser?** One command starts the local server and registers this
 machine as a host:

--- a/examples/parallel_search/README.md
+++ b/examples/parallel_search/README.md
@@ -1,0 +1,41 @@
+# parallel-search
+
+A single-agent example that produces cited, cross-checked web research using
+the existing Omnigent remote-MCP path and the Parallel Search MCP server.
+
+## What it does
+
+Given a question, the agent:
+
+1. decomposes it into focused searches,
+2. uses `web_search` to find candidate sources,
+3. uses `web_fetch` to read the pages it cites,
+4. cross-checks important claims, and
+5. returns a structured answer with inline citations and a Sources list.
+
+## Layout
+
+```
+parallel_search/
+├── config.yaml                         # the agent
+├── tools/mcp/parallel.yaml             # auto-discovered MCP server
+└── skills/parallel-search/SKILL.md     # the research procedure
+```
+
+## Run it
+
+The example's brain uses the `claude-sdk` harness, so configure an LLM provider
+with `omnigent setup` first. The Parallel Search MCP endpoint itself is free
+and needs no account, API key, or OAuth configuration:
+
+```bash
+omnigent run examples/parallel_search/
+```
+
+The server declaration is auto-discovered from `tools/mcp/parallel.yaml`; no
+`tools:` block or local shell environment is required. It exposes
+`web_search` for live search and `web_fetch` for reading a specific URL.
+
+This is an opt-in provider example. The existing
+[`examples/deep-research/`](../deep-research/) bundle and its Keenable server
+remain unchanged.

--- a/examples/parallel_search/config.yaml
+++ b/examples/parallel_search/config.yaml
@@ -1,0 +1,40 @@
+spec_version: 1
+name: parallel-search
+description: >-
+  Single-agent web researcher using Parallel Search MCP for live web search
+  and URL fetching, with cross-checked claims and inline citations.
+
+# "Brain": Claude Agent SDK. No model is pinned, so it runs on whatever
+# Claude provider is configured as the default (`omnigent setup`), and on
+# whichever model that provider's catalog resolves as its default.
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+interaction:
+  conversational: true
+  modalities:
+    input: [text]
+    output: [text]
+
+prompt: |
+  You are a careful web research assistant. Given a question, produce an
+  accurate, cited answer grounded in current web sources rather than memory.
+
+  Your web-research tools come from the Parallel Search MCP server:
+  - web_search — find candidate sources for a focused query.
+  - web_fetch — read the clean Markdown content of a specific URL.
+
+  Method:
+  1. Break the question into 3-6 focused sub-queries.
+  2. Search each sub-query, then fetch the most relevant pages before making
+     claims; a search result snippet is not enough evidence.
+  3. Cross-check important claims against at least two independent sources and
+     mention meaningful disagreements.
+  4. Write a structured answer with inline citations to URLs you fetched.
+  5. End with a Sources list containing the URLs you actually read.
+
+  Be honest about uncertainty and prefer primary, recent sources for
+  time-sensitive claims. Act in the same turn you announce: make the search
+  or fetch tool call instead of ending with only a plan.

--- a/examples/parallel_search/skills/parallel-search/SKILL.md
+++ b/examples/parallel_search/skills/parallel-search/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: parallel-search
+description: Procedure for answering questions with cited, cross-checked web research using Parallel Search MCP.
+---
+
+# parallel-search — cited, cross-checked web research
+
+Use this procedure for questions that need current, verifiable information
+from the web. The deliverable is a concise synthesis where every load-bearing
+claim is backed by a source you actually read.
+
+## Tools
+
+- `web_search(query)` — find candidate pages for a focused question.
+- `web_fetch(url)` — read clean Markdown from a specific URL.
+
+## Procedure
+
+1. **Plan.** Break the question into 3-6 focused sub-queries. For contested or
+   high-stakes topics, include at least two independent angles.
+2. **Search.** Use `web_search` for each sub-query. Prefer primary sources and
+   use recent or date-specific searches for time-sensitive claims.
+3. **Read.** Use `web_fetch` on the most promising pages. Do not cite a result
+   snippet without reading the page behind it.
+4. **Cross-check.** Verify each load-bearing claim against at least two
+   independent sources, and surface meaningful disagreements.
+5. **Synthesize.** Separate well-supported findings from uncertainty, cite the
+   URLs you fetched inline, and finish with a Sources list of those URLs.
+
+If coverage is thin or sources conflict, say so plainly instead of filling the
+gaps from prior knowledge.

--- a/examples/parallel_search/tools/mcp/parallel.yaml
+++ b/examples/parallel_search/tools/mcp/parallel.yaml
@@ -1,0 +1,6 @@
+# Parallel Search MCP — live web search and URL fetching.
+# Auto-discovered by omnigent from tools/mcp/*.yaml; no tools block is needed.
+name: parallel
+description: Live web search and URL fetching through Parallel Search MCP.
+transport: http
+url: https://search.parallel.ai/mcp

--- a/tests/e2e/omnigent/test_example_parallel_search.py
+++ b/tests/e2e/omnigent/test_example_parallel_search.py
@@ -1,0 +1,52 @@
+"""Structural test for the Parallel Search example bundle.
+
+The bundle uses Omnigent's standard auto-discovered HTTP MCP declaration. This
+test loads the spec without credentials or a live connection to the public
+endpoint, so it protects the example's wiring while keeping CI deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_parallel_search.py -> repo root is 3 parents up.
+_PARALLEL_SEARCH_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "parallel_search"
+
+
+@pytest.fixture(scope="module")
+def parallel_search_spec() -> AgentSpec:
+    """Load and validate the Parallel Search bundle once for the module."""
+    return load(_PARALLEL_SEARCH_BUNDLE)
+
+
+def test_parallel_search_loads_with_parallel_mcp(parallel_search_spec: AgentSpec) -> None:
+    """The bundle discovers exactly one configured Parallel HTTP MCP server."""
+    assert parallel_search_spec.name == "parallel-search"
+    assert parallel_search_spec.sub_agents == []
+
+    servers = {server.name: server for server in parallel_search_spec.mcp_servers}
+    assert list(servers) == ["parallel"]
+    parallel = servers["parallel"]
+    assert parallel.transport == "http"
+    assert parallel.url == "https://search.parallel.ai/mcp"
+
+
+def test_parallel_search_skill_present(parallel_search_spec: AgentSpec) -> None:
+    """The web-research procedure is discovered from skills/."""
+    assert sorted(skill.name for skill in parallel_search_spec.skills) == ["parallel-search"]
+
+
+def test_parallel_search_runs_on_claude_sdk(parallel_search_spec: AgentSpec) -> None:
+    """The example leaves the LLM model to the configured Claude provider."""
+    assert parallel_search_spec.executor.config.get("harness") == "claude-sdk"
+    assert parallel_search_spec.executor.model is None
+
+
+def test_parallel_search_has_no_os_environment(parallel_search_spec: AgentSpec) -> None:
+    """The example exposes only its remote web-research MCP tools."""
+    assert parallel_search_spec.os_env is None


### PR DESCRIPTION
## Related issue

N/A — this is a Docs / Test / CI change, so no issue is required.

## Summary

This adds an opt-in agent example for users who want cited, cross-checked web
research through Omnigent's existing remote-MCP path. It leaves the built-in
providers and existing Deep Research example unchanged.

In plain English: users get a ready-to-run research bundle without wiring a
server by hand or adding a credential for the MCP endpoint.

```text
question → Parallel Search agent → web_search/web_fetch MCP → cited answer
```

## Test Plan

- `uv sync --frozen --group dev`
- `git diff --check`
- `uv run --frozen pytest -q --override-ini=addopts= tests/e2e/omnigent/test_example_parallel_search.py tests/e2e/omnigent/test_examples_coverage_sync.py`
- `uv run --frozen ruff check tests/e2e/omnigent/test_example_parallel_search.py`
- `uv build --wheel --sdist`

All checks passed in the credential-free disposable validator.

## Demo

N/A — this is a non-visual example and configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The added e2e test is structural: it loads the bundle, checks MCP discovery
and configuration, and does not contact the external service or require
credentials.

## Changelog

Add an opt-in Parallel Search MCP example for cited web research.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.