### PR TITLE
fix(web): stop rendering single-dollar spans as LaTeX math

### DIFF
--- a/tests/e2e_ui/messages/test_prose_dollar_signs.py
+++ b/tests/e2e_ui/messages/test_prose_dollar_signs.py
@@ -1,0 +1,123 @@
+"""E2E: prose dollar signs render literally instead of turning into math.
+
+Regression guard for the "vertical letter-by-letter math soup" bug. The
+renderer used to accept a single ``$`` as a LaTeX delimiter, so an assistant
+message that mentioned money, rates, or shell variables had any two of its
+dollar signs paired up and everything between them handed to KaTeX — a
+sentence like "about $5/PR versus $2/session" rendered its middle as a stack
+of italic math variables. ``web/src/components/ai-elements/
+streamdown-security.ts`` now requires ``$$`` to open math.
+
+Two deterministic assistant messages (seeded via ``external_assistant_message``
+— no LLM run) cover both halves of the contract:
+
+  - The **prose** paragraph keeps every dollar sign as text and renders **no**
+    KaTeX at all, with the sentence intact.
+  - The **math** message still renders KaTeX, so turning single-dollar math off
+    did not cost us real formulas — one inline span from the ``\\(...\\)`` form
+    that agents actually emit, plus one ``$$``-fenced display block.
+
+Asserting on the absence of ``.katex`` (rather than on the text alone) is what
+ties this to the bug: KaTeX rewrites the characters into positioned spans, so a
+message that "contains the right text" can still be unreadable soup. The prose
+assertion is scoped to its own paragraph because the transcript groups adjacent
+assistant messages into a single bubble.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_AGENT_NAME = "hello_world"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+
+# The reported sentence shape. `$/PR` and `$/session` are the load-bearing
+# tokens: a `$` followed by a slash is neither currency-with-a-digit nor a
+# SCREAMING_CASE variable, so the escaping heuristics this fix replaced never
+# caught them and they paired up into one math span.
+_PROSE_TEXT = (
+    "Cost check: $/PR is down but $/session is up, a 60% saving overall, "
+    "and it still reads $LLM_API_KEY from the environment."
+)
+
+# Real math must survive: an explicit inline TeX span (what agents emit for
+# inline math) and a `$$`-fenced display block.
+_MATH_TEXT = "\n".join(
+    [
+        r"The quadratic roots are \(x = 1\), from:",
+        "",
+        r"$$",
+        r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}",
+        r"$$",
+    ]
+)
+
+_PROSE_MARKER = "Cost check:"
+_MATH_MARKER = "The quadratic roots are"
+
+
+def _seed_message(base_url: str, session_id: str, text: str) -> None:
+    """Append a committed assistant message to the session transcript.
+
+    :param base_url: The live server's base URL.
+    :param session_id: The session to append to.
+    :param text: The assistant message body.
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": text},
+        },
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+@pytest.fixture
+def dollar_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed a session with one prose message and one real-math message.
+
+    :param seeded_session: ``(base_url, session_id)`` for a runner-bound session.
+    :returns: the same ``(base_url, session_id)`` after both replies are seeded.
+    """
+    base_url, session_id = seeded_session
+    _seed_message(base_url, session_id, _PROSE_TEXT)
+    _seed_message(base_url, session_id, _MATH_TEXT)
+    yield (base_url, session_id)
+
+
+def test_prose_dollar_signs_are_not_rendered_as_math(
+    page: Page,
+    dollar_session: tuple[str, str],
+) -> None:
+    """Dollars in prose stay literal text; genuine math still renders."""
+    base_url, session_id = dollar_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    bubble = page.locator(_ASSISTANT, has_text=_MATH_MARKER).first
+    expect(bubble).to_be_visible(timeout=30_000)
+
+    prose = page.locator(f"{_ASSISTANT} p", has_text=_PROSE_MARKER).first
+    expect(prose).to_be_visible(timeout=30_000)
+
+    # The bug: the span between two dollar signs became KaTeX math.
+    assert prose.locator(".katex").count() == 0, "prose dollar signs were rendered as math"
+
+    # And the sentence survives intact, dollar signs and all.
+    expect(prose).to_have_text(_PROSE_TEXT)
+
+    # The counterpart: real math must still render, or the fix went too far.
+    # Exactly one display block, and the inline \(...\) span stays inline
+    # rather than being promoted to a second centered block.
+    expect(bubble.locator(".katex").first).to_be_visible(timeout=30_000)
+    assert bubble.locator(".katex").count() == 2, (
+        "expected one inline TeX span and one display block to render"
+    )
+    assert bubble.locator(".katex-display").count() == 1, (
+        "expected the $$-fenced block to be the only display-mode formula"
+    )

--- a/web/src/components/ai-elements/mathMarkdown.test.ts
+++ b/web/src/components/ai-elements/mathMarkdown.test.ts
@@ -2,49 +2,50 @@ import { describe, expect, it } from "vitest";
 import { normalizeExplicitMathDelimiters } from "./mathMarkdown";
 
 describe("normalizeExplicitMathDelimiters — dollar handling", () => {
-  it("converts TeX delimiters to dollars outside code", () => {
-    expect(normalizeExplicitMathDelimiters("area is \\(a^2\\)")).toBe("area is $a^2$");
+  it("converts TeX delimiters to double dollars outside code", () => {
+    expect(normalizeExplicitMathDelimiters("area is \\(a^2\\)")).toBe("area is $$a^2$$");
     expect(normalizeExplicitMathDelimiters("\\[a+b\\]")).toBe("$$a+b$$");
   });
 
-  it("escapes currency so prose doesn't render as math", () => {
-    expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe("it costs \\$5 or \\$10");
+  it("leaves currency verbatim — a lone dollar is prose, not a delimiter", () => {
+    expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe("it costs $5 or $10");
+    // The reported bug: paired-up rate figures turned the prose between them
+    // into math. `$/PR` is the shape no escaping heuristic caught — a `$`
+    // before a slash. Nothing here may be escaped or rewritten.
+    const rates = "$/PR versus $/session, a 60% saving";
+    expect(normalizeExplicitMathDelimiters(rates)).toBe(rates);
   });
 
-  it("escapes shell-style env-var references so they read as literal text", () => {
-    expect(normalizeExplicitMathDelimiters("Set $LLM_API_KEY")).toBe("Set \\$LLM_API_KEY");
-    expect(
-      normalizeExplicitMathDelimiters(
-        "Unresolved environment variable '$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. " +
-          "Set $LLM_API_KEY or $OMNIGENT_LLM_API_KEY in the environment.",
-      ),
-    ).toBe(
-      "Unresolved environment variable '\\$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. " +
-        "Set \\$LLM_API_KEY or \\$OMNIGENT_LLM_API_KEY in the environment.",
-    );
+  it("leaves shell-style env-var references verbatim", () => {
+    expect(normalizeExplicitMathDelimiters("Set $LLM_API_KEY")).toBe("Set $LLM_API_KEY");
+    const unresolved =
+      "Unresolved environment variable '$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. " +
+      "Set $LLM_API_KEY or $OMNIGENT_LLM_API_KEY in the environment.";
+    expect(normalizeExplicitMathDelimiters(unresolved)).toBe(unresolved);
   });
 
-  it("escapes braced env-var references", () => {
+  it("leaves braced env-var references verbatim", () => {
     expect(normalizeExplicitMathDelimiters("use ${OMNIGENT_LLM_API_KEY} here")).toBe(
-      "use \\${OMNIGENT_LLM_API_KEY} here",
+      "use ${OMNIGENT_LLM_API_KEY} here",
     );
+    expect(normalizeExplicitMathDelimiters("value ${A} here")).toBe("value ${A} here");
   });
 
-  it("escapes a single-char braced reference but not a bare single char", () => {
-    // Braces disambiguate `${A}` as a variable; bare `$A …` stays inline math.
-    expect(normalizeExplicitMathDelimiters("value ${A} here")).toBe("value \\${A} here");
+  it("leaves a single-dollar span verbatim, whatever it contains", () => {
+    // None of these are math delimiters any more, so the text passes through
+    // untouched and renders as the literal characters the agent wrote.
     expect(normalizeExplicitMathDelimiters("the $A + B$ span")).toBe("the $A + B$ span");
-  });
-
-  it("does not match a SCREAMING_CASE prefix of a mixed-case token", () => {
-    // `$FOO` is a prefix of `$FOOBar`; matching it would escape the opener and
-    // strand the closing `$`, breaking the surrounding inline math span.
     expect(normalizeExplicitMathDelimiters("the $FOOBar$ span")).toBe("the $FOOBar$ span");
-  });
-
-  it("leaves genuine inline math intact", () => {
     expect(normalizeExplicitMathDelimiters("the value $x + y$ holds")).toBe(
       "the value $x + y$ holds",
+    );
+  });
+
+  it("still converts delimiters after prose dollars", () => {
+    // A lone `$` must not flip the math-span state, or the conversion below it
+    // would be suppressed for the rest of the message.
+    expect(normalizeExplicitMathDelimiters("costs $5, so \\(x + 1\\)")).toBe(
+      "costs $5, so $$x + 1$$",
     );
   });
 

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,16 +1,3 @@
-// A lone `$` reads as a shell-style variable reference — `$VAR_NAME` or
-// `${VAR_NAME}` — when followed by a SCREAMING_CASE identifier (an env-var
-// convention), so it's treated as literal text rather than a math opener. The
-// braces already disambiguate `${A}`, so a single char is enough there; the
-// bare form requires 2+ chars so a lone `$X …` still reads as inline math.
-// The bare form also demands a full-token boundary (`(?![A-Za-z0-9_])`) so a
-// mixed token like `$FOOBar$` isn't matched by its uppercase prefix — the
-// lookahead rejects any continuing identifier char so greedy backtracking
-// can't settle on `$FOO`; escaping only the opener would strand the closing
-// `$` and break genuine inline math.
-// Anchored at the `$`, which the caller has already matched.
-const SHELL_VAR_RE = /^\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]+(?![A-Za-z0-9_]))/;
-
 // Optional 1–3 space indent + a fence run, per CommonMark. Matching the full
 // run (not just the first three chars) also keeps a ````-fenced block from
 // leaking its fourth backtick into inline-code tracking.
@@ -18,24 +5,19 @@ const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
 
 /**
  * LLMs often emit TeX delimiters (`\(...\)` and `\[...\]`), while remark-math
- * parses dollar delimiters. Convert them to `$`/`$$`, but only where doing so
- * is safe:
+ * parses dollar delimiters. Convert both to `$$`, the only math delimiter the
+ * renderer honours (single-dollar math is off, so prose dollars stay prose —
+ * see `STREAMDOWN_PLUGINS`), but only where doing so is safe:
  *
  * - Not inside fenced or inline code, so code examples stay verbatim.
- * - Not inside an already `$`/`$$`-delimited math span, so a LaTeX line break
+ * - Not inside an already `$$`-delimited math span, so a LaTeX line break
  *   (`\\[1em]`) inside `$$\begin{aligned}…\end{aligned}$$` isn't mistaken for a
  *   display-math opener and turned into `\$$1em]`.
  * - A literal `\\` or `\$` is copied verbatim so its trailing `\[`/`\(` isn't
  *   read as an explicit delimiter and an escaped dollar isn't re-toggled.
  *
- * A single `$` reads as literal prose rather than an inline-math opener when it
- * looks like currency ($5) or a shell-style variable reference ($LLM_API_KEY,
- * ${OMNIGENT_LLM_API_KEY}), so it's escaped and doesn't flip the math span.
- * Otherwise, with single-dollar math enabled, prose like "it costs $5 or $10"
- * or an error such as "Unresolved variable '$LLM_API_KEY' … Set $LLM_API_KEY"
- * renders as a garbled formula. (Genuine inline math that starts with a digit
- * (`$3x$`) or a SCREAMING_CASE identifier (`$N_A$`) is the rare casualty;
- * currency and env-var references in prose are far more common.)
+ * `$$…$$` inside a paragraph stays inline math, so a converted `\(x\)` reads as
+ * inline math and only a `$$` opening its own line renders as a display block.
  */
 export function normalizeExplicitMathDelimiters(text: string): string {
   let result = "";
@@ -47,7 +29,7 @@ export function normalizeExplicitMathDelimiters(text: string): string {
   // when not in inline code. Tracking the run length lets a ``…`` span close
   // only on a matching-length run, so single backticks inside it don't leak.
   let inlineCodeTicks = 0;
-  // Inside a pre-existing `$…$` / `$$…$$` span (toggled on each run of `$`).
+  // Inside a pre-existing `$$…$$` span (toggled on each run of 2+ `$`).
   let inMath = false;
 
   for (let i = 0; i < text.length; i += 1) {
@@ -99,13 +81,10 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     if (char === "$") {
       let run = 1;
       while (text[i + run] === "$") run += 1;
-      const isLiteralDollar =
-        run === 1 && !inMath && (/\d/.test(text[i + 1] ?? "") || SHELL_VAR_RE.test(text.slice(i)));
-      if (isLiteralDollar) {
-        result += "\\$";
-        continue;
-      }
-      inMath = !inMath;
+      // A lone `$` never delimits math, so it stays literal prose and leaves the
+      // span state alone: "$5 … $10" must not swallow the text in between, and a
+      // `\(x\)` after it still converts.
+      if (run > 1) inMath = !inMath;
       result += text.slice(i, i + run);
       i += run - 1;
       continue;
@@ -113,12 +92,7 @@ export function normalizeExplicitMathDelimiters(text: string): string {
 
     if (!inMath) {
       const pair = text.slice(i, i + 2);
-      if (pair === "\\(" || pair === "\\)") {
-        result += "$";
-        i += 1;
-        continue;
-      }
-      if (pair === "\\[" || pair === "\\]") {
+      if (pair === "\\(" || pair === "\\)" || pair === "\\[" || pair === "\\]") {
         result += "$$";
         i += 1;
         continue;

--- a/web/src/components/ai-elements/streamdown-security.ts
+++ b/web/src/components/ai-elements/streamdown-security.ts
@@ -21,7 +21,13 @@ type StreamdownHardenPlugin = StreamdownPluginTuple & {
 export const STREAMDOWN_PLUGINS = {
   cjk,
   code: lazyCodePlugin,
-  math: createMathPlugin({ singleDollarTextMath: true }),
+  // Only `$$…$$` opens math. A single `$` is prose far more often than it is a
+  // math delimiter — currency ($5), rates ($/PR, $/session), shell variables
+  // ($LLM_API_KEY) — and single-dollar math pairs any two of them up, rendering
+  // the whole span between them as letter-by-letter math soup. Explicit TeX
+  // delimiters (`\(…\)`, `\[…\]`), which is what LLMs emit for real math, are
+  // rewritten to `$$…$$` by `normalizeExplicitMathDelimiters`.
+  math: createMathPlugin({ singleDollarTextMath: false }),
   mermaid,
 };
 export const SECURE_STREAMDOWN_REHYPE_PLUGINS = createStreamdownRehypePlugins(false);

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -1158,7 +1158,7 @@ describe("BlockRenderer dispatch", () => {
   describe("math rendering", () => {
     it("normalizes explicit TeX delimiters outside code", () => {
       expect(normalizeExplicitMathDelimiters(String.raw`中文 \(\sqrt{x}\) 文本`)).toBe(
-        String.raw`中文 $\sqrt{x}$ 文本`,
+        String.raw`中文 $$\sqrt{x}$$ 文本`,
       );
       expect(normalizeExplicitMathDelimiters(String.raw`\[\sqrt{x}\]`)).toBe(
         String.raw`$$\sqrt{x}$$`,
@@ -1179,8 +1179,8 @@ describe("BlockRenderer dispatch", () => {
     });
 
     it("does not convert delimiters already inside a dollar-math span", () => {
-      const inline = String.raw`$\[x\]$`;
-      expect(normalizeExplicitMathDelimiters(inline)).toBe(inline);
+      const span = String.raw`$$\[x\]$$`;
+      expect(normalizeExplicitMathDelimiters(span)).toBe(span);
     });
 
     it("skips normalization inside multi-backtick inline code", () => {
@@ -1188,16 +1188,12 @@ describe("BlockRenderer dispatch", () => {
       expect(normalizeExplicitMathDelimiters(doubleTick)).toBe(doubleTick);
     });
 
-    it("escapes currency dollar amounts so prose isn't parsed as inline math", () => {
-      // With single-dollar math enabled, "it costs $5 or $10" would otherwise
-      // parse "5 or " as inline math. Escaping the digit-led `$` renders literal
-      // dollar figures and stops the run from flipping the math toggle.
-      expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe(
-        String.raw`it costs \$5 or \$10`,
-      );
-      // Delimiters after the currency text still normalize — the toggle didn't flip.
+    it("leaves prose dollar amounts verbatim", () => {
+      expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe("it costs $5 or $10");
+      // Delimiters after the currency text still normalize — the lone `$` didn't
+      // flip the math-span toggle.
       expect(normalizeExplicitMathDelimiters(String.raw`$5 then \(x\)`)).toBe(
-        String.raw`\$5 then $x$`,
+        String.raw`$5 then $$x$$`,
       );
     });
 
@@ -1234,6 +1230,30 @@ describe("BlockRenderer dispatch", () => {
         expect(source).toContain('import "streamdown/styles.css"');
       }
       expect(indexCss).toContain('@source "../node_modules/streamdown/dist/*.js"');
+    });
+
+    it("renders prose dollars as literal text, not math", async () => {
+      // `$/PR` and `$/session` are the shape that broke: a `$` before a slash is
+      // neither currency-with-a-digit nor a SCREAMING_CASE variable, so the old
+      // escaping heuristics missed them and single-dollar math paired them up,
+      // rendering the words between as letter-by-letter math soup.
+      const prose = "Costs $/PR versus $/session, a 60% saving on $LLM_API_KEY calls.";
+      const { container } = renderMarkdownText(prose);
+
+      await waitFor(() => expect(container.textContent).toContain("60%"));
+      expect(container.querySelector(".katex")).toBeNull();
+      expect(container.textContent).toContain(prose);
+    });
+
+    it("renders an explicit inline TeX span inline, not as a display block", async () => {
+      // `\(…\)` normalizes to `$$…$$`, which is a display block only when it
+      // opens its own line; mid-paragraph it must stay inline math.
+      const { container } = renderMarkdownText(String.raw`the value \(\sqrt{x + 1}\) holds`);
+
+      await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+      expect(container.querySelector(".katex-display")).toBeNull();
+      expect(container.textContent).toContain("the value");
+      expect(container.textContent).toContain("holds");
     });
 
     it("renders radicals, fractions, and superscripts without dropping the radicand", async () => {


### PR DESCRIPTION
## Related issue

Reported directly rather than via a tracking issue, so there is none to close.

## Summary

A single `$` was treated as a LaTeX delimiter, so any two dollar signs in an
ordinary sentence were paired up and everything between them was handed to
KaTeX. A message like "$/PR is down but $/session is up" rendered its middle as
a run of italic math variables — the "vertical letter-by-letter math soup" in
the screenshots below. The terminal shows the same text fine, so this was
web-only.

- **Only `$$…$$` opens math now** (`streamdown-security.ts`). A lone `$` is
  always literal text, so currency, rates and `$VAR` render as typed.
- **Explicit TeX delimiters now normalize to `$$`** (`mathMarkdown.ts`), so real
  math still renders: `\(x\)` (what agents actually emit for inline math),
  `\[x\]`, and `$$x$$` all work. `$$…$$` mid-paragraph stays *inline*; only a
  `$$` opening its own line becomes a centered block.
- **Deletes the currency/env-var escaping heuristics.** They tried to guess
  prose apart from math by escaping `$5` and `$SCREAMING_CASE`, but could never
  cover the general case — `$/PR` matches neither — and they are dead weight
  once single-dollar math is off.

Trade-off, and the point of the change: an agent that writes genuine inline math
as `$x$` now shows a literal `$x$`. That is the intended behaviour — prose
dollars are vastly more common in this product than bare single-dollar math, and
every other delimiter form still renders.

## Test Plan

- `tests/e2e_ui/messages/test_prose_dollar_signs.py` (new) — seeds a prose
  message and a math message, asserts the prose paragraph renders **zero**
  `.katex` nodes with the sentence intact, and that the math message still
  renders exactly one inline span plus one `.katex-display` block.
- Unit guards in `BlockRenderer.test.tsx` (real render: no `.katex` for prose;
  `\(…\)` renders inline, not as a display block) and `mathMarkdown.test.ts`
  (normalizer leaves prose dollars byte-identical).
- **A/B'd against `main` to prove they are real regression guards**, rebuilding
  the SPA between runs since the e2e harness serves the built bundle: with
  `main`'s renderer the new e2e test fails (`1 != 0` katex nodes in the prose
  paragraph) and 8 unit assertions fail; with the fix all pass.
- Full web suite: **5793 passed**. The 3 failures in `NewChatDialog.test.tsx`
  ("This machine" host selection) are pre-existing on `main` — confirmed by
  stashing this change and re-running.
- `pre-commit run --files …` clean (ruff, prettier, oxlint, tsc).

## Demo

Screenshots of the same seeded transcript, taken from the e2e harness before and
after the fix (attached below).

**Before** — `$/PR is down but $/session` collapses into `/PRisdownbut/`, set in
italic math type, because the two dollar signs were paired into one math span:

> Cost check: */PRisdownbut*/session is up, a 60% saving overall, and it still reads $LLM_API_KEY from the environment.

**After** — the sentence renders exactly as written, dollar signs upright:

> Cost check: $/PR is down but $/session is up, a 60% saving overall, and it still reads $LLM_API_KEY from the environment.

Real math is unaffected in both shots: the inline `\(x = 1\)` still renders as
inline math and the `$$`-fenced quadratic formula still renders as a centered
display block.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Beyond the automated tests, I drove the built SPA in a real browser through the
e2e harness and captured the before/after screenshots above, confirming the
reported sentence renders literally and that inline `\(…\)` math and `$$` display
blocks still render correctly. The A/B described in the Test Plan (revert the two
source files to `main`, rebuild the bundle, re-run) is what proves the new tests
fail without the fix rather than passing vacuously.

## Changelog

Dollar signs in chat messages — prices, rates like `$/PR`, and shell variables — render as plain text instead of being turned into LaTeX math
