### PR TITLE
feat(acp): offer the agent's own approval scopes on the card

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -93,6 +93,11 @@ class _PolicyVerdict(Protocol):
 
 _PolicyEvaluator: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[_PolicyVerdict]]
 _ElicitationHandler: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[bool]]
+# Choice-aware elicitation: offers the agent's own permission options and returns
+# the chosen label (``None`` = declined). Optional; falls back to the yes/no form.
+_ElicitationChoiceHandler: TypeAlias = Callable[
+    [str, _AcpJsonObject, Sequence[str]], Awaitable[str | None]
+]
 _ToolExecutor: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[_AcpJsonObject]]
 
 # ACP error code an agent maps to a filesystem "not found" (ENOENT) when a
@@ -348,6 +353,7 @@ class AcpExecutor(Executor):
         # wired (standalone / unit tests) → permission falls back to allow.
         self._policy_evaluator: _PolicyEvaluator | None = None
         self._elicitation_handler: _ElicitationHandler | None = None
+        self._elicitation_choice_handler: _ElicitationChoiceHandler | None = None
         # Adapter-injected tool-execution bridge (the same ``_tool_executor``
         # attribute the SDK harnesses use); backs the Omnigent MCP relay.
         self._tool_executor: _ToolExecutor | None = None
@@ -716,8 +722,8 @@ class AcpExecutor(Executor):
         error: _AcpJsonObject | None = None
         try:
             if method == _AGENT_REQUEST_REQUEST_PERMISSION:
-                allow = await self._decide_permission(params)
-                result = self._permission_outcome(params, allow=allow)
+                allow, option_id = await self._decide_permission(params)
+                result = self._permission_outcome(params, allow=allow, option_id=option_id)
             elif method == "fs/read_text_file" and self._fs_delegation:
                 result = await self._handle_fs_read(params)
             elif method == "fs/write_text_file" and self._fs_delegation:
@@ -831,23 +837,91 @@ class AcpExecutor(Executor):
             args = cached if isinstance(cached, dict) else {}
         return str(name), args
 
-    async def _decide_permission(self, params: _AcpJsonObject) -> bool:
-        """Decide allow/deny for a permission request — policy then elicitation.
+    @staticmethod
+    def _permission_options(params: _AcpJsonObject) -> list[_AcpJsonObject]:
+        """The agent's offered options, each an ``{optionId, name, kind}`` dict."""
+        return [o for o in (params.get("options") or []) if isinstance(o, dict)]
+
+    def _scoped_options(self, params: _AcpJsonObject) -> list[tuple[str, _AcpJsonObject]] | None:
+        """Label the agent's options for a choice card, or ``None`` if unusable.
+
+        Unusable means: fewer than two options, a blank or duplicated label (the
+        reply names the label, so duplicates are ambiguous), or no ``reject_*``
+        option — a choice card replaces the Approve/Reject buttons, so without one
+        the user would have no way to say no.
+        """
+        labeled = [(str(o.get("name") or "").strip(), o) for o in self._permission_options(params)]
+        if len(labeled) < 2 or any(not name for name, _ in labeled):
+            return None
+        labels = [name for name, _ in labeled]
+        if len(set(labels)) != len(labels):
+            return None
+        if not any("reject" in str(o.get("kind", "")) for _, o in labeled):
+            return None
+        return labeled
+
+    async def _ask_user(
+        self, tool_name: str, tool_input: _AcpJsonObject, params: _AcpJsonObject
+    ) -> tuple[bool, str | None]:
+        """Route a permission request to the user; return ``(allowed, option_id)``.
+
+        Prefers the choice bridge, which puts the agent's *own* options on the
+        card: picking "allow this command for the session" is one click the agent
+        then honors itself, so the same command class stops re-prompting. Falls
+        back to the yes/no bridge, whose grant stays once-scoped.
+        """
+        choice_handler = self._elicitation_choice_handler
+        labeled = self._scoped_options(params) if choice_handler is not None else None
+        if choice_handler is not None and labeled is not None:
+            chosen = await choice_handler(tool_name, tool_input, [name for name, _ in labeled])
+            if chosen is None:
+                return False, None
+            picked = next((o for name, o in labeled if name == chosen), None)
+            if picked is None:
+                logger.warning(
+                    "acp permission choice %r was not offered; denying tool=%s", chosen, tool_name
+                )
+                return False, None
+            option_id = picked.get("optionId")
+            allowed = "allow" in str(picked.get("kind", ""))
+            logger.info(
+                "acp permission %s by user (scope=%s): tool=%s",
+                "allowed" if allowed else "denied",
+                option_id,
+                tool_name,
+            )
+            return allowed, (option_id if isinstance(option_id, str) else None)
+
+        handler = self._elicitation_handler
+        if handler is None:
+            return False, None
+        return bool(await handler(tool_name, tool_input)), None
+
+    async def _decide_permission(self, params: _AcpJsonObject) -> tuple[bool, str | None]:
+        """Decide a permission request — policy then elicitation.
 
         1. **TOOL_CALL policy** (:attr:`_policy_evaluator`): a hard
            ``POLICY_ACTION_DENY`` denies; ``POLICY_ACTION_ASK`` defers to
            elicitation (and **fails closed** when no handler is wired);
            ``ALLOW`` / unspecified falls through.
-        2. **Human-consent elicitation** (:attr:`_elicitation_handler`): routes
-           to the user via a web approval card and returns their accept/deny.
+        2. **Human-consent elicitation**: the agent's own options via
+           :attr:`_elicitation_choice_handler`, else a yes/no card via
+           :attr:`_elicitation_handler`.
 
         When neither bridge is wired (standalone / unit tests), falls back to
         allow so direct use of the executor isn't blocked. In normal runner
         operation the adapter installs both, so destructive actions are gated.
+
+        :returns: ``(allowed, option_id)`` — *option_id* is the scope the user
+            picked from the agent's options, or ``None`` to let
+            :meth:`_permission_outcome` choose the narrowest grant.
         """
         tool_name, tool_input = self._extract_tool_call(params)
-        handler = getattr(self, "_elicitation_handler", None)
         policy_eval = getattr(self, "_policy_evaluator", None)
+        # Either bridge can carry the question to the user.
+        can_ask = (
+            self._elicitation_handler is not None or self._elicitation_choice_handler is not None
+        )
 
         if policy_eval is not None:
             action: str | None
@@ -861,45 +935,40 @@ class AcpExecutor(Executor):
                 action = None
             if action == "POLICY_ACTION_DENY":
                 logger.info("acp permission denied by policy: tool=%s", tool_name)
-                return False
+                return False, None
             if action == "POLICY_ACTION_ASK":
-                if handler is None:
+                if not can_ask:
                     logger.warning(
                         "acp TOOL_CALL policy ASK with no elicitation handler; denying tool=%s",
                         tool_name,
                     )
-                    return False
-                allowed = bool(await handler(tool_name, tool_input))
-                logger.info(
-                    "acp permission %s by user (policy ASK): tool=%s",
-                    "allowed" if allowed else "denied",
-                    tool_name,
-                )
-                return allowed
+                    return False, None
+                return await self._ask_user(tool_name, tool_input, params)
             # ALLOW / UNSPECIFIED / unknown → fall through to elicitation.
 
-        if handler is not None:
-            allowed = bool(await handler(tool_name, tool_input))
-            logger.info(
-                "acp permission %s by user: tool=%s",
-                "allowed" if allowed else "denied",
-                tool_name,
-            )
-            return allowed
+        if can_ask:
+            return await self._ask_user(tool_name, tool_input, params)
 
         logger.debug("acp permission allowed (no policy/elicitation wired): tool=%s", tool_name)
-        return True
+        return True, None
 
     @staticmethod
-    def _permission_outcome(params: _AcpJsonObject, *, allow: bool) -> _AcpJsonObject:
-        """Map an allow/deny decision to an ACP permission ``outcome``.
+    def _permission_outcome(
+        params: _AcpJsonObject, *, allow: bool, option_id: str | None = None
+    ) -> _AcpJsonObject:
+        """Map a decision to an ACP permission ``outcome``.
 
-        On allow, prefer a once-scoped grant (``allow_once``) over
-        ``allow_always`` so we never persist a blanket "always allow". On deny,
-        pick a ``reject_*`` option, or ``cancelled`` when none is offered. The
-        agent's options carry both ``optionId`` and ``kind`` (e.g. ``allow_once``).
+        *option_id* is a scope the user picked from the agent's own options; it is
+        echoed only after confirming the agent offered it, so we never send an id
+        it doesn't know. Without one: on allow prefer a once-scoped grant
+        (``allow_once``) over ``allow_always``, so a blanket "always allow" is
+        only ever sent because the user chose it; on deny pick a ``reject_*``
+        option, or ``cancelled`` when none is offered. The agent's options carry
+        both ``optionId`` and ``kind`` (e.g. ``allow_once``).
         """
-        options = [o for o in (params.get("options") or []) if isinstance(o, dict)]
+        options = AcpExecutor._permission_options(params)
+        if option_id is not None and any(o.get("optionId") == option_id for o in options):
+            return {"outcome": {"outcome": "selected", "optionId": option_id}}
 
         def _pick(*kinds: str) -> _AcpJsonObject | None:
             for kind in kinds:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -16,7 +16,7 @@ import logging
 import secrets
 import uuid
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from fastapi import Response
@@ -171,6 +171,15 @@ class ExecutorAdapter(HarnessApp):
             executor._tool_executor = self._stable_tool_executor  # type: ignore[attr-defined]
         if getattr(executor, "_elicitation_handler", None) is None:
             executor._elicitation_handler = self._stable_elicitation_handler  # type: ignore[attr-defined]
+        # ACP-shaped executors also accept a choice bridge, to offer the agent's own
+        # permission scopes; the others don't define the attribute at all.
+        if (
+            hasattr(executor, "_elicitation_choice_handler")
+            and executor._elicitation_choice_handler is None  # type: ignore[attr-defined]
+        ):
+            executor._elicitation_choice_handler = (  # type: ignore[attr-defined]
+                self._stable_elicitation_choice_handler
+            )
         if getattr(executor, "_policy_evaluator", None) is None:
             executor._policy_evaluator = self._stable_policy_evaluator  # type: ignore[attr-defined]
         self._current_ctx = ctx
@@ -544,6 +553,25 @@ class ExecutorAdapter(HarnessApp):
             return False
 
         elicitation_id = f"elicit_{secrets.token_hex(16)}"
+        params = self._permission_card(tool_name, tool_input)
+        result = await ctx.elicit(elicitation_id, params)
+        if result.action == "decline":
+            # Signal via ctx.cancelled (the SDK swallows exceptions from control-request tasks).
+            ctx.cancelled.set()
+        return result.action == "accept"
+
+    def _permission_card(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        *,
+        requested_schema: dict[str, Any] | None = None,
+    ) -> ElicitationRequestParams:
+        """Build the approval-card params for a tool-permission elicitation.
+
+        With *requested_schema* the card renders one button per choice instead of
+        Approve/Reject; without it, the usual binary card.
+        """
         # Build a concise preview: truncate long args so the UI widget
         # stays readable. 300 chars matches AP's policy-engine preview.
         try:
@@ -553,21 +581,61 @@ class ExecutorAdapter(HarnessApp):
         preview = preview[:300]
 
         label = self._harness_label
-        policy_name = f"{label.lower()}_sdk_permission"
-        params = ElicitationRequestParams(
+        return ElicitationRequestParams(
             mode="form",
             message=f"{label} wants to use **{tool_name}**",
-            requestedSchema=None,
+            requestedSchema=requested_schema,
             url=None,
             phase="tool_call",
-            policy_name=policy_name,
+            policy_name=f"{label.lower()}_sdk_permission",
             content_preview=f"{tool_name}({preview})",
         )
+
+    async def _stable_elicitation_choice_handler(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        options: Sequence[str],
+    ) -> str | None:
+        """Stable bridge for a multiple-choice tool-permission elicitation.
+
+        Same gate as :meth:`_stable_elicitation_handler`, but the card offers the
+        harness's own permission scopes as buttons and the chosen label comes back,
+        so the user can grant the scope the agent already supports instead of
+        re-approving the same action every time.
+
+        :returns: The chosen label, or ``None`` when declined, cancelled, or the
+            reply carried no readable answer.
+        """
+        ctx = self._current_ctx
+        if ctx is None:
+            # No active turn — decline by default, as the binary card does.
+            _logger.error(
+                "elicitation choice callback fired with no active turn context "
+                "(tool=%s); declining by default",
+                tool_name,
+            )
+            return None
+
+        elicitation_id = f"elicit_{secrets.token_hex(16)}"
+        # An ``answer`` enum is what the approval card renders as one button per
+        # option, and the reply names the chosen label in ``content["answer"]``.
+        params = self._permission_card(
+            tool_name,
+            tool_input,
+            requested_schema={
+                "type": "object",
+                "properties": {"answer": {"type": "string", "enum": list(options)}},
+                "required": ["answer"],
+            },
+        )
         result = await ctx.elicit(elicitation_id, params)
-        if result.action == "decline":
-            # Signal via ctx.cancelled (the SDK swallows exceptions from control-request tasks).
-            ctx.cancelled.set()
-        return result.action == "accept"
+        if result.action != "accept":
+            if result.action == "decline":
+                ctx.cancelled.set()
+            return None
+        answer = (result.content or {}).get("answer")
+        return answer if isinstance(answer, str) else None
 
     async def _stable_policy_evaluator(
         self,

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -361,7 +361,7 @@ def test_in_progress_tool_update_emits_nothing() -> None:
 @pytest.mark.asyncio
 async def test_decide_permission_allows_with_no_gates() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x"))
-    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None)
 
 
 @pytest.mark.asyncio
@@ -372,7 +372,7 @@ async def test_decide_permission_denies_on_policy_deny() -> None:
         action = "POLICY_ACTION_DENY"
 
     ex._policy_evaluator = AsyncMock(return_value=_V())
-    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (False, None)
 
 
 @pytest.mark.asyncio
@@ -384,7 +384,7 @@ async def test_decide_permission_ask_defers_to_elicitation() -> None:
 
     ex._policy_evaluator = AsyncMock(return_value=_V())
     ex._elicitation_handler = AsyncMock(return_value=True)
-    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None)
     ex._elicitation_handler.assert_awaited_once()
 
 
@@ -396,7 +396,7 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
         action = "POLICY_ACTION_ASK"
 
     ex._policy_evaluator = AsyncMock(return_value=_V())
-    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (False, None)
 
 
 def _seed_tool_call(ex: AcpExecutor) -> dict[str, object]:
@@ -434,7 +434,7 @@ async def test_decide_permission_policy_sees_the_real_tool_call() -> None:
         action = "POLICY_ACTION_DENY"
 
     ex._policy_evaluator = AsyncMock(return_value=_V())
-    assert await ex._decide_permission(params) is False
+    assert await ex._decide_permission(params) == (False, None)
     ex._policy_evaluator.assert_awaited_once_with(
         "PHASE_TOOL_CALL",
         {"name": "Ran command", "arguments": {"command": "rm -rf build"}},
@@ -452,8 +452,185 @@ async def test_decide_permission_card_names_the_tool() -> None:
     params = _seed_tool_call(ex)
     ex._elicitation_handler = AsyncMock(return_value=True)
 
-    assert await ex._decide_permission(params) is True
+    assert await ex._decide_permission(params) == (True, None)
     ex._elicitation_handler.assert_awaited_once_with("Ran command", {"command": "rm -rf build"})
+
+
+# ---------------------------------------------------------------------------
+# Scoped approval: the agent's own permission options
+# ---------------------------------------------------------------------------
+
+
+def _agent_options() -> list[dict[str, str]]:
+    """Devin-shaped options: allow-once, two scoped always-allows, and a reject.
+
+    Order is the agent's own — narrowest first — and is preserved on the card so
+    the least-privilege choice leads.
+    """
+    return [
+        {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+        {
+            "optionId": "allow_session",
+            "name": "Yes, allow `ls` commands (this session)",
+            "kind": "allow_always",
+        },
+        {
+            "optionId": "allow_always_global",
+            "name": "Yes, always allow `ls` commands in all projects",
+            "kind": "allow_always",
+        },
+        {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+    ]
+
+
+def test_acp_executor_accepts_the_choice_bridge() -> None:
+    """The attribute the adapter installs by name exists, and starts unwired.
+
+    The executor half of a cross-layer contract: the adapter gates its install on
+    this attribute (see ``tests/runtime/harnesses/test_executor_adapter.py``), so a
+    rename here would silently disable scoped approval.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    assert ex._elicitation_choice_handler is None
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_offers_the_agents_own_scopes() -> None:
+    """The card gets every option the agent offered, in the agent's order.
+
+    **What breaks if this fails**: the user is back to Approve/Reject and each
+    grant is once-scoped, so the same command class re-prompts indefinitely.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {
+        "toolCall": {"title": "shell", "rawInput": {"command": "ls"}},
+        "options": _agent_options(),
+    }
+    ex._elicitation_choice_handler = AsyncMock(
+        return_value="Yes, allow `ls` commands (this session)"
+    )
+
+    assert await ex._decide_permission(params) == (True, "allow_session")
+    ex._elicitation_choice_handler.assert_awaited_once_with(
+        "shell",
+        {"command": "ls"},
+        [
+            "Allow",
+            "Yes, allow `ls` commands (this session)",
+            "Yes, always allow `ls` commands in all projects",
+            "Reject",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_scoped_choice_reaches_the_agent_as_that_option() -> None:
+    """End of the chain: the agent is told the exact scope the user picked.
+
+    Mirrors the call site (``_decide_permission`` then ``_permission_outcome``),
+    because the scope only takes effect if it survives into the reply — the agent
+    is what honors it and stops asking.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {"toolCall": {"title": "shell"}, "options": _agent_options()}
+    ex._elicitation_choice_handler = AsyncMock(
+        return_value="Yes, allow `ls` commands (this session)"
+    )
+
+    allow, option_id = await ex._decide_permission(params)
+    assert ex._permission_outcome(params, allow=allow, option_id=option_id) == {
+        "outcome": {"outcome": "selected", "optionId": "allow_session"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_choice_reject_denies() -> None:
+    """Picking the agent's own reject option denies, and names that option."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {"toolCall": {"title": "shell"}, "options": _agent_options()}
+    ex._elicitation_choice_handler = AsyncMock(return_value="Reject")
+
+    assert await ex._decide_permission(params) == (False, "reject_once")
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_choice_declined_denies() -> None:
+    """A dismissed / timed-out choice card denies, with no scope."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {"toolCall": {"title": "shell"}, "options": _agent_options()}
+    ex._elicitation_choice_handler = AsyncMock(return_value=None)
+
+    assert await ex._decide_permission(params) == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_choice_not_offered_denies() -> None:
+    """A label the agent never offered fails closed rather than guessing."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {"toolCall": {"title": "shell"}, "options": _agent_options()}
+    ex._elicitation_choice_handler = AsyncMock(return_value="Yes, do whatever you like")
+
+    assert await ex._decide_permission(params) == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_needs_a_reject_option_for_a_choice_card() -> None:
+    """Without a reject option the binary card is used instead.
+
+    A choice card replaces Approve/Reject with the agent's options, so offering
+    only allow-shaped ones would leave the user no way to say no.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {
+        "toolCall": {"title": "shell"},
+        "options": [
+            {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+            {"optionId": "allow_session", "name": "Allow this session", "kind": "allow_always"},
+        ],
+    }
+    ex._elicitation_choice_handler = AsyncMock(return_value="Allow this session")
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    assert await ex._decide_permission(params) == (True, None)
+    ex._elicitation_choice_handler.assert_not_awaited()
+    ex._elicitation_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_falls_back_on_duplicate_labels() -> None:
+    """Two options sharing a label are ambiguous, since the reply names the label."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    params = {
+        "toolCall": {"title": "shell"},
+        "options": [
+            {"optionId": "a1", "name": "Allow", "kind": "allow_once"},
+            {"optionId": "a2", "name": "Allow", "kind": "allow_always"},
+            {"optionId": "r1", "name": "Reject", "kind": "reject_once"},
+        ],
+    }
+    ex._elicitation_choice_handler = AsyncMock(return_value="Allow")
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    assert await ex._decide_permission(params) == (True, None)
+    ex._elicitation_choice_handler.assert_not_awaited()
+
+
+def test_permission_outcome_honors_a_chosen_scope() -> None:
+    """A user-picked option is echoed verbatim, overriding the once-scoped default."""
+    params = {"options": _agent_options()}
+    out = AcpExecutor._permission_outcome(params, allow=True, option_id="allow_session")
+    assert out == {"outcome": {"outcome": "selected", "optionId": "allow_session"}}
+
+
+def test_permission_outcome_ignores_an_unoffered_scope() -> None:
+    """An id the agent didn't offer is never echoed; the safe default applies.
+
+    Guards against sending the agent an option it can't honor — or a broader one
+    than it advertised — if a stale or hand-crafted id ever reaches here.
+    """
+    params = {"options": _agent_options()}
+    out = AcpExecutor._permission_outcome(params, allow=True, option_id="made_up")
+    assert out == {"outcome": {"outcome": "selected", "optionId": "allow_once"}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -2001,3 +2001,162 @@ async def test_policy_evaluator_no_active_turn_context_is_phase_aware() -> None:
         verdict = await adapter._stable_policy_evaluator(advisory_phase, {})
         assert verdict.action == "POLICY_ACTION_ALLOW", advisory_phase
         assert verdict.reason is None, advisory_phase
+
+
+class _CancelFlag:
+    """Records whether the adapter signalled cancellation.
+
+    A real class rather than MagicMock so an unexpected attribute access on the
+    flag fails loud, per the project's testing rules.
+    """
+
+    def __init__(self) -> None:
+        self.was_set = False
+
+    def set(self) -> None:
+        """Mark the turn cancelled."""
+        self.was_set = True
+
+
+class _ElicitingTurnContext:
+    """Stand-in for :class:`TurnContext` that captures one elicitation.
+
+    Only the surface the elicitation bridges touch is implemented: ``elicit`` and
+    ``cancelled``.
+    """
+
+    def __init__(self, reply: Any) -> None:  # type: ignore[explicit-any]
+        """:param reply: The :class:`ElicitationResult` to answer with."""
+        self.reply = reply
+        self.cancelled = _CancelFlag()
+        self.seen: list[Any] = []  # type: ignore[explicit-any]
+
+    async def elicit(self, elicitation_id: str, params: Any) -> Any:  # type: ignore[explicit-any]
+        """Record the request and return the canned reply."""
+        self.seen.append((elicitation_id, params))
+        return self.reply
+
+
+@pytest.mark.asyncio
+async def test_elicitation_choice_handler_asks_for_one_button_per_option() -> None:
+    """The card is asked for buttons, and the chosen label comes back.
+
+    The ``answer`` enum shape is a contract with the web approval card, which
+    renders one button per enum value and replies ``content={"answer": <label>}``
+    (see ``web/src/components/blocks/ApprovalCard.test.tsx``). A change to either
+    half silently collapses the card back to Approve/Reject, so it is asserted
+    exactly here.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import ElicitationResult
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _ElicitingTurnContext(
+        ElicitationResult(action="accept", content={"answer": "Allow this session"})
+    )
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+
+    chosen = await adapter._stable_elicitation_choice_handler(
+        "Ran command",
+        {"command": "ls"},
+        ["Allow", "Allow this session", "Reject"],
+    )
+
+    assert chosen == "Allow this session"
+    (_elicitation_id, params) = ctx.seen[0]
+    assert params.requestedSchema == {
+        "type": "object",
+        "properties": {
+            "answer": {"type": "string", "enum": ["Allow", "Allow this session", "Reject"]}
+        },
+        "required": ["answer"],
+    }
+    # The card still names the tool and previews its arguments, as the binary one does.
+    assert "Ran command" in params.message
+    assert params.content_preview == 'Ran command({"command": "ls"})'
+    assert params.phase == "tool_call"
+    assert not ctx.cancelled.was_set
+
+
+@pytest.mark.asyncio
+async def test_elicitation_choice_handler_declines_on_a_dismissed_card() -> None:
+    """A declined card returns no choice and signals cancellation, as before."""
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.server.schemas import ElicitationResult
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _ElicitingTurnContext(ElicitationResult(action="decline"))
+    adapter._current_ctx = ctx  # type: ignore[assignment]
+
+    assert (
+        await adapter._stable_elicitation_choice_handler("shell", {}, ["Allow", "Reject"]) is None
+    )
+    assert ctx.cancelled.was_set
+
+
+@pytest.mark.asyncio
+async def test_elicitation_choice_handler_declines_without_a_turn() -> None:
+    """An orphaned callback declines rather than granting a scope unreviewed."""
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    assert adapter._current_ctx is None
+
+    assert (
+        await adapter._stable_elicitation_choice_handler("shell", {}, ["Allow", "Reject"]) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_turn_installs_the_choice_bridge_only_where_supported() -> None:
+    """The choice bridge reaches executors that accept it, and only those.
+
+    Bridges are installed by attribute, so a rename on either side would leave the
+    feature silently inert — the card would quietly stay Approve/Reject. Executors
+    that don't offer the agent's own options must not grow the attribute.
+    """
+    import asyncio
+
+    from omnigent.inner.executor import Executor, ExecutorConfig, Message, ToolSpec, TurnComplete
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.runtime.harnesses._scaffold import TurnContext
+    from omnigent.server.schemas import CreateResponseRequest
+
+    class _ChoiceCapableExecutor(Executor):
+        """Declares the attribute, as :class:`AcpExecutor` does."""
+
+        def __init__(self) -> None:
+            self._elicitation_choice_handler = None
+
+        async def run_turn(
+            self,
+            messages: list[Message],
+            tools: list[ToolSpec],
+            system_prompt: str,
+            config: ExecutorConfig | None = None,
+        ):
+            yield TurnComplete(response="ok")
+
+    class _BinaryOnlyExecutor(Executor):
+        """Declares no choice attribute — e.g. the SDK harnesses."""
+
+        async def run_turn(
+            self,
+            messages: list[Message],
+            tools: list[ToolSpec],
+            system_prompt: str,
+            config: ExecutorConfig | None = None,
+        ):
+            yield TurnComplete(response="ok")
+
+    for executor, expected in ((_ChoiceCapableExecutor(), True), (_BinaryOnlyExecutor(), False)):
+        adapter = ExecutorAdapter(executor_factory=lambda e=executor: e)  # type: ignore[misc]
+        ctx = TurnContext(
+            response_id="resp_bridge", event_queue=asyncio.Queue(), cancelled=asyncio.Event()
+        )
+        await adapter.run_turn(CreateResponseRequest(model="agent", input="hi"), ctx)
+
+        installed = getattr(executor, "_elicitation_choice_handler", None) is not None
+        assert installed is expected, type(executor).__name__
+        # The yes/no bridge is installed on both — the choice bridge is additive.
+        assert getattr(executor, "_elicitation_handler", None) is not None


### PR DESCRIPTION
## Related issue

Closes #5051

> **Stacked on #5050** (`base` is that branch, so this diff is one commit). GitHub
> retargets this to `main` automatically when #5050 merges. Both touch
> `acp_executor.py` and its test file; stacking keeps them conflict-free.

## Summary

An ACP agent can offer several differently-scoped ways to say yes. Devin sends
**six** options for one shell command; we showed two and always answered
`allow_once`:

```json
"options": [
  {"optionId": "allow_once",          "kind": "allow_once",   "name": "Allow"},
  {"optionId": "allow_session",       "kind": "allow_always", "name": "Yes, allow `ls` commands (this session)"},
  {"optionId": "allow_always",        "kind": "allow_always", "name": "…always allow `ls` commands in `<project>`"},
  {"optionId": "allow_always_global", "kind": "allow_always", "name": "…always allow `ls` commands in all projects"},
  {"optionId": "switch_bypass",       "kind": "allow_always", "name": "Yes, switch to bypass mode"},
  {"optionId": "reject_once",         "kind": "reject_once",  "name": "Reject"}
]
```

`allow_once` is the right *default* — but it means the agent is told "just this
once" every time and re-asks for the same command class forever. A dogfooder hit
**50+ prompts in about five minutes** on one small task, and asked for a blanket
auto-approve switch, which is the worst version of this: it trades all oversight
for fewer clicks when the agent already offers graduated scopes.

Now the options go to the card and the user's pick goes back, so "allow `ls` for
this session" is one click that **the agent itself** honors. That mirrors how
claude-native's "Approve & don't ask again" works — it echoes `addRules` so Claude
Code persists the grant — rather than inventing omnigent-side permission state.

**Backend only.** The card already renders an `answer` enum as one button per
choice and replies `content={"answer": <label>}`, with tests
(`ApprovalCard.test.tsx:430`, `:465`). No frontend change.

<details>
<summary>ELI5 + the flow</summary>

Devin asks "may I run `ls`?" and offers six answers, from "just this once" to
"stop asking me". We were reading only the first and last, so the user could only
say "yes, once" — and got asked again for the next `ls`. Now the user sees Devin's
own answers and can pick "yes, for this session", which Devin then remembers.

```
  agent's options ──► _scoped_options()  ──► labels ──► approval card (one button each)
                            │                                   │
              usable? ≥2, distinct labels,                 user picks one
              at least one reject                               │
                            │                                   ▼
                            ▼                       ("allow this session")
                   unusable → binary card                       │
                   (Approve / Reject, allow_once)               ▼
                                                  outcome {selected: allow_session}
                                                        └─► the AGENT stops asking
```
</details>

- `_decide_permission` returns `(allowed, option_id)`; `_permission_outcome` echoes
  that option **only after confirming the agent offered it**, and otherwise still
  prefers the narrowest grant. A blanket "always allow" is now only ever sent
  because the user chose it by name.
- The choice card is skipped — falling back to Approve/Reject — unless the agent
  offers a `reject_*` option (the choice buttons *replace* Approve/Reject, so
  without one the user would have no way to say no) and every label is distinct
  (the reply names the label, so duplicates are ambiguous).
- The adapter installs the richer bridge only on executors that declare the
  attribute, so the SDK harnesses keep the binary card. `qwen`/`goose` keep their
  own independent copies of this method and are untouched.

## ⚠️ One judgment call for the reviewer

Devin's list includes **"Yes, switch to bypass mode"**, which disables its own
prompting for the session. Passing every option through makes that a one-click
button — attractive to exactly the frustrated user this PR is for.

I passed it through anyway, on the principle that these are the agent's own
affordances and Omnigent is transport here: the label says plainly what it does,
the user can already do it in `devin` directly, and filtering it would mean
matching a vendor-specific `optionId`, which is the coupling this design avoids.
Button order is the agent's own (narrowest first), so least-privilege leads. If
you'd rather we drop `allow_always`-kind options that aren't scoped to a command,
say so — it's a one-line filter in `_scoped_options`.

## Test Plan

Ten new tests. The option list in the fixture is the **real captured frame** above
(labels and `optionId`s verbatim), so the mapping is exercised against what Devin
actually sends rather than an invented shape.

- `..._offers_the_agents_own_scopes` — asserts the exact labels handed to the card,
  in the agent's order.
- `..._scoped_choice_reaches_the_agent_as_that_option` — mirrors the call site
  (`_decide_permission` → `_permission_outcome`) and asserts the reply is
  `{"outcome": "selected", "optionId": "allow_session"}`. The scope is worthless if
  it doesn't survive into the reply, since the agent is what honors it.
- `..._choice_reject_denies` / `..._choice_declined_denies` /
  `..._choice_not_offered_denies` — every non-grant path fails closed.
- `..._needs_a_reject_option_for_a_choice_card` and
  `..._falls_back_on_duplicate_labels` — assert the binary handler is used instead
  *and* the choice handler is not awaited.
- `..._permission_outcome_ignores_an_unoffered_scope` — a made-up id is never
  echoed; the safe `allow_once` default applies.
- `test_elicitation_choice_handler_asks_for_one_button_per_option` — pins the
  `answer`-enum schema that the web card renders, plus the message/preview.
- `test_run_turn_installs_the_choice_bridge_only_where_supported` +
  `test_acp_executor_accepts_the_choice_bridge` — the two halves of a cross-layer
  contract. Bridges are installed *by attribute*, so a rename on either side would
  leave this silently inert and the card quietly binary; these fail loudly instead.

The six existing `_decide_permission` assertions are updated for the tuple return
(`is True` → `== (True, None)`); their behaviour is unchanged.

**Suites** — `tests/inner/test_acp_executor.py`,
`tests/inner/test_goose_executor.py`, `tests/inner/test_qwen_executor.py`,
`tests/runtime/harnesses/`, `tests/runtime/test_acp_spawn_env.py` → **427 passed**.
`pyrefly` 0 errors, `ruff` clean, full `pre-commit` on changed files passes,
`uv.lock` untouched.

## Demo

N/A — no frontend change; the buttons are the card's existing enum rendering,
covered by `ApprovalCard.test.tsx`. The schema this PR emits into that renderer is
asserted byte-for-byte in `test_elicitation_choice_handler_asks_for_one_button_per_option`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

I have **not** driven a live scoped approval end to end, and want to be plain about
it: that needs a human to click a button in the web UI, and in headless `-p` mode a
Devin permission request currently produces no visible card at all (a separate
problem, not yet filed). What is machine-verified is every link in the chain — the
labels sent, the schema the card renders, the label→`optionId` mapping, and the
outcome the agent receives — using Devin's real captured option list.

The behaviour a reviewer should weigh, beyond the bypass question above: when the
user picks the agent's own **Reject** option, the reply is `reject_once` and
`ctx.cancelled` is *not* set, where clicking Reject on the binary card does set it.
That looks right to me — ACP has a first-class "rejected" outcome and the agent
adapts, whereas cancelling is a different concept (`session/cancel`) — but it is a
deliberate difference in the new path, so it deserves a second opinion.

## Changelog

Approval prompts from ACP agents now offer the agent's own scopes — e.g. "allow
this command for the session" — so repeating the same action stops re-prompting
