### PR TITLE
fix(web): span the error banner's dashed rule across the chat column

### DIFF
--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -19,7 +19,7 @@ import json
 
 from playwright.sync_api import Page, Route, expect
 
-from tests.e2e_ui.conftest import _server_state
+from tests.e2e_ui.conftest import _server_state, seed_committed_turn
 
 
 def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
@@ -173,3 +173,66 @@ def test_persisted_failure_expands_retries_and_dismisses_locally(
     expect(pill).to_be_visible(timeout=15_000)
     pill.get_by_role("button", name="Dismiss error message").click()
     expect(pill).to_have_count(0)
+
+
+def test_error_row_divider_spans_the_chat_column(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The banner's dashed rule spans the full chat column, not just the pill.
+
+    Regression net for the error-only shrink-wrap: ``MessageContent``
+    defaults to ``w-fit``, so an error-only bubble once clipped the rule to
+    the 560px pill (~592px) instead of the column. Widths are compared
+    against a long-text assistant turn measured in the same viewport — no
+    hardcoded pixel values. The viewport is set wide so the column reaches
+    its ``max-w-3xl`` cap: at the default 1280px the side panels squeeze the
+    column below the pill's width, which masks the shrink-wrap.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    seed_committed_turn(
+        session_id,
+        prompt="Write something long.",
+        reply=(
+            "A long assistant answer that stretches the chat column to its full "
+            "width regardless of the viewport size. " * 12
+        ),
+        response_id="resp_geometry_long",
+    )
+    _seed_error_item(
+        session_id,
+        code="required_terminal_exited",
+        message="Required terminal exited unexpectedly; the runtime is no longer available.",
+    )
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+    page.goto(f"{base_url}/c/{session_id}")
+    pill = page.get_by_test_id("error-pill")
+    expect(pill).to_be_visible(timeout=15_000)
+
+    widths = page.evaluate(
+        """() => {
+          const pill = document.querySelector('[data-testid="error-pill"]');
+          const row = pill.parentElement;
+          const divider = row.querySelector('span[aria-hidden="true"]');
+          const bubbles = [...document.querySelectorAll('[data-testid="message-bubble"]')];
+          const textBubble = bubbles.find((b) =>
+            b.textContent.includes('stretches the chat column'));
+          return {
+            row: row.getBoundingClientRect().width,
+            divider: divider.getBoundingClientRect().width,
+            textTurn: textBubble.firstElementChild.getBoundingClientRect().width,
+          };
+        }"""
+    )
+    assert abs(widths["row"] - widths["textTurn"]) <= 2, (
+        f"error row spans {widths['row']:.0f}px but the chat column spans "
+        f"{widths['textTurn']:.0f}px — the banner shrink-wrapped the pill"
+    )
+    assert abs(widths["divider"] - widths["row"]) <= 1, (
+        f"dashed rule spans {widths['divider']:.0f}px of its {widths['row']:.0f}px row"
+    )

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from playwright.sync_api import Page, Route, expect
 
 from tests.e2e_ui.conftest import _server_state, seed_committed_turn
@@ -175,9 +176,11 @@ def test_persisted_failure_expands_retries_and_dismisses_locally(
     expect(pill).to_have_count(0)
 
 
+@pytest.mark.parametrize("viewport_width", [1440, 2400])
 def test_error_row_divider_spans_the_chat_column(
     page: Page,
     seeded_session: tuple[str, str],
+    viewport_width: int,
 ) -> None:
     """The banner's dashed rule spans the full chat column, not just the pill.
 
@@ -185,12 +188,16 @@ def test_error_row_divider_spans_the_chat_column(
     defaults to ``w-fit``, so an error-only bubble once clipped the rule to
     the 560px pill (~592px) instead of the column. Widths are compared
     against a long-text assistant turn measured in the same viewport — no
-    hardcoded pixel values. The viewport is set wide so the column reaches
-    its ``max-w-3xl`` cap: at the default 1280px the side panels squeeze the
-    column below the pill's width, which masks the shrink-wrap.
+    hardcoded pixel values. Runs at two widths since the column is
+    responsive below its ``max-w-3xl`` cap: 2400px lets the column reach
+    the cap (where the shrink-wrap shows — the pill fits inside it), while
+    1440px squeezes the column below the pill's width (``max-w-full`` caps
+    the pill either way) and locks the invariant against a wrapper that
+    narrows the row below the column.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :param viewport_width: Browser width in CSS pixels for this run.
     :returns: None.
     """
     base_url, session_id = seeded_session
@@ -209,7 +216,7 @@ def test_error_row_divider_spans_the_chat_column(
         message="Required terminal exited unexpectedly; the runtime is no longer available.",
     )
 
-    page.set_viewport_size({"width": 1920, "height": 1080})
+    page.set_viewport_size({"width": viewport_width, "height": 1080})
     page.goto(f"{base_url}/c/{session_id}")
     pill = page.get_by_test_id("error-pill")
     expect(pill).to_be_visible(timeout=15_000)

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -213,6 +213,56 @@ describe("BubbleView dispatch", () => {
     expect(bubble.firstElementChild).toHaveClass("w-full");
   });
 
+  const errorItem = (): AssistantBubble["items"][number] => ({
+    kind: "error",
+    itemId: "err_1",
+    message: "Required terminal exited unexpectedly; the runtime is no longer available.",
+    source: "execution",
+    code: "required_terminal_exited",
+  });
+
+  const errorBubble = (items: AssistantBubble["items"]): AssistantBubble => ({
+    kind: "assistant",
+    responseId: "resp_err",
+    stableId: "resp_err",
+    lifecycle: "completed",
+    error: null,
+    items,
+    createdAtS: 1_750_000_000,
+  });
+
+  it("spans the chat column for an error-only bubble, with no hover footer", () => {
+    // WHY: an error banner is a thread-level element — its dashed rule must
+    // span the width a long-text turn takes (not shrink-wrap the 560px pill
+    // via MessageContent's w-fit), and the timestamp/actions chrome belongs
+    // to assistant prose, never to the error.
+    render(<BubbleView bubble={errorBubble([errorItem()])} />);
+
+    const bubble = screen.getByTestId("message-bubble");
+    expect(screen.getByTestId("error-pill")).toBeInTheDocument();
+    expect(bubble.firstElementChild).toHaveClass("w-full");
+    expect(screen.queryByTestId("message-timestamp")).not.toBeInTheDocument();
+  });
+
+  it("spans the chat column for a text+error turn and keeps the footer", () => {
+    // WHY: a mid-turn error shares the bubble with prose — the rule still
+    // spans the full column even when the prose is short, and the footer
+    // stays because the timestamp/actions describe the text.
+    render(
+      <BubbleView
+        bubble={errorBubble([
+          { kind: "text", itemId: "t1", text: "short answer", final: true },
+          errorItem(),
+        ])}
+      />,
+    );
+
+    const bubble = screen.getByTestId("message-bubble");
+    expect(screen.getByTestId("error-pill")).toBeInTheDocument();
+    expect(bubble.firstElementChild).toHaveClass("w-full");
+    expect(screen.getByTestId("message-timestamp")).toBeInTheDocument();
+  });
+
   it("marks a cancelled assistant turn as Interrupted", () => {
     // WHY: the cancelled lifecycle branch surfaces an explicit Interrupted
     // note so a truncated turn doesn't read as a complete answer.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3862,6 +3862,14 @@ function AssistantBubble({
   const hasElicitation = bubble.items.some((it) => it.kind === "elicitation");
   const isWide =
     hasElicitation || containsMarkdownTable(bubble.items) || containsDisplayMath(bubble.items);
+  // An error banner's dashed rule spans the full chat column: MessageContent
+  // is w-fit, so without w-full an error-only bubble shrink-wraps the 560px
+  // pill and the rule clips to it instead of reaching the column edges.
+  const hasError = bubble.items.some((it) => it.kind === "error");
+  // A bubble carrying an error but no prose stands alone as a thread-level
+  // element — the hover footer's timestamp/actions belong to assistant text,
+  // not to the error.
+  const errorOnly = hasError && !markdownText;
 
   return (
     <>
@@ -3876,7 +3884,7 @@ function AssistantBubble({
             collapsed the row's trailing hairline (a flex-1 span) to zero
             and stopped its click target short of the column. Keeping the
             cap lands the hairline where an answered turn's does. */}
-        <MessageContent className={isWide || foldOnly ? "w-full" : undefined}>
+        <MessageContent className={isWide || foldOnly || hasError ? "w-full" : undefined}>
           <BlockRenderer
             items={bubble.items}
             sessionStatus={sessionStatus}
@@ -3903,9 +3911,11 @@ function AssistantBubble({
             the user can see, and hanging them off a collapsed row spaced
             consecutive rows unevenly depending on hidden narration. Also
             skipped when there is neither a timestamp nor actions to show.
+            Also skipped on an error-only bubble: the banner stands alone as
+            a thread-level element, so no timestamp/actions hang off it.
             40%-visible on touch (no hover), hover/focus-reveal on desktop.
             Order matches the design target: actions, then timestamp. */}
-        {!foldOnly && (ts || markdownText) && (
+        {!foldOnly && !errorOnly && (ts || markdownText) && (
           <div className="flex items-center gap-3 py-1 opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
             {markdownText && (
               <MessageActions>


### PR DESCRIPTION
## Related issue

Follow-up to #4931 (merged as 8aaf72c) — design review found the restyled error banner still rendered at the wrong width and with the wrong chrome in the error-only case.

## Summary

- An error-only assistant bubble shrink-wrapped the 560px pill: `MessageContent` defaults to `w-fit`, so the banner's dashed rule clipped to the pill (~592px) instead of spanning the chat column, and the bubble's hover footer (timestamp + copy/fork) hung off the pill as if it were model prose. Sub-agent failures almost always take this shape (the sub-agent dies before streaming text), which is why the bug clustered in sub-agent threads.
- Bubbles carrying an `error` item now force `MessageContent` to `w-full`, so the dashed rule spans the same width a long-text assistant turn takes (the `max-w-3xl` chat column), with the pill centered as in the prototype.
- An error-only bubble suppresses the hover-revealed footer, so the banner stands as an independent thread-level element. Text+error turns keep the footer since it belongs to the prose.

ELI5: the error pill lives inside a box that hugs its contents. When a turn is only an error, the box hugged the pill, so the dashed line behind it looked short and the pill got a timestamp row meant for real answers. Now the box always stretches to the normal chat width for error turns, and error-only turns drop the timestamp row.

```
before (error-only turn)              after
┌─ chat column (max-w-3xl) ─┐        ┌─ chat column (max-w-3xl) ─┐
│ - - -[ pill ]- - -        │        │ - - - - - [ pill ] - - - - │
│ Jun 16, 10:43 AM          │        │                            │
└───────────────────────────┘        └────────────────────────────┘
 rule clips to w-fit bubble            rule spans the column; no footer
```

## Test Plan

- `npx vitest run src/pages/ src/components/blocks/` — 37 files / 967 tests pass, including 2 new `ChatPage.indicators` cases: error-only bubble → `w-full` content + no timestamp; text+error turn → `w-full` + footer kept.
- `pytest tests/e2e_ui/chat/test_failure_error_card.py tests/e2e_ui/chat/test_composer_attachments.py` — 9 passed (Playwright chromium), including the new `test_error_row_divider_spans_the_chat_column`: seeds a long-text turn beside the error-only turn and asserts the error row and its dashed rule measure the chat column's width at 1440px and 2400px viewports (the column is responsive below its `max-w-3xl` cap; the 2400px run exercises the regime where the original shrink-wrap shows). RED-verified against the pre-fix code (fails: 592px vs 736px).
- `tsc -b`, `oxlint --deny-warnings`, `prettier --check`, `ruff check/format` on the touched specs — clean.
- Manual browser verification against the local dev stack with seeded turns (details in Demo).

## Demo

Verified against a seeded 3-turn session (long text turn, error-only turn, text+error turn) plus a real sub-agent thread (`/c/<sub-agent-id>`), in light and dark themes:

- 1440px viewport: divider 562px = long-text turn width (column squeezed by side panels); 2400px: divider 768px = long-text turn at the `max-w-3xl` cap; pill 560px, centered (104/104 insets).
- Error-only rows have no timestamp/action footer in the DOM; text+error rows keep it.
- Expanded state stays centered with the rule still spanning the column.

![light theme, 2400px](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-pill/tmp-screenshots/verify-wide.png)

![light theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-pill/tmp-screenshots/verify-light.png)

![dark theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-pill/tmp-screenshots/verify-dark.png)

![expanded state, light](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-pill/tmp-screenshots/verify-light-expanded.png)

![sub-agent thread, light](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-error-pill/tmp-screenshots/verify-subagent-light.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the visual contract that unit tests can't: divider spans the same width as a long-text turn at 1440px (562px) and 2400px (768px, the `max-w-3xl` cap), pill centered, no hover chrome on error-only rows, in light + dark themes, for both a main thread and a real sub-agent thread. The new geometry e2e pins the divider-span invariant so this bug class can't ship silently; the existing specs cover pill behaviors (expand, tabs, copy, retry, dismiss, persistence) and pass unmodified.

## Changelog

Error banners on failed turns now span the full chat width and no longer show a message timestamp row
