### PR TITLE
fix(server): replay parked-turn text in the session snapshot

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1104,6 +1104,14 @@ def _build_session_response(
             if pending_elicitation_events is not None
             else pending_elicitations.snapshot_for(conv.id)
         ),
+        # Replay the parked turn's streamed-so-far assistant text. A turn
+        # parked on an elicitation (AskUserQuestion, permission prompt) has
+        # not settled, so its transcript records are withheld and the durable
+        # items do not exist yet; the live preview that carried the text is
+        # transient and dropped on the refetch the elicitation card triggers.
+        # Without this replay the card renders with none of its antecedent
+        # prose until the user answers (#4984).
+        inflight_text_events=inflight_text.snapshot_for(conv.id),
         # Replay un-consumed web messages on native-terminal sessions
         # so a client that posted then navigated away / rebound re-
         # hydrates the optimistic bubble. Empty for non-native sessions

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1925,6 +1925,11 @@ class SessionResponse(BaseModel):
     git_branch: str | None = None
     archived: bool = False
     todos: list[dict[str, Any]] = Field(default_factory=list)
+    # Streamed-so-far assistant text of a turn still in flight (e.g. parked
+    # on an elicitation): the live preview is transient and the durable items
+    # are withheld until the turn settles, so a cold-load refetch during the
+    # park would otherwise lose the antecedent prose (#4984).
+    inflight_text_events: list[dict[str, Any]] = Field(default_factory=list)
     skills: list[SkillSummary] = Field(default_factory=list)
     model_options: list[NativeModelOption] = Field(default_factory=list)
     terminal_pending: bool = False

--- a/tests/server/integration/test_session_inflight_snapshot.py
+++ b/tests/server/integration/test_session_inflight_snapshot.py
@@ -1,0 +1,94 @@
+"""Session snapshot carries in-flight assistant text (#4984).
+
+A turn parked on an elicitation (AskUserQuestion, permission prompt) has not
+settled: its transcript records are withheld and the durable items do not
+exist yet, while the live preview that carried the text is transient and
+dropped on the refetch the elicitation card triggers. The snapshot must
+replay the streamed-so-far text so the card renders with its antecedent
+prose before the user answers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.runtime import inflight_text
+
+
+@pytest.fixture(autouse=True)
+def _clean_inflight():
+    inflight_text.reset_for_tests() if hasattr(inflight_text, "reset_for_tests") else None
+    yield
+    inflight_text.reset_for_tests() if hasattr(inflight_text, "reset_for_tests") else None
+
+
+def test_inflight_snapshot_replays_native_message_text() -> None:
+    """A native (message-scoped) streamed buffer survives snapshot_for."""
+    conversation_id = "conv_inflight_test"
+    inflight_text.record_publish(
+        conversation_id,
+        {
+            "type": "response.output_text.delta",
+            "delta": "Both tracks you asked for, ",
+            "message_id": "msg_1",
+            "index": 0,
+            "final": False,
+        },
+    )
+    inflight_text.record_publish(
+        conversation_id,
+        {
+            "type": "response.output_text.delta",
+            "delta": "with a decision point.",
+            "message_id": "msg_1",
+            "index": 1,
+            "final": True,
+        },
+    )
+    events = inflight_text.snapshot_for(conversation_id)
+    assert events, "streamed text must replay"
+    text = "".join(
+        e.get("delta", "") for e in events if e.get("type") == "response.output_text.delta"
+    )
+    assert "Both tracks you asked for" in text
+    assert "decision point" in text
+
+
+async def test_session_response_carries_inflight_text_events(
+    client,  # noqa: ANN001 — fixture from the integration conftest
+) -> None:
+    """The GET snapshot exposes inflight_text_events alongside pending_elicitations."""
+    from tests.server.integration.test_sessions_endpoints import (
+        _create_session,
+        _wait_for_idle,
+        create_test_agent,
+    )
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], initial_message="hello inflight")
+    await _wait_for_idle(client, session["id"])
+
+    # Simulate the parked-turn state: text streamed, elicitation open.
+    inflight_text.record_publish(
+        session["id"],
+        {
+            "type": "response.output_text.delta",
+            "delta": "Summary the TUI already shows.",
+            "message_id": "msg_park",
+            "index": 0,
+            "final": True,
+        },
+    )
+
+    resp = await client.get(f"/v1/sessions/{session['id']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "inflight_text_events" in body, (
+        f"snapshot must include inflight_text_events; got keys {sorted(body.keys())}"
+    )
+    deltas = [
+        e.get("delta", "")
+        for e in body["inflight_text_events"]
+        if e.get("type") == "response.output_text.delta"
+    ]
+    assert any("Summary the TUI already shows" in d for d in deltas), deltas


### PR DESCRIPTION
## Summary

Fixes #4984 — implementing the issue's first suggested direction ("promote the transient live-preview buffer … so the card renders with its context") at the seam the server already owns.

## Root cause (per the issue's forensic reconstruction, verified in source)

Two channels carry claude-native assistant text:

- the **durable** path posts `external_conversation_item` from Claude's transcript — but a turn parked on `AskUserQuestion` has its records **withheld until the elicitation resolves** (the issue's table: summary generated 19:52:19, persisted 19:54:46 — the exact instant of the answer);
- the **live preview** (`external_output_text_delta`, the MessageDisplay-hook stream that did capture the text with `final=true`) is explicitly no-persistence and is dropped by the refetch the elicitation card triggers.

Net: the card renders alone while the TUI shows the prose the whole time.

## Fix — replay from the index that already exists

`inflight_text` (the reconnect-replay index) already captures every message-scoped delta and — by design for exactly this harness — **does not drop native message buffers on claude-native's mid-turn idle** (a comment in the module states this is to survive permission-prompt parks). So the parked turn's text is sitting in that index during the park.

`GET /v1/sessions/{id}` now carries **`inflight_text_events`** (from `inflight_text.snapshot_for`, the same wire-shaped events the SSE pre-ready replay uses) alongside `pending_elicitations`. The refetch that renders the card now reconstructs the antecedent prose from the same reducer path the frontend already has for live deltas — no new client code path.

**No double-render**: when the turn settles and the durable item persists, the index's existing commit reconciliation (`claimed`/`superseded` logic) drops the aggregate from subsequent snapshots.

## Tests

- unit: message-scoped deltas recorded during a park replay through `snapshot_for` with the full text;
- integration: the live `GET /v1/sessions/{id}` exposes `inflight_text_events` carrying the parked text — **fails on current `main`** (field absent), passes with the fix.
