### PR TITLE
fix(runner): reap failed Claude-native sessions

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3176,10 +3176,16 @@ def kill_session(
         there is no live session to kill.
     :returns: None.
     :raises RuntimeError: If the tmux target is not advertised in
-        time, or if the ``tmux kill-session`` invocation fails.
+        time, or if ``tmux kill-session`` fails for an unexpected reason.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])
+    try:
+        _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])
+    except RuntimeError as exc:
+        detail = str(exc).lower()
+        if "can't find session" in detail or "no server running on" in detail:
+            return
+        raise
 
 
 def inject_slash_command(

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -253,6 +253,14 @@ _INVOCATION_SETTINGS_FILE = "claude-settings.json"
 ToolExecutor = Callable[[str, _JsonObject], Awaitable[object]]
 
 
+class ClaudePromptTimeout(RuntimeError):
+    """Claude Code's input box did not render before delivery timed out."""
+
+
+class TmuxSessionNotAdvertised(RuntimeError):
+    """The bridge's tmux target was not advertised before the deadline."""
+
+
 def _absolute_syntactic_path(path: Path) -> Path:
     """
     Return an absolute path without following symlinks.
@@ -3827,7 +3835,7 @@ def _wait_for_claude_prompt_ready(
     :param tmux_target: tmux pane target string, e.g. ``"main"``.
     :param timeout_s: Seconds to wait for the prompt, e.g. ``30.0``.
     :returns: None.
-    :raises RuntimeError: If the prompt never renders within
+    :raises ClaudePromptTimeout: If the prompt never renders within
         *timeout_s* (Claude failed to boot). The message carries a poll
         count, how many of those polls saw an empty capture, and the tail
         of the last non-empty capture the loop actually observed (see
@@ -3864,7 +3872,7 @@ def _wait_for_claude_prompt_ready(
     # session is alive but capture-pane came back blank); non-empty captures
     # with no box point at Claude never rendering the prompt (a boot crash,
     # e.g. a ``JSON Parse error``, whose text the tail then surfaces).
-    raise RuntimeError(
+    raise ClaudePromptTimeout(
         f"Claude Code terminal did not become ready within {timeout_s}s "
         f"(input prompt never rendered in {polls} polls, "
         f"{empty_polls} empty captures). The message was not delivered."
@@ -3920,7 +3928,7 @@ def _wait_for_tmux_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, str]
     :param bridge_dir: Bridge directory path.
     :param timeout_s: Seconds to wait, e.g. ``30.0``.
     :returns: ``{"socket_path": ..., "tmux_target": ...}``.
-    :raises RuntimeError: If the file never appears with valid
+    :raises TmuxSessionNotAdvertised: If the file never appears with valid
         ``socket_path`` and ``tmux_target`` fields.
     """
     deadline = time.monotonic() + timeout_s
@@ -3932,7 +3940,7 @@ def _wait_for_tmux_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, str]
         if isinstance(socket_path, str) and isinstance(tmux_target, str):
             return {"socket_path": socket_path, "tmux_target": tmux_target}
         time.sleep(0.05)
-    raise RuntimeError(
+    raise TmuxSessionNotAdvertised(
         "Claude terminal tmux target is not advertised yet. Wait for the "
         "terminal to launch before sending messages from the web UI."
     )

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -13,8 +13,10 @@ from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     REQUEST_SESSION_ID_ENV_VAR,
     SWITCH_MODEL_DIALOG_HINT,
+    ClaudePromptTimeout,
     inject_slash_command,
     inject_user_message,
+    kill_session,
     read_active_session_id,
     read_claude_status_model,
     read_launch_model,
@@ -192,10 +194,26 @@ class ClaudeNativeExecutor(Executor):
                         self._bridge_dir,
                         content=text,
                     )
+        except ClaudePromptTimeout as exc:
+            cleanup_error = self._reap_failed_turn()
+            message = describe_exception(exc)
+            if cleanup_error is not None:
+                message = f"{message} Cleanup also failed: {cleanup_error}"
+            yield ExecutorError(message=message)
+            return
         except RuntimeError as exc:
             yield ExecutorError(message=describe_exception(exc))
             return
         yield TurnComplete(response=None)
+
+    def _reap_failed_turn(self) -> str | None:
+        """Kill the Claude pane before a delivery timeout becomes ``failed``."""
+        try:
+            kill_session(self._bridge_dir, timeout_s=1.0)
+        except RuntimeError as exc:
+            _logger.warning("claude-native: failed to reap timed-out session", exc_info=True)
+            return describe_exception(exc)
+        return None
 
     def _model_command_arg(self, wanted_model: str | None) -> str | None:
         """

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -14,6 +14,7 @@ from omnigent.claude_native_bridge import (
     REQUEST_SESSION_ID_ENV_VAR,
     SWITCH_MODEL_DIALOG_HINT,
     ClaudePromptTimeout,
+    TmuxSessionNotAdvertised,
     inject_slash_command,
     inject_user_message,
     kill_session,
@@ -210,6 +211,8 @@ class ClaudeNativeExecutor(Executor):
         """Kill the Claude pane before a delivery timeout becomes ``failed``."""
         try:
             kill_session(self._bridge_dir, timeout_s=1.0)
+        except TmuxSessionNotAdvertised:
+            _logger.debug("claude-native: timed-out session already disappeared")
         except RuntimeError as exc:
             _logger.warning("claude-native: failed to reap timed-out session", exc_info=True)
             return describe_exception(exc)

--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -436,7 +436,11 @@ class NativeInterruptRunner:
         return Response(status_code=204)
 
     async def _claude_stop(self, conv_id: str) -> Response:
-        from omnigent.claude_native_bridge import bridge_dir_for_bridge_id, kill_session
+        from omnigent.claude_native_bridge import (
+            TmuxSessionNotAdvertised,
+            bridge_dir_for_bridge_id,
+            kill_session,
+        )
 
         bridge_id = await _claude_native_bridge_id_for_session(
             server_client=self._server_client,
@@ -445,6 +449,8 @@ class NativeInterruptRunner:
         bridge_dir = bridge_dir_for_bridge_id(bridge_id)
         try:
             await asyncio.to_thread(kill_session, bridge_dir, timeout_s=1.0)
+        except TmuxSessionNotAdvertised:
+            self._logger.debug("claude-native stop: no live tmux for %s", conv_id)
         except RuntimeError as exc:
             return JSONResponse(
                 status_code=503,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -7098,10 +7098,11 @@ async def _cancel_subagent_task(
     # A dispatched child sits in ``launching`` until its runtime emits a real
     # busy edge (see ``mark_subagent_work_started``). Cancellation must still
     # route to the child during that window — otherwise cancelling a slow-to-
-    # start sub-agent would silently no-op and leave it running. A terminal
+    # start sub-agent would silently no-op and leave it running. A failed
     # claude-native entry still falls through because its pane may be alive.
     is_claude_native = entry.wrapper_label == CLAUDE_NATIVE_WRAPPER_VALUE
-    if entry.status not in ("launching", "running", "waiting") and not is_claude_native:
+    can_stop_failed_claude = is_claude_native and entry.status == "failed"
+    if entry.status not in ("launching", "running", "waiting") and not can_stop_failed_claude:
         return json.dumps(
             {
                 "cancelled": entry.status == "cancelled",

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -6998,6 +6998,53 @@ async def _execute_task_lifecycle_tool(
     )
 
 
+async def _post_session_stop(server_client: httpx.AsyncClient, task_id: str) -> str | None:
+    """Hard-stop one claude-native child through the server."""
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{task_id}/events",
+            json={"type": "stop_session", "data": {}},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        return f"Error: sys_cancel_task stop_session failed: {type(exc).__name__}: {exc}"
+    if resp.status_code >= 400:
+        return (
+            f"Error: sys_cancel_task stop_session returned {resp.status_code}: {resp.text[:200]}"
+        )
+    return None
+
+
+async def _cancel_evicted_claude_native_subagent(
+    task_id: str,
+    *,
+    conversation_id: str,
+    server_client: httpx.AsyncClient | None,
+) -> str:
+    """Stop an owned claude-native child after its work entry was evicted."""
+    if server_client is None:
+        return "Error: sys_cancel_task requires server access for sub-agent tasks"
+    try:
+        resp = await server_client.get(f"/v1/sessions/{task_id}", timeout=10.0)
+    except httpx.HTTPError as exc:
+        return f"Error: sys_cancel_task lookup failed: {type(exc).__name__}: {exc}"
+    if resp.status_code != 200:
+        return f"Error: no in-flight task with task_id {task_id}"
+    snapshot = resp.json()
+    labels = snapshot.get("labels") if isinstance(snapshot, dict) else None
+    if (
+        not isinstance(snapshot, dict)
+        or snapshot.get("parent_session_id") != conversation_id
+        or not isinstance(labels, dict)
+        or labels.get(_SESSION_WRAPPER_LABEL_KEY) != CLAUDE_NATIVE_WRAPPER_VALUE
+    ):
+        return f"Error: no in-flight task with task_id {task_id}"
+    stop_error = await _post_session_stop(server_client, task_id)
+    if stop_error is not None:
+        return stop_error
+    return json.dumps({"cancelled": True, "task_id": task_id, "status": "cancelled"})
+
+
 async def _cancel_subagent_task(
     args: _JsonObject,
     *,
@@ -7040,14 +7087,21 @@ async def _cancel_subagent_task(
     if conversation_id is None:
         return "Error: sys_cancel_task requires conversation_id"
     entry = _runner_app.get_subagent_work(str(task_id))
-    if entry is None or entry.parent_session_id != conversation_id:
+    if entry is None:
+        return await _cancel_evicted_claude_native_subagent(
+            str(task_id),
+            conversation_id=conversation_id,
+            server_client=server_client,
+        )
+    if entry.parent_session_id != conversation_id:
         return f"Error: no in-flight task with task_id {task_id}"
     # A dispatched child sits in ``launching`` until its runtime emits a real
     # busy edge (see ``mark_subagent_work_started``). Cancellation must still
     # route to the child during that window — otherwise cancelling a slow-to-
-    # start sub-agent would silently no-op and leave it running. Only terminal
-    # states (``completed`` / ``failed`` / ``cancelled``) short-circuit here.
-    if entry.status not in ("launching", "running", "waiting"):
+    # start sub-agent would silently no-op and leave it running. A terminal
+    # claude-native entry still falls through because its pane may be alive.
+    is_claude_native = entry.wrapper_label == CLAUDE_NATIVE_WRAPPER_VALUE
+    if entry.status not in ("launching", "running", "waiting") and not is_claude_native:
         return json.dumps(
             {
                 "cancelled": entry.status == "cancelled",
@@ -7060,9 +7114,7 @@ async def _cancel_subagent_task(
 
     # claude-native is the only harness with a runner-side hard-stop; every
     # other harness 204 no-ops on stop_session, so route them to interrupt.
-    event_type = (
-        "stop_session" if entry.wrapper_label == CLAUDE_NATIVE_WRAPPER_VALUE else "interrupt"
-    )
+    event_type = "stop_session" if is_claude_native else "interrupt"
 
     try:
         resp = await server_client.post(

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR
+from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR, ClaudePromptTimeout
 from omnigent.inner import claude_native_executor
 from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
 from omnigent.inner.executor import ExecutorConfig, ExecutorError, TurnComplete
@@ -1224,3 +1224,104 @@ async def test_a_routed_first_message_switches_the_model_exactly_once(
     )
     assert msg_calls == ["hello"]
     assert events == [TurnComplete(response=None)]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_reaps_tmux_before_reporting_prompt_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A readiness timeout cannot leave a failed turn's pane alive."""
+    bridge_dir = tmp_path / "bridge"
+    killed: list[Path] = []
+
+    def fail_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptTimeout("terminal did not become ready")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fail_inject)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "kill_session",
+        lambda bridge_dir_arg, *, timeout_s: killed.append(bridge_dir_arg),
+    )
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert killed == [bridge_dir]
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+
+
+@pytest.mark.asyncio
+async def test_run_turn_does_not_reap_unrelated_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only the readiness failure that terminalizes the turn triggers cleanup."""
+    killed: list[Path] = []
+
+    def fail_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise RuntimeError("tmux send-keys failed")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fail_inject)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "kill_session",
+        lambda *args, **kwargs: killed.append(args[0]),
+    )
+
+    executor = ClaudeNativeExecutor(tmp_path / "bridge")
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert killed == []
+    assert isinstance(events[0], ExecutorError)
+
+
+@pytest.mark.asyncio
+async def test_run_turn_reports_reap_failure_with_prompt_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed hard-stop remains visible beside the delivery error."""
+
+    def fail_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptTimeout("terminal did not become ready")
+
+    def fail_kill(bridge_dir_arg: Path, *, timeout_s: float) -> None:
+        del bridge_dir_arg, timeout_s
+        raise RuntimeError("tmux kill failed")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fail_inject)
+    monkeypatch.setattr(claude_native_executor, "kill_session", fail_kill)
+
+    executor = ClaudeNativeExecutor(tmp_path / "bridge")
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert isinstance(events[0], ExecutorError)
+    assert "terminal did not become ready" in events[0].message
+    assert "Cleanup also failed: tmux kill failed" in events[0].message

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -10,7 +10,11 @@ from typing import Any
 
 import pytest
 
-from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR, ClaudePromptTimeout
+from omnigent.claude_native_bridge import (
+    REQUEST_SESSION_ID_ENV_VAR,
+    ClaudePromptTimeout,
+    TmuxSessionNotAdvertised,
+)
 from omnigent.inner import claude_native_executor
 from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
 from omnigent.inner.executor import ExecutorConfig, ExecutorError, TurnComplete
@@ -1325,3 +1329,35 @@ async def test_run_turn_reports_reap_failure_with_prompt_timeout(
     assert isinstance(events[0], ExecutorError)
     assert "terminal did not become ready" in events[0].message
     assert "Cleanup also failed: tmux kill failed" in events[0].message
+
+
+@pytest.mark.asyncio
+async def test_run_turn_ignores_missing_tmux_during_timeout_reap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A pane that exited during readiness polling needs no cleanup error."""
+
+    def fail_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptTimeout("terminal did not become ready")
+
+    def absent_kill(bridge_dir_arg: Path, *, timeout_s: float) -> None:
+        del bridge_dir_arg, timeout_s
+        raise TmuxSessionNotAdvertised("not advertised")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fail_inject)
+    monkeypatch.setattr(claude_native_executor, "kill_session", absent_kill)
+
+    executor = ClaudeNativeExecutor(tmp_path / "bridge")
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert isinstance(events[0], ExecutorError)
+    assert events[0].message == "terminal did not become ready"

--- a/tests/runner/test_native_interrupt_runner.py
+++ b/tests/runner/test_native_interrupt_runner.py
@@ -233,6 +233,33 @@ async def test_codex_interrupt_noop_when_no_bridge_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_claude_stop_is_idempotent_without_advertised_tmux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-absent Claude pane still completes stop teardown."""
+    import omnigent.claude_native_bridge as claude_bridge
+    from omnigent.runner.native import interrupt as interrupt_mod
+
+    async def _fake_bridge_id(*, server_client: Any, session_id: str) -> str:
+        del server_client, session_id
+        return "bridge123"
+
+    def _absent(bridge_dir: Any, *, timeout_s: float) -> None:
+        del bridge_dir, timeout_s
+        raise claude_bridge.TmuxSessionNotAdvertised("not advertised")
+
+    monkeypatch.setattr(interrupt_mod, "_claude_native_bridge_id_for_session", _fake_bridge_id)
+    monkeypatch.setattr(claude_bridge, "bridge_dir_for_bridge_id", lambda bridge_id: bridge_id)
+    monkeypatch.setattr(claude_bridge, "kill_session", _absent)
+
+    runner, captured = _make_runner()
+    resp = await runner.stop("claude-native", "conv_cn")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    assert captured["wakes"] == [("conv_cn", "cancelled", "[System: sub-agent stopped]")]
+
+
+@pytest.mark.asyncio
 async def test_claude_interrupt_resolves_bridge_id_and_injects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5072,6 +5072,44 @@ async def test_sys_cancel_task_stops_terminal_claude_native_entry() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "cancelled"),
+    [("completed", False), ("cancelled", True)],
+)
+async def test_sys_cancel_task_returns_cached_finished_claude_native_status(
+    status: str,
+    cancelled: bool,
+) -> None:
+    """Finished Claude work does not issue a redundant hard-stop."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_finished"
+    child_id = f"conv_child_{status}"
+    entry = runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="worker",
+        title="implementation",
+        wrapper_label="claude-code-native-ui",
+    )
+    entry.status = status
+
+    try:
+        output = json.loads(
+            await _cancel_subagent_task(
+                {"task_id": child_id},
+                conversation_id=parent_id,
+                server_client=None,
+            )
+        )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert output == {"cancelled": cancelled, "task_id": child_id, "status": status}
+
+
+@pytest.mark.asyncio
 async def test_sys_cancel_task_stops_evicted_claude_native_entry() -> None:
     """Server metadata restores the cleanup path after local eviction."""
     from omnigent.runner.tool_dispatch import _cancel_subagent_task

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5029,6 +5029,121 @@ async def test_sys_cancel_task_interrupts_non_native_subagent() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_sys_cancel_task_stops_terminal_claude_native_entry() -> None:
+    """A failed work status does not block cleanup of a live Claude pane."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_terminal"
+    child_id = "conv_child_terminal"
+    entry = runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="worker",
+        title="implementation",
+        wrapper_label="claude-code-native-ui",
+    )
+    entry.status = "failed"
+    posts: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content))
+        entry.status = "cancelled"
+        return httpx.Response(204)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            output = json.loads(
+                await _cancel_subagent_task(
+                    {"task_id": child_id},
+                    conversation_id=parent_id,
+                    server_client=server_client,
+                )
+            )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert posts == [{"type": "stop_session", "data": {}}]
+    assert output == {"cancelled": True, "task_id": child_id, "status": "cancelled"}
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_stops_evicted_claude_native_entry() -> None:
+    """Server metadata restores the cleanup path after local eviction."""
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_evicted"
+    child_id = "conv_child_evicted"
+    posts: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "id": child_id,
+                    "parent_session_id": parent_id,
+                    "labels": {"omnigent.wrapper": "claude-code-native-ui"},
+                },
+            )
+        posts.append(json.loads(request.content))
+        return httpx.Response(204)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = json.loads(
+            await _cancel_subagent_task(
+                {"task_id": child_id},
+                conversation_id=parent_id,
+                server_client=server_client,
+            )
+        )
+
+    assert posts == [{"type": "stop_session", "data": {}}]
+    assert output == {"cancelled": True, "task_id": child_id, "status": "cancelled"}
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_rejects_foreign_evicted_entry() -> None:
+    """Eviction recovery cannot stop another parent's child."""
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    child_id = "conv_child_foreign"
+    posts: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "id": child_id,
+                    "parent_session_id": "conv_other_parent",
+                    "labels": {"omnigent.wrapper": "claude-code-native-ui"},
+                },
+            )
+        posts.append(json.loads(request.content))
+        return httpx.Response(204)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await _cancel_subagent_task(
+            {"task_id": child_id},
+            conversation_id="conv_requesting_parent",
+            server_client=server_client,
+        )
+
+    assert posts == []
+    assert output == f"Error: no in-flight task with task_id {child_id}"
+
+
 def test_session_status_to_task_status_maps_known_values() -> None:
     """
     ``_session_status_to_task_status`` maps a session.status value to the

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3855,16 +3855,19 @@ def test_kill_session_raises_when_tmux_target_never_published(
         kill_session(tmp_path / "bridge", timeout_s=0.0)
 
 
-def test_kill_session_raises_on_tmux_failure(
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "no server running on /tmp/example/tmux.sock",
+        "can't find session: main",
+    ],
+)
+def test_kill_session_is_idempotent_when_tmux_is_absent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    stderr: str,
 ) -> None:
-    """
-    Non-zero ``tmux kill-session`` exit propagates as a RuntimeError.
-
-    The runner handler maps this to a 503 so a wedged tmux server
-    surfaces as a failed stop rather than a silent success.
-    """
+    """A stale tmux advertisement still counts as a successful stop."""
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
         bridge_dir,
@@ -3877,21 +3880,36 @@ def test_kill_session_raises_on_tmux_failure(
 
         returncode = 1
         stdout = ""
-        stderr = "no server running on /tmp/example/tmux.sock"
 
     def _fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
-        """
-        Return a fake non-zero CompletedProcess.
-
-        :param cmd: Argv list passed to subprocess.run.
-        :param kwargs: Subprocess kwargs (ignored).
-        :returns: A fake CompletedProcess with rc=1.
-        """
+        """Return a fake non-zero CompletedProcess."""
         del cmd, kwargs
-        return _FakeCompleted()
+        result = _FakeCompleted()
+        result.stderr = stderr
+        return result
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="no server running"):
+    kill_session(bridge_dir)
+
+
+def test_kill_session_raises_on_unexpected_tmux_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected tmux failures remain visible to the stop caller."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="main",
+    )
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del cmd, kwargs
+        return SimpleNamespace(returncode=1, stdout="", stderr="permission denied")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="permission denied"):
         kill_session(bridge_dir)
 
 


### PR DESCRIPTION
## Related issue

Closes #4357

## Summary

A Claude readiness timeout marked the sub-agent work terminal while leaving its independent tmux process alive. Later cancellation rejected the terminal or evicted work record, so the orphaned process could not be stopped.

- Reap Claude-native tmux sessions before readiness timeouts become failed turns.
- Allow failed Claude-native work to hard-stop, and recover evicted work from owned server session metadata.
- Treat missing or stale tmux targets as an idempotent stop rather than a teardown failure.

**ELI5:** The task tracker said the worker had stopped, but its terminal was still running. This makes failure and cancellation clean up the terminal even when the tracker entry is already finished or gone.

```text
readiness timeout -> reap tmux -> mark turn failed
terminal/evicted cancel -> verify ownership -> stop_session -> no tmux is success
```

## Test Plan

- `env TMPDIR=/tmp uv run --frozen pytest tests/inner/test_claude_native_executor.py tests/test_claude_native_bridge.py -q` (256 passed)
- `env -u OPENAI_API_KEY uv run --frozen pytest tests/runner/test_runner_dispatch.py tests/runner/test_native_interrupt_runner.py -q` (203 passed, 1 skipped)
- `env TMPDIR=/tmp env -u OPENAI_API_KEY uv run --frozen pytest tests/test_claude_native_bridge.py tests/runner/test_runner_dispatch.py tests/runner/test_native_interrupt_runner.py -q` (439 passed, 1 skipped)
- `env TMPDIR=/tmp uv run --frozen pytest tests/inner/test_claude_native_executor.py -q` (25 passed)
- `.venv/bin/ruff format --check <changed files>` and `.venv/bin/ruff check <changed files>`
- `.venv/bin/pyrefly check -c pyrefly.toml omnigent/claude_native_bridge.py omnigent/inner/claude_native_executor.py omnigent/runner/native/interrupt.py omnigent/runner/tool_dispatch.py`

## Demo

N/A — non-visual lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover timeout cleanup, cleanup failure reporting, terminal and evicted cancellation, ownership rejection, and idempotent stop without tmux metadata.

## Changelog

Failed Claude-native sub-agents no longer leave terminal sessions running.