### PR TITLE
fix(web): keep a composer draft's launch state out of project launches

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2538,6 +2538,68 @@ describe("NewChatLandingScreen", () => {
     ).toBeNull();
   });
 
+  it("keeps a global composer draft's launch state out of a project launch, and restores it in its own context", async () => {
+    // The HOST pick is launch-control state: a global draft that picked
+    // machine-2 must not leak into a ?project= launch — the project re-seeds
+    // host / workspace / agent / sandbox from its own config (#5023).
+    // Authored content (the message) still restores everywhere.
+    mockHosts([host("online", 1), host("online", 2)]);
+    const first = renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "machine-1",
+      ),
+    );
+    // Deliberately pick the OTHER host so the draft's choice is distinct
+    // from the first-online default the project render would fall back to.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByText("machine-2"));
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "machine-2",
+      ),
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "finish the migration" },
+    });
+    first.unmount();
+    // Drop the sticky host choice: it's a launch preference that
+    // legitimately persists across renders and would re-select machine-2
+    // independently of the draft — the draft restore path under test is the
+    // only channel that must NOT fire.
+    window.localStorage.removeItem("omnigent:last-host-choice");
+
+    // Project launch: the message survives, the foreign host pick does not
+    // (the auto-seed falls back to the first online host).
+    const second = renderLanding({}, "/?project=docs");
+    await waitFor(() => expect(screen.getByText("docs")).toBeTruthy());
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "finish the migration",
+    );
+    expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain(
+      "machine-2",
+    );
+
+    // A deliberate choice made IN the project context round-trips: reopening
+    // the same project restores its own draft's launch state (the issue's
+    // "returning to the same unfinished project draft" requirement).
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByText("machine-2"));
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-2"),
+    );
+    second.unmount();
+    window.localStorage.removeItem("omnigent:last-host-choice");
+
+    renderLanding({}, "/?project=docs");
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-2"),
+    );
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "finish the migration",
+    );
+  });
+
   it("shows host-provided git credentials tooltip content in the sandbox repo popover", async () => {
     setOmnigentHostConfig({
       docsLinks: { databricksGitCredentials: "Use Databricks Git credentials before cloning." },

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1985,6 +1985,11 @@ function HarnessConfigModal({
 interface LandingDraft {
   message: string;
   files: File[];
+  /** Project context the draft was composed under ("" = the global composer).
+   * Launch-control state below restores only into the SAME context — a
+   * global draft's host/workspace/agent must never leak into a project
+   * launch (#5023). */
+  project: string;
   pickedAgentId: string | null;
   selectedHostId: string | null;
   sandboxSelected: boolean;
@@ -2182,16 +2187,26 @@ export function NewChatLandingScreen() {
   // Project driving this visit, when the sidebar's per-project "new session"
   // pencil landed here with a `?project=` query param. Empty otherwise.
   const projectParam = searchParams.get("project") ?? "";
+  // Launch-control draft state (host / workspace / agent / sandbox / worktree)
+  // restores only into the project context it was composed under: a global
+  // composer draft must not leak its workspace into a project launch, and a
+  // project draft must not leak into another project or the global composer
+  // (#5023). Authored content (message, files) and user preferences (model,
+  // permission modes) always restore regardless.
+  const landingDraftForContext: LandingDraft | null =
+    landingDraft !== null && landingDraft.project === projectParam ? landingDraft : null;
   // Seeded from the persisted last pick so a returning user starts on the
   // agent they used last; validated against the live list in
   // effectiveAgentId below (a stale id falls back to the default). A
   // project-driven visit defers to the project-prefill effect instead
   // (which falls back to the same last pick).
   const [pickedAgentId, setPickedAgentId] = useState<string | null>(
-    () => landingDraft?.pickedAgentId ?? (projectParam !== "" ? null : readLastAgentId()),
+    () =>
+      landingDraftForContext?.pickedAgentId ??
+      (projectParam !== "" ? null : readLastAgentId()),
   );
   const [selectedHostId, setSelectedHostId] = useState<string | null>(
-    () => landingDraft?.selectedHostId ?? null,
+    () => landingDraftForContext?.selectedHostId ?? null,
   );
   // Sessions on the selected host — fetched only when a host is selected,
   // to avoid registering hundreds of sessions into the health poll at idle.
@@ -2200,13 +2215,13 @@ export function NewChatLandingScreen() {
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
   const [sandboxSelected, setSandboxSelected] = useState(
-    () => landingDraft?.sandboxSelected ?? false,
+    () => landingDraftForContext?.sandboxSelected ?? false,
   );
   // Provider the sandbox pick launches on. Seeded to the sticky last pick (or
   // the first offered row) once the picker rows load; null both before that
   // seed and for a single-provider server that names no provider.
   const [sandboxProvider, setSandboxProvider] = useState<string | null>(
-    () => landingDraft?.sandboxProvider ?? null,
+    () => landingDraftForContext?.sandboxProvider ?? null,
   );
   const { data: hostClaudeModelOptions, isLoading: hostClaudeModelsLoading } = useHostModelOptions(
     selectedHostId,
@@ -2267,13 +2282,17 @@ export function NewChatLandingScreen() {
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
   const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
-    () => landingDraft?.sandboxRepoUrl ?? "",
+    () => landingDraftForContext?.sandboxRepoUrl ?? "",
   );
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
-    () => landingDraft?.sandboxRepoBranch ?? "",
+    () => landingDraftForContext?.sandboxRepoBranch ?? "",
   );
-  const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
-  const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
+  const [workspace, setWorkspace] = useState<string>(
+    () => landingDraftForContext?.workspace ?? "",
+  );
+  const [branchName, setBranchName] = useState<string>(
+    () => landingDraftForContext?.branchName ?? "",
+  );
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
   // touches it — clearing the branch name re-arms the auto-fill (see the effect
@@ -2290,7 +2309,7 @@ export function NewChatLandingScreen() {
   // that worktree (no git opts). Editing the field away from it means the user
   // wants a *new* worktree off that name.
   const [prefilledBranch, setPrefilledBranch] = useState<string>(
-    () => landingDraft?.prefilledBranch ?? "",
+    () => landingDraftForContext?.prefilledBranch ?? "",
   );
   // Project to file the new session under. Empty = unfiled. Stamped as the
   // `omni_project` label at create (so the row is filed from its first sidebar
@@ -2339,8 +2358,8 @@ export function NewChatLandingScreen() {
   // switch, seeded from the user's last stored pick for that agent.
   const [pickedHarness, setPickedHarness] = useState<string | null>(
     () =>
-      landingDraft?.pickedHarness ??
-      readLastHarness(landingDraft?.pickedAgentId ?? readLastAgentId()),
+      landingDraftForContext?.pickedHarness ??
+      readLastHarness(landingDraftForContext?.pickedAgentId ?? readLastAgentId()),
   );
   // Per-session model + reasoning effort for the claude-native model picker.
   // "" = unselected: nothing is checked and `model_override` / `reasoning_effort`
@@ -2397,6 +2416,7 @@ export function NewChatLandingScreen() {
   draftRef.current = {
     message,
     files,
+    project: projectParam,
     pickedAgentId,
     selectedHostId,
     sandboxSelected,


### PR DESCRIPTION
Fixes #5023.

## Root cause

The preserved landing draft seeded launch-control state (`workspace`, `selectedHostId`, `pickedAgentId`, sandbox picks, worktree branch) directly into the New Chat state initializers, and the project prefill only fills **empty** slots (`setWorkspace(cur => cur === "" ? … : cur)`, `setSelectedHostId(cur => cur ?? …)`). So whichever slots the global draft occupied, the stale draft won — the session filed under project B while launching from the draft's workspace A, exactly the reported repro. Intermittency explained: a successful create clears the draft, so the next project launch is clean.

## Fix

The draft now records **the project context it was composed under** (`LandingDraft.project`, captured from the `?project=` param), and launch-control state restores only into the *same* context via a single gating view:

```ts
const landingDraftForContext =
  landingDraft !== null && landingDraft.project === projectParam ? landingDraft : null;
```

Gated (launch-control — the issue's list): host, workspace, agent pick, sandbox selected/provider/repo url/branch, worktree `branchName`/`prefilledBranch`, harness pick.
Ungated (always restore): the authored message and attachments, plus user preferences — model, effort, permission/approval/exec modes, cost control — which belong to the user, not the destination.

Effects:
- global draft → `?project=` launch: project prefill owns the launch slots (the "reseeded from the destination project" expectation);
- project draft → another project or the global composer: same isolation both directions;
- reopening the **same** unfinished project draft: its deliberate launch choices still restore (the issue's second requirement).

## Test

`keeps a global composer draft's launch state out of a project launch, and restores it in its own context` — three legs, using the host pick as the marker (deliberately chosen `machine-2`, distinct from the first-online default; the sticky host-choice preference is cleared between renders so the draft is the only channel under test):

1. global draft with `machine-2` + a message →
2. `?project=docs` render: message restores, host falls back to `machine-1` (no `machine-2` leak) — **fails on `main`** (chip shows the leaked `machine-2`); a deliberate `machine-2` pick made *in* the project render →
3. reopen `?project=docs`: the project's own draft restores `machine-2` + message.

Full `NewChatDialog.test.tsx`: 273 passed / 3 pre-existing environment failures (identical set on clean `main`; sandbox-chrome cases), zero regressions.

One honest scope note: the single-slot module draft means a project interlude *replaces* the global draft (unmounting any composer persists its own state as *the* draft). That's pre-existing behavior, unchanged here — per-context drafts would be a larger storage change; the gating makes the single slot safe in every direction it can flow.
