### PR TITLE
fix(cli): fail loud and roll back when `omnigent start` can't connect

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2109,7 +2109,7 @@ def main() -> None:
     except click.ClickException as exc:
         log_cli_exception(exc, prefix="Click CLI error")
         exc.show()
-        if suggest_stale_host_recovery:
+        if suggest_stale_host_recovery and not isinstance(exc, _BackgroundHostConnectError):
             print_stale_host_hint()
         raise SystemExit(exc.exit_code) from exc
     except click.Abort as exc:
@@ -7872,6 +7872,22 @@ def _prompt_stop_local_server() -> None:
 # this long and surface its log instead of falsely reporting success.
 _BACKGROUND_HOST_GRACE_S = 2.0
 
+# How long `start` waits for a background daemon's host tunnel to register
+# online before declaring the server unreachable. A healthy connect takes a
+# few seconds; the daemon retries a dead URL forever, so without a bound the
+# command would report success against an offline host.
+_BACKGROUND_HOST_CONNECT_GRACE_S = 15.0
+
+
+class _BackgroundHostConnectError(click.ClickException):
+    """A ``start`` connect failure whose message names the exact recovery.
+
+    The generic stale-host hint ``main`` appends to CLI errors (``Run
+    `omnigent stop`…``) is wrong for these: a rolled-back spawn leaves
+    nothing to stop, and a reused daemon's error already names the precise
+    teardown command.
+    """
+
 
 def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
     """Fail loud if a freshly spawned background host daemon dies at once.
@@ -7893,6 +7909,41 @@ def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
         if time.time() >= deadline:
             return
         time.sleep(0.1)
+
+
+def _confirm_background_host_connected(record: _HostDaemonRecord) -> None:
+    """Fail loud if a background daemon's host never comes online.
+
+    A live PID does not mean the daemon connected: against a dead server
+    URL, a refused port, or credentials the server rejects, the daemon
+    retries forever in its log while the host reads offline. Without this
+    probe, ``start`` reports success in that state and the only recovery is
+    ``omnigent stop``.
+
+    :param record: Registry record of the daemon to verify.
+    :raises click.ClickException: If the host is not online within
+        :data:`_BACKGROUND_HOST_CONNECT_GRACE_S`, or the daemon exits
+        while connecting.
+    """
+    from omnigent._runner_startup import format_runner_log_tail
+
+    log_path = Path(record.log_path) if record.log_path else None
+    deadline = time.monotonic() + _BACKGROUND_HOST_CONNECT_GRACE_S
+    while True:
+        if _daemon_host_online(record):
+            return
+        if not _pid_alive(record.pid):
+            raise click.ClickException(
+                f"The host daemon exited while connecting.{format_runner_log_tail(log_path)}"
+            )
+        if time.monotonic() >= deadline:
+            raise click.ClickException(
+                f"The host daemon could not connect to {record.target} — no Omnigent "
+                f"server answered there within {_BACKGROUND_HOST_CONNECT_GRACE_S:.0f}s. "
+                "Check that the server is running and the URL is correct."
+                f"{format_runner_log_tail(log_path)}"
+            )
+        time.sleep(0.5)
 
 
 def _run_background_host(
@@ -7922,8 +7973,8 @@ def _run_background_host(
     :param non_interactive: When ``True``, never launch the browser login —
         fail with the ``omnigent login`` hint instead.
     :raises click.ClickException: If the daemon cannot be spawned, exits
-        immediately after starting, or (local mode) never serves its local
-        Omnigent server.
+        immediately after starting, (remote mode) never connects its host
+        tunnel, or (local mode) never serves its local Omnigent server.
     """
     if server:
         _ensure_databricks_server_auth(server, non_interactive=non_interactive)
@@ -7940,13 +7991,14 @@ def _run_background_host(
         raise click.ClickException(
             "Could not spawn the background host daemon. See ~/.omnigent/logs/host/ for details."
         )
-    if previous is not None and previous.pid == record.pid:
+    reused = previous is not None and previous.pid == record.pid
+    if reused:
         headline = _cli_style("Host daemon already running", fg="yellow", bold=True)
     else:
         _confirm_background_host_alive(record)
         headline = _cli_style("Started the host daemon in the background", fg="green", bold=True)
-    click.echo(f"{headline} (pid {record.pid}).")
     if record.mode == "local":
+        click.echo(f"{headline} (pid {record.pid}).")
         # A local-mode daemon owns the local Omnigent server, so this command is
         # the whole "start everything" step — wait for that server and report
         # its URL, otherwise the Web UI is unreachable without a follow-up
@@ -7956,6 +8008,26 @@ def _run_background_host(
         _update_daemon_resolved_server_url(target, server_url)
     else:
         server_url = target
+        try:
+            _confirm_background_host_connected(record)
+        except click.ClickException as exc:
+            if reused:
+                # Not this invocation's daemon to kill: it may recover when
+                # its server returns, and it can own live sessions. Point at
+                # the teardown instead of rolling back.
+                raise _BackgroundHostConnectError(
+                    f"{exc.message}\nThe running daemon (pid {record.pid}) keeps retrying "
+                    f"in the background; if the target is wrong, stop it with "
+                    f"`{stop_command}` and retry."
+                ) from exc
+            # Roll back the daemon this invocation spawned: leaving it would
+            # report success against an offline host and block the next
+            # `start` with "already running" — the state that used to require
+            # an `omnigent stop` before retrying.
+            with contextlib.suppress(click.ClickException):
+                _terminate_daemon(record, force=True)
+            raise _BackgroundHostConnectError(exc.message) from exc
+        click.echo(f"{headline} (pid {record.pid}).")
     _echo_host_field("server", _cli_style(server_url, fg="cyan"))
     if record.log_path is not None:
         _echo_host_field("log", _display_path(Path(record.log_path)))

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -737,6 +737,155 @@ def test_daemon_tunnel_recovers_false_when_never_online(
     assert cli._daemon_tunnel_recovers(_online_record(), grace_s=0.0) is False
 
 
+# ── Background-host connect verification (`start` / `host --background`) ──
+
+
+def _patch_background_host_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    online: bool,
+    pid_alive: bool = True,
+) -> dict[str, object]:
+    """Stub ``_run_background_host``'s collaborators for a remote-target run.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temp dir for the host pidfile + daemon registry.
+    :param online: What the host-online probe reports.
+    :param pid_alive: What the PID liveness check reports.
+    :returns: Capture dict; ``terminated`` records ``(pid, force)`` pairs
+        passed to ``_terminate_daemon`` (which also deletes the record, like
+        the real one), ``args``/``calls`` come from the Popen stub.
+    """
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: pid_alive)
+    monkeypatch.setattr(cli, "_daemon_host_online", lambda record, **_kw: online)
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda server, **kw: None)
+    # Skip the real alive/connect grace waits — the stubs answer on the
+    # first poll, so only the zeroed deadline matters.
+    monkeypatch.setattr(cli, "_BACKGROUND_HOST_GRACE_S", 0.0)
+    monkeypatch.setattr(cli, "_BACKGROUND_HOST_CONNECT_GRACE_S", 0.0)
+    terminated: list[tuple[int, bool]] = []
+
+    def _fake_terminate(record: cli._HostDaemonRecord, *, force: bool) -> None:
+        terminated.append((record.pid, force))
+        cli._delete_daemon_record(record)
+
+    monkeypatch.setattr(cli, "_terminate_daemon", _fake_terminate)
+    captured["terminated"] = terminated
+    return captured
+
+
+def test_run_background_host_remote_reports_start_once_online(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A fresh remote daemon whose host comes online is reported as started."""
+    captured = _patch_background_host_spawn(monkeypatch, tmp_path, online=True)
+
+    cli._run_background_host(
+        "https://server.example.com", stop_command="omnigent stop", non_interactive=True
+    )
+
+    out = capsys.readouterr().out
+    assert "Started the host daemon in the background" in out
+    assert "https://server.example.com" in out
+    assert captured["terminated"] == []
+
+
+def test_run_background_host_remote_rolls_back_when_never_online(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A fresh daemon that never connects is torn down, not reported started.
+
+    The `start` trap: against a dead server URL the daemon retries forever
+    in its log; reporting success here leaves a live record that blocks the
+    next `start` with "already running" — the state that used to require
+    `omnigent stop` before retrying.
+    """
+    captured = _patch_background_host_spawn(monkeypatch, tmp_path, online=False)
+
+    with pytest.raises(click.ClickException, match="could not connect") as exc:
+        cli._run_background_host(
+            "https://server.example.com", stop_command="omnigent stop", non_interactive=True
+        )
+
+    # Marker type: main() must not append the generic "Run `omnigent stop`"
+    # stale-host hint — the rollback already left nothing to stop.
+    assert isinstance(exc.value, cli._BackgroundHostConnectError)
+    out = capsys.readouterr().out
+    assert "Started the host daemon" not in out
+    assert captured["terminated"] == [(7777, True)]
+    # The rollback leaves a clean slate: the next `start` spawns fresh
+    # instead of reusing a zombie.
+    assert cli._find_daemon_record("https://server.example.com") is None
+
+
+def test_run_background_host_reused_daemon_offline_is_not_torn_down(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A pre-existing daemon that never connects errors but keeps running.
+
+    The reused daemon may recover when its server returns and can own live
+    sessions, so `start` fails loud and points at the teardown command
+    instead of killing it — but it must not report "already running" as if
+    the host were fine.
+    """
+    captured = _patch_background_host_spawn(monkeypatch, tmp_path, online=False)
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+        log_path=str(tmp_path / "daemon.log"),
+    )
+
+    with pytest.raises(click.ClickException, match="keeps retrying") as exc:
+        cli._run_background_host(
+            "https://server.example.com",
+            stop_command="omnigent host stop --server https://server.example.com",
+            non_interactive=True,
+        )
+
+    assert "omnigent host stop --server https://server.example.com" in str(exc.value)
+    assert isinstance(exc.value, cli._BackgroundHostConnectError)
+    assert captured["terminated"] == []
+    assert "args" not in captured  # reused, not respawned
+
+
+def test_run_background_host_remote_daemon_dies_while_connecting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A daemon that exits mid-connect is reported with its log, then rolled back."""
+    captured = _patch_background_host_spawn(monkeypatch, tmp_path, online=False, pid_alive=False)
+    # The early-death check has its own message; isolate the connect wait's.
+    monkeypatch.setattr(cli, "_confirm_background_host_alive", lambda record: None)
+
+    with pytest.raises(click.ClickException, match="exited while connecting"):
+        cli._run_background_host(
+            "https://server.example.com", stop_command="omnigent stop", non_interactive=True
+        )
+
+    assert captured["terminated"] == [(7777, True)]
+
+
+def test_start_command_remote_dead_server_fails_and_rolls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`omnigent start --server <dead-url>` exits non-zero and leaves no daemon."""
+    captured = _patch_background_host_spawn(monkeypatch, tmp_path, online=False)
+    monkeypatch.setattr(cli, "_load_effective_config", dict)
+    monkeypatch.setattr(cli, "_workspace_api_server_url", lambda server: server.rstrip("/"))
+
+    result = CliRunner().invoke(cli_group, ["start", "--server", "https://server.example.com"])
+
+    assert result.exit_code != 0
+    assert "could not connect" in result.output
+    assert "Started the host daemon" not in result.output
+    assert captured["terminated"] == [(7777, True)]
+
+
 def test_ensure_backend_exits_clean_on_config_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -682,6 +682,9 @@ def _patch_background_host_spawn(
     monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: checked == pid)
     # Local mode waits for the server the daemon owns; no real server here.
     monkeypatch.setattr("omnigent.cli._discover_local_server_url", lambda: "http://127.0.0.1:6767")
+    # Remote targets verify the tunnel came online; no real server to probe.
+    monkeypatch.setattr("omnigent.cli._daemon_host_online", lambda record, **_kw: True)
+    monkeypatch.setattr("omnigent.cli._BACKGROUND_HOST_CONNECT_GRACE_S", 0.0)
     log_path = tmp_path / "host-test.log"
     log_path.write_text("")
     spawned_args: list[list[str]] = []


### PR DESCRIPTION
## Related issue

Closes #4986

## Summary

`omnigent start` (and `omnigent host --background`) against a server URL with nothing listening printed **Started the host daemon in the background** and exited 0, while the daemon just reconnect-looped in its log and the host stayed offline forever. Because remote-target daemon reuse checks PID liveness only, every later `start` then printed **Host daemon already running** — the machine looked started but nothing worked, and the only way out was `omnigent stop`.

Remote targets now verify the host tunnel actually registered **online** (15s bound) before reporting success:

- A daemon *this invocation* spawned that never connects is terminated and its registry record removed — the next `start` retries from a clean slate, no `omnigent stop` needed.
- A *reused* daemon that is offline fails the command with the exact teardown command in the error, but is deliberately **not** killed: it may recover when its server returns, and it can own live sessions.
- These failures skip the generic "Run \`omnigent stop\`" stale-host hint in `main()` (new `_BackgroundHostConnectError` marker): after a rollback there is nothing to stop, and the reused case already names the precise teardown.

Local mode is unchanged — it already waits for its server (`_discover_local_server_url`) and self-heals zombies on the next run.

**ELI5:** previously `start` checked only that the daemon *process woke up*, not that it *reached the server* — like sending a messenger, watching them leave the building, and declaring the message delivered. Now `start` waits for the messenger's "arrived" call; if it never comes, it cleans up and tells you, so you can fix the address and send again immediately.

```
before:  start → spawn daemon → pid alive? → "Started ✓" (host offline forever)
                    ↑ retry: pid alive → "already running"  ← only `stop` escapes
after:   start → spawn daemon → host online? → yes → "Started ✓"
                                      ↓ no (15s)
                 fresh:  kill daemon + drop record → Error (retry clean)
                 reused: keep daemon (may recover) → Error naming exact stop cmd
```

## Test Plan

- `pytest tests/cli tests/host` — 1482 passed, including 5 new tests in `tests/cli/test_backend.py`:
  - fresh spawn comes online → reported started, nothing terminated
  - fresh spawn never online → error, daemon force-terminated, record gone
  - reused daemon never online → error naming the teardown command, daemon *not* terminated, not respawned
  - daemon dies mid-connect → "exited while connecting" + rollback
  - `start --server <dead-url>` end-to-end via `CliRunner` → non-zero, rollback, no "Started" output
- Updated `tests/host/test_cli_host.py` background-spawn helper for the new online probe; existing `start` / `host --background` wiring tests unchanged and green.
- Manual end-to-end on a dev machine (see Demo).

## Demo

N/A (CLI change). Before/after from manual verification against a dead loopback config target:

```
# before — exit 0, daemon reconnect-looping, later starts say "already running"
$ omnigent start
Started the host daemon in the background (pid 1006750).
  server: http://127.0.0.1:6767

# after — exit 1, clear error, no daemon/record left behind
$ omnigent start
Error: The host daemon could not connect to http://127.0.0.1:6767 — no Omnigent
server answered there within 15s. Check that the server is running and the URL
is correct.

# healthy paths: fresh spawn against a live server succeeds in ~5s;
# reuse of a genuinely connected daemon still prints "Host daemon already running".
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified on a dev machine against real processes: (1) `start` with config `server: http://127.0.0.1:6767` and nothing listening → fails in ~17s, exit 1, no daemon process or registry record left, retry identical (no "already running"); (2) `server --background` + `start` → success in ~5s with a verified-online tunnel, reuse prints "already running"; (3) `start --server <databricks-url>` against a live, healthy remote daemon → "already running" in ~2s, daemon untouched; (4) machine left in its original state (pre-existing remote daemon still online).

## Changelog

`omnigent start` now fails fast with a clear error when the server is unreachable, instead of claiming success and requiring `omnigent stop`

---

This pull request and its description were written by Isaac.