### PR TITLE
fix(docker): honor configured execution timeout

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -304,6 +304,11 @@ def _build_routing(
     return _build_local_llm_routing_client(server_llm), settings
 
 
+def _resolve_execution_timeout(cfg: dict[str, Any]) -> int:
+    """Return the configured execution limit or the RuntimeCaps default."""
+    return int(cfg.get("execution_timeout") or 7200)
+
+
 def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     """Resolve config if needed, wire the stores, and build the app.
 
@@ -374,6 +379,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     routing_client, routing_settings = _build_routing(cfg, server_llm)
 
     caps = RuntimeCaps(
+        execution_timeout=_resolve_execution_timeout(cfg),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -185,3 +185,16 @@ def test_build_routing_defaults_without_a_routing_block() -> None:
     client, settings = _build_routing({}, None)
     assert client is None
     assert settings == RoutingSettings()
+
+
+@pytest.mark.parametrize(
+    ("cfg", "expected_timeout"),
+    [
+        ({"execution_timeout": 86_400}, 86_400),
+        ({}, 7_200),
+    ],
+)
+def test_resolve_execution_timeout(cfg: dict[str, int], expected_timeout: int) -> None:
+    from deploy.docker.entrypoint import _resolve_execution_timeout
+
+    assert _resolve_execution_timeout(cfg) == expected_timeout


### PR DESCRIPTION
## Related issue

OMNI-2818

## Summary

- Forward `execution_timeout` from Docker/Kubernetes server config into `RuntimeCaps`.
- Add a regression test for configured and default timeout resolution.

## Test Plan

- `uv run --group test pytest tests/deploy/test_docker_entrypoint_import.py`
- `.venv/bin/pre-commit run --all-files`

## Demo

N/A — non-visual Docker startup configuration fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test verifies both a configured `execution_timeout: 86400` and the unchanged 7200-second default.

## Changelog

Docker and Kubernetes deployments honor `execution_timeout` from server configuration.
