### PR TITLE
feat(deploy): add a --no-otel Databricks deploy target

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -272,7 +272,23 @@ uv run python deploy/databricks/deploy.py --skip-build --allow-dirty ...
 
 # API-only deploy (drops the SPA from the main wheel).
 uv run python deploy/databricks/deploy.py --skip-web-ui ...
+
+# No-OpenTelemetry deploy: runs `python app.py` instead of under
+# opentelemetry-instrument, drops OTEL_TRACES_SAMPLER, and drops the platform
+# telemetry_export_destinations. Use for workspaces with no OTel collector /
+# UC OTel tables -- otherwise every span export fails DEADLINE_EXCEEDED to
+# localhost:4317. Selects the `prod-no-otel` DAB target (same workspace/state
+# as `prod`).
+uv run python deploy/databricks/deploy.py --no-otel ...
 ```
+
+> [!NOTE]
+> `--no-otel` auto-switches the default `--target prod` to `prod-no-otel`.
+> If you deploy to a custom `--target`, add the OTel-off variable overrides
+> (`app_command`, `app_env`, `otel_export_destinations`) to that target too
+> — see the `prod-no-otel` block in `databricks.yml` for the template. The
+> deploy warns when `--no-otel` is paired with a target that lacks those
+> overrides, since OTel then stays on.
 
 ## Troubleshooting
 

--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -24,6 +24,45 @@ variables:
   features:
     description: "Comma-separated deployment-wide release features."
     default: ""
+  # OTel plumbing is gated on these three complex variables so a workspace
+  # without an OTel collector / UC OTel tables can deploy cleanly. deploy.py
+  # --no-otel selects the `prod-no-otel` target, which overrides them; the
+  # defaults below keep the tracer on exactly as before.
+  app_command:
+    type: complex
+    description: >
+      App entrypoint. Default runs under opentelemetry-instrument so the
+      Databricks Apps platform OTLP endpoint is auto-instrumented. --no-otel
+      overrides this with ["python", "app.py"] (no instrumentation).
+    default: ["opentelemetry-instrument", "python", "app.py"]
+  app_env:
+    type: complex
+    description: >
+      The app's full env list. Default forces the OTel tracer on
+      (OTEL_TRACES_SAMPLER=always_on); --no-otel overrides with the same list
+      minus the sampler, so no exporter is configured (otherwise spans export
+      to localhost:4317 and fail DEADLINE_EXCEEDED when no collector present).
+    default:
+      - name: AP_LAKEBASE_ENDPOINT
+        value_from: postgres
+      - name: AP_ARTIFACT_VOLUME_PATH
+        value_from: artifact_volume
+      - name: OTEL_TRACES_SAMPLER
+        value: 'always_on'
+      - name: OMNIGENT_FEATURES
+        value: "${var.features}"
+  otel_export_destinations:
+    type: complex
+    description: >
+      Databricks Apps platform OTel export destinations (UC tables). Default
+      routes logs/metrics/traces to <otel_table_schema>.otel_*; --no-otel
+      overrides with an empty list (no export). Requires a workspace with a
+      custom storage location — the export API rejects default-storage tables.
+    default:
+      - unity_catalog:
+          logs_table: ${var.otel_table_schema}.otel_logs
+          metrics_table: ${var.otel_table_schema}.otel_metrics
+          traces_table: ${var.otel_table_schema}.otel_spans
 
 resources:
   apps:
@@ -39,16 +78,8 @@ resources:
       # set it out-of-band via apps.create_update in deploy.py before
       # the bundle deploy runs.
       config:
-        command: ["opentelemetry-instrument", "python", "app.py"]
-        env:
-          - name: AP_LAKEBASE_ENDPOINT
-            value_from: postgres
-          - name: AP_ARTIFACT_VOLUME_PATH
-            value_from: artifact_volume
-          - name: OTEL_TRACES_SAMPLER
-            value: 'always_on'
-          - name: OMNIGENT_FEATURES
-            value: "${var.features}"
+        command: ${var.app_command}
+        env: ${var.app_env}
       resources:
         - name: postgres
           postgres:
@@ -61,29 +92,53 @@ resources:
             securable_type: VOLUME
             permission: WRITE_VOLUME
 
+# Reusable workspace block so a target and its no-OTel variant share one
+# host/root_path definition (host must be literal — DAB reads it before
+# resolving vars — so it can't be a ${var.}). To deploy to a different
+# workspace, edit this one anchor.
+.prod_workspace: &prod_workspace
+  host: https://example.databricks.com   # ← your workspace URL
+  # Isolate state per app so one bundle can deploy multiple apps.
+  root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${var.app_name}
+
 targets:
-  # One target per workspace. workspace.host must be literal (DAB reads it
-  # before resolving vars). deploy.py selects via --target. To deploy to a
-  # different workspace, add another target block here and pass
-  # `deploy.py --target <name>`.
+  # One target per workspace. deploy.py selects via --target. `prod` keeps the
+  # OTel tracer on; `prod-no-otel` (below) is the same workspace/state with the
+  # OTel variables overridden off — deploy.py --no-otel selects it. To deploy
+  # to a different workspace, edit the &prod_workspace anchor above.
   prod:
     mode: production
-    workspace:
-      host: https://example.databricks.com   # ← your workspace URL
-      # Isolate state per app so one bundle can deploy multiple apps.
-      root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${var.app_name}
+    workspace: *prod_workspace
     resources:
       apps:
         omnigent:
-          # Optional: Databricks Apps platform OTel export. The platform
-          # auto-injects OTEL_EXPORTER_OTLP_ENDPOINT into the app container
-          # so any OTLP emitter (including telemetry.init() in src/app.py)
-          # routes to the configured UC tables. The export API rejects tables
-          # in default storage ("Cannot export App telemetry to tables in
-          # default storage"), so this requires a workspace with a custom
-          # storage location — drop this block if yours has none.
-          telemetry_export_destinations:
-            - unity_catalog:
-                logs_table: ${var.otel_table_schema}.otel_logs
-                metrics_table: ${var.otel_table_schema}.otel_metrics
-                traces_table: ${var.otel_table_schema}.otel_spans
+          # Databricks Apps platform OTel export. The platform auto-injects
+          # OTEL_EXPORTER_OTLP_ENDPOINT into the app container so any OTLP
+          # emitter (including telemetry.init() in src/app.py) routes to the
+          # configured UC tables. Gated on ${var.otel_export_destinations} so
+          # --no-otel drops it (empty list). The export API rejects tables in
+          # default storage, so this requires a workspace with a custom
+          # storage location — use --no-otel if yours has none.
+          telemetry_export_destinations: ${var.otel_export_destinations}
+
+  # No-OTel variant of `prod`: same workspace + Terraform state (shared
+  # root_path), but overrides the OTel complex variables so the app runs
+  # uninstrumented (`python app.py`, no OTEL_TRACES_SAMPLER, no platform
+  # export). Use for workspaces with no OTel collector / UC OTel tables —
+  # otherwise span exports fail DEADLINE_EXCEEDED to localhost:4317.
+  # Selected by deploy.py --no-otel.
+  prod-no-otel:
+    mode: production
+    workspace: *prod_workspace
+    # Target overrides assign values directly (docs: "Set a variable's value" →
+    # `variables: <name>: <value>`), not nested variable declarations.
+    variables:
+      app_command: ["python", "app.py"]
+      app_env:
+        - name: AP_LAKEBASE_ENDPOINT
+          value_from: postgres
+        - name: AP_ARTIFACT_VOLUME_PATH
+          value_from: artifact_volume
+        - name: OMNIGENT_FEATURES
+          value: "${var.features}"
+      otel_export_destinations: []

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -597,6 +597,30 @@ def _assert_clean_tree(skip: bool) -> None:
     _log(f"clean tree at origin/main {head[:12]}")
 
 
+# Variables a target must override for --no-otel to actually take effect;
+# `prod-no-otel` in databricks.yml is the reference implementation.
+_OTEL_OFF_VARS = ("app_command", "app_env", "otel_export_destinations")
+
+
+def _target_overrides_otel_vars(target: str) -> bool | None:
+    """Whether ``target`` overrides every OTel-off variable in databricks.yml.
+
+    Returns ``None`` when the bundle can't be inspected (no PyYAML, unreadable
+    or malformed file) so callers warn rather than assert either way.
+    """
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        bundle = yaml.safe_load((_deploy_dir() / "databricks.yml").read_text())
+    except (OSError, yaml.YAMLError):
+        return None
+    targets = (bundle or {}).get("targets") or {}
+    variables = (targets.get(target) or {}).get("variables") or {}
+    return all(name in variables for name in _OTEL_OFF_VARS)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -646,6 +670,17 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Comma-separated deployment-wide release features, e.g. "
             "'usage_page'. Empty keeps every release feature off."
+        ),
+    )
+    parser.add_argument(
+        "--no-otel",
+        action="store_true",
+        help=(
+            "Deploy without OpenTelemetry: run 'python app.py' instead of "
+            "under opentelemetry-instrument, drop OTEL_TRACES_SAMPLER, and "
+            "drop the platform telemetry_export_destinations. Use for "
+            "workspaces with no OTel collector / UC OTel tables — otherwise "
+            "span exports fail DEADLINE_EXCEEDED to localhost:4317."
         ),
     )
     parser.add_argument(
@@ -715,7 +750,24 @@ def _parse_args() -> argparse.Namespace:
             "known commit on main."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    # --no-otel selects the tracer-off DAB target (same workspace + state as
+    # `prod`, OTel variables overridden off). Only auto-switch the default
+    # target so an explicit --target still wins — but then the flag is a no-op
+    # unless that target defines the OTel-off overrides itself, so say so
+    # instead of silently deploying with OTel on.
+    if args.no_otel:
+        if args.target == "prod":
+            args.target = "prod-no-otel"
+        elif _target_overrides_otel_vars(args.target) is not True:
+            _log(
+                f"warning: --no-otel has no effect on --target {args.target!r}: it "
+                f"only swaps the default 'prod' target for 'prod-no-otel'. That "
+                f"target does not override {', '.join(_OTEL_OFF_VARS)}, so OTel "
+                "stays ON for this deploy — copy the overrides from the "
+                "prod-no-otel block in databricks.yml, or drop --target."
+            )
+    return args
 
 
 def _clear_env_vars() -> None:

--- a/tests/deploy/test_databricks_deploy_no_otel.py
+++ b/tests/deploy/test_databricks_deploy_no_otel.py
@@ -1,0 +1,266 @@
+"""``--no-otel`` must resolve to a genuinely uninstrumented deploy target.
+
+A workspace with no OTel collector and no UC OTel tables cannot deploy Omnigent
+to Databricks Apps cleanly: the app runs under ``opentelemetry-instrument`` with
+``OTEL_TRACES_SAMPLER=always_on``, so every span export fails
+``DEADLINE_EXCEEDED`` against ``localhost:4317``, and the platform export block
+targets UC tables that do not exist.
+
+``--no-otel`` selects the ``prod-no-otel`` bundle target, which overrides the
+three OTel variables. Two things must hold, and both are asserted here from the
+bundle file itself rather than from a live workspace:
+
+1. the default ``prod`` target's **resolved** app spec is exactly what `main`
+   hardcoded before the variables were introduced — no silent telemetry change
+   for existing deploys;
+2. ``prod-no-otel`` really turns the tracer off: no ``opentelemetry-instrument``
+   entrypoint, no ``OTEL_TRACES_SAMPLER``, and an empty export list.
+
+The flag also only rewrites the *default* target, so pairing it with a custom
+``--target`` must warn rather than silently ship OTel-on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_PY = _ROOT / "deploy" / "databricks" / "deploy.py"
+_BUNDLE_YML = _ROOT / "deploy" / "databricks" / "databricks.yml"
+
+_REQUIRED_ARGS = [
+    "--app-name",
+    "omnigent",
+    "--lakebase-branch",
+    "projects/omnigent/branches/production",
+    "--lakebase-database",
+    "projects/omnigent/branches/production/databases/databricks-postgres",
+    "--volume-name",
+    "main.omnigent.artifacts",
+]
+
+# The app spec `main` hardcoded before app_command / app_env /
+# otel_export_destinations existed. `prod` must still resolve to exactly this.
+_PROD_COMMAND_BEFORE = ["opentelemetry-instrument", "python", "app.py"]
+_PROD_ENV_BEFORE = [
+    {"name": "AP_LAKEBASE_ENDPOINT", "value_from": "postgres"},
+    {"name": "AP_ARTIFACT_VOLUME_PATH", "value_from": "artifact_volume"},
+    {"name": "OTEL_TRACES_SAMPLER", "value": "always_on"},
+    {"name": "OMNIGENT_FEATURES", "value": "${var.features}"},
+]
+_PROD_TELEMETRY_BEFORE = [
+    {
+        "unity_catalog": {
+            "logs_table": "${var.otel_table_schema}.otel_logs",
+            "metrics_table": "${var.otel_table_schema}.otel_metrics",
+            "traces_table": "${var.otel_table_schema}.otel_spans",
+        }
+    }
+]
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    """Load ``deploy.py`` by path — ``deploy/`` is not an installed package."""
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_no_otel", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bundle() -> dict[str, Any]:
+    return yaml.safe_load(_BUNDLE_YML.read_text())
+
+
+def _parse(deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, *extra: str) -> Any:
+    monkeypatch.setattr(sys, "argv", ["deploy.py", *_REQUIRED_ARGS, *extra])
+    return deploy_mod._parse_args()
+
+
+def _resolved_app_spec(bundle: dict[str, Any], target: str) -> dict[str, Any]:
+    """Resolve one target's app command / env / telemetry from the bundle.
+
+    Mirrors how DAB layers a target's ``variables`` over the top-level variable
+    defaults, then substitutes ``${var.<name>}`` in the app resource.
+
+    A top-level declaration carries the value under ``default``; a target
+    override assigns the value directly. The direct form is asserted rather than
+    accommodated, so a nested declaration smuggled into a target is a failure
+    here instead of being silently unwrapped.
+    """
+    values = {name: spec.get("default") for name, spec in bundle["variables"].items()}
+    target_block = bundle["targets"][target]
+    for name, value in (target_block.get("variables") or {}).items():
+        assert not (
+            isinstance(value, dict) and set(value) <= {"default", "type", "description"}
+        ), (
+            f"target {target!r} overrides {name!r} with a variable *declaration*; "
+            "a target override must assign the value directly"
+        )
+        values[name] = value
+
+    def substitute(node: Any) -> Any:
+        if isinstance(node, str):
+            name = node.removeprefix("${var.").removesuffix("}")
+            if node.startswith("${var.") and node.endswith("}") and name in values:
+                return values[name]
+            return node
+        if isinstance(node, list):
+            return [substitute(item) for item in node]
+        if isinstance(node, dict):
+            return {key: substitute(value) for key, value in node.items()}
+        return node
+
+    app = bundle["resources"]["apps"]["omnigent"]
+    target_app = ((target_block.get("resources") or {}).get("apps") or {}).get("omnigent") or {}
+    return {
+        "command": substitute(app["config"]["command"]),
+        "env": substitute(app["config"]["env"]),
+        "telemetry": substitute(target_app.get("telemetry_export_destinations") or []),
+    }
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_command", "expected_env", "expected_telemetry"),
+    [
+        pytest.param(
+            "prod",
+            _PROD_COMMAND_BEFORE,
+            _PROD_ENV_BEFORE,
+            _PROD_TELEMETRY_BEFORE,
+            id="prod-unchanged-from-before-the-variables",
+        ),
+        pytest.param(
+            "prod-no-otel",
+            ["python", "app.py"],
+            [entry for entry in _PROD_ENV_BEFORE if entry["name"] != "OTEL_TRACES_SAMPLER"],
+            [],
+            id="prod-no-otel-drops-instrumentation-sampler-and-export",
+        ),
+    ],
+)
+def test_resolved_app_spec_per_target(
+    bundle: dict[str, Any],
+    target: str,
+    expected_command: list[str],
+    expected_env: list[dict[str, str]],
+    expected_telemetry: list[Any],
+) -> None:
+    resolved = _resolved_app_spec(bundle, target)
+    assert resolved["command"] == expected_command
+    assert resolved["env"] == expected_env
+    assert resolved["telemetry"] == expected_telemetry
+
+
+def test_no_otel_target_overrides_are_direct_values(bundle: dict[str, Any]) -> None:
+    """Target overrides must be plain values, the documented DAB shape."""
+    overrides = bundle["targets"]["prod-no-otel"]["variables"]
+    assert overrides["app_command"] == ["python", "app.py"]
+    assert overrides["otel_export_destinations"] == []
+    assert isinstance(overrides["app_env"], list)
+    assert {entry["name"] for entry in overrides["app_env"]} == {
+        "AP_LAKEBASE_ENDPOINT",
+        "AP_ARTIFACT_VOLUME_PATH",
+        "OMNIGENT_FEATURES",
+    }
+
+
+def test_no_otel_target_has_no_otel_surface_at_all(bundle: dict[str, Any]) -> None:
+    """Belt-and-braces: nothing OTel-shaped survives in the resolved spec."""
+    resolved = _resolved_app_spec(bundle, "prod-no-otel")
+    assert not any("opentelemetry" in part for part in resolved["command"])
+    assert not any(entry["name"].startswith("OTEL_") for entry in resolved["env"])
+    assert resolved["telemetry"] == []
+
+    # And the default target still exports, so this is an opt-in, not a removal.
+    assert _resolved_app_spec(bundle, "prod")["telemetry"] != []
+
+
+def test_no_otel_shares_prod_workspace_and_state(bundle: dict[str, Any]) -> None:
+    """Same host and root_path, so switching targets does not orphan state."""
+    prod = bundle["targets"]["prod"]["workspace"]
+    no_otel = bundle["targets"]["prod-no-otel"]["workspace"]
+    assert prod == no_otel
+    assert bundle["targets"]["prod-no-otel"]["mode"] == "production"
+
+
+def test_no_otel_switches_the_default_target(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = _parse(deploy_mod, monkeypatch, "--no-otel")
+    assert args.target == "prod-no-otel"
+    assert "warning" not in capsys.readouterr().out
+
+
+def test_default_deploy_is_untouched_by_the_new_flag(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without the flag, the target and the bundle vars are exactly as before."""
+    args = _parse(deploy_mod, monkeypatch)
+    assert args.no_otel is False
+    assert args.target == "prod"
+    assert "warning" not in capsys.readouterr().out
+    # --no-otel is a target selector only; it adds no --var to the CLI call.
+    assert not any("app_command" in value for value in deploy_mod._bundle_vars(args))
+
+
+def test_no_otel_warns_when_paired_with_a_target_that_keeps_otel_on(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An explicit --target wins, so the no-op must be reported, not silent."""
+    args = _parse(deploy_mod, monkeypatch, "--no-otel", "--target", "staging")
+    assert args.target == "staging"
+    out = capsys.readouterr().out
+    assert "warning: --no-otel has no effect" in out
+    assert "staging" in out
+    for name in deploy_mod._OTEL_OFF_VARS:
+        assert name in out
+
+
+def test_no_otel_is_quiet_when_the_explicit_target_already_overrides(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = _parse(deploy_mod, monkeypatch, "--no-otel", "--target", "prod-no-otel")
+    assert args.target == "prod-no-otel"
+    assert "warning" not in capsys.readouterr().out
+
+
+def test_target_override_probe_matches_the_bundle(deploy_mod: ModuleType) -> None:
+    """The probe backing the warning must agree with databricks.yml."""
+    assert deploy_mod._target_overrides_otel_vars("prod-no-otel") is True
+    assert deploy_mod._target_overrides_otel_vars("prod") is False
+    assert deploy_mod._target_overrides_otel_vars("no-such-target") is False
+
+
+def test_target_override_probe_is_none_without_pyyaml(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No PyYAML must not turn the warning into a crash or a false claim."""
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    assert deploy_mod._target_overrides_otel_vars("prod-no-otel") is None


### PR DESCRIPTION
## Related issue

Closes #4998

## Summary

**The problem on current `main`.** A Databricks Apps deploy always turns
OpenTelemetry on, and there is no way to turn it off.
`deploy/databricks/databricks.yml` hardcodes the app to run under
`opentelemetry-instrument`, to set `OTEL_TRACES_SAMPLER=always_on`, and to declare
`telemetry_export_destinations` against `<otel_table_schema>.otel_*`.
`git grep no-otel deploy/databricks/` returns nothing.

So on a workspace with no OTel collector and no UC OTel tables the deploy is
either broken or permanently noisy:

- with no collector reachable, every span export fails `DEADLINE_EXCEEDED`
  against `localhost:4317` — continuous error churn for telemetry nobody asked
  for;
- the platform export API rejects tables in default storage, so without a custom
  storage location the export block cannot be satisfied at all.

**The change.** Gate the entrypoint, the app env, and the export destinations on
three `complex` bundle variables, and add a `prod-no-otel` target that overrides
all three. `--no-otel` selects it.

```
                       ┌──────────── app_command ─────────────┐
prod          ────────►│ ["opentelemetry-instrument","python", │  + OTEL_TRACES_SAMPLER
(default,              │   "app.py"]                           │  + telemetry export → UC tables
 unchanged)            └───────────────────────────────────────┘

prod-no-otel  ────────►│ ["python","app.py"]                   │  no OTEL_* env
(--no-otel)            └───────────────────────────────────────┘  telemetry export = []
```

Deliberate details:

- **The flag only rewrites the *default* target**, so an explicit `--target`
  still wins. Because the flag would then be a silent no-op, pairing it with a
  target that does not carry the overrides emits a warning naming the three
  variables instead of quietly deploying with OTel on.
- `prod-no-otel` shares `prod`'s workspace host and `root_path` through a YAML
  anchor, so switching targets does not orphan Terraform state.
- Target overrides assign values directly (`variables: <name>: <value>`), the
  shape the bundle docs specify for setting a variable's value in a target.

**The default target is unchanged.** The literals moved into variable defaults,
but the *resolved* bundle is identical — see the Test Plan.

**Why it stands alone.** Deploy-time telemetry configuration only. No
application code, no auth change, no dependency on any other open PR.

## Test Plan

- New `tests/deploy/test_databricks_deploy_no_otel.py`, table-driven over both
  targets, asserting the resolved `command`, the full `env` list, and the
  telemetry list:
  - `prod` → `["opentelemetry-instrument","python","app.py"]`, env including
    `OTEL_TRACES_SAMPLER=always_on` and `OMNIGENT_FEATURES`, and the three UC
    export tables — compared against the literals `main` hardcoded before the
    variables existed;
  - `prod-no-otel` → `["python","app.py"]`, the same env minus
    `OTEL_TRACES_SAMPLER`, and `[]`.
  Plus: no `OTEL_`-prefixed env key and no `opentelemetry` command fragment
  survives; `prod` still exports (this is opt-in, not removal); both targets
  share one workspace block; target overrides are direct values, not nested
  declarations; `--no-otel` switches only the default target; the no-op warning
  fires and names all three variables; the flag adds no `--var`; and the probe
  behind the warning returns `None` rather than crashing when PyYAML is absent.
- `python -m pytest -q tests/deploy` → **23 passed**.
- Confirmed the gap before the change: `deploy.py … --no-otel` on `main` →
  `deploy.py: error: unrecognized arguments: --no-otel`.
- **Verified the resolved bundle with the real CLI** (`databricks` v1.9.0), which
  is the evidence that matters for the "default target unchanged" claim. Rendering
  `databricks bundle validate --target prod -o json` for `main`'s
  `databricks.yml` and this branch's, then diffing the whole resolved config:
  **identical, zero differences.** The same render for `prod-no-otel` gives
  `command: ["python","app.py"]`, an env of exactly
  `AP_LAKEBASE_ENDPOINT` / `AP_ARTIFACT_VOLUME_PATH` / `OMNIGENT_FEATURES` with no
  `OTEL_` key, and no telemetry export destinations. No live workspace needed.
- `pre-commit run --all-files` → all hooks pass.
- Branch cut fresh from `main` at `86726e0ab`. Note `main` added the
  `OMNIGENT_FEATURES` env entry after this content was first written; it is
  carried into both env defaults, and the test asserts it in each.

## Demo

N/A — non-visual deploy configuration. The user-visible surface is the flag and
the resolved app spec, both shown above and asserted by the tests.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

<!--
Deploy-tooling change with no visual surface, so Demo is N/A and the type boxes
are set accordingly. The linked issue #4998 is kept so the work can still be
prioritized.
-->

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests resolve the bundle themselves, so they run in CI without a
workspace. Manual verification covered the part they cannot: the real
`databricks bundle validate` renderer, used to prove the resolved `prod` bundle is
byte-identical to `main` and that `prod-no-otel` resolves to a genuinely
uninstrumented spec. That is not automated because it needs the Databricks CLI
and a reachable host for `${workspace.current_user.userName}`.

Not covered: a live deploy to a workspace that actually lacks an OTel collector.
The failure mode this addresses (`DEADLINE_EXCEEDED` to `localhost:4317`) is
observed at runtime, and the bundle-level assertions above are what CI can check.

## Changelog

`deploy.py --no-otel` deploys Omnigent to Databricks Apps without OpenTelemetry instrumentation or export
