### PR TITLE
perf(native): overlap session create with the host-online poll

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -800,10 +800,13 @@ async def _prepare_antigravity_terminal_via_daemon(
             _update_progress(startup_progress, "Creating Antigravity session...")
             bridge_id = _mint_agy_conversation_id()
             conversation_id = bridge_id
-            session_id = await _create_antigravity_session(
-                client,
-                session_bundle,
-                bridge_id=bridge_id,
+            session_id, _ = await asyncio.gather(
+                _create_antigravity_session(
+                    client,
+                    session_bundle,
+                    bridge_id=bridge_id,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_progress(startup_progress, "Loading Antigravity session...")
@@ -847,7 +850,8 @@ async def _prepare_antigravity_terminal_via_daemon(
             conversation_id = external if isinstance(external, str) and external else bridge_id
             resume = isinstance(external, str) and bool(external)
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1595,22 +1595,23 @@ async def _prepare_chat_session_via_daemon(
     )
     from omnigent.native_terminal import bind_session_runner
 
-    try:
+    async def resolve_session() -> tuple[str, bool]:
+        """Fork, resume, or create the session to bind, and say if it is fresh.
+
+        :returns: The session id and whether it was created just now.
+        :raises click.ClickException: If the server rejects the create/fork.
+        """
         async with OmnigentClient(base_url=base_url, headers=headers, auth=auth) as sdk:
             try:
                 if fork_session_id is not None:
                     fork_result = await sdk.sessions.fork(fork_session_id)
-                    session_id = fork_result["id"]
-                    fresh_session = False
-                elif resume_conversation_id is not None:
-                    session_id = resume_conversation_id
-                    fresh_session = False
-                else:
-                    created = await sdk.sessions.create(
-                        bundle, filename="agent.tar.gz", workspace=workspace
-                    )
-                    session_id = created.id
-                    fresh_session = True
+                    return fork_result["id"], False
+                if resume_conversation_id is not None:
+                    return resume_conversation_id, False
+                created = await sdk.sessions.create(
+                    bundle, filename="agent.tar.gz", workspace=workspace
+                )
+                return created.id, True
             except ClientOmnigentError as exc:
                 # Any create/fork/resume rejection here is a server-side answer, not
                 # a client bug worth a traceback: a wrong base URL that answers
@@ -1621,6 +1622,7 @@ async def _prepare_chat_session_via_daemon(
                     f"Could not start a session on {base_url}: {exc}"
                 ) from exc
 
+    try:
         # A separate raw httpx client for the host-runner protocol (the daemon
         # launch helpers operate on httpx, not the SDK), pinned to the host's replica.
         timeout = httpx.Timeout(30.0, read=120.0)
@@ -1629,8 +1631,11 @@ async def _prepare_chat_session_via_daemon(
         ) as client:
             if progress is not None:
                 progress.update(STARTUP_PHASE_CONNECTING)
-            await wait_for_host_online(
-                client, host_id, timeout_s=_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S
+            (session_id, fresh_session), _ = await asyncio.gather(
+                resolve_session(),
+                wait_for_host_online(
+                    client, host_id, timeout_s=_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S
+                ),
             )
             if progress is not None:
                 progress.update(STARTUP_PHASE_LAUNCHING_AGENT)

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -853,11 +853,14 @@ async def _prepare_codex_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Codex session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Codex session...")
-            session_id = await _create_codex_session(
-                client,
-                session_bundle,
-                bridge_id=None,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_codex_session(
+                    client,
+                    session_bundle,
+                    bridge_id=None,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Codex session...")
@@ -910,7 +913,8 @@ async def _prepare_codex_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -511,10 +511,13 @@ async def _prepare_cursor_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Cursor session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Cursor session...")
-            session_id = await _create_cursor_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_cursor_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
             # Persist the model pin before the runner binds and launches the
             # TUI (it reads model_override from the snapshot to build --model).
@@ -575,7 +578,8 @@ async def _prepare_cursor_terminal_via_daemon(
                 _update_startup_progress(startup_progress, "Updating Cursor session...")
                 await _patch_cursor_session(client, session_id, patch)
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -326,10 +326,13 @@ async def _prepare_goose_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Goose session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Goose session...")
-            session_id = await _create_goose_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_goose_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Goose session...")
@@ -372,7 +375,8 @@ async def _prepare_goose_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -324,10 +324,13 @@ async def _prepare_hermes_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Hermes session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Hermes session...")
-            session_id = await _create_hermes_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_hermes_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Hermes session...")
@@ -370,7 +373,8 @@ async def _prepare_hermes_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -333,10 +333,13 @@ async def _prepare_kimi_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Kimi session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Kimi session...")
-            session_id = await _create_kimi_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_kimi_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Kimi session...")
@@ -385,7 +388,8 @@ async def _prepare_kimi_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -364,10 +364,13 @@ async def _prepare_kiro_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Kiro session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Kiro session...")
-            session_id = await _create_kiro_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_kiro_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Kiro session...")
@@ -409,7 +412,8 @@ async def _prepare_kiro_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -295,8 +295,11 @@ async def _prepare_opencode_terminal_via_daemon(  # pragma: no cover
                     "Creating an OpenCode session requires a session bundle."
                 )
             _update_startup_progress(startup_progress, "Creating OpenCode session...")
-            session_id = await _create_opencode_session(
-                client, session_bundle, terminal_launch_args=persist_args or None
+            session_id, _ = await asyncio.gather(
+                _create_opencode_session(
+                    client, session_bundle, terminal_launch_args=persist_args or None
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading OpenCode session...")
@@ -337,7 +340,8 @@ async def _prepare_opencode_terminal_via_daemon(  # pragma: no cover
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -377,10 +377,13 @@ async def _prepare_pi_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a Pi session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating Pi session...")
-            session_id = await _create_pi_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_pi_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading Pi session...")
@@ -421,7 +424,8 @@ async def _prepare_pi_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -324,10 +324,13 @@ async def _prepare_qwen_terminal_via_daemon(
             if session_bundle is None:
                 raise click.ClickException("Creating a qwen session requires a session bundle.")
             _update_startup_progress(startup_progress, "Creating qwen session...")
-            session_id = await _create_qwen_session(
-                client,
-                session_bundle,
-                terminal_launch_args=persist_args or None,
+            session_id, _ = await asyncio.gather(
+                _create_qwen_session(
+                    client,
+                    session_bundle,
+                    terminal_launch_args=persist_args or None,
+                ),
+                wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S),
             )
         else:
             _update_startup_progress(startup_progress, "Loading qwen session...")
@@ -370,7 +373,8 @@ async def _prepare_qwen_terminal_via_daemon(
                         f"({resp.status_code}): {error_text(resp)}"
                     )
 
-        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        if not fresh_session:
+            await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
         _update_startup_progress(startup_progress, "Starting runner...")
         runner_id = await launch_or_reuse_daemon_runner(
             client,

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -7476,6 +7476,106 @@ async def test_prepare_codex_terminal_via_daemon_creates_runner_and_ensures_term
 
 
 @pytest.mark.asyncio
+async def test_prepare_codex_terminal_via_daemon_overlaps_create_and_host_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A fresh launch runs session create and the host-online poll concurrently.
+
+    Against a remote server the create costs ~2s and the host poll ~0.6s, and
+    running them back to back paid both. The host wait must therefore start
+    before the create finishes, and a fresh launch must not wait for the host a
+    second time afterwards.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    order: list[str] = []
+    host_waits = 0
+
+    async def fake_create(
+        client: object,
+        bundle: bytes,
+        *,
+        bridge_id: str | None,
+        terminal_launch_args: list[str] | None = None,
+    ) -> str:
+        """Record the create window, yielding so a concurrent wait can start."""
+        del client, bundle, bridge_id, terminal_launch_args
+        order.append("create:start")
+        await asyncio.sleep(0)
+        order.append("create:end")
+        return "conv_new"
+
+    async def fake_host_online(client: object, host_id: str, *, timeout_s: float) -> None:
+        """Record the host-wait window and count how often it is entered."""
+        nonlocal host_waits
+        del client, host_id, timeout_s
+        host_waits += 1
+        order.append("host:start")
+        await asyncio.sleep(0)
+        order.append("host:end")
+
+    async def fake_launch(
+        client: object,
+        *,
+        host_id: str,
+        session_id: str,
+        workspace: str,
+        fresh: bool = False,
+    ) -> str:
+        """Stand in for the runner launch."""
+        del client, host_id, session_id, workspace, fresh
+        return "runner_new"
+
+    async def fake_runner_online(client: object, runner_id: str, *, timeout_s: float) -> None:
+        """Pretend the runner connected."""
+        del client, runner_id, timeout_s
+
+    async def fake_bind(client: object, session_id: str, runner_id: str) -> None:
+        """Skip the re-bind PATCH."""
+        del client, session_id, runner_id
+
+    async def fake_ensure(client: object, session_id: str) -> None:
+        """Skip the terminal ensure request."""
+        del client, session_id
+
+    async def fake_terminal_ready(
+        client: object, session_id: str, *, timeout_s: float
+    ) -> codex_native.LaunchedCodexTerminal:
+        """Return a ready terminal without polling."""
+        del client, session_id, timeout_s
+        return codex_native.LaunchedCodexTerminal(
+            terminal_id="terminal_codex_main",
+            tmux_socket=None,
+            tmux_target=None,
+        )
+
+    monkeypatch.setattr(codex_native, "_create_codex_session", fake_create)
+    monkeypatch.setattr(codex_native, "wait_for_host_online", fake_host_online)
+    monkeypatch.setattr(codex_native, "launch_or_reuse_daemon_runner", fake_launch)
+    monkeypatch.setattr(codex_native, "wait_for_runner_online", fake_runner_online)
+    monkeypatch.setattr(codex_native, "_bind_session_runner", fake_bind)
+    monkeypatch.setattr(codex_native, "_ensure_codex_terminal_on_runner", fake_ensure)
+    monkeypatch.setattr(codex_native, "_wait_for_codex_terminal_ready", fake_terminal_ready)
+
+    prepared = await codex_native._prepare_codex_terminal_via_daemon(
+        base_url="https://example.com",
+        headers={},
+        session_id=None,
+        session_bundle=b"bundle",
+        codex_args=(),
+        model=None,
+        host_id="host_local",
+        workspace="/repo",
+    )
+
+    assert prepared.session_id == "conv_new"
+    assert order.index("host:start") < order.index("create:end")
+    assert host_waits == 1
+
+
+@pytest.mark.asyncio
 async def test_prepare_codex_terminal_via_daemon_live_resume_skips_config_patch(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Related issue

N/A — this is a `Refactor / chore`, which the PR template exempts from requiring a linked issue.

## Summary

On a fresh launch the CLI created the session (`POST /v1/sessions`, ~2.1s) and *then* waited for the host daemon to register its tunnel (`GET /v1/hosts/{id}`, ~0.6s), one after the other. Neither depends on the other. `claude_native` already ran the two concurrently; every other daemon launch path paid the sum.

- Run them under one `asyncio.gather` in `omnigent run` (`chat.py`) and in the ten remaining native harnesses (codex, pi, cursor, goose, kimi, qwen, opencode, hermes, kiro, antigravity), so startup costs the longer of the two rather than both.
- The post-create host wait is now guarded by `fresh_session`, since the fresh path has already done it. A resume still waits for the host on its own.
- For `omnigent run` this also meant lifting the session create/fork into a `resolve_session()` coroutine so it can run underneath the daemon client's host poll, instead of opening and closing the SDK client first.

Expected saving is ~0.6s per fresh launch (the host poll's duration, now hidden under the longer create), derived from measured per-endpoint latencies rather than an end-to-end timing run.

```
before:  [create session ~2.1s] ---> [poll host ~0.6s] ---> launch runner
after:   [create session ~2.1s] ---> launch runner
         [poll host ~0.6s] ......../
```

### Why the two are independent

Worth stating explicitly, since the whole PR rests on it:

- `POST /v1/sessions` is a plain server-side write. The slice-key header routes deterministically by `host_id` (consistent hash), so it does not require the host's tunnel to be registered on the target replica — that is only needed by `POST /v1/hosts/{id}/runners`, which still runs strictly after both.
- `GET /v1/hosts/{id}` reads the host record the daemon registers during its own startup; it never references a session.
- In `chat.py` the create does not even use the slice-keyed client — it goes through `OmnigentClient` with plain auth headers.

Orderings that *are* real and are preserved: the runner launch runs after both (needs `session_id` plus an online host); cursor's `model_override` PATCH still runs after the create; and the resume path's early return on a live terminal still skips the host wait entirely, because the `fresh_session` guard sits after the if/else rather than inside it.

### Known wart

`asyncio.gather` does not cancel siblings when one raises (verified empirically, not just from the docs). If the create fails, the host poll keeps running until the enclosing `async with` closes the client; a request on a closed `AsyncClient` raises `RuntimeError`, which `wait_for_host_online` does not catch. In practice `asyncio.run` cancels the pending task at shutdown and I could not produce any visible noise, and `claude_native` has had this same shape in production. Happy to replace `gather` with a cancel-on-exit helper across all 12 sites in a follow-up if reviewers would rather have the orphan handled explicitly.

## Test Plan

Automated:

- `pytest tests/test_codex_native.py tests/test_cursor_native.py tests/test_goose_native.py tests/test_qwen_native.py tests/test_opencode_native.py tests/test_hermes_native.py tests/test_kiro_native.py tests/test_antigravity_native.py tests/test_pi_native_resume.py tests/cli/` — 1524 passed, 1 skipped.
- New `test_prepare_codex_terminal_via_daemon_overlaps_create_and_host_wait` asserts the host poll starts *before* the create finishes and that the host is waited on exactly once on a fresh launch. Confirmed it fails when the gather is reverted to two sequential awaits.
- The existing `test_prepare_codex_terminal_via_daemon_creates_runner_and_ensures_terminal` still passes, so the full orchestration against a mock Omnigent server is unchanged end to end.
- `pre-commit run` (ruff format, ruff check, pyrefly) clean on the changed files.

**Not yet run — needs a reviewer with a remote server.** I have not exercised this against a live remote server. Suggested checks:

1. Fresh `omnigent run` and fresh `omnigent codex` against a remote server — confirm both still start, and compare startup wall clock against `main`.
2. A **resume** of each, which is the branch most at risk: the guarded `if not fresh_session` host wait must still fire there. A regression would look like a runner launch racing an unregistered host (a 409 "host offline", which the launch retry loop would mask for up to ~16s).
3. One non-codex harness beyond the two above, since only codex has the new ordering test; the other nine received an identical mechanical transformation.

## Demo

N/A — no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Codex carries the new ordering test as the representative harness; the other nine received an identical mechanical transformation and their existing daemon-prepare tests still pass.

The gap is that no test covers the resume path's guarded host wait for the nine harnesses without a dedicated ordering test, and nothing here was run against a live remote server — see items 2 and 3 in the Test Plan.

