### PR TITLE
fix(cli): start fails loudly against an unreachable server

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2750,9 +2750,15 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
         # Remote / explicit ``--server`` mode: the daemon connects to a server
         # we don't own and can't restart, so the config-signature / heal /
         # "re-run" semantics below don't apply (auth posture is the remote's
-        # concern; its own reconnect loop covers transient tunnel drops). Keep
-        # the original PID-liveness reuse so a live daemon for the URL is
-        # reused as-is.
+        # concern; its own reconnect loop covers transient tunnel drops).
+        # PID-liveness alone still reuses a ZOMBIE — a daemon whose tunnel
+        # never came up (dead server URL) sits reconnect-looping forever, and
+        # every later `omnigent start` reports "already running" while the
+        # host reads offline (#4986). Give it the same short reconnect grace
+        # the local path uses, then tear it down and respawn.
+        if background and not _daemon_tunnel_recovers(existing):
+            _terminate_host_unit(existing, reason="host tunnel not online")
+            return _DaemonReuseDecision(reuse=False, config_changed=False)
         return _DaemonReuseDecision(reuse=True, config_changed=False)
 
     if not background:
@@ -7828,6 +7834,11 @@ def _prompt_stop_local_server() -> None:
 # server URL, missing credentials) leaves nothing on the terminal, so we wait
 # this long and surface its log instead of falsely reporting success.
 _BACKGROUND_HOST_GRACE_S = 2.0
+# How long a freshly spawned remote daemon gets for its tunnel to register
+# before `omnigent start` declares failure (connect + register + first
+# heartbeat; generous enough for a slow TLS handshake, short enough to fail
+# fast against a dead URL).
+_BACKGROUND_HOST_ONLINE_WAIT_S = 15.0
 
 
 def _confirm_background_host_alive(record: _HostDaemonRecord) -> None:
@@ -7901,6 +7912,21 @@ def _run_background_host(
         headline = _cli_style("Host daemon already running", fg="yellow", bold=True)
     else:
         _confirm_background_host_alive(record)
+        if record.mode != "local":
+            # A live daemon against an unreachable server is a false success:
+            # the process reconnect-loops forever and the host never registers
+            # (#4986). Wait for the tunnel, then roll the fresh daemon back so
+            # a failed start never requires `omnigent stop` before retrying.
+            if not _daemon_tunnel_recovers(record, grace_s=_BACKGROUND_HOST_ONLINE_WAIT_S):
+                _terminate_host_unit(record, reason="host tunnel never came online")
+                from omnigent._runner_startup import format_runner_log_tail
+
+                log_path = Path(record.log_path) if record.log_path else None
+                raise click.ClickException(
+                    f"The host daemon could not reach {target} — the server is "
+                    "unreachable or rejected the connection."
+                    f"{format_runner_log_tail(log_path)}"
+                )
         headline = _cli_style("Started the host daemon in the background", fg="green", bold=True)
     click.echo(f"{headline} (pid {record.pid}).")
     if record.mode == "local":

--- a/tests/host/test_cli_start_remote.py
+++ b/tests/host/test_cli_start_remote.py
@@ -1,0 +1,77 @@
+"""`omnigent start` against an unreachable server (#4986).
+
+A live-but-offline remote daemon (zombie tunnel) must be torn down and
+respawned rather than reused.
+"""
+
+from __future__ import annotations
+
+from omnigent import cli as cli_module
+from omnigent.cli import _HostDaemonRecord
+
+
+def _record(pid: int, log_path: str | None = "/tmp/host.log") -> _HostDaemonRecord:
+    return _HostDaemonRecord(
+        pid=pid,
+        target="http://127.0.0.1:6767",
+        mode="server",
+        server_url="http://127.0.0.1:6767",
+        log_path=log_path,
+        started_at=1_700_000_000,
+        host_id="host_1",
+        config_sig="sig",
+    )
+
+
+def test_remote_reuse_tears_down_offline_zombie(monkeypatch) -> None:
+    """A live-but-offline remote daemon is torn down and respawned, not reused."""
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(cli_module, "_find_daemon_record", lambda target: _record(4242))
+    monkeypatch.setattr(cli_module, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli_module, "_daemon_host_identity_changed", lambda rec: False)
+    monkeypatch.setattr(cli_module, "_daemon_tunnel_recovers", lambda rec, **kw: False)
+    monkeypatch.setattr(
+        cli_module, "_terminate_host_unit", lambda rec, reason: calls.append(("terminate", reason))
+    )
+
+    decision = cli_module._reuse_existing_daemon_record("http://127.0.0.1:6767")
+    assert decision.reuse is False
+    assert calls and calls[0][0] == "terminate"
+    assert "not online" in calls[0][1]
+
+
+def test_remote_reuse_keeps_recovering_tunnel(monkeypatch) -> None:
+    """A daemon whose tunnel recovers within the grace window is reused."""
+    monkeypatch.setattr(cli_module, "_find_daemon_record", lambda target: _record(4243))
+    monkeypatch.setattr(cli_module, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli_module, "_daemon_host_identity_changed", lambda rec: False)
+    monkeypatch.setattr(cli_module, "_daemon_tunnel_recovers", lambda rec, **kw: True)
+    terminated: list[str] = []
+    monkeypatch.setattr(
+        cli_module, "_terminate_host_unit", lambda rec, reason: terminated.append(reason)
+    )
+
+    decision = cli_module._reuse_existing_daemon_record("http://127.0.0.1:6767")
+    assert decision.reuse is True
+    assert not terminated
+
+
+def test_remote_foreground_daemon_still_reused_by_pid(monkeypatch) -> None:
+    """Foreground hosts (no log_path) keep PID-liveness-only reuse — the CLI
+    never kills an interactive process."""
+    monkeypatch.setattr(
+        cli_module, "_find_daemon_record", lambda target: _record(4244, log_path=None)
+    )
+    monkeypatch.setattr(cli_module, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli_module, "_daemon_host_identity_changed", lambda rec: False)
+    probed: list[object] = []
+    monkeypatch.setattr(
+        cli_module,
+        "_daemon_tunnel_recovers",
+        lambda rec, **kw: probed.append(rec) or False,
+    )
+
+    decision = cli_module._reuse_existing_daemon_record("http://127.0.0.1:6767")
+    assert decision.reuse is True
+    assert not probed, "foreground daemons must not be probed/terminated"


### PR DESCRIPTION
## Summary

Fixes #4986.

## Root cause (per the issue, verified in source)

`_run_background_host` declares success for a remote target once the daemon **process** is alive (`_confirm_background_host_alive`, 2 s) — nothing verifies the host **tunnel** ever registers online. And `_reuse_existing_daemon_record`'s remote arm returns `reuse=True` on **PID liveness alone** (the comment says "its own reconnect loop covers transient tunnel drops" — which also covers *permanent* drops forever). Against a dead server URL:

- `start` exits 0 while the daemon reconnect-loops in its log;
- every later `start` prints "Host daemon already running" — the machine is stuck looking started until a manual `omnigent stop`.

## Fix — both halves

1. **Reuse**: remote targets now apply the zombie check the **local** path already had (`_daemon_tunnel_recovers`): a live-but-offline daemon is **torn down and respawned** instead of reused. Foreground hosts (`log_path is None`) keep PID-only reuse, unchanged — the CLI never kills an interactive process.
2. **Fresh spawn**: after the process-alive grace, a remote daemon must bring its tunnel online within a **15 s** window (connect + register + first heartbeat; generous for slow TLS, short against a dead URL) — otherwise `start` fails loudly with the server URL and the daemon's log tail, and **rolls the fresh daemon back**, so a failed start never requires `omnigent stop` before retrying.

## Tests

`tests/host/test_cli_start_remote.py`:

- live-but-offline remote daemon → torn down, respawn (zombie-teardown test **fails on current `main`** — the remote arm reuses unconditionally);
- recovering tunnel → reused, no teardown;
- foreground daemon → never probed, never terminated (the interactive-process invariant).
