### PR TITLE
fix(acp): resolve the tool identity on a bare permission request

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -332,9 +332,11 @@ class AcpExecutor(Executor):
         self._image_supported: bool = False
         self._system_prompt_sent: bool = False
 
-        # ACP toolCallId → tool name, so a later tool_call_update can close the
-        # right tool card with the name from the originating tool_call.
+        # ACP toolCallId → tool name / rawInput from the originating tool_call, so
+        # a later tool_call_update can close the right tool card, and a permission
+        # request that names only the id can still say what is about to run.
         self._tool_names: dict[str, str] = {}
+        self._tool_inputs: dict[str, _AcpJsonObject] = {}
 
         # Context-window size (tokens) reported via ``usage_update``; surfaced by
         # :meth:`max_context_tokens` so the UI context meter fills.
@@ -798,21 +800,35 @@ class AcpExecutor(Executor):
     # Permission (session/request_permission) → policy + elicitation
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _extract_tool_call(params: _AcpJsonObject) -> tuple[str, _AcpJsonObject]:
+    def _extract_tool_call(self, params: _AcpJsonObject) -> tuple[str, _AcpJsonObject]:
         """Pull ``(tool_name, tool_input)`` from a ``session/request_permission``.
 
         ACP's ``toolCall`` carries a human ``title`` (e.g. ``"shell"``), a
-        ``kind`` (e.g. ``"execute"``), and a ``rawInput`` dict. We prefer the
-        title, else the kind. (Vendor-specific ``_meta`` tool names — e.g.
-        Goose's ``_meta.goose.toolCall.toolName`` — are not read here; ``title``
-        is the portable name every ACP agent supplies.)
+        ``kind`` (e.g. ``"execute"``), and a ``rawInput`` dict; prefer the title,
+        else the kind. An agent may instead send the request bare, carrying only
+        ``toolCallId``, so fall back to what the originating ``tool_call`` update
+        reported for that id — it always arrives first. Without that fallback a
+        bare request degrades to ``"tool"`` with no arguments, so the approval
+        card cannot say what is about to run and no TOOL_CALL policy rule can
+        match it (rules gate on the tool name, then read its arguments).
+
+        (Vendor-specific ``_meta`` tool names — e.g. Goose's
+        ``_meta.goose.toolCall.toolName`` — are not read here; ``title`` is the
+        portable name and ``toolCallId`` the portable correlation.)
         """
         tool_call = params.get("toolCall") or {}
-        name = tool_call.get("title") or tool_call.get("kind") or "tool"
+        call_id = tool_call.get("toolCallId")
+        call_id = call_id if isinstance(call_id, str) else None
+        name = (
+            tool_call.get("title")
+            or tool_call.get("kind")
+            or (self._tool_names.get(call_id) if call_id else None)
+            or "tool"
+        )
         args = tool_call.get("rawInput")
         if not isinstance(args, dict):
-            args = {}
+            cached = self._tool_inputs.get(call_id) if call_id else None
+            args = cached if isinstance(cached, dict) else {}
         return str(name), args
 
     async def _decide_permission(self, params: _AcpJsonObject) -> bool:
@@ -1069,6 +1085,7 @@ class AcpExecutor(Executor):
             args = raw_input if isinstance(raw_input, dict) else {}
             if isinstance(call_id, str) and call_id:
                 self._tool_names[call_id] = str(name)
+                self._tool_inputs[call_id] = args
                 events.append(
                     ToolCallRequest(name=str(name), args=args, metadata={"call_id": call_id})
                 )
@@ -1080,6 +1097,7 @@ class AcpExecutor(Executor):
                 _TOOL_STATUS_FAILED,
             ):
                 name = self._tool_names.pop(call_id, "tool")
+                self._tool_inputs.pop(call_id, None)
                 events.append(
                     ToolCallComplete(
                         name=name,

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -127,7 +127,8 @@ async def test_session_new_client_mode_generates_and_sends_id() -> None:
 
 
 def test_extract_tool_call_prefers_title() -> None:
-    name, args = AcpExecutor._extract_tool_call(
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    name, args = ex._extract_tool_call(
         {"toolCall": {"title": "shell", "kind": "execute", "rawInput": {"command": "ls"}}}
     )
     assert name == "shell"
@@ -135,9 +136,58 @@ def test_extract_tool_call_prefers_title() -> None:
 
 
 def test_extract_tool_call_falls_back_to_kind() -> None:
-    name, args = AcpExecutor._extract_tool_call({"toolCall": {"kind": "read"}})
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    name, args = ex._extract_tool_call({"toolCall": {"kind": "read"}})
     assert name == "read"
     assert args == {}
+
+
+def test_extract_tool_call_recovers_a_bare_permission_request() -> None:
+    """A request naming only ``toolCallId`` resolves via the originating tool_call.
+
+    An agent may ask permission without repeating the tool: Devin sends no
+    ``title`` / ``kind`` / ``rawInput``, only the id it already announced. The
+    ``tool_call`` update always arrives first, so its name and arguments are
+    still on hand.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "toolu_01",
+            "title": "Ran command",
+            "kind": "execute",
+            "rawInput": {"command": "rm -rf build"},
+        }
+    )
+    name, args = ex._extract_tool_call(
+        {
+            "toolCall": {
+                "toolCallId": "toolu_01",
+                "_meta": {"vendor/editableCommand": "rm -rf build"},
+            }
+        }
+    )
+    assert name == "Ran command"
+    assert args == {"command": "rm -rf build"}
+
+
+def test_extract_tool_call_prefers_the_request_over_the_cache() -> None:
+    """A request that carries its own title/rawInput wins; the cache is a fallback."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(
+        {"sessionUpdate": "tool_call", "toolCallId": "c1", "title": "stale", "rawInput": {"a": 1}}
+    )
+    name, args = ex._extract_tool_call(
+        {"toolCall": {"toolCallId": "c1", "title": "shell", "rawInput": {"command": "ls"}}}
+    )
+    assert (name, args) == ("shell", {"command": "ls"})
+
+
+def test_extract_tool_call_unknown_id_degrades_to_tool() -> None:
+    """An id we never saw announced still yields the safe generic fallback."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    assert ex._extract_tool_call({"toolCall": {"toolCallId": "never-announced"}}) == ("tool", {})
 
 
 def test_permission_outcome_allow_prefers_once() -> None:
@@ -209,6 +259,31 @@ def test_tool_call_and_update_emit_cards() -> None:
     assert comp.name == "shell" and comp.status is ToolCallStatus.SUCCESS
     assert comp.metadata == {"call_id": "c1"}
     assert "c1" not in ex._tool_names  # popped
+
+
+def test_tool_call_caches_release_on_completion() -> None:
+    """Both id-keyed caches drop the entry when the call closes.
+
+    They exist only to bridge a tool_call to its permission request and closing
+    update, so a long session must not accumulate one entry per tool call.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._handle_session_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "c1",
+            "title": "shell",
+            "rawInput": {"command": "ls"},
+        }
+    )
+    assert ex._tool_names == {"c1": "shell"}
+    assert ex._tool_inputs == {"c1": {"command": "ls"}}
+
+    ex._handle_session_update(
+        {"sessionUpdate": "tool_call_update", "toolCallId": "c1", "status": "completed"}
+    )
+    assert ex._tool_names == {}
+    assert ex._tool_inputs == {}
 
 
 def test_tool_call_update_failed_maps_to_error() -> None:
@@ -322,6 +397,63 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
 
     ex._policy_evaluator = AsyncMock(return_value=_V())
     assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
+
+
+def _seed_tool_call(ex: AcpExecutor) -> dict[str, object]:
+    """Announce a ``tool_call``, then return the bare permission params for it.
+
+    Mirrors the real frame order for an agent that asks permission without
+    repeating the tool: ``tool_call`` (with the name + command) → then
+    ``session/request_permission`` carrying only the id.
+    """
+    ex._handle_session_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "toolu_01",
+            "title": "Ran command",
+            "kind": "execute",
+            "rawInput": {"command": "rm -rf build"},
+        }
+    )
+    return {"toolCall": {"toolCallId": "toolu_01"}}
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_policy_sees_the_real_tool_call() -> None:
+    """The TOOL_CALL policy is evaluated against the resolved name + arguments.
+
+    Rules gate on the tool name and then read its arguments (the destructive-shell
+    builtin reads ``arguments["command"]``), so a bare request evaluated as
+    ``{"name": "tool", "arguments": {}}`` matches nothing — a "deny ``rm -rf``"
+    policy would sit silent while the command ran.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = _seed_tool_call(ex)
+
+    class _V:
+        action = "POLICY_ACTION_DENY"
+
+    ex._policy_evaluator = AsyncMock(return_value=_V())
+    assert await ex._decide_permission(params) is False
+    ex._policy_evaluator.assert_awaited_once_with(
+        "PHASE_TOOL_CALL",
+        {"name": "Ran command", "arguments": {"command": "rm -rf build"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_card_names_the_tool() -> None:
+    """The approval card describes the call instead of an unnamed "tool".
+
+    The elicitation handler renders ``<tool_name>(<args>)``, so these two values
+    are literally what the user reads before approving.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = _seed_tool_call(ex)
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    assert await ex._decide_permission(params) is True
+    ex._elicitation_handler.assert_awaited_once_with("Ran command", {"command": "rm -rf build"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #5049

## Summary

An ACP agent may send `session/request_permission` carrying **only** a
`toolCallId` — no `title`, no `kind`, no `rawInput`. Devin does exactly this, and
`_extract_tool_call` read `title or kind or "tool"`, so the request collapsed to
the literal name `"tool"` with empty arguments. Two things broke at once:

| | Before | After |
|---|---|---|
| Approval card | *"Devin wants to use **tool**"*, preview `tool({})` | *"Devin wants to use **Ran command**"*, preview `Ran command({"command": …})` |
| TOOL_CALL policy input | `{"name": "tool", "arguments": {}}` | `{"name": "Ran command", "arguments": {"command": "rm -rf build"}}` |

The second row is the one that matters most. Builtin rules gate on the tool name
*first* (`policies/builtins/orchestration.py:55` — `if data.get("name") not in
tool_names: return None`) and only then read `arguments["command"]` (`:395`).
`"tool"` is in no tool set, so evaluation returned before ever seeing the
command: **a "deny `rm -rf`" policy could not fire on an ACP agent's shell
command.** It reported nothing, so it looked configured and worked.

The fix needs no new protocol: the originating `tool_call` update carries the real
name and command and **always arrives first**, and the executor already caches
`toolCallId → name` there to close the right tool card (`:337`). Cache the
`rawInput` beside it, and fall back to both when the request omits them. Values
the request *does* carry still win, so nothing changes for agents that send a full
`toolCall`.

<details>
<summary>ELI5 + the frame order that makes it work</summary>

Devin announces "I'm about to run `ls`" and then asks "may I?" — but the second
message only says "may I? (re: item #17)". We were reading the second message
alone, so all we could tell the user was "Devin wants to use *something*". Now we
look up item #17.

```
  ── from a live `devin acp` session (ids abbreviated) ──────────────────────
  tool_call    id=…GgidjWJty  title='Ran command'  kind='execute'  rawInput={"command": "… && ls"}
                    │  name + args land in the cache
                    ▼
  PERMISSION   id=…GgidjWJty  title=None  kind=None   ← bare: id only
                    │  before: → ("tool", {})
                    │  after:  → ("Ran command", {"command": "… && ls"})
                    ▼
  tool_call_update id=…GgidjWJty status=completed     ← both caches released here
```
</details>

Correlation is by the protocol's own id, so no vendor `_meta` key is read —
`_meta["cognition.ai/editableCommand"]` would have worked for Devin alone, while
the id works for any agent with this frame shape. (`GooseExecutor` does read a
vendor `_meta` name; this stays generic.)

Scope is the permission path only. Tool-card labels on the happy path
(`:1067`) are unchanged, and no frontend code is touched — the card renders the
name it is handed.

## Test Plan

Four new tests, each **confirmed red on `main`** by stashing the fix. The policy
one is the regression that matters:

```
# on main
E   AssertionError: expected await not found.
E   Expected: mock('PHASE_TOOL_CALL', {'name': 'Ran command', 'arguments': {'command': 'rm -rf build'}})
E     Actual: mock('PHASE_TOOL_CALL', {'name': 'tool',        'arguments': {}})

# and the extraction test
E   AssertionError: assert 'tool' == 'Ran command'
```

- `..._recovers_a_bare_permission_request` — id-only request resolves to the real
  name + command.
- `..._policy_sees_the_real_tool_call` — asserts the exact `PHASE_TOOL_CALL`
  payload, i.e. that a content-based rule now *can* match.
- `..._card_names_the_tool` — asserts what the elicitation handler is called with,
  since those two values are literally what the user reads before approving.
- `..._caches_release_on_completion` — both id-keyed caches drop the entry when
  the call closes, so a long session doesn't accumulate one per tool call.

Plus `..._prefers_the_request_over_the_cache` and `..._unknown_id_degrades_to_tool`
for precedence and the residual fallback.

`_extract_tool_call` becomes an instance method (it now reads per-session cache
state); the two existing tests that called it unbound are updated to use an
instance — no behaviour change for the cases they cover, which still pass.

**Suites** — `tests/inner/test_acp_executor.py`,
`tests/inner/test_goose_executor.py`, `tests/inner/test_qwen_executor.py`,
`tests/runtime/test_acp_spawn_env.py` → **246 passed**. The goose/qwen executors
keep their own copies of this method and are deliberately untouched here.
`pyrefly check` 0 errors, `ruff format`/`check` clean, full `pre-commit` on the
changed files passes, `uv.lock` untouched.

## Demo

N/A — no frontend change. The user-visible string is the card's title and preview,
and the two values behind it are asserted directly in
`..._card_names_the_tool` (before: `("tool", {})`; after:
`("Ran command", {"command": "rm -rf build"})`).

The frame capture in the collapsed section above is from a real `devin acp`
session, recorded with a stdio shim that tee'd the agent's frames during a live
turn — that is the evidence the `toolCallId` is shared and the ordering holds.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was capturing the live ACP frames above from a real signed-in
`devin acp` turn, which is what established the two facts the fix rests on: the
permission request and the `tool_call` share a `toolCallId`, and the `tool_call`
arrives first. Those are properties of the agent's behaviour, so no unit test can
establish them — the tests encode the consequence, the capture establishes the
premise.

Two known limits, both deliberate:

- An agent that sends a bare permission request **without** a preceding
  `tool_call` still degrades to `"tool"` — covered by
  `..._unknown_id_degrades_to_tool`. There is nothing to correlate against, and
  guessing would be worse than a generic label.
- This does not change *whether* the user is asked. The ACP path still elicits on
  `POLICY_ACTION_ALLOW` where other harnesses proceed (`acp_executor.py:863` vs
  `claude_sdk_executor.py:2091`), which is why an ACP agent prompts far more than
  Claude Code. That is filed separately — and it should land *after* this, since
  honoring `ALLOW` while policy is still blind would mean blanket auto-approval.

## Changelog

Approval prompts from ACP agents (e.g. Devin) now name the tool and show its
command instead of an unnamed "tool", and tool policies can match on it
