### PR TITLE
fix(pi-native): classify a 200 HTML sign-in page as an auth failure

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -454,7 +454,43 @@ async function postMcpToolsCall(config, toolName, args, rpcId, extraParams) {
         },
       };
     }
-    return { json: await resp.json() };
+    // A 200 with a non-JSON body is an authenticating edge answering the
+    // route with a sign-in page (a reverse proxy or IdP in front of the
+    // server). resp.json() would throw a SyntaxError whose message quotes the
+    // body — leaking sign-in document text (CSRF/state values, tenant ids)
+    // into a tool result — and reads as an unactionable parse error. Classify
+    // it as the auth/edge failure it is, naming no body, header, or URL (#4997).
+    const contentType = resp.headers ? resp.headers.get("content-type") : null;
+    if (contentType && !contentType.toLowerCase().includes("json")) {
+      return {
+        piResult: {
+          content: [
+            {
+              type: "text",
+              text: "Omnigent tool call failed: the server answered with a non-JSON response; authentication may be required (a sign-in page or proxy intercepted the request). Re-authenticate and retry.",
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+    let json;
+    try {
+      json = await resp.json();
+    } catch (_err) {
+      return {
+        piResult: {
+          content: [
+            {
+              type: "text",
+              text: "Omnigent tool call failed: the server answered 200 with an unparseable body; authentication may be required (a sign-in page or proxy intercepted the request). Re-authenticate and retry.",
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+    return { json };
   } catch (err) {
     return {
       piResult: {

--- a/tests/test_pi_native_non_json_200.py
+++ b/tests/test_pi_native_non_json_200.py
@@ -1,0 +1,87 @@
+"""A 200 HTML sign-in page must not be consumed as a JSON tool-call response (#4997).
+
+An authenticating edge (reverse proxy / IdP) answering /mcp with a 200
+text/html sign-in page used to hit resp.json(), whose SyntaxError message
+quotes the body — leaking sign-in document text into a tool result — and
+reads as an unactionable parse error instead of an auth failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_pi_native_extension import _extension_path, _run_node  # shared harness helpers
+
+_HARNESS = r"""
+const assert = require("assert").strict;
+const path = require("path");
+const fs = require("fs");
+
+const extensionPath = process.argv[1];
+const configPath = path.join(require("os").tmpdir(), `pi-signin-${process.pid}.json`);
+fs.writeFileSync(configPath, JSON.stringify({
+  serverUrl: "http://omnigent.test",
+  sessionId: "session-1",
+  authHeaders: { authorization: "Bearer test" },
+  tools: [{ name: "omnigent_search", description: "search", parameters: { type: "object" } }],
+}));
+process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+// The authenticating-edge shape: 200, text/html, a sign-in document with
+// values a tool result must never quote.
+const SIGN_IN_HTML = "<!DOCTYPE html><html><head><title>Sign in</title>" +
+  "<meta name=\"csrf\" content=\"SECRET-CSRF\"></head><body>state=SECRET</body></html>";
+
+let mcpCalls = 0;
+global.fetch = async (_url, request) => {
+  const body = JSON.parse(request.body);
+  if (body.method === "tools/call") {
+    mcpCalls += 1;
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: (name) => (name === "content-type" ? "text/html; charset=utf-8" : null) },
+      json: async () => { throw new SyntaxError("Unexpected token '<', \"" + SIGN_IN_HTML.slice(0, 40) + "\"... is not valid JSON"); },
+      text: async () => SIGN_IN_HTML,
+    };
+  }
+  return { ok: true, headers: { get: () => "application/json" }, json: async () => ({}) };
+};
+global.setInterval = () => ({ fakeInterval: true });
+
+const registered = {};
+const handlers = {};
+const pi = {
+  registerCommand() {},
+  registerTool(tool) { registered[tool.name] = tool; },
+  on(eventName, handler) { handlers[eventName] = handler; },
+};
+require(extensionPath)(pi);
+const ctx = { ui: { setTitle() {}, setStatus() {}, notify() {} }, sessionManager: {} };
+
+(async () => {
+  await handlers["session_start"](ctx, ctx);
+  const tool = registered["omnigent_search"];
+  assert.ok(tool, "extension registered the Omnigent tool");
+
+  const result = await tool.execute("call-1", { q: "hi" });
+  const payload = JSON.stringify(result);
+
+  assert.ok(mcpCalls === 1, "the tool call was dispatched exactly once");
+  assert.ok(!payload.includes("SECRET"), "no sign-in body text may reach the tool result: " + payload);
+  assert.ok(!payload.includes("<!DOCTYPE"), "no HTML may reach the tool result");
+  assert.ok(/non-JSON|authenticat/i.test(payload), "must be classified as auth/edge failure: " + payload);
+  assert.ok(result.isError === true, "must be an isError tool result");
+  console.log("OK");
+})().catch((e) => { console.error(e); process.exit(1); });
+"""
+
+
+def test_html_signin_200_is_auth_failure_not_parse_error():
+    result = _run_node(_HARNESS, str(_extension_path()), "/tmp")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

Fixes #4997.

## Root cause (per the issue's trace, verified)

The pi-native extension's tool-call path (`postMcpToolsCall`) checks only `resp.ok` and then calls `resp.json()`. `resp.ok` is true for a `200 text/html` response — and an authenticating edge (reverse proxy, IdP) answering the `/mcp` route with a sign-in page at 200 is common proxy behavior. Two consequences, per the issue's severity order:

1. **the error message quotes the response body** — `resp.json()`'s `SyntaxError` includes a body prefix, so the model receives `Unexpected token '<', "<!DOCTYPE html>…` — and a sign-in document routinely carries CSRF/`state` values and tenant identifiers;
2. **the failure is unactionable** — "not valid JSON" gives neither the user nor the agent any reason to re-authenticate, which is the actual remedy.

## Fix — guard both sides in `postMcpToolsCall`

- a 200 whose **content-type is not JSON** is classified as an authentication/edge failure **before any parse attempt** → bounded `isError` tool result: *"the server answered with a non-JSON response; authentication may be required (a sign-in page or proxy intercepted the request). Re-authenticate and retry."*
- a JSON-declared 200 that still **fails to parse** gets the same classification and bounded message — the raw `SyntaxError` (with its body-prefix leak) is gone.
- **no body, header, or URL text appears in either result.**

The policy-evaluation path (`PHASE_TOOL_CALL`, the other `resp.ok` site in the issue's excerpt) already fails closed on parse errors without surfacing body text — deliberately unchanged.

## Test

Drives the real extension under Node (the suite's existing `_run_node` harness) with a stubbed `fetch` answering `200 text/html` and a sign-in document carrying `SECRET` CSRF/state values; asserts the dispatched tool's result contains no `SECRET`, no HTML, reads as the auth/edge failure, and is `isError`. **Fails on current `main`** (the body prefix leaks through).
