### PR TITLE
fix(cli): don't crash `host stop` on a stale foreign daemon record

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9188,6 +9188,50 @@ def _stop_daemon_sessions(
     return stopped
 
 
+def _signal_daemon_pid(record: _HostDaemonRecord, sig: int) -> bool:
+    """
+    Signal a daemon's recorded PID, tolerating a stale foreign entry.
+
+    A daemon registry record can outlive the process it names. The recorded
+    PID may since have been reused by an unrelated process — often owned by
+    another user — or the real daemon may have been started under a different
+    account (e.g. ``sudo``). In both cases the PID is no longer this user's
+    daemon and must not be killed.
+
+    ``os.kill`` raises ``PermissionError`` (EPERM) when the caller lacks
+    permission to signal the target — which, since we only ever signal our
+    own daemons, means the record is stale and points at someone else's
+    process. ``_pid_alive`` reports such a PID as alive (``psutil`` maps the
+    same permission failure to ``AccessDenied``), so without this guard
+    ``_terminate_daemon`` would fall through to ``os.kill`` and crash on the
+    unsuppressed EPERM — ``--force`` included, since it dies before the
+    SIGKILL path. Log a warning and treat the record as stale instead.
+
+    :param record: Daemon record whose PID should be signalled.
+    :param sig: Signal number to send, e.g. ``signal.SIGTERM``.
+    :returns: ``True`` if the record is stale and the caller should drop it
+        and stop (either the PID is not ours, or it already exited); ``False``
+        if the signal was delivered and termination should proceed as usual.
+    """
+    try:
+        os.kill(record.pid, sig)
+    except ProcessLookupError:
+        # The process exited between the liveness check and the signal —
+        # nothing left to kill, so the record is stale.
+        return True
+    except PermissionError:
+        # Not our daemon: the record points at another user's process (PID
+        # reuse, or a daemon started under a different account). Drop the
+        # stale record and warn rather than crashing the CLI on the EPERM.
+        click.echo(
+            f"Skipping stale daemon record for {record.target!r}: pid "
+            f"{record.pid} is owned by another user and is not this daemon.",
+            err=True,
+        )
+        return True
+    return False
+
+
 def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     """
     Terminate one local daemon process.
@@ -9199,8 +9243,9 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     if not _pid_alive(record.pid):
         _delete_daemon_record(record)
         return
-    with contextlib.suppress(ProcessLookupError):
-        os.kill(record.pid, signal.SIGTERM)
+    if _signal_daemon_pid(record, signal.SIGTERM):
+        _delete_daemon_record(record)
+        return
     deadline = time.monotonic() + _HOST_DAEMON_STOP_GRACE_S
     while time.monotonic() < deadline:
         if not _pid_alive(record.pid):
@@ -9208,8 +9253,9 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
             return
         time.sleep(0.1)
     if force:
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(record.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        if _signal_daemon_pid(record, getattr(signal, "SIGKILL", signal.SIGTERM)):
+            _delete_daemon_record(record)
+            return
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline:
             if not _pid_alive(record.pid):

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -596,6 +596,65 @@ def test_host_stop_treats_zombie_daemon_as_dead(
     )
 
 
+def test_host_stop_drops_stale_foreign_daemon_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verify ``host stop`` drops a daemon record whose pid it cannot signal.
+
+    A registry record can outlive its daemon: the pid may be reused by
+    another user's process, or the daemon was started under a different
+    account. ``_pid_alive`` reports such a pid as alive (psutil maps the
+    EPERM to ``AccessDenied``), so stop falls through to ``os.kill``, which
+    raises ``PermissionError``. Stop must treat the record as stale — warn
+    and delete it — instead of crashing on the EPERM, even with ``--force``.
+    """
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+
+    daemons_dir = tmp_path / "daemons"
+    daemons_dir.mkdir()
+    # The file name must match _daemon_record_path's derivation (sha256 of
+    # the target, truncated) or stop's record cleanup would unlink a
+    # different path than the one written here.
+    record_path = daemons_dir / (hashlib.sha256(b"local").hexdigest()[:16] + ".json")
+    record_path.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "target": "local",
+                "mode": "local",
+                "server_url": None,
+                "log_path": None,
+                "started_at": 1781200000,
+                "host_id": "host_foreign_test",
+                "resolved_server_url": None,
+                "config_sig": None,
+            }
+        )
+    )
+
+    def _eperm_kill(pid: int, sig: int) -> None:
+        """Simulate signalling a pid owned by another user (EPERM)."""
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda pid: True)
+    monkeypatch.setattr("omnigent.cli.os.kill", _eperm_kill)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["host", "stop", "--all", "--daemon-only", "--force"])
+
+    # Exit code 0 proves the EPERM was treated as a stale record. A nonzero
+    # exit means the PermissionError propagated out of os.kill and crashed
+    # the CLI before the SIGKILL path --force is supposed to reach.
+    assert result.exit_code == 0, f"host stop crashed on a foreign daemon pid: {result.output}"
+    assert "owned by another user" in result.output
+    assert not record_path.exists(), (
+        "stale foreign daemon record survived stop — a subsequent host start "
+        "would be blocked by an 'already running' conflict"
+    )
+
+
 def test_add_daemon_host_status_skips_http_for_dead_process() -> None:
     """Dead processes must not trigger a network round-trip.
 


### PR DESCRIPTION
## Related issue

## Summary

`omnigent host stop` (reachable for users as `isaac omni stop`) could crash instead of stopping the host when the local daemon registry held a **stale record for a PID it no longer owns**.

`_terminate_daemon` only wrapped `os.kill` in `contextlib.suppress(ProcessLookupError)`. When a `~/.omnigent/daemons/<hash>.json` record points at a PID that has since been reused by **another user's** process (or the daemon was started under a different account), `_pid_alive` reports it as alive — `psutil` maps the permission failure to `AccessDenied`, which `_pid_alive` treats as "alive" — so we fall through to `os.kill`, which raises `PermissionError` (EPERM). That is **not** a `ProcessLookupError`, so it propagates and crashes the CLI. `--force` didn't help: the crash happens before the SIGKILL path.

ELI5: the daemon registry is a notebook saying "my daemon is PID 1234". If the daemon died and the OS gave PID 1234 to someone else's program, the old code tried to kill it anyway, got told "permission denied", and crashed. Now it recognizes "permission denied" means "that's not my daemon", crosses the stale note out, and moves on.

The fix adds `_signal_daemon_pid(record, sig)`, which signals the recorded PID and classifies the result:

- **`PermissionError`** → the PID is not our daemon (stale record). Log a warning and treat the record as stale — drop it instead of killing an unrelated process or crashing.
- **`ProcessLookupError`** → the process already exited; treat the record as stale.
- otherwise → the signal was delivered; termination proceeds as before.

`_terminate_daemon` now uses it at both the SIGTERM and SIGKILL sites, so a stale foreign record is cleaned up cleanly rather than aborting `host stop`.

`_pid_alive` is deliberately left unchanged — treating a foreign PID as "alive" is the correct conservative choice for its other callers (port/daemon reuse detection, where you must not reuse a port owned by someone else). The fix is scoped to the one place that actually *acts* on the PID.

```
host stop --all
  └─ _terminate_daemon(record, force)
       ├─ _pid_alive(pid)?  ── no ──► drop record, done
       │                      yes │ (foreign PID: psutil AccessDenied ⇒ "alive")
       ▼
       _signal_daemon_pid(record, SIGTERM)
       ├─ PermissionError (EPERM)  ──► warn + drop stale record   [was: crash]
       ├─ ProcessLookupError       ──► drop stale record          [unchanged]
       └─ delivered                ──► grace-period wait, SIGKILL if --force
```

## Test Plan

- New regression test `test_host_stop_drops_stale_foreign_daemon_record` in `tests/host/test_cli_host.py`: writes a daemon record, patches `_pid_alive` → alive and `os.kill` → `PermissionError`, runs `host stop --all --daemon-only --force`, asserts exit 0, the warning is printed, and the stale record is deleted.
- Verified the test **fails without the fix** (EPERM propagates, nonzero exit) and passes with it.
- `pytest tests/host/test_cli_host.py` — 26 passed.
- `pytest tests/cli/test_backend.py tests/cli/test_server_lifecycle.py` — 111 passed.
- `pytest tests/cli/test_cli.py` — 294 passed.
- `pre-commit run --files omnigent/cli.py tests/host/test_cli_host.py` — all hooks pass (ruff format, ruff check, pyrefly).

## Demo

N/A — CLI error-handling change; no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test simulates the EPERM by patching `os.kill` to raise `PermissionError` with `_pid_alive` reporting alive — the exact internal state a reused foreign PID produces — and was confirmed to fail on the pre-fix code.

## Changelog

`omnigent host stop` no longer crashes when a stale daemon record points at another user's process — it warns and cleans up the record instead
