### PR TITLE
feat(sandbox): add the CoDA provider foundation

### DIFF
--- a/omnigent/onboarding/sandboxes/coda.py
+++ b/omnigent/onboarding/sandboxes/coda.py
@@ -1,0 +1,239 @@
+"""Managed-host launcher for a pre-provisioned CoDA Databricks App."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable, Mapping
+from http.client import HTTPMessage
+from typing import IO, ClassVar
+from urllib import error, request
+from urllib.parse import urlsplit
+
+import click
+
+from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+
+CODA_WORKSPACE_PATH = "/app/python/source_code"
+_CODA_APPS_HOST_SUFFIX = ".databricksapps.com"
+_CONTROL_ERROR_MAX_BYTES = 8192
+
+
+class _NoRedirectHandler(request.HTTPRedirectHandler):
+    """Turn upstream redirects into errors instead of following them."""
+
+    def redirect_request(
+        self,
+        req: request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> request.Request | None:
+        del newurl
+        raise error.HTTPError(req.full_url, code, "redirects disabled", headers, fp)
+
+
+_NO_REDIRECT_OPENER = request.build_opener(_NoRedirectHandler)
+
+
+def validate_coda_app_url(app_url: str) -> str:
+    """Validate and return a trusted CoDA Databricks Apps URL."""
+    if not isinstance(app_url, str) or not app_url.strip():
+        raise ValueError("CoDA app_url must be a non-empty HTTPS Databricks Apps URL")
+    candidate = app_url.strip()
+    try:
+        parsed = urlsplit(candidate)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"CoDA app_url is malformed: {exc}") from exc
+    if parsed.scheme != "https" or hostname is None:
+        raise ValueError("CoDA app_url must use HTTPS and include a hostname")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("CoDA app_url must not contain userinfo")
+    if ":" in parsed.netloc.rsplit("@", 1)[-1]:
+        raise ValueError("CoDA app_url must not contain an explicit port")
+    if parsed.query or parsed.fragment:
+        raise ValueError("CoDA app_url must not contain a query or fragment")
+    if parsed.path not in ("", "/"):
+        raise ValueError("CoDA app_url may contain only an empty or root path")
+    hostname = hostname.lower()
+    prefix = hostname[: -len(_CODA_APPS_HOST_SUFFIX)]
+    if not hostname.endswith(_CODA_APPS_HOST_SUFFIX) or not prefix:
+        raise ValueError("CoDA app_url hostname must have a subdomain under .databricksapps.com")
+    if any(not label for label in prefix.split(".")):
+        raise ValueError("CoDA app_url hostname contains an empty subdomain label")
+    return candidate
+
+
+def _safe_control_error_detail(_raw: object) -> str:
+    """Return a fixed error without exposing any upstream response body."""
+    return "upstream control request failed"
+
+
+def _parse_sandbox_id(sandbox_id: str) -> tuple[str, str]:
+    """Return the app and lease identifiers from a CoDA sandbox id."""
+    if not sandbox_id.startswith("coda:") or "#" not in sandbox_id:
+        raise click.ClickException(f"invalid CoDA sandbox id: {sandbox_id!r}")
+    app_name, lease_id = sandbox_id[5:].rsplit("#", 1)
+    if not app_name or not lease_id:
+        raise click.ClickException(f"invalid CoDA sandbox id: {sandbox_id!r}")
+    return app_name, lease_id
+
+
+class CodaProvider(SandboxHostLauncher):
+    """Lease and control one already-running CoDA Databricks App over HTTP."""
+
+    provider: ClassVar[str] = "coda"
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=False,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+        )
+
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        app_url: str,
+        workspace_path: str = CODA_WORKSPACE_PATH,
+        request_fn: Callable[[str, str, Mapping[str, object] | None], Mapping[str, object]]
+        | None = None,
+        app_getter: Callable[[str], object] | None = None,
+    ) -> None:
+        self._app_name = app_name
+        self._app_url = validate_coda_app_url(app_url).rstrip("/")
+        self._workspace_path = workspace_path
+        self._request_fn = request_fn or self._request
+        self._app_getter = app_getter or self._get_app
+
+    @staticmethod
+    def _get_app(app_name: str) -> object:
+        """Resolve the configured App lazily so the SDK stays optional."""
+        from databricks.sdk import WorkspaceClient
+
+        return WorkspaceClient().apps.get(app_name)
+
+    def _request(
+        self, method: str, path: str, body: Mapping[str, object] | None
+    ) -> Mapping[str, object]:
+        """Make an authenticated control request without exposing raw bodies."""
+        from databricks.sdk.core import Config
+
+        headers = dict(Config().authenticate())
+        data = json.dumps(body).encode() if body is not None else None
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        req = request.Request(f"{self._app_url}{path}", data=data, headers=headers, method=method)
+        try:
+            with _NO_REDIRECT_OPENER.open(req, timeout=30) as response:
+                payload = response.read()
+        except error.HTTPError as exc:
+            raw_detail = exc.read(_CONTROL_ERROR_MAX_BYTES).decode(errors="replace")
+            if exc.code == 409:
+                raise click.ClickException("CoDA app has no available lease capacity") from exc
+            detail = _safe_control_error_detail(raw_detail)
+            raise click.ClickException(
+                f"CoDA control request failed ({exc.code}): {detail}"
+            ) from exc
+        except error.URLError:
+            raise click.ClickException(
+                "CoDA control request failed: upstream unavailable"
+            ) from None
+        try:
+            decoded = json.loads(payload or b"{}")
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            raise click.ClickException("CoDA control response was not valid JSON") from None
+        if not isinstance(decoded, dict):
+            raise click.ClickException("CoDA control response must be a JSON object")
+        return decoded
+
+    def prepare(self) -> None:
+        """Validate App readiness and control-plane authentication without mutation."""
+        app = self._app_getter(self._app_name)
+        compute = getattr(getattr(app, "compute_status", None), "state", None)
+        if str(compute).upper().split(".")[-1] != "ACTIVE":
+            raise click.ClickException(f"CoDA app {self._app_name!r} compute is not ACTIVE")
+        status = self._request_fn("GET", "/api/omnigent-host/status", None)
+        if status.get("ready") is not True:
+            raise click.ClickException(f"CoDA app {self._app_name!r} is not ready")
+
+    def provision(self, name: str) -> str:
+        """Acquire a fenced CoDA lease without creating infrastructure."""
+        lease_id = uuid.uuid4().hex
+        self._request_fn(
+            "POST",
+            "/api/omnigent-host/lease",
+            {
+                "action": "acquire",
+                "app_name": self._app_name,
+                "host_name": name,
+                "lease_id": lease_id,
+            },
+        )
+        return f"coda:{self._app_name}#{lease_id}"
+
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repo_url: str | None = None,
+        repo_branch: str | None = None,
+        repo_name: str | None = None,
+        host_config: dict[str, object] | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """Ask CoDA to start its managed host and return its workspace."""
+        app_name, lease_id = _parse_sandbox_id(sandbox_id)
+        if app_name != self._app_name:
+            raise click.ClickException("CoDA sandbox id targets a different app")
+        if on_stage is not None:
+            on_stage("cloning")
+            on_stage("starting")
+        result = self._request_fn(
+            "POST",
+            "/api/omnigent-host/connect",
+            {
+                "server_url": server_url,
+                "host_token": token,
+                "host_id": host_id,
+                "host_name": host_name,
+                "host_config": host_config,
+                "repo_url": repo_url,
+                "repo_branch": repo_branch,
+                "repo_name": repo_name,
+                "lease_id": lease_id,
+            },
+        )
+        workspace = result.get("workspace") or self._workspace_path
+        if not isinstance(workspace, str) or not workspace.startswith("/"):
+            raise click.ClickException(
+                "CoDA connect response did not contain an absolute workspace"
+            )
+        return workspace
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Release and scrub the lease; never mutate the Databricks App."""
+        app_name, lease_id = _parse_sandbox_id(sandbox_id)
+        if app_name != self._app_name:
+            return
+        try:
+            self._request_fn(
+                "POST",
+                "/api/omnigent-host/disconnect",
+                {"lease_id": lease_id, "scrub": True},
+            )
+        except click.ClickException:
+            return

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -172,6 +172,11 @@ def _builtin_contribution() -> SandboxProviderContribution:
                 launcher_class="omnigent.onboarding.sandboxes.kubernetes:KubernetesSandboxLauncher",
                 managed_token_ttl_s=7 * 24 * 3600,
             ),
+            "coda": SandboxProviderMetadata(
+                name="coda",
+                launcher_class="omnigent.onboarding.sandboxes.coda:CodaProvider",
+                managed_token_ttl_s=13 * 3600,
+            ),
         },
     )
 
@@ -313,6 +318,16 @@ def instantiate(
             f"which is not a SandboxHostLauncher subclass"
         )
     if name == "lakebox" and workspace_host is not None:
-        launcher_factory = cast(_WorkspaceHostLauncherFactory, launcher_cls)
-        return launcher_factory(workspace_host=workspace_host)
-    return launcher_cls()
+        try:
+            launcher_factory = cast(_WorkspaceHostLauncherFactory, launcher_cls)
+            return launcher_factory(workspace_host=workspace_host)
+        except Exception as exc:
+            raise SandboxRegistryError(
+                f"could not instantiate sandbox provider '{name}': {exc}"
+            ) from exc
+    try:
+        return launcher_cls()
+    except Exception as exc:
+        raise SandboxRegistryError(
+            f"could not instantiate sandbox provider '{name}': {exc}"
+        ) from exc

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -180,6 +180,7 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
         "e2b",
         "openshell",
         "kubernetes",
+        "coda",
     }
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
@@ -193,6 +194,7 @@ PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
         "e2b",
         "openshell",
         "kubernetes",
+        "coda",
     }
 )
 
@@ -253,6 +255,11 @@ OPENSHELL_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # reconnects while still expiring tokens of Pods nobody deleted. A relaunch
 # mints a fresh token (and the per-Pod token Secret is replaced).
 KUBERNETES_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# CoDA leases are held by an already-running App. The token lifetime is
+# slightly longer than the App's bounded lease lifetime so a live host can
+# reconnect while stale credentials still expire.
+CODA_MANAGED_TOKEN_TTL_S = 13 * 3600
 
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
@@ -1184,6 +1191,30 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
             secret_mounts=secret_mounts,
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
+    elif provider == "coda":
+        from omnigent.onboarding.sandboxes.coda import validate_coda_app_url
+
+        coda_section = _parse_provider_section(raw, "coda") or {}
+        _reject_unknown_keys(
+            coda_section, {"app_name", "app_url", "workspace_path"}, "sandbox.coda"
+        )
+        app_name = _parse_provider_string(raw, "coda", "app_name")
+        app_url = _parse_provider_string(raw, "coda", "app_url")
+        if app_name is None or app_url is None:
+            raise ValueError("server config 'sandbox.coda' requires app_name and app_url")
+        try:
+            validate_coda_app_url(app_url)
+        except ValueError as exc:
+            raise ValueError(f"server config 'sandbox.coda.app_url' is invalid: {exc}") from exc
+        workspace_path = _parse_provider_string(raw, "coda", "workspace_path")
+        if workspace_path is not None and not workspace_path.startswith("/"):
+            raise ValueError("server config 'sandbox.coda.workspace_path' must be absolute")
+        launcher_factory = _coda_launcher_factory(
+            app_name=app_name,
+            app_url=app_url,
+            workspace_path=workspace_path,
+        )
+        token_ttl_s = CODA_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -2416,6 +2447,26 @@ def _reject_overlapping_kubernetes_mounts(
                     "server config 'sandbox.kubernetes' has nested pvc_mounts / "
                     f"secret_mounts paths: {low!r} contains {high!r}"
                 )
+
+
+def _coda_launcher_factory(
+    *, app_name: str, app_url: str, workspace_path: str | None
+) -> Callable[[], SandboxHostLauncher]:
+    """Build the launcher factory for the YAML ``provider: coda`` path."""
+
+    def _build() -> SandboxHostLauncher:
+        """Construct the CoDA provider lazily so the SDK stays optional."""
+        from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+        if workspace_path is None:
+            return CodaProvider(app_name=app_name, app_url=app_url)
+        return CodaProvider(
+            app_name=app_name,
+            app_url=app_url,
+            workspace_path=workspace_path,
+        )
+
+    return _build
 
 
 def _kubernetes_launcher_factory(

--- a/tests/onboarding/sandboxes/test_coda.py
+++ b/tests/onboarding/sandboxes/test_coda.py
@@ -1,0 +1,205 @@
+"""Tests for the C1 CoDA managed-host provider foundation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes.coda import (
+    CodaProvider,
+    validate_coda_app_url,
+)
+
+
+class _FakeControl:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, object]] = []
+        self.responses: dict[str, dict[str, object]] = {
+            "/api/omnigent-host/status": {"ready": True},
+            "/api/omnigent-host/lease": {},
+            "/api/omnigent-host/connect": {"workspace": "/app/python/source_code"},
+            "/api/omnigent-host/disconnect": {},
+        }
+
+    def __call__(self, method: str, path: str, body: object) -> dict[str, object]:
+        self.calls.append((method, path, body))
+        return self.responses[path]
+
+
+def _provider(control: _FakeControl) -> CodaProvider:
+    return CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com/",
+        request_fn=control,
+        app_getter=lambda _name: SimpleNamespace(compute_status=SimpleNamespace(state="ACTIVE")),
+    )
+
+
+def test_capabilities_are_managed_only() -> None:
+    capabilities = _provider(_FakeControl()).capabilities
+
+    assert capabilities.cli_bootstrap is False
+    assert capabilities.managed_launch is True
+    assert capabilities.local_port_forward is False
+    assert capabilities.resume_stopped is False
+    assert capabilities.programmatic_terminate is True
+
+
+@pytest.mark.parametrize(
+    "app_url",
+    [
+        "plain text",
+        "http://synthetic-coda.aws.databricksapps.com",
+        "https://synthetic-coda.aws.notdatabricksapps.com",
+        "https://synthetic-coda.aws.databricksapps.com.attacker.test",
+        "https://user:password@synthetic-coda.aws.databricksapps.com",
+        "https://synthetic-coda.aws.databricksapps.com:443",
+        "https://synthetic-coda.aws.databricksapps.com/path",
+        "https://synthetic-coda.aws.databricksapps.com/?query=1",
+        "https://synthetic-coda.aws.databricksapps.com/#fragment",
+        "https://databricksapps.com",
+    ],
+)
+def test_coda_app_url_requires_trusted_https_shape(app_url: str) -> None:
+    with pytest.raises(ValueError, match="CoDA app_url"):
+        validate_coda_app_url(app_url)
+    with pytest.raises(ValueError, match="CoDA app_url"):
+        CodaProvider(app_name="synthetic-coda", app_url=app_url)
+
+
+def test_prepare_checks_compute_then_control_plane_without_mutation() -> None:
+    control = _FakeControl()
+
+    _provider(control).prepare()
+
+    assert control.calls == [("GET", "/api/omnigent-host/status", None)]
+
+
+@pytest.mark.parametrize("ready", [None, False, "true", 1])
+def test_prepare_requires_boolean_ready_true(ready: object) -> None:
+    control = _FakeControl()
+    control.responses["/api/omnigent-host/status"] = {"ready": ready}
+
+    with pytest.raises(click.ClickException, match="not ready"):
+        _provider(control).prepare()
+
+
+def test_prepare_rejects_non_active_app_without_control_request() -> None:
+    control = _FakeControl()
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+        request_fn=control,
+        app_getter=lambda _name: SimpleNamespace(compute_status=SimpleNamespace(state="STOPPED")),
+    )
+
+    with pytest.raises(click.ClickException, match="not ACTIVE"):
+        provider.prepare()
+    assert control.calls == []
+
+
+def test_provision_acquires_fenced_lease() -> None:
+    control = _FakeControl()
+    sandbox_id = _provider(control).provision("managed-synthetic")
+
+    method, path, body = control.calls[-1]
+    assert (method, path) == ("POST", "/api/omnigent-host/lease")
+    assert sandbox_id.startswith("coda:synthetic-coda#")
+    assert isinstance(body, dict)
+    assert body["action"] == "acquire"
+    assert body["app_name"] == "synthetic-coda"
+    assert body["host_name"] == "managed-synthetic"
+    assert body["lease_id"] == sandbox_id.rsplit("#", 1)[1]
+
+
+def test_start_host_posts_identity_and_returns_absolute_workspace() -> None:
+    control = _FakeControl()
+    provider = _provider(control)
+    sandbox_id = provider.provision("managed-synthetic")
+    stages: list[str] = []
+
+    workspace = provider.start_host(
+        sandbox_id,
+        token="launch-token",
+        host_id="host-synthetic",
+        host_name="managed-synthetic",
+        server_url="https://server.example.test",
+        repo_url="https://git.example.test/repo",
+        repo_branch="main",
+        repo_name="repo",
+        host_config={"providers": {}},
+        on_stage=stages.append,
+    )
+
+    assert workspace == "/app/python/source_code"
+    assert stages == ["cloning", "starting"]
+    _, path, body = control.calls[-1]
+    assert path == "/api/omnigent-host/connect"
+    assert body == {
+        "server_url": "https://server.example.test",
+        "host_token": "launch-token",
+        "host_id": "host-synthetic",
+        "host_name": "managed-synthetic",
+        "host_config": {"providers": {}},
+        "repo_url": "https://git.example.test/repo",
+        "repo_branch": "main",
+        "repo_name": "repo",
+        "lease_id": sandbox_id.rsplit("#", 1)[1],
+    }
+
+
+def test_start_host_rejects_mismatched_and_relative_workspace() -> None:
+    control = _FakeControl()
+    provider = _provider(control)
+
+    with pytest.raises(click.ClickException, match="different app"):
+        provider.start_host(
+            "coda:other-app#lease",
+            token="token",
+            host_id="host",
+            host_name="host",
+            server_url="https://server.example.test",
+        )
+
+    control.responses["/api/omnigent-host/connect"] = {"workspace": "relative"}
+    with pytest.raises(click.ClickException, match="absolute workspace"):
+        provider.start_host(
+            "coda:synthetic-coda#lease",
+            token="token",
+            host_id="host",
+            host_name="host",
+            server_url="https://server.example.test",
+        )
+
+
+def test_terminate_disconnects_and_never_manages_app_lifecycle() -> None:
+    control = _FakeControl()
+    provider = _provider(control)
+
+    provider.terminate("coda:synthetic-coda#lease")
+
+    assert control.calls == [
+        (
+            "POST",
+            "/api/omnigent-host/disconnect",
+            {"lease_id": "lease", "scrub": True},
+        )
+    ]
+
+
+def test_terminate_is_best_effort_and_bad_ids_are_rejected() -> None:
+    def fail(_method: str, _path: str, _body: object) -> dict[str, object]:
+        raise click.ClickException("network down")
+
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+        request_fn=fail,
+        app_getter=lambda _name: None,
+    )
+    provider.terminate("coda:synthetic-coda#lease")
+
+    with pytest.raises(click.ClickException, match="invalid CoDA sandbox id"):
+        provider.terminate("not-coda")

--- a/tests/onboarding/sandboxes/test_coda_http.py
+++ b/tests/onboarding/sandboxes/test_coda_http.py
@@ -1,0 +1,155 @@
+"""Tests for CoDA control transport failure handling."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from urllib import error, request
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes.coda import CodaProvider, _NoRedirectHandler
+
+
+def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Config:
+        def authenticate(self) -> dict[str, str]:
+            return {}
+
+    core = ModuleType("databricks.sdk.core")
+    core.Config = _Config  # type: ignore[attr-defined]
+    sdk = ModuleType("databricks.sdk")
+    sdk.core = core  # type: ignore[attr-defined]
+    databricks = ModuleType("databricks")
+    databricks.sdk = sdk  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "databricks", databricks)
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk)
+    monkeypatch.setitem(sys.modules, "databricks.sdk.core", core)
+
+
+def test_http_control_errors_use_fixed_classifications(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        def read(self, _size: int = -1) -> bytes:
+            return b'{"error":"' + b"x" * 2000 + b'","field":"value"}'
+
+        def close(self) -> None:
+            pass
+
+    def _open(*args: object, **kwargs: object) -> _Response:
+        raise error.HTTPError(
+            "https://synthetic-coda.aws.databricksapps.com/api/omnigent-host/lease",
+            500,
+            "failure",
+            {},
+            _Response(),
+        )
+
+    _install_fake_sdk(monkeypatch)
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.coda._NO_REDIRECT_OPENER.open", _open)
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+    )
+
+    with pytest.raises(click.ClickException, match="upstream control request failed") as exc_info:
+        provider._request("POST", "/api/omnigent-host/lease", {})
+    assert "value" not in str(exc_info.value)
+
+
+def test_http_409_keeps_capacity_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        def read(self, _size: int = -1) -> bytes:
+            return b'{"error":"' + b"x" * 2000 + b'","field":"value"}'
+
+        def close(self) -> None:
+            pass
+
+    def _open(*args: object, **kwargs: object) -> _Response:
+        raise error.HTTPError(
+            "https://synthetic-coda.aws.databricksapps.com/api/omnigent-host/lease",
+            409,
+            "conflict",
+            {},
+            _Response(),
+        )
+
+    _install_fake_sdk(monkeypatch)
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.coda._NO_REDIRECT_OPENER.open", _open)
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+    )
+
+    with pytest.raises(click.ClickException, match="no available lease capacity") as exc_info:
+        provider._request("POST", "/api/omnigent-host/lease", {})
+    assert "value" not in str(exc_info.value)
+
+
+def test_control_request_does_not_follow_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        def read(self, _size: int = -1) -> bytes:
+            return b"{}"
+
+        def close(self) -> None:
+            pass
+
+    _install_fake_sdk(monkeypatch)
+    calls: list[str] = []
+
+    def _open(req: object, *, timeout: int) -> _Response:
+        calls.append(req.full_url)
+        raise error.HTTPError(
+            calls[-1],
+            302,
+            "redirect",
+            {"Location": "https://attacker.example/collect"},
+            _Response(),
+        )
+
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.coda._NO_REDIRECT_OPENER.open", _open)
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+    )
+
+    with pytest.raises(click.ClickException, match="302"):
+        provider._request("GET", "/api/omnigent-host/status", None)
+    assert calls == ["https://synthetic-coda.aws.databricksapps.com/api/omnigent-host/status"]
+
+    with pytest.raises(error.HTTPError):
+        _NoRedirectHandler().redirect_request(
+            request.Request("https://synthetic-coda.aws.databricksapps.com"),
+            _Response(),
+            302,
+            "redirect",
+            {"Location": "https://attacker.example"},
+            "https://attacker.example",
+        )
+
+
+def test_invalid_utf8_success_response_becomes_click_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def read(self, _size: int = -1) -> bytes:
+            return b"\xff"
+
+    _install_fake_sdk(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.sandboxes.coda._NO_REDIRECT_OPENER.open",
+        lambda _req, timeout: _Response(),
+    )
+    provider = CodaProvider(
+        app_name="synthetic-coda",
+        app_url="https://synthetic-coda.aws.databricksapps.com",
+    )
+
+    with pytest.raises(click.ClickException, match="valid JSON"):
+        provider._request("GET", "/api/omnigent-host/status", None)

--- a/tests/onboarding/sandboxes/test_coda_redaction.py
+++ b/tests/onboarding/sandboxes/test_coda_redaction.py
@@ -1,0 +1,52 @@
+"""Tests for fixed CoDA upstream-error classification."""
+
+from __future__ import annotations
+
+import json
+
+from omnigent.onboarding.sandboxes.coda import _safe_control_error_detail
+
+
+def test_safe_control_error_detail_never_exposes_sensitive_json() -> None:
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature"
+    sensitive_values = (
+        "header.payload.signature",
+        "launch-secret",
+        "api-secret",
+        "private-secret",
+        "cookie-secret",
+        "client-secret",
+        jwt,
+    )
+    raw = json.dumps(
+        {
+            "error": "upstream rejected",
+            "jwt": sensitive_values[0],
+            "host_token": sensitive_values[1],
+            "x-api-key": sensitive_values[2],
+            "private_key": sensitive_values[3],
+            "cookie": f"session={sensitive_values[4]}",
+            "client_secret": sensitive_values[5],
+            "nested": {"message": f'embedded {{"host_token":"{sensitive_values[1]}"}} {jwt}'},
+        }
+    )
+
+    detail = _safe_control_error_detail(raw)
+
+    assert detail == "upstream control request failed"
+    assert len(detail) <= 1024
+    for value in sensitive_values:
+        assert value not in detail
+
+
+def test_safe_control_error_detail_rejects_invalid_inputs() -> None:
+    for raw in ("not-json", "", b"\xff", None, object()):
+        assert _safe_control_error_detail(raw) == "upstream control request failed"
+
+
+def test_safe_control_error_detail_rejects_deeply_nested_json() -> None:
+    deeply_nested_json = "{}"
+    for _ in range(2000):
+        deeply_nested_json = '{"nested":' + deeply_nested_json + "}"
+
+    assert _safe_control_error_detail(deeply_nested_json) == "upstream control request failed"

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -69,6 +69,7 @@ def test_plugin_state_loads_builtins() -> None:
     assert "modal" in state
     assert "blaxel" in state
     assert "kubernetes" in state
+    assert "coda" in state
 
 
 def test_plugin_state_is_cached() -> None:
@@ -104,6 +105,17 @@ def test_get_provider_metadata_known_provider() -> None:
     assert meta is not None
     assert meta.name == "modal"
     assert "omnigent.onboarding.sandboxes.modal:ModalSandboxLauncher" in meta.launcher_class
+
+
+def test_get_coda_provider_metadata() -> None:
+    """CoDA is registered through the same built-in contribution seam."""
+    reset_plugin_state_for_tests()
+
+    meta = get_provider_metadata("coda")
+
+    assert meta is not None
+    assert meta.launcher_class == "omnigent.onboarding.sandboxes.coda:CodaProvider"
+    assert meta.managed_token_ttl_s == 13 * 3600
 
 
 def test_get_provider_metadata_unknown_returns_none() -> None:
@@ -287,6 +299,16 @@ def test_get_launcher_unknown_raises_click_exception() -> None:
         match="Unknown or unavailable sandbox provider",
     ):
         get_launcher("definitely-not-real")
+
+
+def test_get_launcher_coda_reports_configuration_error() -> None:
+    """Provider-specific constructor failures stay controlled at the registry seam."""
+    reset_plugin_state_for_tests()
+
+    with pytest.raises(
+        click.ClickException, match="could not instantiate sandbox provider 'coda'"
+    ):
+        get_launcher("coda")
 
 
 def test_instantiate_rejects_non_launcher_class(

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -219,6 +219,74 @@ def test_parse_non_modal_provider_yields_rejecting_factory() -> None:
     assert "lakebox" in exc.value.detail
 
 
+def test_parse_valid_coda_config_builds_managed_provider_factory() -> None:
+    """A complete CoDA block is registered as a launch-capable provider."""
+    from omnigent.onboarding.sandboxes.coda import CodaProvider
+
+    deployment = parse_sandbox_config(
+        {
+            "provider": "coda",
+            "server_url": "https://server.example.test/",
+            "coda": {
+                "app_name": "synthetic-coda",
+                "app_url": "https://synthetic-coda.aws.databricksapps.com/",
+            },
+        }
+    )
+
+    assert deployment is not None
+    config = deployment.default
+    assert config.provider == "coda"
+    assert config.server_url == "https://server.example.test"
+    assert config.managed_launch_supported is True
+    assert config.token_ttl_s == 13 * 3600
+    launcher = config.launcher_factory()
+    assert isinstance(launcher, CodaProvider)
+    assert launcher.provider == "coda"
+
+
+@pytest.mark.parametrize(
+    "coda_config, message",
+    [
+        ({}, "requires app_name and app_url"),
+        ({"app_name": "synthetic-coda"}, "requires app_name and app_url"),
+        ({"app_url": "https://synthetic-coda.example.test"}, "requires app_name and app_url"),
+        ({"app_name": "synthetic-coda", "app_url": ""}, "must be a non-empty string"),
+        ({"app_name": "synthetic-coda", "app_url": "https://x", "unexpected": True}, "unknown"),
+        (
+            {"app_name": "synthetic-coda", "app_url": "plain text"},
+            "sandbox.coda.app_url",
+        ),
+        (
+            {
+                "app_name": "synthetic-coda",
+                "app_url": "http://synthetic-coda.aws.databricksapps.com",
+            },
+            "sandbox.coda.app_url",
+        ),
+        (
+            {
+                "app_name": "synthetic-coda",
+                "app_url": "https://synthetic-coda.aws.databricksapps.com/path",
+            },
+            "sandbox.coda.app_url",
+        ),
+    ],
+)
+def test_parse_coda_rejects_incomplete_or_unknown_config(
+    coda_config: dict[str, object], message: str
+) -> None:
+    """Incomplete CoDA configuration fails at startup with a safe message."""
+    with pytest.raises(ValueError, match=message):
+        parse_sandbox_config(
+            {
+                "provider": "coda",
+                "server_url": "https://server.example.test",
+                "coda": coda_config,
+            }
+        )
+
+
 def test_parse_valid_daytona_config_builds_parameterized_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #5076

## Summary

**The problem on current `main`.** The current multi-provider managed-sandbox
framework has no CoDA provider foundation. The CoDA implementation is embedded
in the large, conflicting #4384 branch, which couples provider parsing,
control-plane behavior, deployment wiring, runner authentication, lifecycle,
and lease adoption into one review surface.

**The change.** This is the first reconstructed CoDA slice, based fresh on
current `origin/main` (`b2de85a9`):

- register `coda` as a managed sandbox provider;
- validate complete `sandbox.coda` configuration (`app_name`, `app_url`, and
  optional absolute `workspace_path`);
- add the provider launcher for readiness, lease acquisition, connect, and
  disconnect control calls;
- bound and redact JSON error details, classify lease-capacity conflicts, and
  reject unsafe workspace responses;
- preserve the invariant that CoDA does not create or mutate Databricks App
  lifecycle resources.

**Why it stands alone.** This slice establishes the provider/configuration
contract only. Databricks deployment wiring, ingress/owner authentication,
managed runner lifecycle, lease adoption/capacity, native Pi compatibility, and
the approved Track B fixes are separate follow-on slices. No database migration
is introduced.

This is a fresh reconstruction from current main, not a cherry-pick of the
historical #4384 branch.

## Test Plan

- `python -m pytest -q tests/onboarding/sandboxes/test_coda.py
  tests/onboarding/sandboxes/test_coda_redaction.py
  tests/onboarding/sandboxes/test_coda_http.py` → focused CoDA provider,
  redaction, and HTTP robustness cases pass.
- `python -m pytest -q tests/onboarding/sandboxes/test_registry.py
  tests/server/test_managed_hosts.py tests/host/test_connect.py
  tests/runner/test_runner_entry.py tests/server/test_accounts.py
  tests/server/integration/test_host_session_binding.py
  tests/stores/test_conversation_store.py tests/test_pi_native_credentials.py`
  → **277 passed** on Arca/Linux at the current base.
- The focused C1 set → **29 passed**.
- `pre-commit run --all-files` → **all hooks pass** on Arca/Linux, including
  Pyrefly after installing the worktree's declared dependencies. The repository
  exfiltration scan also passes; redaction-only and HTTP transport tests are in
  separate modules so security-test fixtures cannot look like secret-plus-network
  code.
- `git diff --check` → clean.
- Scope audit → eight intended files only; no `uv.lock`, `miniwiki/`, secrets,
  private URLs, workspace identifiers, or generated artifacts.
- Branch: `coda/c1-provider-foundation`, fresh from
  `origin/main` at `b2de85a99625235fb6889b24ce3f64756c89c8b0`.

## Demo

N/A — this is a non-visual provider/configuration foundation. It does not yet
wire CoDA into Databricks deployment or expose a standalone UI flow; those are
separate planned slices. The observable behavior is covered by the provider and
configuration tests above.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

<!--
This is an integration foundation with no standalone visual/user-facing flow.
The Demo is therefore N/A and the type pairing follows the repository hygiene
bot's non-visual guidance. C2 will own deployment/application wiring.
-->

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The provider control plane is mocked in focused tests so endpoint paths,
payloads, readiness, redirect rejection, bounded error classification,
credential redaction, invalid-encoding handling, capacity handling, and
workspace validation can be verified without a live CoDA App. The directly
affected current-main regression suites also pass on Linux/Arca. A live CoDA
control-plane smoke test is deferred until the maintainer confirms the external
lease/workspace contract and C2 supplies the deployment wiring.

## Changelog

<!-- Foundation slice only; no standalone user-facing behavior until deployment/application wiring lands. -->


