### PR TITLE
fix(host,runner): reconnect host + all sessions promptly on laptop wake

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -128,6 +128,7 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
+from omnigent.suspend_watch import watch_for_resume
 from omnigent.tls import client_ssl_context
 from omnigent.version import VERSION
 
@@ -898,6 +899,15 @@ class HostProcess:
         # Strong refs to in-flight frame tasks (create_task results are
         # otherwise GC-able); each discards itself on completion.
         self._frame_tasks: set[asyncio.Task[None]] = set()
+        # Background watcher that force-drops a stale tunnel on wake from system
+        # suspend (laptop sleep) so the reconnect loop reattaches at once
+        # instead of waiting out the ~90s keepalive timeout. See run() /
+        # _on_resume_from_suspend.
+        self._suspend_task: asyncio.Task[None] | None = None
+        # Set by _on_resume_from_suspend when it aborts a live tunnel after a
+        # detected resume; read+cleared in run()'s reconnect handler to force a
+        # prompt reconnect (skip the backoff).
+        self._woke_from_suspend = False
 
     def _tracked_runner_pids(self) -> set[int]:
         """PIDs of runners this host spawned and still tracks directly.
@@ -2634,6 +2644,12 @@ class HostProcess:
         self._reaper_task = asyncio.create_task(
             self._orphan_reaper_loop(), name="host-orphan-reaper"
         )
+        # Detect wake from system suspend (laptop sleep) and force-drop the
+        # then-dead tunnel so the reconnect loop reattaches within seconds
+        # instead of waiting out the ~90s keepalive ping timeout.
+        self._suspend_task = asyncio.create_task(
+            watch_for_resume(self._on_resume_from_suspend), name="host-suspend-watch"
+        )
         # Warm the runner zygote now: start() blocks on its one-time import
         # of the runner graph (~1-2s), which otherwise lands inside the first
         # session launch of the daemon's life. Best-effort — a failure
@@ -2749,16 +2765,29 @@ class HostProcess:
                     # A silent-connect streak overrides the recycle fast path:
                     # prompt reconnects are for endpoints that answer.
                     silent_churn = self._silent_connect_streak >= _SILENT_CONNECT_ESCALATE_ATTEMPTS
-                    recycle = (
-                        explicit_recycle
-                        or (ingress_recycle and not _url_is_loopback(self._server_url))
-                    ) and not silent_churn
+                    # A resume from system suspend (laptop wake) always reconnects
+                    # promptly: _on_resume_from_suspend already aborted the dead
+                    # tunnel, but the abrupt "no close frame" that abort produces
+                    # counts as a benign recycle only on a REMOTE server — a local
+                    # server would otherwise ride the escalating backoff. OR woke in
+                    # outside the silent-churn gate so wake never takes the slow path.
+                    woke = self._woke_from_suspend
+                    self._woke_from_suspend = False
+                    recycle = woke or (
+                        (
+                            explicit_recycle
+                            or (ingress_recycle and not _url_is_loopback(self._server_url))
+                        )
+                        and not silent_churn
+                    )
                     wait_s = _RECONNECT_BASE_S if recycle else backoff
                     _logger.warning(
                         "Host tunnel disconnected: %s. Reconnecting in %.1fs%s",
                         exc,
                         wait_s,
-                        " (recycle — prompt reconnect)" if recycle else "",
+                        " (resumed from suspend — prompt reconnect)"
+                        if woke
+                        else (" (recycle — prompt reconnect)" if recycle else ""),
                     )
                     await asyncio.sleep(wait_s)
                     import random
@@ -2780,6 +2809,11 @@ class HostProcess:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await self._reaper_task
                 self._reaper_task = None
+            if self._suspend_task is not None:
+                self._suspend_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._suspend_task
+                self._suspend_task = None
             if self._zygote_prestart_task is not None:
                 self._zygote_prestart_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -2801,6 +2835,43 @@ class HostProcess:
                 with contextlib.suppress(Exception):
                     self._zygote.stop()
                 self._zygote = None
+
+    def _on_resume_from_suspend(self, gap_s: float) -> None:
+        """Force-drop the tunnel after a detected wake from system suspend.
+
+        On laptop sleep the WebSocket becomes a half-open socket the server
+        already dropped; without this the reconnect loop waits out the ~90s
+        keepalive ping timeout (:data:`TUNNEL_KEEPALIVE_PING_TIMEOUT_S`),
+        leaving the host — and every session it owns — offline that whole
+        time. Aborting the transport makes :meth:`_serve_frames`' ``recv``
+        raise ``ConnectionClosed`` now, and the flag makes :meth:`run` skip the
+        backoff so the reconnect is prompt.
+
+        No-op when no connection is live (e.g. the wake landed during a
+        reconnect backoff): there is nothing to abort, and the pending backoff
+        sleep's deadline is already past so it reconnects immediately anyway.
+        The flag is only set when a live tunnel was actually aborted, so a
+        wake-during-backoff never triggers a spurious prompt reconnect.
+
+        Runs synchronously on the event loop (invoked by the suspend watcher),
+        so reading ``self._ws`` and aborting is atomic w.r.t. ``_serve_frames``
+        — no lock needed.
+
+        :param gap_s: Approximate seconds the machine was asleep (for logging).
+        :returns: None.
+        """
+        ws = self._ws
+        if ws is None:
+            return
+        self._woke_from_suspend = True
+        _logger.info(
+            "Resumed from suspend (~%.0fs); dropping stale host tunnel to reconnect",
+            gap_s,
+        )
+        transport = getattr(ws, "transport", None)
+        if transport is not None:
+            with contextlib.suppress(Exception):
+                transport.abort()
 
     def _cleanup_runners(self) -> None:
         """Terminate all live runners on shutdown.

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -53,6 +53,7 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
+from omnigent.suspend_watch import watch_for_resume
 from omnigent.tls import client_ssl_context
 
 _logger = logging.getLogger(__name__)
@@ -354,6 +355,15 @@ async def serve_tunnel(
         login_redirect_streak = 0
         http_auth_rejection_streak = 0
 
+    # Set by the per-connection suspend watcher (in _serve_tunnel_once) when it
+    # aborts the live tunnel after a wake from system suspend. Read at the
+    # bottom of the loop to force a prompt reconnect (skip the backoff).
+    woke_from_suspend = False
+
+    def _note_resume_from_suspend() -> None:
+        nonlocal woke_from_suspend
+        woke_from_suspend = True
+
     while True:
         if shutdown_event is not None and shutdown_event.is_set():
             # A shutdown requested between reconnect attempts (no live
@@ -380,6 +390,7 @@ async def serve_tunnel(
                 shutdown_event=shutdown_event,
                 on_graceful_shutdown=on_graceful_shutdown,
                 on_connected=_mark_connected,
+                on_resume_note=_note_resume_from_suspend,
                 direct_attach_port=direct_attach_port,
                 direct_attach_token=direct_attach_token,
                 **activity_kwargs,
@@ -491,6 +502,15 @@ async def serve_tunnel(
                         retry_reason = str(exc)
         except (ConnectionError, OSError, ValueError) as exc:
             retry_reason = str(exc)
+        if woke_from_suspend:
+            # A wake from system suspend already aborted the live tunnel (see
+            # _serve_tunnel_once's watcher). The abrupt close would otherwise
+            # ride the escalating backoff; force a prompt reconnect at the base
+            # delay, like a server recycle, so the session reattaches at once.
+            woke_from_suspend = False
+            delay_s = _INITIAL_RECONNECT_DELAY_S
+            recycle = True
+            retry_reason = "resumed from system suspend; reconnecting promptly"
         jittered = delay_s * (
             1.0 + random.uniform(-_RECONNECT_JITTER_FRACTION, _RECONNECT_JITTER_FRACTION)
         )
@@ -652,6 +672,7 @@ async def _serve_tunnel_once(
     shutdown_event: asyncio.Event | None = None,
     on_graceful_shutdown: Callable[[], None] | None = None,
     on_connected: Callable[[], None] | None = None,
+    on_resume_note: Callable[[], None] | None = None,
     direct_attach_port: int | None = None,
     direct_attach_token: str | None = None,
 ) -> None:
@@ -681,6 +702,10 @@ async def _serve_tunnel_once(
     :param on_connected: Optional sync callback fired once the WS
         upgrade is accepted. ``serve_tunnel`` uses it to distinguish a
         runner that has authenticated from one that never has.
+    :param on_resume_note: Optional sync callback fired when a wake from
+        system suspend is detected on this connection (just before the dead
+        socket is aborted). ``serve_tunnel`` uses it to force a prompt
+        reconnect instead of the escalating backoff.
     :returns: None.
     """
     import websockets
@@ -742,6 +767,32 @@ async def _serve_tunnel_once(
             direct_attach_token=direct_attach_token,
         )
         _logger.info("runner %s connected to %s", runner_id, tunnel_url)
+
+        def _on_resume_from_suspend(gap_s: float) -> None:
+            # Wake from system suspend: this socket is now half-open (the server
+            # already dropped it), so abort it to make the read below raise at
+            # once instead of waiting out the ~90s keepalive timeout;
+            # serve_tunnel then reconnects promptly. Skip during a graceful
+            # idle-reaper drain — aborting mid-drain would turn the clean
+            # end-of-stream close into an abrupt runner_disconnected.
+            if shutdown_event is not None and shutdown_event.is_set():
+                return
+            _logger.info(
+                "runner %s resumed from suspend (~%.0fs); dropping tunnel to reconnect",
+                runner_id,
+                gap_s,
+            )
+            if on_resume_note is not None:
+                on_resume_note()
+            transport = getattr(ws, "transport", None)
+            if transport is not None:
+                with contextlib.suppress(Exception):
+                    transport.abort()
+
+        suspend_task = asyncio.create_task(
+            watch_for_resume(_on_resume_from_suspend),
+            name=f"runner-suspend-watch:{runner_id}",
+        )
         try:
             if shutdown_event is None:
                 async for raw in ws:
@@ -820,6 +871,9 @@ async def _serve_tunnel_once(
                     with contextlib.suppress(asyncio.CancelledError):
                         await shutdown_wait
         finally:
+            suspend_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await suspend_task
             await _cancel_dispatch_tasks(dispatch_tasks)
             await _cancel_ws_channels(ws_channels)
 

--- a/omnigent/suspend_watch.py
+++ b/omnigent/suspend_watch.py
@@ -1,0 +1,109 @@
+"""Detect a system suspend/resume (laptop sleep) so live connections can
+reconnect promptly instead of waiting out the WebSocket keepalive.
+
+When a laptop's lid closes the OS freezes the whole process and drops the
+network. Long-lived WebSockets (the host control channel in
+:mod:`omnigent.host.connect`, every runner tunnel in
+:mod:`omnigent.runner.transports.ws_tunnel.serve`) become half-open sockets
+the peer has already dropped. Nothing notices until the ``websockets``
+keepalive ping times out — up to ~120 s (``ping_interval`` 30 s +
+``ping_timeout`` 90 s) — during which the host and its sessions look offline
+to the server and the desktop app.
+
+:func:`watch_for_resume` gives an event loop a cheap way to react the instant
+it wakes: it polls a short interval and compares how far the realtime (wall)
+clock advanced against the monotonic clock. The monotonic clock freezes while
+the machine is asleep (macOS ``mach_absolute_time`` and Linux
+``CLOCK_MONOTONIC`` both exclude sleep) while the realtime clock keeps
+counting, so a resume shows up as a large divergence between the two across a
+single poll. A merely-blocked event loop (a long synchronous call, a GC pause)
+advances *both* clocks equally, so the divergence stays ~0 — this never
+false-fires on CPU stalls, only on a real suspend.
+
+Deliberately uses :func:`time.monotonic`, never the event loop's
+``loop.time()``: uvloop's ``loop.time()`` is backed by libuv's clock, which
+*includes* sleep on macOS (see the same trap documented in
+``omnigent/runtime/harnesses/process_manager.py``), which would zero out the
+divergence and silently disable detection. :func:`time.monotonic` is
+process-wide and loop-independent.
+
+Windows note: ``time.monotonic()`` on Windows counts suspended time, so the
+divergence stays ~0 there and this watcher never fires — the connection falls
+back to the keepalive-timeout behavior it has today (no regression).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+_logger = logging.getLogger(__name__)
+
+# Poll cadence. Detection latency after a wake is at most one interval: the
+# in-flight sleep's deadline is on the frozen monotonic clock, so it elapses
+# shortly after the machine resumes. 5 s keeps wake reconnects snappy at
+# negligible cost — the host already runs a 2 s orphan-reaper and a 5 s
+# harness-readiness loop, so this adds no meaningful wakeups.
+SUSPEND_POLL_INTERVAL_S = 5.0
+
+# Minimum wall-minus-monotonic divergence, in seconds, that counts as a resume.
+# Comfortably above scheduler jitter and clock-read skew. Because the signal is
+# the *divergence* (not raw wall time), a blocked event loop can never reach it
+# no matter how long it blocks — only real suspended time diverges the clocks.
+# A lid-close shorter than this won't fire, but such a short sleep rarely drops
+# the socket (the keepalive budget is 90 s) so the connection stays healthy.
+SUSPEND_GAP_THRESHOLD_S = 15.0
+
+
+async def watch_for_resume(
+    on_resume: Callable[[float], None],
+    *,
+    interval_s: float = SUSPEND_POLL_INTERVAL_S,
+    threshold_s: float = SUSPEND_GAP_THRESHOLD_S,
+    wall_clock: Callable[[], float] = time.time,
+    mono_clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    """Call ``on_resume(gap_s)`` once each time the machine resumes from sleep.
+
+    Loops forever polling ``interval_s`` at a time; whenever the wall clock
+    advanced more than ``threshold_s`` beyond the monotonic clock across one
+    poll, the machine slept and just woke, and ``on_resume`` is invoked with
+    the approximate sleep duration in seconds. Cancel the task to stop.
+
+    ``on_resume`` runs on the event loop and must be sync, non-blocking, and
+    must not raise — callers use it to abort a now-dead socket and flag a
+    prompt reconnect. Any exception it raises is logged and swallowed so the
+    watcher survives.
+
+    :param on_resume: Sync callback invoked once per detected resume with the
+        approximate seconds spent asleep.
+    :param interval_s: Poll cadence; also the worst-case detection latency
+        after a wake.
+    :param threshold_s: Minimum wall-minus-monotonic divergence that counts as
+        a resume.
+    :param wall_clock: Realtime clock reader (advances during sleep).
+        Injectable for tests.
+    :param mono_clock: Monotonic clock reader (freezes during sleep on
+        macOS/Linux). Injectable for tests. Defaults to :func:`time.monotonic`
+        — never ``loop.time()`` (see the module docstring).
+    :param sleep: Awaitable sleeper; injectable so tests can drive the loop
+        deterministically without patching :func:`asyncio.sleep` globally.
+    :returns: Never returns normally; cancel the task to stop it.
+    """
+    while True:
+        wall_before = wall_clock()
+        mono_before = mono_clock()
+        await sleep(interval_s)
+        # Re-sample per iteration (not against a fixed baseline): a resume must
+        # fire exactly once, on the poll that spanned the sleep. The next poll
+        # sees gap ~0 again.
+        gap = (wall_clock() - wall_before) - (mono_clock() - mono_before)
+        if gap >= threshold_s:
+            _logger.info("Resumed from suspend (~%.0fs asleep); notifying", gap)
+            try:
+                on_resume(gap)
+            except Exception:
+                _logger.exception("suspend on_resume callback failed")

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4609,3 +4609,170 @@ def test_direct_spawn_keeps_the_workspace_off_sys_path(
     _host, popen_argvs = _spawn_with_fake_zygote(monkeypatch, tmp_path, zygote)
 
     assert popen_argvs[0][1:] == ["-P", "-m", "omnigent.runner._entry"]
+
+
+async def test_on_resume_from_suspend_aborts_live_tunnel() -> None:
+    """A detected wake aborts the live tunnel and flags a prompt reconnect.
+
+    ``_on_resume_from_suspend`` runs synchronously on the event loop; with a
+    live ``self._ws`` it must abort the transport — so ``_serve_frames``'
+    blocked ``recv`` raises at once instead of waiting out the ~90s keepalive —
+    and set the woke flag that ``run`` reads to skip the reconnect backoff.
+
+    :returns: None.
+    """
+    host = _make_host_process()
+
+    class _Transport:
+        """asyncio-transport stub that records an ``abort()``."""
+
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def abort(self) -> None:
+            """Record the forced close.
+
+            :returns: None.
+            """
+            self.aborted = True
+
+    transport = _Transport()
+    host._ws = SimpleNamespace(transport=transport)  # type: ignore[assignment]
+
+    host._on_resume_from_suspend(3600.0)
+
+    assert transport.aborted is True
+    assert host._woke_from_suspend is True
+
+
+async def test_on_resume_from_suspend_noop_without_live_tunnel() -> None:
+    """With no live tunnel the resume hook does nothing and sets no flag.
+
+    A wake during a reconnect backoff has no socket to abort; the flag must
+    stay clear so an unrelated later drop is not spuriously reclassified as a
+    prompt reconnect.
+
+    :returns: None.
+    """
+    host = _make_host_process()
+    assert host._ws is None
+
+    host._on_resume_from_suspend(3600.0)
+
+    assert host._woke_from_suspend is False
+
+
+async def test_run_reconnects_promptly_after_suspend(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """After a wake, run() aborts the dead tunnel and reconnects at once.
+
+    Drives the real reconnect loop against a *loopback* server, where an
+    abrupt drop is NOT auto-classified as a benign ingress recycle — so a
+    prompt reconnect here is attributable to the suspend-resume path, not the
+    recycle heuristic. A fake watcher fires a resume once the tunnel is live;
+    the real ``_on_resume_from_suspend`` aborts it, and the loop must reconnect
+    (not hang or exit) and attribute the drop to the resume.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Log capture fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+
+    class _BlockingTunnel:
+        """Accepted tunnel whose ``recv()`` blocks until the transport aborts."""
+
+        def __init__(self) -> None:
+            self._dead = asyncio.Event()
+            self.transport = SimpleNamespace(abort=self._dead.set)
+
+        async def send(self, data: str | bytes) -> None:
+            """Accept the ``host.hello`` frame silently.
+
+            :param data: Encoded frame payload (ignored).
+            :returns: None.
+            """
+            del data
+
+        async def recv(self) -> str:
+            """Block until aborted, then fail like a dropped connection.
+
+            :returns: Never returns a frame.
+            :raises ConnectionClosedError: Once the transport is aborted.
+            """
+            await self._dead.wait()
+            raise ConnectionClosedError(None, None)
+
+    class _BlockingConnect:
+        """Async-CM for a successful upgrade to a blocking tunnel."""
+
+        def __init__(self, tunnel: _BlockingTunnel) -> None:
+            self._tunnel = tunnel
+
+        async def __aenter__(self) -> _BlockingTunnel:
+            """Complete the handshake with the blocking tunnel.
+
+            :returns: The blocking tunnel.
+            """
+            return self._tunnel
+
+        async def __aexit__(self, *exc_info: object) -> bool:
+            """No-op async-CM exit.
+
+            :param exc_info: Standard ``__aexit__`` triple (unused).
+            :returns: ``False`` so the disconnect propagates.
+            """
+            del exc_info
+            return False
+
+    tunnel = _BlockingTunnel()
+    connect_calls = {"n": 0}
+
+    def _connect(url: str, **kwargs: object) -> object:
+        """Serve one live tunnel, then stop the loop.
+
+        :param url: Tunnel URL (ignored).
+        :param kwargs: Connect kwargs (ignored).
+        :returns: A blocking-tunnel CM on the first call; a CM that cancels
+            the loop thereafter.
+        """
+        del url, kwargs
+        connect_calls["n"] += 1
+        if connect_calls["n"] == 1:
+            return _BlockingConnect(tunnel)
+        return _HandshakeFailingConnect(asyncio.CancelledError())
+
+    host = _make_host_process()  # loopback server_url (http://localhost:8000)
+
+    async def _fake_watch(on_resume: object, **_kwargs: object) -> None:
+        """Simulate a wake once the first tunnel is live, then idle.
+
+        :param on_resume: The host's real resume hook.
+        :param _kwargs: Ignored watcher tuning args.
+        :returns: None.
+        """
+        # Wait until _serve_frames has set self._ws so there is a live socket
+        # to abort (otherwise the resume hook would be a no-op).
+        while host._ws is None:
+            await asyncio.sleep(0)
+        on_resume(3600.0)  # type: ignore[operator]
+        await asyncio.Event().wait()
+
+    import websockets.asyncio.client as ws_client
+
+    import omnigent.runner._entry as entry_mod
+
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda *, server_url=None: None)
+    monkeypatch.setattr(ws_client, "connect", _connect)
+    monkeypatch.setattr("omnigent.host.connect.watch_for_resume", _fake_watch)
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    # Two connects: the initial live tunnel + the prompt reconnect after wake.
+    assert connect_calls["n"] == 2
+    # The disconnect was attributed to the resume, and the flag was consumed.
+    assert any("resumed from suspend" in r.message for r in caplog.records)
+    assert host._woke_from_suspend is False

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -11,7 +11,12 @@ from typing import Any, TypedDict
 
 import pytest
 from typing_extensions import Unpack
-from websockets.exceptions import InvalidStatus, InvalidURI, WebSocketException
+from websockets.exceptions import (
+    ConnectionClosedError,
+    InvalidStatus,
+    InvalidURI,
+    WebSocketException,
+)
 from websockets.http11 import Response
 
 from omnigent.runner.identity import (
@@ -2002,3 +2007,188 @@ async def test_serve_tunnel_retries_403_forever_once_connected(
     # Backoff escalates to the cap instead of resetting to the base delay on
     # every rejection — a reset would retry every ~0.5s for the whole outage.
     assert sleeps == [0.5, 1.0, 2.0, 4.0, 8.0, 10.0]
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_once_suspend_resume_aborts_tunnel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A detected wake from system suspend aborts the live tunnel at once.
+
+    On laptop wake the socket is half-open — the server already dropped it —
+    so waiting out the ~90s keepalive would leave the session offline that
+    whole time. The per-connection suspend watcher must abort the transport
+    (unblocking the read) and note the resume so ``serve_tunnel`` reconnects
+    promptly.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import websockets
+
+    class _FakeTransport:
+        """asyncio-transport stub whose ``abort()`` kills the pending recv."""
+
+        def __init__(self, dead: asyncio.Event) -> None:
+            self._dead = dead
+            self.aborted = False
+
+        def abort(self) -> None:
+            """Record the abort and unblock the fake ``recv``.
+
+            :returns: None.
+            """
+            self.aborted = True
+            self._dead.set()
+
+    class _FakeWS:
+        """WebSocket stub whose ``recv()`` blocks until the transport aborts."""
+
+        def __init__(self) -> None:
+            self._dead = asyncio.Event()
+            self.transport = _FakeTransport(self._dead)
+            self.sent: list[str] = []
+
+        async def send(self, data: str) -> None:
+            """Accept the hello frame.
+
+            :param data: Encoded frame payload.
+            :returns: None.
+            """
+            self.sent.append(data)
+
+        async def recv(self) -> str:
+            """Block until aborted, then fail like a dropped socket.
+
+            :returns: Never returns a frame.
+            :raises ConnectionClosedError: Once the transport is aborted.
+            """
+            await self._dead.wait()
+            raise ConnectionClosedError(None, None)
+
+    ws = _FakeWS()
+
+    class _Ctx:
+        """Async-CM returned by the fake ``websockets.connect``."""
+
+        async def __aenter__(self) -> _FakeWS:
+            """Yield the fake WebSocket.
+
+            :returns: The fake WebSocket.
+            """
+            return ws
+
+        async def __aexit__(self, *exc_info: object) -> bool:
+            """Propagate any exception.
+
+            :param exc_info: Standard ``__aexit__`` triple (unused).
+            :returns: ``False`` so the disconnect propagates.
+            """
+            del exc_info
+            return False
+
+    async def _fake_watch(on_resume: Any, **_kwargs: Any) -> None:
+        """Fire one resume (simulating a wake), then block until cancelled.
+
+        :param on_resume: The watcher callback under test.
+        :param _kwargs: Ignored watcher tuning args.
+        :returns: None.
+        """
+        on_resume(3600.0)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(websockets, "connect", lambda *_a, **_kw: _Ctx())
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
+    monkeypatch.setattr(serve_module, "watch_for_resume", _fake_watch)
+
+    noted: list[bool] = []
+    # shutdown_event unset -> the production read loop (races recv vs shutdown).
+    with pytest.raises(ConnectionClosedError):
+        await _serve_tunnel_once(
+            _noop_app,
+            tunnel_url="ws://127.0.0.1:8000/v1/runners/runner_wake/tunnel",
+            server_url="http://127.0.0.1:8000",
+            runner_id="runner_wake",
+            runner_version="0.1.0",
+            shutdown_event=asyncio.Event(),
+            on_resume_note=lambda: noted.append(True),
+        )
+
+    assert ws.transport.aborted is True
+    assert noted == [True]
+    # The hello went out before the wake, proving the connection was live.
+    assert ws.sent
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_wake_forces_prompt_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A noted resume resets the reconnect backoff to the base delay.
+
+    Without the reset, the abrupt close an aborted tunnel produces would ride
+    the escalating backoff (e.g. 1s after one prior failure), leaving the
+    session unregistered longer than necessary right when the user reopened
+    the lid. A wake behaves like a server recycle: reconnect promptly.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    outcomes = iter(["error", "wake", "stop"])
+    sleeps: list[float] = []
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        on_resume_note: Any = None,
+        **_kwargs: Any,
+    ) -> None:
+        """Fail once, then simulate a wake-aborted connection, then stop.
+
+        :param app: Runner ASGI app.
+        :param tunnel_url: WebSocket URL.
+        :param server_url: Server base URL.
+        :param runner_id: Stable runner id.
+        :param runner_version: Runner version string.
+        :param on_resume_note: Resume-note callback ``serve_tunnel`` passes in.
+        :raises ConnectionError: On the first attempt (escalates backoff).
+        :raises ConnectionClosedError: On the wake attempt, after noting it.
+        :raises asyncio.CancelledError: On the final attempt to end the test.
+        """
+        del app, tunnel_url, server_url, runner_id, runner_version
+        outcome = next(outcomes)
+        if outcome == "error":
+            raise ConnectionError("temporary outage")
+        if outcome == "wake":
+            if on_resume_note is not None:
+                on_resume_note()
+            raise ConnectionClosedError(None, None)
+        raise asyncio.CancelledError
+
+    async def _sleep(delay: float) -> None:
+        """Record reconnect delays without waiting.
+
+        :param delay: Delay passed to ``asyncio.sleep``.
+        :returns: None.
+        """
+        sleeps.append(delay)
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+    monkeypatch.setattr(serve_module.random, "uniform", lambda *_args, **_kw: 0.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        await serve_tunnel(
+            _noop_app,
+            server_url="http://127.0.0.1:8000",
+            runner_id="runner_wake_reset",
+            runner_version="0.1.0",
+        )
+
+    # Attempt 1 (error) escalates 0.5 -> 1.0; attempt 2 (wake) resets to 0.5
+    # instead of sleeping the escalated 1.0.
+    assert sleeps == [0.5, 0.5]

--- a/tests/test_suspend_watch.py
+++ b/tests/test_suspend_watch.py
@@ -1,0 +1,155 @@
+"""Unit tests for :mod:`omnigent.suspend_watch`.
+
+The suspend watcher must fire exactly once when the wall clock jumps ahead of
+the monotonic clock (a real system sleep), must never fire when both clocks
+advance together (a merely-blocked event loop), and must survive a callback
+that raises. Clocks and the sleeper are injected so the loop is driven
+deterministically without touching real time or patching ``asyncio.sleep``
+globally (which the ``no-global-asyncio-patch`` lint forbids in tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+
+from omnigent.suspend_watch import (
+    SUSPEND_GAP_THRESHOLD_S,
+    SUSPEND_POLL_INTERVAL_S,
+    watch_for_resume,
+)
+
+
+def _clamping_clock(values: list[float]) -> Callable[[], float]:
+    """A clock stub that returns *values* in order, repeating the last.
+
+    Clamping (rather than raising ``StopIteration``) keeps the watcher's
+    ``while True`` loop from crashing on an over-read after the values that
+    matter for the assertion have been consumed.
+
+    :param values: Successive readings the clock should return.
+    :returns: A zero-arg callable yielding each value then the final one.
+    """
+    index = {"i": 0}
+
+    def read() -> float:
+        value = values[min(index["i"], len(values) - 1)]
+        index["i"] += 1
+        return value
+
+    return read
+
+
+async def _run_watcher(
+    *,
+    wall: list[float],
+    mono: list[float],
+    stop_after_sleeps: int,
+    on_resume: Callable[[float], None],
+) -> None:
+    """Drive :func:`watch_for_resume` for a fixed number of polls.
+
+    The injected sleeper raises :class:`asyncio.CancelledError` on the
+    *stop_after_sleeps*-th call to end the otherwise-infinite loop, matching
+    the idiom used in ``tests/runner/transports/ws_tunnel/test_serve.py``.
+
+    :param wall: Wall-clock readings (clamped).
+    :param mono: Monotonic-clock readings (clamped).
+    :param stop_after_sleeps: Sleep call on which to cancel the loop.
+    :param on_resume: Callback forwarded to the watcher.
+    :returns: None.
+    """
+    calls = {"n": 0}
+
+    async def fake_sleep(_delay: float) -> None:
+        calls["n"] += 1
+        if calls["n"] >= stop_after_sleeps:
+            raise asyncio.CancelledError
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await watch_for_resume(
+            on_resume,
+            wall_clock=_clamping_clock(wall),
+            mono_clock=_clamping_clock(mono),
+            sleep=fake_sleep,
+        )
+
+
+async def test_fires_once_on_wall_monotonic_divergence() -> None:
+    """A wall jump the monotonic clock did not share is reported once.
+
+    Models a real sleep: the wall clock advanced 3600 s across one poll while
+    the monotonic clock advanced only 5 s (it froze while suspended). The gap
+    (~3595 s) exceeds the threshold, so ``on_resume`` fires exactly once with
+    that duration.
+
+    :returns: None.
+    """
+    fired: list[float] = []
+    await _run_watcher(
+        wall=[1000.0, 4600.0],
+        mono=[0.0, 5.0],
+        stop_after_sleeps=2,
+        on_resume=lambda gap: fired.append(round(gap, 1)),
+    )
+    assert fired == [3595.0]
+
+
+async def test_does_not_fire_when_clocks_advance_together() -> None:
+    """A blocked event loop (both clocks jump equally) never fires.
+
+    This is the load-bearing false-positive guard: a long synchronous call or
+    GC pause advances the wall AND monotonic clocks by the same amount, so the
+    divergence stays ~0 and no resume is reported — only genuinely suspended
+    time (which the monotonic clock excludes) can trip the watcher.
+
+    :returns: None.
+    """
+    fired: list[float] = []
+    await _run_watcher(
+        wall=[1000.0, 4600.0],
+        mono=[0.0, 3600.0],
+        stop_after_sleeps=2,
+        on_resume=lambda gap: fired.append(gap),
+    )
+    assert fired == []
+
+
+async def test_survives_raising_callback() -> None:
+    """A callback that raises is swallowed so the watcher keeps running.
+
+    ``on_resume`` aborts a socket and flags a reconnect; a bug there must not
+    kill the watcher (which would silently disable wake detection for the rest
+    of the process's life).
+
+    :returns: None.
+    """
+    calls = {"n": 0}
+
+    def raising(_gap: float) -> None:
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    # Loop runs two polls: the first diverges (fires -> raises -> swallowed),
+    # the second is quiet, then the sleeper cancels. Reaching the cancel proves
+    # the raise did not propagate out of the watcher.
+    await _run_watcher(
+        wall=[1000.0, 4600.0, 4605.0],
+        mono=[0.0, 5.0, 10.0],
+        stop_after_sleeps=3,
+        on_resume=raising,
+    )
+    assert calls["n"] == 1
+
+
+def test_default_constants_are_sane() -> None:
+    """The shipped threshold sits above the poll interval and jitter.
+
+    A threshold at or below the interval would risk firing on ordinary
+    scheduling delay; keeping it well above documents the intended margin.
+
+    :returns: None.
+    """
+    assert SUSPEND_GAP_THRESHOLD_S > SUSPEND_POLL_INTERVAL_S
+    assert SUSPEND_POLL_INTERVAL_S > 0


### PR DESCRIPTION
## Problem

Closing a laptop lid (macOS sleep) freezes every Omnigent process and drops the network, killing two kinds of long-lived WebSocket:

1. the **host control channel** (`omnigent host` daemon → server), and
2. every **runner tunnel** — i.e. each active **session**.

On wake, neither reconnected promptly. The only liveness signal was the `websockets` keepalive ping (`ping_interval=30s`, `ping_timeout=90s`), so a half-open post-sleep socket took **up to ~120s** to be noticed. During that window the server had already deregistered the host, so the desktop app showed **"disconnected"** — while the terminal still *read* "connected" (that line is a one-time startup banner that never refreshes). There was **no** sleep/wake/suspend detection anywhere in the repo.

## Fix

New `omnigent/suspend_watch.py` — `watch_for_resume()` detects a resume by polling a short interval and comparing **wall-clock vs monotonic-clock drift**:

- `time.monotonic()` freezes while the machine is asleep (macOS `mach_absolute_time`, Linux `CLOCK_MONOTONIC`); `time.time()` keeps counting — so a resume shows up as a large divergence across one poll.
- A merely-blocked event loop advances **both** clocks equally → divergence ≈ 0, so this **never** false-fires on CPU/GC stalls; only real suspended time trips it.
- Uses `time.monotonic` (never `loop.time()`, which under uvloop *includes* sleep on macOS and would silently disable detection — the same trap already documented in `runtime/harnesses/process_manager.py`).

Wired into both reconnect loops via `ws.transport.abort()` (immediate; `close()` would block up to the 10s close-timeout on a dead socket):

- **Host** (`host/connect.py`): a daemon-lifetime watcher aborts the live tunnel on wake and flags a prompt reconnect, so `run()` reattaches at the base backoff rather than the escalated one. The flag is required on a **loopback** server, where an abrupt close isn't auto-classified as a benign ingress recycle.
- **Runner** (`ws_tunnel/serve.py`): a per-connection watcher aborts the tunnel and notes the resume so `serve_tunnel` reconnects promptly. Every session self-heals on its own event loop — no host orchestration needed.

**Result:** opening the laptop reconnects the host and all its sessions within **~5s** instead of up to ~2 minutes. Windows degrades to today's keepalive behavior (its monotonic clock counts suspend) — no regression.

Kept minimal (core reconnect only): the web sidebar's own wake handling and the stale terminal banner are left out of scope — the desktop badge already re-syncs within ~10s of wake via its existing `/health` poll once the host is back.

## Tests

- `tests/test_suspend_watch.py` — detector fires once on divergence, **never** on a blocked loop (the false-positive guard), and survives a raising callback.
- `tests/host/test_connect.py` — `_on_resume_from_suspend` aborts a live tunnel + sets the flag (no-op with no tunnel); `run()` reconnects promptly after a simulated wake on a loopback server.
- `tests/runner/transports/ws_tunnel/test_serve.py` — a simulated wake aborts the live tunnel; `serve_tunnel` resets the backoff to base on a noted resume.

All new/affected tests pass locally (`uv run --group test pytest`); ruff + pyrefly clean on the changed files.

## Manual verification (please try)

Run `omnigent host` with a live session, close the lid ≥30s, reopen: the daemon should log a resume + a fresh `✓ Connected`, each runner should log a reconnect, and the desktop badge should return to connected within a few seconds.

This pull request and its description were written by Isaac.
