### PR TITLE
fix(openai-agents): preserve reasoning item IDs by default

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -93,6 +93,7 @@ RawToolItem: TypeAlias = Any  # type: ignore[explicit-any]
 # an optional import at type-check time — the executor only constructs
 # one when instantiated.
 AsyncOpenAIClient: TypeAlias = Any  # type: ignore[explicit-any]
+ReasoningItemIdPolicy: TypeAlias = Literal["preserve", "omit"]
 
 # Tool executor callable wired in by ``omnigent.Session``. The result
 # is JSON-ish (dict[str, Any]) but the static type leaks ``Any`` through
@@ -1026,6 +1027,7 @@ class OpenAIAgentsSDKExecutor(Executor):
         base_url_override: str | None = None,
         gateway_host: str | None = None,
         gateway_auth_command: str | None = None,
+        reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     ) -> None:
         """Create an OpenAIAgentsSDKExecutor.
 
@@ -1071,7 +1073,15 @@ class OpenAIAgentsSDKExecutor(Executor):
             ``"databricks auth token --host https://example.databricks.com ..."``
             or ``"printf %s sk-..."``. Set from
             ``HARNESS_OPENAI_AGENTS_GATEWAY_AUTH_COMMAND``.
+        :param reasoning_item_id_policy: Optional Responses API replay policy.
+            ``"preserve"`` retains reasoning item IDs; ``"omit"`` is available
+            for legacy providers that reject orphaned reasoning items. ``None``
+            leaves the setting unspecified and uses the SDK default.
+        :raises ValueError: If *reasoning_item_id_policy* is not ``"preserve"``
+            or ``"omit"``.
         """
+        if reasoning_item_id_policy not in (None, "preserve", "omit"):
+            raise ValueError("reasoning_item_id_policy must be 'preserve', 'omit', or unset")
         self._retry_policy = retry_policy if retry_policy is not None else RetryPolicy()
         raw_client = (
             client
@@ -1100,6 +1110,7 @@ class OpenAIAgentsSDKExecutor(Executor):
         self._profile = profile
         self._use_responses = use_responses
         self._model_override = model
+        self._reasoning_item_id_policy = reasoning_item_id_policy
         self._databricks = _is_databricks_openai_client(self._client)
         self._tool_executor: ToolExecutor | None = None
         self._session_states: dict[str, _AgentsSessionState] = {}
@@ -1525,13 +1536,15 @@ class OpenAIAgentsSDKExecutor(Executor):
             max_tokens=max_tokens,
         )
         current_item_count = len(await state.sdk_session.get_items())
-        run_config = agents_sdk.RunConfig(
-            model=model,
-            model_provider=provider,
-            tracing_disabled=True,
-            reasoning_item_id_policy="omit",
-            call_model_input_filter=self._filter_model_input,
-        )
+        run_config_kwargs: dict[str, object] = {
+            "model": model,
+            "model_provider": provider,
+            "tracing_disabled": True,
+            "call_model_input_filter": self._filter_model_input,
+        }
+        if self._reasoning_item_id_policy is not None:
+            run_config_kwargs["reasoning_item_id_policy"] = self._reasoning_item_id_policy
+        run_config = agents_sdk.RunConfig(**run_config_kwargs)
         max_turns = 1 if stepwise_internal_turns else int(cfg.extra.get("max_turns", 1000))
 
         # ── LLM_REQUEST policy evaluation ────────────────────────

--- a/omnigent/inner/openai_agents_sdk_harness.py
+++ b/omnigent/inner/openai_agents_sdk_harness.py
@@ -83,17 +83,24 @@ Env vars read at startup:
   default. An explicit env-var value still wins as the
   highest-priority switch, so bad specs fail loudly at the gateway
   instead of being silently rewritten.
+- ``HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY``: optional Responses
+  replay policy, either ``"preserve"`` or ``"omit"``. Unset uses the
+  OpenAI Agents SDK default.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from typing import cast
 
 from fastapi import FastAPI
 
 from omnigent.inner.executor import Executor
-from omnigent.inner.openai_agents_sdk_executor import OpenAIAgentsSDKExecutor
+from omnigent.inner.openai_agents_sdk_executor import (
+    OpenAIAgentsSDKExecutor,
+    ReasoningItemIdPolicy,
+)
 from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
 
 _logger = logging.getLogger(__name__)
@@ -107,6 +114,7 @@ _ENV_GATEWAY_HOST = "HARNESS_OPENAI_AGENTS_GATEWAY_HOST"
 _ENV_USE_RESPONSES = "HARNESS_OPENAI_AGENTS_USE_RESPONSES"
 _ENV_GATEWAY_BASE_URL = "HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_OPENAI_AGENTS_GATEWAY_AUTH_COMMAND"
+_ENV_REASONING_ITEM_ID_POLICY = "HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY"
 # Direct OpenAI-compatible API key set when the agent spec declares
 # executor.auth: {type: api_key, api_key: …}. Takes precedence over
 # ambient OPENAI_API_KEY in the caller's environment.
@@ -210,6 +218,10 @@ def _build_openai_agents_sdk_executor() -> Executor:
         _ENV_USE_RESPONSES,
         default=default_use_responses,
     )
+    reasoning_item_id_policy = cast(
+        ReasoningItemIdPolicy | None,
+        os.environ.get(_ENV_REASONING_ITEM_ID_POLICY) or None,
+    )
     return OpenAIAgentsSDKExecutor(
         profile=profile,
         api_key=api_key,
@@ -218,6 +230,7 @@ def _build_openai_agents_sdk_executor() -> Executor:
         base_url_override=os.environ.get(_ENV_GATEWAY_BASE_URL) or None,
         gateway_host=os.environ.get(_ENV_GATEWAY_HOST) or None,
         gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
+        reasoning_item_id_policy=reasoning_item_id_policy,
     )
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1747,6 +1747,18 @@ def _config_flag_is_true(value: object) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes"}
 
 
+def _set_openai_agents_reasoning_item_id_policy_env(
+    env: dict[str, str],
+    value: object | None,
+) -> None:
+    """Validate and encode the OpenAI Agents SDK reasoning replay policy."""
+    if value is None:
+        return
+    if not isinstance(value, str) or value not in {"preserve", "omit"}:
+        raise ValueError("reasoning_item_id_policy must be 'preserve', 'omit', or unset")
+    env["HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY"] = value
+
+
 def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     """
     Build the env-var dict the openai-agents harness wrap reads.
@@ -1754,7 +1766,7 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     Maps spec.executor fields → the ``HARNESS_OPENAI_AGENTS_*``
     env vars defined in
     ``omnigent/inner/openai_agents_sdk_harness.py``. Threads
-    model + auth + use_responses.
+    model + auth + Responses replay settings.
 
     Auth resolution order (highest priority first):
 
@@ -1782,6 +1794,10 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_OPENAI_AGENTS_MODEL"] = model
+    _set_openai_agents_reasoning_item_id_policy_env(
+        env,
+        spec.executor.config.get("reasoning_item_id_policy"),
+    )
 
     # ── Auth resolution ────────────────────────────────────────────────
     # Priority: generic provider → spec.executor.auth → global config auth →

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -1670,10 +1670,9 @@ def _translate_executor_from_def(
         of the supported set so an empty string fails
         hard there.
     :param raw_executor: Optional raw YAML ``executor:`` mapping.
-        When present, ``use_responses`` (``bool | None``) is read
-        from it and forwarded into ``executor.config["use_responses"]``
-        so the openai-agents harness subprocess reads the correct
-        API surface (chat/completions vs. responses). The omnigent
+        When present, OpenAI Agents SDK wire settings are forwarded
+        into ``executor.config`` so the harness subprocess reads the
+        correct API surface and reasoning replay policy. The omnigent
         loader silently drops unknown fields on its own
         :class:`~omnigent.inner.datamodel.ExecutorSpec`, so we
         have to recover this field from the raw dict here.
@@ -1749,9 +1748,8 @@ def _translate_executor_from_def(
         "harness": harness,
         "profile": profile,
     }
-    # ``use_responses`` and ``acp_agent`` are not fields on the omnigent inner
-    # ExecutorSpec (the loader drops unknown keys), so read them from the raw
-    # YAML dict and carry them forward explicitly.
+    # These are not fields on the omnigent inner ExecutorSpec, so read them
+    # from the raw YAML dict and carry them forward explicitly.
     # The openai-agents harness spawn-env builder reads
     # ``spec.executor.config["use_responses"]`` to set
     # ``HARNESS_OPENAI_AGENTS_USE_RESPONSES``, which controls
@@ -1761,6 +1759,8 @@ def _translate_executor_from_def(
         use_responses_raw = raw_executor.get("use_responses")
         if use_responses_raw is not None:
             config["use_responses"] = bool(use_responses_raw)
+        if "reasoning_item_id_policy" in raw_executor:
+            config["reasoning_item_id_policy"] = raw_executor["reasoning_item_id_policy"]
         if "acp_agent" in raw_executor:
             config["acp_agent"] = raw_executor["acp_agent"]
     # ``auth`` is now parsed by the loader into OmniExecutorSpec.auth;

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -445,6 +445,65 @@ class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
 
         _run(_t())
 
+    def test_reasoning_item_id_policy_defaults_to_sdk_behavior(self):
+        async def _t():
+            _FakeRunner.last_calls = []
+            _FakeRunner.next_result = _FakeResult(events=[], final_output="done")
+            executor = OpenAIAgentsSDKExecutor(client=object(), model="gpt-test")
+            with patch(
+                "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+                return_value=_fake_agents_sdk(),
+            ):
+                _ = [
+                    event
+                    async for event in executor.run_turn(
+                        [{"role": "user", "content": "hi"}],
+                        [],
+                        "Be helpful.",
+                    )
+                ]
+
+            run_config = _FakeRunner.last_calls[0]["run_config"]
+            self.assertNotIn("reasoning_item_id_policy", run_config.kwargs)
+
+        _run(_t())
+
+    def test_reasoning_item_id_policy_is_configurable(self):
+        async def _t():
+            for policy in ("preserve", "omit"):
+                with self.subTest(policy=policy):
+                    _FakeRunner.last_calls = []
+                    _FakeRunner.next_result = _FakeResult(events=[], final_output="done")
+                    executor = OpenAIAgentsSDKExecutor(
+                        client=object(),
+                        model="gpt-test",
+                        reasoning_item_id_policy=policy,
+                    )
+                    with patch(
+                        "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+                        return_value=_fake_agents_sdk(),
+                    ):
+                        _ = [
+                            event
+                            async for event in executor.run_turn(
+                                [{"role": "user", "content": "hi"}],
+                                [],
+                                "Be helpful.",
+                            )
+                        ]
+
+                    run_config = _FakeRunner.last_calls[0]["run_config"]
+                    self.assertEqual(run_config.kwargs["reasoning_item_id_policy"], policy)
+
+        _run(_t())
+
+    def test_reasoning_item_id_policy_rejects_invalid_value(self):
+        with self.assertRaisesRegex(ValueError, "reasoning_item_id_policy"):
+            OpenAIAgentsSDKExecutor(
+                client=object(),
+                reasoning_item_id_policy="invalid",  # type: ignore[arg-type]
+            )
+
     def test_sanitize_replay_item_drops_long_ids(self):
         item = {
             "type": "message",

--- a/tests/inner/test_openai_agents_sdk_harness.py
+++ b/tests/inner/test_openai_agents_sdk_harness.py
@@ -77,6 +77,7 @@ def test_executor_factory_reads_databricks_profile_env(
         "https://example.databricks.com/ai-gateway/codex/v1",
     )
     monkeypatch.setenv("HARNESS_OPENAI_AGENTS_GATEWAY_AUTH_COMMAND", "printf token")
+    monkeypatch.delenv("HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY", raising=False)
 
     captured: dict[str, Any] = {}
 
@@ -92,6 +93,7 @@ def test_executor_factory_reads_databricks_profile_env(
         base_url_override: str | None = None,
         gateway_host: str | None = None,
         gateway_auth_command: str | None = None,
+        reasoning_item_id_policy: str | None = None,
     ) -> None:
         captured["client"] = client
         captured["profile"] = profile
@@ -101,6 +103,7 @@ def test_executor_factory_reads_databricks_profile_env(
         captured["base_url_override"] = base_url_override
         captured["gateway_host"] = gateway_host
         captured["gateway_auth_command"] = gateway_auth_command
+        captured["reasoning_item_id_policy"] = reasoning_item_id_policy
 
     with patch(
         "omnigent.inner.openai_agents_sdk_harness.OpenAIAgentsSDKExecutor.__init__",
@@ -113,6 +116,7 @@ def test_executor_factory_reads_databricks_profile_env(
     assert captured["gateway_host"] == "https://example.databricks.com"
     assert captured["base_url_override"] == "https://example.databricks.com/ai-gateway/codex/v1"
     assert captured["gateway_auth_command"] == "printf token"
+    assert captured["reasoning_item_id_policy"] is None
     # ``use_responses`` defaults True when env var absent.
     assert captured["use_responses"] is True
 
@@ -123,6 +127,7 @@ def test_executor_factory_use_responses_default_true(
     """``use_responses`` defaults to ``True`` when the env var is unset."""
     monkeypatch.delenv("HARNESS_OPENAI_AGENTS_MODEL", raising=False)
     monkeypatch.delenv("HARNESS_OPENAI_AGENTS_USE_RESPONSES", raising=False)
+    monkeypatch.delenv("HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY", raising=False)
 
     captured: dict[str, Any] = {}
 
@@ -288,6 +293,26 @@ def test_use_responses_env_var_truthy_parsing(
     assert captured["use_responses"] is expected
 
 
+@pytest.mark.parametrize("policy", ["preserve", "omit"])
+def test_executor_factory_threads_reasoning_item_id_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: str,
+) -> None:
+    monkeypatch.setenv("HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY", policy)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.openai_agents_sdk_harness.OpenAIAgentsSDKExecutor.__init__",
+        _fake_init,
+    ):
+        openai_agents_sdk_harness._build_openai_agents_sdk_executor()
+
+    assert captured["reasoning_item_id_policy"] == policy
+
+
 def test_executor_factory_no_env_returns_blank_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -303,6 +328,7 @@ def test_executor_factory_no_env_returns_blank_config(
         "HARNESS_OPENAI_AGENTS_MODEL",
         "HARNESS_OPENAI_AGENTS_DATABRICKS_PROFILE",
         "HARNESS_OPENAI_AGENTS_USE_RESPONSES",
+        "HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY",
     ):
         monkeypatch.delenv(env_var, raising=False)
 
@@ -320,3 +346,4 @@ def test_executor_factory_no_env_returns_blank_config(
     assert captured["profile"] is None
     assert captured["model"] is None
     assert captured["use_responses"] is True
+    assert captured["reasoning_item_id_policy"] is None

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -49,6 +49,7 @@ def _make_spec(
     model: str | None = "databricks-gpt-5-4-mini",
     profile: str | None = None,
     use_responses: object | None = None,
+    reasoning_item_id_policy: object | None = None,
     auth: ApiKeyAuth | DatabricksAuth | None = None,
 ) -> AgentSpec:
     """
@@ -73,6 +74,8 @@ def _make_spec(
         config["profile"] = profile
     if use_responses is not None:
         config["use_responses"] = use_responses
+    if reasoning_item_id_policy is not None:
+        config["reasoning_item_id_policy"] = reasoning_item_id_policy
     return AgentSpec(
         spec_version=1,
         name="test-openai-agents",
@@ -205,6 +208,32 @@ def test_use_responses_absent_omits_env_var() -> None:
     """When ``use_responses`` is unset, the env var is omitted (harness default applies)."""
     env = _build_openai_agents_sdk_spawn_env(_make_spec(use_responses=None))
     assert "HARNESS_OPENAI_AGENTS_USE_RESPONSES" not in env
+
+
+@pytest.mark.parametrize("policy", ["preserve", "omit"])
+def test_reasoning_item_id_policy_threads_into_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: str,
+) -> None:
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build",
+        lambda *args, **kwargs: None,
+    )
+    env = _build_openai_agents_sdk_spawn_env(
+        _make_spec(model="gpt-4o", reasoning_item_id_policy=policy)
+    )
+    assert env["HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY"] == policy
+
+
+def test_reasoning_item_id_policy_absent_omits_env_var() -> None:
+    env = _build_openai_agents_sdk_spawn_env(_make_spec(reasoning_item_id_policy=None))
+    assert "HARNESS_OPENAI_AGENTS_REASONING_ITEM_ID_POLICY" not in env
+
+
+@pytest.mark.parametrize("policy", ["invalid", True, ["preserve"]])
+def test_reasoning_item_id_policy_rejects_invalid_values(policy: object) -> None:
+    with pytest.raises(ValueError, match="reasoning_item_id_policy"):
+        _build_openai_agents_sdk_spawn_env(_make_spec(reasoning_item_id_policy=policy))
 
 
 def test_no_model_produces_no_model_env_var() -> None:

--- a/tests/spec/test_load.py
+++ b/tests/spec/test_load.py
@@ -357,6 +357,21 @@ def test_load_omnigent_yaml_preserves_use_responses_bool(tmp_path: Path) -> None
     assert spec.executor.config.get("use_responses") is False
 
 
+def test_load_omnigent_yaml_preserves_reasoning_item_id_policy(tmp_path: Path) -> None:
+    yaml_text = textwrap.dedent("""\
+        name: reasoning-replay-test
+        prompt: You are a helpful assistant.
+
+        executor:
+          harness: openai-agents
+          model: databricks-gpt-5-4-mini
+          reasoning_item_id_policy: preserve
+    """)
+    (tmp_path / "reasoning-replay-test.yaml").write_text(yaml_text)
+    spec = load_omnigent_yaml(tmp_path / "reasoning-replay-test.yaml")
+    assert spec.executor.config["reasoning_item_id_policy"] == "preserve"
+
+
 def test_load_omnigent_yaml_threads_executor_extra_max_tokens_to_llm_extra(
     tmp_path: Path,
 ) -> None:

--- a/tests/spec/test_omnigent_adapter.py
+++ b/tests/spec/test_omnigent_adapter.py
@@ -2181,6 +2181,27 @@ def test_use_responses_absent_omits_key_from_executor_config() -> None:
     assert "use_responses" not in spec.executor.config
 
 
+def test_reasoning_item_id_policy_propagates_to_executor_config() -> None:
+    agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
+    raw_yaml["executor"] = {
+        "model": "databricks-gpt-5-4-mini",
+        "harness": "openai-agents",
+        "reasoning_item_id_policy": "preserve",
+    }
+    spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw_yaml)
+    assert spec.executor.config["reasoning_item_id_policy"] == "preserve"
+
+
+def test_reasoning_item_id_policy_absent_omits_key_from_executor_config() -> None:
+    agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
+    raw_yaml["executor"] = {
+        "model": "databricks-gpt-5-4-mini",
+        "harness": "openai-agents",
+    }
+    spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw_yaml)
+    assert "reasoning_item_id_policy" not in spec.executor.config
+
+
 def test_malformed_acp_agent_propagates_for_runtime_validation() -> None:
     agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
     raw_yaml["executor"] = {


### PR DESCRIPTION
## Related issue

Closes #5066

## Summary

Newer OpenAI reasoning models link each function call (`fc_...`) to a preceding reasoning item (`rs_...`). Omnigent forced `reasoning_item_id_policy="omit"`, which removed the reasoning ID but kept the linked function-call ID. The next turn then failed with:

```
Item 'fc_XXXXXXX' of type 'function_call' was provided without its required 'reasoning' item: 'rs_YYYYYY'.
```

This change stops forcing `omit`, so the OpenAI Agents SDK uses its default `preserve` behavior. It also threads an explicit `preserve` or `omit` override from agent YAML through the harness for providers that still need the legacy workaround.

ELI5: the function call points to a reasoning receipt. Omnigent discarded the receipt number but kept the pointer to it, so OpenAI rejected the replay.

```
Before: reasoning(rs_ removed) -> function_call(fc_ -> rs_) -> 400
After:  reasoning(rs_ kept)    -> function_call(fc_ -> rs_) -> accepted
```

Chat Completions behavior is unchanged.

## Test Plan

- `uv run pre-commit run --files omnigent/inner/openai_agents_sdk_executor.py omnigent/inner/openai_agents_sdk_harness.py omnigent/runtime/workflow.py omnigent/spec/omnigent.py tests/inner/test_openai_agents_sdk_executor.py tests/inner/test_openai_agents_sdk_harness.py tests/runtime/test_openai_agents_sdk_spawn_env.py tests/spec/test_load.py tests/spec/test_omnigent_adapter.py` — passed.
- `uv run pytest tests/inner/test_openai_agents_sdk_executor.py tests/inner/test_openai_agents_sdk_harness.py tests/runtime/test_openai_agents_sdk_spawn_env.py tests/spec/test_omnigent_adapter.py tests/spec/test_load.py -k 'not test_non_databricks_model_without_profile_omits_profile_env_var and not test_no_model_produces_no_model_env_var'` — 230 passed, 2 deselected. The deselected tests read a local Codex provider despite their config-isolation fixture; they are unrelated to this change.

## Demo

N/A — this is a backend replay fix with no visual UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies the SDK-default path, both explicit policy values, invalid configuration, and YAML-to-harness propagation.

## Changelog

OpenAI Agents runs now preserve reasoning item IDs required to replay tool calls on newer models.