### PR TITLE
fix(web): stamp assistant bubbles by latest activity, not turn start

### DIFF
--- a/tests/e2e_ui/messages/test_message_timestamps.py
+++ b/tests/e2e_ui/messages/test_message_timestamps.py
@@ -26,10 +26,13 @@ Selectors:
 from __future__ import annotations
 
 import re
+import sqlite3
 import time
 
 import httpx
 from playwright.sync_api import Browser, Locator, Page, expect
+
+from tests.e2e_ui.conftest import _server_state, seed_committed_items
 
 _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 _USER_BUBBLE = '[data-testid="message-bubble"][data-role="user"]'
@@ -158,6 +161,99 @@ def test_hover_reveals_timestamp_on_user_and_assistant_bubbles(
     )
     expect(page.locator(_ASSISTANT_BUBBLE).first.locator(_TIMESTAMP)).to_have_text(
         assistant_stamp, timeout=30_000
+    )
+
+
+def test_assistant_bubble_timestamp_tracks_latest_turn_activity(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A multi-item turn's bubble shows the LATEST item's time, not the first.
+
+    Regression: the bubble took the FIRST stamped block of a response
+    group, so a long turn stayed pinned at turn start (30+ minutes stale
+    in the field report) and a refresh reverted to it. Seeds a settled
+    turn whose items span an hour and asserts the hydrated bubble reads
+    the latest item's minute.
+    """
+    from omnigent.db.db_models import uuid_to_bytes
+    from omnigent.entities import MessageData, NewConversationItem
+
+    base_url, session_id = seeded_session
+    response_id = "resp_ts_latest_activity"
+    seed_committed_items(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "Long turn probe."}],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "Turn start."}],
+                    agent="hello_world",
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "Turn end."}],
+                    agent="hello_world",
+                ),
+            ),
+        ],
+    )
+    # Spread the turn across an hour: the store stamps created_at at
+    # append time, so backdate directly in the spawned server's sqlite —
+    # the same file the page hydrates from.
+    db_path = str(_server_state["database_uri"]).removeprefix("sqlite:///")
+    turn_end = int(time.time())
+    conn = sqlite3.connect(db_path, timeout=10.0)
+    try:
+        rows = conn.execute(
+            "SELECT id FROM conversation_items "
+            "WHERE conversation_id = ? AND response_id = ? ORDER BY position",
+            (uuid_to_bytes(session_id), response_id),
+        ).fetchall()
+        assert len(rows) == 3
+        conn.execute(
+            "UPDATE conversation_items SET created_at = ? WHERE id = ?",
+            (turn_end - 3600, rows[1][0]),
+        )
+        conn.execute(
+            "UPDATE conversation_items SET created_at = ? WHERE id = ?",
+            (turn_end, rows[2][0]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    page.goto(f"{base_url}/c/{session_id}")
+    assistant_ts = page.locator(_ASSISTANT_BUBBLE).first.locator(_TIMESTAMP)
+    expect(assistant_ts).to_have_count(1, timeout=30_000)
+
+    # The browser locale decides 12h vs 24h rendering; both describe the
+    # same minute. The turn start is exactly one hour earlier, so it can
+    # never format to either string.
+    end_local = time.localtime(turn_end)
+    twelve_h = (
+        f"{end_local.tm_hour % 12 or 12}:{end_local.tm_min:02d} "
+        f"{'AM' if end_local.tm_hour < 12 else 'PM'}"
+    )
+    twenty_four_h = f"{end_local.tm_hour}:{end_local.tm_min:02d}"
+    stamp = assistant_ts.inner_text()
+    assert stamp in (twelve_h, twenty_four_h), (
+        f"bubble shows {stamp!r}; expected the turn's latest activity "
+        f"({twelve_h!r} or {twenty_four_h!r}), not its start"
     )
 
 

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -3168,9 +3168,9 @@ describe("buildBubbles — bubble display timestamps", () => {
     expect(bubbles.map((b) => b.kind)).toEqual(["assistant", "user", "assistant"]);
     // Premise: the absorbed result renders into bubble A's tool card.
     const bubbleA = bubbles[0] as Extract<Bubble, { kind: "assistant" }>;
-    expect(bubbleA.items.some((it) => it.kind === "tool" && it.output === "late output")).toBe(
-      true,
-    );
+    expect(
+      bubbleA.items.some((item) => item.kind === "tool" && item.output === "late output"),
+    ).toBe(true);
     // Bubble B keeps its own freshest stamp, not the foreign result's.
     const bubbleB = bubbles[2] as Extract<Bubble, { kind: "assistant" }>;
     expect(bubbleB.createdAtS).toBe(1_753_900_200);

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -3087,7 +3087,7 @@ describe("buildBubbles — bubble display timestamps", () => {
     expect(bubble.createdAtS).toBeUndefined();
   });
 
-  it("stamps an assistant group from its first stamped block", () => {
+  it("stamps an assistant group from its freshest stamped block", () => {
     const bubble = buildBubbles(
       [
         textDone("a1", { clientCreatedAtS: 1_753_900_010 }),
@@ -3095,19 +3095,49 @@ describe("buildBubbles — bubble display timestamps", () => {
       ],
       null,
     )[0] as Extract<Bubble, { kind: "assistant" }>;
-    expect(bubble.createdAtS).toBe(1_753_900_010);
-    // The FIRST stamped block wins — the stamp marks when the response
-    // started, even when a later block carries a different clock (the
-    // live-first/server-tail mix can't occur in practice, but the walk
-    // is deterministic either way).
+    expect(bubble.createdAtS).toBe(1_753_900_020);
+    // The FRESHEST stamp wins regardless of which clock carried it —
+    // a mid-turn reload pairs server-stamped history with a live tail,
+    // and the display must reflect the latest activity, not whichever
+    // block walked first.
     const reloaded = buildBubbles(
       [
-        textDone("a1", { clientCreatedAtS: 1_753_900_010 }),
-        textDone("a2", { createdAtS: 1_753_900_005 }),
+        textDone("a1", { createdAtS: 1_753_900_005 }),
+        textDone("a2", { clientCreatedAtS: 1_753_900_010 }),
       ],
       null,
     )[0] as Extract<Bubble, { kind: "assistant" }>;
     expect(reloaded.createdAtS).toBe(1_753_900_010);
+  });
+
+  it("keeps a long turn's timestamp current instead of pinned to turn start", () => {
+    // Regression: a long turn under one response id showed the FIRST
+    // item's stamp, so an actively streaming "latest message" read
+    // 30+ minutes behind the wall clock.
+    const turnStart = 1_753_900_000;
+    const bubble = buildBubbles(
+      [
+        textDone("a1", { createdAtS: turnStart }),
+        textDone("a2", { createdAtS: turnStart + 40 * 60 }),
+        textDone("a3", { createdAtS: turnStart + 41 * 60 }),
+      ],
+      null,
+    )[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(bubble.createdAtS).toBe(turnStart + 41 * 60);
+  });
+
+  it("never moves the group timestamp backwards for a backdated tail block", () => {
+    // A late-arriving block can carry an older stamp (a relay-backdated
+    // tool result); the displayed time must not jump back.
+    const bubble = buildBubbles(
+      [
+        textDone("a1", { createdAtS: 1_753_900_000 }),
+        textDone("a2", { createdAtS: 1_753_900_300 }),
+        textDone("a3", { createdAtS: 1_753_900_100 }),
+      ],
+      null,
+    )[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(bubble.createdAtS).toBe(1_753_900_300);
   });
 });
 

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -3139,6 +3139,67 @@ describe("buildBubbles — bubble display timestamps", () => {
     )[0] as Extract<Bubble, { kind: "assistant" }>;
     expect(bubble.createdAtS).toBe(1_753_900_300);
   });
+
+  it("does not stamp a bubble from a foreign absorbed tool result", () => {
+    // A delayed function_call_output is relay-backdated to its original
+    // turn's response id, so it lands after the next bubble's blocks and
+    // is absorbed into that bubble's group. It renders into its own
+    // turn's card via crossBubbleResults — it must not stamp the bubble
+    // that merely absorbed it.
+    const blocks: AnyBlock[] = [
+      {
+        type: "tool_group",
+        ctx: ctx({ itemId: "fc_a", responseId: "resp_A", createdAtS: 1_753_900_000 }),
+        executions: [mkExec("spawn_agent", "c1")],
+        iteration: 0,
+      },
+      userBlock({ createdAtS: 1_753_900_100 }),
+      textDone("b1", { createdAtS: 1_753_900_200 }),
+      {
+        type: "tool_result",
+        ctx: ctx({ itemId: "fco_a", responseId: "resp_A", createdAtS: 1_753_900_300 }),
+        name: "",
+        callId: "c1",
+        agentName: "test",
+        output: "late output",
+      },
+    ];
+    const bubbles = buildBubbles(blocks, null);
+    expect(bubbles.map((b) => b.kind)).toEqual(["assistant", "user", "assistant"]);
+    // Premise: the absorbed result renders into bubble A's tool card.
+    const bubbleA = bubbles[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(bubbleA.items.some((it) => it.kind === "tool" && it.output === "late output")).toBe(
+      true,
+    );
+    // Bubble B keeps its own freshest stamp, not the foreign result's.
+    const bubbleB = bubbles[2] as Extract<Bubble, { kind: "assistant" }>;
+    expect(bubbleB.createdAtS).toBe(1_753_900_200);
+  });
+
+  it("still stamps from a tool result whose call lives in the same bubble", () => {
+    // A turn's latest activity is often its trailing tool result —
+    // excluding results wholesale would re-pin the timestamp.
+    const bubble = buildBubbles(
+      [
+        {
+          type: "tool_group",
+          ctx: ctx({ itemId: "fc_1", responseId: "resp_1", createdAtS: 1_753_900_000 }),
+          executions: [mkExec("Bash", "c1")],
+          iteration: 0,
+        },
+        {
+          type: "tool_result",
+          ctx: ctx({ itemId: "fco_1", responseId: "resp_1", createdAtS: 1_753_900_050 }),
+          name: "",
+          callId: "c1",
+          agentName: "test",
+          output: "ok",
+        },
+      ],
+      null,
+    )[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(bubble.createdAtS).toBe(1_753_900_050);
+  });
 });
 
 describe("buildBubbles — continued turns (sub-agent await)", () => {

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -189,8 +189,9 @@ export type Bubble =
        * trailing answer of its own.
        */
       continued?: boolean;
-      /** Epoch seconds of the first block in the group — server-stamped
-       *  from history, client-stamped while live. Display-only. */
+      /** Freshest epoch stamp in the group (latest activity) —
+       *  server-stamped from history, client-stamped while live.
+       *  Display-only. */
       createdAtS?: number;
     }
   | { kind: "compaction_loading"; itemId: string }
@@ -960,10 +961,16 @@ function walkBubbles(
     lastBubbleCount = 1;
     const workedForS = turnWorkedForS(groupBlocks);
     const lastActivityAtS = turnLastActivityAtS(groupBlocks);
-    // Server stamp on cold load, client stamp while live — display only.
+    // Freshest stamp in the group — server stamp on cold load, client
+    // stamp while live, either clock display-only. The max tracks latest
+    // activity and never jumps back for a backdated tail block.
     const groupCreatedAtS = groupBlocks
       .map((bk) => bk.ctx.createdAtS ?? bk.ctx.clientCreatedAtS)
-      .find((v) => v !== undefined);
+      .reduce<number | undefined>(
+        (freshest, v) =>
+          v !== undefined && (freshest === undefined || v > freshest) ? v : freshest,
+        undefined,
+      );
     bubbles.push({
       kind: "assistant",
       responseId: groupResponseId,

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -964,7 +964,22 @@ function walkBubbles(
     // Freshest stamp in the group — server stamp on cold load, client
     // stamp while live, either clock display-only. The max tracks latest
     // activity and never jumps back for a backdated tail block.
+    // A delayed result backdated to an earlier turn is absorbed into this
+    // group but renders into its own turn's card (crossBubbleResults), so
+    // only results whose call lives here count as this bubble's activity.
+    const localResultKeys = new Set<string>();
+    for (const bk of groupBlocks) {
+      if (bk.type === "tool_group") {
+        for (const ex of bk.executions) {
+          localResultKeys.add(`${bk.ctx.responseId}:${ex.callId}`);
+        }
+      }
+    }
     const groupCreatedAtS = groupBlocks
+      .filter(
+        (bk) =>
+          bk.type !== "tool_result" || localResultKeys.has(`${bk.ctx.responseId}:${bk.callId}`),
+      )
       .map((bk) => bk.ctx.createdAtS ?? bk.ctx.clientCreatedAtS)
       .reduce<number | undefined>(
         (freshest, v) =>


### PR DESCRIPTION
## Related issue

N/A (reported via a Slack thread with a screenshot: latest message timestamp 30+ minutes behind wall clock during active streaming; a refresh briefly showed a fresher time, then reverted)

## Summary

The assistant bubble timestamp was pinned to the **first** stamped block of a response group — i.e. the turn's start. On long turns whose items share one `response_id`, an actively streaming "latest message" read arbitrarily far behind the wall clock (30+ minutes in the report), and a mid-turn refresh flashed a fresher live stamp before reverting to the stale hydrated one, because live blocks (client-stamped at attach time) and hydrated blocks (server-stamped at item creation) disagreed.

`groupCreatedAtS` in `web/src/lib/renderItems.ts` now takes the **freshest** stamp in the group instead of the first. ELI5: the bubble's clock now shows "when this answer last did something" instead of "when it started", so it stays honest while a long turn is still working.

```
turn blocks   [t0]---[t1]---[t2]---[t3 latest]
before: bubble shows t0  (stale by the whole turn's duration)
after:  bubble shows t3  (max — advances with activity, never jumps back)
```

This also makes live and hydrated views agree (both track latest activity), eliminating the refresh flash-and-revert, and it never moves the timestamp backwards for a backdated tail block (e.g. a relay-backdated tool result). User bubbles are unaffected (one item per bubble). Note: this applies to settled historical bubbles too — they now show the turn's latest-activity (turn-end) time rather than its start. Display-only change: `turnWorkedForS` / `turnLastActivityAtS` keep their single-clock guards untouched.

## Test Plan

- Updated/added unit tests in `web/src/lib/renderItems.test.ts` ("bubble display timestamps"): freshest-stamp-wins across clocks, a 41-minute long-turn regression, and a backdated-tail-block no-backwards-jump case. The updated tests failed before the fix and pass after.
- `npx vitest run` (full web suite): 5807 passed, 3 expected fail, 1 skipped.
- `npm run type-check` (tsc -b): pass. Prettier: clean.
- Real three-process stack (`omnigent server` :6767, `omnigent host`, Vite :5173), session driven through a claude-native turn running a multi-minute bash loop:
  - Before fix: bubble pinned at turn start (11:06) while streaming at 11:09+; after completion and a refresh, the hydrated "done" bubble (written 11:11) showed 11:06.
  - After fix: the timestamp advances with turn activity (11:16 → 11:20 across a turn), the post-stream state shows latest activity, and a refresh settles on the identical value (live 11:20 == hydrated 11:20) — no revert.
  - Verified in light and dark themes (DOM computed styles + screenshots below).

## Demo

Before — both completed turns pinned to their turn start (11:06 / 11:16) even though they finished minutes later:

![Before: bubbles pinned to turn start](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-timestamps/tmp-screenshots/timestamps-before.png)

After (light) — the same transcript, bubbles show latest activity (11:11 / 11:20), matching the live view and surviving refresh:

![After, light theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-timestamps/tmp-screenshots/timestamps-light.png)

After (dark):

![After, dark theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-timestamps/tmp-screenshots/timestamps-dark.png)

(Timestamps render via the touch/narrow-viewport resting-opacity fallback so they are visible without hover in these captures.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the stamp-selection logic (freshest-wins, mixed clocks, long-turn regression, backdated tail). Existing suites (`blocks`, `blockStream`, `chatStore`, `ChatPage`) cover the surrounding plumbing and pass unchanged. Manual verification covered the real three-process stack: active streaming, post-stream state, refresh/rehydration consistency, and both themes. Existing E2E timestamp tests assert format/ordering/hover behavior, not first-vs-last semantics, so they are unaffected; the full E2E shards run in CI.

## Changelog

Chat message timestamps now track the latest activity in a turn instead of its start, so long-running turns no longer look 30+ minutes stale