### PR TITLE
fix: preserve managed host logs on relaunch

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -712,7 +712,7 @@ class SandboxExecTransport(SandboxLifecycle):
         return self.run(
             sandbox_id,
             f"setsid nohup sh -c {shlex.quote(supervise_host_command(command))} "
-            f"> {log_path} 2>&1 < /dev/null & echo launched",
+            f">> {log_path} 2>&1 < /dev/null & echo launched",
         )
 
     def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -429,7 +429,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         supervisor along with the host, which no in-sandbox loop can survive.
         """
         script = supervise_host_command(command)
-        bg_command = f"{script} > {log_path} 2>&1 < /dev/null"
+        bg_command = f"{script} >> {log_path} 2>&1 < /dev/null"
         self._openshell().exec_background(
             sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
         )

--- a/tests/onboarding/sandboxes/test_base.py
+++ b/tests/onboarding/sandboxes/test_base.py
@@ -78,7 +78,7 @@ def test_run_background_wraps_command_in_sh_c() -> None:
     [cmd] = launcher.commands
     assert cmd == (
         f"setsid nohup sh -c {shlex.quote(supervise_host_command(_HOST_LAUNCH))} "
-        "> /tmp/omnigent-host.log 2>&1 < /dev/null & echo launched"
+        ">> /tmp/omnigent-host.log 2>&1 < /dev/null & echo launched"
     )
     # The env prefix stays attached to the launch inside the quoted script, so
     # the inner shell re-applies it on every supervised restart attempt.

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -232,7 +232,7 @@ def test_run_background_uses_exec_background(monkeypatch: pytest.MonkeyPatch) ->
     assert name == "sb-1"
     assert command[:2] == ["bash", "-lc"]
     assert "omnigent host --server https://s" in command[2]
-    assert "> /tmp/host.log 2>&1 < /dev/null" in command[2]
+    assert ">> /tmp/host.log 2>&1 < /dev/null" in command[2]
     assert fake.exec_calls == []
 
 


### PR DESCRIPTION
## Related issue

OMNI-2860

## Summary

- Append managed-host stdout/stderr logs on relaunch instead of truncating the prior launch record.
- Apply the behavior consistently to standard sandbox and OpenShell background launchers.

## Test Plan

- `uv run --no-sync pytest tests/onboarding/sandboxes/test_base.py tests/onboarding/sandboxes/test_openshell.py`
- `uv run --no-sync ruff check omnigent/onboarding/sandboxes/base.py omnigent/onboarding/sandboxes/openshell.py tests/onboarding/sandboxes/test_base.py tests/onboarding/sandboxes/test_openshell.py`

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated launcher unit tests assert append-mode shell redirects for both background-launch implementations.

## Changelog

Managed-host relaunches preserve prior host logs for troubleshooting.