### PR TITLE
fix(host): recover expired Databricks auth on startup

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3159,9 +3159,10 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     today. A non-200 answer that carries the Databricks edge signature
     (302 to the workspace OAuth page, or a DatabricksRealm 401) means
     the run would otherwise die much later with an opaque "non-JSON
-    response (status=302)" traceback from the session-create call. On a
-    TTY we run the same flow ``omnigent login`` would and continue;
-    headless invocations get the exact command to run instead.
+    response (status=302)" traceback from the session-create call. First,
+    it asks the SDK for a fresh workspace token; only then does a TTY run
+    the same flow ``omnigent login`` would, while headless invocations get
+    the exact command to run instead.
 
     Non-Databricks postures are deliberately left alone: local accounts
     servers auto-authenticate downstream (magic-link redeem), and
@@ -3181,6 +3182,7 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     import httpx as _httpx
 
     from omnigent.chat import _remote_headers
+    from omnigent.cli_auth import load_databricks_org_id, store_databricks_auth
 
     try:
         probe = _httpx.get(
@@ -3197,6 +3199,13 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     workspace_host = _databricks_workspace_login_target(server, probe)
     if workspace_host is None:
         return
+    org_id = load_databricks_org_id(server)
+    token = _databricks_workspace_token(workspace_host)
+    if token is not None:
+        refreshed_probe = _verify_databricks_server_token(server, token, org_id)
+        if refreshed_probe.status_code == 200:
+            store_databricks_auth(server, workspace_host, org_id=org_id)
+            return
     login_cmd = f"omnigent login {server}"
     if non_interactive or not sys.stdin.isatty():
         raise click.ClickException(
@@ -3204,11 +3213,7 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
             f"HTTP {probe.status_code}). Run `{login_cmd}` and retry."
         )
     click.echo(f"Not signed in to {server} — running `{login_cmd}` first.")
-    # Recover the ``?o=`` selector from a prior login record so a re-login
-    # still targets the right workspace.
-    from omnigent.cli_auth import load_databricks_org_id
-
-    _databricks_login(server, workspace_host, org_id=load_databricks_org_id(server))
+    _databricks_login(server, workspace_host, org_id=org_id)
 
 
 def _ensure_backend(server: str | None) -> str:
@@ -10960,7 +10965,7 @@ def _databricks_workspace_token(workspace_host: str) -> str | None:
     try:
         auth, _host = _resolve_databricks_auth(host=workspace_host)
         return auth.current_token()
-    except (DatabricksAuthError, ValueError):
+    except (DatabricksAuthError, ImportError, ValueError):
         return None
 
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -328,6 +328,9 @@ def _connection_refused(exc: BaseException) -> bool:
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 10.0
 _RECONNECT_JITTER = 0.5
+# Fresh hosts get a short auth-retry window for Databricks OAuth refreshes.
+# Established hosts retry auth failures indefinitely to preserve sessions.
+_MAX_CONSECUTIVE_AUTH_ERRORS = 3
 # Consecutive connection-refused failures against a loopback server before the
 # host exits (~5 minutes at the backoff cap). Refused on loopback means no
 # process listens on the port — the local server is gone, not unreachable.
@@ -834,9 +837,7 @@ class HostProcess:
         self._capabilities_initialized = False
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
-        # Consecutive 401/403 upgrade rejections on an already-connected host;
-        # reset by a successful upgrade. Gates the once-per-episode terminal
-        # notice so a VPN outage doesn't spam stderr on every retry.
+        # Reset by a successful upgrade or non-auth error; bounds fresh-host refresh retries.
         self._auth_retry_streak = 0
         # Consecutive connection-refused connect failures; reset by an accepted
         # upgrade or any non-refused error. Fatal past a bounded streak only
@@ -1235,21 +1236,16 @@ class HostProcess:
         """
         if status in _RETRYABLE_UPGRADE_STATUSES or not (400 <= status < 500):
             return None
-        if status in (401, 403) and self._ever_connected:
-            # A host that already completed an upgrade proved its credentials
-            # and authorization are valid, so a later 401/403 is almost always
-            # a network-path artifact — a dropped VPN whose corporate proxy
-            # answers the upgrade with 401/403 before it reaches the server.
-            # Retry forever (mirrors the login-redirect path) so a live host
-            # with running sessions survives the outage and resumes when the
-            # path recovers, instead of exiting and forcing a manual restart.
+        if status in (401, 403):
+            # Fresh hosts can race OAuth refresh; connected hosts preserve active sessions.
             self._auth_retry_streak += 1
-            cause = (
-                f"Connection refused (HTTP {status}): the host tunnel was "
-                "rejected after it had already connected."
+            cause = f"Connection refused (HTTP {status}): the host tunnel was rejected."
+            should_retry = self._ever_connected or (
+                self._auth_retry_streak < _MAX_CONSECUTIVE_AUTH_ERRORS
             )
-            _logger.warning("%s Retrying — check your VPN/network.", cause)
-            if self._auth_retry_streak == 1:
+            if should_retry:
+                _logger.warning("%s Retrying — check your VPN/network.", cause)
+            if should_retry and self._auth_retry_streak == 1:
                 # The warning above lands only in the CLI log file; print once
                 # per outage so a foreground `omnigent host` isn't silent.
                 print(
@@ -1259,19 +1255,20 @@ class HostProcess:
                     file=sys.stderr,
                     flush=True,
                 )
-            return None
+            if should_retry:
+                return None
         if status == 401:
             return HostConnectError(
-                "Authentication failed (HTTP 401): the server rejected the "
-                "supplied credentials. "
+                "Authentication failed (HTTP 401): the server rejected the supplied "
+                f"credentials across {_MAX_CONSECUTIVE_AUTH_ERRORS} consecutive attempts. "
                 + self._credentials_fix_hint()
                 + " "
                 + self._login_fix_hint()
             )
         if status == 403:
             return HostConnectError(
-                "Connection refused (HTTP 403): the credentials authenticated, "
-                "but the server did not accept the host tunnel. Either your "
+                "Connection refused (HTTP 403): the server repeatedly rejected the host "
+                "tunnel. Either your "
                 "identity is not authorized to register a host on this server, "
                 "or the server is running a build that predates the host API "
                 "(the /v1/hosts tunnel route). Confirm you have access and that "
@@ -2668,6 +2665,11 @@ class HostProcess:
                         # riding out a messy restart isn't killed by
                         # redirects accumulated across unrelated errors.
                         self._login_redirect_streak = 0
+                    if not (
+                        isinstance(exc, InvalidStatus) and exc.response.status_code in (401, 403)
+                    ):
+                        # Keep the refresh window limited to consecutive auth rejections.
+                        self._auth_retry_streak = 0
                     # Refused on loopback is decisive: nothing listens on the
                     # port and no network path can heal it, so bound the
                     # retries. Remote refusals retry forever (outages recover).

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1826,6 +1826,46 @@ def test_ensure_backend_databricks_preflight_skips_when_authenticated(
     assert result == "https://myapp-1234.aws.databricksapps.com"
 
 
+def test_databricks_preflight_silent_sdk_refresh_skips_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh SDK token recovers an expired Databricks Apps session silently."""
+    import httpx
+
+    responses = iter([_databricks_probe_response(302), _databricks_probe_response(200)])
+    requests: list[dict[str, object]] = []
+    stored: list[tuple[str, str, str | None]] = []
+    monkeypatch.setattr(
+        "omnigent.chat._remote_headers",
+        lambda server_url=None, *, host_id=None: {"Authorization": "Bearer expired"},
+    )
+
+    def _get(url: str, **kwargs: object) -> object:
+        requests.append(kwargs)
+        return next(responses)
+
+    monkeypatch.setattr(httpx, "get", _get)
+    monkeypatch.setattr(cli, "_databricks_workspace_token", lambda workspace: "fresh-token")
+    monkeypatch.setattr(cli, "_databricks_login", lambda *args, **kwargs: pytest.fail("login"))
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda server: "123")
+
+    def _store(
+        server: str,
+        workspace: str,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> None:
+        stored.append((server, workspace, org_id))
+
+    monkeypatch.setattr("omnigent.cli_auth.store_databricks_auth", _store)
+
+    cli._ensure_databricks_server_auth(_HOST_DATABRICKS_SERVER, non_interactive=True)
+
+    assert requests[1]["headers"] == {"Authorization": "Bearer fresh-token"}
+    assert requests[1]["params"] == {"o": "123"}
+    assert stored == [(_HOST_DATABRICKS_SERVER, "https://example.databricks.com", "123")]
+
+
 # ── Foreground ``host`` auth pre-flight ─────────────────────────────
 #
 # ``host`` runs the same Databricks sign-in pre-flight ``run`` does before

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3773,43 +3773,41 @@ async def test_connected_host_auth_rejection_prints_notice_once(
     assert err.count(f"HTTP {status}") == 1
 
 
-async def test_fresh_host_still_fails_loud_on_auth_rejection(
+@pytest.mark.parametrize("status", [401, 403])
+async def test_fresh_host_retries_auth_rejection_before_failing_loud(
     monkeypatch: pytest.MonkeyPatch,
+    status: int,
 ) -> None:
-    """A never-connected host still fails loud on 401/403.
+    """A never-connected host retries auth errors before failing loud.
 
-    The connected-host retry keys on a prior successful upgrade. A host
-    that has NEVER connected and is rejected with 401/403 is genuinely
-    unauthenticated / unauthorized — it must still raise HostConnectError
-    on the first attempt (→ exit 1 with the fix printed), not loop.
+    Databricks OAuth can refresh after daemon start but before a later
+    tunnel upgrade. The host gets a few attempts, then still raises a
+    clear credential failure instead of looping forever.
     """
-    spy = _ConnectSpy([_invalid_status(403)])
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    spy = _ConnectSpy([_invalid_status(status)])
     _patch_connect(monkeypatch, spy)
     host = _host()
 
     with pytest.raises(HostConnectError):
         await host.run()
 
-    # Exactly one attempt → no silent retry for the fresh-host case.
-    assert spy.call_count == 1
+    assert spy.call_count == 3
 
 
 @pytest.mark.parametrize(
     "status,expected",
     [
-        (401, "HTTP 401"),
-        (403, "HTTP 403"),
         (404, "permanent"),
     ],
 )
 async def test_run_fails_loud_on_permanent_4xx(
     monkeypatch: pytest.MonkeyPatch, status: int, expected: str
 ) -> None:
-    """A permanent 4xx upgrade rejection fails loud on the first attempt.
+    """A non-auth permanent 4xx upgrade rejection fails loud immediately.
 
-    401/403/other-4xx mean unauthenticated / unauthorized / wrong-or-old
-    server — reconnecting can never succeed, so run() must raise
-    HostConnectError immediately rather than backing off.
+    A wrong or old server cannot recover through reconnecting, so run()
+    must raise HostConnectError rather than backing off.
     """
     spy = _ConnectSpy([_invalid_status(status)])
     _patch_connect(monkeypatch, spy)
@@ -3820,8 +3818,6 @@ async def test_run_fails_loud_on_permanent_4xx(
 
     # Message identifies the specific permanent failure.
     assert expected in str(excinfo.value)
-    # Exactly one attempt → no silent reconnect/backoff. If >1, the 4xx
-    # was misclassified as transient and the loop kept retrying.
     assert spy.call_count == 1
 
 
@@ -3838,6 +3834,7 @@ async def test_auth_rejection_suggests_omnigent_login(
     server URL, so the user can copy-paste it.
     """
     server_url = "https://app.example.databricks.com"
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
     spy = _ConnectSpy([_invalid_status(status)])
     _patch_connect(monkeypatch, spy)
     host = _host(server_url=server_url)


### PR DESCRIPTION
## Related issue

Omnigent session Omni-2888

## Summary

- Retry a fresh host's initial HTTP 401/403 tunnel rejections briefly so Databricks OAuth can refresh before the daemon fails loudly.
- Silently verify and persist a freshly minted SDK token during Databricks auth preflight, falling back to the existing login guidance only when it cannot authenticate.
- Preserve infinite retry behavior after an established host loses connectivity.

## Test Plan

- `uv run --frozen --group dev pytest tests/host/test_connect.py tests/cli/test_backend.py -q`
- `uv run --frozen --group dev ruff check omnigent/host/connect.py omnigent/cli.py tests/host/test_connect.py tests/cli/test_backend.py`

## Demo

N/A — non-visual host and CLI authentication behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover fresh host 401/403 retry bounds, established host retry behavior, and successful silent SDK token refresh without browser login.

## Changelog

Host daemons now recover automatically when a Databricks OAuth token expires during startup.
