### PR TITLE
fix(web): show all models in usage sessions table

### DIFF
--- a/web/src/components/usage/UsageSessionTable.tsx
+++ b/web/src/components/usage/UsageSessionTable.tsx
@@ -116,6 +116,18 @@ export function UsageSessionTable({ sessions }: Props) {
                 {primaryModel(s.models) && (
                   <span className="ml-2 text-xs text-muted-foreground">
                     {primaryModel(s.models)}
+                    {Object.keys(s.models).length > 1 && (
+                      <span
+                        className="ml-1.5 inline-flex items-center rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                        title={Object.entries(s.models)
+                          .sort(([, a], [, b]) => b - a)
+                          .slice(1)
+                          .map(([name]) => name)
+                          .join(", ")}
+                      >
+                        +{Object.keys(s.models).length - 1}
+                      </span>
+                    )}
                   </span>
                 )}
               </td>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- When a session involves multiple models, the usage sessions table previously only showed the single highest-cost model. This adds a `+N` badge (matching the existing sub-agent harness pattern) that reveals the additional models on hover.

## Test Plan

1. Run `just dev` and open the usage page.
2. Find a session that used multiple models — the primary model should appear with a `+N` badge next to it.
3. Hover the badge to verify the tooltip lists the remaining models sorted by cost.
4. Verify single-model sessions display as before (no badge).

## Demo

<!-- Attach screenshot or recording showing the +N badge on a multi-model session -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified by inspecting the usage sessions table with sessions that use multiple models. The change is purely presentational — it reads from the existing `models` map that is already populated by the backend.

## Changelog

The usage sessions table now shows all models used in a session, not just the primary one — additional models appear as a +N badge with a hover tooltip.