### PR TITLE
fix(claude-native): settle sub-agent status on the SubagentStop hook

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -513,6 +513,11 @@ class ClaudeHookRecord:
         ``TaskCompleted`` (``"completed"``), or
         ``PostToolUse``/``TaskUpdate`` event (``"in_progress"`` or
         ``"completed"``). ``None`` for all other events.
+    :param subagent_id: Claude-side sub-agent id from a ``SubagentStop``
+        hook payload's ``agent_id``, e.g. ``"a5c7effac5a9a35ab"`` — the
+        same id as the ``agent-<id>`` transcript stem, which is where it
+        is read from when a payload carries only
+        ``agent_transcript_path``. ``None`` for all other events.
     :param background_task_count: Number of background tasks still running
         when a ``Stop`` hook fires — entries in the payload's
         ``background_tasks`` array whose per-task ``status`` is not terminal
@@ -536,6 +541,7 @@ class ClaudeHookRecord:
     task_id: str | None = None
     task_subject: str | None = None
     task_status: str | None = None
+    subagent_id: str | None = None
     background_task_count: int = 0
 
 
@@ -1402,6 +1408,11 @@ def build_hook_settings(
         "SessionStart": [{"hooks": [session_start_hook]}],
         "Stop": [{"hooks": [hook]}],
         "StopFailure": [{"hooks": [hook]}],
+        # ``SubagentStop`` fires when a Task sub-agent finishes. Its
+        # payload's ``agent_id`` names the ``agent-<id>`` transcript, so
+        # the forwarder can settle that child's status on an authoritative
+        # edge instead of guessing from transcript quiet time.
+        "SubagentStop": [{"hooks": [hook]}],
         # ``UserPromptSubmit`` is the symmetric counterpart to
         # ``Stop`` — fires when a new user prompt reaches Claude
         # (web-UI message via tmux send-keys, or direct keystrokes
@@ -2739,6 +2750,18 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
         if isinstance(raw_task_id, str) and raw_task_id:
             task_id = raw_task_id
         task_status = "completed"
+    subagent_id: str | None = None
+    if event_name == "SubagentStop" and isinstance(payload, dict):
+        raw_agent_id = payload.get("agent_id")
+        raw_agent_transcript = payload.get("agent_transcript_path")
+        if isinstance(raw_agent_id, str) and raw_agent_id:
+            subagent_id = raw_agent_id
+        elif isinstance(raw_agent_transcript, str) and raw_agent_transcript:
+            # Older payloads carry only the sub-agent's transcript path;
+            # ``agent-<id>.jsonl`` names the same id.
+            stem = Path(raw_agent_transcript).stem
+            if stem.startswith("agent-"):
+                subagent_id = stem.removeprefix("agent-") or None
     background_task_count = 0
     if event_name == "Stop" and isinstance(payload, dict):
         raw_bg = payload.get("background_tasks")
@@ -2795,6 +2818,7 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
         task_id=task_id,
         task_subject=task_subject,
         task_status=task_status,
+        subagent_id=subagent_id,
         background_task_count=background_task_count,
     )
 

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -69,13 +69,15 @@ _MAX_PERSISTED_COMPACTION_SEQS = 16
 # prose answer can be hundreds of chunks.
 _MAX_SEEN_DELTA_KEYS = 5000
 
-# Seconds of transcript inactivity after which we publish ``idle`` for
-# a sub-agent. The transcript is the only signal we have for sub-agent
-# completion in Phase A (no SubagentStop hook is subscribed); 5s is the
-# shortest window that comfortably absorbs a stalled tool call without
-# flickering the badge. Phase B will replace this with an authoritative
-# hook signal and drop the heuristic.
-_SUBAGENT_IDLE_QUIESCENCE_S = 5.0
+# Fallback only: seconds of transcript inactivity after which we publish
+# ``idle`` for a sub-agent whose ``SubagentStop`` hook never arrived (a
+# Claude build that does not fire the event, or a dropped hook write).
+# The authoritative edge is the hook; this window only has to be wider
+# than any real quiet stretch mid-run, and real sub-agents go minutes
+# between transcript items (a long Bash call, a long thinking block), so
+# it is deliberately generous. A tight window here read a working
+# sub-agent as idle and dropped the parent row's sidebar spinner.
+_SUBAGENT_IDLE_QUIESCENCE_S = 900.0
 
 # Meta-file glob inside ``~/.claude/projects/<encoded>/<session>/subagents/``.
 # One per Claude Task-tool subagent; appears alongside the matching
@@ -797,6 +799,9 @@ async def forward_claude_transcript_to_session(
     task_subjects: dict[str, str] = {}
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
+    # Claude-side ids whose SubagentStop hook has fired. The hook phase
+    # fills it; the sub-agent phase reads it to settle a child's status.
+    stopped_subagent_ids: set[str] = set()
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     from omnigent.cli_auth import open_server_client
 
@@ -853,6 +858,7 @@ async def forward_claude_transcript_to_session(
                         task_subjects = {}
                         task_statuses = {}
                         task_order = []
+                        stopped_subagent_ids = set()
                         # A rotated session is a fresh dedupe context — reseed
                         # so the new session's first model observation doesn't
                         # post against the prior session's baseline.
@@ -889,6 +895,7 @@ async def forward_claude_transcript_to_session(
                         task_subjects = {}
                         task_statuses = {}
                         task_order = []
+                        stopped_subagent_ids = set()
                         # A rotated session is a fresh dedupe context — reseed
                         # so the new session's first model observation doesn't
                         # post against the prior session's baseline.
@@ -954,6 +961,7 @@ async def forward_claude_transcript_to_session(
                             task_subjects=task_subjects,
                             task_statuses=task_statuses,
                             task_order=task_order,
+                            subagent_stops=stopped_subagent_ids,
                             # The turn-end edges (Stop→idle / StopFailure→failed)
                             # carry the turn's response id so ap-web can CLOSE the
                             # streaming ``activeResponse`` opened by the turn-start
@@ -973,6 +981,7 @@ async def forward_claude_transcript_to_session(
                             start_retry_tracker=subagent_start_retries,
                             item_retry_tracker=subagent_item_retries,
                             status_retry_tracker=subagent_status_retries,
+                            stopped_subagent_ids=stopped_subagent_ids,
                         )
                         # Reconcile + POST cumulative cost AFTER sub-agents are
                         # forwarded so the estimate sees this poll's sub-agent
@@ -1277,11 +1286,17 @@ async def _forward_available_subagents(
     start_retry_tracker: _PostRetryTracker,
     item_retry_tracker: _PostRetryTracker,
     status_retry_tracker: _PostRetryTracker,
+    stopped_subagent_ids: set[str],
 ) -> SubagentForwardState:
     """
     Discover new Claude Task-tool sub-agents on disk, mint Omnigent child
-    conversations for them, tail their transcripts, and publish
-    quiescence-based status.
+    conversations for them, tail their transcripts, and publish status.
+
+    A sub-agent reads ``running`` from the moment it is registered until
+    its ``SubagentStop`` hook names it in ``stopped_subagent_ids``. That
+    matters beyond the child's own row: the session list rolls a running
+    child up onto the parent row, so the sidebar keeps showing the session
+    as working while the main agent sits waiting on the sub-agent.
 
     Idempotent across forwarder restarts: ``state`` (persisted to
     ``subagent_forwarder.json``) holds the Omnigent child id and byte
@@ -1305,6 +1320,10 @@ async def _forward_available_subagents(
     :param status_retry_tracker: Backoff tracker for failed
         ``external_session_status`` POSTs (keyed by
         ``status:<child_id>``).
+    :param stopped_subagent_ids: Claude-side ids whose ``SubagentStop``
+        hook has fired, accumulated across polls by
+        :func:`_forward_available_status_events`. Never pruned — one
+        session spawns tens of sub-agents, so the set stays small.
     :returns: Updated state with new sub-agents registered and
         existing sub-agents' cursors advanced.
     """
@@ -1587,20 +1606,20 @@ async def _forward_available_subagents(
                 last_status=entry.last_status,
             )
 
-        # Quiescence-based status. Sub-agent transcripts don't carry
-        # an explicit "done" record (Claude doesn't expose one), so
-        # we infer "running" from item flow and "idle" from quiet
-        # time. The dedupe on ``last_status`` avoids spamming the
-        # cache on every tick when nothing changed.
-        desired_status: str | None = None
-        if had_item:
-            desired_status = "running"
-        elif (
+        # A registered sub-agent is running until Claude says it stopped.
+        # Item flow is NOT the signal: transcripts go minutes quiet
+        # mid-run, which read as finished and dropped both the child's dot
+        # and the parent row's rolled-up spinner. The dedupe on
+        # ``last_status`` avoids spamming the cache on every tick.
+        desired_status: str | None = "running"
+        if subagent_id in stopped_subagent_ids or (
             new_entry.last_activity_ts is not None
             and now - new_entry.last_activity_ts > _SUBAGENT_IDLE_QUIESCENCE_S
-            and new_entry.last_status != "idle"
         ):
             desired_status = "idle"
+        elif new_entry.last_status == "idle":
+            # Already settled; a late transcript flush must not reopen it.
+            desired_status = None
         if desired_status is not None and desired_status != new_entry.last_status:
             retry_key = f"subagent_status:{entry.child_conversation_id}"
             if status_retry_tracker.retry_delay_s(retry_key) is None:
@@ -2595,6 +2614,7 @@ async def _forward_available_status_events(
     task_subjects: dict[str, str],
     task_statuses: dict[str, str],
     task_order: list[str],
+    subagent_stops: set[str],
     response_id: str | None = None,
 ) -> HookForwardState:
     """
@@ -2613,6 +2633,11 @@ async def _forward_available_status_events(
     ``external_session_todos`` events. The ``task_subjects``,
     ``task_statuses``, and ``task_order`` dicts are mutated in-place
     to accumulate per-session task state across polls.
+
+    ``SubagentStop`` records are collected into ``subagent_stops``
+    (mutated in-place) rather than published here: they name a child
+    session, not this one, so the sub-agent phase — which holds the
+    Claude-side id to Omnigent child-id mapping — settles their status.
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
@@ -2633,6 +2658,9 @@ async def _forward_available_status_events(
     :param task_order: Mutable ordered list of task ids in creation order,
         e.g. ``["1", "2", "3"]``. Appended in-place from ``TaskCreated``
         events. Used to render the task list in a stable order.
+    :param subagent_stops: Claude-side sub-agent ids observed to have
+        stopped, mutated in place and read by
+        :func:`_forward_available_subagents`.
     :param response_id: Active turn's response id, stamped on the
         ``Stop``→``idle`` / ``StopFailure``→``failed`` edges so ap-web
         closes the streaming ``activeResponse`` opened by the matching
@@ -2660,6 +2688,8 @@ async def _forward_available_status_events(
     durable = state
     for record in result.records:
         status = _HOOK_EVENT_TO_STATUS.get(record.event_name or "")
+        if record.event_name == "SubagentStop" and record.subagent_id is not None:
+            subagent_stops.add(record.subagent_id)
         next_durable = HookForwardState(
             event_cursor=record.event_cursor,
             byte_offset=record.byte_offset,

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -147,6 +147,7 @@ def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
         "SessionStart",
         "Stop",
         "StopFailure",
+        "SubagentStop",
         "TaskCompleted",
         "TaskCreated",
         "UserPromptSubmit",

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import json
 import logging
 import os
 import queue
 import threading
+import time
 from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -30,6 +32,7 @@ from omnigent.claude_native_bridge import (
     ClaudeTranscriptItem,
     prepare_bridge_dir,
     read_active_session_id,
+    read_hook_events_since_with_position,
     record_hook_event,
     write_active_session_id,
 )
@@ -4841,6 +4844,7 @@ async def test_subagent_watcher_retry_skips_previously_posted_items(
             start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
             item_retry_tracker=item_retry_tracker,
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            stopped_subagent_ids=set(),
         )
         second = await forwarder._forward_available_subagents(
             client=client,
@@ -4852,6 +4856,7 @@ async def test_subagent_watcher_retry_skips_previously_posted_items(
             start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
             item_retry_tracker=item_retry_tracker,
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            stopped_subagent_ids=set(),
         )
 
     assert posted_items == ["user:go", "assistant:done", "assistant:done"]
@@ -7215,6 +7220,7 @@ async def test_standalone_hook_persist_failure_holds_cursor_for_retry(
                 task_subjects={},
                 task_statuses={},
                 task_order=[],
+                subagent_stops=set(),
             )
 
     # Poll 1: persist fails → cursor is held BEFORE the compaction hook record,
@@ -7378,6 +7384,7 @@ async def test_subagent_item_drop_writes_dead_letter(tmp_path: Path) -> None:
                 base_delay_s=0.0, max_permanent_attempts=1
             ),
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            stopped_subagent_ids=set(),
         )
 
     forwarder._reset_forward_health()
@@ -7434,6 +7441,7 @@ async def test_subagent_start_drop_writes_dead_letter(tmp_path: Path) -> None:
             ),
             item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
             status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            stopped_subagent_ids=set(),
         )
 
     forwarder._reset_forward_health()
@@ -7586,6 +7594,7 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
             task_subjects={},
             task_statuses={},
             task_order=[],
+            subagent_stops=set(),
             response_id="resp_turn_1",
         )
 
@@ -7996,3 +8005,154 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_subagent_stays_running_until_stop_hook(tmp_path: Path) -> None:
+    """
+    A quiet sub-agent stays ``running`` until its ``SubagentStop`` fires.
+
+    The sidebar rolls a running child up onto the parent row, so this is
+    what keeps a session reading as working while its main agent waits on
+    a sub-agent. Real sub-agent transcripts go minutes between items (a
+    long tool call, a long thinking block), so quiet time must NOT settle
+    the child — only the hook edge does.
+
+    :param tmp_path: Pytest temp dir for the bridge dir and transcript.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="plan1",
+        agent_type="Plan",
+        description="plan the refactor",
+        tool_use_id="toolu_plan",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-assistant-plan",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            },
+        ],
+    )
+    statuses: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Accept every POST, recording status edges per child session.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        body = json.loads(request.content.decode("utf-8"))
+        if body.get("type") == "external_subagent_start":
+            return httpx.Response(200, json={"child_session_id": "conv_child_plan"})
+        if body.get("type") == "external_session_status":
+            statuses.append((request.url.path, body["data"]["status"]))
+        return httpx.Response(202, json={})
+
+    stops: set[str] = set()
+
+    async def _poll(state: forwarder.SubagentForwardState) -> forwarder.SubagentForwardState:
+        return await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            stopped_subagent_ids=stops,
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await _poll(forwarder.SubagentForwardState(subagents={}))
+        # Registration published running. Now go quiet for far longer than
+        # the old 5s window: the child must still read running.
+        state = forwarder.SubagentForwardState(
+            subagents={
+                "plan1": dataclasses.replace(
+                    state.subagents["plan1"],
+                    last_activity_ts=time.time() - 120.0,
+                )
+            }
+        )
+        state = await _poll(state)
+        assert [s for _, s in statuses] == ["running"]
+
+        # The hook edge settles it, once.
+        stops.add("plan1")
+        state = await _poll(state)
+        state = await _poll(state)
+
+    assert [s for _, s in statuses] == ["running", "idle"]
+    assert all(path.endswith("/conv_child_plan/events") for path, _ in statuses)
+
+
+def test_subagent_stop_hook_record_carries_agent_id(tmp_path: Path) -> None:
+    """
+    A ``SubagentStop`` hook record exposes Claude's ``agent_id``.
+
+    That id is the ``agent-<id>`` transcript stem the sub-agent forwarder
+    keys its child sessions by, so without it the stop edge cannot be
+    matched to a child conversation.
+
+    :param tmp_path: Pytest temp dir for the bridge dir.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "hooks.jsonl").write_text(
+        json.dumps(
+            {
+                "recorded_at": 1.0,
+                "payload": {
+                    "hook_event_name": "SubagentStop",
+                    "agent_id": "plan1",
+                    "agent_type": "Plan",
+                    "transcript_path": "/p/session.jsonl",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = read_hook_events_since_with_position(bridge_dir, 0)
+    assert [r.event_name for r in result.records] == ["SubagentStop"]
+    assert result.records[0].subagent_id == "plan1"
+
+
+def test_subagent_stop_hook_record_falls_back_to_transcript_path(tmp_path: Path) -> None:
+    """
+    Without ``agent_id``, the id comes from the sub-agent transcript stem.
+
+    Claude builds at the supported floor may send only
+    ``agent_transcript_path``; ``agent-<id>.jsonl`` names the same id, so
+    the stop edge still matches a child session.
+
+    :param tmp_path: Pytest temp dir for the bridge dir.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "hooks.jsonl").write_text(
+        json.dumps(
+            {
+                "recorded_at": 1.0,
+                "payload": {
+                    "hook_event_name": "SubagentStop",
+                    "agent_transcript_path": "/p/session/subagents/agent-plan9.jsonl",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = read_hook_events_since_with_position(bridge_dir, 0)
+    assert result.records[0].subagent_id == "plan9"

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -8097,6 +8097,89 @@ async def test_subagent_stays_running_until_stop_hook(tmp_path: Path) -> None:
     assert all(path.endswith("/conv_child_plan/events") for path, _ in statuses)
 
 
+@pytest.mark.asyncio
+async def test_subagent_settles_on_backstop_when_stop_hook_never_fires(tmp_path: Path) -> None:
+    """
+    Without any ``SubagentStop`` edge, the quiescence backstop still settles.
+
+    Covers the degraded path: a Claude build that never fires the event, a
+    dropped hook write, or a hook command that failed. The child must not
+    stay ``running`` forever — the parent row would spin with nothing
+    working — so the widened timer remains the floor under a missing hook.
+
+    :param tmp_path: Pytest temp dir for the bridge dir and transcript.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="nohook1",
+        agent_type="Explore",
+        description="no stop hook available",
+        tool_use_id="toolu_nohook",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-assistant-nohook",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            },
+        ],
+    )
+    statuses: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Accept every POST, recording status edges.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        body = json.loads(request.content.decode("utf-8"))
+        if body.get("type") == "external_subagent_start":
+            return httpx.Response(200, json={"child_session_id": "conv_child_nohook"})
+        if body.get("type") == "external_session_status":
+            statuses.append(body["data"]["status"])
+        return httpx.Response(202, json={})
+
+    async def _poll(
+        client: httpx.AsyncClient, state: forwarder.SubagentForwardState
+    ) -> forwarder.SubagentForwardState:
+        return await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            # Empty for every poll: the hook edge never arrives.
+            stopped_subagent_ids=set(),
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        state = await _poll(client, forwarder.SubagentForwardState(subagents={}))
+        assert statuses == ["running"]
+        # Quiet past the backstop window with no hook edge in sight.
+        state = forwarder.SubagentForwardState(
+            subagents={
+                "nohook1": dataclasses.replace(
+                    state.subagents["nohook1"],
+                    last_activity_ts=time.time() - (forwarder._SUBAGENT_IDLE_QUIESCENCE_S + 1.0),
+                )
+            }
+        )
+        await _poll(client, state)
+
+    assert statuses == ["running", "idle"]
+
+
 def test_subagent_stop_hook_record_carries_agent_id(tmp_path: Path) -> None:
     """
     A ``SubagentStop`` hook record exposes Claude's ``agent_id``.


### PR DESCRIPTION
## Related issue

Closes #4988

Note for triage: #4995 (community, open) also targets #4988 with a narrower fix — it keeps the 5 s
timer and routes it to a new `quiesced` status so the runner's terminal branch never sees it, stating
"sidebar behavior unchanged". That fixes the false inbox completion but preserves the false *badge*,
which is the second symptom below. Its own notes name "option 2 (`SubagentStop` hook)" as the more
authoritative terminal it did not take. This PR is option 2, and fixes both symptoms at the source.
Both touch the same quiescence branch, so they will conflict — pick one.

## Summary

A claude-native Task sub-agent's status came from a **5-second transcript-quiescence timer**, so any
quiet stretch published `idle` while the sub-agent was still working. The constant's own comment
already named the gap: *"Phase B will replace this with an authoritative hook signal and drop the
heuristic."* This is Phase B.

How wrong the timer was, measured over 6 real sub-agent transcripts (66-177 items each): **2-30% of
inter-item gaps exceed 5 s, and quiet stretches reach 280 s.** A long `Bash`, a slow generation, a
big file read — all read as "finished".

Two symptoms, one cause:

- **Sidebar** — `_session_status_with_child_rollup` marks a parent row `running` while any child
  sub-agent is running, which is what keeps a session spinning while its main agent waits on a
  sub-agent. The rollup works; it was being fed `idle`, so the spinner dropped. The Agents rail also
  dims settled rows to `opacity-60`, so a live sub-agent's row faded out mid-run.
- **Inbox** (#4988) — the runner promotes an `idle` child edge to a terminal `completed`, delivering
  a false "sub-agent finished" notice with the child's *first intermediate message* as its result,
  and latching `delivered` so the real completion is discarded.

The fix: register Claude Code's `SubagentStop` hook, key it by the payload's `agent_id` (the same
`agent-<id>` transcript stem the forwarder already keys children by), and keep a sub-agent `running`
from registration until that edge arrives.

```
before:  spawn ──► running ──► [5s quiet] ──► idle ──► item ──► running ──► ...
                                    │
                                    └─► parent row stops spinning; runner fires a false completion

after:   spawn ──► running ─────────────────────────────► SubagentStop ──► idle
                                    ▲                          ▲
                          quiet time is not a signal     authoritative edge, once
```

**ELI5:** we were deciding a helper had finished because it went quiet for five seconds. Helpers go
quiet for minutes while they think or run a slow command. Now we wait for the helper to actually say
it's done.

The quiescence timer survives only as a backstop for a Claude build that never fires the event,
widened (5 s → 900 s) past any real quiet stretch. #4995 rightly argues no threshold is correct; the
point here is that it is no longer the signal, just a floor under a missing hook.

## Compatibility

Per Claude Code's own changelog, both halves of what this relies on land far below Omnigent's
enforced floor (`_CLAUDE_MIN_VERSION = 2.1.161`):

| Capability | Introduced |
|---|---|
| `SubagentStop` hook event (split out of `Stop`) | **1.0.41** |
| `agent_id` + `agent_transcript_path` on its payload | **2.0.42** |

So every client that passes setup fires the event *with* `agent_id`. Beyond that:

- **No wire change.** The forwarder still posts only the pre-existing `running` / `idle` values via
  `external_session_status` — this PR changes *when* they're posted, not the vocabulary. No
  server/runner/forwarder skew to reason about, and no new status the server must learn.
- **No durable-state change.** `SubagentEntry` / `SubagentForwardState` / `HookForwardState` are
  untouched, so an existing `subagent_forwarder.json` keeps working across the upgrade.
  `ClaudeHookRecord.subagent_id` is derived at read time, not persisted, so old `hooks.jsonl` lines
  parse unchanged.
- **An unrecognized hook key is ignored, not fatal.** Verified empirically: a settings file
  containing a bogus event name still loads and the valid hooks in the same file still fire (Claude
  reads hooks by iterating its own known-event allowlist, so unknown keys are never looked at). A
  hypothetical sub-floor client would degrade, not break.
- **The hook can't be dropped by user config.** It goes into the per-session `claude-settings.json`
  the bridge passes via `--settings`, alongside the `Stop` / `StopFailure` hooks that already use the
  identical command — so if it failed to register, turn-end detection would already be broken.

Where it *does* differ from today, honestly: if the edge never arrives, the child settles on the
900 s backstop rather than the old 5 s timer. That is wrong-late instead of wrong-early — a stale
spinner instead of a premature completion — so it is not a byte-for-byte fallback to old behavior.
`test_subagent_settles_on_backstop_when_stop_hook_never_fires` pins that path so it can't regress
into spinning forever. Given the floor, it should be unreachable in practice; it only covers a
dropped hook write or a failed hook command.

## Test Plan

Automated — `406 passed` across `tests/test_claude_native_forwarder.py`,
`tests/test_claude_native_bridge.py`, `tests/server/routes/test_session_updates_ws.py`:

```
uv run pytest tests/test_claude_native_forwarder.py tests/test_claude_native_bridge.py \
              tests/server/routes/test_session_updates_ws.py
```

Four new tests. `test_subagent_stays_running_until_stop_hook` fails on the old behavior (verified by
reverting the constant: it observes the extra `idle`) and covers the whole shape — a sub-agent quiet
for 120 s stays `running`, the hook edge settles it exactly once, and a late transcript flush cannot
reopen a settled child. `test_subagent_settles_on_backstop_when_stop_hook_never_fires` covers the
degraded path with no hook edge at all. The other two pin the id extraction from `agent_id` and from
`agent_transcript_path`.

Verified against the real CLI (2.1.235), not just fixtures — spawned a live sub-agent with a
`SubagentStop` hook configured:

```
{'hook_event_name': 'SubagentStop', 'agent_id': 'afc49178913eec7d7', 'agent_type': 'Plan',
 'agent_transcript_path': '.../subagents/agent-afc49178913eec7d7.jsonl', 'stop_hook_active': False}
```

`agent_id` matches the `agent-afc49178913eec7d7.meta.json` the forwarder keys that child by, which is
what makes the keying in this PR correct rather than assumed.

Manual, in a live session (**not yet run** — see Coverage notes):

1. `just dev`, open a claude-native session.
2. "Use the Explore agent to map how session status reaches the sidebar."
3. The left sidebar row for that session should spin continuously for the sub-agent's whole run
   (before: blinked off within ~5 s of any quiet moment, and stayed off through long thinking).
4. The Agents rail child row should stay full-strength working, then settle once, promptly.
5. No `[System: sub-agent … finished (completed)]` notice should arrive while the sub-agent is still
   working (#4988's symptom).

Note: the hook lands in the bridge's generated settings at launch, so this only affects sessions
started after the change — restart rather than reusing a running pane.

## Demo

N/A — no frontend diff. The change is in the status signal the existing sidebar/rail already render;
the observable effect is described in Test Plan steps 3-4.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the **hook contract**, which is the part unit tests have to assume: a
real `claude` 2.1.235 run with a `SubagentStop` hook wired, confirming the event fires and that its
`agent_id` matches the on-disk `agent-<id>.meta.json` stem. Also confirmed a `Plan` sub-agent writes
the same on-disk artifacts as any other type (`agentType: "Plan"`), so nothing is type-specific.

The timer's wrongness is measured, not assumed: gap analysis over 6 real sub-agent transcripts
(quoted in Summary) is what sets the 900 s backstop above any observed quiet stretch.

Not yet done: the live in-app sidebar/rail check (Test Plan steps 1-5). Existing tests cover the
rollup itself (`test_child_busy_rollup_flows_through_updates_stream`) and the pre-existing
subagent-hook filtering, both still green.

## Changelog

The sidebar keeps showing a session as running while its main agent waits on a sub-agent, and
sub-agents no longer report finishing early.
