### PR TITLE
fix(codex-native): send structured skill input for chat slash invocations

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -459,6 +459,14 @@ def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
     host = home / ".codex" / "skills"
     if host.is_dir():
         sources.append(host)
+    # Vendor-neutral shared skills (the same ``~/.agents/skills`` tree the
+    # Antigravity provider and the agents skill spec read). Lowest priority so
+    # a Codex-specific skill of the same name wins; without it, a skill
+    # installed only in the shared tree is invisible to Codex sessions while
+    # being available to other harnesses (#4935).
+    shared = home / ".agents" / "skills"
+    if shared.is_dir():
+        sources.append(shared)
     return sources
 
 

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -8,6 +8,7 @@ import binascii
 import json
 import logging
 import os
+import re
 from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 from typing import cast
@@ -17,6 +18,7 @@ from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     cancel_pending_mcp_startup,
+    codex_home_for_bridge_dir,
     mcp_startup_waiting_detail,
     read_bridge_startup_error,
     read_bridge_state,
@@ -210,11 +212,13 @@ class CodexNativeExecutor(Executor):
         settings_overrides = _model_effort_overrides(config)
         latest_user_content = _latest_user_content(messages)
         goal_objective = goal_objective_from_content(latest_user_content)
-        input_items: list[dict[str, object]] = (
-            [{"type": "text", "text": goal_objective}]
-            if goal_objective is not None
-            else _content_to_input_items(latest_user_content, self._bridge_dir)
-        )
+        if goal_objective is not None:
+            input_items = [{"type": "text", "text": goal_objective}]
+        else:
+            input_items = (
+                _slash_skill_input_items(latest_user_content, self._bridge_dir)
+                or _content_to_input_items(latest_user_content, self._bridge_dir)
+            )
         if not input_items:
             yield ExecutorError(message="Codex native turn had no user input to send")
             return
@@ -435,6 +439,65 @@ def _latest_user_content(messages: list[Message]) -> object:
         if message.get("role") == "user":
             return message.get("content")
     return None
+
+
+# Leading "/<skill-name>" interception for the chat path. Codex's TUI sends a
+# structured skill input item for slash invocations; the app-server's text
+# path leaves the literal "/name" in the prompt, so a skill command typed in
+# the web chat silently does nothing (#4935).
+_SLASH_SKILL_RE = re.compile(r"^/([^\s/]+)(?:\s+(.*))?$", re.DOTALL)
+
+
+def _slash_skill_input_items(
+    content: object, bridge_dir: Path
+) -> list[dict[str, object]] | None:
+    """Translate a standalone ``/<skill> [args]`` text into skill input items.
+
+    Resolution is against the per-session ``$CODEX_HOME/skills`` — exactly
+    the symlinks the launch path populated and Codex registered as slash
+    commands — so a chat-view invocation matches what the TUI's slash menu
+    sends: a ``{"type": "skill", "name", "path"}`` item naming the
+    SKILL.md, followed by the remaining text as a text item when present.
+
+    Chat text reaches the executor as ``input_text`` blocks; a slash
+    command is intercepted only when the content is text-only (the same
+    normalization ``/goal`` applies) — a multimodal turn's leading text is
+    left to Codex verbatim.
+
+    :param content: Latest user content (string or content blocks).
+    :param bridge_dir: Native Codex bridge directory (locates CODEX_HOME).
+    :returns: Input items, or ``None`` when the text is not a slash command
+        naming a registered skill — unknown commands, path-like text such as
+        ``/etc/hosts``, and everything else fall through to the text path
+        exactly as before.
+    """
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                return None
+            if block.get("type") not in {"input_text", "text"}:
+                return None
+            text = block.get("text")
+            if not isinstance(text, str):
+                return None
+            text_parts.append(text)
+        content = "".join(text_parts)
+    if not isinstance(content, str) or not content.lstrip().startswith("/"):
+        return None
+    match = _SLASH_SKILL_RE.match(content.strip())
+    if match is None:
+        return None
+    name, rest = match.group(1), match.group(2)
+    skill_md = codex_home_for_bridge_dir(bridge_dir) / "skills" / name / "SKILL.md"
+    if not skill_md.is_file():
+        return None
+    items: list[dict[str, object]] = [
+        {"type": "skill", "name": name, "path": str(skill_md)}
+    ]
+    if rest and rest.strip():
+        items.append({"type": "text", "text": rest})
+    return items
 
 
 def _content_to_input_items(content: object, bridge_dir: Path) -> list[dict[str, object]]:

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3299,6 +3299,53 @@ def test_codex_skill_sources_omits_absent_dirs(tmp_path: Path) -> None:
     assert codex_skill_sources(tmp_path / "no-bundle", home) == [home / ".codex" / "skills"]
 
 
+def test_codex_skill_sources_appends_shared_agents_tree(tmp_path: Path) -> None:
+    """``~/.agents/skills`` is the lowest-priority Codex skill source.
+
+    The vendor-neutral shared tree (the one the Antigravity provider and the
+    agents skill spec already read) was invisible to Codex sessions — a
+    skill installed only there could not be invoked from a Codex session
+    while other harnesses saw it fine (#4935). It must come AFTER the
+    Codex-specific trees so a same-named skill in ``.codex/skills`` wins.
+    """
+    from omnigent.inner.codex_executor import codex_skill_sources, select_codex_skill_dirs
+
+    bundle = tmp_path / "bundle"
+    (bundle / "skills").mkdir(parents=True)
+    home = tmp_path / "home"
+    (home / ".codex" / "skills").mkdir(parents=True)
+    shared = home / ".agents" / "skills"
+    shared.mkdir(parents=True)
+
+    assert codex_skill_sources(bundle, home) == [
+        bundle / "skills",
+        home / ".codex" / "skills",
+        shared,
+    ]
+
+    # Shadowing: the .codex copy of a same-named skill wins over the shared
+    # one, and a shared-only skill is selectable.
+    (home / ".codex" / "skills" / "dup").mkdir()
+    (home / ".codex" / "skills" / "dup" / "SKILL.md").write_text("codex", encoding="utf-8")
+    (shared / "dup").mkdir()
+    (shared / "dup" / "SKILL.md").write_text("shared", encoding="utf-8")
+    (shared / "only-shared").mkdir()
+    (shared / "only-shared" / "SKILL.md").write_text("shared", encoding="utf-8")
+
+    selected = select_codex_skill_dirs("all", codex_skill_sources(bundle, home))
+    assert selected["dup"] == home / ".codex" / "skills" / "dup"
+    assert selected["only-shared"] == shared / "only-shared"
+
+
+def test_codex_skill_sources_shared_tree_absent_is_omitted(tmp_path: Path) -> None:
+    """No ``~/.agents/skills`` on the host → the source list is unchanged."""
+    from omnigent.inner.codex_executor import codex_skill_sources
+
+    home = tmp_path / "home"
+    (home / ".codex" / "skills").mkdir(parents=True)
+    assert codex_skill_sources(None, home) == [home / ".codex" / "skills"]
+
+
 def test_clean_codex_env_honors_extra_allow(monkeypatch):
     from omnigent.inner.codex_executor import _clean_codex_env
 

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -239,6 +239,193 @@ def test_goal_command_sets_goal_before_starting_objective_turn(
     ]
 
 
+def test_slash_skill_command_sends_structured_skill_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A registered skill's slash command reaches Codex as a skill input.
+
+    The TUI sends ``{"type": "skill", name, path}`` for slash invocations;
+    the chat path used to send the literal ``/name`` as text, so an explicit
+    skill command silently did nothing (#4935). Resolution is against the
+    per-session ``$CODEX_HOME/skills`` — what the launch path symlinked and
+    Codex registered — and the remainder rides along as a text item.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    skill_md = tmp_path / "codex-home" / "skills" / "ask-matt" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("---\nname: ask-matt\n---\nDo the thing.", encoding="utf-8")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "  /ask-matt verify this service  ")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [
+                    {
+                        "type": "skill",
+                        "name": "ask-matt",
+                        "path": str(skill_md),
+                    },
+                    {"type": "text", "text": "verify this service"},
+                ],
+            },
+        ),
+    ]
+
+
+def test_slash_skill_command_without_args_sends_skill_item_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A bare ``/<skill>`` sends just the skill item, no empty text item."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    skill_md = tmp_path / "codex-home" / "skills" / "ask-matt" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("---\nname: ask-matt\n---\nDo the thing.", encoding="utf-8")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "/ask-matt")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "skill", "name": "ask-matt", "path": str(skill_md)}],
+            },
+        ),
+    ]
+
+
+def test_unknown_slash_command_falls_through_to_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A slash command that names no registered skill stays literal text.
+
+    Codex's own unknown-command handling (and any model-side meaning the
+    text has) must be preserved — interception is opt-in per registered
+    skill, never a blanket rewrite of leading-slash text.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    # A different skill IS registered — proves the miss is by name, not
+    # because no skills exist at all.
+    other = tmp_path / "codex-home" / "skills" / "other-skill" / "SKILL.md"
+    other.parent.mkdir(parents=True)
+    other.write_text("---\nname: other-skill\n---\nOther.", encoding="utf-8")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "/not-a-skill do something")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "text", "text": "/not-a-skill do something"}],
+            },
+        ),
+    ]
+
+
+def test_path_like_slash_text_is_not_intercepted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Path-shaped text (``/etc/hosts``) never becomes a skill invocation.
+
+    The command grammar requires a single token after the slash with no
+    interior ``/``; anything else — paths, fractions, markdown — passes
+    through to the text path untouched.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "/etc/hosts is where it points")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "text", "text": "/etc/hosts is where it points"}],
+            },
+        ),
+    ]
+
+
 def test_system_prompt_does_not_override_collaboration_mode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Fixes #4935.

## Root cause (both halves)

1. **Chat sends skill commands as literal text.** The Codex TUI translates a slash invocation into a structured `UserInput::Skill { name, path }` input item (verified against `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` — serde tag `"type"`, so `{"type": "skill", "name": ..., "path": ...}`, with `path` naming the SKILL.md). The chat path (`CodexNativeExecutor.run_turn` → `_content_to_input_items`) only ever built `{"type": "text", ...}` items, so `/ask-matt verify this` reached the app-server with the slash still in the text and never invoked the skill.
2. **Shared skills were invisible.** `codex_skill_sources` listed only `<bundle>/skills` and `~/.codex/skills` — the vendor-neutral `~/.agents/skills` tree that the Antigravity provider (`_agy_skill_dirs`) and the agents skill spec already read was never a Codex source, so a skill installed only there was not symlinked into the session's `$CODEX_HOME/skills`, not listed by the slash menu, and not invocable.

## Fix

**Structured skill input.** `run_turn` now intercepts a standalone leading `/<name>` (after the existing `/goal` command, before the text path) when `name` resolves inside the session's `$CODEX_HOME/skills/<name>/SKILL.md` — exactly the symlinks the launch path populated via `populate_codex_skills_from_bundle` and Codex registered as slash commands — and sends:

```json
{"input": [
  {"type": "skill", "name": "ask-matt", "path": "…/skills/ask-matt/SKILL.md"},
  {"type": "text", "text": "verify this service"}
]}
```

Interception is opt-in per registered skill:
- an unknown command (`/not-a-skill …`) passes through as text — Codex's own unknown-command handling and any model-side meaning are preserved;
- path-like text (`/etc/hosts is where it points`) can't match the single-token command grammar and passes through;
- multimodal turns (images/files present) are never intercepted — only text-only content, normalized the same way `/goal` does it;
- a bare `/skill` sends just the skill item, no empty text item.

The same `input_items` feed `turn/steer`, so a slash command sent mid-turn steers with the skill item too.

**Shared tree.** `codex_skill_sources` appends `~/.agents/skills` as the **lowest-priority** source (a same-named skill in `.codex/skills` still wins). Because `select_codex_skill_dirs` is the single source of truth shared by the symlink populator and the slash-command menu's `codex_host_skills`, the shared skills automatically appear in all three places: linked into the session, listed by the menu, and invocable via the new interception.

## Tests

- `test_slash_skill_command_sends_structured_skill_input` / `..._without_args_sends_skill_item_only` — the exact `turn/start` payloads; **both fail on `main`** (which sends the literal text).
- `test_unknown_slash_command_falls_through_to_text` (with a *different* skill registered, proving the miss is by name) and `test_path_like_slash_text_is_not_intercepted` — pin the pass-through behavior on both sides.
- `test_codex_skill_sources_appends_shared_agents_tree` — ordering + `.codex` shadowing over the shared copy + shared-only skill selectable; **fails on `main`**. `test_codex_skill_sources_shared_tree_absent_is_omitted` — no behavior change on hosts without the tree.

Regression runs: `test_codex_native_executor.py` + `test_codex_executor.py` + `test_harness_plugins.py` + `tests/spec/` — 711 passed / 13 failed with the fix vs 705 / 13 on clean `main` in the same environment (identical pre-existing Windows-only failure set), zero regressions.
