### PR TITLE
Remove the permanent Shells tab from the desktop side panel [OMNI-3748]

### DIFF
--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -1,7 +1,7 @@
-"""E2E: right rail Shells tab and file viewer.
+"""E2E: right rail shell soft tab and file viewer.
 
 Execution-logs coverage was dropped: that surface used to be a
-``SessionRail`` card but the rail is now tabbed (Agents/Files/Shells)
+``SessionRail`` card but the rail is now tabbed (Files/Changes/Agents)
 and the only entry point left is the ``md:hidden`` mobile session menu —
 unreachable on the desktop viewport these tests run at.
 """
@@ -56,14 +56,14 @@ def test_right_panel_terminals_and_file_viewer(
     page: Page,
     terminal_session: tuple[str, str],
 ) -> None:
-    """Launch a terminal and exercise the Terminals tab + file viewer.
+    """Launch a terminal and exercise the shell soft tab + file viewer.
 
     The terminal session fixture registers the test agent and creates a
     session bound to it. We send ``spin up zsh``, then verify:
 
-    - the right rail's Terminals tab lists the launched terminal, its
-      xterm connects inline, and the maximize button opens the full
-      terminals push panel;
+    - the agent-launched shell appears as a closable soft tab in the rail,
+      its xterm connects inline when the tab is opened, and closing the tab
+      (after the confirm) kills the terminal;
     - the Files tab can open a workspace file and the file viewer renders
       its contents.
 
@@ -96,7 +96,7 @@ def test_right_panel_terminals_and_file_viewer(
     try:
         page.goto(f"{base_url}/c/{session_id}")
         # The rail defaults open but is remembered per session; ensure it is
-        # open so the Shells tab and Files panel below are reachable.
+        # open so the shell tab and Files panel below are reachable.
         open_right_rail(page)
 
         composer = page.get_by_placeholder("Ask the agent anything…")
@@ -104,34 +104,32 @@ def test_right_panel_terminals_and_file_viewer(
         composer.fill("spin up zsh")
         page.get_by_role("button", name="Send", exact=True).click()
 
-        # Open the Shells tab (present by default — the agent declares
-        # terminals). The launched shell's row shows once the agent's
-        # sys_terminal_launch completes (LLM turn → up to 60s); keep
-        # main's generous click timeout for slow CI turns.
-        rail.get_by_role("tab", name=re.compile("Shells")).click(timeout=60_000)
-        terminal_row = rail.get_by_role("button").filter(has_text="zsh").filter(has_text="main")
-        expect(terminal_row.first).to_be_visible(timeout=60_000)
+        # The agent's sys_terminal_launch creates a shell that appears directly
+        # as a closable soft tab in the rail's strip (shells are 1:1 with the
+        # session's terminals — there is no separate Shells tab or list). The
+        # launch rides an LLM turn, so allow main's generous 60s. The tab's
+        # accessible name starts with its label "zsh · main"; the "Close …" x is
+        # a separate button, so anchor the regex to disambiguate.
+        shell_tab = rail.get_by_role("button", name=re.compile(r"^zsh · main"))
+        expect(shell_tab).to_be_visible(timeout=60_000)
 
-        # Clicking a shell row opens it as a tab in the rail's top strip;
-        # its xterm renders inside the rail's content slot and the chat
-        # page is left undisturbed (no main-column takeover). The shell tab
-        # is labeled "zsh · main" and carries a "Close zsh · main" x.
-        terminal_row.first.click()
-        close_tab = rail.get_by_role("button", name="Close zsh · main", exact=True)
-        expect(close_tab).to_be_visible(timeout=20_000)
-        # The shell's xterm mounts in the rail and connects; the chat main
-        # column is not replaced. Assert no VISIBLE main terminal surface:
-        # terminal-first sessions keep a hidden pre-warmed surface mounted
-        # (data-visible="false"), which is not a takeover.
+        # Agent-spawned shells don't steal focus, so click the tab to open it;
+        # its xterm renders inside the rail's content slot and the chat page is
+        # left undisturbed (no main-column takeover). Assert no VISIBLE main
+        # terminal surface: terminal-first sessions keep a hidden pre-warmed
+        # surface mounted (data-visible="false"), which is not a takeover.
+        shell_tab.click()
         terminal_view = rail.get_by_test_id("terminal-view")
         expect(terminal_view.last).to_be_visible(timeout=20_000)
         expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
         expect(
             page.locator('[data-testid="main-terminal-view"][data-visible="true"]')
         ).to_have_count(0)
-        # The tab's x closes the shell — its xterm unmounts and the rail
-        # falls back to the Shells list for the Files steps below.
-        close_tab.click()
+        # Closing the tab kills the terminal, so its "x" confirms first; after
+        # confirming the xterm unmounts and the rail returns to its default
+        # (files) view for the Files steps below.
+        rail.get_by_role("button", name="Close zsh · main", exact=True).click()
+        page.get_by_role("button", name="Close shell").click()
         expect(terminal_view).to_have_count(0)
 
         # Switch to the Files tab and open the seeded file. The

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -13,7 +13,7 @@ Three behaviors are covered:
 1. **"+" → Shell launches and opens a shell.** Picking Shell creates a
    ``zsh`` shell that opens as a rail tab (``zsh · u-…``): its xterm
    connects in the rail's content slot, the chat page is left undisturbed,
-   and the tab's "x" closes it back to the Shells list.
+   and the tab's "x" closes it (after a confirm) and kills the terminal.
 
 2. **The user can type a command into the shell.** We type ``pwd`` into
    the connected shell and assert it keeps running — the keystrokes are
@@ -70,7 +70,7 @@ def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, s
     as a tab in the workspace rail's top strip (labeled ``zsh · u-…``) and
     its xterm renders inside the rail's content slot — the chat page is
     left undisturbed (no ``main-terminal-view`` takeover). The tab's "x"
-    closes it and drops back to the Shells list.
+    closes it (after confirming) and its xterm unmounts.
     """
     base_url, session_id = terminal_session
 
@@ -96,9 +96,11 @@ def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, s
     )
     expect(page.get_by_placeholder("Ask the agent anything…")).to_be_visible()
 
-    # The tab's x closes the shell — its xterm unmounts and the rail falls
-    # back to the Shells list.
+    # The tab's x asks to confirm first (closing a tab kills the terminal);
+    # confirming unmounts the shell's xterm and the rail returns to its
+    # default view.
     close_tab.click()
+    page.get_by_role("button", name="Close shell").click()
     expect(terminal_view).to_have_count(0)
 
 

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -12,6 +12,7 @@ import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTerminal,
+  deleteTerminal,
   fetchTerminals,
   inventoryTerminals,
   isAgentTerminalKey,
@@ -417,6 +418,36 @@ describe("createTerminal", () => {
       ),
     );
     await expect(createTerminal("conv_abc", "zsh")).rejects.toThrow(/not declared/);
+  });
+});
+
+describe("deleteTerminal", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("DELETEs the terminal resource by id", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(null, { ok: true, status: 204 }));
+
+    await deleteTerminal("conv_abc", "terminal_bash_s1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("treats a 404 (already gone) as success", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(null, { ok: false, status: 404 }));
+    await expect(deleteTerminal("conv_abc", "terminal_gone")).resolves.toBeUndefined();
+  });
+
+  it("throws on a non-404 failure", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(null, { ok: false, status: 500 }));
+    await expect(deleteTerminal("conv_abc", "terminal_bash_s1")).rejects.toThrow(/delete failed/);
   });
 });
 

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -73,8 +73,8 @@ export function isAgentTerminalKey(terminalKey: string): boolean {
 
 /**
  * Project the terminal list down to the session's *inventory* — the
- * shells shown in the right-rail Shells tab, its count badge, and the
- * mobile menu entry.
+ * shells shown as the rail's soft tabs and in the mobile Shells menu
+ * entry / drawer.
  *
  * For terminal-first sessions (SDK and native alike) the agent's own
  * terminal is excluded: it is reachable through the pill's Terminal
@@ -269,6 +269,57 @@ export function useCreateTerminal(conversationId: string) {
       const current = queryClient.getQueryData<TerminalInfo[]>(key) ?? [];
       if (current.some((t) => t.id === info.id)) return;
       queryClient.setQueryData<TerminalInfo[]>(key, [...current, info]);
+    },
+  });
+}
+
+/**
+ * Delete (kill) a terminal for a conversation over HTTP.
+ *
+ * Issues DELETE on the terminal resource route, which the server proxies to
+ * the runner to terminate the PTY and drop the resource. The removal is also
+ * broadcast as a ``session.resource.deleted`` SSE delta that prunes the
+ * terminal from the query cache — so the tab closes even for callers that
+ * don't touch the cache themselves.
+ *
+ * :param conversationId: Session/conversation identifier.
+ * :param terminalId: Opaque terminal resource id (NOT the ``terminal:`` tab
+ *     key), e.g. ``"terminal_bash_s1"``.
+ * :raises Error: When the server rejects the delete (a 404 is treated as
+ *     success — the goal state, "no such terminal", already holds).
+ */
+export async function deleteTerminal(conversationId: string, terminalId: string): Promise<void> {
+  const res = await authenticatedFetch(
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/terminals/${encodeURIComponent(terminalId)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`terminal delete failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+/**
+ * Mutation hook around :func:`deleteTerminal`.
+ *
+ * On success the terminal is removed from the query cache immediately (by
+ * id), so its soft tab closes without waiting for the
+ * ``session.resource.deleted`` SSE round-trip (which still arrives and
+ * dedupes as a no-op).
+ *
+ * :param conversationId: Session/conversation identifier.
+ * :returns: TanStack mutation taking the terminal resource id.
+ */
+export function useDeleteTerminal(conversationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (terminalId: string) => deleteTerminal(conversationId, terminalId),
+    onSuccess: (_result, terminalId) => {
+      const key = terminalsQueryKey(conversationId);
+      const current = queryClient.getQueryData<TerminalInfo[]>(key) ?? [];
+      queryClient.setQueryData<TerminalInfo[]>(
+        key,
+        current.filter((t) => t.id !== terminalId),
+      );
     },
   });
 }

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "../lib/identity";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
+import { showToast } from "@/components/ui/toast";
 
 export { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 
@@ -320,6 +321,12 @@ export function useDeleteTerminal(conversationId: string) {
         key,
         current.filter((t) => t.id !== terminalId),
       );
+    },
+    // The kill round-trips to the runner and can fail (offline runner, 403 for
+    // a non-editor, 500). Surface it — otherwise the tab silently reappears
+    // once ``isPending`` clears and the user has no idea the shell survived.
+    onError: () => {
+      showToast("Couldn't close the shell — it's still running.", { duration: 0 });
     },
   });
 }

--- a/web/src/lib/permissionsApi.ts
+++ b/web/src/lib/permissionsApi.ts
@@ -32,6 +32,22 @@ export function isOwnerLevel(level: number | null): boolean {
 }
 
 /**
+ * Numeric permission level required to mutate the session's shared
+ * workspace. Mirrors ``LEVEL_EDIT`` in ``omnigent/server/auth.py``.
+ */
+export const LEVEL_EDIT = 2;
+
+/**
+ * Return whether a permission level grants edit access — mutating the
+ * session's shared workspace, e.g. opening or closing a shell tab (both
+ * server-gated on ``LEVEL_EDIT``). ``null`` is treated permissively
+ * (single-user / still loading), matching ``isOwnerLevel`` / ``useCanEdit``.
+ */
+export function isEditorLevel(level: number | null): boolean {
+  return level == null || level >= LEVEL_EDIT;
+}
+
+/**
  * Derive the effective permission level for the active conversation.
  *
  * Resolution order:

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -8,20 +8,14 @@
 
 import type { RightRailTab } from "@/shell/railTabs";
 
-const RAIL_TABS: readonly RightRailTab[] = [
-  "files",
-  "changes",
-  "subagents",
-  "terminals",
-  "browser",
-];
+const RAIL_TABS: readonly RightRailTab[] = ["files", "changes", "subagents", "browser"];
 
 export interface SessionWorkspaceState {
   /** Whether the rail was left open in this session. */
   open?: boolean;
   /** User-chosen rail width (px) for this session. */
   widthPx?: number;
-  /** The selected rail tab (Files / Changes / Agents / Shells). */
+  /** The selected rail tab (Files / Changes / Agents). */
   rightRailTab?: RightRailTab;
   /** Ordered list of open file tabs. */
   openFiles?: string[];

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -32,9 +32,10 @@ vi.mock("@/hooks/useConversations", async (importOriginal) => ({
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals, EMBEDDED_REPL_TERMINAL_ID)
   // — the REPL rail-inventory tests exercise the real filter; only the
-  // network-backed hook is replaced.
+  // network-backed hooks are replaced.
   ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(() => ({ terminals: [], isLoading: false, error: null })),
+  useDeleteTerminal: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
 }));
 
 vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
@@ -200,10 +201,13 @@ vi.mock("./TerminalsPanel", () => ({
 }));
 
 import { useConversations } from "@/hooks/useConversations";
-import { useTerminals } from "@/hooks/useTerminals";
+import { useTerminals, useDeleteTerminal } from "@/hooks/useTerminals";
 
 const useConvMock = vi.mocked(useConversations);
 const useTerminalsMock = vi.mocked(useTerminals);
+const useDeleteTerminalMock = vi.mocked(useDeleteTerminal);
+// Fresh per test (set in beforeEach) so a rewritten close asserts the kill call.
+let deleteTerminalMutate: ReturnType<typeof vi.fn>;
 
 import {
   useWorkspaceEnvironment,
@@ -486,6 +490,13 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   });
+  deleteTerminalMutate = vi.fn();
+  useDeleteTerminalMock.mockReset();
+  useDeleteTerminalMock.mockReturnValue({
+    mutate: deleteTerminalMutate,
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useDeleteTerminal>);
   useChildSessionsMock.mockReset();
   useChildSessionsMock.mockReturnValue({
     children: [],
@@ -984,110 +995,6 @@ describe("Right-rail terminals card", () => {
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-view", "chat");
   });
 
-  it("renders the Terminals tab in a regular session once a terminal is attached, and the inline section after selecting it", () => {
-    // With the tabbed rail, the inline section only mounts once the user
-    // switches from Files (default) to Terminals. The tab button is present
-    // in a non-terminal-first session as long as a terminal is attached.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-
-    renderShell("/c/conv_abc");
-
-    // Default tab is Files — inline section is unmounted.
-    expect(screen.queryByTestId("inline-terminals-section")).toBeNull();
-    // Tab button is present (regex tolerates the inline count badge "1").
-    const terminalsTab = screen.getByRole("tab", { name: /Shells/i });
-    expect(terminalsTab).toBeInTheDocument();
-
-    // Radix Tabs activates on mousedown, not click.
-    fireEvent.mouseDown(terminalsTab);
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
-  });
-
-  it("hides the Terminals tab in a regular session with no terminal attached", () => {
-    // Terminals are agent-created (the rail has no "new terminal" affordance),
-    // so an empty Terminals tab is a dead end ("No terminals running."). It
-    // must stay hidden until a terminal attaches — matching the mobile
-    // session-menu's rule. This also avoids the snapshot-load flash:
-    // ``hideTerminalsTab`` is label-derived and starts false, so without the
-    // attach gate the tab would briefly appear then vanish once the snapshot
-    // reveals a terminal-first / claude-native-subagent session.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // Default beforeEach mock already returns no terminals; assert explicitly
-    // for clarity that this is the no-terminal case.
-    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
-
-    renderShell("/c/conv_abc");
-
-    expect(screen.queryByRole("tab", { name: /Shells/i })).toBeNull();
-    // The rail still works — Files is the default and remains selected.
-    expect(screen.getByRole("tab", { name: /Files/i })).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("reveals the Terminals tab when a terminal attaches after mount", () => {
-    // The tab is additive: it pops in (no flash-out) the moment a terminal
-    // lands over SSE, which the seed/snapshot streams into the cache.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
-
-    // Stable QueryClient + fresh element per render so the rerender reads the
-    // updated mock (React bails on an identical element reference).
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const makeTree = () => (
-      <QueryClientProvider client={qc}>
-        <TooltipProvider>
-          <MemoryRouter initialEntries={["/c/conv_abc"]}>
-            <Routes>
-              <Route element={<AppShell />}>
-                <Route
-                  path="c/:conversationId"
-                  element={
-                    <>
-                      <TerminalFirstViewProbe />
-                      <LocationDisplay />
-                    </>
-                  }
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        </TooltipProvider>
-      </QueryClientProvider>
-    );
-    const { rerender } = render(makeTree());
-
-    // No terminal yet → tab hidden.
-    expect(screen.queryByRole("tab", { name: /Shells/i })).toBeNull();
-
-    // A terminal lands.
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-    rerender(makeTree());
-
-    // Tab now present (additive — the user wasn't yanked off any tab).
-    expect(screen.getByRole("tab", { name: /Shells/i })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /Files/i })).toHaveAttribute("aria-selected", "true");
-  });
-
   it("opening a file in a terminal-first session keeps the view in Terminal", () => {
     // Regression: openFileViewer used to call setPanelInitialKey(null)
     // unconditionally to "close the terminal panel" — but in terminal-
@@ -1129,9 +1036,16 @@ describe("Right-rail terminals card", () => {
 });
 
 describe("Chat-mode terminal panel layout", () => {
-  it("opens the shell as a rail tab (not the full-width push panel) and keeps chat visible", () => {
-    // Desktop rail click → the shell opens as a tab inside the workspace rail;
-    // the full-width push panel stays closed and chat is not hidden.
+  it("hosts an open shell as a rail tab (not the full-width push panel) and keeps chat visible", () => {
+    // A shell opens as a tab inside the workspace rail — its xterm surfaces in
+    // the rail's content slot, the full-width push panel stays closed, and chat
+    // is not hidden. Seed a restored (open + selected) shell tab so it's live on
+    // load (creation itself is covered in WorkspacePanel's "+" menu tests).
+    writeSessionWorkspaceState("conv_abc", {
+      open: true,
+      openTerminals: ["terminal:terminal_main"],
+      selectedTerminalKey: "terminal:terminal_main",
+    });
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -1145,29 +1059,23 @@ describe("Chat-mode terminal panel layout", () => {
 
     renderShell("/c/conv_abc");
 
-    // Baseline: closed push panel, chat visible. The md:hidden gate lives on
-    // the chat+workspace group (main's parent), not main itself.
+    // The shell tab's xterm is mounted in the rail...
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
+    // ...while the push panel stays closed and chat stays visible. The
+    // md:hidden gate lives on the chat+workspace group (main's parent).
     const chatGroup = () => screen.getByRole("main").parentElement as HTMLElement;
     expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "closed");
     expect(chatGroup().className.split(" ")).not.toContain("md:hidden");
-
-    // Switch the rail to the Shells tab so the inline section mounts, then open
-    // a shell. Radix Tabs activates on mousedown, not click.
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
-    fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
-
-    // After click: the push panel stays closed and chat stays visible — the
-    // shell now lives in a rail tab (its xterm surfaces in the rail's content
-    // slot), so the main column is undisturbed.
-    expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "closed");
-    expect(chatGroup().className.split(" ")).not.toContain("md:hidden");
-    // The shell tab's xterm is mounted in the rail.
-    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
   });
 
-  it("closes a shell tab from the rail — xterm unmounts and the Shells list returns", () => {
-    // Open a shell tab, then close it via the tab's "x". The rail falls back to
-    // the Shells list (no tab selected) and the xterm is gone.
+  it("confirms before closing a shell tab, then kills the terminal", () => {
+    // Closing a tab kills the underlying terminal (destructive), so the "x"
+    // opens a confirm modal first; confirming issues the delete (which the SSE
+    // `resource.deleted` + cache prune turn into the tab disappearing).
+    writeSessionWorkspaceState("conv_abc", {
+      open: true,
+      selectedTerminalKey: "terminal:terminal_main",
+    });
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null },
       isLoading: false,
@@ -1181,17 +1089,101 @@ describe("Chat-mode terminal panel layout", () => {
 
     renderShell("/c/conv_abc");
 
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
-    fireEvent.click(screen.getByRole("button", { name: /rail: open terminal/i }));
-    // The shell tab and its xterm are present.
+    // The shell tab (from the list) and its xterm are present.
     expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
 
-    // Close the tab via its "x" (labeled by the resolved name · session).
+    // Clicking the tab's "x" does NOT kill immediately — it asks first.
     fireEvent.click(screen.getByRole("button", { name: "Close main · u-1" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Close shell?");
+    expect(deleteTerminalMutate).not.toHaveBeenCalled();
 
-    // The xterm unmounts; with no tab selected the Shells list is shown again.
+    // Confirming kills the terminal by its resource id.
+    fireEvent.click(screen.getByRole("button", { name: "Close shell" }));
+    expect(deleteTerminalMutate).toHaveBeenCalledWith("terminal_main");
+  });
+
+  it("does not kill the terminal when the close confirmation is cancelled", () => {
+    writeSessionWorkspaceState("conv_abc", {
+      open: true,
+      selectedTerminalKey: "terminal:terminal_main",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "main", session: "u-1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_abc");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close main · u-1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // No delete, and the shell's xterm is still mounted.
+    expect(deleteTerminalMutate).not.toHaveBeenCalled();
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
+  });
+
+  it("selects a shell tab as active when the user clicks it", () => {
+    // Opening a shell tab (clicking it) makes it the active tab — its xterm
+    // surfaces in the rail's content slot. Two shells, none selected on load.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_click", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [
+        { id: "terminal_a", name: "a", session: "s1", running: true },
+        { id: "terminal_b", name: "b", session: "s2", running: true },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_click");
+
+    // No shell selected yet → its xterm isn't mounted.
     expect(screen.queryByTestId("terminal-view-stub")).toBeNull();
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
+    // Click the second tab's body (title = "name · session") → it activates.
+    fireEvent.click(screen.getByTitle("b · s2"));
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_b");
+  });
+
+  it("greys out and freezes a shell tab while its close (kill) is in flight", () => {
+    // Between confirming a close and the tab disappearing there's a DELETE
+    // round-trip; the tab being killed is dimmed + non-interactive so the wait
+    // reads as "closing". Driven off the delete mutation's pending state.
+    useDeleteTerminalMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      variables: "terminal_main",
+      isError: false,
+    } as unknown as ReturnType<typeof useDeleteTerminal>);
+    writeSessionWorkspaceState("conv_abc", {
+      open: true,
+      selectedTerminalKey: "terminal:terminal_main",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "main", session: "u-1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_abc");
+
+    const tab = screen.getByTitle("main · u-1");
+    expect(tab).toHaveAttribute("aria-busy", "true");
+    expect(tab).toHaveClass("opacity-50", "pointer-events-none");
   });
 });
 
@@ -1585,192 +1577,6 @@ describe("Subagents tab", () => {
     expect(badge.className).not.toContain("text-success");
   });
 
-  it("keeps the terminal count badge neutral when a terminal spawns off-tab", () => {
-    // The tab badge is a quantity indicator, not an error or alert. A new
-    // terminal should update the count without switching to destructive red.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // Baseline: one pre-existing terminal at mount.
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-
-    // Build the tree with a stable QueryClient and a fresh element per call:
-    // React bails on a rerender given the identical element reference, so the
-    // new mock would not be read.
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const makeTree = () => (
-      <QueryClientProvider client={qc}>
-        <TooltipProvider>
-          <MemoryRouter initialEntries={["/c/conv_abc"]}>
-            <Routes>
-              <Route element={<AppShell />}>
-                <Route
-                  path="c/:conversationId"
-                  element={
-                    <>
-                      <TerminalFirstViewProbe />
-                      <LocationDisplay />
-                    </>
-                  }
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        </TooltipProvider>
-      </QueryClientProvider>
-    );
-    const { rerender } = render(makeTree());
-
-    let badge = within(screen.getByRole("tab", { name: /Shells/i })).getByText("1");
-    expect(badge.className).toContain("text-muted-foreground");
-    expect(badge.className).not.toContain("bg-destructive");
-
-    // A second terminal spawns while the user is on the (default) Files tab.
-    useTerminalsMock.mockReturnValue({
-      terminals: [
-        { id: "terminal_main", name: "main", session: "main", running: true },
-        { id: "terminal_2", name: "bash", session: "main", running: true },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    rerender(makeTree());
-
-    badge = within(screen.getByRole("tab", { name: /Shells/i })).getByText("2");
-    expect(badge.className).toContain("text-muted-foreground");
-    expect(badge.className).not.toContain("bg-destructive");
-    expect(badge.className).not.toContain("text-white");
-
-    // Opening the Terminals tab keeps the count in the same neutral style.
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
-    badge = within(screen.getByRole("tab", { name: /Shells/i })).getByText("2");
-    expect(badge.className).toContain("text-muted-foreground");
-    expect(badge.className).not.toContain("bg-destructive");
-  });
-
-  it("keeps the terminal count badge neutral when terminals stream in on connect", () => {
-    // useTerminals is SSE-driven: on connect it seeds [] then snapshot-on-
-    // connect replays a create for every running terminal. The replay should
-    // update the count without making a normal refresh look like an error.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    // Cold cache on connect: empty seed, no terminals yet.
-    useTerminalsMock.mockReturnValue({
-      terminals: [],
-      isLoading: false,
-      error: null,
-    });
-
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const makeTree = () => (
-      <QueryClientProvider client={qc}>
-        <TooltipProvider>
-          <MemoryRouter initialEntries={["/c/conv_abc"]}>
-            <Routes>
-              <Route element={<AppShell />}>
-                <Route
-                  path="c/:conversationId"
-                  element={
-                    <>
-                      <TerminalFirstViewProbe />
-                      <LocationDisplay />
-                    </>
-                  }
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        </TooltipProvider>
-      </QueryClientProvider>
-    );
-    const { rerender } = render(makeTree());
-
-    // Snapshot-on-connect streams two terminals into the cache.
-    useTerminalsMock.mockReturnValue({
-      terminals: [
-        { id: "terminal_main", name: "main", session: "main", running: true },
-        { id: "terminal_2", name: "bash", session: "main", running: true },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    rerender(makeTree());
-
-    const badge = within(screen.getByRole("tab", { name: /Shells/i })).getByText("2");
-    expect(badge.className).toContain("text-muted-foreground");
-    expect(badge.className).not.toContain("bg-destructive");
-    expect(badge.className).not.toContain("text-white");
-  });
-
-  it("keeps the terminal count badge neutral while already viewing Terminals", () => {
-    // The count badge should stay muted regardless of whether the user is
-    // already on the Terminals tab.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const makeTree = () => (
-      <QueryClientProvider client={qc}>
-        <TooltipProvider>
-          <MemoryRouter initialEntries={["/c/conv_abc"]}>
-            <Routes>
-              <Route element={<AppShell />}>
-                <Route
-                  path="c/:conversationId"
-                  element={
-                    <>
-                      <TerminalFirstViewProbe />
-                      <LocationDisplay />
-                    </>
-                  }
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        </TooltipProvider>
-      </QueryClientProvider>
-    );
-    const { rerender } = render(makeTree());
-
-    // Switch to the Terminals tab first. Confirm it actually activated (the
-    // inline section only mounts when the tab is selected) — otherwise the
-    // "no alert" assertion below could pass for the wrong reason.
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
-
-    // Now a terminal spawns while it's the active tab.
-    useTerminalsMock.mockReturnValue({
-      terminals: [
-        { id: "terminal_main", name: "main", session: "main", running: true },
-        { id: "terminal_2", name: "bash", session: "main", running: true },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    rerender(makeTree());
-
-    const badge = within(screen.getByRole("tab", { name: /Shells/i })).getByText("2");
-    expect(badge.className).toContain("text-muted-foreground");
-    expect(badge.className).not.toContain("bg-destructive");
-  });
-
   it("keeps the idle Agents count badge neutral when a sub-agent spawns off-tab", () => {
     // Idle Agents badge counts are quantity indicators, not warning badges.
     // A new child should update the count without switching to destructive red.
@@ -1970,14 +1776,6 @@ describe("Subagents tab", () => {
       isLoading: false,
       error: null,
     });
-    // A terminal is attached so the Terminals tab is present — this test
-    // asserts the three workspace tabs coexist inside a child, not the
-    // Terminals-attach gate itself (covered separately below).
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
     useSessionMock.mockReturnValue({
       session: {
         id: "conv_child",
@@ -2003,7 +1801,6 @@ describe("Subagents tab", () => {
 
     expect(screen.getByRole("tab", { name: /Agents/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Files/i })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /Shells/i })).toBeInTheDocument();
   });
 
   it("keeps the back-to-parent header link when the parent title is unresolved", () => {
@@ -2156,30 +1953,6 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
   });
 
-  it("keeps the card and collapse toggle when terminals are the only rail content", () => {
-    // Same no-filesystem agent, but with an attached terminal: the rail
-    // has a Terminals tab, so the card mounts and the collapse toggle
-    // must render. Failure here means the toggle is still gated on
-    // showFilesPanel alone — the pre-fix bug left a visible card with
-    // no way to collapse it.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: false, root: null, home: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
-
-    renderShell("/c/conv_abc");
-
-    expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /Shells/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
-  });
-
   it("starts open for a fresh session (no stored open-state)", () => {
     // A brand-new session has no persisted open-state, so the Appearance
     // Workspace panel default applies. With no preference stored that
@@ -2292,15 +2065,13 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByTestId("file-viewer-inline")).toHaveAttribute("data-path", "b.ts");
   });
 
-  it("restores the open shell tabs per session (switch away and back keeps them)", () => {
-    // Regression: shell tabs used to live only in transient component state and
-    // were cleared on every conversation switch, so navigating away and back
-    // lost them. They now persist per session like file tabs. Seed a session
-    // with one open + selected shell tab whose terminal is live, and assert the
-    // tab strip restores it and mounts its xterm.
+  it("restores the focused shell per session (switch away and back keeps its xterm)", () => {
+    // Tabs derive 1:1 from the live terminal list, so the strip itself needs no
+    // restoring — but which shell was FOCUSED persists per session. Seed a
+    // selected shell whose terminal is live and assert its tab renders and its
+    // xterm is the one mounted on return.
     writeSessionWorkspaceState("conv_shellmem", {
       open: true,
-      openTerminals: ["terminal:terminal_bash_s1"],
       selectedTerminalKey: "terminal:terminal_bash_s1",
     });
     useEnvironmentMock.mockReturnValue({
@@ -2322,30 +2093,50 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
   });
 
-  it("keeps restored shell tabs while the terminal list is still loading, then prunes dead ones", () => {
-    // The prune effect drops tabs whose terminal is gone — but the incoming
-    // session's list is momentarily empty *while loading*, indistinguishable
-    // from "all closed". Pruning then would wipe the just-restored tabs. The
-    // effect is gated on isLoading: it must skip the load window, then prune
-    // once the real (still-empty) list confirms the terminal is truly gone.
-    writeSessionWorkspaceState("conv_shellload", {
+  it("maps the shell list 1:1 to tabs — an agent-spawned shell appears without the user opening it", () => {
+    // Tabs derive from the live terminal list, so a shell the AGENT spawns (it
+    // lands in the list via SSE) shows as its own tab with no user action and no
+    // persisted state seeding it.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_bash_agent", name: "bash", session: "s9", running: true }],
+      isLoading: false,
+      error: null,
+    });
+    mockConversations([{ id: "conv_1to1", permission_level: null }]);
+
+    renderShell("/c/conv_1to1");
+
+    expect(screen.getByTitle("bash · s9")).toBeInTheDocument();
+  });
+
+  it("drops a shell's tab when its terminal leaves the list (killed / closed)", () => {
+    // The inverse of 1:1: when a terminal disappears from the list (killed via a
+    // tab close, closed by the agent, or the runner emptied it), its tab — and
+    // its xterm if it was active — go with it.
+    writeSessionWorkspaceState("conv_gone", {
       open: true,
-      openTerminals: ["terminal:terminal_bash_s1"],
       selectedTerminalKey: "terminal:terminal_bash_s1",
     });
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null, home: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    // Loading: list empty but not yet resolved.
-    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: true, error: null });
-    mockConversations([{ id: "conv_shellload", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_bash_s1", name: "bash", session: "s1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+    mockConversations([{ id: "conv_gone", permission_level: null }]);
 
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const makeTree = () => (
       <QueryClientProvider client={qc}>
         <TooltipProvider>
-          <MemoryRouter initialEntries={["/c/conv_shellload"]}>
+          <MemoryRouter initialEntries={["/c/conv_gone"]}>
             <Routes>
               <Route element={<AppShell />}>
                 <Route
@@ -2365,45 +2156,68 @@ describe("Right workspace card visibility", () => {
     );
     const { rerender } = render(makeTree());
 
-    // While loading the restored tab survives the transient empty list.
-    expect(screen.getByTitle("terminal_bash_s1")).toBeInTheDocument();
+    // Present: the shell's tab and (since it was the selected key) its xterm.
+    expect(screen.getByTitle("bash · s1")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
 
-    // The list resolves to genuinely empty (the terminal is really gone) —
-    // now the prune runs and drops the dead tab.
+    // The terminal leaves the list → tab and xterm disappear.
     useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
     rerender(makeTree());
 
-    expect(screen.queryByTitle("terminal_bash_s1")).toBeNull();
+    expect(screen.queryByTitle("bash · s1")).toBeNull();
     expect(screen.queryByTestId("terminal-view-stub")).toBeNull();
   });
 
-  it("keeps restored shell tabs when the terminals fetch errors (non-authoritative empty list)", () => {
-    // An errored terminals fetch also yields terminals: [], but that empty list
-    // is not authoritative — we couldn't reach the PTYs, not "they're gone".
-    // Pruning against it would wipe the restored tab, so the prune effect is
-    // gated on error too. The tab must survive an errored read.
-    writeSessionWorkspaceState("conv_shellerr", {
+  it("keeps the active shell selected across a transient empty list while loading", () => {
+    // The selection-prune is gated on isLoading/error so a momentarily-empty
+    // list (mid-load or an errored, non-authoritative read) can't clear the
+    // restored selection: when the list resolves with the terminal, its xterm
+    // is still the one shown.
+    writeSessionWorkspaceState("conv_load", {
       open: true,
-      openTerminals: ["terminal:terminal_bash_s1"],
       selectedTerminalKey: "terminal:terminal_bash_s1",
     });
     useEnvironmentMock.mockReturnValue({
       data: { available: true, root: null, home: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: true, error: null });
+    mockConversations([{ id: "conv_load", permission_level: null }]);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_load"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    // The list resolves with the terminal present — the restored selection was
+    // preserved through the load window, so its xterm is shown.
     useTerminalsMock.mockReturnValue({
-      terminals: [],
+      terminals: [{ id: "terminal_bash_s1", name: "bash", session: "s1", running: true }],
       isLoading: false,
-      error: new Error("terminals fetch failed: 503"),
+      error: null,
     });
-    mockConversations([{ id: "conv_shellerr", permission_level: null }]);
+    rerender(makeTree());
 
-    renderShell("/c/conv_shellerr");
-
-    // The restored tab survives the errored (non-authoritative) empty list —
-    // the strip keeps the tab (title falls back to the raw id until the
-    // terminal loads) instead of pruning it as if the PTY were gone.
-    expect(screen.getByTitle("terminal_bash_s1")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
   });
 });
 
@@ -2441,95 +2255,6 @@ describe("Embedded REPL terminal rail inventory", () => {
     // The pill still sees the REPL terminal — false here would grey out
     // the Terminal pill and make the embedded REPL unreachable.
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminals-available", "true");
-  });
-
-  it("lists only agent-launched terminals in the rail for terminal-first SDK sessions", () => {
-    // With the REPL plus an agent-launched bash terminal, the tab shows
-    // and its badge counts 1 (the bash terminal). 2 would mean the REPL
-    // leaked into the inventory; 0/absent would hide the agent's real
-    // terminal along with it.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null, home: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    useTerminalsMock.mockReturnValue({
-      terminals: [
-        { id: "terminal_tui_main", name: "tui", session: "main", running: true },
-        { id: "terminal_bash_s1", name: "bash", session: "s1", running: true },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    mockConversations([
-      {
-        id: "conv_sdk",
-        permission_level: null,
-        labels: { "omnigent.ui": "terminal" },
-      },
-    ]);
-
-    renderShell("/c/conv_sdk");
-
-    const tab = screen.getByRole("tab", { name: /Shells/i });
-    // The badge renders the inventory count next to the tab title.
-    expect(tab).toHaveTextContent(/Shells\s*1/);
-  });
-
-  it("hides the Shells tab when no shell exists, even if the agent declares shell access", () => {
-    // Shell creation now lives in the tab strip's "+" menu, so the Shells tab
-    // is a pure list — it must NOT show just because the agent declares a
-    // terminals: block. Here the only terminal is the embedded REPL (excluded
-    // from the inventory), so there's no shell to list and no tab.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null, home: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_tui_main", name: "tui", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
-    useSessionAgentMock.mockReturnValue({
-      data: { id: "ag_x", name: "polly", terminals: ["zsh"] },
-    } as ReturnType<typeof useSessionAgent>);
-    mockConversations([
-      {
-        id: "conv_sdk",
-        permission_level: null,
-        labels: { "omnigent.ui": "terminal" },
-      },
-    ]);
-
-    renderShell("/c/conv_sdk");
-
-    expect(screen.queryByRole("tab", { name: /Shells/i })).toBeNull();
-  });
-
-  it("shows the Shells tab once a shell exists", () => {
-    // A real (non-REPL) shell in the inventory surfaces the tab, which lists it.
-    useEnvironmentMock.mockReturnValue({
-      data: { available: true, root: null, home: null },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_zsh_s1", name: "zsh", session: "s1", running: true }],
-      isLoading: false,
-      error: null,
-    });
-    useSessionAgentMock.mockReturnValue({
-      data: { id: "ag_x", name: "polly", terminals: ["zsh"] },
-    } as ReturnType<typeof useSessionAgent>);
-    mockConversations([{ id: "conv_sdk", permission_level: null }]);
-
-    renderShell("/c/conv_sdk");
-
-    const tab = screen.getByRole("tab", { name: /Shells/i });
-    // Display order: Shells sits to the RIGHT of Agents in the strip.
-    const agentsTab = screen.getByRole("tab", { name: /Agents/i });
-    expect(agentsTab.compareDocumentPosition(tab) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    // Selecting it mounts the shells list.
-    fireEvent.mouseDown(tab);
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
   });
 });
 
@@ -2826,13 +2551,6 @@ describe("Right-rail tab switching — file viewer close", () => {
     // another rail tab closes the viewer, and returning to Files shows the
     // panel, not the previously open file.
     setupFilesAvailable();
-    // A terminal is attached so the Terminals tab is available to switch to
-    // (the tab is gated on an attached terminal).
-    useTerminalsMock.mockReturnValue({
-      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
-      isLoading: false,
-      error: null,
-    });
     renderShell("/c/conv_abc");
 
     // Files is the default tab. Open README.md from the panel.
@@ -2840,11 +2558,11 @@ describe("Right-rail tab switching — file viewer close", () => {
     // Failure: openFileViewer did not set selectedFilePath.
     expect(screen.getByTestId("file-viewer-inline")).toHaveAttribute("data-path", "README.md");
 
-    // Switch to Terminals — file viewer must close, terminals section appears.
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /Shells/i }));
+    // Switch to Agents (always present) — file viewer must close, its panel appears.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /Agents/i }));
     // Failure: the tab-change handler did not close the viewer when leaving Files.
     expect(screen.queryByTestId("file-viewer-inline")).toBeNull();
-    expect(screen.getByTestId("inline-terminals-section")).toBeInTheDocument();
+    expect(screen.getByTestId("subagents-panel")).toBeInTheDocument();
 
     // Go back to Files — the panel shows, NOT the previously open file.
     fireEvent.mouseDown(screen.getByRole("tab", { name: /^Files$/i }));

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1071,7 +1071,8 @@ describe("Chat-mode terminal panel layout", () => {
   it("confirms before closing a shell tab, then kills the terminal", () => {
     // Closing a tab kills the underlying terminal (destructive), so the "x"
     // opens a confirm modal first; confirming issues the delete (which the SSE
-    // `resource.deleted` + cache prune turn into the tab disappearing).
+    // `resource.deleted` + cache prune turn into the tab disappearing). Closing
+    // is edit-gated, so this owner-level session shows the "x".
     writeSessionWorkspaceState("conv_abc", {
       open: true,
       selectedTerminalKey: "terminal:terminal_main",
@@ -1080,7 +1081,7 @@ describe("Chat-mode terminal panel layout", () => {
       data: { available: true, root: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    mockConversations([{ id: "conv_abc", permission_level: 4 }]);
     useTerminalsMock.mockReturnValue({
       terminals: [{ id: "terminal_main", name: "main", session: "u-1", running: true }],
       isLoading: false,
@@ -1111,7 +1112,7 @@ describe("Chat-mode terminal panel layout", () => {
       data: { available: true, root: null },
       isLoading: false,
     } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
-    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    mockConversations([{ id: "conv_abc", permission_level: 4 }]);
     useTerminalsMock.mockReturnValue({
       terminals: [{ id: "terminal_main", name: "main", session: "u-1", running: true }],
       isLoading: false,
@@ -1126,6 +1127,31 @@ describe("Chat-mode terminal panel layout", () => {
     // No delete, and the shell's xterm is still mounted.
     expect(deleteTerminalMutate).not.toHaveBeenCalled();
     expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
+  });
+
+  it("hides the shell close affordance from a read-only viewer", () => {
+    // Killing a shell is server-gated on edit access, so a read-only viewer
+    // gets no close "x" — otherwise the click would confirm, DELETE, and 403.
+    writeSessionWorkspaceState("conv_abc", {
+      open: true,
+      selectedTerminalKey: "terminal:terminal_main",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: 1 }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "main", session: "u-1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_abc");
+
+    // The tab and its xterm are present, but the close control is not.
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_main");
+    expect(screen.queryByRole("button", { name: "Close main · u-1" })).toBeNull();
   });
 
   it("selects a shell tab as active when the user clicks it", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -561,6 +561,11 @@ export function AppShell() {
   const markShellCreateStarted = useCallback(() => {
     pendingShellCreateRef.current = new Set(openTerminals);
   }, [openTerminals]);
+  // The create POST failed — disarm the focus snapshot so a later
+  // agent-spawned shell isn't mistaken for the one the user tried to open.
+  const clearShellCreatePending = useCallback(() => {
+    pendingShellCreateRef.current = null;
+  }, []);
   // Whether the agent's spec declares shell access (a ``terminals:`` block).
   // The desktop rail's Shells TAB shows only once a shell exists (creation is
   // via the tab-strip "+" menu), but the MOBILE Shells drawer — which has no
@@ -828,6 +833,12 @@ export function AppShell() {
     setSubagentsPanelOpen(false);
     setShellsPanelOpen(false);
     setFilesPanelShowHidden(true);
+    // Drop shell interaction state carried from the outgoing session: a
+    // still-armed create ref would otherwise auto-focus an unrelated shell in
+    // the new session, and an open "Close shell?" dialog would target a
+    // terminal absent from the new session's list.
+    pendingShellCreateRef.current = null;
+    setTerminalPendingClose(null);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
       // effects stay quiet on non-session routes.
@@ -1774,6 +1785,7 @@ export function AppShell() {
                     onShowHiddenChange={setFilesPanelShowHidden}
                     liveness={liveness}
                     onShellCreateStart={markShellCreateStarted}
+                    onShellCreateFailed={clearShellCreatePending}
                   />
                 )}
               </div>

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -52,6 +52,7 @@ import {
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
   terminalTabKey,
+  useDeleteTerminal,
   useTerminals,
 } from "@/hooks/useTerminals";
 import {
@@ -95,6 +96,7 @@ import { PermissionsModal } from "@/components/PermissionsModal";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "./CommandPalette";
 import { Toaster } from "@/components/ui/toast";
+import { CloseShellDialog } from "./CloseShellDialog";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
@@ -135,9 +137,9 @@ import type { RightRailTab } from "./railTabs";
  * folder tree) and Changes (changed-files-only flat list) are peer tabs —
  * the selected tab *is* the scope. Opening a file (chat link or rail click)
  * forces the rail to a files scope so the viewer is visible. Terminal-first
- * sessions render the terminal inline in main and therefore hide the rail's
- * Terminals tab. The Agents tab only appears once there's more than one
- * agent (the root has at least one child).
+ * sessions render the terminal inline in main. Shells have no nav tab — they
+ * open as closable soft tabs in the rail's tab strip. The Agents tab only
+ * appears once there's more than one agent (the root has at least one child).
  */
 export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
@@ -157,7 +159,7 @@ export function AppShell() {
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
   );
   // The comments panel only contributes to the min width when the rail is
-  // actually showing the file viewer — on the Terminals tab the FileViewer
+  // actually showing the file viewer — on any other tab the FileViewer
   // is unmounted, so the 720 floor would just waste horizontal space. Both
   // the Files and Changes tabs surface the inline viewer, so either qualifies.
   // 240px (CommentsPanel default/min width) + 480px comfortable code viewer
@@ -259,16 +261,12 @@ export function AppShell() {
   const [openFiles, setOpenFiles] = useState<string[]>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).openFiles ?? []) : [],
   );
-  // Ordered list of open shell tabs (``terminalTabKey`` values) shown in the
-  // right rail's tab strip beside the file tabs. ``selectedTerminalKey`` is the
-  // active one (mutually exclusive with ``selectedFilePath`` — the rail's
-  // content slot shows one thing). Persisted per-session (like file tabs) so a
-  // session switch or reload restores the tab strip; the PTYs live on the
-  // server and are re-fetched by ``useTerminals``, and a prune effect drops any
-  // keys whose terminal has actually gone away once the list loads.
-  const [openTerminals, setOpenTerminals] = useState<string[]>(() =>
-    conversationId ? (readSessionWorkspaceState(conversationId).openTerminals ?? []) : [],
-  );
+  // ``selectedTerminalKey`` is the active shell tab (mutually exclusive with
+  // ``selectedFilePath`` — the rail's content slot shows one thing). The set of
+  // tabs itself is not stored: it derives 1:1 from the session's shell
+  // inventory (see ``openTerminals`` below), so the tab strip always mirrors the
+  // live terminal list. Persisted per-session so a switch/reload restores which
+  // shell was focused; the prune effect clears it if that terminal is gone.
   const [selectedTerminalKey, setSelectedTerminalKey] = useState<string | null>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).selectedTerminalKey ?? null) : null,
   );
@@ -526,11 +524,11 @@ export function AppShell() {
   // Claude-native sub-agents have no terminal of their own — the parent
   // owns the tmux pane.
   const isClaudeNativeSubagent = wrapperLabel === "claude-code-native-ui-subagent";
-  // Hide the rail Shells tab only for claude-native sub-agents — they
-  // have no terminals of their own (the parent owns the tmux pane).
-  // Native top-level sessions get the same Shells rail as SDK ones;
-  // their vendor pane is excluded from the inventory like the SDK
-  // REPL (see ``inventoryTerminals``).
+  // Hide shells (the mobile Shells drawer entry) only for claude-native
+  // sub-agents — they have no terminals of their own (the parent owns the
+  // tmux pane). Native top-level sessions get shells like SDK ones; their
+  // vendor pane is excluded from the inventory like the SDK REPL (see
+  // ``inventoryTerminals``).
   const hideTerminalsTab = isClaudeNativeSubagent;
   // Inventory view of the terminal list for the rail tab, its badge,
   // and the mobile menu. The pill surfaces (``terminalsAvailable``,
@@ -540,6 +538,30 @@ export function AppShell() {
     () => inventoryTerminals(terminals, terminalFirst),
     [terminals, terminalFirst],
   );
+  // Shell soft tabs are 1:1 with the session's shell inventory: every shell —
+  // whether the user opened it or the agent spawned it — is its own tab, and a
+  // shell that goes away (killed via a tab close, closed by the agent, or the
+  // runner emptied the list) drops from ``railTerminals`` and takes its tab with
+  // it. The agent's own control terminal is excluded by ``inventoryTerminals``
+  // (it lives behind the connection pill, not as a shell tab).
+  const openTerminals = useMemo(() => railTerminals.map((t) => terminalTabKey(t)), [railTerminals]);
+  const deleteTerminalMutation = useDeleteTerminal(conversationId ?? "");
+  // Tab key awaiting a close confirmation, or null. Closing a tab kills the
+  // terminal, so a user-initiated close routes through a confirm modal first.
+  const [terminalPendingClose, setTerminalPendingClose] = useState<string | null>(null);
+  // A just-opened shell may not be in ``openTerminals`` yet — the tab list
+  // derives from the terminal query, which can lag the ``openTerminalTab``
+  // selection by a render (create round-trip / SSE ``created`` still landing).
+  // Hold that key here so the selection-prune below doesn't deselect it
+  // mid-arrival; cleared once it lands.
+  const pendingTerminalSelectRef = useRef<string | null>(null);
+  // While a close is in flight, grey the tab being killed so the delay between
+  // confirming and the tab disappearing (the DELETE round-trip + its
+  // ``resource.deleted``) reads as "closing", not frozen.
+  const closingTerminalKey =
+    deleteTerminalMutation.isPending && deleteTerminalMutation.variables
+      ? `terminal:${deleteTerminalMutation.variables}`
+      : null;
   // Whether the agent's spec declares shell access (a ``terminals:`` block).
   // The desktop rail's Shells TAB shows only once a shell exists (creation is
   // via the tab-strip "+" menu), but the MOBILE Shells drawer — which has no
@@ -624,31 +646,25 @@ export function AppShell() {
         // Agents tab is unconditional: the panel always lists at least
         // the main agent (its "main" row), so there's never a dead end.
         subagents: true,
-        // Shells tab: shown only once a shell actually exists — creating one
-        // is now done from the tab strip's "+" menu, so an agent that merely
-        // *declares* shell access with no open shell shows no (empty) tab.
-        // Inventory view: the embedded REPL terminal of terminal-first SDK
-        // sessions doesn't count. ``hideTerminalsTab`` is label-derived and
-        // ``railTerminals`` starts empty while the agent loads, so native
-        // sessions don't flash the tab.
-        terminals: !hideTerminalsTab && railTerminals.length > 0,
+        // Shells have no nav tab — they open as closable soft tabs in the
+        // rail's tab strip (see WorkspacePanel's TerminalTabsStrip / "+"
+        // menu). Mobile keeps a shells drawer (see ``showShellsTab`` below).
       }) as const,
-    [showFilesPanel, hideTerminalsTab, railTerminals.length],
+    [showFilesPanel],
   );
   // Whether the rail has anything at all to show. When false the workspace
   // card doesn't mount and the header hides its collapse toggle — a
   // no-filesystem agent with no terminals/sub-agents would otherwise
   // render an empty white card with no way to dismiss it.
   const hasRailContent = Object.values(railTabsAvailable).some(Boolean);
-  // Keep the selected tab valid. When the current tab disappears — files
-  // panel turns off, or the Shells tab hides (native wrapper / no shell
-  // and no shell access) — fall back to the first still-visible tab in
-  // display order (Files · Changes · Agents · Shells · Browser). Picking
+  // Keep the selected tab valid. When the current tab disappears — e.g. the
+  // files panel turns off — fall back to the first still-visible tab in
+  // display order (Files · Changes · Agents · Browser). Picking
   // the first available (rather than ping-ponging between two effects) keeps
   // this convergent even when several tabs vanish at once.
   useEffect(() => {
     if (railTabsAvailable[rightRailTab]) return;
-    const next = (["files", "changes", "subagents", "terminals", "browser"] as const).find(
+    const next = (["files", "changes", "subagents", "browser"] as const).find(
       (t) => railTabsAvailable[t],
     );
     if (next) setRightRailTab(next);
@@ -820,7 +836,6 @@ export function AppShell() {
       setRightRailTab("files");
       setSelectedFilePath(null);
       setOpenFiles([]);
-      setOpenTerminals([]);
       setSelectedTerminalKey(null);
       setPanelInitialKeyState(null);
       stateConvRef.current = null;
@@ -848,11 +863,11 @@ export function AppShell() {
     const nextSelected = urlFile ?? persisted.selectedFilePath ?? null;
     setOpenFiles(nextOpenFiles);
     setSelectedFilePath(nextSelected);
-    // Restore the open shell tabs from the per-session store. The prune effect
-    // drops any key whose terminal no longer exists once this session's
-    // terminal list loads, so a dead PTY can't leave a phantom tab. A restored
-    // shell selection must not coexist with a file selection (one content slot).
-    setOpenTerminals(persisted.openTerminals ?? []);
+    // The tab strip derives from the live terminal list, so there's nothing to
+    // restore for the tabs themselves — only which shell was focused. The prune
+    // effect clears that selection if its terminal no longer exists once this
+    // session's list loads. A restored shell selection must not coexist with a
+    // file selection (one content slot).
     setSelectedTerminalKey(nextSelected ? null : (persisted.selectedTerminalKey ?? null));
     // A maximized rail is transient too — the incoming session starts docked.
     // If we were maximized, restore the sidebar we collapsed on entry (the
@@ -862,7 +877,7 @@ export function AppShell() {
       return false;
     });
     // A selected file must be visible in the rail. The Files and Changes tabs
-    // both surface the inline viewer; the Agents/Terminals tabs don't, so
+    // both surface the inline viewer; the Agents/Browser tabs don't, so
     // pull the rail to Files unless it's already on a files scope.
     if (nextSelected && nextTab !== "files" && nextTab !== "changes") {
       nextTab = "files";
@@ -900,10 +915,9 @@ export function AppShell() {
       rightRailTab,
       openFiles,
       selectedFilePath,
-      openTerminals,
       selectedTerminalKey,
     });
-  }, [rightRailTab, openFiles, selectedFilePath, openTerminals, selectedTerminalKey]);
+  }, [rightRailTab, openFiles, selectedFilePath, selectedTerminalKey]);
 
   const handleFilesSortChange = useCallback((s: ChangedSort) => {
     setFilesPanelSort(s);
@@ -935,9 +949,9 @@ export function AppShell() {
       setFilesPanelOpen(false); // close files drawer so the viewer is unobscured
       setSubagentsPanelOpen(false); // close mobile agents drawer
       // Pull the rail to the Files tab when parked on a tab where the viewer
-      // won't render (Terminals, Subagents). The Files tab surfaces the
+      // won't render (Subagents). The Files tab surfaces the
       // FileViewer inline, so leave it undisturbed.
-      setRightRailTab((prev) => (prev === "terminals" || prev === "subagents" ? "files" : prev));
+      setRightRailTab((prev) => (prev === "subagents" ? "files" : prev));
       // Reveal the rail so the viewer is actually visible — a session the user
       // collapsed (or one that started collapsed via the Appearance default)
       // would otherwise route the file into an invisible panel. Persist
@@ -1254,7 +1268,10 @@ export function AppShell() {
   // shell tab and a file tab can't both be "active".
   const openTerminalTab = useCallback(
     (key: string) => {
-      setOpenTerminals((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      // The tab already exists (tabs derive 1:1 from the terminal list); this
+      // just focuses it and reveals the rail. Mark it pending so the prune
+      // doesn't deselect it if the list hasn't caught up to a fresh create yet.
+      pendingTerminalSelectRef.current = key;
       setSelectedTerminalKey(key);
       setSelectedFilePath(null);
       setFileViewerCommentsOpen(false);
@@ -1269,37 +1286,49 @@ export function AppShell() {
     [clearFileViewerUrl, conversationId],
   );
 
-  // Close a single shell tab. If it was the active one, activate its neighbor
-  // (prefer the previous tab, else the next); when none remain the selection
-  // clears and the rail falls back to the Shells list. Mirrors ``closeFile``.
-  const closeTerminalTab = useCallback((key: string) => {
-    setOpenTerminals((prev) => {
-      const idx = prev.indexOf(key);
-      if (idx === -1) return prev;
-      const next = prev.filter((k) => k !== key);
-      setSelectedTerminalKey((active) => {
-        if (active !== key) return active;
-        if (next.length === 0) return null;
-        return next[idx - 1] ?? next[idx] ?? next[0];
-      });
-      return next;
-    });
+  // User clicked a tab's "x". Closing a tab kills the underlying terminal, so
+  // confirm first rather than acting immediately.
+  const requestCloseTerminal = useCallback((key: string) => {
+    setTerminalPendingClose(key);
   }, []);
+  // Confirmed close: kill the terminal (DELETE). The `session.resource.deleted`
+  // delta + the mutation's cache prune drop it from the list, so its tab
+  // disappears. If it was the active tab, move focus to a neighbor (prefer the
+  // previous, else the next) so the rail doesn't snap back to Files; when none
+  // remain the selection clears.
+  const confirmCloseTerminal = useCallback(() => {
+    const key = terminalPendingClose;
+    if (key === null) return;
+    setTerminalPendingClose(null);
+    setSelectedTerminalKey((active) => {
+      if (active !== key) return active;
+      const idx = openTerminals.indexOf(key);
+      const remaining = openTerminals.filter((k) => k !== key);
+      if (remaining.length === 0) return null;
+      return remaining[idx - 1] ?? remaining[idx] ?? remaining[0];
+    });
+    const info = terminals.find((t) => terminalTabKey(t) === key);
+    if (info && conversationId) deleteTerminalMutation.mutate(info.id);
+  }, [terminalPendingClose, openTerminals, terminals, conversationId, deleteTerminalMutation]);
 
-  // Prune shell tabs whose terminal has gone away (closed by the agent, or the
-  // runner went offline and emptied the list). Keeps the strip from pointing at
-  // dead PTYs; the active selection falls back to the Shells list when its tab
-  // is dropped. Skip while the list is still loading OR the fetch errored so
-  // restored (persisted) tabs aren't wiped by a non-authoritative empty list —
-  // an errored read is `[]` too, and pruning against it would discard tabs
-  // whose PTYs we simply couldn't reach.
+  // Clear the active shell selection when its terminal goes away (closed by the
+  // agent, killed via a tab close, or the runner emptied the list) — the rail
+  // then falls back to its default content. The tab itself drops automatically
+  // (``openTerminals`` derives from the list). Skip while the list is still
+  // loading OR the fetch errored so a non-authoritative empty list can't wipe a
+  // valid selection (an errored read is `[]` too).
   useEffect(() => {
     if (terminalsLoading || terminalsError !== null) return;
     const valid = new Set(terminals.map((t) => terminalTabKey(t)));
-    setOpenTerminals((prev) => {
-      const next = prev.filter((k) => valid.has(k));
-      return next.length === prev.length ? prev : next;
-    });
+    // A just-opened shell is still arriving in the list — leave the selection
+    // alone until it lands (then stop protecting it), so a fresh open/create
+    // doesn't flicker unselected. A restored selection isn't protected, so a
+    // dead persisted terminal still falls back to the default view.
+    const pending = pendingTerminalSelectRef.current;
+    if (pending !== null) {
+      if (valid.has(pending)) pendingTerminalSelectRef.current = null;
+      else return;
+    }
     setSelectedTerminalKey((active) => (active !== null && !valid.has(active) ? null : active));
   }, [terminals, terminalsLoading, terminalsError]);
 
@@ -1340,9 +1369,10 @@ export function AppShell() {
     setSubagentsPanelOpen(true);
   }
 
-  // Mobile FAB → "Shells" opens the desktop rail's Shells tab content as a
-  // full-screen drawer. This preserves the "+ New shell" empty state on
-  // phones instead of requiring an existing shell before the entry works.
+  // Mobile FAB → "Shells" opens the session's shells list as a full-screen
+  // drawer (there is no desktop Shells tab; desktop opens shells as soft
+  // tabs). This preserves the "+ New shell" empty state on phones instead
+  // of requiring an existing shell before the entry works.
   function openShellsPanel() {
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
@@ -1717,8 +1747,6 @@ export function AppShell() {
                     showFilesPanel={showFilesPanel}
                     showBrowserTab={railTabsAvailable.browser}
                     changedCount={changedCount}
-                    showShellsTab={railTabsAvailable.terminals}
-                    terminalsLength={railTerminals.length}
                     subagentsWorking={subagentsWorking}
                     agentCount={agentCount}
                     rootSessionId={rootSessionId}
@@ -1731,7 +1759,8 @@ export function AppShell() {
                     openTerminalTab={openTerminalTab}
                     openTerminals={openTerminals}
                     selectedTerminalKey={selectedTerminalKey}
-                    onCloseTerminal={closeTerminalTab}
+                    closingTerminalKey={closingTerminalKey}
+                    onCloseTerminal={requestCloseTerminal}
                     maximized={rightPanelMaximized}
                     onToggleMaximized={toggleRightPanelMaximized}
                     permissionLevel={permissionLevel}
@@ -1854,6 +1883,17 @@ export function AppShell() {
               }}
             />
           )}
+          <CloseShellDialog
+            open={terminalPendingClose !== null}
+            shellLabel={(() => {
+              if (terminalPendingClose === null) return null;
+              const info = terminals.find((t) => terminalTabKey(t) === terminalPendingClose);
+              if (!info) return null;
+              return info.session ? `${info.name} · ${info.session}` : info.name;
+            })()}
+            onConfirm={confirmCloseTerminal}
+            onCancel={() => setTerminalPendingClose(null)}
+          />
           {/* Agent tools & policies — the mobile counterpart of the desktop
         AgentInfoButton popover, opened from the header's three-dot menu. */}
           {hasAgentInfo && (

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -340,11 +340,7 @@ export function AppShell() {
   // terminal. The hook is react-query-backed and dedup'd with the rail.
   // reconcileWhilePending: self-heals if the live resource.created SSE was
   // missed (see UseTerminalsOptions for the why).
-  const {
-    terminals,
-    isLoading: terminalsLoading,
-    error: terminalsError,
-  } = useTerminals(conversationId ?? null, {
+  const { terminals } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
 
@@ -549,12 +545,6 @@ export function AppShell() {
   // Tab key awaiting a close confirmation, or null. Closing a tab kills the
   // terminal, so a user-initiated close routes through a confirm modal first.
   const [terminalPendingClose, setTerminalPendingClose] = useState<string | null>(null);
-  // A just-opened shell may not be in ``openTerminals`` yet — the tab list
-  // derives from the terminal query, which can lag the ``openTerminalTab``
-  // selection by a render (create round-trip / SSE ``created`` still landing).
-  // Hold that key here so the selection-prune below doesn't deselect it
-  // mid-arrival; cleared once it lands.
-  const pendingTerminalSelectRef = useRef<string | null>(null);
   // While a close is in flight, grey the tab being killed so the delay between
   // confirming and the tab disappearing (the DELETE round-trip + its
   // ``resource.deleted``) reads as "closing", not frozen.
@@ -562,6 +552,15 @@ export function AppShell() {
     deleteTerminalMutation.isPending && deleteTerminalMutation.variables
       ? `terminal:${deleteTerminalMutation.variables}`
       : null;
+  // A user-initiated "+"→Shell create: snapshot the shell tabs present when it
+  // starts so the effect below can focus the newly-created shell the instant
+  // its tab lands in the list. That's decoupled from the create POST, which on
+  // a waking (runner-asleep) session resolves well after the reconcile poll /
+  // SSE has already surfaced the tab.
+  const pendingShellCreateRef = useRef<Set<string> | null>(null);
+  const markShellCreateStarted = useCallback(() => {
+    pendingShellCreateRef.current = new Set(openTerminals);
+  }, [openTerminals]);
   // Whether the agent's spec declares shell access (a ``terminals:`` block).
   // The desktop rail's Shells TAB shows only once a shell exists (creation is
   // via the tab-strip "+" menu), but the MOBILE Shells drawer — which has no
@@ -1269,9 +1268,9 @@ export function AppShell() {
   const openTerminalTab = useCallback(
     (key: string) => {
       // The tab already exists (tabs derive 1:1 from the terminal list); this
-      // just focuses it and reveals the rail. Mark it pending so the prune
-      // doesn't deselect it if the list hasn't caught up to a fresh create yet.
-      pendingTerminalSelectRef.current = key;
+      // just focuses it and reveals the rail. The selection is sticky (never
+      // pruned off the list), so a fresh create that's still landing stays
+      // selected and its xterm surfaces the instant the terminal appears.
       setSelectedTerminalKey(key);
       setSelectedFilePath(null);
       setFileViewerCommentsOpen(false);
@@ -1285,6 +1284,21 @@ export function AppShell() {
     },
     [clearFileViewerUrl, conversationId],
   );
+
+  // Focus a shell the user just created ("+"→Shell) as soon as its tab appears
+  // — a new non-agent terminal key that wasn't present when the create started.
+  // This runs off the live list, so it fires on the reconcile poll / SSE even
+  // before the create POST resolves (which lags on a waking runner), so the
+  // opened shell doesn't sit unselected while its tab is already showing.
+  useEffect(() => {
+    const known = pendingShellCreateRef.current;
+    if (known === null) return;
+    const fresh = openTerminals.find((k) => !known.has(k) && !isAgentTerminalKey(k));
+    if (fresh !== undefined) {
+      pendingShellCreateRef.current = null;
+      openTerminalTab(fresh);
+    }
+  }, [openTerminals, openTerminalTab]);
 
   // User clicked a tab's "x". Closing a tab kills the underlying terminal, so
   // confirm first rather than acting immediately.
@@ -1311,26 +1325,16 @@ export function AppShell() {
     if (info && conversationId) deleteTerminalMutation.mutate(info.id);
   }, [terminalPendingClose, openTerminals, terminals, conversationId, deleteTerminalMutation]);
 
-  // Clear the active shell selection when its terminal goes away (closed by the
-  // agent, killed via a tab close, or the runner emptied the list) — the rail
-  // then falls back to its default content. The tab itself drops automatically
-  // (``openTerminals`` derives from the list). Skip while the list is still
-  // loading OR the fetch errored so a non-authoritative empty list can't wipe a
-  // valid selection (an errored read is `[]` too).
-  useEffect(() => {
-    if (terminalsLoading || terminalsError !== null) return;
-    const valid = new Set(terminals.map((t) => terminalTabKey(t)));
-    // A just-opened shell is still arriving in the list — leave the selection
-    // alone until it lands (then stop protecting it), so a fresh open/create
-    // doesn't flicker unselected. A restored selection isn't protected, so a
-    // dead persisted terminal still falls back to the default view.
-    const pending = pendingTerminalSelectRef.current;
-    if (pending !== null) {
-      if (valid.has(pending)) pendingTerminalSelectRef.current = null;
-      else return;
-    }
-    setSelectedTerminalKey((active) => (active !== null && !valid.has(active) ? null : active));
-  }, [terminals, terminalsLoading, terminalsError]);
+  // The active shell selection is sticky: it changes only on explicit user
+  // action (opening a shell/file, switching a nav tab, closing the active
+  // shell). We deliberately do NOT clear it off the terminal list — the list
+  // churns transiently (runner health-poll clearing the cache, create/SSE
+  // races), and pruning against those windows was stranding a just-opened shell
+  // unselected once its tab recovered. Instead the rail only *shows* the
+  // selected shell's xterm while its terminal is actually present
+  // (``WorkspacePanel`` gates on ``openTerminals``); a selection whose terminal
+  // is momentarily or permanently absent falls back to the default view, and
+  // reappears the instant the terminal returns.
 
   function openExecutionLogsPanel(key: string) {
     setSelectedFilePath(null); // close file viewer
@@ -1769,6 +1773,7 @@ export function AppShell() {
                     filesPanelShowHidden={filesPanelShowHidden}
                     onShowHiddenChange={setFilesPanelShowHidden}
                     liveness={liveness}
+                    onShellCreateStart={markShellCreateStarted}
                   />
                 )}
               </div>

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -500,10 +500,11 @@ export function ChatHeader({
                       : mobileMenu.agentCount}
                   </span>
                 </DropdownMenuItem>
-                {/* Shells — mirrors the desktop rail's Shells tab: visible
-                    when a real shell exists, or when the agent spec declares
-                    shell access so the empty-state "+ New shell" affordance
-                    is reachable on mobile too. */}
+                {/* Shells — the mobile entry into the session's shells
+                    (desktop has no Shells tab; it opens shells as soft tabs):
+                    visible when a real shell exists, or when the agent spec
+                    declares shell access so the empty-state "+ New shell"
+                    affordance is reachable on mobile too. */}
                 {!mobileMenu.hideTerminalsTab && mobileMenu.showShellsTab && (
                   <DropdownMenuItem
                     onSelect={mobileMenu.onOpenShells}

--- a/web/src/shell/CloseShellDialog.tsx
+++ b/web/src/shell/CloseShellDialog.tsx
@@ -1,0 +1,56 @@
+// Confirmation modal for closing a shell soft tab. Closing a tab kills the
+// underlying terminal (its PTY is terminated server-side), so the close is
+// destructive and irreversible — the user confirms first. Only user-initiated
+// closes route through here; a terminal that goes away on its own (the agent
+// closed it, or the PTY died) just drops its tab silently.
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface CloseShellDialogProps {
+  /** Open when a tab close is awaiting confirmation. */
+  open: boolean;
+  /** Display label of the shell being closed (name · session), for the copy. */
+  shellLabel: string | null;
+  /** Confirm — kill the terminal. */
+  onConfirm: () => void;
+  /** Dismiss without closing the terminal. */
+  onCancel: () => void;
+}
+
+export function CloseShellDialog({ open, shellLabel, onConfirm, onCancel }: CloseShellDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Close shell?</DialogTitle>
+          <DialogDescription>
+            {shellLabel ? (
+              <>
+                This terminates <span className="text-foreground">{shellLabel}</span> and ends any
+                process running in it. This can't be undone.
+              </>
+            ) : (
+              "This terminates the shell and ends any process running in it. This can't be undone."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            Close shell
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -1,6 +1,6 @@
 // Inline terminal renderer for terminal-first sessions. Replaces the
 // chat conversation + composer when the user picks "Terminal" in the
-// connection pill, or opens a shell from the rail's Shells tab. Shares
+// connection pill, or opens a shell as a rail soft tab. Shares
 // the lower-level primitives (`useTerminals` + `TerminalView`) with
 // `InlineTerminalsSection` and `TerminalsPanel`, but renders as plain
 // flex content — no drawer chrome, no resize handle, no collapse — so
@@ -10,8 +10,8 @@
 // Two render states, for every session shape (SDK and native alike):
 // the AGENT's terminal (the SDK REPL or the native vendor pane)
 // renders chrome-free, and a rail-opened user shell renders with a
-// single header row (identity + close X). There is no tab strip —
-// shells are enumerated and created in the rail's Shells tab.
+// single header row (identity + close X). There is no tab strip here —
+// shells are opened and created from the rail's tab strip ("+" menu).
 
 import { TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -25,8 +25,8 @@ interface MainTerminalViewProps {
   conversationId: string;
   /**
    * Terminal tab key to focus when the view opens, e.g.
-   * `"terminal:terminal_zsh_main"` from clicking a shell row in the
-   * rail's Shells tab. Falsy values (null / the PANEL_NO_TERMINAL_KEY
+   * `"terminal:terminal_zsh_main"` from opening a shell in the rail.
+   * Falsy values (null / the PANEL_NO_TERMINAL_KEY
    * sentinel) leave the agent-terminal auto-selection in place; an
    * unknown or closed key falls back the same way once terminals load.
    */

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -25,9 +25,6 @@ vi.mock("./FilesPanel", () => ({
     <div data-testid="files-panel-stub" data-flat-view={String(flatView)} />
   ),
 }));
-vi.mock("./InlineTerminalsSection", () => ({
-  InlineTerminalsSection: () => <div data-testid="terminals-stub" />,
-}));
 vi.mock("./SubagentsPanel", () => ({
   SubagentsPanel: () => <div data-testid="subagents-stub" />,
 }));
@@ -84,7 +81,6 @@ function renderWorkspace(
     openFiles?: string[];
     changedCount?: number;
     showBrowserTab?: boolean;
-    showShellsTab?: boolean;
     openTerminals?: string[];
     selectedTerminalKey?: string | null;
     maximized?: boolean;
@@ -108,8 +104,6 @@ function renderWorkspace(
         showFilesPanel
         showBrowserTab={overrides.showBrowserTab ?? false}
         changedCount={overrides.changedCount ?? 0}
-        showShellsTab={overrides.showShellsTab ?? false}
-        terminalsLength={0}
         subagentsWorking={0}
         agentCount={1}
         rootSessionId={null}
@@ -165,6 +159,11 @@ describe("WorkspacePanel surface presentation", () => {
     expect(filesTab).not.toHaveAttribute("title");
     expect(changesTab).not.toHaveAttribute("title");
     expect(agentsTab).not.toHaveAttribute("title");
+  });
+
+  it("has no static Shells nav tab — shells open only as closable soft tabs", () => {
+    renderWorkspace({ openTerminals: [] });
+    expect(screen.queryByRole("tab", { name: /shells/i })).toBeNull();
   });
 
   it("badges the Changes tab (not Files) with the changed-file count", () => {
@@ -308,7 +307,7 @@ describe("WorkspacePanel shell tabs", () => {
 
   it("renders a tab per open shell labeled by name · session", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
-    renderWorkspace({ showShellsTab: true, openTerminals: [termKey] });
+    renderWorkspace({ openTerminals: [termKey] });
 
     // The label resolves through the terminals cache (name · session), not the
     // raw tab key. A failure means the strip didn't render or didn't resolve
@@ -319,7 +318,6 @@ describe("WorkspacePanel shell tabs", () => {
   it("sizes shell tab pills to the same 24px height as file tabs", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     renderWorkspace({
-      showShellsTab: true,
       openFiles: ["src/App.tsx"],
       openTerminals: [termKey],
     });
@@ -334,7 +332,6 @@ describe("WorkspacePanel shell tabs", () => {
   it("surfaces the active shell's xterm in the content slot", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     renderWorkspace({
-      showShellsTab: true,
       openTerminals: [termKey],
       selectedTerminalKey: termKey,
     });
@@ -349,7 +346,6 @@ describe("WorkspacePanel shell tabs", () => {
   it("activates a shell via openTerminalTab when its tab body is clicked", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     const { openTerminalTab } = renderWorkspace({
-      showShellsTab: true,
       openTerminals: [termKey],
     });
 
@@ -361,7 +357,6 @@ describe("WorkspacePanel shell tabs", () => {
   it("closes a shell via onCloseTerminal (and does not also open it) when the x is clicked", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     const { openTerminalTab, onCloseTerminal } = renderWorkspace({
-      showShellsTab: true,
       openTerminals: [termKey],
     });
 
@@ -374,7 +369,6 @@ describe("WorkspacePanel shell tabs", () => {
   it("keeps the static nav tabs inactive while a shell tab is active", () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     renderWorkspace({
-      showShellsTab: true,
       openTerminals: [termKey],
       selectedTerminalKey: termKey,
     });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -116,12 +116,16 @@ function shellConnectState(liveness: SessionLiveness | undefined): ShellConnectS
 function NewTabMenu({
   conversationId,
   onOpenTerminal,
+  onCreateStart,
   triggerClassName,
   liveness,
 }: {
   conversationId: string;
   /** Open a freshly-created terminal as a rail tab by its tab key. */
   onOpenTerminal: (key: string) => void;
+  /** Called when a shell create is initiated (before the POST resolves), so
+   *  the shell can be focused as soon as its tab appears in the list. */
+  onCreateStart?: () => void;
   /** Extra classes on the trigger wrapper — used to cancel the open-tabs
    *  region's gap so the "+" hugs the last tab. */
   triggerClassName?: string;
@@ -149,6 +153,11 @@ function NewTabMenu({
     preferred !== null && declaredTerminals.includes(preferred) ? preferred : declaredTerminals[0];
 
   const launchShell = (name: string) => {
+    // Signal the create is starting so the shell gets focused the moment its
+    // tab lands in the list — not only when this POST resolves. On a waking
+    // (runner-asleep) session the POST can lag the tab's arrival by seconds;
+    // ``onOpenTerminal`` on success is a backstop for when it's already open.
+    onCreateStart?.();
     create.mutate(name, {
       onSuccess: (info) => onOpenTerminal(terminalTabKey(info)),
     });
@@ -588,6 +597,9 @@ interface WorkspacePanelProps {
    *  connect affordance (Reconnecting… / Offline). Absent is treated as
    *  ready. */
   liveness?: SessionLiveness;
+  /** Called when a shell create is initiated from the "+" menu, so the new
+   *  shell is focused as soon as its tab lands (not only on the create POST). */
+  onShellCreateStart?: () => void;
 }
 
 /**
@@ -637,6 +649,7 @@ export function WorkspacePanel({
   filesPanelShowHidden,
   onShowHiddenChange,
   liveness,
+  onShellCreateStart,
 }: WorkspacePanelProps) {
   // Memoized so FileViewer's Escape-to-close effect doesn't re-subscribe its
   // window keydown listener on every render — an inline arrow would change
@@ -815,6 +828,7 @@ export function WorkspacePanel({
             <NewTabMenu
               conversationId={conversationId}
               onOpenTerminal={openTerminalTab}
+              onCreateStart={onShellCreateStart}
               triggerClassName="ml-[2px]"
               liveness={liveness}
             />
@@ -828,6 +842,7 @@ export function WorkspacePanel({
           <NewTabMenu
             conversationId={conversationId}
             onOpenTerminal={openTerminalTab}
+            onCreateStart={onShellCreateStart}
             liveness={liveness}
           />
         )}
@@ -857,7 +872,11 @@ export function WorkspacePanel({
           (tree vs changed-only list); Subagents lists the root's children +
           a "main" link back to the parent. */}
       <div data-workspace-panel-content className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {selectedTerminalKey !== null ? (
+        {selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey) ? (
+          // Show the selected shell's xterm only while its terminal is actually
+          // present. The selection is sticky (AppShell never prunes it off the
+          // list), so during a transient terminals-list churn this falls back to
+          // the default view and the xterm reappears when the terminal returns.
           <RailTerminalView
             conversationId={conversationId}
             terminalKey={selectedTerminalKey}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import { isOwnerLevel } from "@/lib/permissionsApi";
+import { isEditorLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -117,6 +117,7 @@ function NewTabMenu({
   conversationId,
   onOpenTerminal,
   onCreateStart,
+  onCreateError,
   triggerClassName,
   liveness,
 }: {
@@ -126,6 +127,9 @@ function NewTabMenu({
   /** Called when a shell create is initiated (before the POST resolves), so
    *  the shell can be focused as soon as its tab appears in the list. */
   onCreateStart?: () => void;
+  /** Called when the shell create POST fails, so the caller can disarm the
+   *  focus snapshot armed by ``onCreateStart``. */
+  onCreateError?: () => void;
   /** Extra classes on the trigger wrapper — used to cancel the open-tabs
    *  region's gap so the "+" hugs the last tab. */
   triggerClassName?: string;
@@ -160,6 +164,7 @@ function NewTabMenu({
     onCreateStart?.();
     create.mutate(name, {
       onSuccess: (info) => onOpenTerminal(terminalTabKey(info)),
+      onError: () => onCreateError?.(),
     });
   };
 
@@ -383,6 +388,7 @@ function TerminalTabsStrip({
   openTerminals,
   activeTerminalKey,
   closingKey,
+  canClose,
   labelFor,
   onSelect,
   onClose,
@@ -393,6 +399,9 @@ function TerminalTabsStrip({
   activeTerminalKey: string | null;
   /** Tab key whose close (kill) is in flight — greyed + non-interactive. */
   closingKey: string | null;
+  /** Whether the viewer may close (kill) a shell. Closing is server-gated on
+   *  edit access, so a read-only viewer gets no close affordance. */
+  canClose: boolean;
   /** Resolve a tab key to its display label (shell name / session). */
   labelFor: (key: string) => string;
   /** Activate a terminal tab by key. */
@@ -425,7 +434,7 @@ function TerminalTabsStrip({
             title={name}
             onClick={() => !closing && onSelect(key)}
             onAuxClick={(e) => {
-              if (e.button === 1 && !closing) {
+              if (e.button === 1 && !closing && canClose) {
                 e.preventDefault();
                 onClose(key);
               }
@@ -449,19 +458,21 @@ function TerminalTabsStrip({
           >
             <TerminalIcon className="size-4 shrink-0" />
             <span className="min-w-0 truncate text-sm">{name}</span>
-            <span className="absolute inset-y-0 right-0 flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100 [background:linear-gradient(to_right,transparent,color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))_40%)]">
-              <button
-                type="button"
-                aria-label={`Close ${name}`}
-                className="flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose(key);
-                }}
-              >
-                <XIcon className="size-4" />
-              </button>
-            </span>
+            {canClose && (
+              <span className="absolute inset-y-0 right-0 flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100 [background:linear-gradient(to_right,transparent,color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))_40%)]">
+                <button
+                  type="button"
+                  aria-label={`Close ${name}`}
+                  className="flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose(key);
+                  }}
+                >
+                  <XIcon className="size-4" />
+                </button>
+              </span>
+            )}
           </div>
         );
       })}
@@ -600,6 +611,9 @@ interface WorkspacePanelProps {
   /** Called when a shell create is initiated from the "+" menu, so the new
    *  shell is focused as soon as its tab lands (not only on the create POST). */
   onShellCreateStart?: () => void;
+  /** Called when the shell create POST fails, so the focus snapshot armed by
+   *  ``onShellCreateStart`` is disarmed and can't grab an unrelated shell. */
+  onShellCreateFailed?: () => void;
 }
 
 /**
@@ -650,6 +664,7 @@ export function WorkspacePanel({
   onShowHiddenChange,
   liveness,
   onShellCreateStart,
+  onShellCreateFailed,
 }: WorkspacePanelProps) {
   // Memoized so FileViewer's Escape-to-close effect doesn't re-subscribe its
   // window keydown listener on every render — an inline arrow would change
@@ -724,9 +739,15 @@ export function WorkspacePanel({
           className="shrink-0"
           // When a file or shell tab is active no fixed trigger should
           // highlight, so feed the radix group a sentinel that matches none of
-          // them. The active file/shell tab carries its own highlight.
+          // them. The active file/shell tab carries its own highlight. Gate the
+          // shell case on the terminal actually being present (same gate as the
+          // content slot below): a sticky selection whose terminal is gone shows
+          // the fallback nav view, so its nav tab must highlight, not "__tab__".
           value={
-            selectedFilePath !== null || selectedTerminalKey !== null ? "__tab__" : rightRailTab
+            selectedFilePath !== null ||
+            (selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey))
+              ? "__tab__"
+              : rightRailTab
           }
           onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
         >
@@ -816,6 +837,7 @@ export function WorkspacePanel({
                 openTerminals={openTerminals}
                 activeTerminalKey={selectedTerminalKey}
                 closingKey={closingTerminalKey ?? null}
+                canClose={isEditorLevel(permissionLevel)}
                 labelFor={terminalLabelFor}
                 onSelect={openTerminalTab}
                 onClose={onCloseTerminal}
@@ -827,6 +849,7 @@ export function WorkspacePanel({
                 same gap the scroller's gap-0.5 gives between tabs. */}
             <NewTabMenu
               conversationId={conversationId}
+              onCreateError={onShellCreateFailed}
               onOpenTerminal={openTerminalTab}
               onCreateStart={onShellCreateStart}
               triggerClassName="ml-[2px]"
@@ -843,6 +866,7 @@ export function WorkspacePanel({
             conversationId={conversationId}
             onOpenTerminal={openTerminalTab}
             onCreateStart={onShellCreateStart}
+            onCreateError={onShellCreateFailed}
             liveness={liveness}
           />
         )}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -9,7 +9,6 @@ import {
   MaximizeIcon,
   MinimizeIcon,
   PlusIcon,
-  SquareTerminalIcon,
   TerminalIcon,
   XIcon,
 } from "lucide-react";
@@ -37,7 +36,6 @@ import { SuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
-import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 import { type RightRailTab, TAB_BADGE_BASE } from "./railTabs";
@@ -375,6 +373,7 @@ function FileTabsStrip({
 function TerminalTabsStrip({
   openTerminals,
   activeTerminalKey,
+  closingKey,
   labelFor,
   onSelect,
   onClose,
@@ -383,6 +382,8 @@ function TerminalTabsStrip({
   openTerminals: string[];
   /** Currently active terminal key, or null when another tab is active. */
   activeTerminalKey: string | null;
+  /** Tab key whose close (kill) is in flight — greyed + non-interactive. */
+  closingKey: string | null;
   /** Resolve a tab key to its display label (shell name / session). */
   labelFor: (key: string) => string;
   /** Activate a terminal tab by key. */
@@ -403,23 +404,25 @@ function TerminalTabsStrip({
       {openTerminals.map((key) => {
         const name = labelFor(key);
         const active = key === activeTerminalKey;
+        const closing = key === closingKey;
         return (
           <div
             key={key}
             ref={active ? activeTabRef : undefined}
             role="button"
-            tabIndex={0}
+            tabIndex={closing ? -1 : 0}
             aria-current={active}
+            aria-busy={closing}
             title={name}
-            onClick={() => onSelect(key)}
+            onClick={() => !closing && onSelect(key)}
             onAuxClick={(e) => {
-              if (e.button === 1) {
+              if (e.button === 1 && !closing) {
                 e.preventDefault();
                 onClose(key);
               }
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
+              if (!closing && (e.key === "Enter" || e.key === " ")) {
                 e.preventDefault();
                 onSelect(key);
               }
@@ -431,6 +434,8 @@ function TerminalTabsStrip({
               active
                 ? "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground"
                 : "text-muted-foreground hover:bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] hover:text-foreground",
+              // Closing: kill is in flight — dim and freeze the tab until it goes.
+              closing && "pointer-events-none opacity-50",
             )}
           >
             <TerminalIcon className="size-4 shrink-0" />
@@ -526,15 +531,6 @@ interface WorkspacePanelProps {
   showBrowserTab: boolean;
   /** Count of changed files, shown as the Changes tab badge. */
   changedCount: number;
-  /**
-   * Whether the Shells tab is available — AppShell's combined gate
-   * (not a native wrapper, AND either a shell exists or the agent's
-   * spec declares shell access, which makes the tab show by default
-   * with its "+ New shell" empty state).
-   */
-  showShellsTab: boolean;
-  /** Number of open shells, shown as the Shells tab badge when > 0. */
-  terminalsLength: number;
   /** How many child agents are actively working (Agents tab badge). */
   subagentsWorking: number;
   /**
@@ -569,6 +565,9 @@ interface WorkspacePanelProps {
   openTerminals: string[];
   /** Active shell tab key, or null when no shell tab is selected. */
   selectedTerminalKey: string | null;
+  /** Tab key whose close (terminal kill) is in flight — rendered greyed and
+   *  non-interactive until it disappears. Null when no close is pending. */
+  closingTerminalKey?: string | null;
   /** Close a single open shell tab by key. */
   onCloseTerminal: (key: string) => void;
   /** Whether the rail is maximized (occupies the full content area). */
@@ -616,8 +615,6 @@ export function WorkspacePanel({
   showFilesPanel,
   showBrowserTab,
   changedCount,
-  showShellsTab,
-  terminalsLength,
   subagentsWorking,
   agentCount,
   rootSessionId,
@@ -630,6 +627,7 @@ export function WorkspacePanel({
   openTerminalTab,
   openTerminals,
   selectedTerminalKey,
+  closingTerminalKey,
   onCloseTerminal,
   maximized,
   onToggleMaximized,
@@ -646,8 +644,8 @@ export function WorkspacePanel({
   const handleCloseTab = useCallback(() => {
     if (selectedFilePath !== null) onCloseFile(selectedFilePath);
   }, [onCloseFile, selectedFilePath]);
-  // Resolve shell tab keys to display labels. The list is already fetched for
-  // the Shells tab / count badge, so this shares the same query cache.
+  // Resolve shell tab keys to display labels. The terminals list is already
+  // fetched elsewhere for the session, so this shares the same query cache.
   const { terminals } = useTerminals(conversationId);
   const terminalLabelFor = useCallback(
     (key: string) => {
@@ -691,14 +689,12 @@ export function WorkspacePanel({
           className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
         />
       )}
-      {/* Tab strip, in display order Files · Changes · Agents · Shells.
+      {/* Tab strip, in display order Files · Changes · Agents.
           Files (full folder tree) and Changes (changed-files-only list) are
           two peer tabs — same gate (an on-disk workspace), same FilesPanel,
           each pinned to one scope. Agents is always present (the Agents panel
-          lists at least the main agent). Shells shows whenever AppShell's gate
-          allows it (the agent declares shell access, or a shell already
-          exists) — the empty state carries the "+ New shell"
-          affordance, so an empty tab is an entry point, not a dead end.
+          lists at least the main agent). Shells have no nav tab — they open as
+          closable soft tabs (see the "+" NewTabMenu / TerminalTabsStrip below).
           The Agents tab keys off ``rootSessionId``, so inside a child
           it lists the siblings + a "main" link back to the parent. */}
       {/* Tab strip: the static nav tabs + divider stay pinned on the left at
@@ -770,21 +766,6 @@ export function WorkspacePanel({
                 </span>
               </TabsTrigger>
             </WorkspaceTabTooltip>
-            {showShellsTab && (
-              <WorkspaceTabTooltip label="Shells">
-                <TabsTrigger
-                  value="terminals"
-                  aria-label={terminalsLength > 0 ? `Shells ${terminalsLength}` : "Shells"}
-                  className="size-6 shrink-0 p-0 hover:border-1 hover:border-muted rounded-md!"
-                >
-                  <SquareTerminalIcon />
-                  <span className="sr-only">Shells</span>
-                  {terminalsLength > 0 && (
-                    <span className="sr-only text-muted-foreground">{terminalsLength}</span>
-                  )}
-                </TabsTrigger>
-              </WorkspaceTabTooltip>
-            )}
             {showBrowserTab && (
               <WorkspaceTabTooltip label="Browser">
                 <TabsTrigger
@@ -821,6 +802,7 @@ export function WorkspacePanel({
               <TerminalTabsStrip
                 openTerminals={openTerminals}
                 activeTerminalKey={selectedTerminalKey}
+                closingKey={closingTerminalKey ?? null}
                 labelFor={terminalLabelFor}
                 onSelect={openTerminalTab}
                 onClose={onCloseTerminal}
@@ -872,12 +854,8 @@ export function WorkspacePanel({
       </div>
       {/* Tab content — single slot. An open shell tab holds its xterm; a
           file tab holds FileViewer; the Files/Changes tabs show FilesPanel
-          (tree vs changed-only list); the
-          Shells tab holds the list-only inline section (clicking a row
-          opens the shell as a tab above, surfacing its xterm here);
-          Subagents lists the root's children + a "main" link back to the
-          parent. The Shells branch is unreachable when its tab is hidden —
-          native wrappers, claude-native sub-agents, or no shell attached. */}
+          (tree vs changed-only list); Subagents lists the root's children +
+          a "main" link back to the parent. */}
       <div data-workspace-panel-content className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {selectedTerminalKey !== null ? (
           <RailTerminalView
@@ -904,8 +882,6 @@ export function WorkspacePanel({
           <BrowserPane conversationId={conversationId} className="min-h-0 flex-1" />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
-        ) : rightRailTab === "terminals" && showShellsTab ? (
-          <InlineTerminalsSection conversationId={conversationId} onExpand={openTerminalTab} />
         ) : (
           showFilesPanel && (
             <FilesPanel

--- a/web/src/shell/railTabs.ts
+++ b/web/src/shell/railTabs.ts
@@ -5,7 +5,7 @@
  */
 
 /** The selectable tabs in the right workspace rail, in display order. */
-export type RightRailTab = "files" | "changes" | "subagents" | "terminals" | "browser";
+export type RightRailTab = "files" | "changes" | "subagents" | "browser";
 
 /**
  * Count/status badge geometry. Fixed height with min-width == height keeps a


### PR DESCRIPTION
## Related issue

Closes OMNI-3748 — https://linear.app/omnigent/issue/OMNI-3748/remove-shells-permanent-tab-from-the-side-panel

## Summary

- The desktop workspace rail carried a static **"Shells"** nav tab that rendered an aggregated list of the session's shells. New shells already open as closable soft tabs, so the list view is redundant — remove it.
- Shells now appear **only** as closable soft tabs (created via the rail's "+" menu, or restored from persisted state); selecting one surfaces its xterm.
- `"terminals"` is dropped from the `RightRailTab` type, `railTabsAvailable`, the tab-fallback list, and the persisted-tab whitelist, so a user who had the Shells tab selected falls back to **Files** rather than a blank rail.
- **Mobile is unchanged**: the session-menu FAB "Shells" entry and its drawer (`InlineTerminalsSection`) still list/create shells where there is no tab strip.

## Test Plan

- `tsc -b` type-check: clean (apart from a pre-existing `recharts` missing-dep error unrelated to this change).
- `oxlint` + `prettier --check` on all changed files: clean.
- `vitest run` on the affected files (`AppShell`, `WorkspacePanel`, `InlineTerminalsSection`, `sessionWorkspaceState`): **144/144 pass**. Added a regression guard that no Shells nav tab renders; rewrote the desktop shell-tab tests to drive shells through the soft-tab flow; kept all mobile menu/drawer tests.

Manual repro for a reviewer (`cd web && npm run dev`, open a session whose agent has shell access):
1. Desktop rail tab strip shows Files · Changes · Agents (+ Tasks/Browser) and **no** Shells tab.
2. Rail "+" → Shell opens a **closable soft tab** with a live xterm; open another; close one via its × → xterm unmounts and the rail returns to Files.
3. If you'd left the Shells tab selected before, reload → the rail defaults to Files (not a blank pane).
4. Below the `md` breakpoint: session-menu FAB → **Shells** entry still opens the shells drawer with "+ New shell" — mobile unchanged.

## Demo

https://github.com/user-attachments/assets/74c40bfa-ab30-4b02-833e-cac582d2fe7b

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests updated in the same PR: a new regression guard asserts the desktop Shells nav tab is gone, the soft-tab tests were rewritten to exercise shells as closable tabs, and the mobile menu/drawer tests are untouched to prove mobile is unchanged. Behaviour was not manually run in a browser in this environment; the repro steps above are for reviewer verification.

## Changelog

The workspace side panel no longer has a separate Shells tab — shells open as closable tabs instead

This pull request and its description were written by Isaac.
