### PR TITLE
fix(openai-agents): preserve reasoning item IDs across replay by default

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -1525,11 +1525,32 @@ class OpenAIAgentsSDKExecutor(Executor):
             max_tokens=max_tokens,
         )
         current_item_count = len(await state.sdk_session.get_items())
+        # Reasoning item IDs must survive replay by default: newer OpenAI
+        # reasoning models link each function call (``fc_...``) to its
+        # preceding reasoning item (``rs_...``), and the API rejects a replayed
+        # function call whose linked reasoning item arrived ID-less —
+        # "Item 'fc_...' was provided without its required 'reasoning' item"
+        # (#5066). ``omit`` remains selectable per agent for OpenAI-compatible
+        # gateways whose legacy workaround was to strip the IDs.
+        reasoning_item_id_policy_raw = cfg.extra.get("reasoning_item_id_policy")
+        if reasoning_item_id_policy_raw is None:
+            reasoning_item_id_policy = "preserve"
+        elif reasoning_item_id_policy_raw in ("preserve", "omit"):
+            reasoning_item_id_policy = reasoning_item_id_policy_raw
+        else:
+            yield ExecutorError(
+                message=(
+                    "reasoning_item_id_policy must be 'preserve' or 'omit', "
+                    f"got {reasoning_item_id_policy_raw!r}"
+                ),
+                retryable=False,
+            )
+            return
         run_config = agents_sdk.RunConfig(
             model=model,
             model_provider=provider,
             tracing_disabled=True,
-            reasoning_item_id_policy="omit",
+            reasoning_item_id_policy=reasoning_item_id_policy,
             call_model_input_filter=self._filter_model_input,
         )
         max_turns = 1 if stepwise_internal_turns else int(cfg.extra.get("max_turns", 1000))

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -603,6 +603,82 @@ class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
 
         _run(_t())
 
+    def test_reasoning_item_ids_preserved_by_default(self):
+        """Unset policy keeps reasoning item IDs so linked fc/rs items replay.
+
+        Newer OpenAI reasoning models require a replayed function call's
+        linked reasoning item to carry its ID; forcing ``omit`` stripped the
+        reasoning ID while keeping the function-call ID, and the next turn
+        400'd (#5066).
+        """
+
+        async def _t():
+            _FakeRunner.last_calls = []
+            _FakeRunner.next_result = _FakeResult(events=[], final_output="done")
+            executor = OpenAIAgentsSDKExecutor(client=object())
+            with patch(
+                "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+                return_value=_fake_agents_sdk(),
+            ):
+                events = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hi", "session_id": "s1"}],
+                        [],
+                        "Be helpful.",
+                        ExecutorConfig(model="gpt-5.3-codex"),
+                    )
+                ]
+
+            self.assertEqual(events[-1].response, "done")
+            self.assertEqual(
+                _FakeRunner.last_calls[0]["run_config"].kwargs["reasoning_item_id_policy"],
+                "preserve",
+            )
+
+        _run(_t())
+
+    def test_reasoning_item_id_policy_omit_selectable_and_invalid_rejected(self):
+        """``omit`` remains selectable per agent; anything else fails loud."""
+
+        async def _t():
+            _FakeRunner.last_calls = []
+            _FakeRunner.next_result = _FakeResult(events=[], final_output="done")
+            executor = OpenAIAgentsSDKExecutor(client=object())
+            with patch(
+                "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+                return_value=_fake_agents_sdk(),
+            ):
+                events = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hi", "session_id": "s1"}],
+                        [],
+                        "Be helpful.",
+                        ExecutorConfig(model="gpt-5.3-codex", extra={"reasoning_item_id_policy": "omit"}),
+                    )
+                ]
+                self.assertEqual(events[-1].response, "done")
+                self.assertEqual(
+                    _FakeRunner.last_calls[0]["run_config"].kwargs["reasoning_item_id_policy"],
+                    "omit",
+                )
+
+                bad = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hi", "session_id": "s1"}],
+                        [],
+                        "Be helpful.",
+                        ExecutorConfig(model="gpt-5.3-codex", extra={"reasoning_item_id_policy": "strip"}),
+                    )
+                ]
+                self.assertIsInstance(bad[-1], ExecutorError)
+                self.assertFalse(bad[-1].retryable)
+                self.assertIn("reasoning_item_id_policy", bad[-1].message)
+
+        _run(_t())
+
     def test_parallel_tool_calls_can_be_overridden(self):
         async def _t():
             _FakeRunner.last_calls = []


### PR DESCRIPTION
Fixes #5066.

## Root cause

The OpenAI Agents SDK executor hardcoded `reasoning_item_id_policy="omit"` in its `RunConfig`. Per the SDK's own semantics (`openai-agents` `run_config.py`):

> - ``None`` / ``"preserve"`` keeps reasoning item IDs as-is.
> - ``"omit"`` strips reasoning item IDs from model input built by the runner.

Stripping the ID while the linked function call's `fc_...` ID survives means that on newer OpenAI reasoning models — which link every function call to its preceding reasoning item — the next turn's replay is rejected:

```
Error code: 400 - ... Item 'fc_XXXXXXX' of type 'function_call' was provided
without its required 'reasoning' item: 'rs_YYYYYY'.
```

i.e. every tool-calling turn on those models bricks the session's next turn.

## Fix

- Default flips to `"preserve"` (the SDK's own default when the policy is unset).
- `"omit"` remains explicitly selectable per agent via `executor.config.reasoning_item_id_policy` — the legacy workaround for OpenAI-compatible gateways that choke on reasoning IDs.
- Any other value fails loud as a non-retryable `ExecutorError` (`reasoning_item_id_policy must be 'preserve' or 'omit', got ...`), mirroring the reasoning-effort validation immediately above it.

## Tests

- `test_reasoning_item_ids_preserved_by_default` — with no config, the `RunConfig` handed to the SDK carries `"preserve"`. **Fails on `main`** (carries `"omit"`).
- `test_reasoning_item_id_policy_omit_selectable_and_invalid_rejected` — `"omit"` is forwarded as-is; `"strip"` yields a non-retryable `ExecutorError` naming the field. **Both halves fail on `main`** (invalid values were silently forwarded to the SDK).

Full executor suite: 64 passed / 14 pre-existing environment failures with the fix vs 62 / 14 on clean `main` in the same environment — the +2 are the new tests; the 14 are identical (databricks-sdk presence and related environment gaps), zero regressions.
