### PR TITLE
fix(web): map macOS Cmd line-editing shortcuts in the terminal view

### DIFF
--- a/tests/e2e_ui/shells/test_terminal_cmd_line_editing.py
+++ b/tests/e2e_ui/shells/test_terminal_cmd_line_editing.py
@@ -114,9 +114,7 @@ def _connected_shell_textarea(page: Page) -> Locator:
         terminal_view = rail.get_by_test_id("terminal-view").last
         expect(terminal_view).to_be_visible(timeout=60_000)
         try:
-            expect(terminal_view).to_have_attribute(
-                "data-state", "connected", timeout=30_000
-            )
+            expect(terminal_view).to_have_attribute("data-state", "connected", timeout=30_000)
         except AssertionError as exc:
             last_error = exc
             # Close the stuck tab (confirming the kill) and retry fresh.

--- a/tests/e2e_ui/shells/test_terminal_cmd_line_editing.py
+++ b/tests/e2e_ui/shells/test_terminal_cmd_line_editing.py
@@ -1,0 +1,269 @@
+"""E2E: macOS Cmd line-editing shortcuts in the session terminal.
+
+On macOS the standard readline-style Cmd shortcuts in a session's terminal
+did nothing useful:
+
+- **Cmd+Backspace** should kill to the start of the line (Ctrl-U, ``0x15``),
+- **Cmd+Left** should move the cursor to the start of the line (Ctrl-A,
+  ``0x01``),
+- **Cmd+Right** should move the cursor to the end of the line (Ctrl-E,
+  ``0x05``),
+
+because ``terminalKeyEventPayload`` (``web/src/components/blocks/
+TerminalSession.ts``) used to map only Shift+Enter, and xterm.js has no
+default binding for ``metaKey`` combos: Cmd+Left/Right produced no bytes at
+all, and Cmd+Backspace fell through to a plain single-char DEL. The Option
+(Alt) equivalents always worked because xterm encodes Alt-modified keys as
+ESC-prefixed sequences.
+
+Each test drives the real journey: open a shell from the workspace rail's
+"+" menu, type a command line, press the Cmd shortcut, and finish the line so
+that the *shell's own line editing* proves where the cursor was. The typed
+line is arranged so the command only produces its file side-effect when the
+shortcut performed its readline operation — e.g. for Cmd+Backspace the test
+types a poison prefix, presses Cmd+Backspace (which must kill the whole
+line), then types ``touch <file>``; on the buggy build the poison prefix
+survives, the garbled line runs as an ``echo``/not-found, and the file never
+appears. xterm renders to a canvas (stdout is not in the DOM), so the file
+side-effect plus the bytes observed on the terminal-attach WebSocket are the
+machine-checkable signals.
+
+A readiness handshake (a ``touch`` that must land before the scenario) makes
+sure the PTY's shell is accepting and executing input before any Cmd keys are
+sent, so the assertions can only fail on the shortcut behavior itself.
+
+All three tests use the function-scoped ``terminal_session`` fixture (the
+``zsh``-declaring agent, runner-bound session); the launched shell is
+actually ``bash --noprofile --norc``, whose default emacs bindings implement
+Ctrl-A / Ctrl-E / Ctrl-U — exactly what the fix is expected to send.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+from playwright.sync_api import Locator, Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Readline control bytes the Cmd shortcuts are expected to transmit.
+CTRL_A = b"\x01"  # cursor to line start (Cmd+Left)
+CTRL_E = b"\x05"  # cursor to line end   (Cmd+Right)
+CTRL_U = b"\x15"  # kill to line start   (Cmd+Backspace)
+
+
+def _open_new_shell(page: Page) -> None:
+    """Create a shell via the tab strip's "+" -> Shell menu.
+
+    Mirrors ``shells/test_new_shell.py``: opens the desktop Workspace rail
+    and picks the single declared terminal type, which launches it directly.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    """
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+
+def _capture_attach_frames(page: Page) -> list[bytes]:
+    """Record every payload the page sends on terminal-attach WebSockets.
+
+    Registered before navigation so the attach socket — opened
+    asynchronously once the shell's xterm mounts — cannot slip through.
+    Keystrokes are sent as binary frames; text frames are kept too (encoded)
+    so the diagnostic trail is complete.
+
+    :param page: Playwright page, not yet navigated.
+    :returns: A list that fills in as frames are sent.
+    """
+    frames: list[bytes] = []
+
+    def _on_ws(ws: object) -> None:
+        url = ws.url  # type: ignore[attr-defined]
+        if "/attach" not in url:
+            return
+
+        def _on_frame(payload: str | bytes) -> None:
+            frames.append(payload if isinstance(payload, bytes) else payload.encode())
+
+        ws.on("framesent", _on_frame)  # type: ignore[attr-defined]
+
+    page.on("websocket", _on_ws)
+    return frames
+
+
+def _connected_shell_textarea(page: Page) -> Locator:
+    """Open a shell and return its focused xterm input textarea.
+
+    Waits for the rail shell's xterm to report a live attach before
+    returning — input typed before the WS attach opens is dropped. A shell
+    occasionally sticks in ``connecting`` on a loaded box (the attach WS
+    loses the race with the PTY spawn), so a stuck shell is closed and
+    reopened rather than failing the test on harness weather.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    :returns: The shell's ``xterm-helper-textarea`` locator, focused.
+    """
+    rail = page.get_by_role("complementary", name="Workspace")
+    last_error: AssertionError | None = None
+    for _ in range(3):
+        _open_new_shell(page)
+        terminal_view = rail.get_by_test_id("terminal-view").last
+        expect(terminal_view).to_be_visible(timeout=60_000)
+        try:
+            expect(terminal_view).to_have_attribute(
+                "data-state", "connected", timeout=30_000
+            )
+        except AssertionError as exc:
+            last_error = exc
+            # Close the stuck tab (confirming the kill) and retry fresh.
+            rail.get_by_role("button", name=re.compile(r"^Close ")).last.click()
+            page.get_by_role("button", name=re.compile("Close")).last.click()
+            page.wait_for_timeout(1_000)
+            continue
+        textarea = terminal_view.locator("textarea.xterm-helper-textarea")
+        textarea.focus()
+        return textarea
+    raise AssertionError(f"shell never connected after 3 attempts: {last_error}")
+
+
+def _wait_for_file(path: Path, timeout_s: float) -> bool:
+    """Poll for *path* to exist.
+
+    :param path: File the shell command is expected to create.
+    :param timeout_s: How long to keep polling.
+    :returns: True when the file appeared within the deadline.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def _await_shell_ready(page: Page, textarea: Locator, tmp_path: Path) -> None:
+    """Prove the PTY's shell is accepting and executing typed input.
+
+    The xterm attach connects before bash finishes starting, so keystrokes
+    typed immediately can be swallowed. Types a ``touch`` and waits for its
+    file, retyping a few times, so every later assertion can only fail on
+    the Cmd-shortcut behavior itself.
+
+    :param page: Playwright page with the shell focused.
+    :param textarea: The shell's xterm input textarea.
+    :param tmp_path: Pytest temp dir shared with the runner-local shell.
+    """
+    ready = tmp_path / "shell_ready.txt"
+    for _ in range(4):
+        textarea.focus()
+        # Ctrl+C aborts any partially-delivered previous attempt so retries
+        # always start from a clean prompt line.
+        page.keyboard.press("Control+c")
+        page.keyboard.type(f"touch {ready}")
+        page.keyboard.press("Enter")
+        if _wait_for_file(ready, timeout_s=8.0):
+            return
+    raise AssertionError(
+        "shell never executed the readiness command; cannot exercise Cmd shortcuts"
+    )
+
+
+def _run_line_and_expect_file(
+    page: Page, marker: Path, frames: list[bytes], expected_byte: bytes, shortcut: str
+) -> None:
+    """Submit the composed line and assert the shortcut's observable outcome.
+
+    :param page: Playwright page with the shell focused.
+    :param marker: File the line creates only if the shortcut worked.
+    :param frames: Captured attach-WS payloads (diagnostic + wire check).
+    :param expected_byte: Control byte the shortcut must transmit.
+    :param shortcut: Human-readable shortcut name for the failure message.
+    """
+    page.keyboard.press("Enter")
+    file_created = _wait_for_file(marker, timeout_s=15.0)
+    sent = b"".join(frames)
+    assert expected_byte in sent and file_created, (
+        f"{shortcut} did not perform its readline line edit: expected the "
+        f"terminal to transmit {expected_byte!r} and the edited command to "
+        f"create {marker.name} (created={file_created}); bytes sent on the "
+        f"attach WebSocket: {sent!r}"
+    )
+
+
+def test_cmd_backspace_kills_to_line_start(
+    page: Page, terminal_session: tuple[str, str], tmp_path: Path
+) -> None:
+    """Cmd+Backspace deletes to the start of the line (Ctrl-U).
+
+    Journey: open a shell → type a poison prefix → press Cmd+Backspace →
+    type ``touch <marker>`` → Enter. Only if Cmd+Backspace killed the whole
+    line does the clean ``touch`` run and the marker appear; on the buggy
+    build the prefix survives (xterm sends at most a single-char DEL) and
+    the garbled line creates nothing.
+    """
+    base_url, session_id = terminal_session
+    frames = _capture_attach_frames(page)
+    page.goto(f"{base_url}/c/{session_id}")
+    textarea = _connected_shell_textarea(page)
+    _await_shell_ready(page, textarea, tmp_path)
+
+    marker = tmp_path / "cmd_backspace.ok"
+    page.keyboard.type("echo poison_prefix_line_kill")
+    page.keyboard.press("Meta+Backspace")
+    page.keyboard.type(f"touch {marker}")
+    _run_line_and_expect_file(page, marker, frames, CTRL_U, "Cmd+Backspace")
+
+
+def test_cmd_left_moves_cursor_to_line_start(
+    page: Page, terminal_session: tuple[str, str], tmp_path: Path
+) -> None:
+    """Cmd+Left moves the cursor to the start of the line (Ctrl-A).
+
+    Journey: open a shell → type the tail of a ``touch`` command → press
+    Cmd+Left → type the head → Enter. Only if Cmd+Left jumped to the line
+    start does the head land in front of the tail and the marker appear; on
+    the buggy build no bytes are sent, the cursor stays put, and the
+    reversed line fails.
+    """
+    base_url, session_id = terminal_session
+    frames = _capture_attach_frames(page)
+    page.goto(f"{base_url}/c/{session_id}")
+    textarea = _connected_shell_textarea(page)
+    _await_shell_ready(page, textarea, tmp_path)
+
+    marker = tmp_path / "cmd_left.ok"
+    page.keyboard.type(f"{marker}")
+    page.keyboard.press("Meta+ArrowLeft")
+    page.keyboard.type("touch ")
+    _run_line_and_expect_file(page, marker, frames, CTRL_A, "Cmd+Left")
+
+
+def test_cmd_right_moves_cursor_to_line_end(
+    page: Page, terminal_session: tuple[str, str], tmp_path: Path
+) -> None:
+    """Cmd+Right moves the cursor to the end of the line (Ctrl-E).
+
+    Journey: open a shell → type a ``touch`` command missing its suffix →
+    Ctrl+A (a binding that works today) to jump to the line start → press
+    Cmd+Right → type the suffix → Enter. Only if Cmd+Right returned the
+    cursor to the line end does the suffix complete the path and the marker
+    appear; on the buggy build no bytes are sent, the suffix lands at the
+    line start, and the reversed line fails.
+    """
+    base_url, session_id = terminal_session
+    frames = _capture_attach_frames(page)
+    page.goto(f"{base_url}/c/{session_id}")
+    textarea = _connected_shell_textarea(page)
+    _await_shell_ready(page, textarea, tmp_path)
+
+    marker = tmp_path / "cmd_right.ok"
+    stem = str(marker)[: -len(".ok")]
+    page.keyboard.type(f"touch {stem}")
+    page.keyboard.press("Control+a")
+    page.keyboard.press("Meta+ArrowRight")
+    page.keyboard.type(".ok")
+    _run_line_and_expect_file(page, marker, frames, CTRL_E, "Cmd+Right")

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -214,16 +214,10 @@ describe("terminalKeyEventPayload", () => {
   it("maps macOS Cmd line shortcuts to their readline control bytes", () => {
     // WHY: Option+key works because xterm encodes Alt as ESC-prefixes, but
     // Cmd (metaKey) combos reach neither xterm nor the PTY — native-terminal
-    // line editing (delete to start / home / end) silently did nothing (#5029).
-    expect(
-      terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true })),
-    ).toBe("\x15");
-    expect(
-      terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true })),
-    ).toBe("\x01");
-    expect(
-      terminalKeyEventPayload(keyEvent({ key: "ArrowRight", metaKey: true })),
-    ).toBe("\x05");
+    // line editing (delete to start / home / end) silently did nothing.
+    expect(terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true }))).toBe("\x15");
+    expect(terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true }))).toBe("\x01");
+    expect(terminalKeyEventPayload(keyEvent({ key: "ArrowRight", metaKey: true }))).toBe("\x05");
   });
 
   it("keeps browser-owned Cmd combos off the mapping", () => {

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -211,6 +211,41 @@ describe("terminalKeyEventPayload", () => {
     expect(payload).toBe("\x1b[13;2u");
   });
 
+  it("maps macOS Cmd line shortcuts to their readline control bytes", () => {
+    // WHY: Option+key works because xterm encodes Alt as ESC-prefixes, but
+    // Cmd (metaKey) combos reach neither xterm nor the PTY — native-terminal
+    // line editing (delete to start / home / end) silently did nothing (#5029).
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true })),
+    ).toBe("\x15");
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true })),
+    ).toBe("\x01");
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowRight", metaKey: true })),
+    ).toBe("\x05");
+  });
+
+  it("keeps browser-owned Cmd combos off the mapping", () => {
+    // Cmd+C/V/K/R (copy/paste/clear/reload) and every Cmd combo with another
+    // modifier must keep their browser meaning — only the bare three
+    // line-editing combos are synthesized.
+    expect(terminalKeyEventPayload(keyEvent({ key: "c", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "v", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "k", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "r", metaKey: true }))).toBeNull();
+    // Meta combined with another modifier (e.g. Cmd+Shift+Backspace, or a
+    // Windows-flag AltGr-adjacent event) stays on the default path.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true, shiftKey: true })),
+    ).toBeNull();
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true, altKey: true })),
+    ).toBeNull();
+    // Plain, unmodified keys never hit the mapping either.
+    expect(terminalKeyEventPayload(keyEvent({ key: "Backspace" }))).toBeNull();
+  });
+
   it("leaves plain Enter on xterm's default path", () => {
     expect(terminalKeyEventPayload(keyEvent({ key: "Enter" }))).toBeNull();
   });

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -162,18 +162,33 @@ export type TerminalInputListener = () => void;
 /** Kitty Keyboard Protocol / CSI-u encoding for Shift+Enter. */
 export const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
 
+/** Readline line-editing bytes for the macOS Cmd key mappings below. */
+export const CMD_BACKSPACE_LINE_KILL = "\x15"; // Ctrl-U: kill to line start
+export const CMD_LEFT_LINE_START = "\x01"; // Ctrl-A: cursor to line start
+export const CMD_RIGHT_LINE_END = "\x05"; // Ctrl-E: cursor to line end
+
 /**
  * Return the terminal bytes to send for a browser key event.
  *
- * xterm.js does not currently emit Kitty Keyboard Protocol sequences for
- * Shift+Enter, so the browser attach path synthesizes the CSI-u sequence
- * for that one key combination. This mirrors native terminals that support
- * CSI-u while keeping plain Enter and modified Enter variants on xterm's
- * default path.
+ * Two key families need synthesized bytes because neither xterm.js nor the
+ * browser produces them:
+ *
+ * - **Shift+Enter** — xterm does not emit Kitty Keyboard Protocol sequences
+ *   for it, so the browser attach path synthesizes the CSI-u sequence,
+ *   mirroring native terminals that support CSI-u while keeping plain Enter
+ *   and modified Enter variants on xterm's default path.
+ * - **macOS Cmd+Backspace / Cmd+Left / Cmd+Right** — the standard
+ *   readline-style line shortcuts. The Option (Alt) equivalents work because
+ *   xterm encodes Alt-modified keys as ESC-prefixed sequences that
+ *   readline/zsh read as word operations; Cmd (metaKey) combos get no
+ *   encoding at all — the browser eats them and nothing reaches the PTY.
+ *   Each maps to the Ctrl control character a native terminal sends
+ *   (#5029). Only bare Cmd combos are mapped: Cmd+C/V/K/R and friends keep
+ *   their browser/xterm meaning (copy/paste/clear/reload).
  *
  * :param event: Browser keyboard event from xterm's custom key handler.
- * :returns: CSI-u bytes for Shift+Enter, or ``null`` to let xterm handle
- *     the event normally.
+ * :returns: Bytes to send instead of xterm's default handling, or ``null``
+ *     to let xterm handle the event normally.
  */
 export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
   if (
@@ -184,6 +199,11 @@ export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
     !event.metaKey
   ) {
     return SHIFT_ENTER_CSI_U;
+  }
+  if (event.metaKey && !event.altKey && !event.ctrlKey && !event.shiftKey) {
+    if (event.key === "Backspace") return CMD_BACKSPACE_LINE_KILL;
+    if (event.key === "ArrowLeft") return CMD_LEFT_LINE_START;
+    if (event.key === "ArrowRight") return CMD_RIGHT_LINE_END;
   }
   return null;
 }

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -182,9 +182,9 @@ export const CMD_RIGHT_LINE_END = "\x05"; // Ctrl-E: cursor to line end
  *   xterm encodes Alt-modified keys as ESC-prefixed sequences that
  *   readline/zsh read as word operations; Cmd (metaKey) combos get no
  *   encoding at all — the browser eats them and nothing reaches the PTY.
- *   Each maps to the Ctrl control character a native terminal sends
- *   (#5029). Only bare Cmd combos are mapped: Cmd+C/V/K/R and friends keep
- *   their browser/xterm meaning (copy/paste/clear/reload).
+ *   Each maps to the Ctrl control character a native terminal sends. Only
+ *   bare Cmd combos are mapped: Cmd+C/V/K/R and friends keep their
+ *   browser/xterm meaning (copy/paste/clear/reload).
  *
  * :param event: Browser keyboard event from xterm's custom key handler.
  * :returns: Bytes to send instead of xterm's default handling, or ``null``


### PR DESCRIPTION
Fixes #5029 — the issue's exact sketch, on the seam it points at.

## What this does

`terminalKeyEventPayload` (the custom-key seam that already synthesizes Shift+Enter's CSI-u) now also maps the three bare macOS Cmd line-editing combos to their readline control bytes:

| Key | Bytes | Effect |
| --- | --- | --- |
| Cmd+Backspace | `0x15` (Ctrl-U) | kill to line start |
| Cmd+Left | `0x01` (Ctrl-A) | cursor to line start |
| Cmd+Right | `0x05` (Ctrl-E) | cursor to line end |

Why only these: the Option equivalents already work because xterm encodes Alt-modified keys as ESC-prefixed sequences readline/zsh read as word operations; Cmd (`metaKey`) combos get **no** encoding from either the browser or xterm — the browser eats them and nothing reaches the PTY. Each mapped combo sends exactly what a native terminal sends.

Gating, per the issue's constraint: **bare** `metaKey` only — Cmd+C/V/K/R keep their browser meaning (copy/paste/clear/reload), Cmd combined with any other modifier (Cmd+Shift+Backspace, Cmd+Alt+Left) stays on xterm's default path, and unmodified keys are untouched. Non-macOS platforms never produce these metaKey combos, so they're unaffected.

## Tests (`TerminalSession.test.ts`)

- `maps macOS Cmd line shortcuts to their readline control bytes` — all three combos produce their bytes. **Fails on `main`** (returns `null`; nothing is sent).
- `keeps browser-owned Cmd combos off the mapping` — Cmd+C/V/K/R, meta-with-other-modifier combos, and plain keys all stay on the default path (pins the guard on both sides).

Full file: 37/37 with the fix (35 pre-existing + 2 new); with the source reverted the new mapping test fails while the rest pass.
