### PR TITLE
fix(daemon-launch): re-address a wrong-replica runner launch without the slice key

### DIFF
--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -29,6 +29,8 @@ import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from omnigent.errors import ErrorCode
+
 if TYPE_CHECKING:
     import httpx
 
@@ -296,6 +298,84 @@ OMNIGENT_SLICE_KEY_HEADER = "X-Databricks-Omnigent-Slice-Key"
 # request-header builder that keys off it (rather than in the browser-link
 # helpers, which only borrow it).
 WORKSPACE_API_PATH = "/api/2.0/omnigent"
+
+
+def is_wrong_replica_response(resp: httpx.Response) -> bool:
+    """Whether *resp* is a wrong-replica miss to re-address without the key.
+
+    A host-sharded request carries the slice key (:data:`OMNIGENT_SLICE_KEY_HEADER`)
+    so it lands on the replica holding that host's tunnels. When the tunnel has
+    drifted onto another replica — e.g. it re-dialed across a server rebalance
+    while the key still hashes to the old replica — the request reaches a replica
+    without the tunnel and the server answers ``400 {"error": {"code":
+    "wrong_replica"}}``. The request itself is valid; the fix is to reissue it
+    WITHOUT the key (see :data:`~omnigent.errors.ErrorCode.WRONG_REPLICA`).
+
+    Keys off the distinct error code, not the bare 400 — an ``invalid_input`` 400
+    (or a non-JSON SPA-fallback 400) is a real client error, not a routing miss.
+
+    :param resp: A response received on a slice-keyed client.
+    :returns: True only for the wrong-replica code carried on a 400.
+    """
+    if resp.status_code != 400:
+        return False
+    try:
+        body = resp.json()
+    except ValueError:
+        return False
+    error = body.get("error") if isinstance(body, dict) else None
+    return isinstance(error, dict) and error.get("code") == ErrorCode.WRONG_REPLICA
+
+
+async def send_rehealing_wrong_replica(
+    client: httpx.AsyncClient, request: httpx.Request
+) -> httpx.Response:
+    """Send *request*, re-addressing a wrong-replica miss without the slice key.
+
+    Sends *request* as built (slice-keyed, from the client's baked-in headers).
+    On a :func:`is_wrong_replica_response` 400 — the keyed request landed on a
+    replica that does not hold the host's tunnel — reissues it ONCE with the
+    slice-key header dropped, reaching the host via the server's default route.
+    This is the Python client's analogue of the UI fetch path's keyless
+    re-address on a ``wrong_replica`` 400.
+
+    Exactly one re-address is attempted, and only when the request actually
+    carried a key whose body can be replayed: a wrong-replica miss is a stable
+    routing fact (resending the same keyed bytes hits the same wrong replica —
+    only dropping the key changes the routing), so a single keyless reissue is
+    both necessary and sufficient. A request with no key, or a streaming body
+    already consumed by the first send, is returned unhealed.
+
+    :param client: The (slice-keyed) client the request was built from; supplies
+        the transport and per-request auth for both sends.
+    :param request: A request built via ``client.build_request(...)`` so the
+        client's default headers (the slice key included) are already merged in.
+    :returns: The first response when it is not a wrong-replica miss, else the
+        keyless reissue's response.
+    """
+    import httpx
+
+    resp = await client.send(request)
+    if not is_wrong_replica_response(resp):
+        return resp
+    if OMNIGENT_SLICE_KEY_HEADER not in request.headers:
+        return resp
+    try:
+        content = request.content
+    except httpx.RequestNotRead:
+        # A streaming body is already consumed by the first send; a partial
+        # replay would corrupt the request, so surface the miss unhealed.
+        return resp
+    headers = httpx.Headers(request.headers)
+    del headers[OMNIGENT_SLICE_KEY_HEADER]
+    keyless = httpx.Request(
+        request.method,
+        request.url,
+        headers=headers,
+        content=content,
+        extensions=request.extensions,
+    )
+    return await client.send(keyless)
 
 
 def is_workspace_hosted_url(base_url: str) -> bool:

--- a/omnigent/host/daemon_launch.py
+++ b/omnigent/host/daemon_launch.py
@@ -236,10 +236,13 @@ async def launch_or_reuse_daemon_runner(
     :returns: The bound runner id, e.g. ``"runner_abc123"``.
     :raises click.ClickException: If the launch request fails.
     """
+    from omnigent.cli_auth import send_rehealing_wrong_replica
+
     if fresh:
         existing = None
     else:
-        snap = await client.get(f"/v1/sessions/{url_component(session_id)}")
+        snap_req = client.build_request("GET", f"/v1/sessions/{url_component(session_id)}")
+        snap = await send_rehealing_wrong_replica(client, snap_req)
         existing = _json_body(snap).get("runner_id") if snap.status_code == 200 else None
     if isinstance(existing, str) and existing:
         if await runner_is_online(client, existing):
@@ -259,15 +262,23 @@ async def launch_or_reuse_daemon_runner(
     # fails. Retry transient 409s across the reconnect window so
     # high-latency / reconnecting setups start reliably. Bounded, so a
     # genuinely-offline host still fails reasonably fast.
+    #
+    # A distinct failure is a wrong-replica landing (400): the host IS online,
+    # but the slice-keyed launch reached a replica that doesn't hold its tunnel
+    # (a tunnel that drifted across a server rebalance). That is not transient —
+    # `send_rehealing_wrong_replica` heals it in place by reissuing the launch
+    # without the key, so it never surfaces to the 409 backoff below.
     _RETRY_DELAYS_S = (0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.0, 3.0)  # ~16.5s budget
     for attempt in range(len(_RETRY_DELAYS_S) + 1):
         if attempt:
             await asyncio.sleep(_RETRY_DELAYS_S[attempt - 1])
-        resp = await client.post(
+        launch_req = client.build_request(
+            "POST",
             f"/v1/hosts/{url_component(host_id)}/runners",
             json={"session_id": session_id, "workspace": workspace},
             timeout=60.0,
         )
+        resp = await send_rehealing_wrong_replica(client, launch_req)
         if resp.status_code < 400:
             break
         transient = resp.status_code == 409 and "offline" in error_text(resp).lower()

--- a/tests/host/test_daemon_launch.py
+++ b/tests/host/test_daemon_launch.py
@@ -15,9 +15,14 @@ import click
 import httpx
 import pytest
 
-from omnigent.cli_auth import OMNIGENT_SLICE_KEY_HEADER
+from omnigent.cli_auth import (
+    OMNIGENT_SLICE_KEY_HEADER,
+    is_wrong_replica_response,
+    send_rehealing_wrong_replica,
+)
 from omnigent.host import daemon_launch
 from omnigent.host.daemon_launch import (
+    launch_or_reuse_daemon_runner,
     open_daemon_client,
     runner_is_online,
     wait_for_host_online,
@@ -392,3 +397,134 @@ async def test_open_daemon_client_no_slice_key_without_host() -> None:
     """A hostless (local) session leaves routing to the default fallback."""
     async with open_daemon_client("https://ws.example.com/api/2.0/omnigent", {}, None) as client:
         assert OMNIGENT_SLICE_KEY_HEADER not in client.headers
+
+
+def _wrong_replica_body() -> dict[str, object]:
+    """The server's ``400`` wrong-replica error body."""
+    return {"error": {"code": "wrong_replica", "message": "host is on another replica"}}
+
+
+class _WrongReplicaUntilKeyless:
+    """Launch handler: 400 wrong_replica while keyed, 200 once the key is dropped.
+
+    Mirrors a host whose tunnel drifted onto another replica — the slice-keyed
+    launch lands on the wrong replica (400 wrong_replica) until the client
+    re-addresses without the key and reaches the host via the default route.
+    """
+
+    def __init__(self) -> None:
+        self.keyed_launches = 0
+        self.keyless_launches = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and "/v1/sessions/" in request.url.path:
+            return httpx.Response(200, json={})  # no runner bound → launch a fresh one
+        if request.method == "POST" and request.url.path.endswith("/runners"):
+            if OMNIGENT_SLICE_KEY_HEADER in request.headers:
+                self.keyed_launches += 1
+                return httpx.Response(400, json=_wrong_replica_body())
+            self.keyless_launches += 1
+            return httpx.Response(200, json={"runner_id": "runner_healed"})
+        return httpx.Response(404, json={"error": {"code": "not_found"}})
+
+
+async def test_launch_reissues_without_slice_key_on_wrong_replica() -> None:
+    """A wrong-replica launch self-heals by re-addressing keyless.
+
+    The reported ``host is on another replica`` failure: a slice-keyed launch
+    lands on a replica without the host's tunnel. Rather than aborting the
+    session start, the launch is reissued without the key and succeeds — one
+    keyed miss, then one keyless success, no manual ``omnigent stop`` needed.
+    """
+    handler = _WrongReplicaUntilKeyless()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+        headers={OMNIGENT_SLICE_KEY_HEADER: "host_abc123"},
+    ) as client:
+        runner_id = await launch_or_reuse_daemon_runner(
+            client,
+            host_id="host_abc123",
+            session_id="conv_abc123",
+            workspace="/w",
+        )
+    assert runner_id == "runner_healed"
+    assert handler.keyed_launches == 1
+    assert handler.keyless_launches == 1
+
+
+async def test_send_rehealing_wrong_replica_drops_key_and_replays_body() -> None:
+    """The keyless reissue drops only the key and preserves method + body."""
+    seen: list[tuple[bool, bytes]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        keyed = OMNIGENT_SLICE_KEY_HEADER in request.headers
+        seen.append((keyed, request.content))
+        if keyed:
+            return httpx.Response(400, json=_wrong_replica_body())
+        return httpx.Response(200, json={"runner_id": "runner_ok"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+        headers={OMNIGENT_SLICE_KEY_HEADER: "host_abc123"},
+    ) as client:
+        request = client.build_request("POST", "/v1/hosts/h/runners", json={"session_id": "s"})
+        resp = await send_rehealing_wrong_replica(client, request)
+
+    assert resp.status_code == 200
+    assert [keyed for keyed, _ in seen] == [True, False]
+    # Same bytes on the replay — a wrong-replica miss is valid, just misrouted.
+    assert seen[0][1] == seen[1][1]
+
+
+async def test_send_rehealing_wrong_replica_passes_non_wrong_replica_through() -> None:
+    """A plain 400 (real client error) is surfaced, never re-addressed."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(400, json={"error": {"code": "invalid_input", "message": "bad"}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+        headers={OMNIGENT_SLICE_KEY_HEADER: "host_abc123"},
+    ) as client:
+        request = client.build_request("POST", "/v1/hosts/h/runners", json={})
+        resp = await send_rehealing_wrong_replica(client, request)
+
+    assert resp.status_code == 400
+    assert calls == 1  # not retried
+
+
+async def test_send_rehealing_wrong_replica_no_key_is_not_retried() -> None:
+    """Without a key there is nothing to drop, so a 400 is returned as-is."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(400, json=_wrong_replica_body())
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        request = client.build_request("POST", "/v1/hosts/h/runners", json={})
+        resp = await send_rehealing_wrong_replica(client, request)
+
+    assert resp.status_code == 400
+    assert calls == 1
+
+
+def test_is_wrong_replica_response_keys_off_code_not_status() -> None:
+    """Only the wrong-replica code on a 400 counts — not any 400, not other codes."""
+    assert is_wrong_replica_response(httpx.Response(400, json=_wrong_replica_body()))
+    assert not is_wrong_replica_response(
+        httpx.Response(400, json={"error": {"code": "invalid_input"}})
+    )
+    # Wrong-replica maps to 400; the same code on another status is a mismatch.
+    assert not is_wrong_replica_response(httpx.Response(409, json=_wrong_replica_body()))
+    # SPA HTML fallback (non-JSON body) must not be mistaken for a routing miss.
+    assert not is_wrong_replica_response(httpx.Response(400, text="<!doctype html>"))


### PR DESCRIPTION
## Related issue

<!-- Fill in before marking ready for review. -->

Closes #

## Summary

- A slice-keyed runner launch (`POST /v1/hosts/{id}/runners`) can land on a replica that doesn't hold the host's tunnel — the tunnel drifted to another replica across a server rebalance while the key still hashes to the old one. The server returns `400 wrong_replica`, and the CLI aborted the whole session start with `Failed to launch a runner on host ... host is on another replica`, forcing a manual `omnigent stop` + relaunch.
- Per `errors.ErrorCode.WRONG_REPLICA` the request is valid, just misrouted; the documented fix (already used by the UI fetch path) is to reissue it **without** the slice key and reach the host via the default route. This adds the Python-client analogue.
- New `send_rehealing_wrong_replica` / `is_wrong_replica_response` in `cli_auth`; the launch `POST` and the session-snapshot `GET` in `launch_or_reuse_daemon_runner` now go through it. Exactly one keyless reissue, only when the request carried a key with a replayable body — distinct from the transient `409 offline` the launch loop already backs off on.

## Test Plan

- `uv run --no-sync pytest tests/host/test_daemon_launch.py` — 18 passed (6 new): end-to-end launch self-heal (keyed miss → keyless success), the helper drops only the key and replays the same body, a plain `400 invalid_input` is passed through (not retried), a keyless request isn't retried, and `is_wrong_replica_response` keys off the error code (not any 400, not a non-JSON SPA fallback).
- Regression check: `uv run --no-sync pytest tests/host/test_connect.py tests/cli/test_login_databricks.py` — 178 passed (the new module-level `errors` import in `cli_auth` introduces no cycle).
- `ruff check` / `ruff format --check` clean; `pyrefly check` 0 errors on both changed modules.

## Demo

N/A — non-visual (CLI/server request routing).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The self-heal is exercised through the real `launch_or_reuse_daemon_runner` path with an `httpx.MockTransport` standing in for the server (keyed launch → `400 wrong_replica`, keyless launch → `200`), plus focused unit tests on the helper.

## Changelog

Starting a session no longer fails with "host is on another replica" — a runner launch that lands on the wrong server replica now re-addresses itself and launches instead of erroring out.
