### PR TITLE
fix(deploy): make a failed UC traversal grant non-fatal

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -892,6 +892,32 @@ def _profile_arg(args: argparse.Namespace) -> list[str]:
     return ["--profile", args.profile] if args.profile else []
 
 
+# Credential-shaped fragments the CLI can echo back inside an error: a token in
+# a config dump, an Authorization header in a transport error. A grant warning is
+# diagnostic only, so scrub these before it reaches a deploy log or CI transcript.
+# The key half deliberately allows surrounding word characters so an
+# underscore-prefixed env name (DATABRICKS_TOKEN=..., DATABRICKS_CLIENT_SECRET=...)
+# is caught too — a plain \b would not match after the underscore.
+_SECRET_ECHO_RE = re.compile(
+    r"(?i)(bearer\s+|[\w.-]*(?:token|password|passwd|secret|credential|authorization"
+    r"|api[_-]?key)[\w.-]*\s*[=:]\s*)(?:bearer\s+)?\S+"
+)
+
+
+def _grant_failure_detail(exc: subprocess.CalledProcessError) -> str:
+    """Bounded, secret-scrubbed one-line summary of a failed grant subprocess.
+
+    Falls back to the return code when the CLI said nothing on stderr.
+    """
+    first_line = next(
+        (line.strip() for line in (exc.stderr or "").splitlines() if line.strip()),
+        "",
+    )
+    if not first_line:
+        return f"rc={exc.returncode}"
+    return _SECRET_ECHO_RE.sub(r"\1<redacted>", first_line)[:200]
+
+
 def _ensure_app_sp_uc_traversal(
     args: argparse.Namespace,
     app_sp: str | None,
@@ -901,6 +927,12 @@ def _ensure_app_sp_uc_traversal(
     Apps' ``uc_securable`` only grants the leaf (WRITE_VOLUME); the
     SP can boot but 403s on first volume read if the parent catalog
     doesn't grant USE to ``account users``. Idempotent.
+
+    A grant that cannot be applied is warned about, not fatal: the SP often
+    already has traversal by group inheritance, and a deployer without MANAGE
+    on a shared catalog cannot add it. Aborting the deploy there fails a
+    workspace that would have booted fine, and the app-boot smoke check later
+    in :func:`main` is the real gate on whether traversal actually works.
     """
     if not app_sp:
         _log("app SP not resolved yet; skipping UC traversal grants")
@@ -920,21 +952,24 @@ def _ensure_app_sp_uc_traversal(
     ):
         _log(f"granting {priv} on {kind} {fqn} → app SP {app_sp}")
         payload = _json.dumps({"changes": [{"principal": app_sp, "add": [priv]}]})
-        subprocess.run(
-            [
-                "databricks",
-                "grants",
-                "update",
-                kind,
-                fqn,
-                *_profile_arg(args),
-                "--json",
-                payload,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                [
+                    "databricks",
+                    "grants",
+                    "update",
+                    kind,
+                    fqn,
+                    *_profile_arg(args),
+                    "--json",
+                    payload,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            _log(f"warning: {priv} grant on {fqn} failed ({_grant_failure_detail(exc)})")
 
 
 def main() -> int:

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -933,6 +933,8 @@ def _ensure_app_sp_uc_traversal(
     on a shared catalog cannot add it. Aborting the deploy there fails a
     workspace that would have booted fine, and the app-boot smoke check later
     in :func:`main` is the real gate on whether traversal actually works.
+    With ``--no-smoke-check``, this warning is the only post-grant signal that
+    traversal may still be unavailable.
     """
     if not app_sp:
         _log("app SP not resolved yet; skipping UC traversal grants")

--- a/tests/deploy/test_databricks_deploy_uc_grants.py
+++ b/tests/deploy/test_databricks_deploy_uc_grants.py
@@ -1,0 +1,266 @@
+"""A failed Unity Catalog traversal grant must not abort a Databricks deploy.
+
+``_ensure_app_sp_uc_traversal`` grants ``USE_CATALOG`` / ``USE_SCHEMA`` to the
+app service principal on the artifact volume's parents. Both grants routinely
+cannot be applied — the SP frequently already has traversal through group
+inheritance, and a deployer without ``MANAGE`` on a shared catalog is not
+allowed to add it — yet the app boots fine in both cases. Letting the grant
+abort the deploy therefore fails workspaces that would have worked.
+
+The guard is deliberately narrow, so these tests pin both directions:
+
+- a ``CalledProcessError`` from the grant subprocess warns and continues;
+- an unrelated ``CalledProcessError`` (another deploy step) still propagates;
+- a non-``CalledProcessError`` from the grant subprocess still propagates, so a
+  missing ``databricks`` CLI or a timeout is never silently reported as a
+  permission warning;
+- the warning is bounded and secret-scrubbed, because the CLI can echo a token
+  or an ``Authorization`` header back inside an error and the deploy log is
+  routinely a CI transcript.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_PY = _ROOT / "deploy" / "databricks" / "deploy.py"
+
+_REQUIRED_ARGS = [
+    "--app-name",
+    "omnigent",
+    "--lakebase-branch",
+    "projects/omnigent/branches/production",
+    "--lakebase-database",
+    "projects/omnigent/branches/production/databases/databricks-postgres",
+    "--volume-name",
+    "main.omnigent.artifacts",
+]
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    """Load ``deploy.py`` by path — ``deploy/`` is not an installed package."""
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_uc", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse(deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, *extra: str) -> Any:
+    monkeypatch.setattr(sys, "argv", ["deploy.py", *_REQUIRED_ARGS, *extra])
+    return deploy_mod._parse_args()
+
+
+def test_uc_grant_permission_failure_warns_and_continues(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both grants failing must warn per grant and return normally."""
+    args = _parse(deploy_mod, monkeypatch)
+    attempted: list[str] = []
+
+    def fake_run(cmd: list[str], **_: object) -> None:
+        attempted.append(cmd[4])
+        raise subprocess.CalledProcessError(
+            1, cmd, stderr="PERMISSION_DENIED: requires MANAGE on catalog\n"
+        )
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+
+    # Must not raise: the app-boot smoke check later in main() is the real gate.
+    deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    # The second grant is still attempted after the first one fails.
+    assert attempted == ["main", "main.omnigent"]
+
+    out = capsys.readouterr().out
+    assert "warning: USE_CATALOG grant on main failed" in out
+    assert "warning: USE_SCHEMA grant on main.omnigent failed" in out
+    assert "PERMISSION_DENIED" in out
+
+
+@pytest.mark.parametrize(
+    ("stderr", "must_not_contain", "must_contain"),
+    [
+        pytest.param(
+            "Error: default auth: token=dapiSUPERSECRETVALUE host=https://private.example.com",
+            ["dapiSUPERSECRETVALUE"],
+            ["<redacted>"],
+            id="config-dump-token",
+        ),
+        pytest.param(
+            "Error: default auth: DATABRICKS_TOKEN=dapiSUPERSECRETVALUE host=https://wsp.example.com",
+            ["dapiSUPERSECRETVALUE"],
+            ["<redacted>"],
+            id="underscore-prefixed-env-name",
+        ),
+        pytest.param(
+            "DATABRICKS_CLIENT_SECRET=SUPERSECRETVALUE not accepted",
+            ["SUPERSECRETVALUE"],
+            ["<redacted>"],
+            id="underscore-prefixed-client-secret",
+        ),
+        pytest.param(
+            "x-api-key: SUPERSECRETAPIKEY rejected",
+            ["SUPERSECRETAPIKEY"],
+            ["<redacted>"],
+            id="api-key-header",
+        ),
+        pytest.param(
+            "transport error: authorization: Bearer eyJhbGSUPERSECRETJWT.payload.sig",
+            ["eyJhbGSUPERSECRETJWT"],
+            ["<redacted>"],
+            id="bearer-header",
+        ),
+        pytest.param(
+            "failed: client_secret=SUPERSECRETCLIENTSECRET",
+            ["SUPERSECRETCLIENTSECRET"],
+            ["<redacted>"],
+            id="client-secret",
+        ),
+        pytest.param(
+            "PERMISSION_DENIED: requires MANAGE on catalog",
+            ["<redacted>"],
+            ["PERMISSION_DENIED: requires MANAGE on catalog"],
+            id="benign-message-kept-verbatim",
+        ),
+    ],
+)
+def test_grant_warning_is_scrubbed_and_bounded(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    stderr: str,
+    must_not_contain: list[str],
+    must_contain: list[str],
+) -> None:
+    args = _parse(deploy_mod, monkeypatch)
+
+    def fake_run(cmd: list[str], **_: object) -> None:
+        raise subprocess.CalledProcessError(1, cmd, stderr=stderr)
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+    deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    out = capsys.readouterr().out
+    for secret in must_not_contain:
+        assert secret not in out, out
+    for expected in must_contain:
+        assert expected in out, out
+
+
+def test_grant_warning_is_single_line_and_truncated(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A chatty CLI must not dump a stack trace into the deploy log."""
+    args = _parse(deploy_mod, monkeypatch)
+    noisy = "first line of the failure " + "x" * 500 + "\nsecond line\nthird line"
+
+    def fake_run(cmd: list[str], **_: object) -> None:
+        raise subprocess.CalledProcessError(1, cmd, stderr=noisy)
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+    deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    out = capsys.readouterr().out
+    assert "second line" not in out
+    assert "third line" not in out
+    # Two grants, each one line.
+    warnings = [line for line in out.splitlines() if "warning:" in line]
+    assert len(warnings) == 2
+    for line in warnings:
+        assert len(line) < 320, len(line)
+
+
+def test_uc_grant_failure_without_stderr_reports_returncode(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A silent CLI failure still produces an actionable warning."""
+    args = _parse(deploy_mod, monkeypatch)
+
+    def fake_run(cmd: list[str], **_: object) -> None:
+        raise subprocess.CalledProcessError(7, cmd, stderr=None)
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+    deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    assert "rc=7" in capsys.readouterr().out
+
+
+def test_unrelated_called_process_error_still_propagates(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The guard is scoped to the grant call, not to deploys in general.
+
+    ``run_uv_lock`` is another ``check=True`` deploy step. Its
+    ``CalledProcessError`` must still abort the deploy — a broken dependency
+    resolution is not something to warn past.
+    """
+    _parse(deploy_mod, monkeypatch)
+
+    def fake_run(cmd: list[str], **_: object) -> None:
+        raise subprocess.CalledProcessError(1, cmd, stderr="uv lock exploded")
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        deploy_mod.run_uv_lock(tmp_path)
+
+
+def test_grant_non_called_process_error_still_propagates(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing CLI or a timeout must not be swallowed as a grant warning."""
+    args = _parse(deploy_mod, monkeypatch)
+
+    def missing_cli(cmd: list[str], **_: object) -> None:
+        raise FileNotFoundError(2, "No such file or directory: 'databricks'")
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", missing_cli)
+    with pytest.raises(FileNotFoundError):
+        deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    def timed_out(cmd: list[str], **_: object) -> None:
+        raise subprocess.TimeoutExpired(cmd, 30)
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", timed_out)
+    with pytest.raises(subprocess.TimeoutExpired):
+        deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+
+def test_grant_success_path_is_unchanged(
+    deploy_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A working grant emits no warning and still issues both grants."""
+    args = _parse(deploy_mod, monkeypatch)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> None:
+        calls.append(cmd)
+        assert kwargs["check"] is True
+
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+    deploy_mod._ensure_app_sp_uc_traversal(args, "app-sp-1234")
+
+    assert [cmd[3] for cmd in calls] == ["catalog", "schema"]
+    assert "warning" not in capsys.readouterr().out


### PR DESCRIPTION
## Related issue

Closes #4999

## Summary

**The problem on current `main`.** A failed Unity Catalog *traversal* grant aborts
the whole Databricks Apps deploy. `_ensure_app_sp_uc_traversal` in
`deploy/databricks/deploy.py` runs two `databricks grants update` subprocesses
with `check=True`, so a non-zero exit raises and `main()` stops.

Both common failures are benign, and neither prevents the app from working:

1. the app service principal already has traversal by group inheritance, so the
   grant is unnecessary;
2. the deployer does not hold `MANAGE` on a shared catalog, so they are not
   permitted to add it — the normal arrangement where a data admin owns grants and
   an app team owns deploys.

In both cases the deploy fails a workspace that would have booted fine. The grant
is a convenience step; the post-deploy app-boot smoke check later in `main()` is
what actually proves the app can reach the volume.

**The change.** Warn and continue, with the relaxation kept deliberately narrow:

- the `try` wraps **only** the grant `subprocess.run`, so an unrelated
  `CalledProcessError` from any other deploy step still aborts;
- only `CalledProcessError` is caught, so a missing `databricks` CLI
  (`FileNotFoundError`) or a `TimeoutExpired` still propagates rather than being
  misreported as a permission problem;
- the second grant is still attempted after the first fails;
- the warning is bounded and scrubbed: first non-blank stderr line only,
  credential-shaped fragments replaced with `<redacted>`, truncated to 200
  characters, falling back to `rc=<code>` when the CLI said nothing. A deploy log
  is routinely a CI transcript, and the CLI can echo a config dump or an
  `Authorization` header back inside an error.

**Why it stands alone.** One function, one failure domain (authorization). It is
independent of the telemetry change in #5001 and of every other open PR.

## Test Plan

New `tests/deploy/test_databricks_deploy_uc_grants.py` pins both directions:

- a `CalledProcessError` from the grant warns per grant, still attempts the second
  grant (`["main", "main.omnigent"]`), and returns normally;
- an unrelated `CalledProcessError` — raised from `run_uv_lock`, another
  `check=True` deploy step — still propagates;
- `FileNotFoundError` and `TimeoutExpired` from the grant still propagate;
- the success path is unchanged: both grants issued, `check=True` preserved, no
  warning;
- empty stderr reports `rc=7`;
- redaction, table-driven — `DATABRICKS_TOKEN=…`, `DATABRICKS_CLIENT_SECRET=…`,
  `x-api-key: …`, `token=…`, `client_secret=…`, and `authorization: Bearer …` are
  all replaced with `<redacted>`, while a benign
  `PERMISSION_DENIED: requires MANAGE on catalog` is kept verbatim so the warning
  stays diagnostic;
- a chatty multi-line stderr is reduced to one bounded line per grant.

Results:

- `python -m pytest -q tests/deploy` → **25 passed**.
- Confirmed the tests fail before the fix: reverting `deploy.py` gives
  `subprocess.CalledProcessError: Command '['databricks', 'grants', 'update',
  'catalog', 'main', …]' returned non-zero exit status 1.`
- Spot-checked the scrubber directly:
  `'Error: default auth: DATABRICKS_TOKEN=<redacted> host=https://wsp.example.com'`,
  `'transport error: authorization: <redacted>'`,
  `'PERMISSION_DENIED: requires MANAGE on catalog'` (unchanged), `'rc=9'`.
- `pre-commit run --all-files` → all hooks pass.
- Branch cut fresh from `main` at `86726e0ab`.

## Demo

N/A — non-visual deploy behaviour. The observable change is one warning line in
the deploy log instead of an aborted deploy; the exact text is asserted by the
tests.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

<!--
Deploy-script behaviour with no visual surface, so Demo is N/A and the type boxes
are set accordingly. The linked issue #4999 is kept so the work can still be
prioritized.
-->

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests drive the real `_ensure_app_sp_uc_traversal` with `subprocess.run`
monkeypatched, so they cover the exact exception scope rather than a
reimplementation — including the negative cases, which are the point of the
review here: an unrelated failure must still abort.

Residual risk, disclosed: the redaction is pattern-based, so a credential echoed
with no recognisable key prefix (a bare token on its own) would survive into the
warning. It is bounded to one 200-character line, and the alternative — logging
nothing — would make the warning useless for the permission case it exists to
report.

## Changelog

A Unity Catalog traversal grant that cannot be applied now warns instead of aborting the Databricks deploy
