### PR TITLE
fix(codex-native): size the context meter against the effective window

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6278,7 +6278,6 @@ def _session_usage_data_from_params(params: _JsonObject) -> dict[str, int] | Non
     if not isinstance(total, dict):
         return None
     cumulative_input_tokens = total.get("inputTokens")
-    context_window = total.get("contextWindow")
     output_tokens = total.get("outputTokens")
     cached_input_tokens = total.get("cachedInputTokens")
     data: dict[str, int] = {}
@@ -6312,6 +6311,16 @@ def _session_usage_data_from_params(params: _JsonObject) -> dict[str, int] | Non
         data["context_tokens"] = cumulative_input_tokens
     if isinstance(output_tokens, int) and output_tokens >= 0:
         data["cumulative_output_tokens"] = output_tokens
+    # Codex 0.147+ reports the EFFECTIVE window (model context window minus
+    # agent reserves) as ``tokenUsage.modelContextWindow``; the legacy nested
+    # ``total.contextWindow`` carried the raw catalog window. Prefer the
+    # effective field — sizing the meter against the catalog window
+    # under-reports usage badly on reserved-window models (observed 20% in
+    # the web UI vs 79% in the Codex terminal for the same session, #5025) —
+    # and keep the legacy nested field as the fallback for older CLIs.
+    context_window = token_usage.get("modelContextWindow")
+    if not isinstance(context_window, int) or context_window <= 0:
+        context_window = total.get("contextWindow")
     if isinstance(context_window, int) and context_window > 0:
         data["context_window"] = context_window
     if not data:

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -8372,6 +8372,58 @@ def test_session_usage_data_extracts_cumulative_tokens() -> None:
     assert "cumulative_cache_read_input_tokens" not in data
 
 
+def test_session_usage_data_prefers_effective_context_window() -> None:
+    """
+    ``tokenUsage.modelContextWindow`` (Codex 0.147+) wins over the legacy
+    nested ``total.contextWindow`` for the context ring.
+
+    The effective window is the catalog window minus agent reserves; sizing
+    the meter against the catalog window under-reports usage badly on
+    reserved-window models (observed 20% web UI vs 79% Codex terminal for the
+    same session, #5025).
+    """
+    params = {
+        "threadId": "thread_123",
+        "tokenUsage": {
+            "total": {
+                "inputTokens": 206_533,
+                "outputTokens": 250,
+                "contextWindow": 1_050_000,
+            },
+            "last": {"inputTokens": 206_533, "outputTokens": 10, "contextWindow": 1_050_000},
+            "modelContextWindow": 258_400,
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_window"] == 258_400
+    assert data["context_tokens"] == 206_533
+
+    # Legacy-only frame (older CLI): the nested field still works.
+    legacy = {
+        "threadId": "thread_123",
+        "tokenUsage": {
+            "total": {"inputTokens": 1000, "outputTokens": 5, "contextWindow": 200_000},
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(legacy)
+    assert data is not None
+    assert data["context_window"] == 200_000
+
+    # A null/unusable modelContextWindow falls back rather than dropping the
+    # window entirely (0.147 marks the field optional in its protocol).
+    null_window = {
+        "threadId": "thread_123",
+        "tokenUsage": {
+            "total": {"inputTokens": 1000, "outputTokens": 5, "contextWindow": 200_000},
+            "modelContextWindow": None,
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(null_window)
+    assert data is not None
+    assert data["context_window"] == 200_000
+
+
 def test_session_usage_data_forwards_cached_input_tokens() -> None:
     """
     ``cachedInputTokens`` is forwarded as ``cumulative_cache_read_input_tokens``


### PR DESCRIPTION
Fixes #5025.

## Root cause

Codex 0.147 moved the effective context window to a new field. Verified against `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`:

```rust
pub struct ThreadTokenUsage {
    pub total: TokenUsageBreakdown,
    pub last: TokenUsageBreakdown,
    // TODO(aibrahim): make this not optional
    pub model_context_window: Option<i64>,   // → tokenUsage.modelContextWindow
}
```

The forwarder's `_session_usage_data_from_params` read only the legacy nested `total.contextWindow` (the raw catalog window). On reserved-window models like `gpt-5.6-sol`, Codex reserves a large slice for itself, so:

- the new field carries the effective window (258,400 in the repro),
- the legacy nested value / catalog fallback carries ~4× that (1,050,000),
- the meter divides occupancy by the wrong denominator → **20% shown vs 79% actual**.

## Fix

`_session_usage_data_from_params` prefers `tokenUsage.modelContextWindow` for `context_window` and keeps `total.contextWindow` as the fallback:

```python
context_window = token_usage.get("modelContextWindow")
if not isinstance(context_window, int) or context_window <= 0:
    context_window = total.get("contextWindow")
```

Both older-CLI frames (legacy field only) and 0.147 frames with a `null` effective window (the field is explicitly optional upstream) fall back to today's behavior — nothing regresses where the new field is absent.

## Tests

`test_session_usage_data_prefers_effective_context_window` — the issue's exact numbers (206,533 tokens against 258,400 effective vs 1,050,000 catalog) assert the effective window wins; legacy-only and `null`-window frames assert the fallback still works. **Fails on `main`** (prefers the catalog window); with the fix, all 7 usage-extraction tests and the full `test_codex_native.py` + `test_codex_native_forwarder.py` suites pass (303/303).
