### PR TITLE
fix(host): stop the recycle fast path from hammering a dead endpoint

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -329,6 +329,19 @@ def _connection_refused(exc: BaseException) -> bool:
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 10.0
 _RECONNECT_JITTER = 0.5
+# Recycle close-code matching is anchored on word boundaries: bare substring
+# matching misread Windows errno 11001 ("getaddrinfo failed") as WebSocket
+# close code 1001 "going away", classifying a sustained DNS outage as an
+# ingress recycle and reconnecting at the 0.5s prompt cadence indefinitely
+# (#5072).
+_RECYCLE_EXPLICIT_RE = re.compile(r"\b(?:1012|1001)\b|service restart|going away")
+_RECYCLE_INGRESS_RE = re.compile(r"\b(?:no close frame|502)\b")
+# Consecutive never-connected recycle-classified failures before the prompt
+# cadence gives way to the normal backoff ladder. An ingress cycle is brief
+# and self-healing (well under 10 attempts); a sustained 502/DNS outage is
+# not, and hammering a dead endpoint twice a second forever is its own
+# incident (#5072).
+_RECYCLE_PROMPT_MAX_STREAK = 10
 # Fresh hosts get a short auth-retry window for Databricks OAuth refreshes.
 # Established hosts retry auth failures indefinitely to preserve sessions.
 _MAX_CONSECUTIVE_AUTH_ERRORS = 3
@@ -847,6 +860,7 @@ class HostProcess:
         # Consecutive connections that were accepted but died without a single
         # inbound frame; reset by any received frame or a rejected upgrade.
         # Past a bound the reconnect loop escalates instead of fast-recycling.
+        self._recycle_streak = 0
         self._silent_connect_streak = 0
         # Per-connection markers feeding the silent-connect streak.
         self._conn_upgrade_accepted = False
@@ -2758,10 +2772,8 @@ class HostProcess:
                     # genuinely persistent failure surfaces instead of a silent
                     # tight loop).
                     reason = str(exc).lower()
-                    explicit_recycle = any(
-                        t in reason for t in ("1012", "service restart", "1001", "going away")
-                    )
-                    ingress_recycle = any(t in reason for t in ("no close frame", "502"))
+                    explicit_recycle = _RECYCLE_EXPLICIT_RE.search(reason) is not None
+                    ingress_recycle = _RECYCLE_INGRESS_RE.search(reason) is not None
                     # A silent-connect streak overrides the recycle fast path:
                     # prompt reconnects are for endpoints that answer.
                     silent_churn = self._silent_connect_streak >= _SILENT_CONNECT_ESCALATE_ATTEMPTS
@@ -2773,13 +2785,19 @@ class HostProcess:
                     # outside the silent-churn gate so wake never takes the slow path.
                     woke = self._woke_from_suspend
                     self._woke_from_suspend = False
-                    recycle = woke or (
-                        (
-                            explicit_recycle
-                            or (ingress_recycle and not _url_is_loopback(self._server_url))
-                        )
-                        and not silent_churn
-                    )
+                    classified_recycle = (
+                        explicit_recycle
+                        or (ingress_recycle and not _url_is_loopback(self._server_url))
+                    ) and not silent_churn
+                    if classified_recycle:
+                        self._recycle_streak += 1
+                        if self._recycle_streak > _RECYCLE_PROMPT_MAX_STREAK:
+                            # A recycle is a brief, self-healing event; a
+                            # sustained run of them is an outage. Fall back to
+                            # the backoff ladder so a dead endpoint is probed
+                            # gently instead of twice a second forever (#5072).
+                            classified_recycle = False
+                    recycle = woke or classified_recycle
                     wait_s = _RECONNECT_BASE_S if recycle else backoff
                     _logger.warning(
                         "Host tunnel disconnected: %s. Reconnecting in %.1fs%s",
@@ -2936,6 +2954,9 @@ class HostProcess:
         self._auth_retry_streak = 0
         self._refused_streak = 0
         self._conn_upgrade_accepted = True
+        # A completed upgrade proves the endpoint healthy — the next drop's
+        # prompt reconnect is wanted again (#5072).
+        self._recycle_streak = 0
         try:
             await self._serve_frames(ws)
         finally:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4145,6 +4145,73 @@ async def test_launch_cancelled_midspawn_does_not_leak_untracked_runner(
     assert spawned[0].poll() is not None, "abandoned runner was leaked, still alive"
 
 
+async def test_dns_errno_failure_is_not_a_recycle(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Windows errno 11001 (getaddrinfo failed) is not close code 1001.
+
+    The old substring classifier matched "1001" inside "11001", so a
+    sustained DNS outage (VPN down) classified every failure as an explicit
+    recycle and reconnected at the 0.5s prompt cadence indefinitely — 2
+    attempts/second, 122k attempts overnight in the field report (#5072).
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
+    dns_failure = OSError(11001, "getaddrinfo failed")
+    spy = _ConnectSpy([dns_failure, dns_failure, dns_failure, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    assert spy.call_count == 4
+    reconnects = [
+        record.message for record in caplog.records if "Reconnecting in" in record.message
+    ]
+    assert len(reconnects) == 3
+    assert not any("(recycle" in r for r in reconnects), (
+        "a DNS resolution failure must take the backoff ladder, not the "
+        "prompt recycle cadence"
+    )
+
+
+async def test_sustained_recycle_failures_fall_back_to_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A sustained run of recycle-classified failures is an outage, not a cycle.
+
+    The prompt cadence exists for a brief ingress recycle; when the same
+    classification fires attempt after attempt without a connection ever
+    establishing (proxy 502 while the server is down), the daemon must back
+    off instead of hammering the endpoint twice a second forever (#5072).
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECYCLE_PROMPT_MAX_STREAK", 3)
+    # Raised AT CONNECT TIME (never accepted): "server rejected WebSocket
+    # connection: HTTP 502" — an ingress-recycle-classified sustained outage.
+    rejected = RuntimeError("server rejected WebSocket connection: HTTP 502")
+    spy = _ConnectSpy([rejected] * 6 + [asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    assert spy.call_count == 7
+    reconnects = [
+        record.message for record in caplog.records if "Reconnecting in" in record.message
+    ]
+    assert len(reconnects) == 6
+    prompt = [i for i, r in enumerate(reconnects) if "(recycle" in r]
+    # The first _RECYCLE_PROMPT_MAX_STREAK attempts are prompt; every attempt
+    # after that takes the backoff ladder.
+    assert prompt == [0, 1, 2], f"prompt cadence must stop after the streak cap: {prompt}"
+
+
 async def test_silent_connect_streak_escalates_and_slows_reconnects(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Fixes #5072 — two compounding defects, both fixed.

## Defect 1: the classifier read an errno as a close code

The recycle classification matched close codes as **bare substrings**:

```python
any(t in reason for t in ("1012", "service restart", "1001", "going away"))
```

`reason` for the reporter's failure is `"[Errno 11001] getaddrinfo failed"` — and **"1001" is a substring of "11001"**. Every DNS-resolution failure therefore classified as an *explicit recycle* (`1001` = "going away") and took the 0.5 s prompt-reconnect path, which also **resets the backoff ladder** — hence the observed `{0.5s: 588}` distribution over 5.2 minutes and the overnight 122,567-attempt run. (The same substring hazard applied to `"502"` matching inside longer numbers.)

Both patterns are now word-boundary regexes (`(?:1012|1001)|service restart|going away`, `(?:no close frame|502)`) — an errno-embedding message classifies as the transient it is, and takes the existing exponential backoff.

## Defect 2: the fast path had no sustained-failure escape

Even with correct classification, an ingress-classified **sustained** outage (proxy answering `502` to every upgrade while the server is down) would still reconnect at the prompt cadence forever — the fast path exists for a *brief, self-healing* recycle. A consecutive-recycle streak now caps the prompt cadence at `_RECYCLE_PROMPT_MAX_STREAK = 10` never-connected attempts; past the cap the failures take the normal backoff ladder. The streak resets on **any accepted upgrade** — a completed handshake proves the endpoint healthy, so the next drop's prompt reconnect (the ingress-cycle case the fast path was built for) still fires immediately. A wake-from-suspend prompt reconnect is untouched.

Net effect on the field report: the DNS loop takes the backoff ladder from attempt one (defect 1), and any future misclassification or sustained 502 storm is bounded at ~5 seconds of prompt retries (defect 2) instead of 2 Hz forever.

## Tests

- `test_dns_errno_failure_is_not_a_recycle` — three `OSError(11001, "getaddrinfo failed")` attempts take **zero** prompt reconnects. **Fails on `main`** (all three log "(recycle — prompt reconnect)").
- `test_sustained_recycle_failures_fall_back_to_backoff` — six connect-time `HTTP 502` rejections with the streak cap at 3: exactly attempts 0–2 are prompt, 3–5 take the ladder. **Fails on `main`** (all six prompt).

Full `tests/host/test_connect.py`: 122 passed / 13 pre-existing environment failures with the fix, identical failure set on clean `main` (where the two new tests also fail) — zero regressions, including the existing silent-streak and ingress-recycle suites.