### PR TITLE
Fix project new-session draft workspace leakage

### DIFF
--- a/tests/e2e_ui/start_session/test_project_config_prefill.py
+++ b/tests/e2e_ui/start_session/test_project_config_prefill.py
@@ -35,6 +35,7 @@ _HOST_ID = "host_e2e_cfg"
 _PROJECT_ID = "proj_e2e_cfg"
 _PROJECT_NAME = "ConfiguredProject"
 _CONFIG_WORKSPACE = "/work/configured-repo"
+_DRAFT_WORKSPACE = "/work/unfiled-draft"
 # Bare create endpoint (POST captured); NOT the /{id}/... sub-routes.
 _SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
 # One project config endpoint: /v1/projects/<id> (not the bare list).
@@ -121,12 +122,14 @@ def _project_config_body() -> str:
     )
 
 
-def test_composer_prefills_from_project_config(seeded_session: tuple[str, str]) -> None:
-    """A ``?project=`` visit seeds host / workspace / agent from stored config.
+def test_project_config_replaces_unfiled_draft_launch_state(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A project visit keeps draft text but replaces unrelated launch state.
 
-    The pinned agent (``ag_pinned_e2e``) and workspace (``/work/configured-repo``)
-    come from ``config`` — NOT from the default-ranked Claude Code or a recent
-    workspace — and ride along to ``POST /v1/sessions``.
+    An unfinished global composer starts in a recent workspace, then unmounts
+    through normal SPA navigation. The project's sidebar action must restore the
+    message while replacing that workspace and default agent from stored config.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_prefill(base_url, session_id))
@@ -192,9 +195,30 @@ async def _drive_prefill(base_url: str, session_id: str) -> None:
             await page.route(_SESSIONS_RE, handle_sessions)
             await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
 
-            await page.goto(f"{base_url}/?project={_PROJECT_NAME}")
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["{_DRAFT_WORKSPACE}"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
+            )
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "unfiled-draft", timeout=15_000
+            )
+            await page.get_by_test_id("new-chat-landing-input").fill("start here")
+
+            await page.locator(f'a[href="/c/{session_id}"]').click()
+            await page.wait_for_url(f"**/c/{session_id}")
+            await page.get_by_role("link", name=f"New session in {_PROJECT_NAME}").click()
+            await page.wait_for_url(f"**/?project={_PROJECT_NAME}")
+
+            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_value("start here")
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "configured-repo", timeout=15_000
             )
 
             # The agent picker trigger reflects the config-pinned agent (Polly),
@@ -203,7 +227,6 @@ async def _drive_prefill(base_url: str, session_id: str) -> None:
                 "Polly", timeout=15_000
             )
 
-            await page.get_by_test_id("new-chat-landing-input").fill("start here")
             await page.get_by_test_id("new-chat-landing-submit").click()
 
             await _wait_until(lambda: len(create_bodies) == 1)

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -15,7 +15,7 @@ import { useProjectConfig, useProjects } from "@/hooks/useConversations";
 import type { ProjectConfig } from "@/lib/projectsApi";
 import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import type { HostWorktree } from "@/hooks/useHostWorktrees";
-import { NewChatLandingScreen } from "./NewChatDialog";
+import { NewChatLandingScreen, resetLandingDraft } from "./NewChatDialog";
 
 // A `?project=` visit prefills the composer from the project's STORED config
 // (host / working directory / agent / worktree). A field the config leaves
@@ -147,6 +147,7 @@ async function submitAndReadBody(): Promise<Record<string, unknown>> {
 }
 
 beforeEach(() => {
+  resetLandingDraft();
   navigateMock.mockReset();
   vi.mocked(authenticatedFetch).mockReset();
   searchParams = new URLSearchParams("project=Alpha");
@@ -177,6 +178,63 @@ afterEach(() => {
 });
 
 describe("NewChatLandingScreen project prefill", () => {
+  it("applies project defaults after restoring an unfiled draft", async () => {
+    searchParams = new URLSearchParams();
+    setProjectConfig({});
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("foo"),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "keep this draft" },
+    });
+    const file = new File(["data"], "draft.txt", { type: "text/plain" });
+    fireEvent.change(screen.getByTestId("new-chat-landing-file-input"), {
+      target: { files: [file] },
+    });
+
+    cleanup();
+    searchParams = new URLSearchParams("project=Alpha");
+    vi.mocked(useHosts).mockReturnValue({
+      data: [host(), host({ host_id: "host_2", name: "build-box" })],
+    } as ReturnType<typeof useHosts>);
+    setProjectConfig({ host_id: "host_2", workspace: REPO, agent_id: "ag_other" });
+    renderLanding();
+
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "keep this draft",
+    );
+    expect(screen.getByText("draft.txt")).toBeTruthy();
+    const body = await submitAndReadBody();
+    expect(body.host_id).toBe("host_2");
+    expect(body.workspace).toBe(REPO);
+    expect(body.agent_id).toBe("ag_other");
+  });
+
+  it("preserves launch choices when restoring a draft for the same project", async () => {
+    setProjectConfig({ host_id: "host_1", workspace: REPO, agent_id: "ag_other" });
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("alpha"),
+    );
+
+    cleanup();
+    vi.mocked(useHosts).mockReturnValue({
+      data: [host(), host({ host_id: "host_2", name: "build-box" })],
+    } as ReturnType<typeof useHosts>);
+    setProjectConfig({
+      host_id: "host_2",
+      workspace: "/Users/corey/projects/alpha-updated",
+      agent_id: "ag_hello",
+    });
+    renderLanding();
+
+    const body = await submitAndReadBody();
+    expect(body.host_id).toBe("host_1");
+    expect(body.workspace).toBe(REPO);
+    expect(body.agent_id).toBe("ag_other");
+  });
+
   it("seeds host / workspace / agent from the stored config", async () => {
     setProjectConfig({ host_id: "host_1", workspace: REPO, agent_id: "ag_other" });
     renderLanding();

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2394,6 +2394,53 @@ describe("NewChatLandingScreen", () => {
     expect("git" in body).toBe(false);
   });
 
+  it("drops sandbox launch state restored from another project", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    const first = renderLanding(
+      { managed_sandboxes_enabled: true, sandbox_provider: "daytona" },
+      "/?project=Beta",
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "Daytona Sandbox",
+      ),
+    );
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "https://github.com/org/beta" },
+    });
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
+      target: { value: "beta-branch" },
+    });
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "keep sandbox draft" },
+    });
+    first.unmount();
+
+    renderLanding(
+      { managed_sandboxes_enabled: true, sandbox_provider: "modal" },
+      "/?project=Alpha",
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "Modal Sandbox",
+      ),
+    );
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "keep sandbox draft",
+    );
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.workspace).toBeUndefined();
+    expect(body.sandbox_provider).toBe("modal");
+  });
+
   it("carries the picked provider in the managed create when several are offered", async () => {
     // A multi-provider server renders one row per provider. Picking the
     // second (non-default) row must ride into the POST as sandbox_provider,
@@ -4277,6 +4324,23 @@ describe("NewChatLandingScreen Smart Routing harness row", () => {
     openPicker();
     expect(screen.getByTestId(SMART_ROUTING_ROW)).toHaveAttribute("data-active", "true");
     expect(screen.getByTestId("new-chat-landing-agent-a1")).not.toHaveAttribute("data-active");
+  });
+
+  it("drops Smart Routing restored from another project", async () => {
+    const first = renderLanding({ smart_routing_enabled: true }, "/?project=Beta");
+    selectSmartRoutingHarness();
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "keep routing draft" },
+    });
+    first.unmount();
+
+    renderLanding({ smart_routing_enabled: true }, "/?project=Alpha");
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "keep routing draft",
+    );
+    const { body } = await submitAndReadBody();
+    expect(body.harness_override).toBeUndefined();
+    expect(body.smart_routing_message).toBeUndefined();
   });
 
   it.each([

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1872,6 +1872,7 @@ function HarnessConfigModal({
 // when the user navigates into an existing session and back. Module-scoped,
 // not persisted to storage (a page refresh starts clean); cleared on create.
 interface LandingDraft {
+  projectName: string;
   message: string;
   files: File[];
   pickedAgentId: string | null;
@@ -2071,16 +2072,20 @@ export function NewChatLandingScreen() {
   // Project driving this visit, when the sidebar's per-project "new session"
   // pencil landed here with a `?project=` query param. Empty otherwise.
   const projectParam = searchParams.get("project") ?? "";
+  // Launch choices only survive a round-trip back to the same project. The
+  // message and attachments above remain reusable across project boundaries.
+  const matchingProjectDraft = landingDraft?.projectName === projectParam ? landingDraft : null;
+  const projectDraftMismatch = landingDraft !== null && matchingProjectDraft === null;
   // Seeded from the persisted last pick so a returning user starts on the
   // agent they used last; validated against the live list in
   // effectiveAgentId below (a stale id falls back to the default). A
   // project-driven visit defers to the project-prefill effect instead
   // (which falls back to the same last pick).
   const [pickedAgentId, setPickedAgentId] = useState<string | null>(
-    () => landingDraft?.pickedAgentId ?? (projectParam !== "" ? null : readLastAgentId()),
+    () => matchingProjectDraft?.pickedAgentId ?? (projectParam !== "" ? null : readLastAgentId()),
   );
   const [selectedHostId, setSelectedHostId] = useState<string | null>(
-    () => landingDraft?.selectedHostId ?? null,
+    () => matchingProjectDraft?.selectedHostId ?? null,
   );
   // Sessions on the selected host — fetched only when a host is selected,
   // to avoid registering hundreds of sessions into the health poll at idle.
@@ -2089,13 +2094,13 @@ export function NewChatLandingScreen() {
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
   const [sandboxSelected, setSandboxSelected] = useState(
-    () => landingDraft?.sandboxSelected ?? false,
+    () => matchingProjectDraft?.sandboxSelected ?? false,
   );
   // Provider the sandbox pick launches on. Seeded to the sticky last pick (or
   // the first offered row) once the picker rows load; null both before that
   // seed and for a single-provider server that names no provider.
   const [sandboxProvider, setSandboxProvider] = useState<string | null>(
-    () => landingDraft?.sandboxProvider ?? null,
+    () => matchingProjectDraft?.sandboxProvider ?? null,
   );
   const { data: hostClaudeModelOptions, isLoading: hostClaudeModelsLoading } = useHostModelOptions(
     selectedHostId,
@@ -2136,13 +2141,15 @@ export function NewChatLandingScreen() {
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
   const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
-    () => landingDraft?.sandboxRepoUrl ?? "",
+    () => matchingProjectDraft?.sandboxRepoUrl ?? "",
   );
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
-    () => landingDraft?.sandboxRepoBranch ?? "",
+    () => matchingProjectDraft?.sandboxRepoBranch ?? "",
   );
-  const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
-  const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
+  const [workspace, setWorkspace] = useState<string>(() => matchingProjectDraft?.workspace ?? "");
+  const [branchName, setBranchName] = useState<string>(
+    () => matchingProjectDraft?.branchName ?? "",
+  );
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
   // touches it — clearing the branch name re-arms the auto-fill (see the effect
@@ -2159,7 +2166,7 @@ export function NewChatLandingScreen() {
   // that worktree (no git opts). Editing the field away from it means the user
   // wants a *new* worktree off that name.
   const [prefilledBranch, setPrefilledBranch] = useState<string>(
-    () => landingDraft?.prefilledBranch ?? "",
+    () => matchingProjectDraft?.prefilledBranch ?? "",
   );
   // Project to file the new session under. Empty = unfiled. Stamped as the
   // `omni_project` label at create (so the row is filed from its first sidebar
@@ -2208,8 +2215,10 @@ export function NewChatLandingScreen() {
   // switch, seeded from the user's last stored pick for that agent.
   const [pickedHarness, setPickedHarness] = useState<string | null>(
     () =>
-      landingDraft?.pickedHarness ??
-      readLastHarness(landingDraft?.pickedAgentId ?? readLastAgentId()),
+      matchingProjectDraft?.pickedHarness ??
+      (projectDraftMismatch
+        ? null
+        : readLastHarness(matchingProjectDraft?.pickedAgentId ?? readLastAgentId())),
   );
   // Per-session model + reasoning effort for the claude-native model picker.
   // "" = unselected: nothing is checked and `model_override` / `reasoning_effort`
@@ -2222,7 +2231,7 @@ export function NewChatLandingScreen() {
   // (null) defers to the agent spec's default and is omitted from
   // the create body.
   const [costControlMode, _setCostControlMode] = useState<CostControlMode>(
-    () => landingDraft?.costControlMode ?? null,
+    () => matchingProjectDraft?.costControlMode ?? null,
   );
   // Model selection and smart routing are mutually exclusive: enabling
   // routing clears the explicit model pick, and picking a model turns
@@ -2264,6 +2273,7 @@ export function NewChatLandingScreen() {
   const onScreenRef = useRef(true);
   const draftRef = useRef<LandingDraft>(null as unknown as LandingDraft);
   draftRef.current = {
+    projectName: projectParam,
     message,
     files,
     pickedAgentId,
@@ -3185,7 +3195,9 @@ export function NewChatLandingScreen() {
     if (writes.hostId !== undefined) setSelectedHostId((cur) => cur ?? writes.hostId!);
     if (writes.agentId !== undefined) {
       setPickedAgentId((cur) => cur ?? writes.agentId!);
-      if (pickedAgentId === null) setPickedHarness(readLastHarness(writes.agentId));
+      if (pickedAgentId === null) {
+        setPickedHarness(projectDraftMismatch ? null : readLastHarness(writes.agentId));
+      }
     }
     if (writes.workspace !== undefined) {
       setWorkspace((cur) => (cur === "" ? writes.workspace! : cur));
@@ -3201,6 +3213,7 @@ export function NewChatLandingScreen() {
     managedSandboxesEnabled,
     selectedHostId,
     pickedAgentId,
+    projectDraftMismatch,
     prefillConfig,
     defaultSandboxProvider,
   ]);


### PR DESCRIPTION
## Related issue

Closes #5023

## Summary

- Tag preserved New Chat drafts with their source project context.
- Across project boundaries, retain authored message and attachments while reseeding host, workspace, agent, sandbox, worktree, and routing choices from the destination project.
- Preserve full launch-state restoration when returning to the same project context.

ELI5: unfinished text can follow you into another project, but the old project's launch settings cannot.

```mermaid
flowchart LR
    A[Restore unfinished draft] --> B{Same project context?}
    B -- Yes --> C[Restore content and launch choices]
    B -- No --> D[Restore message and attachments]
    D --> E[Apply destination project defaults]
```

## Test Plan

- `cd web && pnpm exec vitest run src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.projectPrefill.test.tsx` — 290 passed.
- `uv run --no-sync pytest tests/e2e_ui/start_session/test_project_config_prefill.py::test_project_config_replaces_unfiled_draft_launch_state -q` — passed.
- `cd web && pnpm run lint && pnpm run type-check && pnpm run build` — passed.
- `uv run --no-sync pre-commit run --all-files` — passed.
- Full Web UI suite — 5,787 passed, 3 expected failures, 1 skipped.

## Demo

N/A — no new visual surface. Playwright drives the visible workspace chip through the failing navigation sequence and verifies the submitted request uses the destination project workspace while preserving draft text.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The colocated Vitest regression covers project mismatch, same-project restoration, managed sandbox state, and Smart Routing state at the create-request boundary. Playwright covers the real SPA navigation path from an unfinished global composer through the project sidebar action.

## Changelog

Project new sessions now use their configured workspace instead of launch settings restored from another unfinished draft.