### PR TITLE
perf(claude-native): drop a duplicate terminal fetch on launch and resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3291,7 +3291,7 @@ async def _wait_for_claude_terminal_ready(
     session_id: str,
     *,
     timeout_s: float,
-) -> str:
+) -> _ClaudeTerminalSnapshot:
     """
     Poll until the runner has auto-created the Claude terminal.
 
@@ -3303,14 +3303,15 @@ async def _wait_for_claude_terminal_ready(
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Session id, e.g. ``"conv_abc123"``.
     :param timeout_s: Max seconds to wait, e.g. ``60.0``.
-    :returns: The terminal resource id, e.g. ``"terminal_claude_main"``.
+    :returns: The terminal snapshot, whose tmux coordinates come from
+        the same response that reported the terminal ready.
     :raises click.ClickException: If no terminal appears in time.
     """
     deadline = asyncio.get_event_loop().time() + timeout_s
     while asyncio.get_event_loop().time() < deadline:
-        terminal_id = await _find_running_claude_terminal(client, session_id)
-        if terminal_id is not None:
-            return terminal_id
+        found = await _find_running_claude_terminal(client, session_id)
+        if found is not None:
+            return found
         await asyncio.sleep(DAEMON_POLL_INTERVAL_S)
     raise click.ClickException(
         f"The runner did not create the Claude terminal for {session_id!r} "
@@ -3545,7 +3546,7 @@ async def _prepare_claude_terminal_via_daemon(
                 startup_progress=startup_progress,
                 progress_message="Starting Claude terminal...",
             )
-            terminal_id = await _wait_for_claude_terminal_ready(
+            terminal = await _wait_for_claude_terminal_ready(
                 client, session_id, timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S
             )
         else:
@@ -3562,7 +3563,7 @@ async def _prepare_claude_terminal_via_daemon(
                 startup_progress=startup_progress,
                 progress_message="Starting Claude terminal...",
             )
-            _, terminal_id = await asyncio.gather(
+            _, terminal = await asyncio.gather(
                 wait_for_runner_online(
                     client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S
                 ),
@@ -3574,21 +3575,16 @@ async def _prepare_claude_terminal_via_daemon(
             startup_profiler,
             "claude terminal ready",
             startup_progress=startup_progress,
+            detail=f"terminal={terminal.terminal_id}",
             progress_message="Claude terminal ready.",
-        )
-        tmux = await _read_claude_terminal_tmux(client, session_id)
-        _mark_startup_step(
-            startup_profiler,
-            "daemon terminal tmux metadata read",
-            startup_progress=startup_progress,
         )
     return PreparedClaudeTerminal(
         session_id=session_id,
-        terminal_id=terminal_id,
+        terminal_id=terminal.terminal_id,
         bridge_dir=bridge_dir_for_conversation_id(session_id),
         reattached=reattached,
-        tmux_socket=tmux.socket,
-        tmux_target=tmux.target,
+        tmux_socket=terminal.tmux.socket,
+        tmux_target=terminal.tmux.target,
     )
 
 
@@ -3902,26 +3898,20 @@ async def _prepare_claude_terminal(
                 "checking existing terminal",
                 startup_progress=startup_progress,
             )
-            existing_terminal_id = await _find_running_claude_terminal(client, session_id)
-            if existing_terminal_id is not None:
+            existing_terminal = await _find_running_claude_terminal(client, session_id)
+            if existing_terminal is not None:
                 _mark_startup_step(
                     startup_profiler,
                     "existing terminal found",
                     startup_progress=startup_progress,
                 )
-                reattach_tmux = await _read_claude_terminal_tmux(client, session_id)
-                _mark_startup_step(
-                    startup_profiler,
-                    "existing terminal tmux metadata read",
-                    startup_progress=startup_progress,
-                )
                 return PreparedClaudeTerminal(
                     session_id=session_id,
-                    terminal_id=existing_terminal_id,
+                    terminal_id=existing_terminal.terminal_id,
                     bridge_dir=bridge_dir_for_bridge_id(bridge_id),
                     reattached=True,
-                    tmux_socket=reattach_tmux.socket,
-                    tmux_target=reattach_tmux.target,
+                    tmux_socket=existing_terminal.tmux.socket,
+                    tmux_target=existing_terminal.tmux.target,
                 )
             # Session exists but no live terminal — recover claude's prior transcript via --resume.
             _mark_startup_step(
@@ -4943,9 +4933,9 @@ async def _launch_claude_terminal(
 async def _find_running_claude_terminal(
     client: httpx.AsyncClient,
     session_id: str,
-) -> str | None:
+) -> _ClaudeTerminalSnapshot | None:
     """
-    Return the existing running ``claude/main`` terminal id if present.
+    Return the existing running ``claude/main`` terminal if present.
 
     Lookup happens before rebinding an existing session to this
     invocation's local runner. That preserves reattach behavior for a
@@ -4954,11 +4944,15 @@ async def _find_running_claude_terminal(
     callers deterministically bind the current local runner and launch
     a fresh terminal.
 
+    The one response carries the tmux coordinates too, so callers that
+    want to attach directly read them off the snapshot instead of
+    re-fetching the same resource (the lookup costs ~2s remotely).
+
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Session/conversation id, e.g.
         ``"conv_abc123"``.
-    :returns: The deterministic Claude terminal id, or ``None`` when
-        the wrapper should launch a new terminal.
+    :returns: The terminal snapshot, or ``None`` when the wrapper should
+        launch a new terminal.
     :raises click.ClickException: If the server rejects the lookup for
         a reason other than "not currently attachable".
     """
@@ -4979,7 +4973,10 @@ async def _find_running_claude_terminal(
         metadata = payload.get("metadata")
         if isinstance(metadata, dict) and metadata.get("running") is False:
             return None
-        return terminal_id
+        return _ClaudeTerminalSnapshot(
+            terminal_id=terminal_id,
+            tmux=_parse_claude_terminal_tmux(metadata),
+        )
     if resp.status_code in {404, 409, 502, 503}:
         return None
     if resp.status_code >= 400:
@@ -5006,18 +5003,63 @@ class _ClaudeTerminalTmux:
     target: str | None
 
 
+@dataclass(frozen=True)
+class _ClaudeTerminalSnapshot:
+    """
+    A running Claude terminal as one lookup saw it.
+
+    Pairs the resource id with the tmux coordinates from the same
+    response so an attach decision needs a single round trip.
+
+    :param terminal_id: The deterministic terminal resource id, e.g.
+        ``"terminal_claude_main"``.
+    :param tmux: Local tmux coordinates the runner advertised.
+    """
+
+    terminal_id: str
+    tmux: _ClaudeTerminalTmux
+
+
+def _parse_claude_terminal_tmux(metadata: object) -> _ClaudeTerminalTmux:
+    """
+    Read the tmux socket/target off a terminal resource's metadata.
+
+    Lets the caller decide whether to attach to the runner's tmux
+    directly (same machine, low latency) instead of relaying over the
+    WebSocket PTY bridge. Best-effort: metadata of the wrong shape or
+    without the coordinates yields ``(None, None)``, which callers treat
+    as "not locally attachable" and fall back to the WebSocket path.
+
+    :param metadata: The ``metadata`` field of a terminal resource
+        payload, e.g. ``{"tmux_socket": "/tmp/x/tmux.sock", "tmux_target":
+        "main"}``.
+    :returns: The tmux coordinates, or ``_ClaudeTerminalTmux(None,
+        None)`` when unavailable.
+    """
+    if not isinstance(metadata, dict):
+        return _ClaudeTerminalTmux(socket=None, target=None)
+    raw_socket = metadata.get("tmux_socket")
+    raw_target = metadata.get("tmux_target")
+    socket = Path(raw_socket) if isinstance(raw_socket, str) and raw_socket else None
+    target = raw_target if isinstance(raw_target, str) and raw_target else None
+    return _ClaudeTerminalTmux(socket=socket, target=target)
+
+
 async def _read_claude_terminal_tmux(
     client: httpx.AsyncClient,
     session_id: str,
 ) -> _ClaudeTerminalTmux:
     """
-    Read the tmux socket/target the Claude terminal resource exposes.
+    Fetch the tmux socket/target the Claude terminal resource exposes.
 
-    Lets the caller decide whether to attach to the runner's tmux
-    directly (same machine, low latency) instead of relaying over the
-    WebSocket PTY bridge. Best-effort: any lookup failure, non-200, or
-    missing metadata yields ``(None, None)``, which callers treat as
-    "not locally attachable" and fall back to the WebSocket path.
+    For callers holding no terminal snapshot — the launch path, whose
+    ``POST`` answers before the runner has published its tmux coordinates.
+    Callers that just looked the terminal up read ``snapshot.tmux``
+    instead of paying for a second round trip.
+
+    Best-effort: any lookup failure, non-200, or missing metadata yields
+    ``(None, None)``, which callers treat as "not locally attachable" and
+    fall back to the WebSocket path.
 
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Session/conversation id, e.g. ``"conv_abc123"``.
@@ -5035,14 +5077,7 @@ async def _read_claude_terminal_tmux(
         return _ClaudeTerminalTmux(socket=None, target=None)
     if resp.status_code != 200:
         return _ClaudeTerminalTmux(socket=None, target=None)
-    metadata = resp.json().get("metadata")
-    if not isinstance(metadata, dict):
-        return _ClaudeTerminalTmux(socket=None, target=None)
-    raw_socket = metadata.get("tmux_socket")
-    raw_target = metadata.get("tmux_target")
-    socket = Path(raw_socket) if isinstance(raw_socket, str) and raw_socket else None
-    target = raw_target if isinstance(raw_target, str) and raw_target else None
-    return _ClaudeTerminalTmux(socket=socket, target=target)
+    return _parse_claude_terminal_tmux(resp.json().get("metadata"))
 
 
 def _claude_terminal_request(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -1738,35 +1738,23 @@ async def test_prepare_daemon_terminal_reports_progress_steps(
         session_id: str,
         *,
         timeout_s: float,
-    ) -> str:
+    ) -> claude_native._ClaudeTerminalSnapshot:
         """
-        Return the Claude terminal id once the wait phase is reached.
+        Return the Claude terminal once the wait phase is reached.
 
         :param client: HTTP client created by the prepare helper.
         :param session_id: Created conversation id.
         :param timeout_s: Timeout supplied by production.
-        :returns: Fixed terminal id.
+        :returns: Snapshot carrying the terminal id and tmux coordinates.
         """
         del client, timeout_s
         assert session_id == "conv_daemon_progress"
-        return claude_native.claude_terminal_resource_id()
-
-    async def fake_read_tmux(
-        client: object,
-        session_id: str,
-    ) -> claude_native._ClaudeTerminalTmux:
-        """
-        Return local tmux metadata for direct attach.
-
-        :param client: HTTP client created by the prepare helper.
-        :param session_id: Created conversation id.
-        :returns: Fake tmux coordinates.
-        """
-        del client
-        assert session_id == "conv_daemon_progress"
-        return claude_native._ClaudeTerminalTmux(
-            socket=tmp_path / "tmux.sock",
-            target="claude:main",
+        return claude_native._ClaudeTerminalSnapshot(
+            terminal_id=claude_native.claude_terminal_resource_id(),
+            tmux=claude_native._ClaudeTerminalTmux(
+                socket=tmp_path / "tmux.sock",
+                target="claude:main",
+            ),
         )
 
     monkeypatch.setattr(claude_native, "_create_claude_session", fake_create_session)
@@ -1782,7 +1770,22 @@ async def test_prepare_daemon_terminal_reports_progress_steps(
         "_wait_for_claude_terminal_ready",
         fake_wait_for_terminal_ready,
     )
-    monkeypatch.setattr(claude_native, "_read_claude_terminal_tmux", fake_read_tmux)
+
+    async def fail_read_tmux(
+        client: object,
+        session_id: str,
+    ) -> claude_native._ClaudeTerminalTmux:
+        """
+        Fail if prepare re-fetches the terminal just for its tmux coordinates.
+
+        :param client: HTTP client created by the prepare helper.
+        :param session_id: Created conversation id.
+        :returns: Never returns.
+        """
+        del client
+        raise AssertionError(f"unexpected second terminal lookup for {session_id}")
+
+    monkeypatch.setattr(claude_native, "_read_claude_terminal_tmux", fail_read_tmux)
 
     prepared = await claude_native._prepare_claude_terminal_via_daemon(
         base_url="https://example.com",
@@ -2191,17 +2194,20 @@ async def test_prepare_reattaches_existing_claude_terminal(
     """
     calls: list[str] = []
 
-    async def fake_find(client: object, session_id: str) -> str | None:
+    async def fake_find(client: object, session_id: str) -> claude_native._ClaudeTerminalSnapshot:
         """
         Return the existing terminal and record lookup order.
 
         :param client: HTTP client created by the prepare helper.
         :param session_id: Existing session id.
-        :returns: Existing terminal id.
+        :returns: Snapshot of the existing terminal.
         """
         del client
         calls.append(f"find:{session_id}")
-        return claude_native.claude_terminal_resource_id()
+        return claude_native._ClaudeTerminalSnapshot(
+            terminal_id=claude_native.claude_terminal_resource_id(),
+            tmux=claude_native._ClaudeTerminalTmux(socket=None, target=None),
+        )
 
     async def fail_bind(client: object, session_id: str, runner_id: str) -> None:
         """
@@ -2303,7 +2309,8 @@ async def test_find_running_claude_terminal_reads_resource_endpoint() -> None:
     async with httpx.AsyncClient(transport=transport, base_url="https://example.com") as client:
         found = await claude_native._find_running_claude_terminal(client, "conv with space")
 
-    assert found == terminal_id
+    assert found is not None
+    assert found.terminal_id == terminal_id
     assert requested_urls == [
         "https://example.com/v1/sessions/conv%20with%20space"
         "/resources/terminals/terminal_claude_main"
@@ -5079,7 +5086,9 @@ async def test_prepare_claude_terminal_cold_resume_injects_external_session_id(
     """
     captured_terminal_args: dict[str, Any] = {}
 
-    async def _fake_find_running(_client: object, _session_id: str) -> str | None:
+    async def _fake_find_running(
+        _client: object, _session_id: str
+    ) -> claude_native._ClaudeTerminalSnapshot | None:
         """
         No live terminal → force the cold-resume code path.
 

--- a/tests/test_claude_native_daemon.py
+++ b/tests/test_claude_native_daemon.py
@@ -430,3 +430,46 @@ def test_run_with_remote_server_unreachable_server_raises_clean_error(
     assert "Could not reach the omnigent server at https://unreachable.example" in str(
         exc_info.value
     )
+
+
+async def test_wait_for_claude_terminal_ready_returns_tmux_from_one_lookup() -> None:
+    """
+    The readiness poll hands back tmux coordinates from its own response.
+
+    The terminal resource GET costs ~2.3s against a remote server, and the
+    caller needs both "is it up" and "where is its tmux". Re-fetching the
+    same resource for the coordinates doubled that cost on every launch, so
+    the poll's own payload must carry them.
+    """
+    requests: list[str] = []
+    terminal_id = claude_native.claude_terminal_resource_id()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Answer the terminal lookup with a running terminal + tmux metadata."""
+        requests.append(f"{request.method} {request.url.path}")
+        return httpx.Response(
+            200,
+            json={
+                "id": terminal_id,
+                "type": "terminal",
+                "metadata": {
+                    "running": True,
+                    "tmux_socket": "/tmp/omnigent/tmux.sock",
+                    "tmux_target": "claude:main",
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://e.com"
+    ) as client:
+        found = await claude_native._wait_for_claude_terminal_ready(
+            client, "conv_a", timeout_s=5.0
+        )
+
+    assert found.terminal_id == terminal_id
+    assert found.tmux.socket == Path("/tmp/omnigent/tmux.sock")
+    assert found.tmux.target == "claude:main"
+    assert requests == [
+        f"GET /v1/sessions/conv_a/resources/terminals/{terminal_id}",
+    ]


### PR DESCRIPTION
## Related issue

N/A — this is a `Refactor / chore`, which the PR template exempts from requiring a linked issue.

## Summary

`_prepare_claude_terminal_via_daemon` polled the terminal resource until it reported ready, then immediately re-fetched *the very same resource* just to read its tmux coordinates. Against a remote server that lookup costs ~2.3s, so every launch and every resume paid it twice.

The readiness poll now returns a `_ClaudeTerminalSnapshot` carrying both the resource id and the tmux coordinates off the one response it already had. `_read_claude_terminal_tmux` stays for the launch path, which holds no snapshot, and now shares its metadata parsing with the poll.

```
before:  [poll terminal ~2.3s] -> ... -> ready -> [fetch tmux ~2.3s]
after:   [poll terminal ~2.3s] -> ... -> ready (tmux included)
```

Expected saving is ~2.3s per launch and per resume, derived from a measured per-endpoint latency (`GET /v1/sessions/{id}/resources/terminals/{id}` ~2261ms against a remote Databricks-fronted server) rather than from an end-to-end timing run.

### Why the coordinates are always present

The one way this could regress *quietly* is if the runner published `running: true` before the tmux coordinates — then the readiness poll's payload would lack them where the dropped second fetch, a full round trip later, would have seen them. The attach would silently fall back to the WebSocket PTY bridge instead of a direct tmux attach: slower, but no error.

It cannot. `terminal_resource_view` (`omnigent/entities/session_resources.py:136`) projects `running`, `tmux_socket`, and `tmux_target` together from one live `TerminalListEntry` on every read — a stateless projection of the registry entry, not incrementally published state. Any response that describes the terminal at all carries the coordinates from the same `entry.instance` snapshot, so the dropped fetch could never observe fields the first response was missing.

This also *removes* a failure mode: a transient error on that second fetch used to downgrade the attach to the bridge silently. There is now no second fetch to fail.

### Scope note

An earlier revision of this PR also changed the status-poll cadence (treating `DAEMON_POLL_INTERVAL_S` as a floor measured from the start of each request rather than a gap after it). That was dropped: it bought up to 500ms per wait but raised request volume against the already-slow status endpoints by up to ~1.85x, which is a load-for-latency trade rather than a pure win, and it was unrelated to the duplicate fetch. `omnigent/host/daemon_launch.py` is untouched by this PR.

## Test Plan

Automated:

- `pytest tests/host/test_daemon_launch.py tests/test_claude_native.py tests/test_claude_native_daemon.py` — 311 passed.
- New `test_wait_for_claude_terminal_ready_returns_tmux_from_one_lookup` asserts the readiness poll returns the tmux coordinates and issues exactly one request.
- `test_prepare_daemon_terminal_reports_progress_steps` now fails if the prepare path re-fetches the terminal for its coordinates; confirmed by re-adding the second fetch.
- `pre-commit run` (ruff format, ruff check, pyrefly) clean on the changed files.

**Not yet run — needs a reviewer with a remote server.** I have not exercised this against a live remote server, so the latency figure above is analytical, not measured end to end. Suggested checks:

1. `OMNIGENT_CLAUDE_STARTUP_PROFILE=1 omnigent claude --server <remote>` — the `daemon terminal tmux metadata read` mark should be gone, and `claude terminal ready` should carry a `terminal=...` detail. Compare total startup against `main`.
2. Resume into a live session and confirm you still get a **direct tmux attach**, not the WebSocket PTY bridge — a regression here degrades quietly rather than raising. See "Why the coordinates are always present" for why this should hold; the check is to confirm it in practice.

Note: `test_resolve_native_claude_config_ambient_key` and `..._ambient_prefixed_key` fail identically on pristine `main` in my environment — pre-existing, unrelated files.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test pins the property that matters: `_wait_for_claude_terminal_ready` returns tmux coordinates from a single round trip. The guard against re-introducing the second fetch was confirmed to fail when the fetch is re-added.

The gap is end-to-end: no automated test measures startup wall clock, and the direct-tmux-attach path on resume is covered by unit tests but not by a real attach — so item 2 in the Test Plan is worth a reviewer's eyes before merge.

## Changelog

Sessions start faster — `omnigent claude` no longer refetches the terminal resource it just found.
