### PR TITLE
feat(acp): honor permission_mode so an ACP agent can run unattended

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -190,6 +190,11 @@ class AcpAgentConfig:
         the agent authenticates with — an agent that reads a variable must name
         it here (or in ``os_env.sandbox.env_passthrough``) or it starts
         unauthenticated. Names only; values come from the host environment.
+    :param permission_mode: Omnigent permission stance, e.g. ``"auto"``
+        (default) or ``"bypassPermissions"``. Only the latter changes anything:
+        it skips the human approval card for a request no policy had an opinion
+        on, matching claude-sdk's ``can_use_tool`` gate. Policy still runs in
+        every mode, so a DENY still blocks and an explicit ASK still prompts.
     """
 
     command: str
@@ -199,6 +204,7 @@ class AcpAgentConfig:
     send_model_in_session_new: bool = False
     omnigent_mcp: bool = True
     env_passthrough: tuple[str, ...] = ()
+    permission_mode: str = "auto"
 
 
 class _AcpRequestError(Exception):
@@ -837,6 +843,18 @@ class AcpExecutor(Executor):
             args = cached if isinstance(cached, dict) else {}
         return str(name), args
 
+    @property
+    def _bypass_permissions(self) -> bool:
+        """Whether the user opted out of approval cards for this agent.
+
+        Mirrors :class:`~omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor`'s
+        ``can_use_tool`` stance: ``"bypassPermissions"`` and nothing else, so the ``"auto"``
+        default keeps prompting. (Cursor also treats ``"auto"`` as no-prompt;
+        ACP agents ask only about actions they consider permission-worthy, so
+        silencing the default would drop meaningful prompts.)
+        """
+        return self._config.permission_mode == "bypassPermissions"
+
     @staticmethod
     def _permission_options(params: _AcpJsonObject) -> list[_AcpJsonObject]:
         """The agent's offered options, each an ``{optionId, name, kind}`` dict."""
@@ -906,7 +924,10 @@ class AcpExecutor(Executor):
            ``ALLOW`` / unspecified falls through.
         2. **Human-consent elicitation**: the agent's own options via
            :attr:`_elicitation_choice_handler`, else a yes/no card via
-           :attr:`_elicitation_handler`.
+           :attr:`_elicitation_handler`. Skipped under
+           ``permission_mode="bypassPermissions"`` — but only for a request no
+           policy had an opinion on, so a DENY still blocks and a policy that
+           says ASK still prompts.
 
         When neither bridge is wired (standalone / unit tests), falls back to
         allow so direct use of the executor isn't blocked. In normal runner
@@ -946,8 +967,15 @@ class AcpExecutor(Executor):
                 return await self._ask_user(tool_name, tool_input, params)
             # ALLOW / UNSPECIFIED / unknown → fall through to elicitation.
 
-        if can_ask:
+        if can_ask and not self._bypass_permissions:
             return await self._ask_user(tool_name, tool_input, params)
+        if can_ask:
+            # bypassPermissions: no policy had an opinion and the user asked not
+            # to be prompted. Logged at info so the audit trail still names what
+            # ran unreviewed. Answered per-request (never the agent's own bypass
+            # option) so every later call stays visible to policy.
+            logger.info("acp permission allowed (bypassPermissions): tool=%s", tool_name)
+            return True, None
 
         logger.debug("acp permission allowed (no policy/elicitation wired): tool=%s", tool_name)
         return True, None

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -34,6 +34,9 @@ Env vars read at startup:
   value is read from this process's own environment.
 - ``HARNESS_ACP_PROMPT_TIMEOUT_S``: optional idle (time-without-progress) deadline in
   seconds for a prompt turn (default 300); must be positive and finite or the child aborts.
+- ``HARNESS_ACP_PERMISSION_MODE``: Omnigent permission stance, ``auto`` (default) or
+  ``bypassPermissions`` — the latter skips the approval card for a tool call no
+  policy had an opinion on, so a headless agent runs without parking on prompts.
 """
 
 from __future__ import annotations
@@ -60,6 +63,8 @@ _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
+_ENV_PERMISSION_MODE = "HARNESS_ACP_PERMISSION_MODE"
+_DEFAULT_PERMISSION_MODE = "auto"
 
 
 def _env_enabled(name: str, *, default: bool) -> bool:
@@ -127,6 +132,7 @@ def _build_acp_executor() -> Executor:
     send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
     omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
+    permission_mode = os.environ.get(_ENV_PERMISSION_MODE, "").strip() or _DEFAULT_PERMISSION_MODE
 
     config = AcpAgentConfig(
         command=command,
@@ -136,6 +142,7 @@ def _build_acp_executor() -> Executor:
         send_model_in_session_new=send_model,
         omnigent_mcp=omnigent_mcp,
         env_passthrough=_env_passthrough_names(),
+        permission_mode=permission_mode,
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1556,6 +1556,12 @@ def _build_acp_cli_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_ACP_OS_ENV"] = os_env_payload
+    # Permission stance for approval cards. Absent leaves the harness wrap on its
+    # ``auto`` default (prompt); ``bypassPermissions`` skips the card for a call no
+    # policy had an opinion on, so a headless ACP worker doesn't park on a prompt.
+    permission_mode = spec.executor.config.get("permission_mode")
+    if permission_mode is not None:
+        env["HARNESS_ACP_PERMISSION_MODE"] = str(permission_mode)
     return env
 
 
@@ -1668,6 +1674,12 @@ def _build_acp_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_ACP_OS_ENV"] = os_env_payload
+    # Permission stance for approval cards. Absent leaves the harness wrap on its
+    # ``auto`` default (prompt); ``bypassPermissions`` skips the card for a call no
+    # policy had an opinion on, so a headless ACP worker doesn't park on a prompt.
+    permission_mode = spec.executor.config.get("permission_mode")
+    if permission_mode is not None:
+        env["HARNESS_ACP_PERMISSION_MODE"] = str(permission_mode)
     return env
 
 

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -634,6 +634,150 @@ def test_permission_outcome_ignores_an_unoffered_scope() -> None:
 
 
 # ---------------------------------------------------------------------------
+# permission_mode (bypassPermissions)
+# ---------------------------------------------------------------------------
+
+
+def _bypass_executor() -> AcpExecutor:
+    """An executor whose spec opted out of approval cards."""
+    return AcpExecutor(AcpAgentConfig(command="x", permission_mode="bypassPermissions"))
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_skips_the_card() -> None:
+    """``bypassPermissions`` allows a policy-silent call without prompting.
+
+    **What breaks if this fails**: a headless ACP worker (a polly sub-agent, a
+    scheduled task) parks on an approval card nobody is watching, so the turn
+    stalls rather than running unattended.
+    """
+    ex = _bypass_executor()
+    ex._elicitation_handler = AsyncMock(return_value=True)
+    ex._elicitation_choice_handler = AsyncMock(return_value="Allow")
+
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None)
+    ex._elicitation_handler.assert_not_awaited()
+    ex._elicitation_choice_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_still_denies_on_policy_deny() -> None:
+    """Policy runs in every mode, so a DENY still blocks under bypass.
+
+    This is the invariant that makes the mode safe to offer: it waives the
+    *human* gate, never the user's own rules.
+    """
+    ex = _bypass_executor()
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    class _V:
+        action = "POLICY_ACTION_DENY"
+
+    ex._policy_evaluator = AsyncMock(return_value=_V())
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_still_prompts_on_policy_ask() -> None:
+    """A policy that says ASK outranks bypass — the user asked to be asked."""
+    ex = _bypass_executor()
+
+    class _V:
+        action = "POLICY_ACTION_ASK"
+
+    ex._policy_evaluator = AsyncMock(return_value=_V())
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None)
+    ex._elicitation_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_default_permission_mode_still_asks() -> None:
+    """The ``auto`` default is unchanged: a policy-silent call still prompts.
+
+    **What breaks if this fails**: every ACP agent silently stops asking for
+    approval — the mode would be a default-off switch instead of an opt-in.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    assert ex._config.permission_mode == "auto"
+    ex._elicitation_handler = AsyncMock(return_value=True)
+
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None)
+    ex._elicitation_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_permission_mode_still_asks() -> None:
+    """Only the exact ``bypassPermissions`` waives the card; anything else prompts.
+
+    A typo (``"bypass"``) or a mode borrowed from another harness
+    (``"acceptEdits"``) must fail toward asking, not toward silence.
+    """
+    for mode in ("bypass", "acceptEdits", "default", ""):
+        ex = AcpExecutor(AcpAgentConfig(command="x", permission_mode=mode))
+        ex._elicitation_handler = AsyncMock(return_value=True)
+        assert await ex._decide_permission({"toolCall": {"title": "shell"}}) == (True, None), mode
+        assert ex._elicitation_handler.await_count == 1, mode
+
+
+@pytest.mark.asyncio
+async def test_bypass_never_sends_the_agents_own_bypass_option() -> None:
+    """Bypass answers each request; it never tells the agent to stop asking.
+
+    Devin offers ``switch_bypass`` ("switch to bypass mode"). Selecting it would
+    end the request stream, so omnigent would no longer see the agent's tool
+    calls and the TOOL_CALL policy could not gate them. The narrow
+    ``allow_once`` grant keeps every later call visible.
+    """
+    ex = _bypass_executor()
+    ex._elicitation_handler = AsyncMock(return_value=True)
+    params = {
+        "toolCall": {"title": "shell"},
+        "options": [
+            {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+            {
+                "optionId": "switch_bypass",
+                "name": "Yes, switch to bypass mode",
+                "kind": "allow_always",
+            },
+            {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+        ],
+    }
+
+    allow, option_id = await ex._decide_permission(params)
+    assert ex._permission_outcome(params, allow=allow, option_id=option_id) == {
+        "outcome": {"outcome": "selected", "optionId": "allow_once"}
+    }
+
+
+def test_harness_wrap_reads_permission_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wrap decodes the forwarded mode, closing spawn env → child config."""
+    from omnigent.inner import acp_harness
+
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "devin acp")
+    monkeypatch.setenv("HARNESS_ACP_PERMISSION_MODE", "bypassPermissions")
+    ex = acp_harness._build_acp_executor()
+    assert isinstance(ex, AcpExecutor)
+    assert ex._config.permission_mode == "bypassPermissions"
+    assert ex._bypass_permissions is True
+
+
+def test_harness_wrap_permission_mode_defaults_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset (or blank) var leaves the wrap prompting, as before this option."""
+    from omnigent.inner import acp_harness
+
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "devin acp")
+    monkeypatch.delenv("HARNESS_ACP_PERMISSION_MODE", raising=False)
+    assert acp_harness._build_acp_executor()._config.permission_mode == "auto"
+
+    monkeypatch.setenv("HARNESS_ACP_PERMISSION_MODE", "   ")
+    ex = acp_harness._build_acp_executor()
+    assert ex._config.permission_mode == "auto"
+    assert ex._bypass_permissions is False
+
+
+# ---------------------------------------------------------------------------
 # warm model switch (session/set_config_option)
 # ---------------------------------------------------------------------------
 

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -50,12 +50,15 @@ def _make_spec(
     harness: str,
     model: str | None = None,
     acp_agent: object = _MISSING,
+    permission_mode: str | None = None,
 ) -> AgentSpec:
     config: dict[str, object] = {"harness": harness}
     if model is not None:
         config["model"] = model
     if acp_agent is not _MISSING:
         config["acp_agent"] = acp_agent
+    if permission_mode is not None:
+        config["permission_mode"] = permission_mode
     return AgentSpec(
         spec_version=1,
         name="test-acp",
@@ -315,3 +318,25 @@ def test_embedded_agent_round_trip_preserves_all_fields(
     # env_passthrough preservation
     if "expected_env_passthrough" in agent_fields:
         assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == agent_fields["expected_env_passthrough"]
+
+
+def test_permission_mode_threads_into_env_var(_isolate_config: Path) -> None:
+    """``executor.config.permission_mode`` sets ``HARNESS_ACP_PERMISSION_MODE``.
+
+    Closes spec -> spawn env; the wrap's half is covered in
+    ``tests/inner/test_acp_executor.py``. Without this the option is inert:
+    the child never learns the user opted out of approval cards.
+    """
+    _write_acp_config(_isolate_config)
+    env = _build_acp_spawn_env(
+        _make_spec(harness="acp:goose", permission_mode="bypassPermissions")
+    )
+    assert env["HARNESS_ACP_PERMISSION_MODE"] == "bypassPermissions"
+
+
+def test_no_permission_mode_omits_env_var(_isolate_config: Path) -> None:
+    """Absent ``permission_mode`` leaves the harness wrap on its ``auto`` default."""
+    _write_acp_config(_isolate_config)
+    assert "HARNESS_ACP_PERMISSION_MODE" not in _build_acp_spawn_env(
+        _make_spec(harness="acp:goose")
+    )

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -48,12 +48,20 @@ _FAKE_ROW = AcpCliHarness(
 )
 
 
-def _spec(harness: str, os_env: OSEnvSpec | None = None) -> AgentSpec:
+def _spec(
+    harness: str,
+    os_env: OSEnvSpec | None = None,
+    *,
+    permission_mode: str | None = None,
+) -> AgentSpec:
+    config: dict[str, object] = {"harness": harness}
+    if permission_mode is not None:
+        config["permission_mode"] = permission_mode
     return AgentSpec(
         spec_version=1,
         name=f"test-{harness}",
         instructions="Test agent.",
-        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+        executor=ExecutorSpec(type="omnigent", config=config),
         os_env=os_env,
     )
 
@@ -218,3 +226,26 @@ def test_setup_drill_in_ignores_unknown_row() -> None:
     from omnigent import cli_config
 
     cli_config._show_acp_cli_harness("definitely-not-a-row")
+
+
+def test_spawn_env_forwards_permission_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A builtin row honors ``permission_mode`` too, not just configured agents.
+
+    Devin and Grok Build are builtin rows, so they take this builder rather than
+    ``_build_acp_spawn_env``. Missing it here would leave the option working for
+    a self-registered ``acp:devin`` but silently inert for the builtin ``devin``
+    the picker offers.
+    """
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", _FAKE_ROW)
+    monkeypatch.setattr(
+        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/bin/fakecli"
+    )
+
+    env = _build_acp_cli_spawn_env(
+        _spec("fakecli", permission_mode="bypassPermissions"), harness="fakecli"
+    )
+    assert env["HARNESS_ACP_PERMISSION_MODE"] == "bypassPermissions"
+    # Absent -> unset, so the wrap keeps its prompting default.
+    assert "HARNESS_ACP_PERMISSION_MODE" not in _build_acp_cli_spawn_env(
+        _spec("fakecli"), harness="fakecli"
+    )


### PR DESCRIPTION
## Related issue

Closes #5052

> **Stacked on #5053** (`base` is that branch, so this diff is one commit).
> GitHub retargets it to `main` when #5053 merges. Both change
> `_decide_permission` and its test file; stacking keeps them conflict-free.

## Summary

Every other harness family lets a spec opt out of per-tool approval prompts via
`executor.config.permission_mode`. Generic ACP honored no such mode:

| harness | env var | skips the card when |
|---|---|---|
| claude-sdk | `HARNESS_CLAUDE_SDK_PERMISSION_MODE` | `bypassPermissions` (`claude_sdk_executor.py:2227`) |
| cursor | `HARNESS_CURSOR_PERMISSION_MODE` | `auto` or `bypassPermissions` (`cursor_executor.py:655`) |
| claude-native | hook payload | `!= "bypassPermissions"` gates (`claude_native_hook.py:928`) |
| antigravity-native | argv | `bypassPermissions` → bypass flag (`antigravity_native_launch.py:192`) |
| **generic ACP** | **— (this PR adds it)** | **never — it always asked** |

So an ACP agent asked on every `session/request_permission` regardless of how it
was configured, and a **headless** one parked on a card nobody was watching —
`ctx.elicit` waits on a Future until answered or the turn is cancelled. Same
class as #4484, and the cursor builder's own comment says its default exists
precisely "so headless / Polly Cursor SDK workers don't stall". Concretely:
`examples/polly-demo/agents/claude_code/config.yaml:12` sets
`permission_mode: auto` and the Devin sub-agent beside it had no equivalent.

```yaml
executor:
  config:
    harness: devin
    permission_mode: bypassPermissions   # ← now honored
```

<details>
<summary>ELI5 + where the decision lands</summary>

Devin keeps asking "may I?" and someone has to click yes. If you launched it to
work on its own, there is nobody to click — so it just waits. Other harnesses
already have a "don't ask me" setting; ACP didn't. Now it does, and it still
obeys any rule you wrote that says "deny this" or "ask me about this".

```
  session/request_permission
            │
            ▼
    TOOL_CALL policy ─── DENY ──────────────► deny            (every mode)
            │
            ├─────────── ASK ───────────────► human card      (every mode)
            │
     nothing matched
            │
            ├── permission_mode == bypassPermissions ► allow, no card, logged
            └── otherwise (auto / default / typo) ───► human card   (unchanged)
```
</details>

Wired the established way: `AcpAgentConfig.permission_mode`, the wrap reads
`HARNESS_ACP_PERMISSION_MODE`, and **both** ACP spawn-env builders forward it —
`_build_acp_cli_spawn_env` too, so the builtin `devin` row the picker offers
behaves like a self-registered `acp:devin`. Missing that second builder would
have made the option silently inert for exactly the harness people use.

Three deliberate constraints:

- **Only `bypassPermissions` waives the card.** `auto` is the default when unset,
  so treating it as no-prompt (as cursor does) would silently stop *every*
  existing ACP agent from asking. An unrecognized value prompts. Cursor's
  prompts are blanket per-native-tool; an ACP agent asks only about actions it
  considers permission-worthy, so those prompts carry more signal and the
  conservative reading is right here.
- **Policy runs in every mode**, matching claude-sdk's gate ("This runs in EVERY
  permission mode … so connector-native MCP tools can't slip past policy"): DENY
  still blocks, an explicit ASK still prompts. Bypass waives the *human* gate,
  never the user's rules.
- **Bypass answers each request individually** and never selects the agent's own
  `switch_bypass` option. Selecting it would end the request stream, so
  omnigent would stop seeing the agent's tool calls and the TOOL_CALL policy
  could no longer gate any of them.

## Test Plan

Eleven new tests. Because this adds a field, "red on main" would just be a
missing-kwarg `TypeError` — so instead I verified the **gate** carries the
behavior: keeping the new field but reverting the one condition
(`if can_ask and not self._bypass_permissions:` → `if can_ask:`) fails exactly
the test that matters:

```
E   AssertionError: Expected mock to not have been awaited. Awaited 1 times.
    (test_bypass_permissions_skips_the_card)
```

- `..._bypass_permissions_skips_the_card` — neither elicitation bridge is awaited.
- `..._bypass_permissions_still_denies_on_policy_deny` and
  `..._still_prompts_on_policy_ask` — the invariant that makes the mode safe.
- `..._default_permission_mode_still_asks` — pins that `auto` is unchanged, so
  this can't become a default-off switch.
- `..._unrecognized_permission_mode_still_asks` — `"bypass"`, `"acceptEdits"`,
  `"default"`, `""` all still prompt (fail toward asking).
- `..._bypass_never_sends_the_agents_own_bypass_option` — with Devin's real
  option list, the outcome is `allow_once`, not `switch_bypass`. A guard, not a
  discriminating regression test: it also passes with the gate reverted.
- `test_harness_wrap_reads_permission_mode` / `..._defaults_to_auto` (blank string
  included) — closes spawn env → child config.
- `test_permission_mode_threads_into_env_var` / `..._omits_env_var` for the
  configured builder, and `test_spawn_env_forwards_permission_mode` for the
  builtin-row builder, which is the one Devin takes.

**Suites** — `tests/inner/test_acp_executor.py`, `..._timeout_config.py`,
`tests/runtime/test_acp_spawn_env.py`, `tests/test_acp_cli_harnesses.py`,
`tests/runtime/test_spawn_env_cwd.py`, `test_goose_spawn_env.py`,
`test_cursor_spawn_env.py`, `test_claude_sdk_spawn_env.py`,
`tests/inner/test_goose_executor.py`, `test_qwen_executor.py` → **332 passed**;
`tests/runtime/harnesses/` → **171 passed**. `pyrefly` 0 errors, `ruff` clean,
full `pre-commit` on the changed files passes, `uv.lock` untouched.

Two shared test helpers (`_make_spec`, `_spec`) gained an optional keyword-only
`permission_mode`, mirroring how `tests/runtime/test_cursor_spawn_env.py` already
does it; no existing call site changes.

## Demo

N/A — no frontend change. The user-visible effect is the *absence* of an approval
card for a policy-silent call under `bypassPermissions`, asserted directly by
`..._skips_the_card` (neither bridge awaited).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

I have **not** driven a live `bypassPermissions` ACP turn end to end, and want to
be plain about it: confirming it means watching an approval card *not* appear
while a real Devin turn runs shell commands, which is a human observation. What
is machine-verified is every link — the spec key reaching each spawn-env builder,
the wrap decoding it, the gate skipping only the policy-silent branch, and the
outcome sent to the agent.

Two things for a reviewer to weigh:

- **This is a real reduction in oversight when opted into**, so the DENY/ASK
  invariant above is the load-bearing part of the design. It is asserted by two
  tests, and `#5049` (merged) is what makes those rules able to match an ACP tool
  call by content in the first place — before it, a policy couldn't see the
  command, so this mode would have been an unqualified auto-approve. Worth
  confirming you agree that ordering is now satisfied.
- **`permission_mode` semantics are already inconsistent across harnesses**
  (cursor treats `auto` as no-prompt; claude-sdk doesn't). I followed claude-sdk
  as the conservative reading rather than unifying them, which would change
  cursor's behavior and belongs in its own change.

Also corrected while working on this: #5052 originally claimed ACP mishandles
`POLICY_ACTION_ALLOW` where other harnesses proceed. It doesn't — claude-sdk
falls through on ALLOW inside its *policy* gate and then still runs the human
card unless bypassing. The issue is updated with that correction. Separately,
an explicit rule-matched ALLOW is **not** distinguishable from the no-match
default at the executor boundary (`runtime/policies/engine.py:399` returns ALLOW
with `reason=None` and no `deciding_policies` either way), so "honor an explicit
ALLOW" isn't implementable today — which is why this is a permission mode.

## Changelog

ACP agents (e.g. Devin) now honor `permission_mode: bypassPermissions` in their
spec, so a headless one runs without waiting on approval cards — policy deny/ask
rules still apply
