### PR TITLE
perf(host): share parallel harness probes across launches

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -92,8 +92,13 @@ from omnigent.onboarding.harness_install import (
     ui_install_key,
 )
 from omnigent.onboarding.harness_readiness import (
-    configured_harness_map,
-    harness_is_configured,
+    HarnessProbeKey,
+    HarnessProbeSpec,
+    availability_allows_launch,
+    configured_harness_probe_specs,
+    harness_probe_spec,
+    probe_harness_availability,
+    probe_harness_launchability,
 )
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, OPENAI_FAMILY
 from omnigent.process_logging import (
@@ -147,17 +152,6 @@ def _coerce_int(value: object) -> int:
 HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0
 # Auth changes and removals need the full, potentially expensive readiness map.
 HARNESS_READINESS_FULL_REFRESH_INTERVAL_S = 60.0
-
-
-def _unavailable_harness_became_ready(
-    previous: Mapping[str, HarnessAvailability],
-) -> bool:
-    """Detect newly available binaries; auth changes wait for the full refresh."""
-    return any(
-        (availability is False or availability == HARNESS_BINARY_MISSING)
-        and harness_is_configured(harness)
-        for harness, availability in previous.items()
-    )
 
 
 def _runner_log_dir() -> Path:
@@ -343,8 +337,13 @@ _LOOPBACK_REFUSED_FATAL_ATTEMPTS = 30
 # endpoint that accepts and never speaks is functionally down.
 _SILENT_CONNECT_ESCALATE_ATTEMPTS = 10
 
-# Capability discovery is advisory and must not delay the host channel forever.
-_HOST_CAPABILITY_INIT_TIMEOUT_S = 15.0
+# Harness probes are subprocess-heavy; parallelize distinct harnesses without
+# flooding the machine. Fresh startup results accelerate the first launch while
+# short negative/error windows let a just-installed CLI recover quickly.
+_HARNESS_PROBE_CONCURRENCY = 4
+_HARNESS_PROBE_POSITIVE_TTL_S = 60.0
+_HARNESS_PROBE_NEGATIVE_TTL_S = 5.0
+_HARNESS_LAUNCH_PROBE_TIMEOUT_S = 12.0
 
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
@@ -774,6 +773,19 @@ def _paginate_list_dir(
 
 
 @dataclass
+class _HarnessProbeEntry:
+    """Cached readiness plus one shared in-flight probe for a harness key."""
+
+    generation: int = 0
+    availability: HarnessAvailability | None = None
+    checked_at: float = 0.0
+    task: asyncio.Task[HarnessAvailability] | None = None
+    launchable: bool | None = None
+    launch_checked_at: float = 0.0
+    launch_task: asyncio.Task[bool] | None = None
+
+
+@dataclass
 class _RunnerHandle:
     """A spawned runner subprocess and where its output lands.
 
@@ -835,6 +847,11 @@ class HostProcess:
         self._configured_harnesses: dict[str, HarnessAvailability] | None = None
         self._gateway_inference: dict[str, bool] | None = None
         self._capabilities_initialized = False
+        self._capability_discovery_task: asyncio.Task[None] | None = None
+        self._harness_probe_entries: dict[HarnessProbeKey, _HarnessProbeEntry] = {}
+        self._harness_probe_tasks: set[asyncio.Task[Any]] = set()
+        self._harness_probe_epoch = 0
+        self._harness_probe_semaphore = asyncio.Semaphore(_HARNESS_PROBE_CONCURRENCY)
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
         # Reset by a successful upgrade or non-auth error; bounds fresh-host refresh retries.
@@ -1313,16 +1330,43 @@ class HostProcess:
         # first turn dies confusingly inside the executor. ``None`` (an
         # older server, or a session with no resolvable harness) skips the
         # check so version skew fails open.
-        if frame.harness is not None and not harness_is_configured(frame.harness):
-            return HostLaunchRunnerResultFrame(
-                request_id=frame.request_id,
-                status="failed",
-                error=(
-                    f"harness {frame.harness!r} is not configured on host "
-                    f"{self._identity.name!r} — {harness_setup_hint(frame.harness)}"
-                ),
-                error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
-            )
+        if frame.harness is not None:
+            spec = harness_probe_spec(frame.harness)
+            try:
+                launchable = await asyncio.wait_for(
+                    asyncio.shield(self._probe_harness_launchability(spec)),
+                    timeout=_HARNESS_LAUNCH_PROBE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                return HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error=(
+                        f"timed out while inspecting harness {frame.harness!r} "
+                        f"on host {self._identity.name!r}"
+                    ),
+                    error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                )
+            except Exception as exc:  # noqa: BLE001 — probe failure becomes a launch result
+                return HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error=(
+                        f"could not inspect harness {frame.harness!r} on host "
+                        f"{self._identity.name!r}: {exc}"
+                    ),
+                    error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                )
+            if not launchable:
+                return HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error=(
+                        f"harness {frame.harness!r} is not configured on host "
+                        f"{self._identity.name!r} — {harness_setup_hint(frame.harness)}"
+                    ),
+                    error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                )
 
         workspace = Path(frame.workspace).expanduser()
         if not workspace.is_dir():
@@ -1978,16 +2022,16 @@ class HostProcess:
         """Handle a ``host.install_harness`` request from the server.
 
         Runs the same installer :func:`try_install_harness_cli` (hence
-        ``omnigent setup``) uses, then recomputes readiness so the result frame
-        carries a fresh ``configured_harnesses`` map. The ``ui_install_key``
+        ``omnigent setup``) uses. The async dispatcher invalidates and attaches
+        a fresh readiness snapshot after this core succeeds. The ``ui_install_key``
         guard re-checks the allowlist as defence in depth against a spoofed
         frame. Idempotent: an already-installed CLI skips the install. Runs off
         the event loop (it shells out / probes ``PATH``).
 
         :param frame: The install request frame. ``frame.harness`` is a UI
             harness identifier, e.g. ``"claude"``.
-        :returns: Result frame with ``status`` ``"ok"``/``"failed"``, the
-            refreshed readiness map on success, and a reason on failure.
+        :returns: Core result with ``status`` ``"ok"``/``"failed"``; the
+            dispatcher adds refreshed readiness on success.
         """
         key = ui_install_key(frame.harness)
         if key is None:
@@ -2003,8 +2047,6 @@ class HostProcess:
             return HostInstallHarnessResultFrame(
                 request_id=frame.request_id,
                 status="ok",
-                configured_harnesses=configured_harness_map(),
-                gateway_inference=gateway_inference_map(),
             )
         installed, reason = try_install_harness_cli(key)
         if not installed:
@@ -2017,8 +2059,6 @@ class HostProcess:
         return HostInstallHarnessResultFrame(
             request_id=frame.request_id,
             status="ok",
-            configured_harnesses=configured_harness_map(),
-            gateway_inference=gateway_inference_map(),
         )
 
     def _handle_store_secret(self, frame: HostStoreSecretFrame) -> HostStoreSecretResultFrame:
@@ -2029,9 +2069,8 @@ class HostProcess:
         :func:`adopt_env_credential`) the ``omnigent setup`` wizard's
         "add a key / gateway" path uses — the secret goes to the OS keychain
         (else ``~/.omnigent/secrets.json``) and ``config.yaml`` gets a
-        ``providers:`` entry referencing it, never the raw secret. Then it
-        recomputes readiness so the result frame flips the badge (yellow →
-        green) without a reconnect.
+        ``providers:`` entry referencing it, never the raw secret. The async
+        dispatcher invalidates and attaches fresh readiness after the write.
 
         The ``ui_install_key`` guard re-checks the allowlist as defence in depth
         against a spoofed frame — only the UI-auth families (Claude/Codex/Pi)
@@ -2040,8 +2079,8 @@ class HostProcess:
 
         :param frame: The store-secret request. ``frame.harness`` is a UI
             harness id; ``frame.kind`` is ``"key"`` / ``"gateway"`` / ``"adopt"``.
-        :returns: Result with ``status`` ``"ok"``/``"failed"``, refreshed
-            readiness on success, and a non-secret reason on failure.
+        :returns: Core result with ``status`` ``"ok"``/``"failed"`` and a
+            non-secret reason on failure; dispatch adds readiness on success.
         """
         # Resolve the harness to a provider family, re-checking the allowlist.
         # claude→anthropic, codex→openai; pi consumes both and prefers anthropic
@@ -2119,8 +2158,6 @@ class HostProcess:
         return HostStoreSecretResultFrame(
             request_id=frame.request_id,
             status="ok",
-            configured_harnesses=configured_harness_map(),
-            gateway_inference=gateway_inference_map(),
         )
 
     def _handle_detect_credentials(
@@ -2547,24 +2584,239 @@ class HostProcess:
             ],
         )
 
+    def _harness_probe_entry(self, key: HarnessProbeKey) -> _HarnessProbeEntry:
+        """Return the daemon-lifetime cache entry for one semantic harness."""
+        return self._harness_probe_entries.setdefault(key, _HarnessProbeEntry())
+
+    async def _run_harness_probe(
+        self,
+        spec: HarnessProbeSpec,
+    ) -> HarnessAvailability:
+        """Run one readiness probe off-loop under bounded parallelism."""
+        async with self._harness_probe_semaphore:
+            with self._host_subprocess_op():
+                return await asyncio.to_thread(
+                    probe_harness_availability,
+                    spec.canonical,
+                )
+
+    async def _run_harness_launch_probe(
+        self,
+        spec: HarnessProbeSpec,
+    ) -> bool:
+        """Run the launch-only gate without waiting for picker auth checks."""
+        async with self._harness_probe_semaphore:
+            with self._host_subprocess_op():
+                return await asyncio.to_thread(
+                    probe_harness_launchability,
+                    spec.canonical,
+                )
+
+    def _finish_harness_launch_probe(
+        self,
+        key: HarnessProbeKey,
+        generation: int,
+        task: asyncio.Task[bool],
+    ) -> None:
+        """Publish a launch-gate result when its generation is current."""
+        entry = self._harness_probe_entries.get(key)
+        if entry is None or entry.launch_task is not task:
+            return
+        entry.launch_task = None
+        if task.cancelled() or entry.generation != generation:
+            return
+        try:
+            launchable = task.result()
+        except Exception:  # noqa: BLE001 — waiters receive the probe failure
+            return
+        entry.launchable = launchable
+        entry.launch_checked_at = asyncio.get_running_loop().time()
+
+    def _start_harness_launch_probe(
+        self,
+        spec: HarnessProbeSpec,
+    ) -> asyncio.Task[bool]:
+        """Start or join the launch-only single-flight for *spec*."""
+        entry = self._harness_probe_entry(spec.key)
+        if entry.launch_task is not None:
+            return entry.launch_task
+        generation = entry.generation
+        task = asyncio.create_task(
+            self._run_harness_launch_probe(spec),
+            name=f"host-harness-launch-probe:{':'.join(spec.key)}",
+        )
+        entry.launch_task = task
+        self._harness_probe_tasks.add(task)
+        task.add_done_callback(self._harness_probe_tasks.discard)
+        task.add_done_callback(
+            lambda completed, key=spec.key, gen=generation: self._finish_harness_launch_probe(
+                key, gen, completed
+            )
+        )
+        return task
+
+    async def _probe_harness_launchability(
+        self,
+        spec: HarnessProbeSpec,
+        *,
+        force: bool = False,
+    ) -> bool:
+        """Return a cached authoritative launch verdict or share its probe."""
+        entry = self._harness_probe_entry(spec.key)
+        launchable = entry.launchable
+        if launchable is not None and not force:
+            ttl = _HARNESS_PROBE_POSITIVE_TTL_S if launchable else _HARNESS_PROBE_NEGATIVE_TTL_S
+            if asyncio.get_running_loop().time() - entry.launch_checked_at <= ttl:
+                return launchable
+        return await asyncio.shield(self._start_harness_launch_probe(spec))
+
+    def _finish_harness_probe(
+        self,
+        key: HarnessProbeKey,
+        generation: int,
+        task: asyncio.Task[HarnessAvailability],
+    ) -> None:
+        """Publish a completed probe only if its generation is still current."""
+        entry = self._harness_probe_entries.get(key)
+        if entry is None or entry.task is not task:
+            return
+        entry.task = None
+        if task.cancelled() or entry.generation != generation:
+            return
+        try:
+            availability = task.result()
+        except Exception:  # noqa: BLE001 — waiters receive the probe failure
+            return
+        entry.availability = availability
+        entry.checked_at = asyncio.get_running_loop().time()
+
+    def _start_harness_probe(
+        self,
+        spec: HarnessProbeSpec,
+    ) -> asyncio.Task[HarnessAvailability]:
+        """Start or join the single in-flight probe for *spec*."""
+        entry = self._harness_probe_entry(spec.key)
+        if entry.task is not None:
+            return entry.task
+        generation = entry.generation
+        task = asyncio.create_task(
+            self._run_harness_probe(spec),
+            name=f"host-harness-probe:{':'.join(spec.key)}",
+        )
+        entry.task = task
+        self._harness_probe_tasks.add(task)
+        task.add_done_callback(self._harness_probe_tasks.discard)
+        task.add_done_callback(
+            lambda completed, key=spec.key, gen=generation: self._finish_harness_probe(
+                key, gen, completed
+            )
+        )
+        return task
+
+    async def _probe_harness(
+        self,
+        spec: HarnessProbeSpec,
+        *,
+        force: bool = False,
+    ) -> HarnessAvailability:
+        """Return a fresh-enough result, sharing concurrent probe work."""
+        entry = self._harness_probe_entry(spec.key)
+        availability = entry.availability
+        if availability is not None and not force:
+            ttl = (
+                _HARNESS_PROBE_POSITIVE_TTL_S
+                if availability_allows_launch(availability)
+                else _HARNESS_PROBE_NEGATIVE_TTL_S
+            )
+            if asyncio.get_running_loop().time() - entry.checked_at <= ttl:
+                return availability
+        return await asyncio.shield(self._start_harness_probe(spec))
+
+    def _invalidate_all_harness_probes(self) -> None:
+        """Invalidate all results after install or provider-config mutation."""
+        self._harness_probe_epoch += 1
+        for entry in self._harness_probe_entries.values():
+            entry.generation += 1
+            entry.availability = None
+            entry.checked_at = 0.0
+            entry.task = None
+            entry.launchable = None
+            entry.launch_checked_at = 0.0
+            entry.launch_task = None
+
+    async def _refresh_capabilities_after_mutation(
+        self,
+    ) -> tuple[dict[str, HarnessAvailability] | None, dict[str, bool] | None]:
+        """Return a post-mutation snapshot that cannot join stale probes."""
+        self._invalidate_all_harness_probes()
+        while True:
+            epoch = self._harness_probe_epoch
+            configured, gateway = await asyncio.gather(
+                self._probe_configured_harnesses(startup=False, force=True),
+                self._probe_gateway_inference(startup=False),
+            )
+            if epoch == self._harness_probe_epoch:
+                self._configured_harnesses = configured
+                self._gateway_inference = gateway
+                return configured, gateway
+
+    def _has_unknown_harness_probe_results(self) -> bool:
+        """Return whether any advertised harness lacks a completed result."""
+        return any(
+            self._harness_probe_entries.get(spec.key) is None
+            or self._harness_probe_entries[spec.key].availability is None
+            for spec in configured_harness_probe_specs()
+        )
+
     async def _probe_configured_harnesses(
         self,
         *,
         startup: bool,
+        force: bool = False,
     ) -> dict[str, HarnessAvailability] | None:
-        """Collect harness readiness without letting a probe break the channel."""
-        try:
-            return await asyncio.to_thread(configured_harness_map)
-        except Exception as exc:
-            _logger.exception("Host harness readiness probe failed")
-            if startup:
-                print(
-                    "⚠ Could not inspect installed harnesses; the host will "
-                    f"connect with harness readiness unknown: {exc}",
-                    file=sys.stderr,
-                    flush=True,
+        """Probe unique harnesses concurrently and assemble one full snapshot."""
+        specs = configured_harness_probe_specs()
+        remaining = iter(specs)
+        results: dict[HarnessProbeKey, HarnessAvailability | Exception] = {}
+
+        async def _worker() -> None:
+            for spec in remaining:
+                try:
+                    # Publish the launch-only verdict first. A launch arriving
+                    # during discovery joins this stage and never waits for the
+                    # picker-only authentication probe that follows.
+                    await self._probe_harness_launchability(spec, force=force)
+                    results[spec.key] = await self._probe_harness(spec, force=force)
+                except Exception as exc:  # noqa: BLE001 — preserve per-harness failure
+                    results[spec.key] = exc
+
+        workers = [
+            asyncio.create_task(_worker(), name=f"host-harness-probe-worker:{idx}")
+            for idx in range(min(_HARNESS_PROBE_CONCURRENCY, len(specs)))
+        ]
+        await asyncio.gather(*workers)
+
+        snapshot: dict[str, HarnessAvailability] = {}
+        for spec in specs:
+            result = results[spec.key]
+            if isinstance(result, BaseException):
+                _logger.error(
+                    "Host harness readiness probe failed for %s: %s",
+                    spec.canonical,
+                    result,
+                    exc_info=(type(result), result, result.__traceback__),
                 )
-            return None
+                if startup:
+                    print(
+                        f"⚠ Could not inspect harness {spec.canonical!r}; "
+                        f"readiness is unknown: {result}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                continue
+            for spelling in spec.spellings:
+                snapshot[spelling] = result
+        return snapshot or None
 
     async def _probe_gateway_inference(self, *, startup: bool) -> dict[str, bool] | None:
         """Collect gateway metadata without letting a probe break the channel."""
@@ -2582,30 +2834,17 @@ class HostProcess:
             return None
 
     async def _initialize_capabilities(self) -> None:
-        """Build the initial capability snapshot once, before any handshake."""
+        """Build capabilities in the background without delaying connection."""
         if self._capabilities_initialized:
             return
-        try:
-            configured, gateway = await asyncio.wait_for(
-                asyncio.gather(
-                    self._probe_configured_harnesses(startup=True),
-                    self._probe_gateway_inference(startup=True),
-                ),
-                timeout=_HOST_CAPABILITY_INIT_TIMEOUT_S,
-            )
-        except TimeoutError:
-            configured = gateway = None
-            _logger.error(
-                "Host capability discovery exceeded %.0fs; continuing with unknown metadata",
-                _HOST_CAPABILITY_INIT_TIMEOUT_S,
-            )
-            print(
-                "⚠ Host capability discovery timed out; connecting with readiness unknown.",
-                file=sys.stderr,
-                flush=True,
-            )
-        self._configured_harnesses = configured
-        self._gateway_inference = gateway
+        epoch = self._harness_probe_epoch
+        configured, gateway = await asyncio.gather(
+            self._probe_configured_harnesses(startup=True),
+            self._probe_gateway_inference(startup=True),
+        )
+        if epoch == self._harness_probe_epoch:
+            self._configured_harnesses = configured
+            self._gateway_inference = gateway
         self._capabilities_initialized = True
 
     async def run(self) -> None:
@@ -2620,10 +2859,14 @@ class HostProcess:
             authorization / outdated server, or a loopback server that
             kept refusing connections (the local server is gone).
         """
-        # Capability probes may shell out or inspect local config, so perform
-        # them once during daemon initialization. They are advisory: a broken
-        # harness is reported as unknown and must not prevent registration.
-        await self._initialize_capabilities()
+        # Capability discovery is advisory. Start it once, but connect
+        # immediately; hello reports the snapshot available at send time and
+        # the live readiness loop publishes the completed map later.
+        if self._capability_discovery_task is None:
+            self._capability_discovery_task = asyncio.create_task(
+                self._initialize_capabilities(),
+                name="host-capability-discovery",
+            )
 
         # Reap orphaned harness/tool grandchildren that reparent here when a
         # runner dies (this host is PID 1 in a container, or a subreaper
@@ -2775,6 +3018,16 @@ class HostProcess:
         finally:
             # Await the cancellations: a bare cancel() leaves the tasks
             # pending at loop close ("Task was destroyed but it is pending!").
+            if self._capability_discovery_task is not None:
+                self._capability_discovery_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._capability_discovery_task
+                self._capability_discovery_task = None
+            for task in list(self._harness_probe_tasks):
+                task.cancel()
+            for task in list(self._harness_probe_tasks):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
             if self._reaper_task is not None:
                 self._reaper_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -3002,7 +3255,13 @@ class HostProcess:
             flush=True,
         )
 
-        readiness_task = asyncio.create_task(self._harness_readiness_loop(ws))
+        readiness_task = asyncio.create_task(
+            self._harness_readiness_loop(
+                ws,
+                reported_configured=hello.configured_harnesses,
+                reported_gateway=hello.gateway_inference,
+            )
+        )
         try:
             while True:
                 raw = await ws.recv()
@@ -3030,32 +3289,70 @@ class HostProcess:
     async def _harness_readiness_loop(
         self,
         ws: websockets.asyncio.client.ClientConnection,
+        *,
+        reported_configured: dict[str, HarnessAvailability] | None,
+        reported_gateway: dict[str, bool] | None,
     ) -> None:
-        """Refresh advisory capabilities without endangering the tunnel."""
-        configured = self._configured_harnesses
-        gateway = self._gateway_inference
+        """Publish background discovery, then refresh cached capabilities."""
+        configured = reported_configured
+        gateway = reported_gateway
+
+        # Discovery may finish between constructing hello and starting this
+        # task. Compare against what hello actually carried, not the current
+        # cache, so the completed result cannot be lost in that race.
+        discovery = self._capability_discovery_task
+        if discovery is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.shield(discovery)
+        latest = self._configured_harnesses
+        latest_gateway = self._gateway_inference
+        if latest is not None and (latest != configured or latest_gateway != gateway):
+            await ws.send(
+                encode_host_frame(
+                    HostHarnessReadinessFrame(
+                        configured_harnesses=latest,
+                        gateway_inference=latest_gateway,
+                    )
+                )
+            )
+            configured = latest
+            gateway = latest_gateway
+
         loop = asyncio.get_running_loop()
         next_quick = loop.time() + HARNESS_READINESS_REFRESH_INTERVAL_S
         next_full = loop.time() + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
         while True:
             await asyncio.sleep(max(0.0, min(next_quick, next_full) - loop.time()))
             now = loop.time()
-            refresh_full = configured is None or now >= next_full
+            full_refresh = now >= next_full
+            quick_refresh = (
+                configured is None
+                or self._has_unknown_harness_probe_results()
+                or any(
+                    value is False or value == HARNESS_BINARY_MISSING
+                    for value in (configured or {}).values()
+                )
+            )
             if now >= next_quick:
                 next_quick = now + HARNESS_READINESS_REFRESH_INTERVAL_S
-                if not refresh_full and configured is not None:
-                    try:
-                        refresh_full = await asyncio.to_thread(
-                            _unavailable_harness_became_ready, configured
-                        )
-                    except Exception:
-                        _logger.exception("Host harness quick readiness probe failed")
-            if not refresh_full:
+            elif not full_refresh:
+                continue
+            if not full_refresh and not quick_refresh:
                 continue
 
-            latest = await self._probe_configured_harnesses(startup=False)
-            latest_gateway = await self._probe_gateway_inference(startup=False)
-            next_full = now + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
+            epoch = self._harness_probe_epoch
+            if full_refresh:
+                latest, latest_gateway = await asyncio.gather(
+                    self._probe_configured_harnesses(startup=False, force=True),
+                    self._probe_gateway_inference(startup=False),
+                )
+                next_full = now + HARNESS_READINESS_FULL_REFRESH_INTERVAL_S
+            else:
+                latest = await self._probe_configured_harnesses(startup=False)
+                latest_gateway = gateway
+
+            if epoch != self._harness_probe_epoch:
+                continue
             new_configured = latest if latest is not None else configured
             new_gateway = latest_gateway if latest_gateway is not None else gateway
             if new_configured is None:
@@ -3208,11 +3505,19 @@ class HostProcess:
             # The installer shells out (npm) and can run for minutes, so run
             # it off the event loop and reply when it completes.
             install_result = await asyncio.to_thread(self._handle_install_harness, frame)
+            if install_result.status == "ok":
+                configured, gateway = await self._refresh_capabilities_after_mutation()
+                install_result.configured_harnesses = configured
+                install_result.gateway_inference = gateway
             await ws.send(encode_host_frame(install_result))
         elif isinstance(frame, HostStoreSecretFrame):
             # The credential write touches the OS keychain / config file, so run
             # it off the event loop and reply when it completes.
             secret_result = await asyncio.to_thread(self._handle_store_secret, frame)
+            if secret_result.status == "ok":
+                configured, gateway = await self._refresh_capabilities_after_mutation()
+                secret_result.configured_harnesses = configured
+                secret_result.gateway_inference = gateway
             await ws.send(encode_host_frame(secret_result))
         elif isinstance(frame, HostDetectCredentialsFrame):
             # Ambient detection may probe files / a localhost socket, so run it

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
 import omnigent.onboarding.kimi_auth as _kimi_auth
@@ -35,6 +36,7 @@ from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.harness_availability import (
     CODEX_CANONICAL_HARNESSES,
     HARNESS_BINARY_MISSING,
+    HARNESS_NEEDS_AUTH,
     HARNESS_VERSION_TOO_LOW,
     HarnessAvailability,
 )
@@ -445,6 +447,96 @@ def _harness_availability(canonical: str) -> HarnessAvailability:
     return _harness_availability_core(canonical)
 
 
+HarnessProbeKey = tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HarnessProbeSpec:
+    """One semantic readiness probe and the spellings it serves."""
+
+    key: HarnessProbeKey
+    canonical: str
+    spellings: tuple[str, ...]
+
+
+def _probe_key_for_canonical(canonical: str) -> HarnessProbeKey:
+    """Return the cache key for an already-normalized harness spelling."""
+    if _is_codex_family_harness(canonical):
+        return ("codex",)
+    return ("harness", canonical)
+
+
+def harness_probe_key(harness: str) -> HarnessProbeKey:
+    """Return the semantic cache key shared by equivalent spellings."""
+    return _probe_key_for_canonical(_canonical_harness(harness))
+
+
+def harness_probe_spec(harness: str) -> HarnessProbeSpec:
+    """Build a probe spec for one launch-request harness spelling."""
+    canonical = _canonical_harness(harness)
+    return HarnessProbeSpec(
+        key=_probe_key_for_canonical(canonical),
+        canonical=canonical,
+        spellings=(harness,),
+    )
+
+
+def _configured_harness_spellings() -> set[str]:
+    """Return every spelling included in the host readiness snapshot."""
+    spellings: set[str] = set(_HARNESS_FAMILY)
+    spellings.update(valid_harnesses())
+    spellings.update(harness_install_keys())
+    spellings.update(_EXECUTOR_TYPE_HARNESS_ALIASES)
+    spellings.update(HARNESS_ALIASES)
+    spellings.update(_PI_HARNESSES)
+    spellings.update(_OPENCODE_HARNESSES)
+    spellings.update(_CURSOR_NATIVE_HARNESSES)
+    spellings.update(_KIRO_NATIVE_HARNESSES)
+    spellings.update(_GOOSE_NATIVE_HARNESSES)
+    spellings.update(_KIMI_NATIVE_HARNESSES)
+    spellings.update(_HERMES_NATIVE_HARNESSES)
+    spellings.update(_QWEN_HARNESSES)
+    spellings.update({CURSOR_KEY, KIMI_SURFACE, GOOSE_KEY, HERMES_KEY, COPILOT_KEY})
+    return spellings
+
+
+def configured_harness_probe_specs() -> tuple[HarnessProbeSpec, ...]:
+    """Return deterministic unique probes for a complete readiness map."""
+    grouped: dict[HarnessProbeKey, tuple[str, set[str]]] = {}
+    for spelling in sorted(_configured_harness_spellings()):
+        canonical = _canonical_harness(spelling)
+        key = _probe_key_for_canonical(canonical)
+        existing = grouped.get(key)
+        if existing is None:
+            grouped[key] = (canonical, {spelling})
+        else:
+            existing[1].add(spelling)
+    return tuple(
+        HarnessProbeSpec(key=key, canonical=canonical, spellings=tuple(sorted(spellings)))
+        for key, (canonical, spellings) in sorted(grouped.items())
+    )
+
+
+def probe_harness_availability(harness: str) -> HarnessAvailability:
+    """Run the picker-facing readiness probe for one canonical harness."""
+    return _harness_availability(_canonical_harness(harness))
+
+
+def probe_harness_launchability(harness: str) -> bool:
+    """Run the authoritative launch gate without picker-only auth checks."""
+    return _harness_availability_core(harness) is True
+
+
+def availability_allows_launch(availability: HarnessAvailability) -> bool:
+    """Map picker readiness onto the existing launch-gate semantics.
+
+    ``needs-auth`` is launchable because native CLI login/provider failures are
+    intentionally surfaced by the harness at runtime; missing/old binaries and
+    credential-gated SDK surfaces remain blocked.
+    """
+    return availability is True or availability == HARNESS_NEEDS_AUTH
+
+
 def harness_is_configured(harness: str) -> bool:
     """Return whether *harness* can be launched on this machine.
 
@@ -506,14 +598,14 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.update(_QWEN_HARNESSES)
     spellings.add(CURSOR_KEY)
     spellings.add(KIMI_SURFACE)
-    spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
-    spellings.add(HERMES_KEY)  # Hermes Agent wraps the ``hermes`` CLI
+    spellings.add(GOOSE_KEY)
+    spellings.add(HERMES_KEY)
     spellings.add(COPILOT_KEY)
-    availability_cache: dict[tuple[str, ...], HarnessAvailability] = {}
+    availability_cache: dict[HarnessProbeKey, HarnessAvailability] = {}
     result: dict[str, HarnessAvailability] = {}
     for spelling in spellings:
         canonical = _canonical_harness(spelling)
-        cache_key = ("codex",) if _is_codex_family_harness(canonical) else ("harness", canonical)
+        cache_key = _probe_key_for_canonical(canonical)
         if cache_key not in availability_cache:
             availability_cache[cache_key] = _harness_availability(canonical)
         result[spelling] = availability_cache[cache_key]

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -11,7 +11,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from websockets.datastructures import Headers
@@ -760,10 +760,9 @@ async def test_handle_launch_refuses_unconfigured_harness(
     host = _make_host_process()
     workspace = tmp_path / "project"
     workspace.mkdir()
-    # Patch the symbol connect.py imported, with the real function's
-    # signature; the workspace exists so ONLY the harness check can fail.
+    # The workspace exists so only the cached per-harness probe can fail.
     monkeypatch.setattr(
-        "omnigent.host.connect.harness_is_configured",
+        "omnigent.host.connect.probe_harness_launchability",
         lambda harness: False,
     )
 
@@ -805,7 +804,7 @@ async def test_handle_launch_native_cursor_message_points_at_cursor_installer(
     workspace = tmp_path / "project"
     workspace.mkdir()
     monkeypatch.setattr(
-        "omnigent.host.connect.harness_is_configured",
+        "omnigent.host.connect.probe_harness_launchability",
         lambda harness: False,
     )
 
@@ -844,7 +843,7 @@ async def test_handle_launch_configured_harness_proceeds_to_spawn(
     workspace = tmp_path / "project"
     workspace.mkdir()
     monkeypatch.setattr(
-        "omnigent.host.connect.harness_is_configured",
+        "omnigent.host.connect.probe_harness_launchability",
         lambda harness: True,
     )
 
@@ -897,16 +896,12 @@ async def test_handle_launch_without_harness_skips_check(
     workspace = tmp_path / "project"
     workspace.mkdir()
 
-    def _must_not_be_called(harness: str) -> bool:
-        """Fail the test if the readiness check runs for harness=None.
-
-        :param harness: The harness the production code passed.
-        :returns: Never returns.
-        """
-        raise AssertionError("harness_is_configured must not be called when frame.harness is None")
+    def _must_not_be_called(harness: str) -> object:
+        """Fail the test if the readiness probe runs for harness=None."""
+        raise AssertionError("readiness probe must not run when frame.harness is None")
 
     monkeypatch.setattr(
-        "omnigent.host.connect.harness_is_configured",
+        "omnigent.host.connect.probe_harness_launchability",
         _must_not_be_called,
     )
 
@@ -1022,6 +1017,23 @@ class _FakeTunnel:
         raise ConnectionError("test disconnect")
 
 
+class _HoldingTunnel:
+    """Tunnel that stays open while background readiness publishes updates."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.sent_event = asyncio.Event()
+        self._closed = asyncio.Event()
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+        self.sent_event.set()
+
+    async def recv(self) -> str:
+        await self._closed.wait()
+        raise ConnectionError("test closed")
+
+
 class _ConnectionErrorTunnel:
     """Tunnel that returns one server connection error after host.hello."""
 
@@ -1073,16 +1085,6 @@ async def test_live_host_refreshes_harness_readiness_without_reconnect(
     The refresh now runs in :meth:`HostProcess._harness_readiness_loop`, off the
     receive loop, so a slow probe can never stall the tunnel keepalive.
     """
-    readiness = iter(({"pi": True},))
-    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
-    monkeypatch.setattr(
-        "omnigent.host.connect.configured_harness_map",
-        lambda: next(readiness),
-    )
-    monkeypatch.setattr(
-        "omnigent.host.connect.harness_is_configured",
-        lambda harness: harness == "pi",
-    )
     monkeypatch.setattr(
         "omnigent.host.connect.HARNESS_READINESS_REFRESH_INTERVAL_S",
         0.01,
@@ -1090,9 +1092,21 @@ async def test_live_host_refreshes_harness_readiness_without_reconnect(
     host = _make_host_process()
     host._configured_harnesses = {"pi": False}
     host._gateway_inference = {"codex": True}
+
+    async def _ready(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        return {"pi": True}
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _ready)
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws))
+    task = asyncio.create_task(
+        host._harness_readiness_loop(
+            ws,
+            reported_configured={"pi": False},
+            reported_gateway={"codex": True},
+        )
+    )
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1109,12 +1123,6 @@ async def test_live_host_full_refresh_detects_auth_completion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The full-refresh fallback catches readiness changes beyond binary installs."""
-    readiness = iter(({"codex": True},))
-    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
-    monkeypatch.setattr(
-        "omnigent.host.connect.configured_harness_map",
-        lambda: next(readiness),
-    )
     monkeypatch.setattr(
         "omnigent.host.connect.HARNESS_READINESS_FULL_REFRESH_INTERVAL_S",
         0.01,
@@ -1122,9 +1130,22 @@ async def test_live_host_full_refresh_detects_auth_completion(
     host = _make_host_process()
     host._configured_harnesses = {"codex": "needs-auth"}
     host._gateway_inference = {"codex": True}
+
+    async def _ready(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        return {"codex": True}
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _ready)
+    monkeypatch.setattr(host, "_probe_gateway_inference", AsyncMock(return_value={"codex": True}))
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws))
+    task = asyncio.create_task(
+        host._harness_readiness_loop(
+            ws,
+            reported_configured={"codex": "needs-auth"},
+            reported_gateway={"codex": True},
+        )
+    )
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1147,8 +1168,6 @@ async def test_live_host_does_not_repeat_unchanged_readiness(
         calls["n"] += 1
         return {"codex": "needs-auth"}
 
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _unchanged_map)
-    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", lambda: {"codex": True})
     monkeypatch.setattr(
         "omnigent.host.connect.HARNESS_READINESS_FULL_REFRESH_INTERVAL_S",
         0.01,
@@ -1156,9 +1175,22 @@ async def test_live_host_does_not_repeat_unchanged_readiness(
     host = _make_host_process()
     host._configured_harnesses = {"codex": "needs-auth"}
     host._gateway_inference = {"codex": True}
+
+    async def _ready(*, startup: bool, force: bool = False) -> dict[str, str]:
+        del startup, force
+        return _unchanged_map()
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _ready)
+    monkeypatch.setattr(host, "_probe_gateway_inference", AsyncMock(return_value={"codex": True}))
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws))
+    task = asyncio.create_task(
+        host._harness_readiness_loop(
+            ws,
+            reported_configured={"codex": "needs-auth"},
+            reported_gateway={"codex": True},
+        )
+    )
     try:
         # Let at least two full refreshes recompute-and-compare before stopping.
         for _ in range(400):
@@ -1179,23 +1211,32 @@ async def test_live_host_repushes_when_only_gateway_inference_changes(
     """A gateway-inference flip alone must reach the server, readiness unchanged."""
     gateway = iter(({"codex": False}, {"codex": True}))
     monkeypatch.setattr(
-        "omnigent.host.connect.configured_harness_map",
-        lambda: {"codex": True},
-    )
-    monkeypatch.setattr(
-        "omnigent.host.connect.gateway_inference_map",
-        lambda: next(gateway, {"codex": True}),
-    )
-    monkeypatch.setattr(
         "omnigent.host.connect.HARNESS_READINESS_FULL_REFRESH_INTERVAL_S",
         0.01,
     )
     host = _make_host_process()
     host._configured_harnesses = {"codex": True}
     host._gateway_inference = {"codex": False}
+
+    async def _ready(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        return {"codex": True}
+
+    async def _gateway(*, startup: bool) -> dict[str, bool]:
+        del startup
+        return next(gateway, {"codex": True})
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _ready)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _gateway)
     ws = _RecordingWS()
 
-    task = asyncio.create_task(host._harness_readiness_loop(ws))
+    task = asyncio.create_task(
+        host._harness_readiness_loop(
+            ws,
+            reported_configured={"codex": True},
+            reported_gateway={"codex": False},
+        )
+    )
     try:
         await asyncio.wait_for(ws.first_send.wait(), timeout=2.0)
     finally:
@@ -1207,6 +1248,271 @@ async def test_live_host_repushes_when_only_gateway_inference_changes(
     assert refresh.configured_harnesses == {"codex": True}
     assert refresh.gateway_inference == {"codex": True}
     _cleanup_host(host)
+
+
+async def test_parallel_probes_share_inflight_work_with_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Independent harnesses overlap and a real launch joins its probe."""
+    from omnigent.onboarding.harness_readiness import HarnessProbeSpec
+
+    specs = (
+        HarnessProbeSpec(("harness", "alpha"), "alpha", ("alpha",)),
+        HarnessProbeSpec(("harness", "beta"), "beta", ("beta",)),
+    )
+    entered = threading.Barrier(3)
+    release = threading.Event()
+    calls: list[str] = []
+
+    def _probe(harness: str) -> bool:
+        calls.append(harness)
+        entered.wait(timeout=2.0)
+        release.wait(timeout=2.0)
+        return False
+
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_probe_specs", lambda: specs)
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_launchability", _probe)
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_availability", lambda harness: False)
+    host = _make_host_process()
+
+    discovery = asyncio.create_task(host._probe_configured_harnesses(startup=False))
+    await asyncio.to_thread(entered.wait, 2.0)
+    assert sorted(calls) == ["alpha", "beta"]
+
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    launch = asyncio.create_task(
+        host._handle_launch(
+            HostLaunchRunnerFrame(
+                request_id="shared_launch",
+                binding_token="token",
+                workspace=str(workspace),
+                harness="alpha",
+            )
+        )
+    )
+    await asyncio.sleep(0)
+    assert not launch.done()
+    assert calls.count("alpha") == 1
+    release.set()
+
+    snapshot, launch_result = await asyncio.gather(discovery, launch)
+    assert snapshot == {"alpha": False, "beta": False}
+    assert launch_result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    assert calls.count("alpha") == 1
+
+
+async def test_harness_probe_parallelism_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the configured number of subprocess-heavy probes run at once."""
+    from omnigent.onboarding.harness_readiness import HarnessProbeSpec
+
+    monkeypatch.setattr("omnigent.host.connect._HARNESS_PROBE_CONCURRENCY", 2)
+    specs = tuple(
+        HarnessProbeSpec(("harness", name), name, (name,)) for name in ("alpha", "beta", "gamma")
+    )
+    lock = threading.Lock()
+    two_entered = threading.Event()
+    release = threading.Event()
+    active = 0
+    max_active = 0
+    calls: list[str] = []
+
+    def _probe(harness: str) -> bool:
+        nonlocal active, max_active
+        with lock:
+            calls.append(harness)
+            active += 1
+            max_active = max(max_active, active)
+            if active == 2:
+                two_entered.set()
+        release.wait(timeout=2.0)
+        with lock:
+            active -= 1
+        return True
+
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_probe_specs", lambda: specs)
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_launchability", _probe)
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_availability", lambda harness: True)
+    host = _make_host_process()
+    probing = asyncio.create_task(host._probe_configured_harnesses(startup=False))
+
+    assert await asyncio.to_thread(two_entered.wait, 2.0)
+    await asyncio.sleep(0.02)
+    assert len(calls) == 2
+    release.set()
+    assert await probing == {"alpha": True, "beta": True, "gamma": True}
+    assert max_active == 2
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "ttl_name"),
+    [
+        (True, False, "_HARNESS_PROBE_POSITIVE_TTL_S"),
+        (False, True, "_HARNESS_PROBE_NEGATIVE_TTL_S"),
+    ],
+)
+async def test_harness_probe_cache_expires(
+    monkeypatch: pytest.MonkeyPatch,
+    first: bool,
+    second: bool,
+    ttl_name: str,
+) -> None:
+    """Positive and negative launch cache entries both refresh after TTL."""
+    import omnigent.host.connect as connect_module
+    from omnigent.onboarding.harness_readiness import harness_probe_spec
+
+    values = iter((first, second))
+    calls = 0
+
+    def _probe(_harness: str) -> bool:
+        nonlocal calls
+        calls += 1
+        return next(values)
+
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_launchability", _probe)
+    host = _make_host_process()
+    spec = harness_probe_spec("codex")
+
+    assert await host._probe_harness_launchability(spec) is first
+    entry = host._harness_probe_entries[spec.key]
+    entry.launch_checked_at -= getattr(connect_module, ttl_name) + 1.0
+    assert await host._probe_harness_launchability(spec) is second
+    assert calls == 2
+
+
+async def test_mutation_generation_rejects_stale_probe_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-mutation probe cannot overwrite the post-mutation result."""
+    from omnigent.onboarding.harness_readiness import harness_probe_spec
+
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def _probe(_harness: str) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            release.wait(timeout=2.0)
+            return False
+        return True
+
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_availability", _probe)
+    host = _make_host_process()
+    spec = harness_probe_spec("codex")
+    stale = asyncio.create_task(host._probe_harness(spec))
+    await asyncio.to_thread(started.wait, 2.0)
+
+    host._invalidate_all_harness_probes()
+    assert await host._probe_harness(spec) is True
+    release.set()
+    assert await stale is False
+    assert await host._probe_harness(spec) is True
+    assert calls == 2
+
+
+async def test_failed_probe_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed single-flight releases waiters and the next request retries."""
+    from omnigent.onboarding.harness_readiness import harness_probe_spec
+
+    calls = 0
+
+    def _probe(_harness: str) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise PermissionError("probe denied")
+        return True
+
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_availability", _probe)
+    host = _make_host_process()
+    spec = harness_probe_spec("codex")
+
+    with pytest.raises(PermissionError, match="probe denied"):
+        await host._probe_harness(spec)
+    assert await host._probe_harness(spec) is True
+    assert calls == 2
+
+
+async def test_launch_probe_failure_sends_structured_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe exceptions produce a reply and leave the tunnel usable."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    def _probe(_harness: str) -> bool:
+        raise PermissionError("cannot execute codex")
+
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_launchability", _probe)
+    host = _make_host_process()
+    ws = _RecordingWS()
+    await host._dispatch_host_frame(
+        ws,  # type: ignore[arg-type]
+        HostLaunchRunnerFrame(
+            request_id="launch_probe_failure",
+            binding_token="token",
+            workspace=str(workspace),
+            harness="codex",
+        ),
+    )
+
+    result = decode_host_frame(ws.sent[0])
+    assert isinstance(result, HostLaunchRunnerResultFrame)
+    assert result.status == "failed"
+    assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    assert "cannot execute codex" in (result.error or "")
+    assert host._runners == {}
+
+    await host._dispatch_host_frame(  # type: ignore[arg-type]
+        ws,
+        HostStatFrame(request_id="still_usable", path=str(workspace)),
+    )
+    assert len(ws.sent) == 2
+
+
+async def test_launch_probe_timeout_sends_structured_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow probe fails the launch without blocking the receive loop."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    release = threading.Event()
+
+    def _probe(_harness: str) -> bool:
+        release.wait(timeout=2.0)
+        return True
+
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_launchability", _probe)
+    monkeypatch.setattr("omnigent.host.connect._HARNESS_LAUNCH_PROBE_TIMEOUT_S", 0.01)
+    host = _make_host_process()
+
+    result = await host._handle_launch(
+        HostLaunchRunnerFrame(
+            request_id="launch_probe_timeout",
+            binding_token="token",
+            workspace=str(workspace),
+            harness="codex",
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    assert "timed out" in (result.error or "")
+    release.set()
+    tasks = [
+        entry.launch_task for entry in host._harness_probe_entries.values() if entry.launch_task
+    ]
+    await asyncio.gather(*tasks)
 
 
 async def test_handle_launch_immediate_exit_reports_exit_code_and_log_tail(
@@ -1481,27 +1787,125 @@ async def test_unreported_exit_flushes_after_reconnect(
     assert host._unreported_exits == {}
 
 
-async def test_capability_probe_timeout_does_not_block_connection(
+async def test_run_connects_while_capability_discovery_is_blocked(
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A hung startup probe degrades to unknown metadata after its deadline."""
+    """The daemon enters its connection loop before capability probes finish."""
+    host = _host()
+    release = asyncio.Event()
+    readiness_started = asyncio.Event()
+    gateway_started = asyncio.Event()
+    connect_called = asyncio.Event()
+
+    async def _readiness(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        readiness_started.set()
+        await release.wait()
+        return {"codex": True}
+
+    async def _gateway(*, startup: bool) -> dict[str, bool]:
+        del startup
+        gateway_started.set()
+        await release.wait()
+        return {"codex": True}
+
+    async def _connect() -> None:
+        connect_called.set()
+        await asyncio.gather(readiness_started.wait(), gateway_started.wait())
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _readiness)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _gateway)
+    monkeypatch.setattr(host, "_connect_and_serve", _connect)
+
+    await asyncio.wait_for(host.run(), timeout=1.0)
+    assert connect_called.is_set()
+    assert readiness_started.is_set()
+    assert gateway_started.is_set()
+
+
+async def test_capability_discovery_does_not_block_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hello is sent with unknown metadata while discovery is still running."""
     host = _make_host_process()
     never = asyncio.Event()
 
-    async def _blocked(*, startup: bool) -> None:
+    async def _blocked_readiness(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        await never.wait()
+        return {"codex": True}
+
+    async def _blocked_gateway(*, startup: bool) -> dict[str, bool]:
         del startup
         await never.wait()
+        return {"codex": True}
 
-    monkeypatch.setattr(host, "_probe_configured_harnesses", _blocked)
-    monkeypatch.setattr(host, "_probe_gateway_inference", _blocked)
-    monkeypatch.setattr("omnigent.host.connect._HOST_CAPABILITY_INIT_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _blocked_readiness)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _blocked_gateway)
+    discovery = asyncio.create_task(host._initialize_capabilities())
+    host._capability_discovery_task = discovery
+    tunnel = _FakeTunnel()
 
-    await host._initialize_capabilities()
+    with pytest.raises(ConnectionError, match="test disconnect"):
+        await host._serve_frames(tunnel)  # type: ignore[arg-type]
 
-    assert host._configured_harnesses is None
-    assert host._gateway_inference is None
-    assert "capability discovery timed out" in capsys.readouterr().err
+    hello = decode_host_frame(tunnel.sent[0])
+    assert isinstance(hello, HostHelloFrame)
+    assert hello.configured_harnesses is None
+    assert hello.gateway_inference is None
+    assert not discovery.done()
+    discovery.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await discovery
+
+
+async def test_completed_background_discovery_updates_connected_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hello with unknown metadata is followed by one complete snapshot."""
+    host = _make_host_process()
+    release = asyncio.Event()
+
+    async def _readiness(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
+        await release.wait()
+        return {"claude-native": True, "codex-native": False}
+
+    async def _gateway(*, startup: bool) -> dict[str, bool]:
+        del startup
+        await release.wait()
+        return {"claude-native": True}
+
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _readiness)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _gateway)
+    discovery = asyncio.create_task(host._initialize_capabilities())
+    host._capability_discovery_task = discovery
+    tunnel = _HoldingTunnel()
+    serving = asyncio.create_task(host._serve_frames(tunnel))  # type: ignore[arg-type]
+
+    while not tunnel.sent:
+        await tunnel.sent_event.wait()
+        tunnel.sent_event.clear()
+    hello = decode_host_frame(tunnel.sent[0])
+    assert isinstance(hello, HostHelloFrame)
+    assert hello.configured_harnesses is None
+
+    release.set()
+    for _ in range(100):
+        if len(tunnel.sent) >= 2:
+            break
+        await asyncio.sleep(0.01)
+    refresh = decode_host_frame(tunnel.sent[1])
+    assert isinstance(refresh, HostHarnessReadinessFrame)
+    assert refresh.configured_harnesses == {
+        "claude-native": True,
+        "codex-native": False,
+    }
+
+    serving.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serving
 
 
 async def test_capability_probe_failure_does_not_block_registration(
@@ -1510,10 +1914,16 @@ async def test_capability_probe_failure_does_not_block_registration(
 ) -> None:
     """Optional startup discovery fails visibly but hello still reaches the server."""
 
-    def _denied() -> dict[str, bool]:
+    from omnigent.onboarding.harness_readiness import harness_probe_spec
+
+    def _denied(_harness: str) -> bool:
         raise PermissionError(13, "Permission denied", "/usr/local/bin/codex")
 
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _denied)
+    monkeypatch.setattr(
+        "omnigent.host.connect.configured_harness_probe_specs",
+        lambda: (harness_probe_spec("codex"),),
+    )
+    monkeypatch.setattr("omnigent.host.connect.probe_harness_availability", _denied)
     monkeypatch.setattr(
         "omnigent.host.connect.gateway_inference_map",
         lambda: {"codex": False},
@@ -2862,26 +3272,17 @@ def test_handle_create_dir_expands_tilde(tmp_path: Path, monkeypatch) -> None:
 # ── host.install_harness handler ────────────────────────
 
 
-def test_handle_install_harness_success_returns_refreshed_readiness(
+def test_handle_install_harness_success_runs_installer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A successful install returns ``ok`` and the recomputed readiness map.
-
-    The server flips the UI badge off this map, so the handler must run the
-    installer and then re-probe readiness, returning the fresh result.
+    A successful core install returns ``ok``; async dispatch refreshes readiness.
     """
     import omnigent.host.connect as connect
 
     # Not yet installed, so the handler runs the installer.
     monkeypatch.setattr(connect, "harness_cli_installed", lambda key: False)
     monkeypatch.setattr(connect, "try_install_harness_cli", lambda key: (True, None))
-    monkeypatch.setattr(
-        connect,
-        "configured_harness_map",
-        lambda: {"claude-native": True, "codex-native": "needs-auth"},
-    )
-
     host = _make_host_process()
     result = host._handle_install_harness(
         HostInstallHarnessFrame(request_id="i1", harness="claude")
@@ -2890,7 +3291,7 @@ def test_handle_install_harness_success_returns_refreshed_readiness(
     assert isinstance(result, HostInstallHarnessResultFrame)
     assert result.status == "ok"
     assert result.error is None
-    assert result.configured_harnesses == {"claude-native": True, "codex-native": "needs-auth"}
+    assert result.configured_harnesses is None
 
 
 def test_handle_install_harness_already_installed_skips_installer(
@@ -2912,7 +3313,6 @@ def test_handle_install_harness_already_installed_skips_installer(
         raise AssertionError("installer ran despite the harness already being installed")
 
     monkeypatch.setattr(connect, "try_install_harness_cli", _must_not_install)
-    monkeypatch.setattr(connect, "configured_harness_map", lambda: {"opencode-native": True})
 
     host = _make_host_process()
     result = host._handle_install_harness(
@@ -2920,7 +3320,57 @@ def test_handle_install_harness_already_installed_skips_installer(
     )
 
     assert result.status == "ok"
+    assert result.configured_harnesses is None
+
+
+async def test_install_dispatch_returns_post_mutation_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Install dispatch invalidates a stale result before its response."""
+    import omnigent.host.connect as connect
+    from omnigent.onboarding.harness_readiness import HarnessProbeSpec
+
+    spec = HarnessProbeSpec(
+        ("harness", "opencode-native"),
+        "opencode-native",
+        ("opencode-native",),
+    )
+    state = {"ready": False}
+    picker_calls = 0
+    launch_calls = 0
+
+    def _probe(_harness: str) -> bool:
+        nonlocal picker_calls
+        picker_calls += 1
+        return state["ready"]
+
+    def _launch_probe(_harness: str) -> bool:
+        nonlocal launch_calls
+        launch_calls += 1
+        return state["ready"]
+
+    monkeypatch.setattr(connect, "harness_cli_installed", lambda key: True)
+    monkeypatch.setattr(connect, "configured_harness_probe_specs", lambda: (spec,))
+    monkeypatch.setattr(connect, "probe_harness_availability", _probe)
+    monkeypatch.setattr(connect, "probe_harness_launchability", _launch_probe)
+    host = _make_host_process()
+    monkeypatch.setattr(host, "_probe_gateway_inference", AsyncMock(return_value={"codex": False}))
+    assert await host._probe_harness_launchability(spec) is False
+    assert await host._probe_harness(spec) is False
+    state["ready"] = True
+    ws = _RecordingWS()
+
+    await host._dispatch_host_frame(  # type: ignore[arg-type]
+        ws,
+        HostInstallHarnessFrame(request_id="install_refresh", harness="opencode"),
+    )
+
+    result = decode_host_frame(ws.sent[0])
+    assert isinstance(result, HostInstallHarnessResultFrame)
     assert result.configured_harnesses == {"opencode-native": True}
+    assert result.gateway_inference == {"codex": False}
+    assert picker_calls == 2
+    assert launch_calls == 2
 
 
 def test_handle_install_harness_failure_surfaces_reason(
@@ -2975,15 +3425,10 @@ def test_handle_install_harness_rejects_non_allowlisted(
     assert result.configured_harnesses is None
 
 
-def test_handle_store_secret_key_writes_and_returns_readiness(
+def test_handle_store_secret_key_writes_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A key store-secret request calls the core and returns fresh readiness.
-
-    The handler is a thin wrapper: resolve family, call the non-interactive
-    core, then recompute readiness so the server flips the badge (yellow →
-    green) without a reconnect.
-    """
+    """A key store-secret request calls the non-interactive write core."""
     import omnigent.host.connect as connect
     from omnigent.onboarding.harness_auth import StoreCredentialResult
 
@@ -2994,7 +3439,6 @@ def test_handle_store_secret_key_writes_and_returns_readiness(
         return StoreCredentialResult(True, "anthropic", None)
 
     monkeypatch.setattr(connect, "store_harness_credential", _store)
-    monkeypatch.setattr(connect, "configured_harness_map", lambda: {"claude-native": True})
 
     host = _make_host_process()
     result = host._handle_store_secret(
@@ -3008,7 +3452,7 @@ def test_handle_store_secret_key_writes_and_returns_readiness(
     )
     assert isinstance(result, HostStoreSecretResultFrame)
     assert result.status == "ok"
-    assert result.configured_harnesses == {"claude-native": True}
+    assert result.configured_harnesses is None
     # The core was called with the resolved family + the frame's fields.
     assert calls == [
         {
@@ -3020,6 +3464,65 @@ def test_handle_store_secret_key_writes_and_returns_readiness(
             "wire_api": None,
         }
     ]
+
+
+async def test_store_secret_dispatch_returns_post_mutation_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential writes invalidate readiness before returning to the UI."""
+    import omnigent.host.connect as connect
+    from omnigent.onboarding.harness_auth import StoreCredentialResult
+    from omnigent.onboarding.harness_readiness import HarnessProbeSpec
+
+    spec = HarnessProbeSpec(
+        ("harness", "claude-native"),
+        "claude-native",
+        ("claude-native",),
+    )
+    state = {"availability": "needs-auth"}
+    picker_calls = 0
+    launch_calls = 0
+
+    def _probe(_harness: str) -> object:
+        nonlocal picker_calls
+        picker_calls += 1
+        return state["availability"]
+
+    def _launch_probe(_harness: str) -> bool:
+        nonlocal launch_calls
+        launch_calls += 1
+        return True
+
+    monkeypatch.setattr(
+        connect,
+        "store_harness_credential",
+        lambda **kwargs: StoreCredentialResult(True, "anthropic", None),
+    )
+    monkeypatch.setattr(connect, "configured_harness_probe_specs", lambda: (spec,))
+    monkeypatch.setattr(connect, "probe_harness_availability", _probe)
+    monkeypatch.setattr(connect, "probe_harness_launchability", _launch_probe)
+    host = _make_host_process()
+    monkeypatch.setattr(host, "_probe_gateway_inference", AsyncMock(return_value={}))
+    assert await host._probe_harness_launchability(spec) is True
+    assert await host._probe_harness(spec) == "needs-auth"
+    state["availability"] = True
+    ws = _RecordingWS()
+
+    await host._dispatch_host_frame(  # type: ignore[arg-type]
+        ws,
+        HostStoreSecretFrame(
+            request_id="credential_refresh",
+            harness="claude",
+            kind="key",
+            secret_value="sk-ant-test",
+        ),
+    )
+
+    result = decode_host_frame(ws.sent[0])
+    assert isinstance(result, HostStoreSecretResultFrame)
+    assert result.configured_harnesses == {"claude-native": True}
+    assert picker_calls == 2
+    assert launch_calls == 2
 
 
 def test_handle_store_secret_pi_maps_to_anthropic_family(
@@ -3036,7 +3539,6 @@ def test_handle_store_secret_pi_maps_to_anthropic_family(
         return StoreCredentialResult(True, "anthropic", None)
 
     monkeypatch.setattr(connect, "store_harness_credential", _store)
-    monkeypatch.setattr(connect, "configured_harness_map", lambda: {"pi": True})
 
     host = _make_host_process()
     result = host._handle_store_secret(
@@ -3067,7 +3569,6 @@ def test_handle_store_secret_adopt_calls_adopt_core(
             DetectedCredential(family="openai", source="$OPENAI_API_KEY", env_var="OPENAI_API_KEY")
         ],
     )
-    monkeypatch.setattr(connect, "configured_harness_map", lambda: {"codex-native": True})
 
     host = _make_host_process()
     result = host._handle_store_secret(
@@ -3107,7 +3608,6 @@ def test_handle_store_secret_pi_adopt_uses_detected_family_not_harness(
             DetectedCredential(family="openai", source="$OPENAI_API_KEY", env_var="OPENAI_API_KEY")
         ],
     )
-    monkeypatch.setattr(connect, "configured_harness_map", lambda: {"pi": True})
 
     host = _make_host_process()
     result = host._handle_store_secret(
@@ -4003,7 +4503,7 @@ async def test_accepted_connect_resets_loopback_refused_streak(
     monkeypatch.setattr("omnigent.host.connect._LOOPBACK_REFUSED_FATAL_ATTEMPTS", 3)
     # The accepted connect sends a real hello; skip its slow CLI probes —
     # only the streak accounting is under test here.
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_probe_specs", tuple)
     refused = _refused_exc()
     # 2 refusals (one short of fatal), an accepted upgrade (its tunnel
     # drops on first recv), then refusals repeating until fatal.
@@ -4154,7 +4654,7 @@ async def test_silent_connect_streak_escalates_and_slows_reconnects(
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_probe_specs", tuple)
     monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
     spy = _ConnectSpy([None, None, None, None, None, asyncio.CancelledError()])
     _patch_connect(monkeypatch, spy)
@@ -4183,7 +4683,7 @@ async def test_inbound_frame_resets_silent_connect_streak(
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
     monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 3)
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", dict)
+    monkeypatch.setattr("omnigent.host.connect.configured_harness_probe_specs", tuple)
     monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", dict)
     spy = _ConnectSpy([None, None, 1, None, None, asyncio.CancelledError()])
     _patch_connect(monkeypatch, spy)
@@ -4232,30 +4732,29 @@ async def test_retryable_connection_error_escapes_live_receive_path() -> None:
     assert host._frame_tasks == set()
 
 
-async def test_capabilities_are_initialized_once_across_reconnects(
+async def test_capabilities_are_initialized_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Reconnect handshakes reuse startup metadata instead of rerunning probes."""
-    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    """Repeated initialization calls reuse the daemon-lifetime snapshot."""
     calls = {"readiness": 0, "gateway": 0}
+    host = _host()
 
-    def _readiness() -> dict[str, bool]:
+    async def _readiness(*, startup: bool, force: bool = False) -> dict[str, bool]:
+        del startup, force
         calls["readiness"] += 1
         return {"pi": True}
 
-    def _gateway() -> dict[str, bool]:
+    async def _gateway(*, startup: bool) -> dict[str, bool]:
+        del startup
         calls["gateway"] += 1
         return {"codex": True}
 
-    monkeypatch.setattr("omnigent.host.connect.configured_harness_map", _readiness)
-    monkeypatch.setattr("omnigent.host.connect.gateway_inference_map", _gateway)
-    spy = _ConnectSpy([None, None, asyncio.CancelledError()])
-    _patch_connect(monkeypatch, spy)
-    host = _host()
+    monkeypatch.setattr(host, "_probe_configured_harnesses", _readiness)
+    monkeypatch.setattr(host, "_probe_gateway_inference", _gateway)
 
-    await host.run()
+    await host._initialize_capabilities()
+    await host._initialize_capabilities()
 
-    assert spy.call_count == 3
     assert calls == {"readiness": 1, "gateway": 1}
 
 

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -227,8 +227,10 @@ def test_claude_ready_via_configured_provider_without_cli_login(
         "omnigent.onboarding.harness_readiness._family_provider_configured", lambda _h: True
     )
 
-    def _must_not_probe(_key: str, **_kw: object) -> bool:
-        raise AssertionError("CLI login probed despite a configured provider")
+    def _must_not_probe(key: str, **_kw: object) -> bool:
+        if key == "anthropic":
+            raise AssertionError("Claude login probed despite a configured provider")
+        return False
 
     monkeypatch.setattr(hi, "harness_cli_logged_in", _must_not_probe)
     assert configured_harness_map()["claude-native"] is True
@@ -513,6 +515,26 @@ def test_configured_harness_map_probes_codex_readiness_once(
     assert result["codex"] == "needs-auth"
     assert result["codex-native"] == "needs-auth"
     assert result["native-codex"] == "needs-auth"
+
+
+def test_probe_specs_deduplicate_codex_aliases() -> None:
+    """Parallel host discovery retains the existing Codex family collapse."""
+    from omnigent.onboarding.harness_readiness import configured_harness_probe_specs
+
+    codex_specs = [spec for spec in configured_harness_probe_specs() if spec.key == ("codex",)]
+    assert len(codex_specs) == 1
+    assert {"codex", "codex-native", "native-codex"}.issubset(codex_specs[0].spellings)
+
+
+def test_picker_availability_maps_to_launch_policy() -> None:
+    """Auth warnings launch, while missing and outdated binaries remain blocked."""
+    from omnigent.onboarding.harness_readiness import availability_allows_launch
+
+    assert availability_allows_launch(True)
+    assert availability_allows_launch("needs-auth")
+    assert not availability_allows_launch(False)
+    assert not availability_allows_launch("binary-missing")
+    assert not availability_allows_launch("version-too-low")
 
 
 def test_kimi_readiness_keys_off_binary_and_credential(

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -404,7 +404,13 @@ async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
         {
             "type": "websocket.receive",
             "text": encode_host_frame(
-                HostHarnessReadinessFrame(configured_harnesses={"pi": True})
+                HostHarnessReadinessFrame(
+                    configured_harnesses={
+                        "pi": True,
+                        "codex-native": "needs-auth",
+                        "claude-native": "binary-missing",
+                    }
+                )
             ),
         }
     )
@@ -412,7 +418,11 @@ async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
     async def _wait_until_ready() -> None:
         while True:
             host = store.get_host(_HOST_ID)
-            if host is not None and host.configured_harnesses == {"pi": True}:
+            if host is not None and host.configured_harnesses == {
+                "pi": True,
+                "codex-native": "needs-auth",
+                "claude-native": "binary-missing",
+            }:
                 return
             await asyncio.sleep(0.01)
 
@@ -420,7 +430,11 @@ async def test_host_tunnel_refreshes_harness_readiness_without_reconnect(
 
     conn = registry.get(_HOST_ID)
     assert conn is not None
-    assert conn.hello.configured_harnesses == {"pi": True}
+    assert conn.hello.configured_harnesses == {
+        "pi": True,
+        "codex-native": "needs-auth",
+        "claude-native": "binary-missing",
+    }
     assert updates == [_HOST_ID]
 
 


### PR DESCRIPTION
   ## Related issue

   Closes
 [OMNI-4197](https://linear.app/omnigent/issue/OMNI-4197/parallelize-and-cache-host
 -harness-readiness-probes)

   ## Summary

   - Connect the host immediately while bounded per-harness capability discovery
 runs in the background.
   - Cache fresh launchability and picker-readiness results per semantic harness
 key, sharing in-flight probes with runner launches and across aliases.
   - Invalidate cached generations after installs or credential writes, and return
 structured launch failures when a probe raises or times out.

   ELI5: instead of checking every installed agent before the host can connect, the
 host checks up to four agents in parallel. If a user launches one while its check
 is running, the launch waits on that same check rather than starting another one.

   ```text
   host starts ───────────────► connect + host.hello
        │
        └─ parallel probes (max 4)
             ├─ cached launch gate ─◄─ launch joins in-flight work
             └─ picker readiness ───► live readiness update
   ```

   ## Test Plan

   - `uv run pytest tests/onboarding/test_harness_readiness.py
 tests/host/test_connect.py tests/host/test_frames.py
 tests/server/integration/test_host_tunnel_route.py
 tests/server/integration/test_hosts_install_harness.py
 tests/server/integration/test_hosts_store_credential.py -q` (322 passed)
   - `uv run ruff check omnigent/onboarding/harness_readiness.py
 omnigent/host/connect.py tests/onboarding/test_harness_readiness.py
 tests/host/test_connect.py tests/server/integration/test_host_tunnel_route.py`
   - `uv run pyrefly check omnigent/onboarding/harness_readiness.py                 
 omnigent/host/connect.py`                                                          
                                                                                    
   ## Performance                                                                   
                                                                                    
   ### Methodology

   The benchmark compared an isolated `main` checkout with the PR checkout on the
 same machine.

   Both checkouts used:

   - separate `.venv` environments;
   - separate `HOME`, `OMNIGENT_CONFIG_HOME`, and `OMNIGENT_DATA_DIR`;
   - the same already-running local server;
   - warmed dependencies;
   - randomized A/B run order;
   - 10 measured runs per checkout.

   #### Prepare both checkouts

   ```bash
   MAIN=/path/to/omnigent-main
   PR=/path/to/omnigent-pr

   (cd "$MAIN" && uv sync --extra all --group dev)
   (cd "$PR" && uv sync --extra all --group dev)
   ```

   #### Start the shared server

   ```bash
   cd "$PR"

   OMNIGENT_CONFIG_HOME=/tmp/omni-harness-bench-server-config \
   OMNIGENT_DATA_DIR=/tmp/omni-harness-bench-server-data \
   OMNIGENT_SKIP_WEB_UI=true \
   uv run omnigent server \
     --host 127.0.0.1 \
     --port 18767 \
     --no-open
   ```
                                                                                    
   Wait for it to become healthy:                                                   
                                                                                    
   ```bash                                                                          
   until curl -fsS http://127.0.0.1:18767/health >/dev/null; do                     
     sleep 0.5                                                                      
   done                                                                             
   ```                                                                              
                                                                                    
   #### Host-online benchmark                                                       
                                                                                    
   For each checkout, each measured run stopped any previous daemon, timed a fresh  
 background start, and stopped it again:                                            
                                                                                    
   ```bash                                                                          
   SERVER=http://127.0.0.1:18767                                                    
   CHECKOUT="$MAIN" # repeat with "$PR"                                             
   BENCH_ROOT=/tmp/omni-harness-bench-main # use ...-pr for the PR                  
                                                                                    
   HOME="$BENCH_ROOT/home" \                                                        
   OMNIGENT_CONFIG_HOME="$BENCH_ROOT/config" \                                      
   OMNIGENT_DATA_DIR="$BENCH_ROOT/data" \                                           
   OMNIGENT_DISABLE_KEYRING=1 \                                                     
   "$CHECKOUT/.venv/bin/omnigent" host stop \                                       
     --server "$SERVER" \                                                           
     --daemon-only \                                                                
     --force                                                                        
                                                                                    
   time \                                                                           
   HOME="$BENCH_ROOT/home" \                                                        
   OMNIGENT_CONFIG_HOME="$BENCH_ROOT/config" \                                      
   OMNIGENT_DATA_DIR="$BENCH_ROOT/data" \                                           
   OMNIGENT_DISABLE_KEYRING=1 \                                                     
   "$CHECKOUT/.venv/bin/omnigent" host \                                            
     --background \                                                                 
     --server "$SERVER" \                                                           
     --non-interactive                                                              
                                                                                    
   HOME="$BENCH_ROOT/home" \                                                        
   OMNIGENT_CONFIG_HOME="$BENCH_ROOT/config" \                                      
   OMNIGENT_DATA_DIR="$BENCH_ROOT/data" \                                           
   OMNIGENT_DISABLE_KEYRING=1 \                                                     
   "$CHECKOUT/.venv/bin/omnigent" host stop \                                       
     --server "$SERVER" \                                                           
     --daemon-only \
     --force
   ```

   A Python harness repeated this sequence 10 times per checkout, randomized the
 main/PR order with a fixed seed, measured with `time.perf_counter()`, and reported
 the median.

   #### Readiness-completion benchmark

   After the background start returned, the benchmark polled the existing host
 endpoint every 10ms:

   ```bash
   SERVER=http://127.0.0.1:18767
   HOST_ID=<host-id-from-$BENCH_ROOT/home/.omnigent/config.yaml>

   while true; do
     BODY=$(curl -fsS "$SERVER/v1/hosts/$HOST_ID")

     python3 -c '
   import json, sys
   body = json.load(sys.stdin)
   configured = body.get("configured_harnesses")
   raise SystemExit(0 if isinstance(configured, dict) and configured else 1)
   ' <<<"$BODY" && break

     sleep 0.01
   done
   ```

   This produced two timestamps for every run:

   ```text
   T_online = command start → host background command returns online
   T_ready  = command start → configured_harnesses contains all 48 entries
   ```

   #### Launch-readiness microbenchmark

   To isolate harness-readiness overhead from process spawn, runner tunnel setup,
 TUI startup, and LLM/provider latency, the benchmark replaced the readiness probe
 with a deterministic 50ms function:

   ```python
   def probe(_harness: str) -> bool:
       probe_calls += 1
       time.sleep(0.05)
       return True
   ```

   The same benchmark script was executed under both checkout environments:

   ```bash
   HOME=/tmp/omni-harness-bench-main/home \
   OMNIGENT_CONFIG_HOME=/tmp/omni-harness-bench-main/config \
   OMNIGENT_DATA_DIR=/tmp/omni-harness-bench-main/data \
   "$MAIN/.venv/bin/python" /tmp/bench_launch_probe.py

   HOME=/tmp/omni-harness-bench-pr/home \
   OMNIGENT_CONFIG_HOME=/tmp/omni-harness-bench-pr/config \
   OMNIGENT_DATA_DIR=/tmp/omni-harness-bench-pr/data \
   "$PR/.venv/bin/python" /tmp/bench_launch_probe.py
   ```

   The script called `HostProcess._handle_launch()` with `harness="codex"` and a
 deliberately nonexistent workspace. Harness validation runs before workspace
 validation, so this measured readiness cost without spawning a runner.

   It measured:

   - 20 sequential launch checks on one daemon;
   - first/cold launch duration;
   - warm-launch median;
   - total probe invocation count;
   - two concurrent launches for the same harness;
   - concurrent probe invocation count.

   The launch figures therefore represent only harness-readiness overhead. They do
 not include runner process creation, runner tunnel connection, TUI initialization,
 or provider/LLM latency.                                                           

   ### Host startup and readiness

   | Metric | Main median | PR median | Improvement |
   |---|---:|---:|---:|
   | Command start → host online | 3.716s | 3.233s | **13.0% faster** |
   | Command start → 48 readiness entries | 3.720s | 3.237s | **13.0% faster** |

   A separate host-online-only 10-run pass measured:

   | Main median | PR median | Improvement |
   |---:|---:|---:|
   | 3.907s | 3.266s | **16.4% faster** |

   Across both runs, observed host-start improvement was approximately **13–16%**,
 saving about **0.5–0.6 seconds** on this machine.

   ### Launch readiness

   | Metric | Main | PR |
   |---|---:|---:|
   | First/cold launch check | 55.07ms | 55.85ms |
   | Warm launch median | 55.07ms | **0.054ms** |
   | Probe calls across 20 launches | 20 | **1** |
   | Two concurrent launches | 110.29ms | **54.93ms** |
   | Probe calls for two concurrent launches | 2 | **1** |

   The cold path is effectively unchanged. Once a result is cached, repeated
 launch-readiness overhead drops by approximately **99.9%** in the controlled
 benchmark.

   Two concurrent launches share one in-flight probe, cutting readiness-check time
 and probe subprocess count roughly in half.

   These launch figures measure only harness-readiness overhead. Total end-to-end
 runner startup will show a smaller percentage improvement because process spawn,
 runner tunnel connection, TUI initialization, and provider work remain unchanged.

   ## Demo

   N/A — backend/CLI performance and reliability change.

   ## Type of change

   - [ ] Bug fix
   - [x] Feature
   - [ ] UI / frontend change
   - [ ] Refactor / chore
   - [ ] Docs
   - [ ] Test / CI
   - [ ] Breaking change

   ## Test coverage

   - [x] Unit tests added / updated
   - [x] Integration tests added / updated
   - [ ] E2E tests added / updated
   - [ ] Manual verification completed
   - [ ] Existing tests cover this change
   - [ ] Not applicable

   ## Coverage notes

   Automated coverage exercises non-blocking connection, bounded parallelism,
 alias/in-flight sharing, positive and negative TTL expiry, probe failures and
 timeouts, stale-generation rejection, mutation invalidation, and atomic server
 readiness replacement.

   ## Changelog

   Host startup and first runner launch are faster by sharing bounded, parallel
 harness readiness checks.                                                          