### PR TITLE
fix(tools): render the Keenable search snippet, not the empty meta description

### DIFF
--- a/omnigent/tools/builtins/web_search_keenable.py
+++ b/omnigent/tools/builtins/web_search_keenable.py
@@ -114,7 +114,10 @@ def _format_results(data: dict[str, Any], max_results: int) -> str:
     """
     Format Keenable's ``/v1/search`` JSON response into readable text.
 
-    Keenable returns ``{"results": [{"title", "url", "description", ...}]}``.
+    Keenable returns ``{"results": [{"title", "url", "description",
+    "snippet", ...}]}``. ``snippet`` carries the page text and is the
+    grounding the model needs; ``description`` is only the page's meta
+    description and is empty for most pages, so it is the fallback (#5088).
     The list is sliced to ``max_results`` and rendered as numbered entries.
 
     :param data: The parsed JSON response from Keenable.
@@ -131,6 +134,6 @@ def _format_results(data: dict[str, Any], max_results: int) -> str:
             continue
         title = item.get("title", "")
         url = item.get("url", "")
-        snippet = item.get("description") or ""
+        snippet = item.get("snippet") or item.get("description") or ""
         formatted.append(f"{i + 1}. {title}\n   {url}\n   {snippet}")
     return "\n\n".join(formatted) if formatted else "No results found."

--- a/tests/tools/builtins/test_web_search.py
+++ b/tests/tools/builtins/test_web_search.py
@@ -632,6 +632,59 @@ def test_keenable_backend_via_spec_config(tool_ctx: ToolContext) -> None:
     assert "Web search API for AI agents." in result
 
 
+def test_keenable_renders_snippet_page_text_over_empty_description(
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    The real Keenable response carries the page text in ``snippet``; the meta
+    ``description`` is empty for most pages. Reading ``description`` first
+    rendered every result with a blank third line and left the model nothing
+    to ground on beyond the URL (#5088).
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "results": [
+            {
+                "title": "Pydantic",
+                "url": "https://docs.pydantic.dev",
+                "description": "",
+                "snippet": "Data validation using Python type hints.",
+            },
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "pydantic"}), tool_ctx)
+
+    assert "Data validation using Python type hints." in result, (
+        "the snippet's page text must be rendered, not the empty description"
+    )
+
+
+def test_keenable_snippet_falls_back_to_description() -> None:
+    """Results with only a meta description still render it (legacy shape)."""
+    from omnigent.tools.builtins.web_search_keenable import _format_results
+
+    rendered = _format_results(
+        {
+            "results": [
+                {
+                    "title": "Docs",
+                    "url": "https://example.com",
+                    "description": "meta description only",
+                },
+            ],
+        },
+        5,
+    )
+    assert "meta description only" in rendered
+
+
 def test_keenable_keyless_by_default(tool_ctx: ToolContext) -> None:
     """
     Without api_key, Keenable hits the keyless public endpoint and sends


### PR DESCRIPTION
Fixes #5088 — the exact one-line field mixup, plus the fixture gap that hid it.

## Change

`_format_results` now reads the page text from `snippet` first, with the meta `description` as the fallback:

```python
snippet = item.get("snippet") or item.get("description") or ""
```

The docstring documents the real response shape (both fields on every result; `snippet` = page text, `description` = meta description, empty for most pages).

## Why the tests missed it

The existing fixture used `{"description": "...", }` with no `snippet` — a shape the API doesn't return (per the issue's curl against the live endpoint). The new tests cover both:

- `test_keenable_renders_snippet_page_text_over_empty_description` — the real shape (`description: ""`, `snippet: "the page text"`); asserts the page text is rendered. **Fails on `main`** (blank third line).
- `test_keenable_snippet_falls_back_to_description` — description-only results still render it (legacy shape, pinned on both sides).

Full file: 51/51 with the fix; the snippet test fails on unpatched `main`.