### PR TITLE
[OMNI-3262] Skip the interactive profile-name prompt on `omnigent login`

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10853,15 +10853,26 @@ def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None
             "The Databricks CLI is required to log in to a workspace. "
             "Install it first: https://docs.databricks.com/dev-tools/cli/install.html"
         )
+    # Pass --profile so the CLI doesn't stall on its interactive profile-name
+    # prompt. The derived name reuses an existing profile for this host, else
+    # the workspace's DNS label — the same default the prompt would have shown.
+    # Token resolution stays host-keyed (see _databricks_workspace_token), so
+    # naming the cfg section here doesn't couple resolution to the name.
+    from omnigent.onboarding.setup import (
+        _derive_workspace_profile_name,
+        _existing_profile_hosts,
+    )
+
+    profile = _derive_workspace_profile_name(workspace_host, _existing_profile_hosts())
     login_host = _host_with_org(workspace_host, org_id)
     click.echo(f"Opening browser to log in to {login_host} ...")
     result = subprocess.run(
-        [databricks_bin, "auth", "login", "--host", login_host],
+        [databricks_bin, "auth", "login", "--host", login_host, "--profile", profile],
         check=False,
     )
     if result.returncode != 0:
         raise click.ClickException(
-            f"`databricks auth login --host {login_host}` failed "
+            f"`databricks auth login --host {login_host} --profile {profile}` failed "
             f"(exit {result.returncode}). If the workspace is unreachable from "
             "this machine (VPN / IP access lists), resolve that and retry."
         )

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10854,10 +10854,8 @@ def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None
             "Install it first: https://docs.databricks.com/dev-tools/cli/install.html"
         )
     # Pass --profile so the CLI doesn't stall on its interactive profile-name
-    # prompt. The derived name reuses an existing profile for this host, else
-    # the workspace's DNS label — the same default the prompt would have shown.
-    # Token resolution stays host-keyed (see _databricks_workspace_token), so
-    # naming the cfg section here doesn't couple resolution to the name.
+    # prompt; the derived name reuses an existing profile for this host, else
+    # the workspace's DNS label. Token resolution stays host-keyed regardless.
     from omnigent.onboarding.setup import (
         _derive_workspace_profile_name,
         _existing_profile_hosts,

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -106,6 +106,7 @@ def _patch_login_env(
     fake_httpx: _FakeHttpx,
     sdk_installed: bool = True,
     cached_tokens: list[str | None] | None = None,
+    existing_profiles: dict[str, str] | None = None,
 ) -> list[str]:
     """Patch the login command's collaborators for a scripted run.
 
@@ -116,11 +117,20 @@ def _patch_login_env(
         results, e.g. ``[None, "tok"]`` for "no cached grant, then a
         token after ``databricks auth login`` runs". Defaults to a
         cached token on first try.
+    :param existing_profiles: ``{profile_name: host}`` the profile-name
+        derivation sees in ``~/.databrickscfg``. Defaults to empty, so the
+        derived ``--profile`` falls back to the workspace's DNS label.
     :returns: A list capturing each ``subprocess.run`` argv (the
         ``databricks auth login`` invocations).
     """
 
     monkeypatch.setattr(httpx, "get", fake_httpx.get)
+    # Derivation shells out to `databricks auth profiles` via the setup module
+    # (not cli's subprocess), so stub it here for a deterministic profile name.
+    monkeypatch.setattr(
+        "omnigent.onboarding.setup._existing_profile_hosts",
+        lambda: dict(existing_profiles or {}),
+    )
     # URL normalization has its own probe + dedicated tests; identity here
     # keeps each login test's scripted response sequence aligned with the
     # login body's own requests.
@@ -245,8 +255,10 @@ def test_login_runs_databricks_auth_login_when_no_cached_grant(
 ) -> None:
     """No cached host-keyed grant → ``databricks auth login --host <ws>`` runs.
 
-    The login is host-keyed (no ``--profile`` / profile name anywhere);
-    after it succeeds the token resolves and the record is stored.
+    ``--profile`` is passed with the derived default name (the workspace's DNS
+    label here, since no existing profile matches) so the Databricks CLI never
+    stalls on its interactive profile-name prompt. Token resolution stays
+    host-keyed, so naming the cfg section does not couple resolution to it.
     """
     from omnigent.cli_auth import load_databricks_workspace_host
 
@@ -266,11 +278,37 @@ def test_login_runs_databricks_auth_login_when_no_cached_grant(
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code == 0, result.output
-    # Exactly one browser login, host-keyed, with no profile flag — a
-    # `--profile` here would recreate the named-profile coupling this
-    # flow exists to remove.
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    # Exactly one browser login, carrying the derived --profile so the CLI
+    # doesn't prompt. No existing profile matches, so the name is the DNS label.
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile example"]
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
+
+
+def test_login_reuses_existing_profile_name_for_workspace(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """An existing ``~/.databrickscfg`` profile for the host is reused by name.
+
+    Rather than a fresh DNS-label profile, ``databricks auth login`` targets the
+    section the user already has for this workspace, so no duplicate is created.
+    """
+    fake = _FakeHttpx(
+        responses=[
+            _response(302, headers={"location": _APPS_REDIRECT}),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    login_calls = _patch_login_env(
+        monkeypatch,
+        fake_httpx=fake,
+        cached_tokens=[None, "tok-fresh"],
+        existing_profiles={"my-ws": _WORKSPACE},
+    )
+
+    result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
+
+    assert result.exit_code == 0, result.output
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile my-ws"]
 
 
 def test_login_fails_loud_when_app_rejects_workspace_token(
@@ -354,7 +392,7 @@ def test_login_stale_cached_grant_triggers_fresh_login_and_retry(
     assert result.exit_code == 0, result.output
     # Exactly one forced re-login — a second rejection must fail loud,
     # not loop the browser flow.
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile example"]
     # The retry verify presented the freshly minted token, not the stale one.
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
@@ -389,7 +427,7 @@ def test_foreign_subprocess_calls_stay_out_of_the_login_recorder(
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code == 0, result.output
-    assert login_calls == [f"auth login --host {_WORKSPACE}"]
+    assert login_calls == [f"auth login --host {_WORKSPACE} --profile example"]
     # Delegated to the real runner rather than stubbed out from under it.
     assert probe.returncode == 0
     assert b"git version" in probe.stdout
@@ -478,7 +516,7 @@ def test_login_threads_org_id_through_workspace_login_and_verify(
 
     assert result.exit_code == 0, result.output
     # The browser login carries the selector so the profile is workspace-scoped.
-    assert login_calls == [f"auth login --host {_WORKSPACE}/?o={_ORG_ID}"]
+    assert login_calls == [f"auth login --host {_WORKSPACE}/?o={_ORG_ID} --profile example"]
     # The verify request routes to the workspace via ?o= (and used the token).
     assert fake.requests[-1]["params"] == {"o": _ORG_ID}
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"


### PR DESCRIPTION
## Related issue

Linear: [OMNI-3262 — Databricks workspace name](https://linear.app/omnigent/issue/OMNI-3262/databricks-workspace-name)

## Summary

- After the browser sign-in, `omnigent login <workspace-url>` stalled on the
  **Databricks CLI's** interactive prompt `Databricks profile name [<default>]:`.
  That prompt fires because `_run_databricks_browser_login` ran
  `databricks auth login --host <ws>` **without** `--profile`. Users didn't
  realize they could just press Enter to accept the bracketed default, so the
  flow felt like it demanded a decision it didn't.

**Before:**
<img width="1041" height="163" alt="Screenshot 2026-08-18 at 5 14 38 PM" src="https://github.com/user-attachments/assets/5dd03163-a498-42f3-ad4e-90604e7115cb" />

- Now we pass `--profile <name>` with the **same default the CLI would have
  shown**, derived via the existing `_derive_workspace_profile_name`: reuse an
  existing `~/.databrickscfg` profile that already points at this host, else the
  workspace's DNS label (e.g. `dbc-a5d4177a-49dc`). No interactive prompt.
- Token resolution afterward (`_databricks_workspace_token` →
  `_resolve_databricks_auth(host=...)`) is keyed by **host**, independent of the
  profile *name*, so naming the cfg section does not couple resolution to it —
  the host-keyed design the flow intended is preserved.

## Test Plan

- `pytest tests/cli/test_login_databricks.py` — **49 passed**. Updated the tests
  that pinned the no-`--profile` argv, and added
  `test_login_reuses_existing_profile_name_for_workspace` asserting an existing
  host profile is reused by name.
- Verified the derivation directly: `_derive_workspace_profile_name` returns the
  existing profile name when one matches the host, else the DNS label
  (`https://example.databricks.com` → `example`,
  `https://dbc-a5d4177a-49dc.cloud.databricks.com` → `dbc-a5d4177a-49dc`).
- Manual: run `omnigent login <workspace-url>`, complete the browser login, and
  confirm it no longer stops at `Databricks profile name [...]:` — it proceeds
  to store the token. Re-run when a profile for that workspace already exists and
  confirm that profile is reused (no duplicate section).

## Demo

Before — the flow blocked here waiting for input:

```
Opening browser to log in to https://dbc-a5d4177a-49dc.cloud.databricks.com ...
✓ Databricks profile name [dbc-a5d4177a-49dc]: ▮      # user had to type/Enter
```

After — no prompt; the derived profile name is used automatically:

```
Opening browser to log in to https://dbc-a5d4177a-49dc.cloud.databricks.com ...
# proceeds straight to storing the token
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage in `tests/cli/test_login_databricks.py` asserts the derived
`--profile` is passed for a first-time login (DNS-label name) and that an
existing host profile is reused by name. Manual verification covers the real
Databricks CLI browser flow, which the tests stub.

## Changelog

`omnigent login` no longer prompts for a Databricks profile name — it reuses an
existing profile for the workspace, or defaults to the workspace name.
