### PR TITLE
fix(codex): surface gateway auth failures instead of a silent 600s stall

### DIFF
--- a/omnigent/_native_forwarder_health.py
+++ b/omnigent/_native_forwarder_health.py
@@ -49,6 +49,19 @@ def record_post_failure(event_type: str, error: BaseException) -> None:
     _state["last_post_failure"] = (time.monotonic(), f"{event_type}: {error!r}")
 
 
+def record_transport_failure(detail: str) -> None:
+    """Record an already-formatted transport failure into the shared slot.
+
+    The SDK codex head has no forwarder POST path, but its subprocess still
+    runs under the same idle-turn watchdog. When the model gateway rejects the
+    CLI (e.g. a 401 read off the CLI's stderr), the turn emits no events and the
+    watchdog would otherwise blame a generic "wedged LLM". Recording the parsed
+    cause here lets the watchdog attribute the real failure, exactly as the
+    native forwarder path does. *detail* is a ready-to-surface human string.
+    """
+    _state["last_post_failure"] = (time.monotonic(), detail)
+
+
 def note_post_success() -> None:
     """
     Clear the failure record after a POST that reached the server.

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -195,10 +195,8 @@ class _CodexGatewayError:
         reason = f" {self.reason}" if self.reason else ""
         target = f" for {model}" if model else ""
         where = f" at {self.url}" if self.url else ""
-        return (
-            f"gateway returned {self.code}{reason}{target}{where} "
-            "(auth likely expired/misconfigured)"
-        )
+        hint = " (auth likely expired/misconfigured)" if self.fatal else ""
+        return f"gateway returned {self.code}{reason}{target}{where}{hint}"
 
 
 def _parse_codex_gateway_error(line: str) -> _CodexGatewayError | None:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias, cast
 
+from omnigent import _native_forwarder_health as native_forwarder_health
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary
 from omnigent.codex_model_vocabulary import (
@@ -115,6 +116,11 @@ CodexToolExecutor: TypeAlias = Callable[
 # but keep waiting — a long-running tool or model call can legitimately
 # block events far longer than any fixed deadline.
 _TURN_EVENT_WARN_SECONDS = 600.0
+# The idle wait polls on this shorter interval so a fatal gateway error the
+# stderr loop sets mid-wait is acted on promptly, rather than only when the
+# 600s warn window elapses. Chosen to divide the warn window evenly so the
+# warning cadence is unchanged.
+_TURN_EVENT_POLL_SECONDS = 5.0
 _TURN_COMPLETED_DRAIN_SECONDS = 1.0
 # Wall-clock budget for the ``codex --version`` probe. A broken codex
 # build that blocks (e.g. on stdin) must not stall session startup — on
@@ -152,6 +158,64 @@ _CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
 # the codex CLI uses its subscription auth (``auth.json``) rather than a
 # developer API key that would charge separately.
 _CODEX_ENV_DENY_EXACT: frozenset[str] = frozenset({"OPENAI_API_KEY"})
+
+# The codex CLI logs a rejected gateway request to stderr as
+# ``unexpected status <code> <reason>: {...}, url: <url>`` and precedes it with
+# ``Reconnecting... N/5`` retry lines. These parse that shape so the head can
+# attribute the real gateway error to a turn that otherwise emits no events.
+_CODEX_STDERR_STATUS_RE = re.compile(
+    r"unexpected status (?P<code>\d{3})(?:\s+(?P<reason>[A-Za-z][A-Za-z ]*?))?\s*[:,]"
+)
+_CODEX_STDERR_URL_RE = re.compile(r"url:\s*(?P<url>\S+)")
+_CODEX_STDERR_RETRY_EXHAUSTED_RE = re.compile(
+    r"Reconnecting\.{0,3}\s*(?P<n>\d+)\s*/\s*(?P<total>\d+)"
+)
+# HTTP statuses that are not transient — a retry can never fix them, so the
+# head fails the turn fast instead of riding the full idle watchdog.
+_CODEX_STDERR_FATAL_STATUSES: frozenset[int] = frozenset({401, 403})
+
+
+class _CodexGatewayError:
+    """A parsed gateway rejection read off the codex CLI's stderr.
+
+    ``code`` is the HTTP status; ``fatal`` marks an auth-class status that a
+    retry cannot fix (the turn should fail fast rather than stall).
+    """
+
+    __slots__ = ("code", "fatal", "reason", "url")
+
+    def __init__(self, code: int, reason: str | None, url: str | None) -> None:
+        self.code = code
+        self.reason = reason
+        self.url = url
+        self.fatal = code in _CODEX_STDERR_FATAL_STATUSES
+
+    def detail(self, *, model: str | None = None) -> str:
+        """A concise, actionable one-line cause for the turn-failure message."""
+        reason = f" {self.reason}" if self.reason else ""
+        target = f" for {model}" if model else ""
+        where = f" at {self.url}" if self.url else ""
+        return (
+            f"gateway returned {self.code}{reason}{target}{where} "
+            "(auth likely expired/misconfigured)"
+        )
+
+
+def _parse_codex_gateway_error(line: str) -> _CodexGatewayError | None:
+    """Return a parsed gateway rejection from a codex stderr *line*, else None.
+
+    Only lines carrying an ``unexpected status <code>`` shape are classified;
+    ordinary stderr (including the ``Reconnecting`` retry lines) returns None.
+    """
+    match = _CODEX_STDERR_STATUS_RE.search(line)
+    if match is None:
+        return None
+    code = int(match.group("code"))
+    raw_reason = match.group("reason")
+    reason = raw_reason.strip() if raw_reason else None
+    url_match = _CODEX_STDERR_URL_RE.search(line)
+    url = url_match.group("url").rstrip(",") if url_match else None
+    return _CodexGatewayError(code, reason, url)
 
 
 def _extract_codex_last_turn_usage(params: object, model: str | None) -> dict[str, object] | None:
@@ -2042,6 +2106,16 @@ class _CodexAppServerSession:
         # field (it is silently dropped), hence the separate settings update.
         self._applied_effort: str | None = None
         self._recent_stderr: list[str] = []
+        # Auth-class gateway rejection tracking, read off the CLI's stderr so a
+        # turn that emits no events fails fast with the real cause instead of
+        # stalling to the idle watchdog. ``_pending`` holds a parsed fatal
+        # (401/403) rejection; ``_saw_retries_exhausted`` records a final
+        # ``Reconnecting N/N``. Fast-fail arms (``_fatal_gateway_error``) only
+        # when BOTH are seen, so a blip the CLI recovers from can't kill a
+        # healthy turn. All three reset at turn start.
+        self._pending_fatal_gateway_error: _CodexGatewayError | None = None
+        self._saw_retries_exhausted = False
+        self._fatal_gateway_error: _CodexGatewayError | None = None
         self._recent_events: list[CodexMessage] = []
         self._process_cwd: Path | None = None
         # Private CODEX_HOME so the subprocess never writes to the user's ~/.codex/.
@@ -2335,6 +2409,14 @@ class _CodexAppServerSession:
         await self.start()
         assert self._proc is not None
 
+        # Fresh turn: forget any prior turn's gateway-error signals and clear
+        # the shared watchdog slot so a resolved earlier failure can't be
+        # misattributed to this turn.
+        self._pending_fatal_gateway_error = None
+        self._saw_retries_exhausted = False
+        self._fatal_gateway_error = None
+        native_forwarder_health.note_post_success()
+
         is_new_thread = self.thread_id is None
         if is_new_thread:
             params: CodexParams = {
@@ -2498,14 +2580,30 @@ class _CodexAppServerSession:
             while True:
                 event_task = asyncio.ensure_future(self._events.get())
                 idle_seconds = 0.0
+                seconds_since_warn = 0.0
+                fatal_gateway_error: _CodexGatewayError | None = None
+                # Poll on the shorter of the two intervals so a fatal gateway
+                # error set mid-wait is acted on promptly; when a test shrinks
+                # the warn window below the poll interval, poll at the warn
+                # window so the warning cadence is preserved.
+                poll_interval = min(_TURN_EVENT_POLL_SECONDS, _TURN_EVENT_WARN_SECONDS)
                 try:
                     while True:
-                        done, _ = await asyncio.wait(
-                            {event_task}, timeout=_TURN_EVENT_WARN_SECONDS
-                        )
+                        done, _ = await asyncio.wait({event_task}, timeout=poll_interval)
                         if event_task in done:
                             break
-                        idle_seconds += _TURN_EVENT_WARN_SECONDS
+                        # The stderr loop sets this once the CLI has exhausted
+                        # its retries on an auth-class gateway rejection. Fail
+                        # fast with the real cause rather than stalling to the
+                        # idle watchdog on a turn that will never emit events.
+                        if self._fatal_gateway_error is not None:
+                            fatal_gateway_error = self._fatal_gateway_error
+                            break
+                        idle_seconds += poll_interval
+                        seconds_since_warn += poll_interval
+                        if seconds_since_warn < _TURN_EVENT_WARN_SECONDS:
+                            continue
+                        seconds_since_warn = 0.0
                         pending_tool_summaries = [
                             {
                                 "call_id": call_id,
@@ -2531,6 +2629,14 @@ class _CodexAppServerSession:
                     with suppress(BaseException):
                         await event_task
                     raise
+                if fatal_gateway_error is not None:
+                    event_task.cancel()
+                    with suppress(BaseException):
+                        await event_task
+                    yield ExecutorError(
+                        message=fatal_gateway_error.detail(model=model), retryable=False
+                    )
+                    return
                 message = event_task.result()
 
                 self._record_event(message)
@@ -2901,8 +3007,30 @@ class _CodexAppServerSession:
                 if len(self._recent_stderr) > 20:
                     self._recent_stderr.pop(0)
                 logger.debug("codex app-server stderr: %s", text)
+                self._note_stderr_gateway_error(text)
         except asyncio.CancelledError:
             raise
+
+    def _note_stderr_gateway_error(self, text: str) -> None:
+        """Attribute (and, when fatal, arm fast-fail for) a gateway rejection.
+
+        The gateway cause is recorded into the shared watchdog slot the moment
+        it is seen, so a stalled turn surfaces the real error. An auth-class
+        (401/403) rejection arms fast-fail only once the CLI has also exhausted
+        its own retry budget (a final ``Reconnecting N/N``); the two signals can
+        arrive in either order, so both are tracked and fast-fail arms when both
+        hold — a single blip the CLI recovers from never kills a healthy turn.
+        """
+        retry = _CODEX_STDERR_RETRY_EXHAUSTED_RE.search(text)
+        if retry is not None and retry.group("n") == retry.group("total"):
+            self._saw_retries_exhausted = True
+        error = _parse_codex_gateway_error(text)
+        if error is not None:
+            native_forwarder_health.record_transport_failure(error.detail())
+            if error.fatal:
+                self._pending_fatal_gateway_error = error
+        if self._pending_fatal_gateway_error is not None and self._saw_retries_exhausted:
+            self._fatal_gateway_error = self._pending_fatal_gateway_error
 
 
 @dataclass

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -2631,6 +2631,10 @@ class _CodexAppServerSession:
                     event_task.cancel()
                     with suppress(BaseException):
                         await event_task
+                    try:
+                        await asyncio.wait_for(self.interrupt_turn(), timeout=0.5)
+                    except Exception as exc:  # noqa: BLE001 — interrupt is best-effort
+                        logger.debug("Codex auth-failure turn interrupt failed: %s", exc)
                     yield ExecutorError(
                         message=fatal_gateway_error.detail(model=model), retryable=False
                     )

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3575,6 +3575,7 @@ def test_app_server_run_turn_fails_fast_on_gateway_auth_error():
             side_effect=[
                 {"result": {"thread": {"id": "thread-1"}}},
                 {"result": {"turn": {"id": "turn-1"}}},
+                {"result": {}},
             ]
         )
 
@@ -3609,6 +3610,10 @@ def test_app_server_run_turn_fails_fast_on_gateway_auth_error():
         assert "databricks-gpt-5" in message
         assert "wedged LLM" not in message
         assert errors[-1].retryable is False
+        session._request.assert_any_await(
+            "turn/interrupt",
+            {"threadId": "thread-1", "turnId": "turn-1"},
+        )
         native_forwarder_health.clear()
 
     _run(_t())

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from omnigent import _native_forwarder_health as native_forwarder_health
 from omnigent.codex_model_vocabulary import codex_spawn_model
 from omnigent.inner.codex_executor import (
     _TURN_EVENT_WARN_SECONDS,
@@ -24,6 +25,7 @@ from omnigent.inner.codex_executor import (
     _databricks_codex_config_overrides,
     _dynamic_tool_result_payload,
     _goal_objective_from_content,
+    _parse_codex_gateway_error,
     _prompt_for_turn,
     _provider_codex_config_overrides,
     _to_codex_input_items,
@@ -3475,5 +3477,184 @@ def test_run_turn_defaults_to_a_codex_model_on_codexs_own_login():
         model = fake_session.calls[0]["model"]
         assert model == CODEX_DEFAULT_MODEL
         assert codex_spawn_model(model) == model, "not codex's own spelling"
+
+    _run(_t())
+
+
+# ── Gateway-auth error surfacing (issue: codex SDK head swallows 401s) ──────
+
+
+def test_parse_codex_gateway_error_extracts_status_and_url():
+    """The real ``unexpected status 401 … url: …`` stderr line is classified."""
+    line = (
+        'ERROR: unexpected status 401 Unauthorized: {"error_code":401,"message":'
+        '"Credential was not sent or was of an unsupported type for this API."}, '
+        "url: https://host/ai-gateway/codex/v1/responses"
+    )
+    error = _parse_codex_gateway_error(line)
+    assert error is not None
+    assert error.code == 401
+    assert error.reason == "Unauthorized"
+    assert error.url == "https://host/ai-gateway/codex/v1/responses"
+    assert error.fatal is True
+    detail = error.detail(model="databricks-gpt-5")
+    assert "401" in detail
+    assert "databricks-gpt-5" in detail
+    assert "ai-gateway/codex/v1/responses" in detail
+
+
+def test_parse_codex_gateway_error_ignores_ordinary_stderr():
+    """Ordinary stderr (including the retry lines) is not misclassified."""
+    assert _parse_codex_gateway_error("Reconnecting... 3/5") is None
+    assert _parse_codex_gateway_error("some unrelated log line") is None
+    assert _parse_codex_gateway_error("") is None
+
+
+def test_parse_codex_gateway_error_5xx_not_fatal():
+    """A 5xx is attributed but not treated as fast-fail (a retry might fix it)."""
+    error = _parse_codex_gateway_error(
+        "unexpected status 503 Service Unavailable: {}, url: https://h/x"
+    )
+    assert error is not None
+    assert error.code == 503
+    assert error.fatal is False
+
+
+def test_note_stderr_gateway_error_records_into_health_slot():
+    """A parsed gateway rejection is recorded where the idle watchdog reads it."""
+    native_forwarder_health.clear()
+    try:
+        session = _CodexAppServerSession(
+            codex_path="/bin/echo", cwd="/tmp/w", env={}, tool_executor=None
+        )
+        session._note_stderr_gateway_error(
+            "unexpected status 401 Unauthorized: {}, url: https://h/ai-gateway/codex/v1/responses"
+        )
+        detail = native_forwarder_health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "gateway returned 401" in detail
+        assert "ai-gateway/codex/v1/responses" in detail
+    finally:
+        native_forwarder_health.clear()
+
+
+def test_fatal_gateway_arms_only_after_retries_exhausted():
+    """Fast-fail arms only when BOTH a 401 and a final ``Reconnecting N/N`` are seen."""
+    native_forwarder_health.clear()
+    try:
+        session = _CodexAppServerSession(
+            codex_path="/bin/echo", cwd="/tmp/w", env={}, tool_executor=None
+        )
+        # A 401 alone (retries not yet exhausted) must not arm fast-fail.
+        session._note_stderr_gateway_error("Reconnecting... 3/5")
+        session._note_stderr_gateway_error(
+            "unexpected status 401 Unauthorized: {}, url: https://h/x"
+        )
+        assert session._fatal_gateway_error is None
+        # The final retry line arms it.
+        session._note_stderr_gateway_error("Reconnecting... 5/5")
+        assert session._fatal_gateway_error is not None
+        assert session._fatal_gateway_error.code == 401
+    finally:
+        native_forwarder_health.clear()
+
+
+def test_app_server_run_turn_fails_fast_on_gateway_auth_error():
+    """An auth-class gateway rejection surfaces the real cause promptly as an
+    ExecutorError, instead of stalling to the generic idle-watchdog message."""
+
+    async def _t():
+        native_forwarder_health.clear()
+        session = _CodexAppServerSession(
+            codex_path="/bin/echo", cwd="/tmp/workspace", env={}, tool_executor=None
+        )
+        session.start = AsyncMock()
+        session._proc = _FakeProcess()
+        session._request = AsyncMock(
+            side_effect=[
+                {"result": {"thread": {"id": "thread-1"}}},
+                {"result": {"turn": {"id": "turn-1"}}},
+            ]
+        )
+
+        # The stderr loop would set this once the CLI exhausts its retries on a
+        # 401; simulate that arriving mid-wait (no turn events ever emitted).
+        async def _inject_gateway_error() -> None:
+            await asyncio.sleep(0.01)
+            session._note_stderr_gateway_error("Reconnecting... 5/5")
+            session._note_stderr_gateway_error(
+                "unexpected status 401 Unauthorized: {}, "
+                "url: https://h/ai-gateway/codex/v1/responses"
+            )
+
+        inject_task = asyncio.create_task(_inject_gateway_error())
+        events = [
+            event
+            async for event in session.run_turn(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                system_prompt="Be helpful.",
+                model="databricks-gpt-5",
+                cwd=".",
+                sandbox="workspace-write",
+            )
+        ]
+        await inject_task
+
+        errors = [e for e in events if isinstance(e, ExecutorError)]
+        assert errors, f"expected an ExecutorError, got {events}"
+        message = errors[-1].message
+        assert "401" in message
+        assert "databricks-gpt-5" in message
+        assert "wedged LLM" not in message
+        assert errors[-1].retryable is False
+        native_forwarder_health.clear()
+
+    _run(_t())
+
+
+def test_run_turn_clears_stale_gateway_error_at_turn_start():
+    """A new turn forgets a prior turn's fatal signal so it can't misfire."""
+
+    async def _t():
+        session = _CodexAppServerSession(
+            codex_path="/bin/echo", cwd="/tmp/workspace", env={}, tool_executor=None
+        )
+        session.start = AsyncMock()
+        session._proc = _FakeProcess()
+        session._request = AsyncMock(
+            side_effect=[
+                {"result": {"thread": {"id": "thread-1"}}},
+                {"result": {"turn": {"id": "turn-1"}}},
+            ]
+        )
+        # Pretend a prior turn left a fatal signal set.
+        session._fatal_gateway_error = _parse_codex_gateway_error(
+            "unexpected status 401 Unauthorized: {}, url: https://h/x"
+        )
+
+        async def _inject_turn_completed() -> None:
+            await asyncio.sleep(0.01)
+            session._events.put_nowait(
+                {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+            )
+
+        inject_task = asyncio.create_task(_inject_turn_completed())
+        events = [
+            event
+            async for event in session.run_turn(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                system_prompt="Be helpful.",
+                model="databricks-gpt-5",
+                cwd=".",
+                sandbox="workspace-write",
+            )
+        ]
+        await inject_task
+        # The stale signal was cleared at turn start, so the turn completes
+        # normally rather than fast-failing on it.
+        assert any(isinstance(e, TurnComplete) for e in events), events
+        assert not any(isinstance(e, ExecutorError) for e in events), events
 
     _run(_t())

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3518,6 +3518,7 @@ def test_parse_codex_gateway_error_5xx_not_fatal():
     assert error is not None
     assert error.code == 503
     assert error.fatal is False
+    assert "auth likely" not in error.detail()
 
 
 def test_note_stderr_gateway_error_records_into_health_slot():

--- a/tests/test_native_forwarder_health.py
+++ b/tests/test_native_forwarder_health.py
@@ -91,3 +91,15 @@ def test_note_post_success_clears_a_prior_failure() -> None:
         assert health.recent_post_failure(60.0) is None
     finally:
         health.clear()
+
+
+def test_record_transport_failure_surfaces_preformatted_detail() -> None:
+    """A ready-to-surface detail (e.g. an SDK head's parsed gateway 401) is
+    stored verbatim and returned within the recency window."""
+    health.clear()
+    try:
+        health.record_transport_failure("gateway returned 401 Unauthorized at https://h/x")
+        detail = health.recent_post_failure(60.0)
+        assert detail == "gateway returned 401 Unauthorized at https://h/x"
+    finally:
+        health.clear()


### PR DESCRIPTION
## Related issue

Closes #4512

Supersedes #4612, which contains the original fix but is blocked by the external-contributor maintainer-approval gate. This branch preserves the original commit authorship and ports it onto current `main`.

## Summary

- Parse Codex app-server stderr for gateway status failures and retain the actionable status, model, and URL.
- Fail fast after Codex exhausts retries on non-transient `401`/`403` responses instead of waiting for the 600-second idle watchdog.
- Feed parsed transport failures into the existing watchdog attribution path, while avoiding credential hints for non-auth failures such as `503`.

**ELI5:** Codex already knew the gateway rejected its credentials, but Omnigent ignored that stderr message and waited ten minutes. This makes Omnigent report the real authentication error as soon as Codex finishes retrying.

```text
Codex stderr -> parse gateway failure -> retries exhausted?
                                         | yes, 401/403
                                         v
                              immediate actionable turn error
```

## Test Plan

- `uv run --no-sync python -m pytest tests/inner/test_codex_executor.py tests/test_native_forwarder_health.py tests/runtime/harnesses/test_scaffold.py -q` — 151 passed.
- `uv run --no-sync python -m pytest tests/inner/test_codex_executor.py -q -k 'gateway_error or gateway_auth'` — 6 passed.
- `uv run --no-sync ruff check omnigent/_native_forwarder_health.py omnigent/inner/codex_executor.py tests/inner/test_codex_executor.py tests/test_native_forwarder_health.py`.
- `uv run --no-sync ruff format --check omnigent/_native_forwarder_health.py omnigent/inner/codex_executor.py tests/inner/test_codex_executor.py tests/test_native_forwarder_health.py`.
- `uv run --no-sync pyrefly check` — 0 errors.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed.

## Demo

N/A — backend error handling. A failed gateway-auth turn now reports `gateway returned 401 Unauthorized ... (auth likely expired/misconfigured)` in seconds instead of a generic idle-watchdog error after roughly ten minutes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests exercise the real stderr shape from #4512, retry-exhaustion ordering, fast-fail behavior, stale-state clearing, watchdog attribution, and non-auth status wording.

## Changelog

Codex gateway authentication failures now report the real cause in seconds instead of hanging until the ten-minute idle watchdog.
