### PR TITLE
fix(web): recreate a deleted source worktree when forking under its own name

### DIFF
--- a/web/src/hooks/useHostFilesystem.ts
+++ b/web/src/hooks/useHostFilesystem.ts
@@ -278,6 +278,25 @@ export async function checkHostDirectory(hostId: string, path: string): Promise<
   return detail ?? `Couldn't verify the working directory (HTTP ${res.status}).`;
 }
 
+/**
+ * Whether a host path is 404-missing, as opposed to every other pre-flight
+ * problem (exists-but-unlistable, host offline, network error).
+ *
+ * The fork dialog uses this to distinguish "the source's worktree directory
+ * was deleted — recreatable at the same path/branch" from problems where
+ * falling back to worktree creation would be wrong (#5031).
+ */
+export async function hostDirectoryMissing(hostId: string, path: string): Promise<boolean> {
+  const baseUrl = buildHostFilesystemUrl(hostId, path);
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  try {
+    const res = await authenticatedFetch(`${baseUrl}${sep}limit=1`);
+    return res.status === 404;
+  } catch {
+    return false;
+  }
+}
+
 /** Shape returned by ``POST /v1/hosts/{id}/directories``. */
 interface CreateHostDirectoryResponse {
   object: string;

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -18,7 +18,11 @@ import { useSessionAgent } from "@/hooks/useAgents";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
-import { checkHostDirectory, useHostFilesystem } from "@/hooks/useHostFilesystem";
+import {
+  checkHostDirectory,
+  hostDirectoryMissing,
+  useHostFilesystem,
+} from "@/hooks/useHostFilesystem";
 
 const navigateMock = vi.fn();
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -37,6 +41,7 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({ useRunnerHealthRegistration: vi
 vi.mock("@/hooks/useHostFilesystem", () => ({
   useHostFilesystem: vi.fn(),
   checkHostDirectory: vi.fn(),
+  hostDirectoryMissing: vi.fn(),
 }));
 // The tree browser only mounts when browsing; coding-fork tests rely on the
 // directory being prefilled from the source, so the real picker never opens —
@@ -59,6 +64,7 @@ const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
 const checkHostDirectoryMock = vi.mocked(checkHostDirectory);
+const hostDirectoryMissingMock = vi.mocked(hostDirectoryMissing);
 const prefetchAvailableAgentDetailsMock = vi.mocked(prefetchAvailableAgentDetails);
 
 function host(overrides: Partial<Host> = {}): Host {
@@ -173,6 +179,7 @@ beforeEach(() => {
   // The submit pre-flight passes by default; the nonexistent-directory
   // test overrides it with a failure message.
   checkHostDirectoryMock.mockReset();
+  hostDirectoryMissingMock.mockReset();
   checkHostDirectoryMock.mockResolvedValue(null);
   prefetchAvailableAgentDetailsMock.mockReset();
   setAgents(AVAILABLE_AGENTS, "claude-sdk");
@@ -704,6 +711,50 @@ describe("ForkSessionDialog", () => {
         "host_1",
         "/Users/a/repo-worktrees/fix-1",
       );
+    });
+
+    it("recreates the source worktree when its directory was deleted and the name is untouched", async () => {
+      forkSessionMock.mockResolvedValue({
+        id: "conv_fork",
+      } as unknown as Awaited<ReturnType<typeof forkSession>>);
+      launchRunnerMock.mockResolvedValue({ runnerId: "r1" });
+      // The pre-flight fails — the worktree directory is gone — but the
+      // miss is a 404, so the fork recreates the worktree at the same
+      // branch instead of erroring (#5031).
+      checkHostDirectoryMock.mockResolvedValue(
+        "The working directory /Users/a/repo-worktrees/fix-1 doesn't exist on this host (or isn't a directory).",
+      );
+      hostDirectoryMissingMock.mockResolvedValue(true);
+      renderDialog(WORKTREE_CODING);
+
+      fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+      await waitFor(() => expect(launchRunnerMock).toHaveBeenCalledTimes(1));
+      // Launched from the REPO path with the prefilled branch (which already
+      // exists) — the host adds the worktree back at the conventional path.
+      expect(launchRunnerMock).toHaveBeenCalledWith("host_1", "conv_fork", "/Users/a/repo", {
+        branchName: "fix-1",
+        baseBranch: "fix-1",
+      });
+    });
+
+    it("still errors when the pre-flight fails for a reason other than a missing directory", async () => {
+      forkSessionMock.mockResolvedValue({
+        id: "conv_fork",
+      } as unknown as Awaited<ReturnType<typeof forkSession>>);
+      // Host unreachable: NOT a 404 miss, so no worktree-recreate fallback.
+      checkHostDirectoryMock.mockResolvedValue(
+        "Couldn't verify the working directory. Check your connection and try again.",
+      );
+      hostDirectoryMissingMock.mockResolvedValue(false);
+      renderDialog(WORKTREE_CODING);
+
+      fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+      await waitFor(() =>
+        expect(screen.getByText(/Couldn't verify the working directory/i)).toBeTruthy(),
+      );
+      expect(launchRunnerMock).not.toHaveBeenCalled();
     });
 
     it("creates a fresh worktree off the source branch when the branch is renamed", async () => {

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -37,7 +37,7 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { agentRootName, forkTargetCarriesHistory } from "@/lib/forkHarness";
-import { checkHostDirectory } from "@/hooks/useHostFilesystem";
+import { checkHostDirectory, hostDirectoryMissing } from "@/hooks/useHostFilesystem";
 import { getCliServerUrl } from "@/lib/host";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { WorkspacePathField } from "./WorkspacePathField";
@@ -452,11 +452,24 @@ export function ForkSessionForm({
       // launch below is detached and its failure is swallowed, so a
       // nonexistent path would otherwise leave a clone that silently
       // never starts.
+      let recreateSourceWorktree = false;
       if (isCodingSource && selectedHostId) {
         const problem = await checkHostDirectory(selectedHostId, effectiveWorkspace);
         if (problem !== null) {
-          setError(problem);
-          return;
+          // Deleted source worktree + untouched name: recreate the worktree
+          // at the same path/branch instead of erroring — the host's
+          // create-worktree handles an already-existing branch (no -b).
+          // Only this exact case falls back; every other problem (offline
+          // host, unlistable path, network) still aborts the fork (#5031).
+          if (
+            usingSourceWorktree &&
+            (await hostDirectoryMissing(selectedHostId, effectiveWorkspace))
+          ) {
+            recreateSourceWorktree = true;
+          } else {
+            setError(problem);
+            return;
+          }
         }
       }
       const trimmed = title.trim();
@@ -489,8 +502,11 @@ export function ForkSessionForm({
         void launchRunner(
           selectedHostId,
           fork.id,
-          effectiveWorkspace,
-          trimmedBranch !== "" && !usingSourceWorktree
+          // Recreating a deleted source worktree launches from the REPO
+          // path (the server derives the worktree directory from the
+          // branch), exactly like the renamed-branch path.
+          recreateSourceWorktree ? workspaceTrimmed : effectiveWorkspace,
+          trimmedBranch !== "" && (!usingSourceWorktree || recreateSourceWorktree)
             ? {
                 branchName: trimmedBranch,
                 baseBranch: baseOnSource && sourceBranch ? sourceBranch : undefined,


### PR DESCRIPTION
Fixes #5031.

## Root cause (as sketched in the issue, verified in the code)

With the pre-filled repo + source-branch left untouched, `usingSourceWorktree` is true and the fork binds to the source's worktree **path** verbatim — no worktree is created. `handleFork` then pre-flights that path with `checkHostDirectory`; a deleted directory fails the check and the fork aborts with "The working directory … doesn't exist on this host". Renaming the branch flips `usingSourceWorktree` off, which takes the create-worktree path and works — hence the workaround.

## Fix

Exactly the issue's sketch, with one addition needed to make it safe — distinguishing *why* the pre-flight failed:

- **`hostDirectoryMissing(hostId, path)`** (new, in `useHostFilesystem.ts`): returns true only for a 404 on the directory probe. `checkHostDirectory`'s 404 message conflates "missing" with "exists but isn't listable", and its other failures (host offline, network) must NOT trigger a recreate.
- **`handleFork`**: when the pre-flight fails for a worktree-**reusing** fork **and** the miss is a 404, the fork falls back to the worktree-create submission — launched from the **repo** path (the server derives the worktree directory from the branch, same as the renamed-branch path) with the pre-filled `{branchName, baseBranch}`. The branch already exists, so the host's `create_worktree` runs `git worktree add <path> <branch>` without `-b` — recreating the worktree at the same conventional directory. Every other pre-flight failure still aborts exactly as before.

So: deleted source worktree + untouched name → the clone gets the worktree back at the same path/branch, no Advanced-settings detour. This is also the unblock for the #5021-era world, where archive-time cleanup makes deleted-worktree sessions routine.

## Tests (`ForkSessionDialog.test.tsx`)

- `recreates the source worktree when its directory was deleted and the name is untouched` — pre-flight fails with the missing-directory message, probe says 404 → `launchRunner` receives the repo path and `{branchName: "fix-1", baseBranch: "fix-1"}` (the prefilled existing branch). **Fails on `main`** (the fork aborts on the pre-flight; no launch happens).
- `still errors when the pre-flight fails for a reason other than a missing directory` — a connection failure (non-404) keeps today's abort-and-error behavior; no launch, no silent fallback.

Full file: 35/35 with the fix; on unpatched `main` the same file runs 34/35 — only the new recreate test fails.

Part of the worktree-lifecycle series with #5028 (shared-worktree delete guard) and the forthcoming #5021 archive cleanup.
