### PR TITLE
fix(kubernetes): resume dormant managed hosts

### DIFF
--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -16,7 +16,7 @@ creates the Job — an init container prepares the workspace (``mkdir`` + option
 which dials back over the existing managed launch-token tunnel. Because the host
 is never started by ``exec``-ing into an already-running container, this launcher
 needs no ``pods/exec`` rights and no exec transport — it implements only
-``prepare`` / ``provision`` / ``start_host`` / ``terminate``.
+``prepare`` / ``provision`` / ``start_host`` / ``resume`` / ``terminate``.
 
 Platform notes that shape this launcher:
 
@@ -982,7 +982,9 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
     Server-managed only and entrypoint-as-host: :meth:`provision` reserves a Job
     name, :meth:`start_host` creates a per-Job token Secret and a Job whose Pod
     template's init container prepares the workspace and whose main container runs
-    ``omnigent host``, and :meth:`terminate` deletes both.  The Job uses
+    ``omnigent host``. :meth:`resume` removes a dormant Job and its stale token
+    Secret so the managed-host wake path can recreate both under the same sandbox
+    id, while :meth:`terminate` permanently deletes them. The Job uses
     ``restartPolicy: OnFailure`` so the kubelet automatically restarts a crashed
     host container, providing automatic failover within the Job's
     ``backoffLimit``.  All transport rides the official ``kubernetes`` client's
@@ -992,6 +994,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
     """
 
     provider: ClassVar[str] = "kubernetes"
+    can_resume: ClassVar[bool] = True
 
     @property
     def capabilities(self) -> SandboxCapabilities:
@@ -999,7 +1002,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             cli_bootstrap=False,
             managed_launch=True,
             local_port_forward=False,
-            resume_stopped=False,
+            resume_stopped=True,
             programmatic_terminate=True,
             classifies_runner_by_agent=True,
         )
@@ -1735,6 +1738,23 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             self._close_clients()
         if first_error is not None:
             raise first_error
+
+    def resume(self, sandbox_id: str) -> None:
+        """
+        Prepare a dormant Kubernetes sandbox for recreation in place.
+
+        Kubernetes Jobs cannot be restarted after their host process exits.
+        Remove the old Job and launch-token Secret so the shared managed-host
+        wake path can call :meth:`start_host` with the same sandbox id and a
+        freshly armed token. Operator-managed PVCs are external resources and
+        are not touched.
+
+        :param sandbox_id: The dormant Job name to recreate.
+        :raises click.ClickException: On an API delete failure other than
+            not-found.
+        """
+        click.echo(f"▸ Resuming Kubernetes sandbox '{sandbox_id}'")
+        self.terminate(sandbox_id)
 
     def _delete_with_retry(self, kind: str, name: str, delete: Callable[[], object]) -> None:
         """

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -932,6 +932,24 @@ def test_terminate_deletes_job_and_secret(
     assert core.deleted_secrets == ["omnigent-job-6-token"]
 
 
+def test_resume_recycles_job_and_token_secret(
+    fake_clients: tuple[_FakeCore, _FakeBatch],
+) -> None:
+    """Resume clears stale launch resources so start_host can recreate the same id."""
+    core, batch = fake_clients
+    launcher = _launcher()
+
+    assert launcher.can_resume is True
+    assert launcher.capabilities.resume_stopped is True
+
+    launcher.resume("omnigent-job-resume")
+
+    assert batch.deleted_jobs == ["omnigent-job-resume"]
+    assert batch.last_delete_body.propagation_policy == "Foreground"
+    assert core.deleted_pods == ["omnigent-job-resume"]
+    assert core.deleted_secrets == ["omnigent-job-resume-token"]
+
+
 def test_terminate_is_idempotent_on_404(
     fake_clients: tuple[_FakeCore, _FakeBatch],
 ) -> None:


### PR DESCRIPTION
## Related issue

OMNI-2747

## Summary

- Mark the Kubernetes sandbox launcher as resumable so dormant managed hosts enter the existing wake path instead of becoming permanently offline.
- Recycle the completed Job and stale launch-token Secret during resume, allowing `start_host` to recreate them with the same sandbox ID and a fresh token without touching operator-managed PVCs.

**ELI5:** Kubernetes cannot restart a completed Job in place, so waking a host now clears the old launch objects and rebuilds them under the same identity.

```text
dormant Job + stale Secret
           |
        resume()
           v
 delete Job + Secret only
           |
      start_host()
           v
same sandbox ID + fresh token
```

## Test Plan

- `uv run --group test pytest tests/onboarding/sandboxes/test_kubernetes.py -q`
- `uv run --group lint ruff check omnigent/onboarding/sandboxes/kubernetes.py tests/onboarding/sandboxes/test_kubernetes.py`
- `uv run --group lint ruff format --check omnigent/onboarding/sandboxes/kubernetes.py tests/onboarding/sandboxes/test_kubernetes.py`
- `uv run --group lint pyrefly check omnigent/onboarding/sandboxes/kubernetes.py`
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — non-visual managed-host lifecycle change.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test verifies the capability gate and the exact Job, fallback Pod, and token Secret resources recycled by `resume()`; the existing Kubernetes launcher suite covers recreation and cleanup behavior.

## Changelog

Dormant Kubernetes managed hosts can be resumed instead of leaving sessions permanently offline.
