### PR TITLE
fix(host): reconnect with a short open timeout and capped backoff

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -328,6 +328,37 @@ def _connection_refused(exc: BaseException) -> bool:
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 10.0
 _RECONNECT_JITTER = 0.5
+# WebSocket open timeouts for the tunnel handshake. The INITIAL connect keeps
+# the 10 s library default: a cold server (or a slow TLS handshake through the
+# Apps ingress) legitimately takes seconds to answer a first upgrade. Once a
+# host has connected at least once, the server has proven it serves this host —
+# a healthy server answers the re-upgrade well inside 5 s, and one that doesn't
+# fails fast so the reconnect loop retries promptly instead of hanging ~10 s
+# per attempt. Recovery from a transient blip then costs one short timeout,
+# not two stacked ~10 s budgets (#4980).
+_INITIAL_OPEN_TIMEOUT_S = 10.0
+_RECONNECT_OPEN_TIMEOUT_S = 5.0
+
+# Backoff ceiling once the host has connected at least once (see
+# _reconnect_backoff_cap).
+_RECONNECT_CAP_AFTER_CONNECT_S = 5.0
+
+
+def _reconnect_backoff_cap(ever_connected: bool) -> float:
+    """The reconnect backoff ceiling for this host's connection history.
+
+    The full 10 s cap guards a host hammering a server it has never reached.
+    A previously connected host knows the endpoint is real, so its retries
+    stay on a shorter leash — a transient interruption should not need the
+    full cold-start budget to recover — while remaining bounded against
+    hammering during a real outage.
+
+    :param ever_connected: Whether this host has completed an upgrade once.
+    :returns: The backoff ceiling in seconds.
+    """
+    return _RECONNECT_CAP_AFTER_CONNECT_S if ever_connected else _RECONNECT_CAP_S
+
+
 # Consecutive connection-refused failures against a loopback server before the
 # host exits (~5 minutes at the backoff cap). Refused on loopback means no
 # process listens on the port — the local server is gone, not unreachable.
@@ -2766,7 +2797,7 @@ class HostProcess:
                     else:
                         backoff = min(
                             backoff * 2 * (1 + random.random() * _RECONNECT_JITTER),
-                            _RECONNECT_CAP_S,
+                            _reconnect_backoff_cap(self._ever_connected),
                         )
         except (KeyboardInterrupt, asyncio.CancelledError):
             pass
@@ -2839,6 +2870,14 @@ class HostProcess:
                 url,
                 additional_headers=headers,
                 max_size=100 * 1024 * 1024,
+                # Reconnects (a previously connected host) use the short open
+                # timeout above; only the very first attempt keeps the
+                # cold-server-tolerant default.
+                open_timeout=(
+                    _RECONNECT_OPEN_TIMEOUT_S
+                    if self._ever_connected
+                    else _INITIAL_OPEN_TIMEOUT_S
+                ),
                 ssl=ssl_ctx,
                 # Align the host->server tunnel's protocol keepalive to the same
                 # 90 s app-level budget as the runner tunnel (not the 20 s library

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3349,16 +3349,20 @@ class _ConnectSpy:
         """
         self._exceptions = exceptions
         self.call_count = 0
+        # kwargs of each production connect() call, aligned with call_count —
+        # lets tests assert handshake parameters like open_timeout.
+        self.kwargs_log: list[dict[str, object]] = []
 
     def __call__(self, url: str, **kwargs: object) -> _HandshakeFailingConnect | _AcceptingConnect:
         """Return an async-CM scripting the handshake for this call.
 
         :param url: Tunnel URL passed by production (ignored).
-        :param kwargs: Connect kwargs passed by production (ignored).
+        :param kwargs: Connect kwargs passed by production (recorded).
         :returns: A context manager whose ``__aenter__`` raises the
             queued exception, or completes the handshake for a ``None``
             entry.
         """
+        self.kwargs_log.append(dict(kwargs))
         exc = self._exceptions[min(self.call_count, len(self._exceptions) - 1)]
         self.call_count += 1
         if exc is None or isinstance(exc, int):
@@ -3991,6 +3995,97 @@ async def test_remote_host_retries_connection_refused_past_threshold(
 
     # 5 = 4 retried refusals (past the threshold of 3) + the ending cancel.
     assert spy.call_count == 5
+
+
+async def test_reconnect_after_successful_connect_uses_shorter_open_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnects hand websockets a shorter open_timeout than the first attempt.
+
+    A transient tunnel drop used to inherit the ~10 s cold-start open timeout
+    for every re-upgrade, stacking with backoff on top and stretching recovery
+    well past the blip itself (#4980). The FIRST attempt must keep the
+    cold-server-tolerant default; only a host that has completed an upgrade
+    once may reconnect on the short timeout.
+    """
+    import omnigent.host.connect as connect_mod
+
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    # The accepted connect sends a real hello; skip its slow CLI probes.
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    # attempt 1 accepts then drops (marks the host ever-connected); attempt 2
+    # is the reconnect; CancelledError ends the loop there.
+    spy = _ConnectSpy([None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+    # Skip the one-time capability probes: their harness/gateway discovery
+    # shells out and is irrelevant to the handshake parameters under test.
+    host._capabilities_initialized = True
+
+    await host.run()
+
+    assert spy.call_count == 2
+    assert spy.kwargs_log[0]["open_timeout"] == connect_mod._INITIAL_OPEN_TIMEOUT_S
+    assert spy.kwargs_log[1]["open_timeout"] == connect_mod._RECONNECT_OPEN_TIMEOUT_S
+    assert connect_mod._RECONNECT_OPEN_TIMEOUT_S < connect_mod._INITIAL_OPEN_TIMEOUT_S
+
+
+def test_backoff_cap_tracks_connection_history() -> None:
+    """The backoff ceiling reads the host's connection history.
+
+    A never-connected host retries against the full 10 s cap (guards a host
+    hammering an unreachable server); once an upgrade has succeeded, further
+    backoff is capped at the shorter recovery leash (#4980).
+    """
+    import omnigent.host.connect as connect_mod
+
+    assert (
+        connect_mod._reconnect_backoff_cap(False) == connect_mod._RECONNECT_CAP_S
+    )
+    assert (
+        connect_mod._reconnect_backoff_cap(True)
+        == connect_mod._RECONNECT_CAP_AFTER_CONNECT_S
+    )
+    assert (
+        connect_mod._RECONNECT_CAP_AFTER_CONNECT_S < connect_mod._RECONNECT_CAP_S
+    )
+
+
+async def test_run_backoff_uses_connected_history_after_first_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run()'s backoff update consults the connected-history cap after success.
+
+    Wires _reconnect_backoff_cap into the live loop: once attempt 1 completes
+    an upgrade, every subsequent backoff cap lookup must report the
+    ever-connected history.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    seen: list[bool] = []
+
+    def _record(ever_connected: bool) -> float:
+        seen.append(ever_connected)
+        return 0.0
+
+    monkeypatch.setattr("omnigent.host.connect._reconnect_backoff_cap", _record)
+    # attempt 1 accepts then drops; attempts 2-3 fail with a retryable 503
+    # (each failing the backoff update); attempt 4 cancels out of run().
+    spy = _ConnectSpy([None, _invalid_status(503), _invalid_status(503), asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+    # Skip the one-time capability probes (see the open_timeout test above).
+    host._capabilities_initialized = True
+
+    await host.run()
+
+    assert spy.call_count == 4
+    # Attempt 1's abrupt drop is classified as an ingress recycle (remote
+    # server, "no close frame") and takes the prompt-reconnect path, which
+    # resets backoff without consulting the cap. The two 503s take the
+    # backoff path; the cancel never updates backoff. Every cap lookup
+    # follows the successful first upgrade.
+    assert seen == [True, True]
 
 
 async def test_accepted_connect_resets_loopback_refused_streak(


### PR DESCRIPTION
Fixes #4980 (the remaining, retry-cadence half — see "Scope" below).

## What was already fixed

The report has two halves. The "hello waits for local readiness probes" half landed as #4769 the day after the report: capability probes moved to daemon init (bounded by `_HOST_CAPABILITY_INIT_TIMEOUT_S`), `host.hello` is sent from the cached snapshot immediately after the upgrade, and readiness is refreshed asynchronously in `_harness_readiness_loop`. I verified this reading current `main`; nothing more to do there.

## What this PR fixes

The retry cadence after a previously-successful connection drops:

1. **Re-upgrades inherit the ~10 s cold-start open timeout.** `websockets.asyncio.client.connect` defaults `open_timeout=10`, and the tunnel connect never overrode it — so a host recovering from a blip pays up to 10 s *per attempt* just waiting on the WS open.
2. **Backoff can stack another 10 s.** `_RECONNECT_CAP_S = 10` applies equally to a host that has never reached the server and one that served traffic for hours.

Both knobs now key off the existing `_ever_connected` latch (set on the first accepted upgrade):

- `open_timeout`: initial connect keeps the 10 s default (a cold server or slow TLS handshake through the Apps ingress legitimately needs it); reconnects use **5 s** — a server that just served this host answers quickly, and one that doesn't fails fast so the loop retries promptly instead of hanging.
- backoff ceiling via `_reconnect_backoff_cap(ever_connected)`: **5 s** once the host has connected at least once; never-connected hosts keep the full 10 s cap (that guard exists precisely for hammering an unreachable server).

The prompt "recycle" reconnect path (explicit 1012/1001 close codes, ingress cycling on a remote server) is untouched — it already reconnects immediately, which is why a plain Apps recycle never needed this.

Worst case for a previously-connected host changes from ~10 s hang + up-to-10 s backoff per attempt to ≤5 s + ≤5 s — matching the report's "retry promptly" expectation while initial startup stays cold-server tolerant.

## Tests

`_ConnectSpy` now records each production `connect()` call's kwargs (recording only; existing behavior unchanged):

- `test_reconnect_after_successful_connect_uses_shorter_open_timeout` — first attempt gets `_INITIAL_OPEN_TIMEOUT_S` (10 s), the reconnect after a successful serve gets `_RECONNECT_OPEN_TIMEOUT_S` (5 s). **Fails on `main`**, which passes no `open_timeout` at all.
- `test_backoff_cap_tracks_connection_history` — the helper's mapping and the invariant `after-connect cap < full cap`.
- `test_run_backoff_uses_connected_history_after_first_upgrade` — live `run()` loop with a scripted accept→drop, two 503s, and a cancel: every backoff-cap lookup after the first successful upgrade reports the connected history (the abrupt drop itself takes the prompt recycle path, which resets backoff without consulting the cap — asserted explicitly).

All three fail on unmodified `main` and pass with the fix. Full `tests/host/` run: 318 passed / 28 failed with the fix vs 315 / 28 on clean `main` in the same environment — identical pre-existing failure set (Windows-only platform gaps: posix reaping, sigkill escalation, codex discovery shelling), zero regressions.
