### PR TITLE
Make assistant message width structural

### DIFF
--- a/tests/e2e_ui/chat/test_code_block_highlighting.py
+++ b/tests/e2e_ui/chat/test_code_block_highlighting.py
@@ -31,6 +31,8 @@ import pytest
 from playwright.sync_api import Page, expect
 
 _AGENT_NAME = "hello_world"
+_ASSISTANT_BUBBLE = '[data-testid="message-bubble"][data-role="assistant"]'
+_CODE_BLOCK = '[data-streamdown="code-block"]'
 _CODE_BODY = '[data-streamdown="code-block-body"]'
 # Streamdown emits one span per highlighted token, each carrying its Shiki color
 # via the `--sdm-c` custom property. The raw (pre-highlight) path has no such
@@ -77,6 +79,16 @@ def test_code_block_becomes_syntax_highlighted(
     # The assistant bubble and its rendered code block must mount first.
     body = page.locator(_CODE_BODY).first
     expect(body).to_be_visible(timeout=30_000)
+
+    # Short fenced blocks keep their compact surface even though the assistant
+    # bubble structurally owns the full chat column.
+    bubble_box = page.locator(_ASSISTANT_BUBBLE).first.bounding_box()
+    block_box = page.locator(_CODE_BLOCK).first.bounding_box()
+    assert bubble_box is not None
+    assert block_box is not None
+    assert abs(block_box["x"] - bubble_box["x"]) <= 1
+    assert block_box["width"] < bubble_box["width"] - 1
+    assert block_box["x"] + block_box["width"] <= bubble_box["x"] + bubble_box["width"] + 1
 
     # The lazy @streamdown/code import + tokenization resolves asynchronously and
     # re-renders the block with per-token colored spans. Wait for more than one.

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -184,16 +184,9 @@ def test_error_row_divider_spans_the_chat_column(
 ) -> None:
     """The banner's dashed rule spans the full chat column, not just the pill.
 
-    Regression net for the error-only shrink-wrap: ``MessageContent``
-    defaults to ``w-fit``, so an error-only bubble once clipped the rule to
-    the 560px pill (~592px) instead of the column. Widths are compared
-    against a long-text assistant turn measured in the same viewport — no
-    hardcoded pixel values. Runs at two widths since the column is
-    responsive below its ``max-w-3xl`` cap: 2400px lets the column reach
-    the cap (where the shrink-wrap shows — the pill fits inside it), while
-    1440px squeezes the column below the pill's width (``max-w-full`` caps
-    the pill either way) and locks the invariant against a wrapper that
-    narrows the row below the column.
+    Widths are compared against another assistant turn measured in the same
+    viewport, with no hardcoded pixel values. Running at two widths locks the
+    role-owned full-column invariant across responsive column caps.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` from the local server.
@@ -242,4 +235,57 @@ def test_error_row_divider_spans_the_chat_column(
     )
     assert abs(widths["divider"] - widths["row"]) <= 1, (
         f"dashed rule spans {widths['divider']:.0f}px of its {widths['row']:.0f}px row"
+    )
+
+
+@pytest.mark.parametrize("viewport_width", [1440, 2400])
+def test_markdown_table_block_uses_the_full_assistant_column(
+    page: Page,
+    seeded_session: tuple[str, str],
+    viewport_width: int,
+) -> None:
+    """A markdown table inherits the assistant column without a content whitelist."""
+    base_url, session_id = seeded_session
+    seed_committed_turn(
+        session_id,
+        prompt="Summarize the release checks in a table.",
+        reply=(
+            "| Check | Owner | Status |\n"
+            "| --- | --- | --- |\n"
+            "| Unit tests | Runtime | Passing |\n"
+            "| Browser geometry | Web | Passing |"
+        ),
+        response_id="resp_geometry_table",
+    )
+
+    page.set_viewport_size({"width": viewport_width, "height": 1080})
+    page.goto(f"{base_url}/c/{session_id}")
+    table = page.locator('[data-streamdown="table"]').first
+    expect(table).to_be_visible(timeout=15_000)
+
+    widths = table.evaluate(
+        """(table) => {
+          const bubble = table.closest('[data-testid="message-bubble"]');
+          const content = bubble.firstElementChild;
+          const contentRect = content.getBoundingClientRect();
+          const tableRect = table.getBoundingClientRect();
+          return {
+            bubble: bubble.getBoundingClientRect().width,
+            content: contentRect.width,
+            table: tableRect.width,
+            leftInset: tableRect.left - contentRect.left,
+            rightInset: contentRect.right - tableRect.right,
+          };
+        }"""
+    )
+    assert abs(widths["content"] - widths["bubble"]) <= 1, (
+        f"table content spans {widths['content']:.0f}px but its assistant row spans "
+        f"{widths['bubble']:.0f}px"
+    )
+    assert widths["leftInset"] >= 0 and widths["rightInset"] >= 0, (
+        f"table overflows its {widths['content']:.0f}px content column"
+    )
+    assert abs(widths["leftInset"] - widths["rightInset"]) <= 1, (
+        f"table insets are asymmetric: {widths['leftInset']:.0f}px left and "
+        f"{widths['rightInset']:.0f}px right"
     )

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -30,13 +30,28 @@ describe("MessageContent", () => {
     expect(content).not.toHaveClass("text-[0.8125rem]", "leading-[1.125rem]");
     expect(content).not.toHaveClass("group-[.is-user]:px-4", "group-[.is-user]:py-3");
   });
+
+  it("fills assistant messages while user content stays shrink-wrapped", () => {
+    render(<MessageContent>Message text</MessageContent>);
+
+    expect(screen.getByText("Message text")).toHaveClass(
+      "group-[.is-assistant]:w-full",
+      "group-[.is-user]:w-fit",
+    );
+  });
 });
 
 describe("Message", () => {
-  it("keeps the message shrinkable", () => {
+  it("fills the available width for assistant messages", () => {
     render(<Message data-testid="message" from="assistant" />);
 
-    expect(screen.getByTestId("message")).toHaveClass("min-w-0");
+    expect(screen.getByTestId("message")).toHaveClass("min-w-0", "max-w-full");
+  });
+
+  it("keeps the user message capped and right-aligned", () => {
+    render(<Message data-testid="message" from="user" />);
+
+    expect(screen.getByTestId("message")).toHaveClass("min-w-0", "max-w-[95%]", "ml-auto");
   });
 
   it("keeps a caller's width override alongside min-w-0", () => {

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -122,7 +122,18 @@ describe("MessageResponse", () => {
   });
 });
 
-describe("MessageResponse code-block copy", () => {
+describe("MessageResponse code blocks", () => {
+  it("keeps a fenced block compact within the message column", async () => {
+    const { container } = render(
+      <MessageResponse>{"```ts\nconst value = 1;\n```"}</MessageResponse>,
+    );
+
+    await waitFor(() => {
+      const block = container.querySelector('[data-streamdown="code-block"]');
+      expect(block?.parentElement).toHaveClass("w-fit", "max-w-full");
+    });
+  });
+
   it("copies the exact fenced code text through the fallback path", async () => {
     const copiedText: string[] = [];
     Object.defineProperty(Navigator.prototype, "clipboard", {

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -425,7 +425,14 @@ function ChatCodeBlockPre({ children }: ComponentProps<"pre">) {
     : children;
 
   return (
-    <div className={cn("relative", wrap && "chat-code-wrap")}>
+    <div
+      className={cn(
+        // Keep short fenced blocks compact inside the structural assistant column.
+        // Long blocks still stop at the column edge and wrap within it.
+        "relative w-fit max-w-full",
+        wrap && "chat-code-wrap",
+      )}
+    >
       {block}
       {/* Overlay actions, anchored left of Streamdown's own download button
           (which sits at the header's right edge). A flex row lets the buttons

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -37,8 +37,8 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
       // min-w-0 lets this flex item shrink below its content's intrinsic width instead of widening the column.
-      "group flex w-full min-w-0 max-w-[95%] flex-col gap-2",
-      from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
+      "group flex w-full min-w-0 flex-col gap-2",
+      from === "user" ? "is-user ml-auto max-w-[95%] justify-end" : "is-assistant max-w-full",
       className,
     )}
     {...props}
@@ -52,11 +52,11 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
     className={cn(
       // User and assistant prose share the settings-driven interface text
       // token, so their size and line-height stay in lockstep.
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 text-ui",
-      "group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-2xl group-[.is-user]:bg-muted group-[.is-user]:px-3 group-[.is-user]:py-2 group-[.is-user]:text-foreground group-[.is-user]:ring-1 group-[.is-user]:ring-border/60",
+      "is-user:dark flex min-w-0 max-w-full flex-col gap-2 text-ui",
+      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:overflow-hidden group-[.is-user]:rounded-2xl group-[.is-user]:bg-muted group-[.is-user]:px-3 group-[.is-user]:py-2 group-[.is-user]:text-foreground group-[.is-user]:ring-1 group-[.is-user]:ring-border/60",
       // Tighter than the user bubble's gap-2 so muted single-line tool
       // ("See N steps") / reasoning rows don't look orphaned between prose.
-      "group-[.is-assistant]:gap-1.5 group-[.is-assistant]:text-foreground",
+      "group-[.is-assistant]:w-full group-[.is-assistant]:gap-1.5 group-[.is-assistant]:text-foreground",
       className,
     )}
     {...props}

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -200,17 +200,18 @@ describe("BubbleView dispatch", () => {
     render(<BubbleView bubble={assistantText("the answer is 42")} />);
     const bubble = screen.getByTestId("message-bubble");
     expect(bubble).toHaveAttribute("data-role", "assistant");
-    expect(bubble).toHaveClass("gap-2");
+    expect(bubble).toHaveClass("gap-2", "max-w-full");
+    expect(bubble.firstElementChild).toHaveClass("group-[.is-assistant]:w-full");
     expect(bubble).toHaveTextContent("the answer is 42");
     expect(screen.getByRole("button", { name: "Copy" })).toHaveAttribute("data-size", "icon-xxs");
   });
 
-  it("uses full-width layout for assistant display math", () => {
+  it("inherits the full-width assistant layout for display math", () => {
     render(<BubbleView bubble={assistantText(String.raw`$$d = \sqrt{x^2 + y^2}$$`)} />);
 
     const bubble = screen.getByTestId("message-bubble");
     expect(bubble).toHaveClass("max-w-full");
-    expect(bubble.firstElementChild).toHaveClass("w-full");
+    expect(bubble.firstElementChild).toHaveClass("group-[.is-assistant]:w-full");
   });
 
   const errorItem = (): AssistantBubble["items"][number] => ({
@@ -233,14 +234,14 @@ describe("BubbleView dispatch", () => {
 
   it("spans the chat column for an error-only bubble, with no hover footer", () => {
     // WHY: an error banner is a thread-level element — its dashed rule must
-    // span the width a long-text turn takes (not shrink-wrap the 560px pill
-    // via MessageContent's w-fit), and the timestamp/actions chrome belongs
-    // to assistant prose, never to the error.
+    // inherit the assistant column width, and the timestamp/actions chrome
+    // belongs to assistant prose, never to the error.
     render(<BubbleView bubble={errorBubble([errorItem()])} />);
 
     const bubble = screen.getByTestId("message-bubble");
     expect(screen.getByTestId("error-pill")).toBeInTheDocument();
-    expect(bubble.firstElementChild).toHaveClass("w-full");
+    expect(bubble).toHaveClass("max-w-full");
+    expect(bubble.firstElementChild).toHaveClass("group-[.is-assistant]:w-full");
     expect(screen.queryByTestId("message-timestamp")).not.toBeInTheDocument();
   });
 
@@ -259,7 +260,8 @@ describe("BubbleView dispatch", () => {
 
     const bubble = screen.getByTestId("message-bubble");
     expect(screen.getByTestId("error-pill")).toBeInTheDocument();
-    expect(bubble.firstElementChild).toHaveClass("w-full");
+    expect(bubble).toHaveClass("max-w-full");
+    expect(bubble.firstElementChild).toHaveClass("group-[.is-assistant]:w-full");
     expect(screen.getByTestId("message-timestamp")).toBeInTheDocument();
   });
 
@@ -332,16 +334,13 @@ describe("BubbleView dispatch", () => {
     expect(screen.getByTestId("message-bubble").children).toHaveLength(1);
   });
 
-  it("spans the column for a fold-only turn so the row's hairline draws", () => {
-    // WHY: shrink-wrapped to the ~110px summary row, the trailing hairline
-    // (a flex-1 span) collapses to zero width and the click target stops
-    // short of the column. The max-w-3xl cap keeps it aligned with the rule
-    // under an answered turn.
+  it("inherits the assistant column for a fold-only turn so the row's hairline draws", () => {
+    // WHY: the trailing hairline and click target should span the same
+    // structural column as every other assistant block.
     render(<BubbleView bubble={foldOnlyBubble([toolItem("c4")])} />);
     const bubble = screen.getByTestId("message-bubble");
-    expect(bubble).toHaveClass("max-w-3xl");
-    expect(bubble.firstElementChild).toHaveClass("w-full");
-    expect(bubble.firstElementChild).not.toHaveClass("w-fit");
+    expect(bubble).toHaveClass("max-w-full");
+    expect(bubble.firstElementChild).toHaveClass("group-[.is-assistant]:w-full");
   });
 
   it("keeps the copy action on a folded turn that answers for itself", () => {

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -18,7 +18,6 @@ import {
   collectPendingElicitations,
   computeIsWorking,
   computeShowsWorking,
-  containsMarkdownTable,
   dispatchInitialPrompt,
   isCostRoutingEligible,
   isSubagentRoutingEligible,
@@ -1140,34 +1139,6 @@ describe("subAgentComposerLabel", () => {
   it("falls back to a generic label when every name field is null", () => {
     // Degenerate snapshot — the tray still needs something to render.
     expect(subAgentComposerLabel(mkSession())).toBe("sub-agent");
-  });
-});
-
-// ── containsMarkdownTable ──────────────────────────────────────────────────
-
-describe("containsMarkdownTable", () => {
-  it("detects markdown tables in assistant text", () => {
-    const items: RenderItem[] = [
-      {
-        kind: "text",
-        itemId: "i1",
-        text: "| Name | Value |\n| --- | --- |\n| Alpha | 1 |",
-        final: true,
-      },
-    ];
-    expect(containsMarkdownTable(items)).toBe(true);
-  });
-
-  it("does not treat ordinary pipe text as a table", () => {
-    const items: RenderItem[] = [
-      {
-        kind: "text",
-        itemId: "i1",
-        text: "Use `cmd | grep foo` in a shell.",
-        final: true,
-      },
-    ];
-    expect(containsMarkdownTable(items)).toBe(false);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -354,32 +354,6 @@ export function collectBubbleMarkdown(items: RenderItem[]): string {
 // All chat-column elements must share this width to stay aligned.
 const CHAT_COLUMN_WIDTH = "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-5xl";
 
-const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
-const DISPLAY_MATH_RE = /(^|\n)\s*(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\])/;
-
-function isMarkdownTableRow(line: string): boolean {
-  return line.trim().includes("|");
-}
-
-export function containsMarkdownTable(items: RenderItem[]): boolean {
-  return items.some((item) => {
-    if (item.kind !== "text") return false;
-    const lines = item.text.split("\n");
-    return lines.some(
-      (line, index) =>
-        TABLE_SEPARATOR_RE.test(line) &&
-        index > 0 &&
-        index < lines.length - 1 &&
-        isMarkdownTableRow(lines[index - 1] ?? "") &&
-        isMarkdownTableRow(lines[index + 1] ?? ""),
-    );
-  });
-}
-
-export function containsDisplayMath(items: RenderItem[]): boolean {
-  return items.some((item) => item.kind === "text" && DISPLAY_MATH_RE.test(item.text));
-}
-
 /**
  * Build optimistic user bubbles from the pending-send queue.
  *
@@ -2133,10 +2107,9 @@ function MainAgentSurface({
                       <Message
                         key={item.elicitationId}
                         from="assistant"
-                        className="max-w-full"
                         data-testid="bottom-elicitation"
                       >
-                        <MessageContent className="w-full">
+                        <MessageContent>
                           <ElicitationCard item={item} />
                         </MessageContent>
                       </Message>
@@ -3857,14 +3830,6 @@ function AssistantBubble({
     showsWorking,
   });
 
-  // Elicitation cards (e.g. AskUserQuestion form) want full chat-column
-  // width to match the composer, not the default w-fit shrink-to-content.
-  const hasElicitation = bubble.items.some((it) => it.kind === "elicitation");
-  const isWide =
-    hasElicitation || containsMarkdownTable(bubble.items) || containsDisplayMath(bubble.items);
-  // An error banner's dashed rule spans the full chat column: MessageContent
-  // is w-fit, so without w-full an error-only bubble shrink-wraps the 560px
-  // pill and the rule clips to it instead of reaching the column edges.
   const hasError = bubble.items.some((it) => it.kind === "error");
   // A bubble carrying an error but no prose stands alone as a thread-level
   // element — the hover footer's timestamp/actions belong to assistant text,
@@ -3873,18 +3838,8 @@ function AssistantBubble({
 
   return (
     <>
-      <Message
-        from="assistant"
-        data-testid="message-bubble"
-        data-role="assistant"
-        className={isWide ? "max-w-full" : "max-w-3xl"}
-      >
-        {/* A fold-only bubble takes w-full at the ordinary max-w-3xl cap
-            rather than shrink-wrapping to the summary row's ~110px, which
-            collapsed the row's trailing hairline (a flex-1 span) to zero
-            and stopped its click target short of the column. Keeping the
-            cap lands the hairline where an answered turn's does. */}
-        <MessageContent className={isWide || foldOnly || hasError ? "w-full" : undefined}>
+      <Message from="assistant" data-testid="message-bubble" data-role="assistant">
+        <MessageContent>
           <BlockRenderer
             items={bubble.items}
             sessionStatus={sessionStatus}


### PR DESCRIPTION
## Related issue

N/A — architectural refactor/chore; no linked issue is required.

## Summary

Assistant block types have repeatedly needed to join a manual `isWide` whitelist to avoid shrink-wrapped tables, display math, elicitation cards, Worked folds, and error rows.

- Make width role-owned: assistant `Message` / `MessageContent` fill the chat column by default, while user content remains shrink-to-content and visually unchanged.
- Remove the `isWide` whitelist plus markdown-table and display-math content detectors.
- Preserve local block geometry, full-row Worked click targets, compact tool-summary triggers, and error-only footer suppression.

**ELI5:** The assistant lane now owns its width once, instead of every new block asking for permission to be wide.

```mermaid
flowchart LR
  A[Message role] --> B[Assistant: full chat column]
  A --> C[User: shrink-to-content]
  B --> D[Child blocks own local geometry]
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `./node_modules/.bin/vitest run src/components/ai-elements/message.test.tsx src/pages/ChatPage.indicators.test.tsx src/pages/ChatPage.test.ts` — 209 tests passed
- `npm run type-check`
- Focused oxlint, Prettier, Ruff format/check, and `git diff --check`
- Focused Playwright geometry at 1440px and 2400px:
  - error row/divider spans the assistant column
  - markdown table inherits full assistant content width with symmetric insets
  - 4 parametrized cases passed
- Manual light/dark verification of normal and short prose, tool card, Worked fold, table, display math, elicitation, error-only, text+error, hover/footer behavior, and unchanged user bubbles

## Demo

Light theme — prose, tool summary, Worked fold, table, and display math:

![Assistant width light theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-assistant-width/tmp-screenshots/light.png)

Light theme — error rows and elicitation:

![Assistant width light theme errors and elicitation](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-assistant-width/tmp-screenshots/light-lower.png)

Dark theme — prose, tool summary, Worked fold, table, and display math:

![Assistant width dark theme](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-assistant-width/tmp-screenshots/dark.png)

Dark theme — error rows and elicitation:

![Assistant width dark theme errors and elicitation](https://raw.githubusercontent.com/zhengwin/omnigent/tmp-screenshots-assistant-width/tmp-screenshots/dark-lower.png)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified identical assistant-column geometry in light and dark themes at 1440×1061. Assistant content measured 562px throughout; user content remained shrink-wrapped and right-aligned. Worked retained its full-row click target, the grouped-tool trigger remained compact, normal footers appeared on hover, error-only footers stayed suppressed, and text+error retained timestamp/copy actions.

## Changelog

Assistant messages now align consistently across prose, tools, tables, math, elicitation, and error states.
