### PR TITLE
Archive-time git worktree cleanup behind a safety check

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -58,6 +58,8 @@ from omnigent.host.frames import (
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
+    HostInspectWorktreeFrame,
+    HostInspectWorktreeResultFrame,
     HostInstallHarnessFrame,
     HostInstallHarnessResultFrame,
     HostLaunchRunnerFrame,
@@ -86,6 +88,7 @@ from omnigent.host.frames import (
 from omnigent.host.git_worktree import (
     WorktreeError,
     create_worktree,
+    inspect_worktree,
     list_worktrees,
     remove_worktree,
 )
@@ -2911,6 +2914,43 @@ class HostProcess:
             status="ok",
         )
 
+    async def _handle_inspect_worktree(
+        self,
+        frame: HostInspectWorktreeFrame,
+    ) -> HostInspectWorktreeResultFrame:
+        """Handle a ``host.inspect_worktree`` request from the server.
+
+        Runs the blocking git reads in a worker thread so the tunnel
+        loop keeps servicing pings.
+
+        :param frame: The inspect-worktree request frame.
+        :returns: Result frame with the inspection facts on success, or
+            ``status: "failed"`` with an error message.
+        """
+        try:
+            # Pause the orphan reaper while git runs — see
+            # _handle_create_worktree above and _reap_orphans_once.
+            with self._host_subprocess_op():
+                inspection = await asyncio.to_thread(
+                    inspect_worktree,
+                    worktree_path=frame.worktree_path,
+                    branch=frame.branch,
+                )
+        except WorktreeError as exc:
+            return HostInspectWorktreeResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=exc.message,
+            )
+        return HostInspectWorktreeResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            dirty_files=inspection.dirty_files,
+            unpushed_commits=inspection.unpushed_commits,
+            merged=inspection.merged,
+            default_ref=inspection.default_ref,
+        )
+
     async def _handle_list_worktrees(
         self,
         frame: HostListWorktreesFrame,
@@ -3819,6 +3859,8 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_remove_worktree(frame)))
         elif isinstance(frame, HostListWorktreesFrame):
             await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
+        elif isinstance(frame, HostInspectWorktreeFrame):
+            await ws.send(encode_host_frame(await self._handle_inspect_worktree(frame)))
         elif isinstance(frame, HostFsRequestFrame):
             # Git status and directory walks can block, so run the read
             # off the event loop and reply when it completes.

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -62,6 +62,13 @@ class HostFrameKind(str, Enum):
     REMOVE_WORKTREE_RESULT = "host.remove_worktree_result"
     LIST_WORKTREES = "host.list_worktrees"
     LIST_WORKTREES_RESULT = "host.list_worktrees_result"
+    # Server -> host: inspect a worktree for work removal would lose
+    # (dirty files, unpushed commits, unmerged branch). Distinct frame
+    # from remove_worktree so an older host that doesn't know it IGNORES
+    # it (no result -> the server keeps the worktree) instead of
+    # executing a removal it wasn't asked to double-check.
+    INSPECT_WORKTREE = "host.inspect_worktree"
+    INSPECT_WORKTREE_RESULT = "host.inspect_worktree_result"
     CREATE_DIR = "host.create_dir"
     CREATE_DIR_RESULT = "host.create_dir_result"
     INSTALL_HARNESS = "host.install_harness"
@@ -629,6 +636,55 @@ class HostCreateDirResultFrame:
 
 
 @dataclass
+class HostInspectWorktreeFrame:
+    """Request frame asking the host to inspect a worktree.
+
+    ``branch`` is required (not optional like remove's): the inspection
+    exists to judge whether the BRANCH's commits are safe, so a request
+    without it is meaningless.
+
+    :param request_id: Unique request identifier for correlation.
+    :param worktree_path: Absolute path of the worktree to inspect, e.g.
+        ``"/Users/alice/myrepo-worktrees/feature-login"``.
+    :param branch: Branch checked out in the worktree, e.g.
+        ``"feature/login"``.
+    """
+
+    request_id: str
+    worktree_path: str
+    branch: str
+
+
+@dataclass
+class HostInspectWorktreeResultFrame:
+    """Result frame returned by the host after inspecting a worktree.
+
+    Count fields are ``None`` on failure. ``merged`` is tri-state even
+    on success: ``None`` means no default branch ref could be resolved
+    (cannot determine), which callers must treat as not-merged.
+
+    :param request_id: Correlation id from the request frame.
+    :param status: ``"ok"`` or ``"failed"``.
+    :param dirty_files: Modified tracked + untracked files, e.g. ``3``.
+    :param unpushed_commits: Commits on the branch unreachable from all
+        remote-tracking refs (every commit when the repo has no remotes).
+    :param merged: Whether the branch is an ancestor of the default
+        branch; ``None`` when undeterminable.
+    :param default_ref: Ref ``merged`` was checked against, e.g.
+        ``"origin/main"``; ``None`` when unresolved.
+    :param error: Error message when status is ``"failed"``.
+    """
+
+    request_id: str
+    status: str
+    dirty_files: int | None = None
+    unpushed_commits: int | None = None
+    merged: bool | None = None
+    default_ref: str | None = None
+    error: str | None = None
+
+
+@dataclass
 class HostInstallHarnessFrame:
     """Server → host: install a harness CLI on the host.
 
@@ -967,6 +1023,8 @@ HostFrame = (
     | HostRemoveWorktreeResultFrame
     | HostListWorktreesFrame
     | HostListWorktreesResultFrame
+    | HostInspectWorktreeFrame
+    | HostInspectWorktreeResultFrame
     | HostCreateDirFrame
     | HostCreateDirResultFrame
     | HostInstallHarnessFrame
@@ -1222,6 +1280,28 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "request_id": frame.request_id,
                 "status": frame.status,
                 "worktrees": frame.worktrees,
+                "error": frame.error,
+            }
+        )
+    if isinstance(frame, HostInspectWorktreeFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.INSPECT_WORKTREE.value,
+                "request_id": frame.request_id,
+                "worktree_path": frame.worktree_path,
+                "branch": frame.branch,
+            }
+        )
+    if isinstance(frame, HostInspectWorktreeResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.INSPECT_WORKTREE_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "dirty_files": frame.dirty_files,
+                "unpushed_commits": frame.unpushed_commits,
+                "merged": frame.merged,
+                "default_ref": frame.default_ref,
                 "error": frame.error,
             }
         )
@@ -1483,6 +1563,10 @@ def _decode_known_host_frame(
             return _decode_list_worktrees(msg)
         case HostFrameKind.LIST_WORKTREES_RESULT:
             return _decode_list_worktrees_result(msg)
+        case HostFrameKind.INSPECT_WORKTREE:
+            return _decode_inspect_worktree(msg)
+        case HostFrameKind.INSPECT_WORKTREE_RESULT:
+            return _decode_inspect_worktree_result(msg)
         case HostFrameKind.CREATE_DIR:
             return _decode_create_dir(msg)
         case HostFrameKind.CREATE_DIR_RESULT:
@@ -1842,6 +1926,71 @@ def _decode_list_worktrees_result(
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
         worktrees=raw,
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_inspect_worktree(msg: _JsonObject) -> HostInspectWorktreeFrame:
+    """Decode a host.inspect_worktree request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.inspect_worktree frame.
+    """
+    return HostInspectWorktreeFrame(
+        request_id=_required_str(msg, "request_id"),
+        worktree_path=_required_str(msg, "worktree_path"),
+        branch=_required_str(msg, "branch"),
+    )
+
+
+def _optional_nullable_int(msg: _JsonObject, field: str) -> int | None:
+    """Read an optional int field that may be null; reject other types.
+
+    ``bool`` is an ``int`` subclass, so it must be excluded explicitly —
+    a wire bug sending ``true`` for a count must not read as ``1``.
+
+    :param msg: Decoded frame object.
+    :param field: Field name to read.
+    :returns: The int value, or ``None`` when absent/null.
+    :raises ValueError: If the field is present but not an int or null.
+    """
+    value = msg.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"frame field must be an int or null: {field!r}")
+    return value
+
+
+def _optional_nullable_bool(msg: _JsonObject, field: str) -> bool | None:
+    """Read an optional bool field that may be null; reject other types.
+
+    :param msg: Decoded frame object.
+    :param field: Field name to read.
+    :returns: The bool value, or ``None`` when absent/null.
+    :raises ValueError: If the field is present but not a bool or null.
+    """
+    value = msg.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError(f"frame field must be a bool or null: {field!r}")
+    return value
+
+
+def _decode_inspect_worktree_result(msg: _JsonObject) -> HostInspectWorktreeResultFrame:
+    """Decode a host.inspect_worktree_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.inspect_worktree_result frame.
+    """
+    return HostInspectWorktreeResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        dirty_files=_optional_nullable_int(msg, "dirty_files"),
+        unpushed_commits=_optional_nullable_int(msg, "unpushed_commits"),
+        merged=_optional_nullable_bool(msg, "merged"),
+        default_ref=_optional_nullable_str(msg, "default_ref"),
         error=_optional_nullable_str(msg, "error"),
     )
 

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -465,6 +465,118 @@ def _main_repo_for_worktree(worktree_path: str) -> str:
     return str(common_dir.parent)
 
 
+@dataclass
+class WorktreeInspection:
+    """Facts about whether a worktree holds work that exists nowhere else.
+
+    The server combines these into a remove-vs-keep decision when a
+    worktree-attached session is archived: only a clean tree with nothing
+    unpushed and the branch merged may be removed.
+
+    :param dirty_files: Modified tracked files plus untracked files in
+        the worktree, e.g. ``3``.
+    :param unpushed_commits: Commits on ``branch`` unreachable from every
+        remote-tracking ref. When the repo has no remotes at all this is
+        every commit on the branch — nothing has been pushed anywhere.
+    :param merged: Whether ``branch`` is an ancestor of the default
+        branch. ``None`` when no default branch ref could be resolved
+        (cannot determine — callers must treat it as not-merged).
+    :param default_ref: The ref ``merged`` was checked against, e.g.
+        ``"origin/main"`` or ``"main"``. ``None`` when unresolved.
+    """
+
+    dirty_files: int
+    unpushed_commits: int
+    merged: bool | None
+    default_ref: str | None
+
+
+def _default_branch_ref(repo_root: str) -> str | None:
+    """Resolve the ref considered the repo's default branch.
+
+    Prefers the remote's HEAD (``origin/main`` — what a PR would merge
+    into), falling back to a local ``main`` or ``master`` for remote-less
+    repos.
+
+    :param repo_root: Absolute repo work-tree root, e.g.
+        ``"/Users/alice/myrepo"``.
+    :returns: The default ref name, or ``None`` when nothing resolves.
+    """
+    sym = _run_git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd=repo_root)
+    if sym.returncode == 0:
+        ref = sym.stdout.strip()
+        prefix = "refs/remotes/"
+        if ref.startswith(prefix):
+            return ref[len(prefix) :]
+    for candidate in ("main", "master"):
+        if _local_branch_exists(repo_root, candidate):
+            return candidate
+    return None
+
+
+def inspect_worktree(
+    *,
+    worktree_path: str,
+    branch: str,
+) -> WorktreeInspection:
+    """Inspect a worktree for work that would be lost by removing it.
+
+    Read-only: gathers the dirty-file count, the unpushed-commit count,
+    and whether the branch is merged into the default branch. Any git
+    failure raises — a check that cannot complete must never read as an
+    all-clear, because the caller keeps the worktree only when the
+    inspection says it is safe to remove.
+
+    :param worktree_path: Absolute path of the worktree to inspect, e.g.
+        ``"/Users/alice/myrepo-worktrees/feature-login"``.
+    :param branch: Branch checked out in the worktree, e.g.
+        ``"feature/login"``. Validated before reaching argv (it arrives
+        over the tunnel).
+    :returns: The inspection facts.
+    :raises WorktreeError: If the path is missing/not a worktree, the
+        branch is invalid or no longer exists, or a git command fails.
+    """
+    validate_branch_name(branch)
+    main_repo = _main_repo_for_worktree(worktree_path)
+    if not _local_branch_exists(main_repo, branch):
+        raise WorktreeError(f"branch does not exist: {branch!r}")
+
+    status = _run_git(
+        ["status", "--porcelain", "--untracked-files=all"],
+        cwd=worktree_path,
+    )
+    if status.returncode != 0:
+        raise _git_error("git status failed", status)
+    dirty_files = sum(1 for line in status.stdout.splitlines() if line.strip())
+
+    # Commits on the branch no remote-tracking ref can reach. With no
+    # remotes configured, --remotes matches nothing and every commit
+    # counts — there is nowhere the work could have been pushed to.
+    rev_list = _run_git(
+        ["rev-list", "--count", branch, "--not", "--remotes"],
+        cwd=main_repo,
+    )
+    if rev_list.returncode != 0:
+        raise _git_error("git rev-list failed", rev_list)
+    unpushed_commits = int(rev_list.stdout.strip())
+
+    merged: bool | None = None
+    default_ref = _default_branch_ref(main_repo)
+    if default_ref is not None:
+        probe = _run_git(["merge-base", "--is-ancestor", branch, default_ref], cwd=main_repo)
+        if probe.returncode == 0:
+            merged = True
+        elif probe.returncode == 1:
+            merged = False
+
+    return WorktreeInspection(
+        dirty_files=dirty_files,
+        unpushed_commits=unpushed_commits,
+        merged=merged,
+        default_ref=default_ref,
+    )
+
+
 def remove_worktree(
     *,
     worktree_path: str,

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -224,6 +224,9 @@ class HostConnection:
         in-flight ``host.remove_worktree`` requests. Resolved when
         the host sends ``host.remove_worktree_result``. Values
         carry ``status`` and ``error``.
+    :param pending_inspect_worktrees: Per-``request_id`` futures for
+        in-flight ``host.inspect_worktree`` safety checks (archive-time
+        cleanup). Same ``Any`` typing rationale as ``pending_stats``.
     :param pending_create_dirs: Per-``request_id`` futures for
         in-flight ``host.create_dir`` requests. Resolved when the
         host sends ``host.create_dir_result``. Values carry the
@@ -288,6 +291,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_remove_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_inspect_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
     pending_list_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(

--- a/omnigent/server/routes/_host_worktree.py
+++ b/omnigent/server/routes/_host_worktree.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from omnigent.host.frames import (
     HostCreateWorktreeFrame,
+    HostInspectWorktreeFrame,
     HostListWorktreesFrame,
     HostRemoveWorktreeFrame,
     encode_host_frame,
@@ -78,6 +79,29 @@ class CreatedWorktree:
 
     worktree_path: str
     branch: str
+
+
+@dataclass(frozen=True)
+class WorktreeInspection:
+    """
+    Server-side view of a host worktree inspection.
+
+    :param dirty_files: Modified tracked files plus untracked files in
+        the worktree, e.g. ``3``.
+    :param unpushed_commits: Commits on the branch unreachable from
+        every remote-tracking ref (every commit when the repo has no
+        remotes).
+    :param merged: Whether the branch is an ancestor of the default
+        branch. ``None`` when the host could not determine it —
+        callers must treat that as not-merged.
+    :param default_ref: The ref ``merged`` was checked against, e.g.
+        ``"origin/main"``. ``None`` when unresolved.
+    """
+
+    dirty_files: int
+    unpushed_commits: int
+    merged: bool | None
+    default_ref: str | None
 
 
 async def _await_host_worktree_result(
@@ -234,6 +258,68 @@ async def remove_worktree_on_host(
         raise WorktreeProxyError(
             f"worktree removal failed: {result.get('error') or 'host reported no detail'}"
         )
+
+
+async def inspect_worktree_on_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    worktree_path: str,
+    branch: str,
+) -> WorktreeInspection:
+    """
+    Send a ``host.inspect_worktree`` frame and await the result.
+
+    Used by archive-time cleanup to decide whether a worktree is safe to
+    remove. Every failure path raises — the caller must treat a failed
+    check as "keep the worktree", never as an all-clear.
+
+    :param host_registry: Server-side registry; used to enqueue the
+        outbound frame on the host's send queue.
+    :param host_conn: Live host connection that owns the worktree.
+    :param worktree_path: Absolute path of the worktree to inspect on
+        the host, e.g. ``"/Users/alice/myrepo-worktrees/feature-login"``.
+    :param branch: Branch checked out in the worktree, e.g.
+        ``"feature/login"``.
+    :returns: The inspection facts.
+    :raises WorktreeHostUnavailableError: If the host connection drops
+        or doesn't respond within :data:`_WORKTREE_TIMEOUT_S` (an older
+        host that doesn't know the frame never replies, landing here).
+    :raises WorktreeProxyError: If the host reports an inspection
+        failure or returns an incomplete result.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostInspectWorktreeFrame(
+            request_id=request_id,
+            worktree_path=worktree_path,
+            branch=branch,
+        )
+    )
+    result = await _await_host_worktree_result(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        pending=host_conn.pending_inspect_worktrees,
+        request_id=request_id,
+        frame=frame,
+        op="worktree inspection",
+    )
+    if result.get("status") != "ok":
+        raise WorktreeProxyError(
+            f"worktree inspection failed: {result.get('error') or 'host reported no detail'}"
+        )
+    dirty_files = result.get("dirty_files")
+    unpushed_commits = result.get("unpushed_commits")
+    if not isinstance(dirty_files, int) or not isinstance(unpushed_commits, int):
+        raise WorktreeProxyError("host returned an incomplete worktree inspection")
+    merged = result.get("merged")
+    default_ref = result.get("default_ref")
+    return WorktreeInspection(
+        dirty_files=dirty_files,
+        unpushed_commits=unpushed_commits,
+        merged=merged if isinstance(merged, bool) else None,
+        default_ref=default_ref if isinstance(default_ref, str) else None,
+    )
 
 
 async def list_worktrees_on_host(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -285,6 +285,7 @@ from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
     ARCHIVED_AT_LABEL_KEY,
     PINNED_LABEL_KEY,
+    WORKTREE_KEPT_LABEL_KEY,
     ConversationNotFoundError,
     NameAlreadyExistsError,
 )
@@ -8362,6 +8363,172 @@ async def _remove_session_worktree_best_effort(
         )
 
 
+async def _cleanup_worktree_on_archive(
+    *,
+    session_id: str,
+    workspace: str | None,
+    git_branch: str | None,
+    host_id: str | None,
+    conversation_store: ConversationStore,
+    host_registry: HostRegistry | None,
+) -> None:
+    """
+    Remove a session's git worktree on archive — but only when provably safe.
+
+    A worktree is removed (with its branch) only when every check passes:
+    no other live session shares it, the host is reachable and reports a
+    clean tree, no commits exist beyond every remote, and the branch is
+    merged into the default branch. Anything else keeps the worktree and
+    records why on the session's ``omnigent.worktree_kept`` label so the
+    Archived page can show it. Never raises — archiving must not fail
+    over cleanup.
+
+    :param session_id: The conversation being archived.
+    :param workspace: The session's workspace (the worktree path).
+    :param git_branch: Branch checked out in the worktree; the cleanup
+        gate — a session without one was never worktree-created.
+    :param host_id: Host that owns the worktree.
+    :param conversation_store: Store for the in-use check and labels.
+    :param host_registry: Registry for reaching the owning host.
+    """
+    from omnigent.server.routes._host_worktree import (
+        WorktreeProxyError,
+        inspect_worktree_on_host,
+        remove_worktree_on_host,
+    )
+
+    async def _kept(value: str) -> None:
+        """Record why the worktree was kept, best-effort.
+
+        :param value: JSON label value.
+        """
+        try:
+            await asyncio.to_thread(
+                conversation_store.set_labels,
+                session_id,
+                {WORKTREE_KEPT_LABEL_KEY: value},
+            )
+        except SQLAlchemyError:
+            _logger.warning(
+                "Failed to record worktree-kept label on session %s",
+                session_id,
+                exc_info=True,
+            )
+
+    if not workspace or not git_branch or not host_id or host_registry is None:
+        return
+
+    # Another live session in the same worktree? Keep it regardless of
+    # cleanliness — removing would pull the working directory out from
+    # under that session (#5028). Archived sessions don't count: they no
+    # longer run anything, and the last one out cleans up.
+    others = await asyncio.to_thread(
+        conversation_store.list_conversations,
+        limit=100000,
+        include_archived=False,
+    )
+    in_use = any(
+        c.id != session_id and c.host_id == host_id and c.workspace == workspace
+        for c in others.data
+    )
+    if in_use:
+        _logger.info(
+            "Keeping worktree %s on archive of session %s: still in use by another session",
+            workspace,
+            session_id,
+        )
+        await _kept(json.dumps({"reason": "in_use"}))
+        return
+
+    host_conn = host_registry.get(host_id)
+    if host_conn is None:
+        _logger.info(
+            "Keeping worktree %s on archive of session %s: host %s offline",
+            workspace,
+            session_id,
+            host_id,
+        )
+        await _kept(json.dumps({"reason": "host_offline"}))
+        return
+
+    try:
+        inspection = await inspect_worktree_on_host(
+            host_registry=host_registry,
+            host_conn=host_conn,
+            worktree_path=workspace,
+            branch=git_branch,
+        )
+    except WorktreeProxyError:
+        # An old host that doesn't know the frame, a dead connection, a
+        # failed git check — all read as "cannot verify", so keep.
+        _logger.info(
+            "Keeping worktree %s on archive of session %s: inspection failed",
+            workspace,
+            session_id,
+            exc_info=True,
+        )
+        await _kept(json.dumps({"reason": "unknown"}))
+        return
+
+    safe = (
+        inspection.dirty_files == 0
+        and inspection.unpushed_commits == 0
+        and inspection.merged is True
+    )
+    if not safe:
+        _logger.info(
+            "Keeping worktree %s on archive of session %s: dirty=%d unpushed=%d merged=%s",
+            workspace,
+            session_id,
+            inspection.dirty_files,
+            inspection.unpushed_commits,
+            inspection.merged,
+        )
+        await _kept(
+            json.dumps(
+                {
+                    "dirty_files": inspection.dirty_files,
+                    "unpushed_commits": inspection.unpushed_commits,
+                    "merged": inspection.merged,
+                    "default_ref": inspection.default_ref,
+                }
+            )
+        )
+        return
+
+    try:
+        await remove_worktree_on_host(
+            host_registry=host_registry,
+            host_conn=host_conn,
+            worktree_path=workspace,
+            branch=git_branch,
+            delete_branch=True,
+        )
+    except WorktreeProxyError:
+        # Removal of a verified-safe worktree failing is a nuisance, not
+        # a data risk — log and leave the directory in place.
+        _logger.warning(
+            "Failed to remove verified-safe worktree %s on archive of session %s",
+            workspace,
+            session_id,
+            exc_info=True,
+        )
+        return
+    _logger.info(
+        "Removed worktree %s (branch %s) on archive of session %s",
+        workspace,
+        git_branch,
+        session_id,
+    )
+    # Clear a stale kept-note from a previous archive, when one exists
+    # (labels are upsert-only, so overwrite with the empty string the UI
+    # ignores — and only when set, to avoid a junk empty label on every
+    # cleanly-removed worktree).
+    current = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+    if current is not None and WORKTREE_KEPT_LABEL_KEY in current.labels:
+        await _kept("")
+
+
 def _resolve_subagent_spec(
     *,
     agent: Agent,
@@ -8762,6 +8929,14 @@ def _reject_server_reserved_label_seed(labels: dict[str, str] | None) -> None:
     if ARCHIVED_AT_LABEL_KEY in labels:
         raise OmnigentError(
             f"label {ARCHIVED_AT_LABEL_KEY!r} is server-internal and cannot be set by clients",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    # The archive-time worktree cleanup owns this key: a client-seeded
+    # value would fake a "worktree kept — …" note the server never
+    # wrote, or mask a real one the user should see.
+    if WORKTREE_KEPT_LABEL_KEY in labels:
+        raise OmnigentError(
+            f"label {WORKTREE_KEPT_LABEL_KEY!r} is server-internal and cannot be set by clients",
             code=ErrorCode.INVALID_INPUT,
         )
     # Pins are per-user: the client may only write the bare canonical

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -205,6 +205,7 @@ from omnigent.server.routes._sessions.helpers import (
     _build_new_item,
     _build_policy_engine_from_spec,
     _child_session_summary_from_conversation,
+    _cleanup_worktree_on_archive,
     _codex_subagent_labels_from_body,
     _coerce_cumulative_field,
     _collect_descendant_conversation_ids,
@@ -670,6 +671,11 @@ async def _archive_stop(
     "working" against a dead pane — the failure
     :func:`_stop_session_host_runner` exists to prevent.
 
+    When the session owns a git worktree, archive also attempts cleanup:
+    :func:`_cleanup_worktree_on_archive` removes the worktree (and its
+    branch) only after verifying removal would lose nothing, and records
+    why on the session's labels when it keeps the directory instead.
+
     Every step is best-effort: a wedged, offline, or already-stopped
     runner must not leave the session un-archived.
 
@@ -694,30 +700,54 @@ async def _archive_stop(
             extra={"session_id": session_id},
         )
         return
-    if conv is None or not conv.host_id or not conv.runner_id:
+    if conv is None:
         return
-    # Mark the tunnel drop intentional BEFORE tearing it down so the relay
-    # renders a quiet stopped state rather than "runner_disconnected".
-    _intentional_stop_sessions.add(session_id)
+    if conv.host_id and conv.runner_id:
+        # Mark the tunnel drop intentional BEFORE tearing it down so the
+        # relay renders a quiet stopped state rather than
+        # "runner_disconnected".
+        _intentional_stop_sessions.add(session_id)
+        try:
+            delivered = await _facade._stop_session_host_runner(
+                session_id,
+                conv.host_id,
+                conv.runner_id,
+                host_registry,
+            )
+        except Exception:  # noqa: BLE001
+            _logger.debug(
+                "Archive host-runner teardown failed for %s",
+                session_id,
+                exc_info=True,
+            )
+            delivered = False
+        if not delivered:
+            # No tunnel drop will follow, so the marker would outlive this
+            # stop and later swallow a genuine runner_disconnected as a
+            # quiet idle.
+            _intentional_stop_sessions.discard(session_id)
+
+    # Worktree cleanup is independent of the runner teardown above: a
+    # session without a live runner (never started, already stopped, or
+    # host-relaunched) can still own a worktree. Best-effort and
+    # safety-gated inside — it never raises by contract, but keep the
+    # guard so an unexpected error can't fail the archive teardown.
     try:
-        delivered = await _facade._stop_session_host_runner(
-            session_id,
-            conv.host_id,
-            conv.runner_id,
-            host_registry,
+        await _cleanup_worktree_on_archive(
+            session_id=session_id,
+            workspace=conv.workspace,
+            git_branch=conv.git_branch,
+            host_id=conv.host_id,
+            conversation_store=conversation_store,
+            host_registry=host_registry,
         )
     except Exception:  # noqa: BLE001
         _logger.debug(
-            "Archive host-runner teardown failed for %s",
+            "Archive worktree cleanup failed for %s",
             session_id,
             exc_info=True,
             extra={"session_id": session_id},
         )
-        delivered = False
-    if not delivered:
-        # No tunnel drop will follow, so the marker would outlive this stop
-        # and later swallow a genuine runner_disconnected as a quiet idle.
-        _intentional_stop_sessions.discard(session_id)
 
 
 def _spawn_archive_stop(

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -37,6 +37,7 @@ from omnigent.host.frames import (
     HostHelloFrame,
     HostImportLocalDoneFrame,
     HostImportLocalSessionFrame,
+    HostInspectWorktreeResultFrame,
     HostInstallHarnessResultFrame,
     HostLaunchRunnerResultFrame,
     HostListDirResultFrame,
@@ -676,6 +677,21 @@ async def _receive_loop(
                     {
                         "status": frame.status,
                         "worktrees": frame.worktrees,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostInspectWorktreeResultFrame):
+            inspect_wt_future = conn.pending_inspect_worktrees.pop(frame.request_id, None)
+            if inspect_wt_future is not None and not inspect_wt_future.done():
+                inspect_wt_future.set_result(
+                    {
+                        "status": frame.status,
+                        "dirty_files": frame.dirty_files,
+                        "unpushed_commits": frame.unpushed_commits,
+                        "merged": frame.merged,
+                        "default_ref": frame.default_ref,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -26,6 +26,15 @@ from omnigent.session_import import IMPORT_PROVENANCE_LABEL_KEYS
 # layer; the server route and the SQLAlchemy store both import it.
 FORK_SOURCE_LABEL_KEY = "omnigent.fork.source_id"
 
+# Server-internal label set on archive when a session's git worktree was
+# left in place instead of removed. The value is a small JSON object:
+# either ``{"reason": "in_use" | "host_offline" | "unknown"}`` when no
+# safety check could run, or ``{"dirty_files": N, "unpushed_commits": M,
+# "merged": bool, "default_ref": str | null}`` when the host inspected
+# the worktree and found work that removing it would lose. The Archived
+# settings page renders this as a "Worktree kept — …" note.
+WORKTREE_KEPT_LABEL_KEY = "omnigent.worktree_kept"
+
 # One-shot fork directive: the SOURCE session's runtime-native session id
 # (e.g. the source claude-native Claude Code session uuid), stamped on the
 # clone at fork time when the source had one. A native harness launching

--- a/tests/e2e_ui/sessions/test_archived_worktree_kept_note.py
+++ b/tests/e2e_ui/sessions/test_archived_worktree_kept_note.py
@@ -1,0 +1,133 @@
+"""E2E: the Archived view explains when an archived session's worktree was kept.
+
+Archiving a worktree-bound session removes the worktree only when the host
+verifies nothing would be lost; otherwise the directory stays on disk and the
+server records why on the session's ``omnigent.worktree_kept`` label. The
+Archived settings view surfaces that label as a "Worktree kept — …" note on
+the row, so the user isn't left thinking the disk was cleaned when it wasn't.
+
+The label is server-internal (the PATCH route rejects it from clients), and
+reproducing a real host + dirty worktree end-to-end would need a live host
+tunnel — so, like ``test_host_badge.py``, this patches the browser's view
+instead: seed and archive two plain sessions over REST, then inject the label
+into one row's ``GET /v1/sessions`` payload via route interception.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import uuid
+from collections.abc import Iterator
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+_KEPT_LABEL = {
+    "dirty_files": 2,
+    "unpushed_commits": 1,
+    "merged": False,
+    "default_ref": "origin/main",
+}
+
+
+@pytest.fixture(autouse=True)
+def _drop_routes(page: Page) -> Iterator[None]:
+    """Drop this module's route handlers before the page closes.
+
+    :param page: Playwright page fixture.
+    :returns: Iterator yielding once, then unrouting.
+    """
+    yield
+    page.unroute_all(behavior="ignoreErrors")
+
+
+def _seed_archived_session(base_url: str, *, title: str) -> str:
+    """Create a hello_world session and archive it.
+
+    Plain (non-worktree) sessions archive without any cleanup frames, so the
+    server sets no kept-label itself — the test injects one over interception.
+
+    :param base_url: The live server base URL.
+    :param title: Unique title so the row is easy to spot on the shared server.
+    :returns: The new session id.
+    """
+    create_resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", _build_hello_world_bundle(), "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+    patch_resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title, "archived": True},
+        timeout=10.0,
+    )
+    patch_resp.raise_for_status()
+    return session_id
+
+
+def _inject_kept_label(page: Page, session_id: str) -> None:
+    """Patch ``GET /v1/sessions`` so ``session_id``'s row carries the kept-label.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session whose list row should carry the label.
+    """
+
+    def _patch_list(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/v1/sessions":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict) and row.get("id") == session_id:
+                    labels = dict(row.get("labels") or {})
+                    labels["omnigent.worktree_kept"] = json.dumps(_KEPT_LABEL)
+                    row["labels"] = labels
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions**", _patch_list)
+
+
+def test_archived_row_shows_worktree_kept_note(live_server: str, page: Page) -> None:
+    """A labeled archived session explains its kept worktree; a plain one doesn't.
+
+    :param live_server: Spawned server fixture — base URL.
+    :param page: Playwright page.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    kept_title = f"kept-worktree-{suffix}"
+    plain_title = f"plain-archived-{suffix}"
+    kept_id = _seed_archived_session(live_server, title=kept_title)
+    plain_id = _seed_archived_session(live_server, title=plain_title)
+    _inject_kept_label(page, kept_id)
+    try:
+        page.goto(f"{live_server}/settings/archived")
+
+        kept_row = page.locator("li[data-testid='archived-row']", has_text=kept_title)
+        note = kept_row.get_by_test_id("worktree-kept-note")
+        expect(note).to_have_text(
+            "Worktree kept — 2 uncommitted changes, 1 unpushed commit, "
+            "branch not merged into origin/main."
+        )
+
+        plain_row = page.locator("li[data-testid='archived-row']", has_text=plain_title)
+        expect(plain_row.get_by_test_id("worktree-kept-note")).to_have_count(0)
+    finally:
+        for session_id in (kept_id, plain_id):
+            with contextlib.suppress(httpx.HTTPError):
+                httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -23,6 +23,8 @@ from omnigent.host.frames import (
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
+    HostInspectWorktreeFrame,
+    HostInspectWorktreeResultFrame,
     HostInstallHarnessFrame,
     HostInstallHarnessResultFrame,
     HostLaunchRunnerFrame,
@@ -1233,6 +1235,86 @@ def test_list_worktrees_result_frame_rejects_non_list() -> None:
     )
     with pytest.raises(ValueError, match="worktrees"):
         decode_host_frame(bad)
+
+
+# ── host.inspect_worktree frames ────────────────────────
+
+
+def test_inspect_worktree_frame_round_trip() -> None:
+    """Verify HostInspectWorktreeFrame survives encode → decode.
+
+    A garbled worktree_path or branch would inspect the wrong worktree
+    and could make an unsafe removal read as safe.
+    """
+    original = HostInspectWorktreeFrame(
+        request_id="req_wt_in_1",
+        worktree_path="/Users/alice/myrepo-worktrees/feature-login",
+        branch="feature/login",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostInspectWorktreeFrame)
+    assert decoded == original
+
+
+def test_inspect_worktree_frame_non_str_branch_raises() -> None:
+    """A non-string branch is rejected, not coerced."""
+    bad = (
+        '{"kind": "host.inspect_worktree", "request_id": "r", "worktree_path": "/x", "branch": 42}'
+    )
+    with pytest.raises(ValueError, match="branch"):
+        decode_host_frame(bad)
+
+
+def test_inspect_worktree_result_frame_round_trip() -> None:
+    """Verify HostInspectWorktreeResultFrame survives encode → decode.
+
+    The counts and the merged flag drive the server's remove-vs-keep
+    decision on archive; a dropped field must not silently coerce.
+    """
+    original = HostInspectWorktreeResultFrame(
+        request_id="req_wt_in_1",
+        status="ok",
+        dirty_files=2,
+        unpushed_commits=3,
+        merged=False,
+        default_ref="origin/main",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostInspectWorktreeResultFrame)
+    assert decoded == original
+
+
+def test_inspect_worktree_result_frame_unknown_merged_round_trip() -> None:
+    """``merged=None`` (no resolvable default branch) must survive the wire.
+
+    'Cannot determine' is a distinct outcome from 'not merged' — the
+    server keeps the worktree either way, but conflating them would
+    misreport why.
+    """
+    original = HostInspectWorktreeResultFrame(
+        request_id="req_wt_in_1",
+        status="ok",
+        dirty_files=0,
+        unpushed_commits=0,
+        merged=None,
+        default_ref=None,
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostInspectWorktreeResultFrame)
+    assert decoded == original
+
+
+def test_inspect_worktree_result_frame_failure_round_trip() -> None:
+    """A failed inspection carries its error and null fields."""
+    original = HostInspectWorktreeResultFrame(
+        request_id="req_wt_in_1",
+        status="failed",
+        error="worktree path does not exist: /x",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostInspectWorktreeResultFrame)
+    assert decoded.dirty_files is None
+    assert decoded.error == "worktree path does not exist: /x"
 
 
 # ── host.create_dir frames ──────────────────────────────

--- a/tests/host/test_git_worktree.py
+++ b/tests/host/test_git_worktree.py
@@ -18,6 +18,7 @@ from omnigent.host.git_worktree import (
     CreatedWorktree,
     WorktreeError,
     create_worktree,
+    inspect_worktree,
     list_worktrees,
     remove_worktree,
     validate_branch_name,
@@ -441,6 +442,149 @@ def test_validate_branch_name_rejects_bad(bad: str) -> None:
     """Branch names violating git ref-format are rejected before reaching argv."""
     with pytest.raises(WorktreeError):
         validate_branch_name(bad)
+
+
+# ── inspect_worktree ─────────────────────────────────────
+
+
+def _add_origin(git_repo: Path, tmp_path: Path) -> None:
+    """Attach a bare ``origin`` remote and push ``main`` to it.
+
+    Also points ``refs/remotes/origin/HEAD`` at ``origin/main`` the way a
+    clone would, so the default-branch resolution has its primary signal.
+
+    :param git_repo: The working repo to configure.
+    :param tmp_path: Test temp dir to create the bare remote under.
+    """
+    bare = (tmp_path / "origin.git").resolve()
+    _git(tmp_path, "init", "-q", "--bare", str(bare))
+    _git(git_repo, "remote", "add", "origin", str(bare))
+    _git(git_repo, "push", "-q", "origin", "main")
+    _git(
+        git_repo,
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        "refs/remotes/origin/main",
+    )
+
+
+def test_inspect_worktree_clean_pushed_merged_reports_safe(git_repo: Path, tmp_path: Path) -> None:
+    """A pristine worktree whose branch is pushed and merged reports all-clear.
+
+    This is the shape that lets the server remove the worktree on archive:
+    zero dirty files, zero unpushed commits, and the branch tip reachable
+    from the default branch.
+    """
+    _add_origin(git_repo, tmp_path)
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/login")
+    _git(git_repo, "push", "-q", "origin", "feature/login")
+
+    result = inspect_worktree(worktree_path=created.worktree_path, branch="feature/login")
+
+    assert result.dirty_files == 0
+    assert result.unpushed_commits == 0
+    assert result.merged is True
+    assert result.default_ref == "origin/main"
+
+
+def test_inspect_worktree_counts_dirty_files(git_repo: Path, tmp_path: Path) -> None:
+    """Modified tracked files and untracked files each count as dirty."""
+    _add_origin(git_repo, tmp_path)
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/dirty")
+    wt = Path(created.worktree_path)
+    # One tracked modification + one untracked file = 2 dirty entries.
+    (wt / "README.md").write_text("changed")
+    (wt / "new.txt").write_text("untracked")
+
+    result = inspect_worktree(worktree_path=created.worktree_path, branch="feature/dirty")
+
+    assert result.dirty_files == 2
+
+
+def test_inspect_worktree_counts_unpushed_commits(git_repo: Path, tmp_path: Path) -> None:
+    """A commit that no remote-tracking ref can reach counts as unpushed."""
+    _add_origin(git_repo, tmp_path)
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/wip")
+    wt = Path(created.worktree_path)
+    (wt / "wip.txt").write_text("wip")
+    _git(wt, "add", ".")
+    _git(wt, "commit", "-q", "-m", "wip")
+
+    result = inspect_worktree(worktree_path=created.worktree_path, branch="feature/wip")
+
+    assert result.unpushed_commits == 1
+    assert result.dirty_files == 0
+
+
+def test_inspect_worktree_no_remote_counts_all_commits_unpushed(git_repo: Path) -> None:
+    """With no remote at all, every commit on the branch is unpushed.
+
+    A repo without remotes has nowhere the work could have been pushed to,
+    so nothing about the branch may read as safe-to-discard. The local
+    ``main`` still serves as the merge-base reference.
+    """
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/local")
+    wt = Path(created.worktree_path)
+    (wt / "local.txt").write_text("local")
+    _git(wt, "add", ".")
+    _git(wt, "commit", "-q", "-m", "local work")
+
+    result = inspect_worktree(worktree_path=created.worktree_path, branch="feature/local")
+
+    # init commit + the branch commit — nothing is reachable from any remote.
+    assert result.unpushed_commits == 2
+    assert result.default_ref == "main"
+    assert result.merged is False
+
+
+def test_inspect_worktree_pushed_but_unmerged_branch(git_repo: Path, tmp_path: Path) -> None:
+    """A fully pushed branch still reports ``merged=False`` off the default branch."""
+    _add_origin(git_repo, tmp_path)
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/open-pr")
+    wt = Path(created.worktree_path)
+    (wt / "pr.txt").write_text("open pr")
+    _git(wt, "add", ".")
+    _git(wt, "commit", "-q", "-m", "pr commit")
+    _git(git_repo, "push", "-q", "origin", "feature/open-pr")
+
+    result = inspect_worktree(worktree_path=created.worktree_path, branch="feature/open-pr")
+
+    assert result.unpushed_commits == 0
+    assert result.merged is False
+
+
+def test_inspect_worktree_missing_path_fails(git_repo: Path) -> None:
+    """Inspecting a worktree path that doesn't exist fails loud."""
+    with pytest.raises(WorktreeError) as exc:
+        inspect_worktree(
+            worktree_path=str(git_repo.parent / "myrepo-worktrees" / "ghost"),
+            branch="feature/ghost",
+        )
+    assert "does not exist" in exc.value.message
+
+
+def test_inspect_worktree_unknown_branch_fails(git_repo: Path) -> None:
+    """Inspecting against a branch that doesn't exist fails loud.
+
+    The server must treat a failed check as 'keep the worktree', so the
+    check has to fail rather than invent all-clear numbers. (A branch
+    that vanished out from under its worktree lands here too — git
+    refuses to delete a checked-out branch, but a stale session row can
+    still name one that no longer resolves.)
+    """
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/stays")
+
+    with pytest.raises(WorktreeError) as exc:
+        inspect_worktree(worktree_path=created.worktree_path, branch="feature/never-existed")
+    assert "does not exist" in exc.value.message
+
+
+@pytest.mark.parametrize("bad", ["-f", "--all", "a..b"])
+def test_inspect_worktree_rejects_invalid_branch(git_repo: Path, bad: str) -> None:
+    """Branch names arrive over the tunnel — validate before they reach argv."""
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/ok")
+    with pytest.raises(WorktreeError):
+        inspect_worktree(worktree_path=created.worktree_path, branch=bad)
 
 
 @pytest.mark.parametrize("good", ["feature/login", "fix-123", "a/b/c", "release_2", "v1.2"])

--- a/tests/server/integration/test_session_worktree_archive.py
+++ b/tests/server/integration/test_session_worktree_archive.py
@@ -1,0 +1,350 @@
+"""
+Integration tests for git worktree cleanup on session archive.
+
+Drives ``PATCH /v1/sessions/{id}`` with ``{"archived": true}`` through
+the full app with a fake host registered in ``app.state.host_registry``.
+Verifies the archive flow inspects the worktree first, removes it (with
+branch) only when the host reports it safe — clean tree, nothing
+unpushed, branch merged — and otherwise keeps it, recording why on the
+session's ``omnigent.worktree_kept`` label.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.db.utils import generate_agent_id
+from omnigent.host.frames import (
+    HostHelloFrame,
+    HostInspectWorktreeFrame,
+    HostRemoveWorktreeFrame,
+    decode_host_frame,
+)
+from omnigent.server.auth import RESERVED_USER_LOCAL
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store import WORKTREE_KEPT_LABEL_KEY
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.host_store import HostStore
+
+pytestmark = pytest.mark.asyncio
+
+_HOST_ID = "b76c8d9e4613a95946c9134383308ac7"
+_WORKTREE_PATH = "/Users/alice/myrepo-worktrees/feature-login"
+_BRANCH = "feature/login"
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in (the registry only enqueues)."""
+
+    async def send_text(self, data: str) -> None:
+        """No-op send — frames flow through the outbound queue.
+
+        :param data: JSON-encoded frame text (ignored).
+        """
+
+
+class _CapturedFrames:
+    """Accumulates the worktree frames the server sends to the fake host."""
+
+    def __init__(self) -> None:
+        """Initialize empty captures and the default inspect reply."""
+        self.inspect: list[HostInspectWorktreeFrame] = []
+        self.remove: list[HostRemoveWorktreeFrame] = []
+        # Tests override fields before archiving. Default is the
+        # all-clear: clean, nothing unpushed, merged.
+        self.inspect_reply: dict[str, Any] = {
+            "status": "ok",
+            "dirty_files": 0,
+            "unpushed_commits": 0,
+            "merged": True,
+            "default_ref": "origin/main",
+            "error": None,
+        }
+
+
+async def _register_fake_host(app: FastAPI, db_uri: str) -> _CapturedFrames:
+    """Register a fake host and start a drain that answers worktree frames.
+
+    :param app: The app whose ``host_registry`` to register into.
+    :param db_uri: DB URI so the host row (FK target) can be upserted.
+    :returns: The capture object accumulating inspect/remove frames.
+    """
+    # Upsert the host row so the conversation's host_id FK resolves.
+    HostStore(db_uri).upsert_on_connect(_HOST_ID, "wt-host", RESERVED_USER_LOCAL)
+    registry = app.state.host_registry
+    conn = registry.register(
+        host_id=_HOST_ID,
+        ws=_FakeWebSocket(),  # type: ignore[arg-type] — duck-typed
+        hello=HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="wt-host"),
+        owner=RESERVED_USER_LOCAL,
+    )
+    captured = _CapturedFrames()
+
+    async def _drain() -> None:
+        """Capture worktree frames and reply with the configured results."""
+        while True:
+            frame_text = await conn.outbound_queue.get()
+            if frame_text is None:
+                return
+            frame = decode_host_frame(frame_text)
+            if isinstance(frame, HostInspectWorktreeFrame):
+                captured.inspect.append(frame)
+                fut = conn.pending_inspect_worktrees.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result(captured.inspect_reply)
+            elif isinstance(frame, HostRemoveWorktreeFrame):
+                captured.remove.append(frame)
+                fut = conn.pending_remove_worktrees.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result({"status": "ok", "error": None})
+
+    task = asyncio.create_task(_drain())
+    # Stash so the caller can stop the drain on teardown.
+    conn._drain_task_for_test = task  # type: ignore[attr-defined]
+    return captured
+
+
+def _make_worktree_conversation(db_uri: str) -> str:
+    """Create a session row that looks like a server-created worktree.
+
+    :param db_uri: DB URI for the conversation/agent stores.
+    :returns: The new conversation id.
+    """
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    # Unique name: built-in agent names share a global unique index, and
+    # tests seeding two worktree sessions create two agents.
+    agent_store.create(
+        agent_id,
+        name=f"test-agent-{agent_id[:8]}",
+        bundle_location="test:///bundle",
+    )
+    conv = conv_store.create_conversation(
+        agent_id=agent_id,
+        host_id=_HOST_ID,
+        workspace=_WORKTREE_PATH,
+        git_branch=_BRANCH,
+    )
+    return conv.id
+
+
+async def _wait_for(predicate: object, description: str) -> None:
+    """Poll ``predicate`` until truthy, failing after a few seconds.
+
+    The archive teardown runs detached (the PATCH response must not wait
+    out host round-trips), so tests poll for its observable effects.
+
+    :param predicate: Zero-arg callable returning truthy when done.
+    :param description: What is being awaited, for the failure message.
+    :raises AssertionError: When the condition never becomes true.
+    """
+    check = predicate
+    for _ in range(100):
+        if check():  # type: ignore[operator]
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {description}")
+
+
+def _kept_label(db_uri: str, conv_id: str) -> dict[str, Any] | None:
+    """Read the session's ``omnigent.worktree_kept`` label as parsed JSON.
+
+    :param db_uri: DB URI for the conversation store.
+    :param conv_id: Conversation to read.
+    :returns: The parsed label value, or ``None`` when unset.
+    """
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(conv_id)
+    assert conv is not None
+    raw = conv.labels.get(WORKTREE_KEPT_LABEL_KEY)
+    # Empty string is the soft-cleared state — reads as absent.
+    return json.loads(raw) if raw else None
+
+
+async def test_archive_safe_worktree_inspects_then_removes(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Archiving a clean, pushed, merged worktree removes it and its branch.
+
+    The inspect frame must fire first and carry the STORED path/branch
+    (not request input); the remove frame then follows with
+    ``delete_branch=True``. No kept-label is left behind.
+    """
+    captured = await _register_fake_host(app, db_uri)
+    conv_id = _make_worktree_conversation(db_uri)
+
+    resp = await client.patch(f"/v1/sessions/{conv_id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    await _wait_for(lambda: len(captured.remove) == 1, "host.remove_worktree frame")
+    # Inspection happened before removal, with the stored identifiers.
+    assert len(captured.inspect) == 1
+    assert captured.inspect[0].worktree_path == _WORKTREE_PATH
+    assert captured.inspect[0].branch == _BRANCH
+    frame = captured.remove[0]
+    assert frame.worktree_path == _WORKTREE_PATH
+    assert frame.branch == _BRANCH
+    assert frame.delete_branch is True
+    # A removed worktree leaves no "kept" note.
+    assert _kept_label(db_uri, conv_id) is None
+
+
+async def test_archive_unsafe_worktree_is_kept_and_labeled(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Unpushed commits on the branch keep the worktree and record why.
+
+    No remove frame may be sent — removing here would destroy commits
+    that exist nowhere else. The kept-label carries the facts so the UI
+    can say what would have been lost.
+    """
+    captured = await _register_fake_host(app, db_uri)
+    captured.inspect_reply.update({"dirty_files": 0, "unpushed_commits": 2, "merged": False})
+    conv_id = _make_worktree_conversation(db_uri)
+
+    resp = await client.patch(f"/v1/sessions/{conv_id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    await _wait_for(
+        lambda: _kept_label(db_uri, conv_id) is not None,
+        "omnigent.worktree_kept label",
+    )
+    assert captured.inspect != []
+    assert captured.remove == []
+    label = _kept_label(db_uri, conv_id)
+    assert label is not None
+    assert label["unpushed_commits"] == 2
+    assert label["dirty_files"] == 0
+    assert label["merged"] is False
+
+
+async def test_archive_failed_inspection_is_kept_and_labeled(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A failed inspection keeps the worktree — 'cannot determine' is unsafe.
+
+    The host reported the check itself failed (e.g. the worktree path is
+    unreadable), so there is no all-clear to act on. The label says the
+    state is unknown rather than inventing counts.
+    """
+    captured = await _register_fake_host(app, db_uri)
+    captured.inspect_reply.clear()
+    captured.inspect_reply.update(
+        {"status": "failed", "error": "worktree path does not exist: /x"}
+    )
+    conv_id = _make_worktree_conversation(db_uri)
+
+    resp = await client.patch(f"/v1/sessions/{conv_id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    await _wait_for(
+        lambda: _kept_label(db_uri, conv_id) is not None,
+        "omnigent.worktree_kept label",
+    )
+    assert captured.remove == []
+    label = _kept_label(db_uri, conv_id)
+    assert label is not None
+    assert label["reason"] == "unknown"
+
+
+async def test_archive_offline_host_is_kept_and_labeled(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """An offline host keeps the worktree — no way to verify means keep.
+
+    No host is registered, so no inspect frame can run. The label names
+    the offline host as the reason rather than reporting work at risk.
+    """
+    conv_id = _make_worktree_conversation(db_uri)
+    # No host registered in app.state.host_registry.
+
+    resp = await client.patch(f"/v1/sessions/{conv_id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    await _wait_for(
+        lambda: _kept_label(db_uri, conv_id) is not None,
+        "omnigent.worktree_kept label",
+    )
+    label = _kept_label(db_uri, conv_id)
+    assert label is not None
+    assert label["reason"] == "host_offline"
+
+
+async def test_archive_shared_worktree_is_kept_for_the_other_session(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A worktree another live session uses is never removed on archive.
+
+    Forks reuse the source's worktree directory by default, so two
+    sessions can share one worktree. Removing it when one archives would
+    pull the working directory out from under the other (the delete path
+    has the same hazard — #5028). The guard runs BEFORE inspection: an
+    in-use worktree is kept regardless of how clean it is.
+    """
+    captured = await _register_fake_host(app, db_uri)
+    conv_id = _make_worktree_conversation(db_uri)
+    # A second, still-active session in the same worktree.
+    other_id = _make_worktree_conversation(db_uri)
+
+    resp = await client.patch(f"/v1/sessions/{conv_id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    await _wait_for(
+        lambda: _kept_label(db_uri, conv_id) is not None,
+        "omnigent.worktree_kept label",
+    )
+    assert captured.inspect == []
+    assert captured.remove == []
+    label = _kept_label(db_uri, conv_id)
+    assert label is not None
+    assert label["reason"] == "in_use"
+    # The other session is untouched.
+    assert _kept_label(db_uri, other_id) is None
+
+
+async def test_archive_plain_session_sends_no_worktree_frames(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Archiving a session with no worktree sends no inspect/remove frames.
+
+    The cleanup gate keys off ``git_branch IS NOT NULL`` (plus workspace
+    and host); without it a plain archive would ask the host to inspect
+    a directory that isn't a session worktree at all.
+    """
+    captured = await _register_fake_host(app, db_uri)
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    agent_store.create(
+        agent_id, name=f"test-agent-{agent_id[:8]}", bundle_location="test:///bundle"
+    )
+    conv = conv_store.create_conversation(agent_id=agent_id)
+
+    resp = await client.patch(f"/v1/sessions/{conv.id}", json={"archived": True})
+    assert resp.status_code == 200
+
+    # Give the detached archive teardown a chance to (wrongly) fire.
+    await asyncio.sleep(0.5)
+    assert captured.inspect == []
+    assert captured.remove == []
+    assert _kept_label(db_uri, conv.id) is None

--- a/tests/server/routes/test_host_worktree.py
+++ b/tests/server/routes/test_host_worktree.py
@@ -18,6 +18,7 @@ import pytest
 from omnigent.host.frames import (
     HostCreateWorktreeFrame,
     HostHelloFrame,
+    HostInspectWorktreeFrame,
     HostRemoveWorktreeFrame,
     decode_host_frame,
 )
@@ -26,6 +27,7 @@ from omnigent.server.routes._host_worktree import (
     WorktreeHostUnavailableError,
     WorktreeProxyError,
     create_worktree_on_host,
+    inspect_worktree_on_host,
     remove_worktree_on_host,
 )
 
@@ -79,6 +81,7 @@ async def host_setup() -> AsyncIterator[HostRegistry]:
 
     create_reply: dict[str, Any] = {}
     remove_reply: dict[str, Any] = {}
+    inspect_reply: dict[str, Any] = {}
     # Frames the proxy sent, captured here (registry.send_text enqueues
     # to outbound_queue rather than ws.send_text, so we record from the
     # drain task instead of from the fake ws).
@@ -100,10 +103,15 @@ async def host_setup() -> AsyncIterator[HostRegistry]:
                 fut = conn.pending_remove_worktrees.pop(frame.request_id, None)
                 if fut is not None and not fut.done():
                     fut.set_result(remove_reply)
+            elif isinstance(frame, HostInspectWorktreeFrame):
+                fut = conn.pending_inspect_worktrees.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result(inspect_reply)
 
     drain_task = asyncio.create_task(_drain())
     registry._create_reply_for_test = create_reply  # type: ignore[attr-defined]
     registry._remove_reply_for_test = remove_reply  # type: ignore[attr-defined]
+    registry._inspect_reply_for_test = inspect_reply  # type: ignore[attr-defined]
     registry._sent_frames_for_test = sent_frames  # type: ignore[attr-defined]
 
     try:
@@ -297,3 +305,113 @@ async def test_create_worktree_timeout_raises_unavailable(
             base_branch=None,
         )
     assert "did not respond" in exc.value.message
+
+
+# ── inspect_worktree_on_host ─────────────────────────────
+
+
+async def test_inspect_worktree_success_returns_facts(host_setup: HostRegistry) -> None:
+    """A successful inspect reply is unpacked into the inspection facts.
+
+    Every field feeds the server's remove-vs-keep policy on archive, so
+    each must thread through the request_id/future plumbing undamaged.
+    """
+    registry = host_setup
+    registry._inspect_reply_for_test.update(  # type: ignore[attr-defined]
+        {
+            "status": "ok",
+            "dirty_files": 1,
+            "unpushed_commits": 2,
+            "merged": False,
+            "default_ref": "origin/main",
+            "error": None,
+        }
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    result = await inspect_worktree_on_host(
+        host_registry=registry,
+        host_conn=conn,
+        worktree_path="/Users/alice/myrepo-worktrees/feature-login",
+        branch="feature/login",
+    )
+    assert result.dirty_files == 1
+    assert result.unpushed_commits == 2
+    assert result.merged is False
+    assert result.default_ref == "origin/main"
+    sent = registry._sent_frames_for_test[-1]  # type: ignore[attr-defined]
+    assert isinstance(sent, HostInspectWorktreeFrame)
+    assert sent.worktree_path == "/Users/alice/myrepo-worktrees/feature-login"
+    assert sent.branch == "feature/login"
+
+
+async def test_inspect_worktree_unknown_merged_threads_through(
+    host_setup: HostRegistry,
+) -> None:
+    """``merged=None`` (undeterminable) must survive the proxy, not coerce to False."""
+    registry = host_setup
+    registry._inspect_reply_for_test.update(  # type: ignore[attr-defined]
+        {
+            "status": "ok",
+            "dirty_files": 0,
+            "unpushed_commits": 0,
+            "merged": None,
+            "default_ref": None,
+            "error": None,
+        }
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    result = await inspect_worktree_on_host(
+        host_registry=registry,
+        host_conn=conn,
+        worktree_path="/wt",
+        branch="b",
+    )
+    assert result.merged is None
+    assert result.default_ref is None
+
+
+async def test_inspect_worktree_failure_surfaced(host_setup: HostRegistry) -> None:
+    """A host ``status: failed`` inspect reply raises with the host's error."""
+    registry = host_setup
+    registry._inspect_reply_for_test.update(  # type: ignore[attr-defined]
+        {"status": "failed", "error": "worktree path does not exist: /ghost"}
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    with pytest.raises(WorktreeProxyError) as exc:
+        await inspect_worktree_on_host(
+            host_registry=registry,
+            host_conn=conn,
+            worktree_path="/ghost",
+            branch="feature/ghost",
+        )
+    # A failed check must read as failure — silently treating it as an
+    # all-clear inspection would let archive destroy unverified work.
+    assert "does not exist" in exc.value.message
+
+
+async def test_inspect_worktree_incomplete_result_rejected(host_setup: HostRegistry) -> None:
+    """An ``ok`` inspect reply missing the counts is rejected, not accepted."""
+    registry = host_setup
+    registry._inspect_reply_for_test.update(  # type: ignore[attr-defined]
+        {
+            "status": "ok",
+            "dirty_files": None,
+            "unpushed_commits": None,
+            "merged": None,
+            "default_ref": None,
+            "error": None,
+        }
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+    with pytest.raises(WorktreeProxyError) as exc:
+        await inspect_worktree_on_host(
+            host_registry=registry,
+            host_conn=conn,
+            worktree_path="/wt",
+            branch="b",
+        )
+    assert "incomplete worktree inspection" in exc.value.message

--- a/web/src/lib/worktreeKept.test.ts
+++ b/web/src/lib/worktreeKept.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for {@link worktreeKeptNote} — the Archived-page note explaining
+ * why an archived session's git worktree was left in place.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { worktreeKeptNote } from "./worktreeKept";
+
+describe("worktreeKeptNote", () => {
+  it("returns null when the label is absent or soft-cleared", () => {
+    expect(worktreeKeptNote(undefined)).toBeNull();
+    expect(worktreeKeptNote("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(worktreeKeptNote("not json")).toBeNull();
+    expect(worktreeKeptNote("[1,2]")).toBeNull();
+  });
+
+  it("explains an in-use worktree", () => {
+    expect(worktreeKeptNote('{"reason": "in_use"}')).toBe(
+      "Worktree kept — another session is still using it.",
+    );
+  });
+
+  it("explains an offline host", () => {
+    expect(worktreeKeptNote('{"reason": "host_offline"}')).toBe(
+      "Worktree kept — its host is offline, so it couldn't be checked.",
+    );
+  });
+
+  it("explains a failed check", () => {
+    expect(worktreeKeptNote('{"reason": "unknown"}')).toBe(
+      "Worktree kept — Omnigent couldn't verify it was safe to remove.",
+    );
+  });
+
+  it("lists every unsafe fact the host reported", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({
+        dirty_files: 2,
+        unpushed_commits: 3,
+        merged: false,
+        default_ref: "origin/main",
+      }),
+    );
+    expect(note).toBe(
+      "Worktree kept — 2 uncommitted changes, 3 unpushed commits, " +
+        "branch not merged into origin/main.",
+    );
+  });
+
+  it("singularizes single counts", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({ dirty_files: 1, unpushed_commits: 1, merged: true }),
+    );
+    expect(note).toBe("Worktree kept — 1 uncommitted change, 1 unpushed commit.");
+  });
+
+  it("omits the merge claim when the branch is merged", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({ dirty_files: 1, unpushed_commits: 0, merged: true }),
+    );
+    expect(note).toBe("Worktree kept — 1 uncommitted change.");
+  });
+
+  it("says so when the merge status is undeterminable", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({ dirty_files: 0, unpushed_commits: 0, merged: null }),
+    );
+    expect(note).toBe("Worktree kept — merge status couldn't be determined.");
+  });
+
+  it("omits the default ref when absent", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({ dirty_files: 0, unpushed_commits: 0, merged: false }),
+    );
+    expect(note).toBe("Worktree kept — branch not merged.");
+  });
+
+  it("returns null for an all-clear shape (nothing unsafe to explain)", () => {
+    const note = worktreeKeptNote(
+      JSON.stringify({
+        dirty_files: 0,
+        unpushed_commits: 0,
+        merged: true,
+        default_ref: "origin/main",
+      }),
+    );
+    expect(note).toBeNull();
+  });
+});

--- a/web/src/lib/worktreeKept.ts
+++ b/web/src/lib/worktreeKept.ts
@@ -1,0 +1,82 @@
+/**
+ * Build the "Worktree kept — …" note for an archived session whose git
+ * worktree was left in place instead of removed.
+ *
+ * Archive-time cleanup stores its reason on the session's
+ * ``omnigent.worktree_kept`` label as a small JSON object:
+ *
+ * - ``{"reason": "in_use" | "host_offline" | "unknown"}`` when no safety
+ *   check could run, or
+ * - ``{"dirty_files": N, "unpushed_commits": M, "merged": bool | null,
+ *   "default_ref": string | null}`` when the host inspected the worktree
+ *   and found work that removing it would lose.
+ *
+ * A missing, empty, or malformed value yields ``null`` (no note); an
+ * inspection with nothing unsafe also yields ``null`` — that shape would
+ * mean the worktree was removed, so there is nothing to explain.
+ */
+
+export const WORKTREE_KEPT_LABEL = "omnigent.worktree_kept";
+
+interface WorktreeKeptInspection {
+  dirty_files?: unknown;
+  unpushed_commits?: unknown;
+  merged?: unknown;
+  default_ref?: unknown;
+  reason?: unknown;
+}
+
+/** Pluralize a counted noun phrase: 1 → "1 commit", 3 → "3 commits". */
+function counted(n: number, singular: string, plural: string): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+/**
+ * Render the label value as a human sentence, or ``null`` for no note.
+ *
+ * :param raw: The session's ``omnigent.worktree_kept`` label value.
+ * :returns: Sentence like ``"Worktree kept — 2 uncommitted changes,
+ *   branch not merged into origin/main."``, or ``null``.
+ */
+export function worktreeKeptNote(raw: string | undefined): string | null {
+  if (!raw) return null;
+  let parsed: WorktreeKeptInspection;
+  try {
+    parsed = JSON.parse(raw) as WorktreeKeptInspection;
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+
+  // Reason-only shapes: no inspection ran, so there's one broad cause.
+  switch (parsed.reason) {
+    case "in_use":
+      return "Worktree kept — another session is still using it.";
+    case "host_offline":
+      return "Worktree kept — its host is offline, so it couldn't be checked.";
+    case "unknown":
+      return "Worktree kept — Omnigent couldn't verify it was safe to remove.";
+  }
+
+  // Inspected-but-unsafe: list what removing the worktree would lose.
+  const parts: string[] = [];
+  const dirty = parsed.dirty_files;
+  if (typeof dirty === "number" && dirty > 0) {
+    parts.push(counted(dirty, "uncommitted change", "uncommitted changes"));
+  }
+  const unpushed = parsed.unpushed_commits;
+  if (typeof unpushed === "number" && unpushed > 0) {
+    parts.push(counted(unpushed, "unpushed commit", "unpushed commits"));
+  }
+  if (parsed.merged === false) {
+    const ref =
+      typeof parsed.default_ref === "string" && parsed.default_ref !== ""
+        ? ` into ${parsed.default_ref}`
+        : "";
+    parts.push(`branch not merged${ref}`);
+  } else if (parsed.merged === null) {
+    parts.push("merge status couldn't be determined");
+  }
+  if (parts.length === 0) return null;
+  return `Worktree kept — ${parts.join(", ")}.`;
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -939,6 +939,40 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("location").textContent).toBe("/c/conv_archived");
   });
 
+  it("shows the kept-worktree note when archive cleanup left the directory", () => {
+    mocks.conversations = [
+      conv("conv_archived", {
+        archived: true,
+        title: "Old chat",
+        labels: {
+          "omnigent.worktree_kept": JSON.stringify({
+            dirty_files: 2,
+            unpushed_commits: 1,
+            merged: false,
+            default_ref: "origin/main",
+          }),
+        },
+      }),
+    ];
+    renderPage("/settings/archived");
+
+    // The user archived expecting cleanup; the note tells them the
+    // directory is still on disk and what removing it would have lost.
+    const note = screen.getByTestId("worktree-kept-note");
+    expect(note.textContent).toBe(
+      "Worktree kept — 2 uncommitted changes, 1 unpushed commit, " +
+        "branch not merged into origin/main.",
+    );
+  });
+
+  it("shows no kept-worktree note when the label is absent", () => {
+    mocks.conversations = [conv("conv_archived", { archived: true, title: "Old chat" })];
+    renderPage("/settings/archived");
+
+    expect(screen.getByTestId("archived-row")).toBeInTheDocument();
+    expect(screen.queryByTestId("worktree-kept-note")).toBeNull();
+  });
+
   it("deletes an archived session after confirming, with no row-click navigation", () => {
     mocks.conversations = [conv("conv_archived", { archived: true, title: "Old chat" })];
     renderPage("/settings/archived");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -111,6 +111,7 @@ import {
 } from "@/hooks/useConversations";
 import { conversationDisplayLabel } from "@/shell/sidebarNav";
 import { absoluteTime } from "@/lib/relativeTime";
+import { WORKTREE_KEPT_LABEL, worktreeKeptNote } from "@/lib/worktreeKept";
 import { useNavigate } from "@/lib/routing";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { ImportSessionsPanel } from "@/shell/ImportSessionsPanel";
@@ -2628,6 +2629,11 @@ function ArchivedRow({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const label = conversationDisplayLabel(conversation);
   const busy = archive.isPending || del.isPending;
+  // Set by archive-time worktree cleanup when it left the worktree in
+  // place (uncommitted/unpushed/unmerged work, another session using it,
+  // or no way to verify) — the user should know the directory is still
+  // on disk and why.
+  const worktreeKept = worktreeKeptNote(conversation.labels?.[WORKTREE_KEPT_LABEL]);
 
   return (
     <li
@@ -2660,6 +2666,11 @@ function ArchivedRow({
             </span>
           )}
         </div>
+        {worktreeKept !== null && (
+          <div className="text-sm text-muted-foreground" data-testid="worktree-kept-note">
+            {worktreeKept}
+          </div>
+        )}
       </div>
       {/* Actions reveal on hover (desktop) / always shown on touch.
           Hidden in selection mode — bulk bar owns the actions. */}


### PR DESCRIPTION
## Related issue

Closes #5021

## Summary

- Archiving now removes a session worktree only after its host proves the tree is clean, pushed, merged, and unused by another live session.
- Unsafe or unverifiable worktrees stay on disk, and the Archived page explains why with a `Worktree kept` note.
- Cleanup remains best-effort: an old/offline host or failed inspection cannot fail archive or lose work.

**ELI5:** Omnigent checks that the scratch folder contains nothing unique before deleting it. If it cannot prove deletion is safe, it keeps the folder and tells you why.

```text
archive -> inspect on host -> safe? -> remove worktree + branch
                                  \-> keep worktree + show reason
```

## Test Plan

- `uv run --no-sync pytest tests/host/test_git_worktree.py tests/host/test_frames.py tests/server/routes/test_host_worktree.py tests/server/integration/test_session_worktree_archive.py tests/server/integration/test_session_worktree_delete.py tests/server/routes/test_sessions_crud.py` — 178 passed.
- `NODE_OPTIONS='--localstorage-file=/tmp/omnigent-5061-vitest-localstorage' pnpm exec vitest run src/lib/worktreeKept.test.ts` — 11 passed; the two affected Archived-row tests in `SettingsPage.test.tsx` also passed.
- `uv run --no-sync pytest tests/e2e_ui/sessions/test_archived_worktree_kept_note.py` — 1 passed in a real browser against the assembled app.
- `uv run --no-sync pre-commit run --all-files` — all repository gates passed.

## Demo

Captured from the real browser E2E scenario:

![Archived session row showing why its worktree was kept](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-5061-archived-worktree-kept.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The browser test creates and archives sessions through the real server, intercepts the server-internal safety label, and confirms only the labeled Archived row renders the explanation.

## Changelog

Archiving a session now safely removes its git worktree or explains why the worktree was kept