### PR TITLE
fix(codex): attach local environment to web turns

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -1196,6 +1196,7 @@ async def _prepare_codex_terminal(
                         socket_path=codex_ws_url,
                         thread_id=thread_id,
                         codex_home=str(codex_home),
+                        cwd=str(Path.cwd()),
                     ),
                 )
             if runner_id is not None:
@@ -1417,6 +1418,7 @@ async def _initialize_fresh_terminal_thread(
             socket_path=app_server_url,
             thread_id=thread_id,
             codex_home=str(codex_home_for_bridge_dir(prepared.bridge_dir)),
+            cwd=str(Path.cwd()),
         ),
     )
     return thread_id

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -76,6 +76,8 @@ class CodexNativeBridgeState:
         ``"0196..."``.
     :param codex_home: Private per-session ``CODEX_HOME`` path, e.g.
         ``"/home/user/.omnigent/codex-native/x/codex-home"``.
+    :param cwd: Native Codex thread working directory, e.g.
+        ``"/home/user/project"``.
     :param active_turn_id: Current Codex turn id, if one is running,
         e.g. ``"turn_abc123"``.
     """
@@ -85,6 +87,7 @@ class CodexNativeBridgeState:
     thread_id: str
     codex_home: str
     active_turn_id: str | None = None
+    cwd: str | None = None
 
 
 def bridge_dir_for_bridge_id(bridge_id: str) -> Path:
@@ -425,6 +428,7 @@ def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
                     "thread_id": state.thread_id,
                     "codex_home": state.codex_home,
                     "active_turn_id": state.active_turn_id,
+                    "cwd": state.cwd,
                 },
                 handle,
                 sort_keys=True,
@@ -686,6 +690,7 @@ def read_bridge_state(bridge_dir: Path) -> CodexNativeBridgeState | None:
     thread_id = raw.get("thread_id")
     codex_home = raw.get("codex_home")
     active_turn_id = raw.get("active_turn_id")
+    cwd = raw.get("cwd")
     if (
         not isinstance(session_id, str)
         or not session_id
@@ -706,6 +711,7 @@ def read_bridge_state(bridge_dir: Path) -> CodexNativeBridgeState | None:
         thread_id=thread_id,
         codex_home=codex_home,
         active_turn_id=parsed_active_turn_id,
+        cwd=cwd if isinstance(cwd, str) and cwd else None,
     )
 
 
@@ -729,6 +735,7 @@ def update_active_turn_id(bridge_dir: Path, active_turn_id: str | None) -> None:
             thread_id=state.thread_id,
             codex_home=state.codex_home,
             active_turn_id=active_turn_id,
+            cwd=state.cwd,
         ),
     )
 
@@ -757,6 +764,7 @@ def update_thread_id(bridge_dir: Path, thread_id: str, active_turn_id: str | Non
             thread_id=thread_id,
             codex_home=state.codex_home,
             active_turn_id=active_turn_id,
+            cwd=state.cwd,
         ),
     )
 
@@ -802,6 +810,7 @@ def clear_active_turn_id_if_matches(bridge_dir: Path, completed_turn_id: str | N
             thread_id=state.thread_id,
             codex_home=state.codex_home,
             active_turn_id=None,
+            cwd=state.cwd,
         ),
     )
     return True

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -319,6 +319,12 @@ class CodexNativeExecutor(Executor):
                         turn_params: dict[str, object] = {
                             "threadId": state.thread_id,
                             "input": input_items,
+                            "environments": [
+                                {
+                                    "environmentId": "local",
+                                    "cwd": state.cwd or str(Path.cwd()),
+                                }
+                            ],
                         }
                         response = await client.request("turn/start", turn_params)
                         result = _json_object(response.get("result"))

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -173,6 +173,7 @@ def test_web_started_codex_turn_returns_without_waiting_for_terminal_event(
             thread_id="thread_123",
             codex_home=str(tmp_path / "codex-home"),
             active_turn_id=None,
+            cwd=str(tmp_path),
         ),
     )
     executor = CodexNativeExecutor(bridge_dir=tmp_path)
@@ -189,6 +190,7 @@ def test_web_started_codex_turn_returns_without_waiting_for_terminal_event(
             {
                 "threadId": "thread_123",
                 "input": [{"type": "text", "text": "first"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
             },
         )
     ]
@@ -214,6 +216,7 @@ def test_goal_command_sets_goal_before_starting_objective_turn(
             thread_id="thread_123",
             codex_home=str(tmp_path / "codex-home"),
             active_turn_id=None,
+            cwd=str(tmp_path),
         ),
     )
     executor = CodexNativeExecutor(bridge_dir=tmp_path)
@@ -234,6 +237,7 @@ def test_goal_command_sets_goal_before_starting_objective_turn(
             {
                 "threadId": "thread_123",
                 "input": [{"type": "text", "text": "Finish the implementation and tests"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
             },
         ),
     ]
@@ -261,6 +265,7 @@ def test_system_prompt_does_not_override_collaboration_mode(
             thread_id="thread_123",
             codex_home=str(tmp_path / "codex-home"),
             active_turn_id=None,
+            cwd=str(tmp_path),
         ),
     )
     executor = CodexNativeExecutor(bridge_dir=tmp_path)
@@ -282,6 +287,7 @@ def test_system_prompt_does_not_override_collaboration_mode(
             {
                 "threadId": "thread_123",
                 "input": [{"type": "text", "text": "hello"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
             },
         ),
     ]
@@ -760,6 +766,7 @@ def _start_state(tmp_path: Path) -> None:
             thread_id="thread_123",
             codex_home=str(tmp_path / "codex-home"),
             active_turn_id=None,
+            cwd=str(tmp_path),
         ),
     )
 
@@ -834,6 +841,7 @@ def test_web_model_pick_applied_via_thread_settings_update(
             {
                 "threadId": "thread_123",
                 "input": [{"type": "text", "text": "hello"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
             },
         ),
     ]
@@ -903,8 +911,8 @@ def test_no_settings_update_when_overrides_unset(
 
     A native thread that never touches the web picker must keep its
     launch-pinned model — a stray ``thread/settings/update`` could
-    clobber it. An empty/None config issues only the bare
-    ``{threadId, input}`` ``turn/start``.
+    clobber it. An empty/None config still selects the native local
+    environment on ``turn/start``.
     """
     _FakeCodexNativeClient.requests = []
     _FakeCodexNativeClient.created = []
@@ -916,11 +924,18 @@ def test_no_settings_update_when_overrides_unset(
     _start_state(tmp_path)
     executor = CodexNativeExecutor(bridge_dir=tmp_path)
 
-    # A config with neither field set produces the bare turn/start params.
+    # A config with neither field set still selects the native local environment.
     _run_turn_with_config(executor, "a", ExecutorConfig())
 
     assert _FakeCodexNativeClient.requests == [
-        ("turn/start", {"threadId": "thread_123", "input": [{"type": "text", "text": "a"}]}),
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "text", "text": "a"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
+            },
+        ),
     ]
 
 

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -64,8 +64,24 @@ def _seed_active_turn(bridge_dir: Path, active_turn_id: str | None) -> None:
             thread_id="thread_test",
             codex_home=str(bridge_dir / "codex-home"),
             active_turn_id=active_turn_id,
+            cwd=str(bridge_dir),
         ),
     )
+
+
+def test_bridge_state_preserves_native_working_directory(tmp_path: Path) -> None:
+    """Bridge state retains the cwd used for web-driven Codex turns."""
+    _seed_active_turn(tmp_path, "turn_1")
+
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.cwd == str(tmp_path)
+
+    clear_active_turn_id_if_matches(tmp_path, "turn_1")
+
+    updated = read_bridge_state(tmp_path)
+    assert updated is not None
+    assert updated.cwd == str(tmp_path)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Related issue

OMNI-2531

## Summary

- Persist the native Codex thread working directory in bridge state.
- Include Codex's reserved `local` environment in every web-driven `turn/start`, restoring shell, MCP, plan, and goal tools for translated model arms.
- Preserve the stored working directory across turn and thread state updates.

**ELI5:** Codex only loads its tools when a turn says where it is running. Web turns omitted that location, so this change sends the same local workspace context that native Codex turns use.

```text
Web message -> CodexNativeExecutor -> turn/start
                                      + environments: [local cwd]
                                      -> tool registry enabled
```

## Test Plan

- `.venv/bin/python -m pytest tests/inner/test_codex_native_executor.py tests/test_codex_native_bridge.py tests/test_codex_native.py tests/test_codex_native_forwarder.py -q` (345 passed)
- `.venv/bin/pre-commit run --all-files` hooks passed, including ruff, pyrefly, frontend type checks, lock normalization, and repository policy checks. The host volume required running the final TypeScript checks separately after package-cache cleanup; both passed.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The executor tests assert that `turn/start` carries the reserved local environment and correct native workspace. Bridge-state tests verify the workspace survives active-turn state transitions.

## Changelog

Codex web sessions now retain shell and MCP tools when using translated model arms.
