### PR TITLE
fix(native): deliver spec.instructions to native harness launches

### DIFF
--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3174,6 +3174,7 @@ async def _run_auto_create_claude_terminal_for_routing_class(
     session_id: str,
     routed: bool,
     auto_harness: bool = False,
+    agent_spec: Any = None,
 ) -> Any:
     """Drive the claude-native launch and return the captured terminal spec.
 
@@ -3182,6 +3183,8 @@ async def _run_auto_create_claude_terminal_for_routing_class(
     :param auto_harness: Stamp the auto-harness label and sentinel WITHOUT the
         cost-control field, which is the shape a sub-agent child of a routed
         parent is created with.
+    :param agent_spec: Resolved agent spec for the session, threaded through so
+        a bundle's ``instructions:`` reaches ``--append-system-prompt`` (#3530).
     """
     from omnigent.claude_native import ClaudeNativeUcodeConfig
 
@@ -3264,6 +3267,7 @@ async def _run_auto_create_claude_terminal_for_routing_class(
             _FakeResourceRegistry(),
             lambda _sid, _evt: None,
             server_client=fake_client,
+            agent_spec=agent_spec,
         )
     finally:
         from omnigent.runner import subagent_routing, turn_routing
@@ -3605,3 +3609,125 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
         assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed
 
     await fake_client.aclose()
+
+
+# ── Bundle instructions reach the native session (#3530) ────────────────────
+#
+# A bundle declaring ``instructions: <sibling file>`` had that text silently
+# dropped for harness executors: ``build_instructions`` composed it into the
+# turn's ``system_prompt``, and every native executor's ``run_turn`` opens
+# ``del tools, system_prompt`` because a native harness drives an
+# already-running CLI no per-turn prompt can reach. Delivery therefore happens
+# at LAUNCH, through each harness's additive instruction channel — for
+# claude-native, ``--append-system-prompt``.
+#
+# That channel already carried Smart Routing's routed-spawn note, so the two
+# texts must COMPOSE. These tests pin all four corners of that matrix.
+
+_BUNDLE_INSTRUCTIONS = "# Ferrous Sparrow Protocol\n\nAlways greet in Latin."
+
+
+def _claude_append_system_prompt(spec: Any) -> str | None:
+    """Return the value passed to ``--append-system-prompt``, or ``None``."""
+    if "--append-system-prompt" not in spec.args:
+        return None
+    return spec.args[spec.args.index("--append-system-prompt") + 1]
+
+
+async def test_claude_native_launch_delivers_bundle_instructions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pinned session's bundle instructions reach ``--append-system-prompt``.
+
+    The regression #3530 reports: a distinctive heading in the bundle's
+    instructions file never appears in the launched session's context. Before
+    the fix this argv carried no ``--append-system-prompt`` at all, because the
+    flag was fed solely from the routed-spawn note and a pinned session has none.
+    """
+    spec = await _run_auto_create_claude_terminal_for_routing_class(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="4a1c9b1d1f0e4c5da0a1b2c3d4e5f610",
+        routed=True,
+        agent_spec=AgentSpec(spec_version=1, name="sparrow", instructions=_BUNDLE_INSTRUCTIONS),
+    )
+
+    assert spec.args.count("--append-system-prompt") == 1
+    assert _claude_append_system_prompt(spec) == _BUNDLE_INSTRUCTIONS
+
+
+async def test_claude_native_launch_composes_instructions_with_spawn_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both the bundle instructions AND the routed-spawn note arrive.
+
+    The rebase hazard that stalled the first attempt at this fix: the
+    routed-spawn note already owned ``--append-system-prompt``, so writing the
+    spec's instructions into it naively drops the note (or vice versa). One flag
+    is emitted, and it carries both texts — user-authored first, framework
+    policy last, matching ``append_framework_instructions``.
+    """
+    from omnigent.inner.hook_scripts.subagent_router import smart_routing_spawn_note
+
+    spec = await _run_auto_create_claude_terminal_for_routing_class(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="4a1c9b1d1f0e4c5da0a1b2c3d4e5f611",
+        routed=True,
+        auto_harness=True,
+        agent_spec=AgentSpec(spec_version=1, name="sparrow", instructions=_BUNDLE_INSTRUCTIONS),
+    )
+
+    # Claude Code accepts the flag once; a second occurrence would mean one
+    # text was appended as a rival flag rather than composed into the slot.
+    assert spec.args.count("--append-system-prompt") == 1
+    composed = _claude_append_system_prompt(spec)
+    assert composed is not None
+    note = smart_routing_spawn_note("claude-native")
+    assert _BUNDLE_INSTRUCTIONS in composed
+    assert note.strip() in composed
+    # Ordering is load-bearing: framework policy gets the final word.
+    assert composed.index(_BUNDLE_INSTRUCTIONS) < composed.index(note.strip())
+
+
+async def test_claude_native_launch_without_instructions_keeps_argv_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``instructions:`` in the bundle → the note alone, unchanged.
+
+    The launch sites treat "a session that contributes nothing extra keeps an
+    argv byte-identical to before" as an invariant. Composition must not perturb
+    the note — notably it must not ``.strip()`` it, since the note ends in a
+    space from ``_mcp_discovery_note``.
+    """
+    from omnigent.inner.hook_scripts.subagent_router import smart_routing_spawn_note
+
+    spec = await _run_auto_create_claude_terminal_for_routing_class(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="4a1c9b1d1f0e4c5da0a1b2c3d4e5f612",
+        routed=True,
+        auto_harness=True,
+        agent_spec=AgentSpec(spec_version=1, name="sparrow"),
+    )
+
+    assert _claude_append_system_prompt(spec) == smart_routing_spawn_note("claude-native")
+
+
+async def test_claude_native_plain_launch_still_appends_no_system_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither instructions nor note → the flag is absent entirely.
+
+    Guards the other direction of the byte-identity invariant: the fix must not
+    start emitting an empty ``--append-system-prompt`` for plain sessions.
+    """
+    spec = await _run_auto_create_claude_terminal_for_routing_class(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="4a1c9b1d1f0e4c5da0a1b2c3d4e5f613",
+        routed=True,
+        agent_spec=AgentSpec(spec_version=1, name="sparrow", instructions="   \n  "),
+    )
+
+    assert "--append-system-prompt" not in spec.args

--- a/tests/runner/test_native_launch_instructions.py
+++ b/tests/runner/test_native_launch_instructions.py
@@ -1,0 +1,59 @@
+"""Focused coverage for raw author instructions used by native launches.
+
+The shared resolver feeds claude-native's ``--append-system-prompt`` and
+codex-native's ``developer_instructions`` launch channels. Composition with
+framework-owned routing notes is covered at those launch boundaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.native.orchestration import (
+    ResolvedSpec,
+    _native_startup_raw_instructions_from_spec,
+)
+from omnigent.spec.types import AgentSpec
+
+_INSTRUCTIONS = "# Ferrous Sparrow Protocol\n\nAlways greet in Latin."
+
+
+def test_native_startup_instructions_are_read_from_a_bare_agent_spec() -> None:
+    """Resolved bundle instructions are read directly from ``AgentSpec``."""
+    spec = AgentSpec(spec_version=1, name="sparrow", instructions=_INSTRUCTIONS)
+
+    assert _native_startup_raw_instructions_from_spec(spec) == _INSTRUCTIONS
+
+
+def test_native_startup_instructions_are_read_through_a_resolved_spec_wrapper() -> None:
+    """Managed launch sites may receive a ``ResolvedSpec`` wrapper."""
+    spec = AgentSpec(spec_version=1, name="sparrow", instructions=_INSTRUCTIONS)
+    resolved = ResolvedSpec(spec=spec, workdir=Path("/tmp"))
+
+    assert _native_startup_raw_instructions_from_spec(resolved) == _INSTRUCTIONS
+
+
+@pytest.mark.parametrize(
+    "agent_spec",
+    [
+        None,
+        AgentSpec(spec_version=1, name="sparrow"),
+        AgentSpec(spec_version=1, name="sparrow", instructions="  \n\t "),
+    ],
+    ids=["missing-spec", "missing-instructions", "blank-instructions"],
+)
+def test_missing_or_blank_native_startup_instructions_contribute_nothing(
+    agent_spec: AgentSpec | None,
+) -> None:
+    """Empty inputs do not cause either native launch channel to be emitted."""
+    assert _native_startup_raw_instructions_from_spec(agent_spec) is None
+
+
+def test_native_startup_instructions_preserve_author_whitespace() -> None:
+    """Nonblank author text remains byte-identical for the launch channel."""
+    instructions = f"  {_INSTRUCTIONS}  "
+    spec = AgentSpec(spec_version=1, name="sparrow", instructions=instructions)
+
+    assert _native_startup_raw_instructions_from_spec(spec) == instructions

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2246,3 +2246,51 @@ def test_resolve_databricks_codex_model_matches_servable_ids() -> None:
             _resolve_databricks_codex_model("https://h.example.com", "prof", "databricks-gpt-9-9")
             == "databricks-gpt-9-9"
         )
+
+
+def test_bundle_instructions_and_spawn_note_share_developer_instructions(
+    tmp_path: Path,
+) -> None:
+    """A bundle's ``instructions:`` ride codex's additive channel WITH the note (#3530).
+
+    codex-native has exactly one additive instruction slot, and the routed-spawn
+    note already owned it. The launch site therefore composes the bundle's
+    instructions with the note and passes ONE string; this asserts that string
+    survives the sidecar round trip intact — both texts present, layered on top
+    of the user's own guidance, and fully reversible on a resumed / pinned
+    launch so a session leaving auto-harness mode carries neither stale routing
+    framing nor stale agent instructions.
+    """
+    from omnigent.inner.hook_scripts.subagent_router import smart_routing_spawn_note
+    from omnigent.runner.native.orchestration import (
+        _native_startup_raw_instructions_from_spec,
+    )
+    from omnigent.spec.types import AgentSpec
+
+    bundle_instructions = "# Ferrous Sparrow Protocol\n\nAlways greet in Latin."
+    note = smart_routing_spawn_note("codex-native")
+    author_instructions = _native_startup_raw_instructions_from_spec(
+        AgentSpec(spec_version=1, name="sparrow", instructions=bundle_instructions)
+    )
+    composed = "\n\n".join(x for x in [author_instructions, note] if x) or None
+    assert composed is not None
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text('developer_instructions = "Keep user guidance."\n', encoding="utf-8")
+
+    _sync_codex_developer_instructions(codex_home, composed)
+
+    active = tomllib.loads(config_path.read_text(encoding="utf-8"))["developer_instructions"]
+    # The regression #3530 reports: this heading never reached the session.
+    assert "Ferrous Sparrow Protocol" in active
+    # ...and the routing framing it used to displace is still there too.
+    assert "sys_session_create" in active
+    assert active.startswith("Keep user guidance.")
+    assert active.index(bundle_instructions) < active.index(note.strip())
+
+    _sync_codex_developer_instructions(codex_home, None)
+
+    resumed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert resumed["developer_instructions"] == "Keep user guidance."


### PR DESCRIPTION
## Related issue

Part of #3530

## Summary

- Deliver bundle `instructions:` during native Claude and Codex launch, where each CLI can receive additive instructions.
- Compose bundle instructions with Smart Routing's existing spawn note without changing launches that have no bundle instructions.
- ELI5: native sessions now receive their agent instructions when the CLI starts instead of dropping them before the first turn.

```mermaid
flowchart LR
  A[Bundle instructions] --> B[Native launch]
  C[Routing note] --> B
  B --> D[Claude or Codex additive instructions]
```

## Test Plan

- `uv run --frozen pytest tests/runner/test_native_launch_instructions.py tests/runner/test_app_sessions_native_terminals_autocreate.py tests/test_codex_native_app_server.py` → 143 passed.
- `git diff --check` → passed.

## Demo

![Before and after native launch instruction delivery for Claude and Codex](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-5035-review-evidence.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover Claude and Codex launch delivery, composition with routing instructions, empty-instruction behavior, and existing native terminal launch paths.

## Changelog

Native Claude and Codex sessions now receive bundle instructions when they launch.

