### PR TITLE
fix(server): don't remove a worktree another session still uses

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7749,6 +7749,8 @@ async def _remove_session_worktree_best_effort(
     delete_branch: bool,
     request: Request,
     reason: str,
+    conversation_store: ConversationStore | None = None,
+    exclude_conversation_id: str | None = None,
 ) -> None:
     """
     Best-effort removal of a session's git worktree.
@@ -7768,12 +7770,44 @@ async def _remove_session_worktree_best_effort(
     :param request: FastAPI request carrying the host registry.
     :param reason: Short label for log lines, e.g.
         ``"create-rollback"`` or ``"session-delete"``.
+    :param conversation_store: Optional store for the shared-worktree guard;
+        when omitted the guard is skipped (legacy callers).
+    :param exclude_conversation_id: The conversation whose deletion triggered
+        this removal; other conversations referencing the same
+        (host, worktree) suppress the removal.
     """
     from omnigent.server.routes._host_worktree import (
         WorktreeProxyError,
         remove_worktree_on_host,
     )
 
+    # Shared-worktree guard: a fork reusing the source's directory or any
+    # sessions attached to the same existing worktree keep their cwd alive —
+    # removing the directory under them wedges their runners (#5028). When
+    # another conversation still references the same (host, path), skip the
+    # removal entirely (the session row deletion proceeds; the worktree stays
+    # for the surviving session). Best-effort like everything here: a store
+    # that can't answer counts as unshared so cleanup never silently stops.
+    if conversation_store is not None and exclude_conversation_id is not None:
+        try:
+            shared = await asyncio.to_thread(
+                conversation_store.count_other_conversations_with_workspace,
+                host_id=host_id,
+                workspace=worktree_path,
+                exclude_conversation_id=exclude_conversation_id,
+            )
+        except NotImplementedError:
+            shared = 0
+        if shared > 0:
+            _logger.info(
+                "Skipping worktree removal (%s) for %s: %d other conversation(s) "
+                "still reference it on host %s",
+                reason,
+                worktree_path,
+                shared,
+                host_id,
+            )
+            return
     host_registry = getattr(request.app.state, "host_registry", None)
     if host_registry is None:
         return

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -2029,6 +2029,8 @@ def register_events_routes(
                 delete_branch=True,
                 request=request,
                 reason="session-delete",
+                conversation_store=conversation_store,
+                exclude_conversation_id=conv.id,
             )
         _interrupt_fenced_sessions.discard(session_id)
         _intentional_stop_sessions.discard(session_id)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1657,6 +1657,29 @@ class ConversationStore(ABC):
         """
         ...
 
+    def count_other_conversations_with_workspace(
+        self,
+        *,
+        host_id: str,
+        workspace: str,
+        exclude_conversation_id: str,
+    ) -> int:
+        """Count conversations OTHER than *exclude_conversation_id* on (*host_id*, *workspace*).
+
+        Sessions can share one worktree directory — a fork reusing the source's
+        worktree, or several sessions attached to an existing worktree via the
+        picker. Delete-time worktree cleanup must not remove a directory another
+        live session still points at (#5028); this count is the "is it shared?"
+        answer. Returns 0 when no other conversation references the pair.
+
+        :param host_id: Host owning the worktree, e.g. ``"host_a1b2..."``.
+        :param workspace: Absolute worktree path, e.g. ``"/w/feature-login"``.
+        :param exclude_conversation_id: The conversation being deleted — its own
+            row must not count as "another session".
+        :returns: Number of other conversations referencing the same pair.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     async def delete_conversation(self, conversation_id: str) -> bool:
         """

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3903,6 +3903,33 @@ class SqlAlchemyConversationStore(ConversationStore):
             raise LookupError(f"conversation not found: {conversation_id!r}")
         return conv
 
+    def count_other_conversations_with_workspace(
+        self,
+        *,
+        host_id: str,
+        workspace: str,
+        exclude_conversation_id: str,
+    ) -> int:
+        """Count other conversations sharing (*host_id*, *workspace*) — see the
+        protocol docstring. One indexed-column query over the metadata table;
+        the conversation being deleted is excluded by id, not deleted first,
+        so the caller can decide BEFORE removing anything (#5028).
+        """
+        from sqlalchemy import func as sa_func
+
+        with self._session("count_other_conversations_with_workspace") as meta_sess:
+            count = meta_sess.scalar(
+                select(sa_func.count())
+                .select_from(SqlConversationMetadata)
+                .where(
+                    SqlConversationMetadata.workspace_id == current_workspace_id(),
+                    SqlConversationMetadata.host_id == host_id,
+                    SqlConversationMetadata.workspace == workspace,
+                    SqlConversationMetadata.id != exclude_conversation_id,
+                )
+            )
+            return int(count or 0)
+
     async def delete_conversation(self, conversation_id: str) -> bool:
         """
         Delete a conversation and all of its descendants, cleaning up

--- a/tests/server/integration/test_session_worktree_delete.py
+++ b/tests/server/integration/test_session_worktree_delete.py
@@ -153,6 +153,77 @@ async def test_delete_without_flag_sends_no_remove_worktree(
     assert captured == []
 
 
+async def test_delete_shared_worktree_keeps_directory_until_last_session(
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    A shared worktree survives session deletes until the LAST referencing
+    session is deleted.
+
+    Two sessions commonly share one directory — a fork reusing the source's
+    worktree, or several sessions attached to the same existing worktree.
+    Deleting one of them must not remove the directory under the other's
+    runner; deleting the final one may (#5028).
+    """
+    captured = await _register_fake_host(app, db_uri)
+    first = _make_worktree_conversation(db_uri)
+    second = _make_worktree_conversation(db_uri)
+    assert first != second
+
+    # Delete the first sharer: no remove frame — the survivor keeps its cwd.
+    resp = await client.delete(f"/v1/sessions/{first}?delete_branch=true")
+    assert resp.status_code == 200
+    assert captured == [], (
+        "worktree removed while another session still references it — "
+        "the surviving session's runner is now wedged on a deleted cwd"
+    )
+
+    # Delete the last sharer: the frame now fires with the shared path.
+    resp = await client.delete(f"/v1/sessions/{second}?delete_branch=true")
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    assert captured[0].worktree_path == "/Users/alice/myrepo-worktrees/feature-login"
+    assert captured[0].delete_branch is True
+
+
+def test_count_other_conversations_with_workspace_excludes_self(db_uri: str) -> None:
+    """The store-level guard query: other sessions on the pair count, self
+    doesn't, and a different path/host never counts."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    mine = _make_worktree_conversation(db_uri)
+    # Same (host, workspace) — a fork reusing the directory.
+    theirs = _make_worktree_conversation(db_uri)
+
+    assert (
+        conv_store.count_other_conversations_with_workspace(
+            host_id=_HOST_ID,
+            workspace="/Users/alice/myrepo-worktrees/feature-login",
+            exclude_conversation_id=mine,
+        )
+        == 1
+    )
+    # Self-exclusion: from the other session's perspective mine counts.
+    assert (
+        conv_store.count_other_conversations_with_workspace(
+            host_id=_HOST_ID,
+            workspace="/Users/alice/myrepo-worktrees/feature-login",
+            exclude_conversation_id=theirs,
+        )
+        == 1
+    )
+    # A different workspace never counts.
+    assert (
+        conv_store.count_other_conversations_with_workspace(
+            host_id=_HOST_ID,
+            workspace="/Users/alice/myrepo-worktrees/somewhere-else",
+            exclude_conversation_id=mine,
+        )
+        == 0
+    )
+
+
 async def test_delete_non_worktree_session_ignores_flag(
     app: FastAPI,
     client: httpx.AsyncClient,


### PR DESCRIPTION
Fixes #5028.

## What this does

Exactly the issue's fix sketch, following its suggested shape:

1. **Store query** — `ConversationStore.count_other_conversations_with_workspace(host_id, workspace, exclude_conversation_id)`, implemented on `SqlAlchemyConversationStore` as one indexed-column `COUNT` over the conversation metadata table (`host_id` + `workspace` + workspace-tenant filter, excluding the conversation being deleted by id — not by deleting it first, so the decision happens *before* anything is removed).
2. **Guard** — `_remove_session_worktree_best_effort` now takes optional `conversation_store` + `exclude_conversation_id`; when another conversation still references the same `(host_id, worktree_path)`, the removal is skipped and logged at INFO, and only the session row is deleted. The surviving session keeps its working directory. When the LAST referencing session is deleted, the frame fires as before.
3. **Wiring** — the session-delete caller passes its store and the conversation id. The create-rollback caller is unchanged (its worktree is brand-new, nothing else references it — and the guard is opt-in per call), so no behavior change there.

The guard inherits the path's best-effort contract: a store that can't answer (`NotImplementedError` from any future implementation that hasn't added the method) or a caller that passes none counts as unshared — cleanup never silently stops.

## Tests (`tests/server/integration/test_session_worktree_delete.py`)

- `test_delete_shared_worktree_keeps_directory_until_last_session` — two conversations sharing one worktree: DELETE the first with `delete_branch=true` → **no** `host.remove_worktree` frame (the exact frame-capture harness the issue pointed at); DELETE the second → exactly one frame with the shared path. **Fails on `main`** (the first delete already removes the directory under the survivor).
- `test_count_other_conversations_with_workspace_excludes_self` — the query itself: the other sharer counts from each side (self-exclusion is by id), and a different path never counts. **Fails on `main`** (method absent).

Full file: 5/5 with the fix; the three pre-existing tests unchanged (the single-session delete still removes the worktree — the common case is untouched). Neighbor suites `test_session_worktree_create.py` + `test_hosts_worktrees.py`: 11/11.

## Notes

- #5021 (archive-time cleanup) needs the same guard; when that lands, it can pass the same two parameters to this helper rather than duplicating the check.
- The issue also suggests labeling this `good first issue` — with the sketch now landed as code, the archive-side follow-up is indeed a good first issue.
