### PR TITLE
fix: quiescence badge no longer drives sub-agent terminal delivery

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -1589,18 +1589,23 @@ async def _forward_available_subagents(
 
         # Quiescence-based status. Sub-agent transcripts don't carry
         # an explicit "done" record (Claude doesn't expose one), so
-        # we infer "running" from item flow and "idle" from quiet
-        # time. The dedupe on ``last_status`` avoids spamming the
-        # cache on every tick when nothing changed.
+        # we infer "running" from item flow and quiescence from quiet
+        # time. The quiescence edge posts as "quiesced" — a BADGE
+        # signal only: any >5s transcript gap (a long Bash, a slow
+        # WebFetch, a stalled tool) used to post "idle", which the
+        # runner consumed as an authoritative terminal completion,
+        # latching the inbox entry delivered and discarding the sub-
+        # agent's real result (#4988). The dedupe on
+        # ``last_status`` avoids spamming the cache on every tick.
         desired_status: str | None = None
         if had_item:
             desired_status = "running"
         elif (
             new_entry.last_activity_ts is not None
             and now - new_entry.last_activity_ts > _SUBAGENT_IDLE_QUIESCENCE_S
-            and new_entry.last_status != "idle"
+            and new_entry.last_status != "quiesced"
         ):
-            desired_status = "idle"
+            desired_status = "quiesced"
         if desired_status is not None and desired_status != new_entry.last_status:
             retry_key = f"subagent_status:{entry.child_conversation_id}"
             if status_retry_tracker.retry_delay_s(retry_key) is None:

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -99,8 +99,11 @@ _EXTERNAL_ELICITATION_RESOLVED_TYPE: str = "external_elicitation_resolved"
 _EXTERNAL_SESSION_STATUS_TYPE: str = "external_session_status"
 
 
+# "quiesced": the claude-native sub-agent transcript-quiescence badge — a
+# UI signal only, never a terminal edge (the runner must not deliver a
+# parent-inbox completion from it; #4988).
 _EXTERNAL_SESSION_STATUS_VALUES: frozenset[str] = frozenset(
-    {"idle", "running", "waiting", "failed"}
+    {"idle", "running", "waiting", "failed", "quiesced"}
 )
 
 

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1054,6 +1054,21 @@ def register_events_routes(
             if effective_status != status:
                 status = effective_status
                 body.data["status"] = status
+            if status == "quiesced":
+                # The claude-native sub-agent transcript-quiescence badge: a
+                # UI signal only. Publish it for the badge, but never forward
+                # it to the runner — the runner's terminal-delivery branch
+                # consumes "idle"/"failed" as authoritative completions, and a
+                # >5s transcript gap is not one (#4988).
+                _publish_status(
+                    session_id,
+                    "idle",
+                    status_error,
+                    response_id=response_id,
+                    background_task_count=bg_count,
+                    blocked_on=blocked_on,
+                )
+                return {"queued": False}
             _publish_status(
                 session_id,
                 status,

--- a/tests/runner/test_quiesced_badge_no_delivery.py
+++ b/tests/runner/test_quiesced_badge_no_delivery.py
@@ -1,0 +1,44 @@
+"""The quiescence badge must not feed sub-agent terminal delivery (#4988).
+
+A >5s transcript gap in a claude-native Task sub-agent posted status "idle",
+which the runner consumed as an authoritative completion: a false "sub-agent
+finished" inbox notice ~1-2 min after spawn, and the real completion was
+discarded once ``delivered`` latched. The badge now posts a distinct
+"quiesced" status that the server publishes for the UI but never forwards to
+the runner.
+"""
+
+from __future__ import annotations
+
+from omnigent.server.routes._sessions.common import _EXTERNAL_SESSION_STATUS_VALUES
+
+
+def test_quiesced_is_an_accepted_status_value() -> None:
+    assert "quiesced" in _EXTERNAL_SESSION_STATUS_VALUES
+
+
+def test_forwarder_quiescence_posts_quiesced_not_idle() -> None:
+    """The forwarder's quiescence branch emits the badge value, never idle."""
+    import inspect
+
+    from omnigent import claude_native_forwarder as fwd
+
+    src = inspect.getsource(fwd)
+    # The quiescence branch sets desired_status = "quiesced"; asserting on the
+    # source keeps the regression tied to the branch itself (any revert to
+    # "idle" reintroduces the false-terminal path).
+    quiescence_block = src[src.index("Quiescence-based status") : src.index("Quiescence-based status") + 1400]
+    assert 'desired_status = "quiesced"' in quiescence_block
+    assert 'desired_status = "idle"' not in quiescence_block
+
+
+def test_runner_terminal_branch_ignores_quiesced() -> None:
+    """The runner's terminal-delivery condition admits only idle/failed."""
+    import inspect
+
+    from omnigent.runner import app as runner_app
+
+    src = inspect.getsource(runner_app)
+    terminal_block = src[src.index('if status in ("idle", "failed"):') : src.index('if status in ("idle", "failed"):') + 400]
+    assert 'status == "idle"' in terminal_block
+    assert '"quiesced"' not in terminal_block, "the badge value must never appear in the terminal path"


### PR DESCRIPTION
## Summary

Fixes #4988 — implementing the issue's **option 1** (split the signals), the smallest contained fix that preserves the genuine-dispatch inbox contract.

## Root cause (per the issue's trace, verified)

The claude-native sub-agent forwarder infers status from **transcript quiescence**: any >5 s gap posts `idle`, and the runner's `if status in ("idle", "failed")` branch consumes that as an **authoritative terminal completion** — delivering a false "sub-agent finished (completed)" parent-inbox notice ~1–2 min after spawn with the child's *first intermediate message* as its "result", and latching `delivered` so the **real** completion is silently discarded. The issue notes the code itself already documents this exact failure mode for the main session (the PTY heuristic was replaced by the `Stop` hook because it "fired a premature completion that idempotently locked out the real one") — the sub-agent path never got the fix.

## Fix — split the badge from the terminal

- The forwarder's quiescence branch posts a **distinct `quiesced`** status — the badge `post_external_session_status`'s own docstring always described ("the sub-agent quiescence badge … doesn't map to a turn").
- The server accepts the value, **publishes it as an idle UI badge** (sidebar behavior unchanged), and **returns before any runner forward** — the runner's terminal branch never sees it: no false completion, no delivered-latch eating the real result.
- **Genuinely dispatched sub-agents are untouched**: their real terminal edges still post `idle`/`failed`, and the `test_native_subagent_inbox_delivery` contract holds.

Raising the 5 s constant would not be a fix (any threshold is wrong for an agent legitimately blocking on a slow tool); this removes the heuristic from the terminal path entirely rather than tuning it.

## Tests

Three layer-pinned regressions (`tests/runner/test_quiesced_badge_no_delivery.py`): `quiesced` is an accepted status value; the forwarder's quiescence branch emits `quiesced` (never `idle`); the runner's terminal branch admits only `idle`/`failed`. The first two **fail on current `main`**.

## Notes

Options 2 (`SubagentStop` hook) and 3 (parent-transcript `toolUseId` correlation) are the more authoritative long-term terminals, and option 4 (suppress delivery for Claude-native Task children entirely) is the product decision — all flagged on the issue for the maintainers.
