### PR TITLE
[OMNI-3751] Change document view mode toggle to dropdown

### DIFF
--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -24,6 +24,7 @@ import {
   AlertTriangleIcon,
   ArrowLeftIcon,
   CheckIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   CloudOffIcon,
@@ -806,6 +807,8 @@ function FileViewerBody({
     key: string;
     /** Accessible name for the inline icon button. */
     label: string;
+    /** Text label for the inline icon button. */
+    textLabel?: string;
     /** Tooltip + dropdown row text; falls back to `label` when omitted. */
     tooltip?: string;
     icon: ReactNode;
@@ -876,6 +879,7 @@ function FileViewerBody({
     toolbarActions.push({
       key: "md-view-mode",
       label: `View mode: ${activeMode.label}`,
+      textLabel: activeMode.label,
       tooltip: "View mode",
       icon: activeMode.icon,
       options: modeOptions,
@@ -1091,11 +1095,13 @@ function FileViewerBody({
                   <Button
                     type="button"
                     variant="ghost"
-                    size="icon-sm"
+                    size={action.textLabel ? "sm" : "icon-sm"}
                     aria-label={action.label}
                     tabIndex={interactive ? undefined : -1}
                   >
                     {action.icon}
+                    {action.textLabel}
+                    <ChevronDownIcon />
                   </Button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
@@ -1107,7 +1113,7 @@ function FileViewerBody({
             {action.options.map((option) => (
               <DropdownMenuItem
                 key={option.key}
-                className={cn("whitespace-nowrap", option.active && "bg-muted dark:bg-muted/50")}
+                className={cn("whitespace-nowrap")}
                 onSelect={interactive ? option.onSelect : undefined}
               >
                 {option.icon}


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-3751/change-document-view-mode-toggle-to-dropdown

<!-- OMNI-3751 is tracked in Jira; no linked GitHub issue. -->

## Summary

- Changes the document view-mode control in the file viewer from an icon-only toggle to a labeled dropdown button: the trigger now shows the active mode's text label alongside its icon and a `ChevronDownIcon` affordance.
- The trigger button grows to `sm` size when a text label is present (staying `icon-sm` for label-less actions), so existing icon-only actions are unaffected.
- Drops the active-row background highlight in the dropdown menu items (`bg-muted` / `dark:bg-muted/50`), leaving just the `whitespace-nowrap` styling.

## Test Plan

- Ran the web app locally and opened the file viewer; confirmed the view-mode control renders as a dropdown button with the active mode label + chevron, opens the menu, and switches modes.
- Verified icon-only actions in the same toolbar are unchanged (still `icon-sm`, no stray label).

## Demo

<img width="335" height="221" alt="Screenshot 2026-08-19 at 10 02 43" src="https://github.com/user-attachments/assets/b10967c4-216f-4aa7-8fa4-f713171ff02a" />

<img width="254" height="210" alt="Screenshot 2026-08-19 at 10 02 54" src="https://github.com/user-attachments/assets/30b4c123-80c1-47a7-aa24-3aed54fd7af7" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually in the running web app: the view-mode control now renders as a labeled dropdown, opens/selects modes correctly, and icon-only toolbar actions are visually unchanged. This is a small presentational change to one component with no logic branch worth a dedicated automated test.

## Changelog

Document view mode is now a labeled dropdown button instead of an icon-only toggle