### PR TITLE
feat(acp): honor executor.config.permission_mode

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -185,6 +185,14 @@ class AcpAgentConfig:
         the agent authenticates with — an agent that reads a variable must name
         it here (or in ``os_env.sandbox.env_passthrough``) or it starts
         unauthenticated. Names only; values come from the host environment.
+    :param permission_mode: Opt-out of the per-tool human approval card, the
+        same ``executor.config.permission_mode`` knob the other harness
+        families read. ``"bypassPermissions"`` (claude-sdk / claude-native /
+        antigravity semantics) and ``"auto"`` (cursor semantics — its default
+        exists so headless workers don't stall) skip the card and allow;
+        every other value (and unset) behaves exactly as before. TOOL_CALL
+        policy still applies ahead of the skip, so a hard DENY still blocks
+        (#5052).
     """
 
     command: str
@@ -194,6 +202,7 @@ class AcpAgentConfig:
     send_model_in_session_new: bool = False
     omnigent_mcp: bool = True
     env_passthrough: tuple[str, ...] = ()
+    permission_mode: str | None = None
 
 
 class _AcpRequestError(Exception):
@@ -831,6 +840,21 @@ class AcpExecutor(Executor):
             args = cached if isinstance(cached, dict) else {}
         return str(name), args
 
+    # Permission modes that skip the human approval card. ``bypassPermissions``
+    # matches the claude-sdk / claude-native / antigravity semantics;
+    # ``auto`` matches cursor's (its default exists precisely so headless /
+    # Polly workers don't stall on a card nobody answers). Policy DENY still
+    # applies ahead of the skip in _decide_permission (#5052).
+    _ELICITATION_SKIP_MODES = frozenset({"bypassPermissions", "auto"})
+
+    def _elicitation_skipped(self) -> bool:
+        """Whether the configured permission mode skips the human approval card.
+
+        :returns: ``True`` only for the opt-in modes; unset / other values keep
+            today's always-ask behavior.
+        """
+        return (self._config.permission_mode or "") in self._ELICITATION_SKIP_MODES
+
     async def _decide_permission(self, params: _AcpJsonObject) -> bool:
         """Decide allow/deny for a permission request — policy then elicitation.
 
@@ -863,6 +887,11 @@ class AcpExecutor(Executor):
                 logger.info("acp permission denied by policy: tool=%s", tool_name)
                 return False
             if action == "POLICY_ACTION_ASK":
+                if self._elicitation_skipped():
+                    logger.info(
+                        "acp permission auto-allowed (permission mode): tool=%s", tool_name
+                    )
+                    return True
                 if handler is None:
                     logger.warning(
                         "acp TOOL_CALL policy ASK with no elicitation handler; denying tool=%s",
@@ -877,6 +906,10 @@ class AcpExecutor(Executor):
                 )
                 return allowed
             # ALLOW / UNSPECIFIED / unknown → fall through to elicitation.
+
+        if self._elicitation_skipped():
+            logger.info("acp permission auto-allowed (permission mode): tool=%s", tool_name)
+            return True
 
         if handler is not None:
             allowed = bool(await handler(tool_name, tool_input))

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -57,6 +57,7 @@ _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
+_ENV_PERMISSION_MODE = "HARNESS_ACP_PERMISSION_MODE"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -136,6 +137,7 @@ def _build_acp_executor() -> Executor:
         send_model_in_session_new=send_model,
         omnigent_mcp=omnigent_mcp,
         env_passthrough=_env_passthrough_names(),
+        permission_mode=os.environ.get(_ENV_PERMISSION_MODE, "").strip() or None,
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1549,6 +1549,10 @@ def _build_acp_cli_spawn_env(
         "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
         "HARNESS_ACP_NAME": row.label,
     }
+    # Permission mode: see _build_acp_spawn_env (#5052).
+    permission_mode = spec.executor.config.get("permission_mode")
+    if permission_mode is not None:
+        env["HARNESS_ACP_PERMISSION_MODE"] = str(permission_mode)
     # Session workspace (selected working folder). ``None`` lets the wrap fall
     # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
     if cwd is not None:
@@ -1661,6 +1665,13 @@ def _build_acp_spawn_env(
     # else: no agent configured — leave HARNESS_ACP_COMMAND unset so the wrap
     # raises a clear request-time error pointing the user at `omnigent setup`.
 
+    # Permission mode: the same ``executor.config.permission_mode`` knob the
+    # other harness families read. ``bypassPermissions`` / ``auto`` skip the
+    # per-tool human approval card in the executor (TOOL_CALL policy still
+    # applies); unset keeps today's always-ask behavior (#5052).
+    permission_mode = spec.executor.config.get("permission_mode") if isinstance(cfg, dict) else None
+    if permission_mode is not None:
+        env["HARNESS_ACP_PERMISSION_MODE"] = str(permission_mode)
     # Session workspace (selected working folder). ``None`` lets the acp
     # harness fall back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
     if cwd is not None:

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -398,6 +398,51 @@ async def test_decide_permission_ask_without_handler_fails_closed() -> None:
     ex._policy_evaluator = AsyncMock(return_value=_V())
     assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
 
+@pytest.mark.asyncio
+async def test_decide_permission_bypass_mode_skips_elicitation_not_policy() -> None:
+    """bypassPermissions skips the human card but never the TOOL_CALL policy.
+
+    A headless ACP agent (polled sub-agent, scheduled task, ``omni run -p``)
+    parks forever on an elicitation nobody answers; the permission mode is the
+    same opt-out the other harness families offer. A policy DENY must still
+    block — the mode removes the human prompt, not governance (#5052).
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", permission_mode="bypassPermissions"))
+
+    class _Ask:
+        action = "POLICY_ACTION_ASK"
+
+    class _Deny:
+        action = "POLICY_ACTION_DENY"
+
+    ex._policy_evaluator = AsyncMock(return_value=_Ask())
+    ex._elicitation_handler = AsyncMock(return_value=False)
+    # Policy ASK + no-gates default both allow WITHOUT consulting the card…
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    ex._elicitation_handler.assert_not_awaited()
+    # …while a hard DENY still denies.
+    ex._policy_evaluator = AsyncMock(return_value=_Deny())
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_auto_mode_matches_bypass() -> None:
+    """``auto`` (cursor semantics — its default exists for headless workers)
+    skips the card exactly like bypassPermissions."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", permission_mode="auto"))
+    ex._elicitation_handler = AsyncMock(return_value=False)
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is True
+    ex._elicitation_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_decide_permission_unknown_mode_still_asks() -> None:
+    """Any other value (and unset) keeps today's always-ask behavior."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", permission_mode="default"))
+    ex._elicitation_handler = AsyncMock(return_value=False)
+    assert await ex._decide_permission({"toolCall": {"title": "shell"}}) is False
+    ex._elicitation_handler.assert_awaited_once()
+
 
 def _seed_tool_call(ex: AcpExecutor) -> dict[str, object]:
     """Announce a ``tool_call``, then return the bare permission params for it.

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -50,10 +50,13 @@ def _make_spec(
     harness: str,
     model: str | None = None,
     acp_agent: object = _MISSING,
+    permission_mode: str | None = None,
 ) -> AgentSpec:
     config: dict[str, object] = {"harness": harness}
     if model is not None:
         config["model"] = model
+    if permission_mode is not None:
+        config["permission_mode"] = permission_mode
     if acp_agent is not _MISSING:
         config["acp_agent"] = acp_agent
     return AgentSpec(
@@ -315,3 +318,24 @@ def test_embedded_agent_round_trip_preserves_all_fields(
     # env_passthrough preservation
     if "expected_env_passthrough" in agent_fields:
         assert env["HARNESS_ACP_ENV_PASSTHROUGH"] == agent_fields["expected_env_passthrough"]
+
+
+def test_permission_mode_forwarded(_isolate_config: Path) -> None:
+    """executor.config.permission_mode rides the spawn env to the wrap (#5052)."""
+    _write_acp_config(_isolate_config)
+    env = _build_acp_spawn_env(_make_spec(harness="acp:goose", permission_mode="bypassPermissions"))
+    assert env["HARNESS_ACP_PERMISSION_MODE"] == "bypassPermissions"
+    # Unset keeps today's behavior: no var, the wrap defaults to always-ask.
+    env = _build_acp_spawn_env(_make_spec(harness="acp:goose"))
+    assert "HARNESS_ACP_PERMISSION_MODE" not in env
+
+
+def test_permission_mode_forwarded_for_cli_rows(_isolate_config: Path) -> None:
+    """Builtin ACP CLI rows (devin etc.) forward the same knob via the cli builder."""
+    from omnigent.runtime.workflow import _build_acp_cli_spawn_env
+
+    _write_acp_config(_isolate_config)
+    env = _build_acp_cli_spawn_env(
+        _make_spec(harness="devin", permission_mode="auto"), harness="devin"
+    )
+    assert env["HARNESS_ACP_PERMISSION_MODE"] == "auto"


### PR DESCRIPTION
Fixes #5052.

## What this does

Generic ACP was the only harness family with no permission-mode opt-out of the per-tool approval card:

| harness | env var | skips the card when |
|---|---|---|
| claude-sdk | `HARNESS_CLAUDE_SDK_PERMISSION_MODE` | `bypassPermissions` |
| cursor | `HARNESS_CURSOR_PERMISSION_MODE` | `auto` / `bypassPermissions` |
| claude-native | hook payload | `!= "bypassPermissions"` gates |
| antigravity-native | argv | `bypassPermissions` |
| **generic ACP** | **—** | **never** |

This PR threads the same `executor.config.permission_mode` knob through all three layers, mirroring the existing families exactly:

- **`_build_acp_spawn_env` / `_build_acp_cli_spawn_env`** (workflow) forward the value as `HARNESS_ACP_PERMISSION_MODE`, parallel to `HARNESS_CLAUDE_SDK_PERMISSION_MODE` / `HARNESS_CURSOR_PERMISSION_MODE`. Unset emits nothing — the wrap's default is today's always-ask.
- **`acp_harness`** reads the var into a new `AcpAgentConfig.permission_mode`.
- **`AcpExecutor._decide_permission`** skips the human card — in **both** the policy-`ASK` arm and the fall-through elicitation arm — when the mode is `bypassPermissions` **or** `auto`. I included `auto` because cursor treats it as the headless-safe default ("so headless / Polly Cursor SDK workers don't stall"), and the polly bundle in this repo's own examples sets `permission_mode: auto` — honoring only `bypassPermissions` would leave the Devin sub-agent from the issue's repro still parked. Every other value keeps today's behavior.

## The mode removes the human prompt, not governance

The TOOL_CALL policy gate still runs first, and a hard `POLICY_ACTION_DENY` **still blocks** under `bypassPermissions` — the same layering the issue's corrected analysis describes for claude-sdk (policy gate → then `_can_use_tool_gate` unless the mode says skip). So an org policy that denies a tool cannot be opted out of by an agent's permission mode; only the human-in-the-loop card is skippable. The no-handler fail-closed arm also remains for non-opt-out modes.

(Per the issue's own confirmation: honoring an *explicit* rule-matched ALLOW is not implementable today — the engine returns `ALLOW` with `reason=None` and no `deciding_policies` for both rule-matched and no-match — which is why this is a permission mode rather than an ALLOW short-circuit.)

## Tests

- `test_decide_permission_bypass_mode_skips_elicitation_not_policy` — policy `ASK` allows without consulting the handler, the no-gates path allows without a handler, and a hard `DENY` still denies.
- `test_decide_permission_auto_mode_matches_bypass` — `auto` behaves identically.
- `test_decide_permission_unknown_mode_still_asks` — `default` (any non-opt-out value) still elicits.
- `test_permission_mode_forwarded` / `..._for_cli_rows` — both spawn-env builders emit `HARNESS_ACP_PERMISSION_MODE` when set and omit it when unset.

All five fail on unpatched `main` (the config field and env var don't exist) and pass with the change; full `test_acp_executor.py` + `test_acp_spawn_env.py`: 94/94.

## Usage

```yaml
executor:
  harness: devin            # or any acp:<slug> / embedded acp_agent
  config:
    permission_mode: bypassPermissions   # or auto
```
