### PR TITLE
feat(web): show sub-agent harnesses in usage sessions table

### DIFF
--- a/omnigent/server/routes/usage.py
+++ b/omnigent/server/routes/usage.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Request
 
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY
 from omnigent.entities import Conversation
-from omnigent.runtime.policies.builder import load_session_usage
+from omnigent.runtime.policies.builder import load_session_tree, load_session_usage
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.feature_flags import Feature, FeatureFlags, resolve_feature_flags
 from omnigent.server.routes._auth_helpers import require_user
@@ -63,6 +63,22 @@ def _session_models(usage: dict[str, Any]) -> dict[str, float]:
         except (TypeError, ValueError):
             continue
     return models
+
+
+def _collect_other_harnesses(
+    primary: str | None,
+    tree: list[Conversation],
+    root_id: str,
+) -> list[str] | None:
+    """Distinct harnesses used by sub-agents, excluding the primary."""
+    seen: set[str] = set()
+    for conv in tree:
+        if conv.id == root_id:
+            continue
+        h = _resolve_session_harness(conv)
+        if h and h != primary:
+            seen.add(h)
+    return sorted(seen) if seen else None
 
 
 def _resolve_session_harness(conv: Conversation) -> str | None:
@@ -152,6 +168,15 @@ def _build_usage_report(
             if conv.agent_id is None:
                 continue
             usage = load_session_usage(conv.id, conversation_store)
+            primary_harness = (
+                _resolve_session_harness(conv) if include_page_details else None
+            )
+            other_harnesses = None
+            if include_page_details:
+                tree = load_session_tree(conv.id, conversation_store)
+                other_harnesses = _collect_other_harnesses(
+                    primary_harness, tree, conv.id
+                )
             sessions.append(
                 SessionUsage(
                     id=conv.id,
@@ -160,7 +185,8 @@ def _build_usage_report(
                     title=conv.title,
                     cost_usd=_session_cost(usage),
                     models=_session_models(usage),
-                    harness=_resolve_session_harness(conv) if include_page_details else None,
+                    harness=primary_harness,
+                    other_harnesses=other_harnesses,
                     llm_model=(
                         conv.model_override or _resolve_llm_model(conv)
                         if include_page_details

--- a/omnigent/server/routes/usage.py
+++ b/omnigent/server/routes/usage.py
@@ -168,15 +168,11 @@ def _build_usage_report(
             if conv.agent_id is None:
                 continue
             usage = load_session_usage(conv.id, conversation_store)
-            primary_harness = (
-                _resolve_session_harness(conv) if include_page_details else None
-            )
+            primary_harness = _resolve_session_harness(conv) if include_page_details else None
             other_harnesses = None
             if include_page_details:
                 tree = load_session_tree(conv.id, conversation_store)
-                other_harnesses = _collect_other_harnesses(
-                    primary_harness, tree, conv.id
-                )
+                other_harnesses = _collect_other_harnesses(primary_harness, tree, conv.id)
             sessions.append(
                 SessionUsage(
                     id=conv.id,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2440,6 +2440,7 @@ class SessionUsage(BaseModel):
     cost_usd: float = 0.0
     models: dict[str, float] = Field(default_factory=dict)
     harness: str | None = None
+    other_harnesses: list[str] | None = None
     llm_model: str | None = None
     agent_name: str | None = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -6094,6 +6094,20 @@
             "title": "Models",
             "type": "object"
           },
+          "other_harnesses": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Other Harnesses"
+          },
           "title": {
             "anyOf": [
               {

--- a/tests/e2e_ui/sessions/test_usage_page_feature.py
+++ b/tests/e2e_ui/sessions/test_usage_page_feature.py
@@ -69,3 +69,45 @@ def test_usage_page_route_and_navigation_are_available_when_feature_is_on(
     expect(page.get_by_test_id("usage-nav")).to_be_visible(timeout=30_000)
     expect(page.get_by_role("heading", name="Usage", exact=True)).to_be_visible()
     expect(page.get_by_text("$0.00", exact=True)).to_be_visible()
+
+
+def test_session_table_shows_other_harnesses_badge(
+    page: Page,
+    live_server: str,
+) -> None:
+    """A session with sub-agent harnesses shows a '+N' badge."""
+    _stub_server_info(page, usage_page=True)
+    report = json.dumps(
+        {
+            "cost_today": 1.50,
+            "cost_last_7d": 1.50,
+            "cost_last_30d": 1.50,
+            "total_cost_usd": 1.50,
+            "daily_costs": [],
+            "sessions": [
+                {
+                    "id": "conv_abc",
+                    "created_at": 1700000000,
+                    "updated_at": 1700000100,
+                    "title": "Multi-harness session",
+                    "cost_usd": 1.50,
+                    "models": {"claude-opus-4-8": 1.50},
+                    "harness": "claude-sdk",
+                    "other_harnesses": ["antigravity", "openai-agents"],
+                    "llm_model": "claude-opus-4-8",
+                    "agent_name": None,
+                },
+            ],
+        }
+    )
+
+    def handle_usage(route: Route) -> None:
+        route.fulfill(status=200, content_type="application/json", body=report)
+
+    page.route("**/v1/usage", handle_usage)
+    page.goto(f"{live_server}/usage")
+
+    expect(page.get_by_text("claude-sdk")).to_be_visible(timeout=30_000)
+    badge = page.get_by_text("+2")
+    expect(badge).to_be_visible()
+    expect(badge).to_have_attribute("title", "antigravity, openai-agents")

--- a/tests/e2e_ui/sessions/test_usage_page_feature.py
+++ b/tests/e2e_ui/sessions/test_usage_page_feature.py
@@ -107,7 +107,11 @@ def test_session_table_shows_other_harnesses_badge(
     page.route("**/v1/usage", handle_usage)
     page.goto(f"{live_server}/usage")
 
-    expect(page.get_by_text("claude-sdk")).to_be_visible(timeout=30_000)
-    badge = page.get_by_text("+2")
+    table = page.locator("table")
+    expect(table).to_be_visible(timeout=30_000)
+    row = table.locator("tr", has_text="Multi-harness session")
+    expect(row).to_be_visible()
+    expect(row.get_by_text("claude-sdk")).to_be_visible()
+    badge = row.get_by_text("+2")
     expect(badge).to_be_visible()
     expect(badge).to_have_attribute("title", "antigravity, openai-agents")

--- a/tests/e2e_ui/sessions/test_usage_page_feature.py
+++ b/tests/e2e_ui/sessions/test_usage_page_feature.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 
 from playwright.sync_api import Page, Route, expect
 
@@ -77,6 +78,7 @@ def test_session_table_shows_other_harnesses_badge(
 ) -> None:
     """A session with sub-agent harnesses shows a '+N' badge."""
     _stub_server_info(page, usage_page=True)
+    now = int(time.time())
     report = json.dumps(
         {
             "cost_today": 1.50,
@@ -87,8 +89,8 @@ def test_session_table_shows_other_harnesses_badge(
             "sessions": [
                 {
                     "id": "conv_abc",
-                    "created_at": 1700000000,
-                    "updated_at": 1700000100,
+                    "created_at": now - 3600,
+                    "updated_at": now,
                     "title": "Multi-harness session",
                     "cost_usd": 1.50,
                     "models": {"claude-opus-4-8": 1.50},

--- a/tests/e2e_ui/sessions/test_usage_page_feature.py
+++ b/tests/e2e_ui/sessions/test_usage_page_feature.py
@@ -107,10 +107,11 @@ def test_session_table_shows_other_harnesses_badge(
     page.route("**/v1/usage", handle_usage)
     page.goto(f"{live_server}/usage")
 
-    table = page.locator("table")
-    expect(table).to_be_visible(timeout=30_000)
-    row = table.locator("tr", has_text="Multi-harness session")
-    expect(row).to_be_visible()
+    expect(page.get_by_test_id("usage-nav")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("heading", name="Usage", exact=True)).to_be_visible()
+
+    row = page.locator("table tr", has_text="Multi-harness session")
+    expect(row).to_be_visible(timeout=10_000)
     expect(row.get_by_text("claude-sdk")).to_be_visible()
     badge = row.get_by_text("+2")
     expect(badge).to_be_visible()

--- a/web/src/components/usage/UsageSessionTable.tsx
+++ b/web/src/components/usage/UsageSessionTable.tsx
@@ -119,7 +119,17 @@ export function UsageSessionTable({ sessions }: Props) {
                   </span>
                 )}
               </td>
-              <td className="px-3 py-2 text-muted-foreground">{s.harness ?? "—"}</td>
+              <td className="px-3 py-2 text-muted-foreground">
+                {s.harness ?? "—"}
+                {s.otherHarnesses && s.otherHarnesses.length > 0 && (
+                  <span
+                    className="ml-1.5 inline-flex items-center rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                    title={s.otherHarnesses.join(", ")}
+                  >
+                    +{s.otherHarnesses.length}
+                  </span>
+                )}
+              </td>
               <td className="px-3 py-2 text-right tabular-nums">
                 {formatSessionCostUsd(s.costUsd)}
               </td>

--- a/web/src/lib/usageApi.ts
+++ b/web/src/lib/usageApi.ts
@@ -15,6 +15,7 @@ interface SessionUsageWire {
   cost_usd: number;
   models: Record<string, number>;
   harness: string | null;
+  other_harnesses: string[] | null;
   llm_model: string | null;
   agent_name: string | null;
 }
@@ -43,6 +44,7 @@ export interface SessionUsage {
   costUsd: number;
   models: Record<string, number>;
   harness: string | null;
+  otherHarnesses: string[] | null;
   llmModel: string | null;
   agentName: string | null;
 }
@@ -76,6 +78,7 @@ export async function fetchUsageReport(): Promise<UsageReport> {
       costUsd: s.cost_usd,
       models: s.models ?? {},
       harness: s.harness ?? null,
+      otherHarnesses: s.other_harnesses ?? null,
       llmModel: s.llm_model ?? null,
       agentName: s.agent_name ?? null,
     })),


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The usage page Sessions table previously showed only the top-level session's harness, even when sub-agents ran on different harnesses. Cost aggregation was correct, but the Harness column was misleading for multi-harness sessions.
- Added `other_harnesses` field to the backend `SessionUsage` schema, populated by walking the session's sub-agent tree and collecting distinct harnesses that differ from the primary.
- The frontend now shows a "+N" pill badge next to the primary harness when sub-agents used different harnesses, with a native tooltip listing them on hover.

## Test Plan

1. Enable the usage page: `OMNIGENT_FEATURES=usage_page`
2. Create a session that spawns sub-agents on a different harness (e.g. a `claude-sdk` brain delegating to `openai-agents` workers)
3. Open the Usage page and check the Sessions table
4. Verify the primary harness shows with a "+1" (or more) badge
5. Hover over the badge to confirm the tooltip lists the other harness names
6. Verify single-harness sessions show no badge (unchanged behavior)

## Demo

N/A — feature-flagged behind `usage_page`

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified frontend type-check passes (`tsc --noEmit`) and backend schema loads correctly. The usage page is behind a feature flag (`usage_page`) and manual verification was done against the compiled frontend and backend import paths.

## Changelog

Usage sessions table shows a "+N" badge when sub-agents used different harnesses