### PR TITLE
fix(pi-native): treat a 2xx non-JSON tool-call reply as an auth failure

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -436,6 +436,56 @@ function mcpInputRequired(json) {
  *   200 response; ``piResult`` is a terminal fail-closed tool result the caller
  *   returns as-is.
  */
+/**
+ * Bounded classification for a 2xx ``/mcp`` reply that is not an MCP JSON body.
+ *
+ * ``resp.ok`` is not proof of a JSON answer: an authenticating edge (reverse
+ * proxy, IdP) in front of the server can answer any route with a sign-in
+ * document and status 200. The text names the classification only — never the
+ * body, headers, or URL — because a sign-in document routinely carries tokens
+ * and tenant identifiers.
+ */
+function nonJsonMcpPiResult() {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          "Omnigent tool call failed: the server answered 2xx with a non-JSON " +
+          "body, which usually means an authenticating proxy or sign-in page " +
+          "answered instead of Omnigent. Re-authenticate and retry.",
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * False when ``resp`` declares a content type that is not JSON.
+ *
+ * A declared ``text/html`` (the sign-in case) is rejected. An absent or
+ * unreadable content type is not treated as a signal, so the parse attempt
+ * stays the decider there.
+ */
+function mcpContentTypeIsJson(resp) {
+  let declared = null;
+  try {
+    // Both the property read and the lookup are inside the try: a `headers`
+    // getter can throw just as `get()` can.
+    const headers = resp && resp.headers;
+    if (headers && typeof headers.get === "function") {
+      declared = headers.get("content-type");
+    }
+  } catch (_headerErr) {
+    // An unreadable header is not a signal, so fall through to the parse.
+    // Swallow it here: letting it reach the outer catch would put its message —
+    // which can quote header or body text — into the tool result.
+    return true;
+  }
+  if (typeof declared !== "string" || declared.trim() === "") return true;
+  return /^application\/(?:[\w.+-]+\+)?json\s*(?:;|$)/i.test(declared.trim());
+}
+
 async function postMcpToolsCall(config, toolName, args, rpcId, extraParams) {
   const url = `${config.serverUrl}/v1/sessions/${encodeURIComponent(config.sessionId)}/mcp`;
   const body = JSON.stringify({
@@ -466,7 +516,16 @@ async function postMcpToolsCall(config, toolName, args, rpcId, extraParams) {
         },
       };
     }
-    return { json: await resp.json() };
+    // Status, content type, and parseability must all agree before this body is
+    // treated as an MCP response. A parse failure is classified here rather
+    // than by the outer catch, whose message would echo the offending body back
+    // through ``err.message``.
+    if (!mcpContentTypeIsJson(resp)) return { piResult: nonJsonMcpPiResult() };
+    try {
+      return { json: await resp.json() };
+    } catch (_parseErr) {
+      return { piResult: nonJsonMcpPiResult() };
+    }
   } catch (err) {
     return {
       piResult: {

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -1278,6 +1278,259 @@ require(extensionPath)(pi);
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_mcp_200_html_signin_is_classified_not_parsed_as_json(
+    tmp_path: Path,
+) -> None:
+    """A ``200 text/html`` sign-in page is an auth failure, not an MCP response.
+
+    ``resp.ok`` is true for a sign-in document served with status 200, so status
+    alone cannot distinguish it from a real answer. Before the fix the bare
+    ``resp.ok`` check fell straight through to ``resp.json()``, which threw and
+    surfaced an unclassified parse error whose ``err.message`` echoed the start
+    of the sign-in body back to the model.
+
+    Asserts, at the ``/mcp`` tool-call call site only:
+
+    1. a declared ``text/html`` 200 resolves to ``isError: true`` naming an
+       authentication / sign-in classification, without throwing;
+    2. the message leaks no part of the body, no header value, and no URL;
+    3. a declared ``application/json`` 200 still round-trips normally;
+    4. a JSON content type with an unparseable body is classified the same
+       bounded way rather than echoing the body through the outer catch;
+    5. a header accessor that *throws* is treated as an unreadable content type
+       rather than escaping to the outer catch, whose message would carry the
+       header/body text the accessor complained about — covering both a throwing
+       ``headers.get()`` and a throwing ``headers`` property getter.
+
+    Not covered here, and unchanged from ``main``: the outer catch still reports
+    a *transport* error's ``err.message``, which can name the request URL. That
+    predates this change and is asserted by
+    ``test_mcp_unreachable_fails_closed_without_throwing``.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = r"""
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+
+const extensionPath = process.argv[1];
+const tmpDir = process.argv[2];
+const inboxDir = path.join(tmpDir, "inbox");
+const configPath = path.join(tmpDir, "config.json");
+
+fs.mkdirSync(inboxDir, { recursive: true });
+fs.writeFileSync(
+  configPath,
+  JSON.stringify({
+    serverUrl: "http://omnigent.test",
+    sessionId: "conv_abc",
+    inboxDir,
+    authHeaders: {},
+    tools: [
+      { name: "sys_os_shell", description: "", parameters: { type: "object", properties: {} } },
+    ],
+  }),
+);
+
+process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+// A realistic edge sign-in document: served 200, carries an identifier a
+// classification string must never echo back to the model.
+const SIGNIN_HTML =
+  '<!DOCTYPE html><html><head><title>Sign in</title></head><body>' +
+  '<form action="/oauth2/authorize"><input name="state" ' +
+  'value="SECRET-STATE-b3f9c1"></form></body></html>';
+
+function headersOf(contentType) {
+  return { get: (name) => (String(name).toLowerCase() === "content-type" ? contentType : null) };
+}
+
+let mode = "html";
+global.fetch = async () => {
+  if (mode === "html") {
+    return {
+      ok: true,
+      status: 200,
+      headers: headersOf("text/html; charset=utf-8"),
+      async json() {
+        // What a real Response does with an HTML body: the message quotes it.
+        throw new SyntaxError(
+          'Unexpected token \'<\', "' + SIGNIN_HTML.slice(0, 24) + '"... is not valid JSON',
+        );
+      },
+      async text() {
+        return SIGNIN_HTML;
+      },
+    };
+  }
+  if (mode === "throwing-headers-getter") {
+    return {
+      ok: true,
+      status: 200,
+      get headers() {
+        throw new Error(
+          'headers getter blew up: set-cookie=SESSION=SECRET-STATE-b3f9c1; body=' + SIGNIN_HTML,
+        );
+      },
+      async json() {
+        return {
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "real answer" }] },
+        };
+      },
+    };
+  }
+  if (mode === "throwing-headers") {
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get() {
+          throw new Error(
+            'header parse failed: set-cookie=SESSION=SECRET-STATE-b3f9c1; body=' + SIGNIN_HTML,
+          );
+        },
+      },
+      async json() {
+        return {
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "real answer" }] },
+        };
+      },
+    };
+  }
+  if (mode === "json-unparseable") {
+    return {
+      ok: true,
+      status: 200,
+      headers: headersOf("application/json"),
+      async json() {
+        throw new SyntaxError('Unexpected token \'x\', "SECRET-STATE-b3f9c1" is not valid JSON');
+      },
+    };
+  }
+  return {
+    ok: true,
+    status: 200,
+    headers: headersOf("application/json; charset=utf-8"),
+    async json() {
+      return {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { content: [{ type: "text", text: "real answer" }] },
+      };
+    },
+  };
+};
+global.setInterval = () => ({ fakeInterval: true });
+
+const registered = {};
+const pi = {
+  registerCommand() {},
+  on() {},
+  registerTool(spec) { registered[spec.name] = spec; },
+  sendUserMessage() {},
+};
+
+require(extensionPath)(pi);
+
+function soleText(result) {
+  assert.ok(result && Array.isArray(result.content), JSON.stringify(result));
+  return result.content.map((block) => block.text || "").join("");
+}
+
+(async () => {
+  // 1. A 200 text/html sign-in page is a classified auth/edge failure.
+  const html = await registered.sys_os_shell.execute("call-1", {});
+  assert.equal(html.isError, true, JSON.stringify(html));
+  const htmlText = soleText(html);
+  assert.ok(
+    /sign-in|sign in|authenticat/i.test(htmlText),
+    "message does not name an authentication classification: " + htmlText,
+  );
+
+  // 2. No part of the body, no header value, and no URL may appear.
+  for (const forbidden of [
+    "SECRET-STATE-b3f9c1",
+    "<!DOCTYPE",
+    "<html",
+    "oauth2/authorize",
+    "text/html",
+    "http://omnigent.test",
+    "conv_abc",
+  ]) {
+    assert.ok(
+      htmlText.indexOf(forbidden) === -1,
+      "classification leaked " + forbidden + ": " + htmlText,
+    );
+  }
+
+  // 3. A declared application/json 200 still round-trips unchanged.
+  mode = "json";
+  const good = await registered.sys_os_shell.execute("call-2", {});
+  assert.equal(good.isError, false, JSON.stringify(good));
+  assert.equal(soleText(good), "real answer");
+
+  // 4. A JSON content type with an unparseable body is bounded the same way.
+  mode = "json-unparseable";
+  const bad = await registered.sys_os_shell.execute("call-3", {});
+  assert.equal(bad.isError, true, JSON.stringify(bad));
+  const badText = soleText(bad);
+  assert.ok(
+    badText.indexOf("SECRET-STATE-b3f9c1") === -1,
+    "parse-failure path leaked the body: " + badText,
+  );
+
+  // 5. An unreadable (throwing) header accessor must not become an error
+  //    message carrying header or body text.
+  mode = "throwing-headers";
+  const thrower = await registered.sys_os_shell.execute("call-4", {});
+  const throwerText = soleText(thrower);
+  for (const forbidden of ["SECRET-STATE-b3f9c1", "<!DOCTYPE", "set-cookie", "oauth2/authorize"]) {
+    assert.ok(
+      throwerText.indexOf(forbidden) === -1,
+      "throwing header accessor leaked " + forbidden + ": " + throwerText,
+    );
+  }
+  // Unreadable is not a signal, so the parse still decides: this body is valid
+  // JSON and must round-trip.
+  assert.equal(thrower.isError, false, JSON.stringify(thrower));
+  assert.equal(throwerText, "real answer");
+
+  //    Same for a throwing `headers` *property* getter, not just get().
+  mode = "throwing-headers-getter";
+  const getterThrower = await registered.sys_os_shell.execute("call-5", {});
+  const getterText = soleText(getterThrower);
+  for (const forbidden of ["SECRET-STATE-b3f9c1", "<!DOCTYPE", "set-cookie", "oauth2/authorize"]) {
+    assert.ok(
+      getterText.indexOf(forbidden) === -1,
+      "throwing headers getter leaked " + forbidden + ": " + getterText,
+    );
+  }
+  assert.equal(getterThrower.isError, false, JSON.stringify(getterThrower));
+  assert.equal(getterText, "real answer");
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+
+    result = subprocess.run(
+        [node, "-e", script, str(_extension_path()), str(tmp_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_input_required_denied_fails_closed_not_false_success(tmp_path: Path) -> None:
     """A declined ASK gate fails CLOSED (isError) — never reports false success.
 


### PR DESCRIPTION
## Related issue

Closes #4997

## Summary

**The problem on current `main`.** In
`omnigent/resources/pi_native/omnigent_pi_native_extension.js`, the `/mcp`
tool-call path checks only `resp.ok` and then parses:

```js
if (!resp.ok) { /* HTTP error tool result */ }
return { json: await resp.json() };
```

`resp.ok` is true for a `200 text/html` reply, so when an authenticating edge — a
reverse proxy or IdP — answers the route with a sign-in document and status 200,
`resp.json()` throws. The enclosing `catch` keeps the session alive, but the tool
result handed to the model is an unclassified parse error **that quotes the
response body**, because `Response.json()`'s `SyntaxError` includes a body
prefix:

```
Omnigent tool call failed: Unexpected token '<', "<!DOCTYPE html><html><he"... is not valid JSON
```

A sign-in document routinely carries CSRF/`state` values and tenant identifiers,
so that is both a leak and an unactionable error — nothing tells the user or the
agent to re-authenticate.

**The change.** One file, one call site. Require status, declared content type,
and parseability to all agree before treating a body as an MCP response, and
classify the mismatch with a fixed string that names no body, header, or URL:

- a **declared** non-JSON content type is rejected before parsing;
- the parse itself is guarded, so a parse failure is classified here instead of
  reaching the outer catch that would echo the body;
- an **absent or unreadable** content type is deliberately *not* treated as a
  signal — the parse attempt stays the decider — so servers and existing test
  doubles that omit the header behave exactly as before;
- the header read is fully guarded, so neither a throwing `headers` getter nor a
  throwing `headers.get()` can escape and put header text into the result.

The declared-JSON happy path is untouched.

**Why it stands alone.** Self-contained JavaScript in one file, with its unit
tests already in the repo. No Python, no server change, no migration, and no
dependency on any other open PR.

## Test Plan

- New case in `tests/test_pi_native_extension.py`:
  `test_mcp_200_html_signin_is_classified_not_parsed_as_json`. It drives the real
  extension under Node through a registered tool's `execute` and asserts:
  1. a `200` + `content-type: text/html` sign-in body → `isError: true` naming an
     authentication/sign-in classification, no throw;
  2. the message contains none of the body, the `state` value, `<!DOCTYPE`,
     `set-cookie`, the content type, the server URL, or the session id;
  3. a declared `application/json` `200` still round-trips (`isError: false`);
  4. a JSON content type with an unparseable body is bounded the same way;
  5. a throwing `headers.get()` **and** a throwing `headers` property getter are
     treated as unreadable, leak nothing, and still let the valid JSON body
     round-trip.
- Confirmed it fails before the fix. Against `main`'s copy of the extension:
  `message does not name an authentication classification: Omnigent tool call
  failed: Unexpected token '<', "<!DOCTYPE html><html><he"... is not valid JSON`
  — which is also a direct demonstration of the body leak. After: passes.
- `python -m pytest -q tests/test_pi_native_extension.py` → **41 passed**
  (40 pre-existing + 1 new), so no regression in the tool-bridge, policy,
  streaming, compaction, or model-switch paths in that file.
- `pre-commit run --all-files` → all hooks pass.
- Branch cut fresh from `main` at `86726e0ab`.

## Demo

N/A — non-visual change at an HTTP/JSON boundary; the observable difference is
the text of a tool result, shown above and asserted by the new test.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

<!--
No user-visible or visual surface: the change only reclassifies an error string
at one HTTP boundary, which is what the Demo bot asks for here. The linked issue
#4997 is kept so the work can still be prioritized.
-->

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new case is a real Node execution of the shipped extension with a stubbed
`fetch`, so it covers the actual `/mcp` call site rather than a reimplementation.
The 40 existing cases in the same file cover the surrounding paths and all still
pass, which is what pins the "absent content type is not a signal" decision — a
stricter check would have broken the existing doubles that omit the header.

**Known limitation, unchanged by this PR:** the outer `catch` still reports a
*transport* error's `err.message`, which can name the request URL and session id
(e.g. `Failed to parse URL from http://…/v1/sessions/<id>/mcp`). That behaviour
is identical on `main` today and is asserted by the existing
`test_mcp_unreachable_fails_closed_without_throwing`, so bounding it is a
separate change rather than something to fold in here.

## Changelog

A sign-in page returned with HTTP 200 is now reported as an authentication failure instead of a JSON parse error
