### PR TITLE
fix(web_search): read Keenable page text from snippet, not description

### DIFF
--- a/omnigent/tools/builtins/web_search_keenable.py
+++ b/omnigent/tools/builtins/web_search_keenable.py
@@ -110,11 +110,31 @@ def _search_keenable(
     return _format_results(resp.json(), _resolve_max_results(config))
 
 
+#: Characters of page text kept per result. Keenable returns the whole page on
+#: every search result, an order of magnitude more than a search snippet.
+_SNIPPET_MAX_CHARS = 500
+
+
+def _snippet(item: dict[str, Any]) -> str:
+    """
+    Return the page text of one result.
+
+    Keenable sends both ``snippet`` and ``description``: ``snippet`` carries the
+    page text and ``description`` is the page's meta description, which is empty
+    for most pages. The text is whole-page, so it is collapsed and capped.
+
+    :param item: One entry of the Keenable ``results`` list.
+    :returns: The result's text, or an empty string when it has none.
+    """
+    text = str(item.get("snippet") or item.get("description") or "")
+    return " ".join(text.split())[:_SNIPPET_MAX_CHARS].strip()
+
+
 def _format_results(data: dict[str, Any], max_results: int) -> str:
     """
     Format Keenable's ``/v1/search`` JSON response into readable text.
 
-    Keenable returns ``{"results": [{"title", "url", "description", ...}]}``.
+    Keenable returns ``{"results": [{"title", "url", "snippet", ...}]}``.
     The list is sliced to ``max_results`` and rendered as numbered entries.
 
     :param data: The parsed JSON response from Keenable.
@@ -131,6 +151,6 @@ def _format_results(data: dict[str, Any], max_results: int) -> str:
             continue
         title = item.get("title", "")
         url = item.get("url", "")
-        snippet = item.get("description") or ""
+        snippet = _snippet(item)
         formatted.append(f"{i + 1}. {title}\n   {url}\n   {snippet}")
     return "\n\n".join(formatted) if formatted else "No results found."

--- a/tests/tools/builtins/test_web_search.py
+++ b/tests/tools/builtins/test_web_search.py
@@ -12,6 +12,9 @@ from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins import get_builtin_tool
 from omnigent.tools.builtins.web_search import WebSearchTool
 from omnigent.tools.builtins.web_search_keenable import (
+    _SNIPPET_MAX_CHARS as _SNIPPET_MAX_CHARS_KEENABLE,
+)
+from omnigent.tools.builtins.web_search_keenable import (
     _resolve_max_results as _resolve_max_results_keenable,
 )
 from omnigent.tools.builtins.web_search_nimble import _resolve_max_results
@@ -614,7 +617,8 @@ def test_keenable_backend_via_spec_config(tool_ctx: ToolContext) -> None:
             {
                 "title": "Keenable Docs",
                 "url": "https://docs.keenable.ai",
-                "description": "Web search API for AI agents.",
+                "description": "",
+                "snippet": "Web search API for AI agents.",
             },
         ],
     }
@@ -630,6 +634,50 @@ def test_keenable_backend_via_spec_config(tool_ctx: ToolContext) -> None:
     assert "1. Keenable Docs" in result
     assert "https://docs.keenable.ai" in result
     assert "Web search API for AI agents." in result
+
+
+def test_keenable_reads_page_text_from_snippet(tool_ctx: ToolContext) -> None:
+    """
+    Keenable sends both fields and ``description`` is empty for most pages, so
+    the page text has to come from ``snippet``. It is whole-page text, so it is
+    collapsed and capped.
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "results": [
+            {
+                "title": "Wrapped",
+                "url": "https://example.com/wrapped",
+                "description": "",
+                "snippet": "line one\n\nline two",
+            },
+            {
+                "title": "Long",
+                "url": "https://example.com/long",
+                "description": "",
+                "snippet": "word " * 400,
+            },
+            {
+                "title": "Meta only",
+                "url": "https://example.com/meta",
+                "description": "only a meta description",
+            },
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "keenable"}), tool_ctx)
+
+    assert "line one line two" in result
+    assert "only a meta description" in result
+    long_line = next(line for line in result.splitlines() if line.startswith("   word"))
+    # 2000 chars of page text in, one search-snippet's worth out.
+    assert _SNIPPET_MAX_CHARS_KEENABLE - 10 < len(long_line.strip()) <= _SNIPPET_MAX_CHARS_KEENABLE
 
 
 def test_keenable_keyless_by_default(tool_ctx: ToolContext) -> None:


### PR DESCRIPTION
Closes #5088.

`_format_results` reads `description`, which Keenable leaves empty on most pages; the page text is in `snippet`, so every result renders as a title, a URL and a blank line.

Prefers `snippet` now with `description` as the fallback, capped at 500 chars since Keenable returns whole pages. The fixture is updated to the real response shape.
