### PR TITLE
fix(deploy): a failed UC traversal grant warns instead of aborting

### DIFF
--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -791,7 +791,7 @@ def _ensure_app_sp_uc_traversal(
     ):
         _log(f"granting {priv} on {kind} {fqn} → app SP {app_sp}")
         payload = _json.dumps({"changes": [{"principal": app_sp, "add": [priv]}]})
-        subprocess.run(
+        proc = subprocess.run(
             [
                 "databricks",
                 "grants",
@@ -802,10 +802,27 @@ def _ensure_app_sp_uc_traversal(
                 "--json",
                 payload,
             ],
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
         )
+        if proc.returncode != 0:
+            # A traversal grant is a convenience step, not the correctness
+            # gate: the SP often already has traversal through group
+            # inheritance, and on a shared/governed catalog the deployer
+            # routinely lacks MANAGE on the catalog — both fail this call on
+            # a workspace where the app would boot fine. The post-deploy
+            # app-boot smoke check in main() remains the real gate. Warn and
+            # continue; a missing databricks CLI surfaces as FileNotFoundError
+            # from subprocess.run and still aborts (#4999).
+            detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+            detail_line = detail[-1] if detail else f"exit {proc.returncode}"
+            _log(
+                f"WARNING: could not grant {priv} on {kind} {fqn} to the app SP "
+                f"({detail_line}). The SP may already have traversal via group "
+                "inheritance, or the deployer lacks MANAGE on the catalog. "
+                "Continuing — the app-boot smoke check will prove volume access."
+            )
 
 
 def main() -> int:

--- a/tests/deploy/test_traversal_grant_nonfatal.py
+++ b/tests/deploy/test_traversal_grant_nonfatal.py
@@ -1,0 +1,76 @@
+"""A failed UC traversal grant must not abort the deploy (#4999).
+
+Both common failures are benign: the SP already has traversal via group
+inheritance, or the deployer lacks MANAGE on a shared catalog. The
+post-deploy app-boot smoke check is the real gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY = REPO_ROOT / "deploy" / "databricks" / "deploy.py"
+
+spec = importlib.util.spec_from_file_location("deploy_mod", DEPLOY)
+deploy = importlib.util.module_from_spec(spec)
+sys.modules["deploy_mod"] = deploy
+spec.loader.exec_module(deploy)
+
+
+def _args():
+    return argparse.Namespace(
+        volume_name="main.omnigent.artifacts", profile=None
+    )
+
+
+def test_failed_grant_warns_and_continues(capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        # CalledProcessError semantics are gone (check=False now); return failure.
+        return types.SimpleNamespace(returncode=3, stdout="", stderr="Error: PERMISSION_DENIED")
+
+    orig_run = deploy.subprocess.run
+    deploy.subprocess.run = fake_run
+    try:
+        deploy._ensure_app_sp_uc_traversal(_args(), "sp-123")
+    finally:
+        deploy.subprocess.run = orig_run
+
+    out = capsys.readouterr().out
+    assert len(calls) == 2, "both grants attempted despite the first failing"
+    assert "WARNING" in out and "PERMISSION_DENIED" in out
+    assert "Continuing" in out
+    # No raise happened (we got here).
+
+
+def test_success_path_unchanged(capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    orig_run = deploy.subprocess.run
+    deploy.subprocess.run = fake_run
+    try:
+        deploy._ensure_app_sp_traversal = deploy._ensure_app_sp_uc_traversal
+        deploy._ensure_app_uc = deploy._ensure_app_sp_uc_traversal
+        deploy._ensure_app_sp_uc_traversal(_args(), "sp-123")
+    finally:
+        deploy.subprocess.run = orig_run
+
+    out = capsys.readouterr().out
+    assert len(calls) == 2
+    assert "WARNING" not in out
+
+
+def test_missing_sp_still_skips(capsys):
+    deploy._ensure_app_sp_uc_traversal(_args(), None)
+    assert "skipping" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fixes #4999.

## Root cause (per the issue's trace, verified)

`_ensure_app_sp_uc_traversal` runs both `databricks grants update` subprocesses with `check=True`, so a non-zero exit raises `CalledProcessError` and aborts the whole deploy. Both common failures are benign and neither prevents the app from working:

1. the app SP **already has traversal through group inheritance** (re-granting is unnecessary, and can still fail depending on catalog config);
2. the deployer **doesn't hold `MANAGE` on a shared catalog** — the normal situation on a governed catalog where a data admin owns grants and an app team owns deploys.

The grant is a convenience step; the post-deploy app-boot smoke check in `main()` is what actually proves the app can reach the volume.

## Fix — narrow warn-and-continue

- The two grant calls drop `check=True` and inspect the return code: non-zero → **WARNING** naming the privilege/kind/FQN, the CLI's last stderr line, the two benign causes, and that the smoke check remains the gate — then continue to the second grant.
- **Narrowness per the issue's constraints**: the relaxation applies only inside the traversal loop (an unrelated `CalledProcessError` anywhere else in the deploy is untouched), and a **missing `databricks` CLI still raises** (`FileNotFoundError` from `subprocess.run` — never becomes a permission warning). Volume-name validation and the missing-SP early-skip are unchanged.

## Tests

The deploy module imported under test with `subprocess.run` stubbed:

- a failed grant warns (with the stderr detail) and **the second grant still runs** — fails on current `main` (the first failure raises);
- the success path emits no warning and fires both grants;
- missing-SP still skips.
