### PR TITLE
fix(codex): forward effective context window

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6278,7 +6278,9 @@ def _session_usage_data_from_params(params: _JsonObject) -> dict[str, int] | Non
     if not isinstance(total, dict):
         return None
     cumulative_input_tokens = total.get("inputTokens")
-    context_window = total.get("contextWindow")
+    context_window = token_usage.get("modelContextWindow")
+    if context_window is None:
+        context_window = total.get("contextWindow")
     output_tokens = total.get("outputTokens")
     cached_input_tokens = total.get("cachedInputTokens")
     data: dict[str, int] = {}

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6279,7 +6279,7 @@ def _session_usage_data_from_params(params: _JsonObject) -> dict[str, int] | Non
         return None
     cumulative_input_tokens = total.get("inputTokens")
     context_window = token_usage.get("modelContextWindow")
-    if context_window is None:
+    if not isinstance(context_window, int) or context_window <= 0:
         context_window = total.get("contextWindow")
     output_tokens = total.get("outputTokens")
     cached_input_tokens = total.get("cachedInputTokens")

--- a/tests/e2e/test_usage_e2e.py
+++ b/tests/e2e/test_usage_e2e.py
@@ -21,6 +21,8 @@ import httpx
 import pytest
 import yaml
 
+from omnigent import codex_native_forwarder
+
 _OWNER_EMAIL = "usage-owner@e2e.test"
 _AGENT_NAME = "e2e-usage-test"
 
@@ -80,3 +82,40 @@ def test_usage_report_happy_path(http_client: httpx.Client) -> None:
     # No turn ran, so the fresh session is priced at zero with no per-model cost.
     assert by_id[session_id]["cost_usd"] == 0.0
     assert by_id[session_id]["models"] == {}
+
+
+@pytest.mark.compat_smoke
+def test_codex_effective_context_window_reaches_session_snapshot(
+    http_client: httpx.Client,
+) -> None:
+    """A Codex usage frame persists its effective window through the live server."""
+    session_id = _create_session(http_client, email=_OWNER_EMAIL)
+    usage_data = codex_native_forwarder._session_usage_data_from_params(
+        {
+            "tokenUsage": {
+                "modelContextWindow": 258_400,
+                "total": {
+                    "inputTokens": 206_533,
+                    "outputTokens": 1_000,
+                    "contextWindow": 1_050_000,
+                },
+                "last": {"inputTokens": 206_533},
+            },
+        }
+    )
+    assert usage_data is not None
+
+    resp = http_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_session_usage", "data": usage_data},
+        headers={"X-Forwarded-Email": _OWNER_EMAIL},
+    )
+    assert resp.status_code == 202, resp.text
+
+    snapshot = http_client.get(
+        f"/v1/sessions/{session_id}",
+        headers={"X-Forwarded-Email": _OWNER_EMAIL},
+    )
+    snapshot.raise_for_status()
+    assert snapshot.json()["last_total_tokens"] == 206_533
+    assert snapshot.json()["context_window"] == 258_400

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -8418,6 +8418,55 @@ def test_session_usage_data_without_output_tokens_omits_cumulative_output() -> N
     assert "cumulative_output_tokens" not in data
 
 
+def test_session_usage_data_uses_effective_model_context_window() -> None:
+    """The context ring uses Codex's effective model window when available."""
+    params = {
+        "tokenUsage": {
+            "modelContextWindow": 258_400,
+            "total": {
+                "inputTokens": 200_000,
+                "outputTokens": 10_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 258_400
+
+
+def test_session_usage_data_prefers_effective_context_window_over_legacy() -> None:
+    """Codex's effective window takes precedence over the legacy total field."""
+    params = {
+        "tokenUsage": {
+            "modelContextWindow": 258_400,
+            "total": {
+                "inputTokens": 200_000,
+                "outputTokens": 10_000,
+                "contextWindow": 1_050_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 258_400
+
+
+def test_session_usage_data_invalid_effective_window_falls_back_to_legacy() -> None:
+    """Malformed effective windows do not suppress a valid legacy fallback."""
+    params = {
+        "tokenUsage": {
+            "modelContextWindow": 0,
+            "total": {
+                "inputTokens": 200_000,
+                "contextWindow": 1_050_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 1_050_000
+
+
 def test_session_usage_data_context_tokens_uses_last_turn_input() -> None:
     """
     ``context_tokens`` (the context-ring value) should reflect the LAST

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -729,10 +729,11 @@ def _usage_event(input_tokens: int, context_window: int = 200_000) -> dict[str, 
         "params": {
             "threadId": "thread_123",
             "tokenUsage": {
+                "modelContextWindow": context_window,
                 "total": {
                     "inputTokens": input_tokens,
-                    "contextWindow": context_window,
                 },
+                "last": {"inputTokens": input_tokens},
             },
         },
     }


### PR DESCRIPTION
## Related issue

Closes #5025

## Summary

- Read Codex 0.147 effective context size from `tokenUsage.modelContextWindow`.
- Preserve `tokenUsage.total.contextWindow` as a compatibility fallback, including when the effective field is malformed or non-positive.
- Add parser regressions and a live-server E2E journey proving the effective window reaches the session snapshot.

ELI5: Omnigent counted the right tokens but divided them by the wrong maximum. This forwards and persists the maximum Codex actually uses.

```text
Codex token usage -> native forwarder -> external_session_usage -> session snapshot
  effective: 258,400       258,400                258,400          258,400
  legacy:  1,050,000       ignored
```

## Test Plan

- `uv run pytest tests/test_codex_native.py -k 'session_usage_data or forwarder_posts_codex_usage_live_per_frame' -q`
  - 10 passed.
- `uv run pytest -o addopts='' tests/e2e/test_usage_e2e.py --llm-api-key=test-key -q`
  - 2 passed.
- `uv run pre-commit run --files omnigent/codex_native_forwarder.py tests/test_codex_native.py tests/e2e/test_usage_e2e.py`
  - All hooks passed.

## Demo

The new live-server E2E sends a Codex frame containing conflicting windows, receives `202 Accepted`, then verifies the real session snapshot:

```text
modelContextWindow: 258400
legacy contextWindow: 1050000
snapshot context_window: 258400
snapshot last_total_tokens: 206533
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Parser tests cover the effective field, precedence over the legacy field, malformed-field fallback, and older payload compatibility. The E2E test boots the real server, posts the parsed usage event, and verifies the persisted session snapshot.

## Changelog

Codex sessions now show context usage against the effective context window reported by Codex.
