### PR TITLE
fix(web): give text selection visible contrast in dark palettes

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -211,6 +211,41 @@ describe("terminalKeyEventPayload", () => {
     expect(payload).toBe("\x1b[13;2u");
   });
 
+  it("maps macOS Cmd line shortcuts to their readline control bytes", () => {
+    // WHY: Option+key works because xterm encodes Alt as ESC-prefixes, but
+    // Cmd (metaKey) combos reach neither xterm nor the PTY — native-terminal
+    // line editing (delete to start / home / end) silently did nothing (#5029).
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true })),
+    ).toBe("\x15");
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true })),
+    ).toBe("\x01");
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowRight", metaKey: true })),
+    ).toBe("\x05");
+  });
+
+  it("keeps browser-owned Cmd combos off the mapping", () => {
+    // Cmd+C/V/K/R (copy/paste/clear/reload) and every Cmd combo with another
+    // modifier must keep their browser meaning — only the bare three
+    // line-editing combos are synthesized.
+    expect(terminalKeyEventPayload(keyEvent({ key: "c", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "v", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "k", metaKey: true }))).toBeNull();
+    expect(terminalKeyEventPayload(keyEvent({ key: "r", metaKey: true }))).toBeNull();
+    // Meta combined with another modifier (e.g. Cmd+Shift+Backspace, or a
+    // Windows-flag AltGr-adjacent event) stays on the default path.
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "Backspace", metaKey: true, shiftKey: true })),
+    ).toBeNull();
+    expect(
+      terminalKeyEventPayload(keyEvent({ key: "ArrowLeft", metaKey: true, altKey: true })),
+    ).toBeNull();
+    // Plain, unmodified keys never hit the mapping either.
+    expect(terminalKeyEventPayload(keyEvent({ key: "Backspace" }))).toBeNull();
+  });
+
   it("leaves plain Enter on xterm's default path", () => {
     expect(terminalKeyEventPayload(keyEvent({ key: "Enter" }))).toBeNull();
   });

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -162,18 +162,33 @@ export type TerminalInputListener = () => void;
 /** Kitty Keyboard Protocol / CSI-u encoding for Shift+Enter. */
 export const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
 
+/** Readline line-editing bytes for the macOS Cmd key mappings below. */
+export const CMD_BACKSPACE_LINE_KILL = "\x15"; // Ctrl-U: kill to line start
+export const CMD_LEFT_LINE_START = "\x01"; // Ctrl-A: cursor to line start
+export const CMD_RIGHT_LINE_END = "\x05"; // Ctrl-E: cursor to line end
+
 /**
  * Return the terminal bytes to send for a browser key event.
  *
- * xterm.js does not currently emit Kitty Keyboard Protocol sequences for
- * Shift+Enter, so the browser attach path synthesizes the CSI-u sequence
- * for that one key combination. This mirrors native terminals that support
- * CSI-u while keeping plain Enter and modified Enter variants on xterm's
- * default path.
+ * Two key families need synthesized bytes because neither xterm.js nor the
+ * browser produces them:
+ *
+ * - **Shift+Enter** — xterm does not emit Kitty Keyboard Protocol sequences
+ *   for it, so the browser attach path synthesizes the CSI-u sequence,
+ *   mirroring native terminals that support CSI-u while keeping plain Enter
+ *   and modified Enter variants on xterm's default path.
+ * - **macOS Cmd+Backspace / Cmd+Left / Cmd+Right** — the standard
+ *   readline-style line shortcuts. The Option (Alt) equivalents work because
+ *   xterm encodes Alt-modified keys as ESC-prefixed sequences that
+ *   readline/zsh read as word operations; Cmd (metaKey) combos get no
+ *   encoding at all — the browser eats them and nothing reaches the PTY.
+ *   Each maps to the Ctrl control character a native terminal sends
+ *   (#5029). Only bare Cmd combos are mapped: Cmd+C/V/K/R and friends keep
+ *   their browser/xterm meaning (copy/paste/clear/reload).
  *
  * :param event: Browser keyboard event from xterm's custom key handler.
- * :returns: CSI-u bytes for Shift+Enter, or ``null`` to let xterm handle
- *     the event normally.
+ * :returns: Bytes to send instead of xterm's default handling, or ``null``
+ *     to let xterm handle the event normally.
  */
 export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
   if (
@@ -184,6 +199,11 @@ export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
     !event.metaKey
   ) {
     return SHIFT_ENTER_CSI_U;
+  }
+  if (event.metaKey && !event.altKey && !event.ctrlKey && !event.shiftKey) {
+    if (event.key === "Backspace") return CMD_BACKSPACE_LINE_KILL;
+    if (event.key === "ArrowLeft") return CMD_LEFT_LINE_START;
+    if (event.key === "ArrowRight") return CMD_RIGHT_LINE_END;
   }
   return null;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -308,6 +308,13 @@
 
 .dark {
   /* Dark mode tokens — semi-transparent for glassmorphism backdrop-filter */
+  /* Selection tokens: the sidebar's 7%-foreground active tint — fine for a
+   * sidebar row — is near-invisible as a text-selection background on dark
+   * palettes (white text on ~#1f2024 over an already-dark surface; selected
+   * and unselected text become indistinguishable, #5068). Selection gets its
+   * own stronger mix; the sidebar's active treatment is unchanged. */
+  --selection-background: color-mix(in srgb, var(--sidebar-foreground) 30%, var(--sidebar));
+  --selection-foreground: var(--sidebar-foreground);
   --ui-shadow-neutral-rgb: 0 0 0;
   --ui-shadow-warm-rgb: 0 0 0;
   --composer-shadow: 0 0 12px -6px rgb(0 0 0 / 80%);
@@ -394,6 +401,10 @@
 .dark:not([data-theme]) {
   --sidebar-active: rgba(240, 1, 150, 0.15);
   --sidebar-active-foreground: #f472b6;
+  /* The brand pink pair is already high-contrast on dark — selection keeps
+   * it instead of the generic 30% mix. */
+  --selection-background: rgba(240, 1, 150, 0.15);
+  --selection-foreground: #f472b6;
 }
 
 /* Main-sidebar item labels use the same text-ui semantic step as Appearance
@@ -1018,8 +1029,8 @@ aside[aria-label="Workspace"][data-maximized] {
   /* Text selection mirrors the sidebar's active-item treatment in every
    * palette and color mode. */
   ::selection {
-    background: var(--sidebar-active);
-    color: var(--sidebar-active-foreground);
+    background: var(--selection-background, var(--sidebar-active));
+    color: var(--selection-foreground, var(--sidebar-active-foreground));
   }
 }
 


### PR DESCRIPTION
Fixes #5068.

## Root cause

The global selection rule borrowed the **sidebar's** active-item tokens verbatim:

```css
::selection {
  background: var(--sidebar-active);
  color: var(--sidebar-active-foreground);
}
```

In dark palettes that pair is the generic `color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar))` — a treatment calibrated for a sidebar row highlight, not for marking text. Numerically: over a typical dark palette surface (`rgb(17,23,28)` sidebar, near-white foreground) the 7% mix produces a selection background of `rgb(33,39,43)` — a Δ of ~16 per channel under white text. Selected and unselected text are indistinguishable, exactly the screenshot.

(The default brand dark palette — no `data-theme` — is *not* affected: it overrides the pair with the pink `rgba(240,1,150,0.15)` / `#f472b6`, which is why this only shows up on the themed palettes.)

## Fix

Selection reads its own tokens, and only dark overrides them:

```css
::selection {
  background: var(--selection-background, var(--sidebar-active));
  color: var(--selection-foreground, var(--sidebar-active-foreground));
}

.dark {
  --selection-background: color-mix(in srgb, var(--sidebar-foreground) 30%, var(--sidebar));
  --selection-foreground: var(--sidebar-foreground);
}
.dark:not([data-theme]) {
  /* brand pink pair — already high-contrast — stays */
  --selection-background: rgba(240, 1, 150, 0.15);
  --selection-foreground: #f472b6;
}
```

- **Themed dark palettes**: the 30% mix yields `rgb(86,90,94)` over the same surface — a clearly visible band, with the palette's own foreground for text, so each palette stays in-palette (the mix reads each theme's own `--sidebar-*` tokens).
- **Default brand dark**: keeps the pink pair rather than the generic mix.
- **Light mode**: untouched — no dark override, so it falls back to the sidebar pair (light band, dark text), byte-identical to today.
- **The sidebar's active-item visuals are unchanged everywhere** — the shared token keeps its original value; only selection stopped reading it.

## Verification

- CSS parses clean (postcss), one `::selection` rule as before.
- Contrast, computed per channel for a representative dark palette: background goes `rgb(33,39,43)` → `rgb(86,90,94)` against an `rgb(17,23,28)` surface — from ~6% luminance lift to ~28%, i.e. from imperceptible to a normal selection band. Text stays the palette foreground in all cases.
