### PR TITLE
fix(opencode): honor runner env passthrough

### DIFF
--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -81,6 +81,7 @@ _ENV_PASSTHROUGH_KEYS = (
     "http_proxy",
     "https_proxy",
 )
+_RUNNER_ENV_PASSTHROUGH_ENV_VAR = "OMNIGENT_RUNNER_ENV_PASSTHROUGH"
 # OpenCode env vars that point the server at the user's GLOBAL config — they
 # would defeat the per-session XDG isolation by re-introducing whatever
 # config/model/permission settings the parent shell has set. Dropped from
@@ -334,20 +335,30 @@ def filtered_server_env(
 
     Per-session XDG dirs isolate OpenCode's state from the user's global
     config; ``OPENCODE_SERVER_PASSWORD`` secures the loopback server. Only
-    provider/proxy env from the parent is passed through.
+    provider/proxy env and operator-declared runner passthrough vars from the
+    parent are passed through.
 
     :param bridge_dir: Native OpenCode bridge directory.
     :param auth_secret: Server password for basic auth.
     :param extra_env: Additional provider env (e.g. from Omnigent setup).
     :returns: The environment mapping for the server subprocess.
     """
+    extra_names = {
+        name.strip()
+        for name in os.environ.get(_RUNNER_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+        if name.strip()
+    }
     env: dict[str, str] = {}
     for key, value in os.environ.items():
         if key in _ENV_OPENCODE_CONFIG_DENYLIST:
             # Never inherit the parent's global OpenCode config — the
             # per-session XDG dirs are the only config source.
             continue
-        if key in _ENV_PASSTHROUGH_KEYS or key.startswith(_ENV_PASSTHROUGH_PREFIXES):
+        if (
+            key in _ENV_PASSTHROUGH_KEYS
+            or key.startswith(_ENV_PASSTHROUGH_PREFIXES)
+            or key in extra_names
+        ):
             env[key] = value
     env.update(extra_env or {})
     env["XDG_DATA_HOME"] = str(xdg_data_home_for_bridge_dir(bridge_dir))

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -103,6 +103,22 @@ def test_filtered_server_env_sets_xdg_and_password(
     assert "RANDOM_UNRELATED" not in env  # unrelated env filtered out
 
 
+def test_filtered_server_env_honors_runner_passthrough(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "GH_TOKEN, GH_CONFIG_DIR, MISSING")
+    monkeypatch.setenv("GH_TOKEN", "ghp_example")
+    monkeypatch.setenv("GH_CONFIG_DIR", "/home/user/.config/gh")
+    monkeypatch.setenv("UNLISTED_SECRET", "nope")
+
+    env = filtered_server_env(bridge_dir=tmp_path, auth_secret="pw")
+
+    assert env["GH_TOKEN"] == "ghp_example"
+    assert env["GH_CONFIG_DIR"] == "/home/user/.config/gh"
+    assert "MISSING" not in env
+    assert "UNLISTED_SECRET" not in env
+
+
 def test_filtered_server_env_drops_global_opencode_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -117,6 +133,9 @@ def test_filtered_server_env_drops_global_opencode_config(
     monkeypatch.setenv("OPENCODE_CONFIG", "/home/user/.config/opencode/opencode.json")
     monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", '{"model": "evil/model"}')
     monkeypatch.setenv("OPENCODE_DISABLE_AUTOUPDATE", "1")
+    monkeypatch.setenv(
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH", "OPENCODE_CONFIG,OPENCODE_CONFIG_CONTENT"
+    )
     env = filtered_server_env(bridge_dir=tmp_path, auth_secret="pw")
     assert "OPENCODE_CONFIG" not in env
     assert "OPENCODE_CONFIG_CONTENT" not in env


### PR DESCRIPTION
## Related issue

Closes #4916

## Summary

- Forward variables explicitly named by `OMNIGENT_RUNNER_ENV_PASSTHROUGH` into the `opencode serve` process.
- Keep OpenCode's global config denylist authoritative, even when an operator explicitly names those variables.
- Add regression coverage for `GH_TOKEN` / `GH_CONFIG_DIR`, missing variables, unlisted secrets, and denied OpenCode config.

**ELI5:** The daemon already handed selected variables to the runner, but OpenCode applied a second filter and dropped them. This change teaches that second filter to honor the same explicit list without opening access to other host secrets.

```text
host daemon --explicit allowlist--> runner --same explicit allowlist--> opencode serve
```

## Test Plan

- `uv run --no-sync pytest tests/test_opencode_native_app_server.py -q`
- `pre-commit run --all-files`
- Verified the full `_build_runner_env()` → `filtered_server_env()` path preserves `GH_TOKEN` and `GH_CONFIG_DIR`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually exercised the two filtering stages with `OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR` and confirmed both named values reach the final OpenCode server environment while unrelated values remain absent.

## Changelog

`opencode-native` sessions can use environment variables explicitly forwarded with `OMNIGENT_RUNNER_ENV_PASSTHROUGH`.
