### PR TITLE
fix(host,runner): run git on a dedicated bounded thread pool

### DIFF
--- a/omnigent/git_executor.py
+++ b/omnigent/git_executor.py
@@ -1,0 +1,93 @@
+"""Dedicated, bounded thread pool for running git subprocesses.
+
+Both the host (session-start worktree operations, :mod:`omnigent.host.git_worktree`)
+and the runner (changed-files / diff view, :mod:`omnigent.runtime.filesystem_registry`)
+shell out to ``git``. Those calls block, so they are run off the event loop in a
+worker thread — but if they use :func:`asyncio.to_thread` they land on asyncio's
+*shared* default ``ThreadPoolExecutor``. That pool also serves the control plane:
+the host mints a launch's auth token, polls runners, and stops them through it. A
+burst of slow or stuck git commands (a large repo, a cold untracked cache, a
+network ``git fetch``) then pins every default-pool worker for the full git
+timeout, and every other ``to_thread`` call queues behind them — the event loop
+stays alive answering pings while the host stops making progress.
+
+Running git on this separate pool contains that blast radius: a slow git can only
+exhaust these workers, never the ones the control plane needs. ``max_workers``
+doubles as a cap on concurrent git *processes*, so a stampede of session starts
+can't exhaust the box's PIDs/FDs either. Because git is isolated, a generous
+subprocess timeout is safe — a hung git delays only other git work, not the host.
+
+Tune the cap with ``OMNIGENT_GIT_MAX_WORKERS`` (positive integer; default 4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import os
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+_DEFAULT_MAX_GIT_WORKERS = 4
+
+_executor: ThreadPoolExecutor | None = None
+_executor_lock = threading.Lock()
+
+
+def _max_workers() -> int:
+    """Return the git pool size, honoring ``OMNIGENT_GIT_MAX_WORKERS``.
+
+    Read once at pool creation. Falls back to :data:`_DEFAULT_MAX_GIT_WORKERS`
+    on unset / invalid / non-positive values.
+    """
+    raw = os.environ.get("OMNIGENT_GIT_MAX_WORKERS")
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+    return _DEFAULT_MAX_GIT_WORKERS
+
+
+def git_executor() -> ThreadPoolExecutor:
+    """Return the process-wide git thread pool, creating it on first use.
+
+    Lazily built (and cached) so importing this module is cheap and tests can
+    set ``OMNIGENT_GIT_MAX_WORKERS`` before the first git call. The pool is
+    never explicitly shut down; ``ThreadPoolExecutor``'s atexit hook drains it
+    at interpreter exit.
+
+    :returns: The shared bounded executor, threads named ``omni-git-*``.
+    """
+    global _executor
+    if _executor is None:
+        with _executor_lock:
+            if _executor is None:
+                _executor = ThreadPoolExecutor(
+                    max_workers=_max_workers(),
+                    thread_name_prefix="omni-git",
+                )
+    return _executor
+
+
+async def run_git(func: Callable[..., _T], /, *args: object, **kwargs: object) -> _T:
+    """Run a blocking, git-invoking callable on the dedicated git pool.
+
+    Drop-in replacement for ``await asyncio.to_thread(func, ...)`` that routes
+    to :func:`git_executor` instead of the shared default pool, so a slow git
+    can't starve the control plane (see the module docstring).
+
+    :param func: A callable that shells out to git, e.g.
+        :func:`omnigent.host.git_worktree.create_worktree`.
+    :param args: Positional arguments forwarded to *func*.
+    :param kwargs: Keyword arguments forwarded to *func*.
+    :returns: Whatever *func* returns.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(git_executor(), functools.partial(func, *args, **kwargs))

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -29,6 +29,7 @@ from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
 from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.gateway_inference import gateway_inference_map
+from omnigent.git_executor import run_git
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
 from omnigent.host import HOST_FATAL_EXIT_CODE
@@ -2442,7 +2443,7 @@ class HostProcess:
             # but not tracked runners — the reaper must not wait() them out
             # from under subprocess (#1782).
             with self._host_subprocess_op():
-                created = await asyncio.to_thread(
+                created = await run_git(
                     create_worktree,
                     repo_path=frame.repo_path,
                     branch_name=frame.branch_name,
@@ -2483,7 +2484,7 @@ class HostProcess:
             # Pause the orphan reaper while remove_worktree runs git — see
             # _handle_create_worktree above and _reap_orphans_once (#1782).
             with self._host_subprocess_op():
-                await asyncio.to_thread(
+                await run_git(
                     remove_worktree,
                     worktree_path=frame.worktree_path,
                     branch=frame.branch,
@@ -2523,7 +2524,7 @@ class HostProcess:
             # Pause the orphan reaper while git runs — see
             # _handle_create_worktree above and _reap_orphans_once.
             with self._host_subprocess_op():
-                worktrees = await asyncio.to_thread(
+                worktrees = await run_git(
                     list_worktrees,
                     repo_path=frame.repo_path,
                 )
@@ -3226,9 +3227,12 @@ class HostProcess:
         elif isinstance(frame, HostListWorktreesFrame):
             await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
         elif isinstance(frame, HostFsRequestFrame):
-            # Git status and directory walks can block, so run the read
-            # off the event loop and reply when it completes.
-            fs_result = await asyncio.to_thread(self._handle_fs_request, frame)
+            # Workspace reads for host-less sessions — the changed-files op
+            # shells out to ``git status``, which is slow on a large/stale
+            # tree. Run on the dedicated git pool (not the shared default
+            # executor) so a slow scan can't starve the workers the host's
+            # control plane needs for launch/stop/poll/auth.
+            fs_result = await run_git(self._handle_fs_request, frame)
             await ws.send(encode_host_frame(fs_result))
         elif isinstance(frame, HostModelOptionsFrame):
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7962,8 +7962,7 @@ def create_runner_app(
         session_id: str,
         environment_id: str,  # noqa: ARG001
     ) -> JSONResponse:
-        import asyncio as _asyncio
-
+        from omnigent.git_executor import run_git
         from omnigent.runtime.filesystem_registry import GitStatusUnavailable
 
         await _require_os_env(session_id)
@@ -7971,12 +7970,14 @@ def create_runner_app(
         session_registry = await _resolve_session_fs_registry(session_id)
         try:
             # ``list_changed_files`` shells out to ``git status`` synchronously,
-            # which on a large repo (cold untracked cache) can take seconds.
-            # Offload to a thread so it never blocks the event loop — a blocked
-            # loop can't answer the server's runner-stream relay probe and the
-            # session's first turn 503s with runner_unavailable.
+            # which on a large repo (cold untracked cache) can take seconds. Run
+            # it on the dedicated git pool (not the shared default executor) so it
+            # never blocks the event loop and a slow git can't starve the workers
+            # the control plane needs — a stalled loop can't answer the server's
+            # runner-stream relay probe and the first turn 503s with
+            # runner_unavailable.
             raw_changes = (
-                await _asyncio.to_thread(
+                await run_git(
                     session_registry.list_changed_files,
                     session_id,
                     limit=10_000,
@@ -8046,17 +8047,15 @@ def create_runner_app(
                 },
             )
 
-        import asyncio as _asyncio
-
+        from omnigent.git_executor import run_git
         from omnigent.runtime.filesystem_registry import GitStatusUnavailable
 
         try:
-            # Offloaded like list_filesystem_changes: get_changed_file shells out
-            # to git (status + show) synchronously, so keep it off the loop.
+            # Run on the dedicated git pool like list_filesystem_changes:
+            # get_changed_file shells out to git (status + show) synchronously,
+            # so keep it off the loop and off the shared default executor.
             record = (
-                await _asyncio.to_thread(
-                    session_registry.get_changed_file, session_id, relative_path
-                )
+                await run_git(session_registry.get_changed_file, session_id, relative_path)
                 if session_registry is not None
                 else None
             )
@@ -8081,7 +8080,7 @@ def create_runner_app(
         is_deleted = record.get("status") == "deleted"
 
         before: str | None = (
-            await _asyncio.to_thread(session_registry.get_baseline, relative_path)
+            await run_git(session_registry.get_baseline, relative_path)
             if session_registry is not None
             else None
         )

--- a/tests/test_git_executor.py
+++ b/tests/test_git_executor.py
@@ -1,0 +1,93 @@
+"""Tests for the dedicated, bounded git thread pool.
+
+The point of the pool is isolation: git runs here, never on asyncio's shared
+default executor, so a slow git can't starve the workers the host/runner
+control plane needs, and ``max_workers`` caps concurrent git processes.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+
+import pytest
+
+import omnigent.git_executor as git_executor
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool() -> Iterator[None]:
+    """Rebuild the process-wide pool per test so env changes take effect."""
+    git_executor._executor = None
+    yield
+    pool = git_executor._executor
+    git_executor._executor = None
+    if pool is not None:
+        pool.shutdown(wait=True)
+
+
+def test_max_workers_default() -> None:
+    """Unset/invalid env falls back to the default cap."""
+    assert git_executor._max_workers() == git_executor._DEFAULT_MAX_GIT_WORKERS
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"), [("2", 2), ("16", 16), ("0", 4), ("nope", 4), ("-3", 4)]
+)
+def test_max_workers_env_override(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: int
+) -> None:
+    """A positive integer overrides the cap; junk/non-positive uses the default."""
+    monkeypatch.setenv("OMNIGENT_GIT_MAX_WORKERS", raw)
+    assert git_executor._max_workers() == expected
+
+
+def test_executor_is_singleton() -> None:
+    """Repeated calls return the same pool, tagged for git."""
+    assert git_executor.git_executor() is git_executor.git_executor()
+    assert git_executor.git_executor()._thread_name_prefix == "omni-git"
+
+
+async def test_run_git_returns_value_off_the_main_thread() -> None:
+    """run_git executes the callable on a git-pool worker and returns its result."""
+    result = await git_executor.run_git(lambda x: (x * 2, threading.current_thread().name), 21)
+    value, thread_name = result
+    assert value == 42
+    assert thread_name.startswith("omni-git")
+
+
+async def test_pool_caps_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No more than ``max_workers`` git callables run at once; the rest queue.
+
+    This is the containment guarantee: a burst of git work can occupy at most
+    the cap, so it can never exhaust the box's processes or (were it the shared
+    pool) the control-plane workers.
+    """
+    import asyncio
+
+    monkeypatch.setenv("OMNIGENT_GIT_MAX_WORKERS", "2")
+    git_executor._executor = None  # rebuild with the new cap
+
+    release = threading.Event()
+    lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def _blocking() -> None:
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        release.wait(timeout=5)
+        with lock:
+            active -= 1
+
+    tasks = [asyncio.ensure_future(git_executor.run_git(_blocking)) for _ in range(4)]
+    # Let the pool pick up work; with a cap of 2 only 2 can be running.
+    await asyncio.sleep(0.3)
+    with lock:
+        assert active == 2
+        assert peak == 2
+    release.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2


### PR DESCRIPTION
## Related issue

No filed issue. This came out of investigating host/runner responsiveness under load; it is an internal execution-isolation change with no user-facing behavior change, so per the template no issue is required.

## Summary

Git subprocesses now run on a dedicated, bounded thread pool instead of asyncio's shared default executor.

- The host (session-start worktree ops) and the runner (changed-files / diff view) shell out to git via `asyncio.to_thread`, which lands on the process-wide default `ThreadPoolExecutor` (~`cpu+4` workers). That same pool serves the host control plane: minting a launch's auth token, polling runners, stopping them, and host-less-session fs reads.
- A slow git (large or stale working tree, a network `git fetch`) can occupy every default-pool worker for the full timeout, so every other `to_thread` call queues behind it. The event loop stays alive answering pings, but the host stops making progress: launches, stops, and status calls stall.
- New `omnigent/git_executor.py` provides a lazily-created, bounded pool (`OMNIGENT_GIT_MAX_WORKERS`, default 4) and a `run_git()` helper. Every git-invoking call is routed through it: the host worktree + fs-request handlers (`connect.py`) and the runner changed-files / diff endpoints (`app.py`). A slow git can now only exhaust git-pool workers, never the control-plane pool, and `max_workers` also caps how many git processes run at once. Subprocess timeouts are unchanged.

ELI5: git had to share one small pool of worker threads with the important "is this host alive / start me a runner" work. One slow `git status` on a big messy repo could grab all the threads and everything else waited. Now git gets its own small pool, so it can be slow on its own without freezing the rest.

```
before:                          after:
 default pool (cpu+4)             default pool              git pool (4)
 ├─ git status (slow) ─┐          ├─ auth token             ├─ git status (slow)
 ├─ auth token   [waits]          ├─ runner poll            ├─ git worktree add
 ├─ runner poll  [waits]          ├─ runner stop            └─ git fetch
 └─ runner stop  [waits]          └─ fs reads
```

## Test Plan

- `pytest tests/test_git_executor.py` (new) - pool is a singleton tagged `omni-git`, runs callables off the main thread, honors `OMNIGENT_GIT_MAX_WORKERS`, and caps concurrency at `max_workers`.
- `pytest tests/host/test_git_worktree.py tests/host/test_connect.py` - host worktree + fs-request paths still pass through the rewired `run_git`.
- `pytest tests/runtime/test_filesystem_registry.py tests/e2e/test_filesystem_changed_files_e2e.py` - runner changed-files / diff endpoints exercised end-to-end through `run_git`.
- `pytest tests/server/integration/test_session_worktree_create.py tests/server/integration/test_host_runner_launch_worktree.py` - session-start worktree integration.
- `ruff check` / `ruff format` clean on changed files. (pyrefly runs in CI from the main checkout.)

All green (220+ tests across the suites above).

## Demo

N/A (non-visual, internal execution change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the executor itself (isolation, singleton, env cap, concurrency cap). The rewired call sites are covered by the existing host worktree/connect, runner filesystem-registry, and changed-files E2E suites, which now run through `run_git`.
