### PR TITLE
fix(codex): use effective context window

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6278,7 +6278,9 @@ def _session_usage_data_from_params(params: _JsonObject) -> dict[str, int] | Non
     if not isinstance(total, dict):
         return None
     cumulative_input_tokens = total.get("inputTokens")
-    context_window = total.get("contextWindow")
+    context_window = token_usage.get("modelContextWindow")
+    if not isinstance(context_window, int) or context_window <= 0:
+        context_window = total.get("contextWindow")
     output_tokens = total.get("outputTokens")
     cached_input_tokens = total.get("cachedInputTokens")
     data: dict[str, int] = {}

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -8417,6 +8417,39 @@ def test_session_usage_data_without_output_tokens_omits_cumulative_output() -> N
     assert "cumulative_output_tokens" not in data
 
 
+def test_session_usage_data_uses_effective_model_context_window() -> None:
+    """The context ring uses Codex's effective model window when available."""
+    params = {
+        "tokenUsage": {
+            "modelContextWindow": 258_400,
+            "total": {
+                "inputTokens": 200_000,
+                "outputTokens": 10_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 258_400
+
+
+def test_session_usage_data_prefers_effective_context_window_over_legacy() -> None:
+    """Codex's effective window takes precedence over the legacy total field."""
+    params = {
+        "tokenUsage": {
+            "modelContextWindow": 258_400,
+            "total": {
+                "inputTokens": 200_000,
+                "outputTokens": 10_000,
+                "contextWindow": 1_050_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 258_400
+
+
 def test_session_usage_data_context_tokens_uses_last_turn_input() -> None:
     """
     ``context_tokens`` (the context-ring value) should reflect the LAST


### PR DESCRIPTION
## Related issue

Closes #5025

## Summary

- Read Codex's `tokenUsage.modelContextWindow` as the effective context window reported for the active model.
- Retain `tokenUsage.total.contextWindow` as a fallback for older Codex payloads.
- Add regression coverage for payloads where the effective and catalog-sized legacy windows differ.

## Test Plan

- `uv run pytest tests/test_codex_native.py -k 'session_usage_data' -q`
- `uvx pre-commit run --files omnigent/codex_native_forwarder.py tests/test_codex_native.py`

## Demo

N/A — the fix corrects forwarded usage metadata; regression tests verify the Web UI receives the effective window.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The parser tests cover the new field, precedence over the legacy field, and the existing legacy fallback path.

## Changelog

Codex sessions now show context usage against the effective context window reported by Codex.
