### PR TITLE
OMNI-3747-remove-margin-around-shell-in-right-side-panel

### DIFF
--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -481,7 +481,7 @@ function RailTerminalView({
     );
   }
   return (
-    <div key={terminal.id} className="flex h-full min-h-0 flex-col p-2">
+    <div key={terminal.id} className="flex h-full min-h-0 flex-col">
       <TerminalView
         sessionId={conversationId}
         terminalId={terminal.id}


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-3747/remove-margin-around-shell-in-right-side-panel

## Summary

- The shell in the right-side workspace panel rendered inside a wrapper with `p-2`, leaving an 8px margin around the terminal on all sides.
- Removed that padding so the shell fills the panel edge-to-edge, flush under the tab strip — matching the sibling `FileViewer` (which renders `frameless`) and the intended design.
- One-line change in `RailTerminalView` (`web/src/shell/WorkspacePanel.tsx`); the height/flex classes stay so the terminal still fills the panel.

## Test Plan

1. Start the web dev server (`just dev`) and open a session.
2. Open the right-side workspace panel → **Shells** tab → open a shell tab.
3. Confirm the terminal touches the panel's left/right/bottom edges and sits flush under the tab strip, with no gray gutter around it (see Before/After below).

## Demo

### Before

<img width="1375" height="596" alt="pbefore" src="https://github.com/user-attachments/assets/e1ddb224-d0bd-4cc6-95ad-640d3918ae1e" />

### After

<img width="1378" height="604" alt="pafter" src="https://github.com/user-attachments/assets/6a0faa60-25f4-4e5c-82c9-0d598296d75a" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually in the web UI (before/after screenshots above). This is a
CSS-only padding removal with no logic change; no automated test asserted the
old `p-2` padding, so none needed updating.

## Changelog

Removed the margin around the shell in the right-side panel so the terminal fills the panel edge-to-edge
