### PR TITLE
fix(opencode-native): honor OMNIGENT_RUNNER_ENV_PASSTHROUGH in server env

### DIFF
--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -93,6 +93,29 @@ _ENV_OPENCODE_CONFIG_DENYLIST = frozenset(
     }
 )
 
+# Operator escape hatch for the runner→server hop: comma-separated EXTRA env
+# var *names* to forward. The host already honors this same list when building
+# the runner subprocess environment (omnigent.host.connect forwards both the
+# named vars and this control var), but without re-honoring it here the
+# hardcoded families above drop the names again before ``opencode serve`` —
+# and every session shell inheriting from it — can see them, so gh/acli-style
+# credentials (GH_TOKEN, GH_CONFIG_DIR, ...) never reach a dispatched
+# opencode-native session (#4916). (Literal, not an import of
+# host.connect.RUNNER_ENV_PASSTHROUGH_ENV_VAR: the host module is the outer
+# layer and shouldn't be dragged into the app-server's import graph.)
+_RUNNER_ENV_PASSTHROUGH_ENV_VAR = "OMNIGENT_RUNNER_ENV_PASSTHROUGH"
+
+
+def _runner_passthrough_keys(env: Mapping[str, str]) -> frozenset[str]:
+    """Env-var names the operator listed in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH``.
+
+    Whitespace-padded and empty list entries are tolerated, matching how the
+    host-side parser in ``omnigent.host.connect`` reads the same value.
+    """
+    return frozenset(
+        name.strip() for name in env.get(_RUNNER_ENV_PASSTHROUGH_ENV_VAR, "").split(",") if name.strip()
+    )
+
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
 # Strip ANSI escape sequences from ``opencode models`` output.
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -334,7 +357,10 @@ def filtered_server_env(
 
     Per-session XDG dirs isolate OpenCode's state from the user's global
     config; ``OPENCODE_SERVER_PASSWORD`` secures the loopback server. Only
-    provider/proxy env from the parent is passed through.
+    provider/proxy env from the parent is passed through, plus any names the
+    operator listed in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH`` (still subject to
+    the OpenCode-config denylist, so per-session isolation cannot be opted out
+    of by listing a denylisted name).
 
     :param bridge_dir: Native OpenCode bridge directory.
     :param auth_secret: Server password for basic auth.
@@ -342,12 +368,18 @@ def filtered_server_env(
     :returns: The environment mapping for the server subprocess.
     """
     env: dict[str, str] = {}
+    extra_keys = _runner_passthrough_keys(os.environ)
     for key, value in os.environ.items():
         if key in _ENV_OPENCODE_CONFIG_DENYLIST:
             # Never inherit the parent's global OpenCode config — the
-            # per-session XDG dirs are the only config source.
+            # per-session XDG dirs are the only config source. Checked first
+            # so isolation wins even when the operator listed the name.
             continue
-        if key in _ENV_PASSTHROUGH_KEYS or key.startswith(_ENV_PASSTHROUGH_PREFIXES):
+        if (
+            key in _ENV_PASSTHROUGH_KEYS
+            or key in extra_keys
+            or key.startswith(_ENV_PASSTHROUGH_PREFIXES)
+        ):
             env[key] = value
     env.update(extra_env or {})
     env["XDG_DATA_HOME"] = str(xdg_data_home_for_bridge_dir(bridge_dir))

--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -93,28 +93,18 @@ _ENV_OPENCODE_CONFIG_DENYLIST = frozenset(
     }
 )
 
-# Operator escape hatch for the runner→server hop: comma-separated EXTRA env
-# var *names* to forward. The host already honors this same list when building
-# the runner subprocess environment (omnigent.host.connect forwards both the
-# named vars and this control var), but without re-honoring it here the
-# hardcoded families above drop the names again before ``opencode serve`` —
-# and every session shell inheriting from it — can see them, so gh/acli-style
-# credentials (GH_TOKEN, GH_CONFIG_DIR, ...) never reach a dispatched
-# opencode-native session (#4916). (Literal, not an import of
-# host.connect.RUNNER_ENV_PASSTHROUGH_ENV_VAR: the host module is the outer
-# layer and shouldn't be dragged into the app-server's import graph.)
+# Additional environment-variable names explicitly forwarded by the runner.
 _RUNNER_ENV_PASSTHROUGH_ENV_VAR = "OMNIGENT_RUNNER_ENV_PASSTHROUGH"
 
 
 def _runner_passthrough_keys(env: Mapping[str, str]) -> frozenset[str]:
-    """Env-var names the operator listed in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH``.
-
-    Whitespace-padded and empty list entries are tolerated, matching how the
-    host-side parser in ``omnigent.host.connect`` reads the same value.
-    """
+    """Return the operator-declared runner environment passthrough names."""
     return frozenset(
-        name.strip() for name in env.get(_RUNNER_ENV_PASSTHROUGH_ENV_VAR, "").split(",") if name.strip()
+        name.strip()
+        for name in env.get(_RUNNER_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+        if name.strip()
     )
+
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
 # Strip ANSI escape sequences from ``opencode models`` output.
@@ -357,10 +347,8 @@ def filtered_server_env(
 
     Per-session XDG dirs isolate OpenCode's state from the user's global
     config; ``OPENCODE_SERVER_PASSWORD`` secures the loopback server. Only
-    provider/proxy env from the parent is passed through, plus any names the
-    operator listed in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH`` (still subject to
-    the OpenCode-config denylist, so per-session isolation cannot be opted out
-    of by listing a denylisted name).
+    provider/proxy env and operator-declared runner passthrough vars from the
+    parent are passed through.
 
     :param bridge_dir: Native OpenCode bridge directory.
     :param auth_secret: Server password for basic auth.
@@ -372,8 +360,7 @@ def filtered_server_env(
     for key, value in os.environ.items():
         if key in _ENV_OPENCODE_CONFIG_DENYLIST:
             # Never inherit the parent's global OpenCode config — the
-            # per-session XDG dirs are the only config source. Checked first
-            # so isolation wins even when the operator listed the name.
+            # per-session XDG dirs are the only config source.
             continue
         if (
             key in _ENV_PASSTHROUGH_KEYS

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -126,6 +126,43 @@ def test_filtered_server_env_drops_global_opencode_config(
     assert env["XDG_CONFIG_HOME"] == str(tmp_path / "xdg-config")
 
 
+def test_filtered_server_env_honors_runner_env_passthrough_names(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Names listed in OMNIGENT_RUNNER_ENV_PASSTHROUGH survive this hop.
+
+    The host honors the same list when building the runner's environment
+    (``omnigent.host.connect._build_runner_env`` forwards both the listed
+    vars and the control var itself). Without re-honoring it here, the
+    hardcoded provider-prefix families strip the names again before
+    ``opencode serve`` — and every session shell inheriting from it — sees
+    them, so gh/acli-style credentials never reach a dispatched
+    opencode-native session (#4916).
+    """
+    monkeypatch.setenv("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "GH_TOKEN, GH_CONFIG_DIR,,")
+    monkeypatch.setenv("GH_TOKEN", "ghp-token")
+    monkeypatch.setenv("GH_CONFIG_DIR", "/opt/gh-config")
+    monkeypatch.setenv("STILL_UNRELATED", "nope")
+    env = filtered_server_env(bridge_dir=tmp_path, auth_secret="pw")
+    assert env["GH_TOKEN"] == "ghp-token"
+    assert env["GH_CONFIG_DIR"] == "/opt/gh-config"
+    # Only the listed names escape the filter; everything else still drops.
+    assert "STILL_UNRELATED" not in env
+    # The control var itself carries names, not secrets, and the server has no
+    # use for it — it stays filtered out unless the operator lists it.
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in env
+
+
+def test_filtered_server_env_denylist_beats_runner_passthrough(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Listing a denylisted name does not defeat per-session XDG isolation."""
+    monkeypatch.setenv("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "OPENCODE_CONFIG")
+    monkeypatch.setenv("OPENCODE_CONFIG", "/home/user/.config/opencode/opencode.json")
+    env = filtered_server_env(bridge_dir=tmp_path, auth_secret="pw")
+    assert "OPENCODE_CONFIG" not in env
+
+
 def _server(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> OpenCodeNativeServer:
     monkeypatch.setattr(appsrv.shutil, "which", lambda name: f"/usr/bin/{name}")
     return OpenCodeNativeServer(

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -129,16 +129,7 @@ def test_filtered_server_env_drops_global_opencode_config(
 def test_filtered_server_env_honors_runner_env_passthrough_names(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Names listed in OMNIGENT_RUNNER_ENV_PASSTHROUGH survive this hop.
-
-    The host honors the same list when building the runner's environment
-    (``omnigent.host.connect._build_runner_env`` forwards both the listed
-    vars and the control var itself). Without re-honoring it here, the
-    hardcoded provider-prefix families strip the names again before
-    ``opencode serve`` — and every session shell inheriting from it — sees
-    them, so gh/acli-style credentials never reach a dispatched
-    opencode-native session (#4916).
-    """
+    """Operator-declared environment variables survive the server filter."""
     monkeypatch.setenv("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "GH_TOKEN, GH_CONFIG_DIR,,")
     monkeypatch.setenv("GH_TOKEN", "ghp-token")
     monkeypatch.setenv("GH_CONFIG_DIR", "/opt/gh-config")
@@ -146,10 +137,8 @@ def test_filtered_server_env_honors_runner_env_passthrough_names(
     env = filtered_server_env(bridge_dir=tmp_path, auth_secret="pw")
     assert env["GH_TOKEN"] == "ghp-token"
     assert env["GH_CONFIG_DIR"] == "/opt/gh-config"
-    # Only the listed names escape the filter; everything else still drops.
     assert "STILL_UNRELATED" not in env
-    # The control var itself carries names, not secrets, and the server has no
-    # use for it — it stays filtered out unless the operator lists it.
+    # The control list is runner metadata, not server configuration.
     assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in env
 
 


### PR DESCRIPTION
Fixes #4916.

## Root cause

`gh`/`acli`-style credentials configured via `OMNIGENT_RUNNER_ENV_PASSTHROUGH` reach the runner but die one hop later:

1. **Host → runner works.** `_build_runner_env()` (`omnigent/host/connect.py`) reads the comma-separated names in `OMNIGENT_RUNNER_ENV_PASSTHROUGH` and forwards both the named vars and the control var itself into the runner subprocess environment.
2. **Runner → `opencode serve` strips them.** `filtered_server_env()` (`omnigent/opencode_native_app_server.py`) re-filters `os.environ` through the hardcoded `_ENV_PASSTHROUGH_PREFIXES` (provider families like `ANTHROPIC_`, `OPENCODE_`, …) plus a handful of exact keys. `GH_TOKEN` / `GH_CONFIG_DIR` match none of them, so they're dropped right before the server process — and every session shell that inherits from it — boots.

This is exactly the "separate code path" the issue suspected: the #3445 fix routes the inner executors (`pi`/`codex`/`qwen`/`acp`) through `clean_agent_env()` + `os_env.sandbox.env_passthrough`, but opencode-native launches through `opencode_native_app_server.py`, which has its own allowlist that never consulted the operator list.

## Fix

`filtered_server_env()` now treats the names listed in `OMNIGENT_RUNNER_ENV_PASSTHROUGH` as additional exact passthrough keys, parsed identically to the host-side reader (whitespace-padded and empty entries tolerated):

```python
extra_keys = _runner_passthrough_keys(os.environ)
for key, value in os.environ.items():
    if key in _ENV_OPENCODE_CONFIG_DENYLIST:
        continue  # isolation wins even when the name is listed
    if key in _ENV_PASSTHROUGH_KEYS or key in extra_keys or key.startswith(_ENV_PASSTHROUGH_PREFIXES):
        env[key] = value
```

Two deliberate scope choices:

- **The `_ENV_OPENCODE_CONFIG_DENYLIST` check stays first**, so listing `OPENCODE_CONFIG`/`OPENCODE_CONFIG_CONTENT` in the passthrough cannot opt out of per-session XDG isolation — pinned by a dedicated regression test.
- **The control var itself is not forwarded** unless listed: it carries names, not secrets, and the server has no use for it.

Since both call sites (`OpenCodeNativeServer.env` for server launches, and the model-options CLI env in the runner) go through `filtered_server_env()`, the fix covers the dispatched-session shell path from the issue's repro with no other wiring changes.

## Testing

New regression tests in `tests/test_opencode_native_app_server.py`:

- `test_filtered_server_env_honors_runner_env_passthrough_names` — listed names (`GH_TOKEN`, `GH_CONFIG_DIR`, with padding/dup empty entries in the list) survive; unlisted vars still drop; the control var itself stays out. **Fails on `main`** (`KeyError: 'GH_TOKEN'`), passes with the fix.
- `test_filtered_server_env_denylist_beats_runner_passthrough` — a listed denylisted name is still dropped.

Full suite results: `test_opencode_native_app_server.py` 26/26 passed; `test_opencode_http_transport.py` unchanged. (The 3 failures in `test_opencode_native_bridge.py` around `chmod`-0600/`mkdir` assertions also fail on unmodified `main` in my environment — Windows filesystem semantics, unrelated to this change.)

With this, the issue's exact repro works: set `OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR` on the host daemon with a real `GH_CONFIG_DIR`, dispatch an `opencode-native` session, and `gh auth status` inside the session now resolves the forwarded config dir.
