### PR TITLE
fix(ci): audit mutually exclusive extras as separate resolution sets

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -152,10 +152,28 @@ jobs:
           # third-party pinned packages anyway — OSV has no advisories for
           # local source. Filtering all `-e` lines (rather than naming each
           # workspace member) keeps this correct if members are added later.
-          uv export --frozen --format requirements-txt --all-extras \
-            > /tmp/uv-req-full.txt
-          grep -v '^-e ' /tmp/uv-req-full.txt > /tmp/uv-req.txt
-          uvx pip-audit --requirement /tmp/uv-req.txt --no-deps
+          #
+          # The extras are NOT mutually installable: `antigravity` declares
+          # conflicts with `cwsandbox`/`modal`/`databricks` (and the lint
+          # group), so a single `--all-extras` export dies during resolution
+          # and thereby blocks every gated CI job on any PR that changes
+          # uv.lock (#4942). Audit the maximal compatible resolution sets
+          # separately instead: everything except the conflicting extra, then
+          # the conflicting extra alone with no default groups. The two files
+          # are deliberately NOT merged into one pip-audit run: a package can
+          # legitimately pin different versions per set (e.g. protobuf 6.x for
+          # cwsandbox/modal vs 7.x for antigravity), which a single
+          # requirements file would present as conflicting pins. Overlapping
+          # base pins are simply audited twice — harmless.
+          uv export --frozen --format requirements-txt \
+            --all-extras --no-extra antigravity > /tmp/uv-req-set-a.txt
+          uv export --frozen --format requirements-txt \
+            --extra antigravity --no-default-groups > /tmp/uv-req-set-b.txt
+          for reqs in /tmp/uv-req-set-a.txt /tmp/uv-req-set-b.txt; do
+            grep -v '^-e ' "$reqs" > /tmp/uv-req.txt
+            echo "pip-audit: $(grep -c '==' /tmp/uv-req.txt) pinned packages from $reqs"
+            uvx pip-audit --requirement /tmp/uv-req.txt --no-deps
+          done
 
       - name: Semgrep (changed files, local rules)
         if: ${{ steps.gate.outputs.scan == 'true' }}


### PR DESCRIPTION
Fixes #4942.

## Root cause

The OSV step's single export combines every extra:

```bash
uv export --frozen --format requirements-txt --all-extras
```

but `pyproject.toml` deliberately declares `antigravity` as conflicting with `cwsandbox`, `modal`, `databricks`, and the `lint` group (protobuf 7.x vs <7 forks), so uv refuses the combined resolution before anything is exported — every uv.lock-touching PR from an untrusted author fails the scan, and with it every gated CI job (the exact population the scan exists to vet; #4923 and #4941 are the live casualties).

## Fix

Export the two maximal compatible resolution sets and `pip-audit` each:

```bash
uv export --frozen --format requirements-txt --all-extras --no-extra antigravity
uv export --frozen --format requirements-txt --extra antigravity --no-default-groups
```

The two files are **deliberately not merged** into one audit run: a shared package legitimately pins different versions per set — on current `main`, `protobuf==6.33.6` in the all-but-antigravity set and `protobuf==7.35.1` under antigravity — and a single requirements file would hand pip-audit conflicting pins. Overlapping base pins are simply audited twice, which is harmless.

The comment block in the workflow explains the conflict structure and where to add a third set if another conflicting extra ever lands.

## Verification (against current `main`'s lockfile)

- Combined export fails exactly as reported: `error: Extras 'antigravity' and 'cwsandbox' are incompatible with the declared conflicts …` (exit 2).
- Both set exports succeed (3692 and 1581 requirement lines; 4 and 3 editable entries filtered by the existing `-e` grep).
- `pip-audit --no-deps` passes on the antigravity set end-to-end locally; the all-but-antigravity set resolves on Linux (it contains `boxlite`, which publishes manylinux but no Windows wheels — my local Windows dry-run can't install it, the ubuntu-latest runner can; it was equally present in the pre-conflict `--all-extras` export that used to pass).

## Note for reviewers

This PR edits `.github/workflows/security-scan.yml`, which trips this repo's own sensitive-path guard for untrusted authors — correctly, since workflow edits can weaken gates. It will need the maintainer review + `skip-security-scan` label path the guard prescribes; flagging it here so nobody is surprised by the red check. The change is confined to the OSV step's shell logic: same trigger, same trust gate, same audit tool and flags — only the export strategy changes from one impossible resolution to two compatible ones.
