### PR TITLE
fix(deploy): add --no-otel for Databricks Apps deploys

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -145,6 +145,24 @@ snapshot limit (10 MB). If a wheel exceeds it, rebuild with
 `--skip-web-ui` or reduce the wheel size; uv lockfiles cannot point at
 UC Volume wheel paths because `uv lock` validates path sources locally.
 
+### Deploying without OpenTelemetry
+
+The default deploy enables OTel end to end (the
+`opentelemetry-instrument` wrapper, `OTEL_TRACES_SAMPLER=always_on`,
+and platform export to `<otel_table_schema>.otel_{logs,metrics,spans}`).
+On a workspace without an OTel collector or without UC tables outside
+default storage (the platform export API rejects default-storage
+tables), add `--no-otel`:
+
+```bash
+uv run python deploy/databricks/deploy.py     --app-name omnigent     --profile <your-profile>     --lakebase-branch projects/omnigent/branches/production     --lakebase-database projects/omnigent/branches/production/databases/databricks-postgres     --volume-name main.omnigent.artifacts     --no-otel
+```
+
+`--no-otel` deploys with a plain `python app.py` command,
+`OTEL_TRACES_SAMPLER=always_off`, and no platform export destinations —
+no span-export failures against `localhost:4317`, no dependency on
+UC tables. Existing (default) deploys are byte-for-byte unchanged.
+
 Re-running is safe — every step is idempotent.
 
 Release features are off by default. Enable one or more for the whole app by

--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -24,6 +24,23 @@ variables:
   features:
     description: "Comma-separated deployment-wide release features."
     default: ""
+  otel_command:
+    description: >
+      App entry command. Default enables the opentelemetry-instrument
+      wrapper; deploy.py --no-otel overrides it to plain python for
+      workspaces without an OTel collector (#4998).
+    default: '["opentelemetry-instrument", "python", "app.py"]'
+  otel_traces_sampler:
+    description: >
+      OTEL_TRACES_SAMPLER for the wrapper. Inert without the wrapper;
+      deploy.py --no-otel sets always_off for belt-and-braces.
+    default: always_on
+  otel_destinations:
+    description: >
+      Platform telemetry export destinations (JSON list). Default routes
+      logs/metrics/spans to the otel_table_schema tables; deploy.py
+      --no-otel passes an empty list to disable platform export.
+    default: '[{"unity_catalog": {"logs_table": "main.omnigent_logs.otel_logs", "metrics_table": "main.omnigent_logs.otel_metrics", "traces_table": "main.omnigent_logs.otel_spans"}}]'
 
 resources:
   apps:
@@ -39,14 +56,14 @@ resources:
       # set it out-of-band via apps.create_update in deploy.py before
       # the bundle deploy runs.
       config:
-        command: ["opentelemetry-instrument", "python", "app.py"]
+        command: ${var.otel_command}
         env:
           - name: AP_LAKEBASE_ENDPOINT
             value_from: postgres
           - name: AP_ARTIFACT_VOLUME_PATH
             value_from: artifact_volume
           - name: OTEL_TRACES_SAMPLER
-            value: 'always_on'
+            value: "${var.otel_traces_sampler}"
           - name: OMNIGENT_FEATURES
             value: "${var.features}"
       resources:
@@ -82,8 +99,7 @@ targets:
           # in default storage ("Cannot export App telemetry to tables in
           # default storage"), so this requires a workspace with a custom
           # storage location — drop this block if yours has none.
-          telemetry_export_destinations:
-            - unity_catalog:
-                logs_table: ${var.otel_table_schema}.otel_logs
-                metrics_table: ${var.otel_table_schema}.otel_metrics
-                traces_table: ${var.otel_table_schema}.otel_spans
+          # Empty when deploy.py --no-otel is used (destinations as a
+          # JSON-encoded list var; empty list disables platform export
+          # without any conditional syntax DAB doesn't support).
+          telemetry_export_destinations: ${var.otel_destinations}

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -576,6 +576,16 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--no-otel",
+        action="store_true",
+        help=(
+            "Deploy without OpenTelemetry: no opentelemetry-instrument "
+            "wrapper, OTEL_TRACES_SAMPLER=always_off, and no platform "
+            "telemetry export destinations. For workspaces without an OTel "
+            "collector or without UC tables outside default storage (#4998)."
+        ),
+    )
+    parser.add_argument(
         "--target",
         default="prod",
         help=(
@@ -741,8 +751,32 @@ def _ensure_compute_size(
     )
 
 
+def _otel_destinations_var(otel_table_schema: str) -> str:
+    """Platform telemetry export destinations as a JSON-encoded list var.
+
+    Kept in one place so the enabled and disabled shapes provably mirror
+    databricks.yml's default (a single unity_catalog entry; empty list
+    disables the platform export without any conditional syntax DAB's
+    bundle templates do not support).
+    """
+    import json
+
+    return json.dumps(
+        [
+            {
+                "unity_catalog": {
+                    "logs_table": f"{otel_table_schema}.otel_logs",
+                    "metrics_table": f"{otel_table_schema}.otel_metrics",
+                    "traces_table": f"{otel_table_schema}.otel_spans",
+                }
+            }
+        ]
+    )
+
+
 def _bundle_vars(args: argparse.Namespace) -> list[str]:
     """CLI args to pass to `databricks bundle` as --var pairs."""
+    no_otel = getattr(args, "no_otel", False)
     return [
         "--var",
         f"app_name={args.app_name}",
@@ -756,6 +790,13 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         f"otel_table_schema={args.otel_table_schema}",
         "--var",
         f"features={args.features}",
+        "--var",
+        'otel_command='
+        + ('["python", "app.py"]' if no_otel else '["opentelemetry-instrument", "python", "app.py"]'),
+        "--var",
+        f"otel_traces_sampler={'always_off' if no_otel else 'always_on'}",
+        "--var",
+        "otel_destinations=" + ("[]" if no_otel else _otel_destinations_var(args.otel_table_schema)),
     ]
 
 


### PR DESCRIPTION
## Summary

Fixes #4998.

## Root cause (per the issue's trace, verified)

`deploy/databricks/databricks.yml` hardcodes all three OTel pieces — the `opentelemetry-instrument` wrapper, `OTEL_TRACES_SAMPLER=always_on`, and `telemetry_export_destinations` — and `git grep no-otel deploy/databricks/` returns nothing. On a workspace without an OTel collector or without UC tables outside default storage:

- every span export fails `DEADLINE_EXCEEDED` against `localhost:4317` — continuous error churn in the app logs for telemetry nobody configured;
- the platform export API rejects default-storage tables, so the destinations block **cannot be satisfied at all**.

## Fix — `deploy.py --no-otel`, defaults byte-for-byte unchanged

`databricks.yml` parameterizes the three pieces with plain substitution vars (DAB bundle templates have no conditional syntax):

| var | default (= today's spec) | `--no-otel` |
|---|---|---|
| `otel_command` | `["opentelemetry-instrument", "python", "app.py"]` | `["python", "app.py"]` |
| `otel_traces_sampler` | `always_on` | `always_off` (inert without the wrapper; belt-and-braces) |
| `otel_destinations` | JSON list with the `otel_table_schema` tables | `[]` |

The enabled/disabled destination JSON is built by **one helper** on both paths, so the two shapes provably mirror; a custom `--otel-table-schema` flows into the enabled JSON as before. README gains a "Deploying without OpenTelemetry" section with the full invocation.

## Verification

Programmatic (the deploy module imported, `_bundle_vars` driven both ways):

- enabled vars match the current literals exactly — **existing deploys unchanged**;
- disabled vars produce the three off-shapes;
- `--otel-table-schema` override flows into the enabled destinations.

(Couldn't run a real `databricks bundle validate` — needs the Databricks CLI + a workspace; the YAML is schema-validated locally.)
