### PR TITLE
fix(host): TTL-cache the readiness quick probe's binary resolution

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -144,10 +145,41 @@ def _coerce_int(value: object) -> int:
     return int(cast(str | bytes | bytearray | SupportsInt | SupportsIndex, value))
 
 
-# Binary appearance is cheap to probe, so new CLI installs surface quickly.
+# Quick-probe cadence. "Binary appearance is cheap to probe" held when the
+# probe was a handful of PATH stats; on Windows with a long PATH and
+# endpoint-security filter drivers, a single shutil.which miss costs
+# 200-400ms of supervised filesystem stats, and with several harnesses not
+# installed the 5s cadence burned a full CPU core for as long as a tunnel
+# session was established (measured ~1.09 cores sustained, 11-12W standby
+# drain) — hence the verdict cache below (#5073).
 HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0
 # Auth changes and removals need the full, potentially expensive readiness map.
 HARNESS_READINESS_FULL_REFRESH_INTERVAL_S = 60.0
+# How long a quick-probe verdict stays cached. New-CLI installs surface within
+# this window (a minute of badge staleness is invisible); the quick probe's
+# 5s cadence re-uses the cached verdict for free. Matches the full-refresh
+# cadence so the loop's own expensive pass doubles as the cache refill.
+HARNESS_READINESS_QUICK_PROBE_CACHE_TTL_S = 60.0
+_quick_probe_cache: dict[str, float] = {}
+_quick_probe_cached: dict[str, bool] = {}
+
+
+def _invalidate_quick_probe_cache() -> None:
+    """Drop cached quick-probe verdicts (tests; installs refilled within TTL)."""
+    _quick_probe_cache.clear()
+    _quick_probe_cached.clear()
+
+
+def _harness_now_configured(harness: str) -> bool:
+    """harness_is_configured through the quick-probe TTL cache (#5073)."""
+    now = time.monotonic()
+    stamp = _quick_probe_cache.get(harness)
+    if stamp is not None and now - stamp < HARNESS_READINESS_QUICK_PROBE_CACHE_TTL_S:
+        return _quick_probe_cached[harness]
+    verdict = harness_is_configured(harness)
+    _quick_probe_cache[harness] = now
+    _quick_probe_cached[harness] = verdict
+    return verdict
 
 
 def _unavailable_harness_became_ready(
@@ -156,7 +188,7 @@ def _unavailable_harness_became_ready(
     """Detect newly available binaries; auth changes wait for the full refresh."""
     return any(
         (availability is False or availability == HARNESS_BINARY_MISSING)
-        and harness_is_configured(harness)
+        and _harness_now_configured(harness)
         for harness, availability in previous.items()
     )
 

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1065,6 +1065,65 @@ async def _cancel(task: asyncio.Task[None]) -> None:
         await task
 
 
+def test_unavailable_harness_quick_probe_is_ttl_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The quick probe resolves each unavailable harness once per TTL (#5073).
+
+    The readiness loop wakes every 5s and re-probed every unavailable
+    harness with a full shutil.which PATH scan (200-400ms each on Windows
+    with endpoint security, several harnesses uninstalled → a sustained
+    full CPU core while a tunnel session was established). Within the TTL
+    the cached verdict serves the cadence; expiry re-probes so a new
+    install still surfaces.
+    """
+    from omnigent.host import connect as connect_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        connect_mod, "harness_is_configured", lambda h: calls.append(h) or False
+    )
+    connect_mod._invalidate_quick_probe_cache()
+    try:
+        previous = {"goose-native": False, "qwen-native": False}
+
+        # Burst of quick probes well inside the TTL.
+        for _ in range(12):
+            assert connect_mod._unavailable_harness_became_ready(previous) is False
+        # Each harness resolved exactly ONCE — the cadence served from cache.
+        assert sorted(calls) == ["goose-native", "qwen-native"]
+
+        # A harness that becomes configured is seen once the verdict expires.
+        monkeypatch.setattr(connect_mod, "harness_is_configured", lambda h: h == "goose-native")
+        monkeypatch.setattr(
+            connect_mod, "HARNESS_READINESS_QUICK_PROBE_CACHE_TTL_S", 0.0
+        )
+        assert connect_mod._unavailable_harness_became_ready(previous) is True
+    finally:
+        connect_mod._invalidate_quick_probe_cache()
+        monkeypatch.undo()
+
+
+def test_quick_probe_cache_survives_configured_flip_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Within the TTL a cached miss is authoritative — an external install
+    surfaces on the next expiry, not the next 5s tick (#5073)."""
+    from omnigent.host import connect as connect_mod
+
+    state = {"configured": False}
+    monkeypatch.setattr(
+        connect_mod, "harness_is_configured", lambda _h: state["configured"]
+    )
+    connect_mod._invalidate_quick_probe_cache()
+    try:
+        assert connect_mod._unavailable_harness_became_ready({"goose-native": False}) is False
+        state["configured"] = True
+        # Still inside the TTL: cached miss wins.
+        assert connect_mod._unavailable_harness_became_ready({"goose-native": False}) is False
+        # Expiry re-probes and sees the install.
+        monkeypatch.setattr(connect_mod, "HARNESS_READINESS_QUICK_PROBE_CACHE_TTL_S", 0.0)
+        assert connect_mod._unavailable_harness_became_ready({"goose-native": False}) is True
+    finally:
+        connect_mod._invalidate_quick_probe_cache()
+
+
 async def test_live_host_refreshes_harness_readiness_without_reconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #5073.

## Root cause — confirmed as reported

`_harness_readiness_loop` wakes every `HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0` and, for every currently-unavailable harness, runs `_unavailable_harness_became_ready → harness_is_configured → _harness_availability_core → resolve_cli_binary → shutil.which` (plus the second pass via `harness_cli_installed`). On the reporter's machine that's 6+ full misses of a 95-entry PATH × PATHEXT scan every 5 seconds, every stat behind endpoint-security filter drivers — the measured sustained ~1.09 cores, and the standby-drain consequence, follow directly. The comment's "binary appearance is cheap to probe" is the assumption that fails on Windows.

## Fix — the loop layer only, TTL-cached verdicts

The quick probe's `harness_is_configured` call is wrapped in a 60s TTL cache (`_harness_now_configured`), keyed per harness:

- the 5s cadence re-reads the cached verdict for free — the CPU burn is gone at its source;
- a new CLI install surfaces at the next expiry — one minute of badge staleness instead of a pegged core. The TTL deliberately matches `HARNESS_READINESS_FULL_REFRESH_INTERVAL_S = 60.0`, so the loop's own expensive full pass doubles as the cache refill;
- **launch, setup, and the explicit readiness-map refreshes are untouched** — they call `harness_is_configured` directly and stay exact. I first tried caching inside `harness_readiness` itself and reverted: it polluted the module's per-case monkeypatched tests and would have made every caller cache-aware for one loop's benefit. The loop owns the cadence; the loop owns the cache.

Of the issue's three suggested fixes this is essentially (1)+(3) combined at the narrowest possible seam — caching the `which()` resolution *as seen by the 5s probe* and letting the TTL back the cadence off. (2) (skip never-configured harnesses) would change which harnesses can newly appear, which the loop exists to detect.

## Tests

`tests/host/test_connect.py`:

- `test_unavailable_harness_quick_probe_is_ttl_cached` — a 12-tick burst resolves each unavailable harness **exactly once**; after TTL expiry a harness that became configured is seen. **Fails on `main`** (no cache exists; also asserts the call-count contract that kills the burn).
- `test_quick_probe_cache_survives_configured_flip_within_ttl` — pins the bounded-staleness semantics: within the TTL a cached miss is authoritative; expiry re-probes.

Full `tests/host/test_connect.py`: 122 passed / 13 failed with the fix vs 120 / 13 on clean `main` in the same environment (identical pre-existing Windows-only failure set; the +2 are the new tests) — zero regressions. `tests/test_harness_readiness.py`: 10/10 unchanged (the module is untouched).