### PR TITLE
chore(ucode): pin OSS ucode to a fixed commit

### DIFF
--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -12,11 +12,12 @@ from omnigent.onboarding.databricks_config import normalize_workspace_url
 from omnigent.onboarding.ucode_state import read_ucode_state
 
 _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
-# Pin to the ``main`` branch (not a SHA) so setup always tracks the latest
-# ucode. A branch ref is mutable, so uvx would otherwise serve a stale cached
-# build of an older ``main`` commit; ``--refresh-package ucode`` defeats that
-# cache and forces re-resolution of the branch HEAD on every run.
-_UCODE_GIT_REF = "main"
+# Pin ucode to a fixed commit so setup is reproducible, rather than tracking
+# ucode's ``main`` HEAD (a mutable ref that can move under us between runs and
+# break setup unexpectedly). A full SHA is immutable, so uvx caches the built
+# wheel by ref and reuses it across runs — no ``--refresh-package`` needed to
+# defeat a mutable branch's stale cache.
+_UCODE_GIT_REF = "94271a78c7139220b7333bcae91e522f95ef3af3"
 _UCODE_UVX_SOURCE = f"git+https://github.com/databricks/ucode@{_UCODE_GIT_REF}"
 
 
@@ -50,8 +51,8 @@ def build_ucode_configure_command(
     """Build the ``ucode configure`` command Omnigent runs.
 
     :param ucode_command: Command prefix that invokes ucode, e.g.
-        ``("/usr/bin/ucode",)`` or ``("uvx", "--refresh-package", "ucode",
-        "--from", "git+https://github.com/databricks/ucode@main", "ucode")``.
+        ``("/usr/bin/ucode",)`` or ``("uvx", "--from",
+        "git+https://github.com/databricks/ucode@<sha>", "ucode")``.
     :param workspace_urls: Workspace URLs to configure. Must be non-empty.
     :param agents: ucode agent names to configure non-interactively,
         e.g. ``("claude", "codex", "pi")``.
@@ -126,22 +127,22 @@ def ucode_workspace_exists(workspace_url: str) -> bool:
 def find_ucode_command() -> list[str]:
     """Return a command prefix that invokes ``ucode``.
 
-    Prefers an ephemeral ``uvx`` run pinned to ucode's ``main`` branch so
-    setup always uses the latest ucode rather than whatever (possibly stale)
-    ``ucode`` the user installed long ago. A locally-installed binary is used
-    only as a last resort when ``uvx`` is unavailable. This ordering matters:
-    an old persistently-installed ``ucode`` predates options like
+    Prefers an ephemeral ``uvx`` run pinned to a fixed ucode commit, so setup
+    uses a known-good ucode rather than whatever (possibly stale) ``ucode`` the
+    user installed long ago. A locally-installed binary is used only as a last
+    resort when ``uvx`` is unavailable. This ordering matters: an old
+    persistently-installed ``ucode`` predates options like
     ``configure --workspaces`` and would otherwise win and break setup.
 
     :returns: Command prefix, e.g.
-        ``["uvx", "--refresh-package", "ucode", "--from",
-        "git+https://github.com/databricks/ucode@main", "ucode"]`` or, when
+        ``["uvx", "--from",
+        "git+https://github.com/databricks/ucode@<sha>", "ucode"]`` or, when
         ``uvx`` is absent, ``["/usr/bin/ucode"]``.
     :raises click.ClickException: If neither ``uvx`` nor ``ucode`` is on PATH.
     """
     uvx = shutil.which("uvx")
     if uvx is not None:
-        return [uvx, "--refresh-package", "ucode", "--from", _UCODE_UVX_SOURCE, "ucode"]
+        return [uvx, "--from", _UCODE_UVX_SOURCE, "ucode"]
 
     ucode = shutil.which("ucode")
     if ucode is None:

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -20,21 +20,20 @@ from omnigent.onboarding.ucode_setup import (
 )
 
 
-def test_find_ucode_command_prefers_uvx_from_main() -> None:
-    """Prefers an ephemeral uvx run pinned to main, even if ucode is installed.
+def test_find_ucode_command_prefers_uvx_pinned_commit() -> None:
+    """Prefers an ephemeral uvx run pinned to a fixed commit, even if ucode is
+    installed.
 
     The locally-installed binary may be stale (predating
-    ``configure --workspaces``), so uvx-from-main must win when both are
-    present. ``--refresh-package ucode`` forces re-resolution of the mutable
-    ``main`` ref so the cache can't serve an old commit.
+    ``configure --workspaces``), so uvx-from-pinned-commit must win when both
+    are present. The ref is a full SHA so setup resolves a reproducible ucode
+    rather than a moving ``main`` HEAD.
     """
     with patch("shutil.which", return_value="/usr/bin/uvx"):
         assert find_ucode_command() == [
             "/usr/bin/uvx",
-            "--refresh-package",
-            "ucode",
             "--from",
-            "git+https://github.com/databricks/ucode@main",
+            "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
             "ucode",
         ]
 
@@ -88,10 +87,8 @@ def test_build_ucode_configure_command_supports_uvx_prefix() -> None:
     command = build_ucode_configure_command(
         (
             "/usr/bin/uvx",
-            "--refresh-package",
-            "ucode",
             "--from",
-            "git+https://github.com/databricks/ucode@main",
+            "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
             "ucode",
         ),
         workspace_urls=("https://one.example.databricks.com",),
@@ -99,10 +96,8 @@ def test_build_ucode_configure_command_supports_uvx_prefix() -> None:
 
     assert command == [
         "/usr/bin/uvx",
-        "--refresh-package",
-        "ucode",
         "--from",
-        "git+https://github.com/databricks/ucode@main",
+        "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
         "ucode",
         "configure",
         "--workspaces",


### PR DESCRIPTION
## Related issue

N/A — `Refactor / chore` (dependency pin); no issue required per the template.

## Summary

Omnigent's `uvx` setup path resolved ucode from the mutable `main` branch, so an install could silently pick up a new ucode commit between runs — an unannounced change that can break setup. This pins `_UCODE_GIT_REF` to a fixed, known-good commit (`94271a78c7139220b7333bcae91e522f95ef3af3`) so setup is reproducible.

A full SHA is immutable, so `uvx` caches the built wheel by ref and reuses it across runs; this also drops `--refresh-package ucode`, which existed only to defeat the mutable branch's stale cache.

## Test Plan

- `uv run pytest tests/onboarding/test_ucode_setup.py` — 10 passed (updated the two tests that asserted the old `@main` + `--refresh-package` command shape).
- `uv run ruff check` / `ruff format --check` — clean.
- Manual (reviewer, optional, needs network + `uvx`): `uvx --from git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3 ucode --version` resolves, and `ucode configure --help` shows the expected options.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two `test_ucode_setup.py` cases that pin the resolved `uvx` command (`test_find_ucode_command_prefers_uvx_pinned_commit` and `test_build_ucode_configure_command_supports_uvx_prefix`) now assert the pinned SHA and the dropped `--refresh-package`. Live `uvx` resolution against the pinned SHA was not exercised here (no outbound network in the sandbox); it is listed as an optional manual check above.

This pull request and its description were written by Isaac.
