### PR TITLE
fix(deploy): full-UI Databricks Apps deploys stage the SPA loose

### DIFF
--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -24,6 +24,12 @@ variables:
   features:
     description: "Comma-separated deployment-wide release features."
     default: ""
+  web_ui_dist:
+    description: >
+      OMNIGENT_WEB_UI_DIST override. Empty (the default) serves the SPA from
+      the wheel's package data; deploy.py sets /Workspace/.../src/web-ui when
+      it stages the SPA as loose files for a full-UI deploy (#5003).
+    default: ""
 
 resources:
   apps:
@@ -49,6 +55,11 @@ resources:
             value: 'always_on'
           - name: OMNIGENT_FEATURES
             value: "${var.features}"
+          # When deploy.py stages the SPA as loose files under src/web-ui
+          # (a full-UI deploy, #5003), serve them from there instead of the
+          # wheel's package data. Empty default keeps the wheel-internal path.
+          - name: OMNIGENT_WEB_UI_DIST
+            value: "${var.web_ui_dist}"
       resources:
         - name: postgres
           postgres:

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -225,6 +225,31 @@ class _ClassifiedWheels:
     oversize: list[Path]
 
 
+def _stage_web_ui_as_loose_files() -> bool:
+    """Stage the built SPA as loose files under src/web-ui for a full-UI deploy.
+
+    The ~25 MB of SPA assets take the main wheel to ~10.9 MB, over the
+    10 MB per-file cap; every individual asset is well under it. Ship the
+    SPA as loose files in the app source tree (each uploaded on its own) and
+    point the server at them via OMNIGENT_WEB_UI_DIST — the override
+    omnigent/server/app.py already documents for exactly this shape (#5003).
+
+    :returns: True when a built SPA was found and staged.
+    """
+    root = _repo_root()
+    spa = root / "omnigent" / "server" / "static" / "web-ui"
+    if not spa.is_dir() or not any(spa.iterdir()):
+        _log("no built web UI found (skip-web-ui build?); nothing to stage")
+        return False
+
+    dest = _deploy_dir() / "src" / "web-ui"
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(spa, dest)
+    _log(f"staged web UI as loose files: src/web-ui ({sum(1 for _ in dest.rglob('*') if _.is_file())} files)")
+    return True
+
+
 def _classify_wheels(wheels: Iterable[Path]) -> _ClassifiedWheels:
     main_wheel = next(w for w in wheels if w.name.startswith("omnigent-"))
     small: list[Path] = []
@@ -743,7 +768,7 @@ def _ensure_compute_size(
 
 def _bundle_vars(args: argparse.Namespace) -> list[str]:
     """CLI args to pass to `databricks bundle` as --var pairs."""
-    return [
+    vars_: list[str] = [
         "--var",
         f"app_name={args.app_name}",
         "--var",
@@ -757,6 +782,9 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         "--var",
         f"features={args.features}",
     ]
+    if getattr(args, "web_ui_dist", None):
+        vars_ += ["--var", f"web_ui_dist={args.web_ui_dist}"]
+    return vars_
 
 
 def _profile_arg(args: argparse.Namespace) -> list[str]:
@@ -846,12 +874,34 @@ def main() -> int:
         size_mb = wheel.stat().st_size / 1024 / 1024
         _log(f"  {wheel.name}  {size_mb:.2f} MB")
     if classified.oversize:
-        raise SystemExit(
-            "uv-based Databricks Apps deploys require all Omnigent wheels "
-            "to fit in the app source snapshot. Rebuild with --skip-web-ui "
-            "or reduce wheel size; UC Volume wheel paths are not used "
-            "because uv lock validates path sources locally."
+        # A full-UI build puts the SPA in the main wheel and pushes it over
+        # the 10 MB cap. Rather than aborting to an API-only instruction,
+        # stage the SPA as loose files (server reads them via the
+        # OMNIGENT_WEB_UI_DIST override its app.py already documents) and
+        # rebuild without the SPA in package data (#5003).
+        spa = _repo_root() / "omnigent" / "server" / "static" / "web-ui"
+        oversize_is_main_with_spa = (
+            classified.oversize == [classified.main]
+            and spa.is_dir()
+            and any(spa.iterdir())
         )
+        if oversize_is_main_with_spa:
+            _log("main wheel over the 10 MB cap with a built web UI: "
+                 "staging the SPA as loose files and rebuilding without it")
+            if _stage_web_ui_as_loose_files():
+                args.web_ui_dist = "src/web-ui"
+                wheels = _build_wheels(skip_web_ui=True)
+                classified = _classify_wheels(wheels)
+                for wheel in wheels:
+                    size_mb = wheel.stat().st_size / 1024 / 1024
+                    _log(f"  {wheel.name}  {size_mb:.2f} MB (rebuilt)")
+        if classified.oversize:
+            raise SystemExit(
+                "uv-based Databricks Apps deploys require all Omnigent wheels "
+                "to fit in the app source snapshot. Rebuild with --skip-web-ui "
+                "or reduce wheel size; UC Volume wheel paths are not used "
+                "because uv lock validates path sources locally."
+            )
 
     # Late-import the SDK so `--help` works without it installed.
     from databricks.sdk import WorkspaceClient

--- a/tests/deploy/test_full_ui_deploy.py
+++ b/tests/deploy/test_full_ui_deploy.py
@@ -1,0 +1,80 @@
+"""Full-UI Databricks Apps deploys: oversize SPA stages loose, not aborts (#5003).
+
+The ~25 MB SPA pushed the main wheel to ~10.9 MB (over the 10 MB cap) and the
+deploy aborted to an API-only instruction. Now the SPA stages as loose files
+under src/web-ui (each asset under the cap), the server reads them via the
+OMNIGENT_WEB_UI_DIST override app.py already documents, and the rebuild fits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY = REPO_ROOT / "deploy" / "databricks" / "deploy.py"
+
+spec = importlib.util.spec_from_file_location("deploy_mod", DEPLOY)
+deploy = importlib.util.module_from_spec(spec)
+sys.modules["deploy_mod"] = deploy
+spec.loader.exec_module(deploy)
+
+
+@pytest.fixture()
+def spa_build(tmp_path, monkeypatch):
+    """Pretend the repo root is tmp_path with a built SPA + deploy/src."""
+    (tmp_path / "omnigent" / "server" / "static" / "web-ui").mkdir(parents=True)
+    (tmp_path / "omnigent" / "server" / "static" / "web-ui" / "index.html").write_text("<html>")
+    (tmp_path / "omnigent" / "server" / "static" / "web-ui" / "app.js").write_text("console.log(1)")
+    (tmp_path / "deploy" / "databricks" / "src").mkdir(parents=True)
+    monkeypatch.setattr(deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy, "_deploy_dir", lambda: tmp_path / "deploy" / "databricks")
+    return tmp_path
+
+
+def test_stage_web_ui_copies_loose_files(spa_build):
+    staged = deploy._stage_web_ui_as_loose_files()
+    dest = spa_build / "deploy" / "databricks" / "src" / "web-ui"
+    assert staged is True
+    assert (dest / "index.html").read_text() == "<html>"
+    assert (dest / "app.js").exists()
+
+
+def test_stage_web_ui_noop_without_spa(tmp_path, monkeypatch):
+    (tmp_path / "deploy" / "databricks" / "src").mkdir(parents=True)
+    monkeypatch.setattr(deploy, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy, "_deploy_dir", lambda: tmp_path / "deploy" / "databricks")
+    assert deploy._stage_web_ui_as_loose_files() is False
+
+
+def test_bundle_vars_pass_web_ui_dist_when_set():
+    args = argparse.Namespace(
+        app_name="omnigent",
+        lakebase_branch="b",
+        lakebase_database="d",
+        volume_name="v",
+        otel_table_schema="s",
+        features="",
+        web_ui_dist="src/web-ui",
+    )
+    flat = " ".join(deploy._bundle_vars(args))
+    assert "web_ui_dist=src/web-ui" in flat
+
+
+def test_bundle_vars_omit_web_ui_dist_by_default():
+    args = argparse.Namespace(
+        app_name="omnigent",
+        lakebase_branch="b",
+        lakebase_database="d",
+        volume_name="v",
+        otel_table_schema="s",
+        features="",
+    )
+    flat = " ".join(deploy._bundle_vars(args))
+    assert "web_ui_dist" not in flat


### PR DESCRIPTION
## Summary

Fixes #5003.

## Root cause (per the issue's trace, verified)

`build.sh` bakes the ~25 MB SPA into `omnigent/server/static/web-ui/` (wheel package data), taking the main wheel to ~10.87 MB — over the 10 MB per-file cap the deploy itself enforces — so `deploy.py` aborted with a rebuild-with-`--skip-web-ui` instruction. **There was no supported path to a Databricks Apps deployment that served the web UI.** Meanwhile `server/app.py` already reads `OMNIGENT_WEB_UI_DIST`, with a comment describing exactly this deploy shape ("loose files in the app source tree, to keep the wheel under a per-file size cap"); `git grep OMNIGENT_WEB_UI_DIST deploy/` returned nothing.

## Fix — stage the SPA loose, use the documented override

When the oversize wheel **is the main wheel and a built SPA is present** (the one recoverable shape):

1. **stage** `omnigent/server/static/web-ui` → `deploy/databricks/src/web-ui` — every individual asset is well under the cap (~3.6 MB largest observed), so each uploads on its own;
2. set `web_ui_dist=src/web-ui` (resolved relative to the app's source-root cwd at runtime);
3. **rebuild** with `--skip-web-ui` — the main wheel fits;
4. continue the deploy.

The app spec gains an `OMNIGENT_WEB_UI_DIST` env var driven by a `web_ui_dist` bundle var with an **empty default**: existing and API-only deploys' resolved specs are unchanged (the empty string falls through to the wheel-internal path).

**Scope**: any *other* oversize wheel (a genuinely too-big dependency, not the SPA case) still aborts with the original message.

## Tests

- staging copies the SPA loose files into `src/web-ui` (real `shutil.copytree` against a fake repo root); safe no-op when no SPA is present;
- `_bundle_vars` carries `web_ui_dist` exactly when set, omits it otherwise.

(Couldn't run a real `databricks bundle deploy` — needs the Databricks CLI + a workspace.)
