### PR TITLE
fix(runner): route sub-agent cancellation from the harness stop registry

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -7008,7 +7008,7 @@ async def _execute_task_lifecycle_tool(
 
 
 # Native sub-agent cancellation capabilities, resolved from the harness set
-# rather than a single wrapper label (#5086). Mirrors the child runner's
+# rather than a single wrapper label. Mirrors the child runner's
 # ``stop_session`` dispatch (``NativeInterruptRunner.stop`` +
 # ``_UNIFORM_STOP`` in ``runner/native/interrupt.py``): the runner-side
 # hard-stop exists for claude plus the six uniform-stop harnesses; codex and
@@ -7052,6 +7052,46 @@ def _native_cancel_capability(wrapper_label: str | None) -> str:
     if wrapper_label in _BEST_EFFORT_NATIVE_WRAPPERS:
         return "best_effort"
     return "inprocess"
+
+
+# Terminal-registry short names for the stop-capable natives — the pane a
+# failed child would still be resident in, keyed by its wrapper label.
+_STOP_CAPABLE_TERMINAL_NAMES = {
+    CLAUDE_NATIVE_WRAPPER_VALUE: "claude",
+    CURSOR_NATIVE_WRAPPER_VALUE: "cursor",
+    GOOSE_NATIVE_WRAPPER_VALUE: "goose",
+    KIRO_NATIVE_WRAPPER_VALUE: "kiro",
+    KIMI_NATIVE_WRAPPER_VALUE: "kimi",
+    HERMES_NATIVE_WRAPPER_VALUE: "hermes",
+    QWEN_NATIVE_WRAPPER_VALUE: "qwen",
+}
+
+
+async def _native_child_pane_alive(task_id: str, wrapper_label: str | None) -> bool:
+    """Probe whether a failed native child's pane still answers.
+
+    ``failed`` does not say whether the harness process is still resident:
+    a required-terminal exit fails the entry after the process died, while
+    a harness-side failure can leave the pane alive. The uniform bridge
+    stop cannot kill a dead tmux session — it answers 503 — so a failed
+    entry earns its hard-stop only when its registered pane is verifiably
+    alive; otherwise the cached terminal failure is the truthful answer.
+    """
+    from omnigent.runtime import get_terminal_registry
+
+    terminal_name = _STOP_CAPABLE_TERMINAL_NAMES.get(wrapper_label or "")
+    if terminal_name is None:
+        return False
+    try:
+        instance = get_terminal_registry().get(task_id, terminal_name, "main")
+    except Exception:
+        return False
+    if instance is None:
+        return False
+    try:
+        return await instance.is_alive()
+    except Exception:
+        return False
 
 
 async def _post_session_stop(server_client: httpx.AsyncClient, task_id: str) -> str | None:
@@ -7128,12 +7168,14 @@ async def _cancel_subagent_task(
       delivers a terminal payload to the parent inbox and auto-wakes
       it. A bare interrupt only cancelled the current turn and left the
       worker process alive; a stop frees it. A ``failed`` stop-capable
-      entry still routes — failed does not mean exited.
+      entry still routes when its pane answers the liveness probe —
+      failed does not mean exited; a dead pane returns the cached
+      failure instead of a bridge 503.
     * best-effort natives (``codex``, ``pi``, ``antigravity``,
       ``opencode``) and in-process harnesses — POST ``interrupt``, the
       path those harnesses actually honor. No runner-side hard-stop is
       wired for them, so the result is reported best-effort rather
-      than implying process termination (#5086).
+      than implying process termination.
 
     :param args: Tool arguments containing ``task_id`` or
         ``handle_id``, e.g. ``{"task_id": "conv_child456"}``.
@@ -7164,11 +7206,16 @@ async def _cancel_subagent_task(
     # start sub-agent would silently no-op and leave it running. A failed
     # claude-native entry still falls through because its pane may be alive.
     capability = _native_cancel_capability(entry.wrapper_label)
-    # A failed native entry with a hard-stop still routes: its process may be
-    # alive (failed ≠ exited), and the stop frees it. Failed entries without
-    # a hard-stop return their cached terminal status — there is nothing this
-    # path could forward that would change it (#5086).
-    can_stop_failed = capability == "stop" and entry.status == "failed"
+    # A failed native entry with a hard-stop still routes when its pane is
+    # verifiably alive (failed ≠ exited), and the stop frees it. A failed
+    # entry whose pane already died returns its cached terminal status — the
+    # uniform bridge stop cannot kill a dead tmux session, so routing it
+    # would answer 503 instead of the task's terminal failure.
+    can_stop_failed = (
+        capability == "stop"
+        and entry.status == "failed"
+        and await _native_child_pane_alive(str(task_id), entry.wrapper_label)
+    )
     if entry.status not in ("launching", "running", "waiting") and not can_stop_failed:
         return json.dumps(
             {
@@ -7182,7 +7229,7 @@ async def _cancel_subagent_task(
 
     # Route from the harness capability: stop-capable natives get the
     # runner-side hard-stop; the rest (best-effort natives + in-process
-    # harnesses) get the interrupt the child actually honors (#5086).
+    # harnesses) get the interrupt the child actually honors.
     event_type = "stop_session" if capability == "stop" else "interrupt"
 
     try:

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -47,8 +47,17 @@ if TYPE_CHECKING:
 import httpx
 
 from omnigent._wrapper_labels import (
+    ANTIGRAVITY_NATIVE_WRAPPER_VALUE,
     CLAUDE_NATIVE_WRAPPER_VALUE,
     CODEX_NATIVE_WRAPPER_VALUE,
+    CURSOR_NATIVE_WRAPPER_VALUE,
+    GOOSE_NATIVE_WRAPPER_VALUE,
+    HERMES_NATIVE_WRAPPER_VALUE,
+    KIMI_NATIVE_WRAPPER_VALUE,
+    KIRO_NATIVE_WRAPPER_VALUE,
+    OPENCODE_NATIVE_WRAPPER_VALUE,
+    PI_NATIVE_WRAPPER_VALUE,
+    QWEN_NATIVE_WRAPPER_VALUE,
 )
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.model_override import (
@@ -6998,6 +7007,53 @@ async def _execute_task_lifecycle_tool(
     )
 
 
+# Native sub-agent cancellation capabilities, resolved from the harness set
+# rather than a single wrapper label (#5086). Mirrors the child runner's
+# ``stop_session`` dispatch (``NativeInterruptRunner.stop`` +
+# ``_UNIFORM_STOP`` in ``runner/native/interrupt.py``): the runner-side
+# hard-stop exists for claude plus the six uniform-stop harnesses; codex and
+# pi alias stop to interrupt; antigravity and opencode have no native stop
+# handler and fall through to the in-process turn cancel.
+_STOP_CAPABLE_NATIVE_WRAPPERS = frozenset(
+    {
+        CLAUDE_NATIVE_WRAPPER_VALUE,
+        CURSOR_NATIVE_WRAPPER_VALUE,
+        GOOSE_NATIVE_WRAPPER_VALUE,
+        KIRO_NATIVE_WRAPPER_VALUE,
+        KIMI_NATIVE_WRAPPER_VALUE,
+        HERMES_NATIVE_WRAPPER_VALUE,
+        QWEN_NATIVE_WRAPPER_VALUE,
+    }
+)
+# Native harnesses whose stop aliases to interrupt (codex, pi) or that have
+# no native stop handler at all (antigravity, opencode): cancelling them is
+# best-effort and the result says so instead of implying process termination.
+_BEST_EFFORT_NATIVE_WRAPPERS = frozenset(
+    {
+        CODEX_NATIVE_WRAPPER_VALUE,
+        PI_NATIVE_WRAPPER_VALUE,
+        ANTIGRAVITY_NATIVE_WRAPPER_VALUE,
+        OPENCODE_NATIVE_WRAPPER_VALUE,
+    }
+)
+
+
+def _native_cancel_capability(wrapper_label: str | None) -> str:
+    """Classify a child's wrapper label for cancellation routing.
+
+    :param wrapper_label: The work entry's wrapper label, e.g.
+        ``"cursor-native-ui"``; ``None``/non-native for in-process harnesses.
+    :returns: ``"stop"`` when the child's runner has a true hard-stop,
+        ``"best_effort"`` when the event is forwarded but no hard-stop is
+        wired, ``"inprocess"`` otherwise (turn cancel via interrupt).
+    """
+    if wrapper_label in _STOP_CAPABLE_NATIVE_WRAPPERS:
+        return "stop"
+    if wrapper_label in _BEST_EFFORT_NATIVE_WRAPPERS:
+        return "best_effort"
+    return "inprocess"
+
+
 async def _post_session_stop(server_client: httpx.AsyncClient, task_id: str) -> str | None:
     """Hard-stop one claude-native child through the server."""
     try:
@@ -7015,13 +7071,19 @@ async def _post_session_stop(server_client: httpx.AsyncClient, task_id: str) -> 
     return None
 
 
-async def _cancel_evicted_claude_native_subagent(
+async def _cancel_evicted_native_subagent(
     task_id: str,
     *,
     conversation_id: str,
     server_client: httpx.AsyncClient | None,
 ) -> str:
-    """Stop an owned claude-native child after its work entry was evicted."""
+    """Stop an owned stop-capable native child after its work entry was evicted.
+
+    Ownership is still verified against the snapshot's ``parent_session_id``
+    and the wrapper label must name a harness with a runner-side hard-stop —
+    an evicted entry means the parent no longer knows the child's state, so
+    trusting the caller's task id alone could stop someone else's session.
+    """
     if server_client is None:
         return "Error: sys_cancel_task requires server access for sub-agent tasks"
     try:
@@ -7036,7 +7098,7 @@ async def _cancel_evicted_claude_native_subagent(
         not isinstance(snapshot, dict)
         or snapshot.get("parent_session_id") != conversation_id
         or not isinstance(labels, dict)
-        or labels.get(_SESSION_WRAPPER_LABEL_KEY) != CLAUDE_NATIVE_WRAPPER_VALUE
+        or labels.get(_SESSION_WRAPPER_LABEL_KEY) not in _STOP_CAPABLE_NATIVE_WRAPPERS
     ):
         return f"Error: no in-flight task with task_id {task_id}"
     stop_error = await _post_session_stop(server_client, task_id)
@@ -7054,23 +7116,24 @@ async def _cancel_subagent_task(
     """
     Cancel a running sub-agent worker, routing by the child's harness.
 
-    Only ``claude-native`` has a runner-side hard-stop, so the cancel
-    event is chosen per harness — the child runner's ``stop_session``
-    handler 204 no-ops for every other harness, so posting it there
-    would silently do nothing:
+    The cancel event is chosen from the child harness's capability
+    (``_native_cancel_capability``), mirroring the child runner's own
+    ``stop_session`` dispatch — the runner-side hard-stop exists for
+    claude plus the six uniform-stop natives (cursor, goose, kiro, kimi,
+    hermes, qwen):
 
-    * ``claude-native`` — POST ``stop_session``. The child runner
-      hard-kills the worker's tmux pane via ``_handle_claude_native_stop``
-      and marks the work entry cancelled, delivering a terminal payload to
-      the parent inbox and auto-waking it. A bare interrupt (Escape) only
-      cancelled the current turn and left the worker process alive; a stop
-      frees it.
-    * everything else (in-process harnesses, ``codex-native``) — POST
-      ``interrupt``, the path those harnesses actually honor. For an
-      in-process child the runner marks the turn cancelled (via
-      ``_interrupted_sessions`` → ``_on_proxy_stream_end``) and wakes the
-      parent. ``codex-native`` has no runner-side stop yet, so its cancel
-      stays best-effort (see message).
+    * stop-capable natives — POST ``stop_session``: the child runner
+      hard-stops the worker (claude kills its tmux pane; the uniform
+      six run their bridge stop), marks the work entry cancelled,
+      delivers a terminal payload to the parent inbox and auto-wakes
+      it. A bare interrupt only cancelled the current turn and left the
+      worker process alive; a stop frees it. A ``failed`` stop-capable
+      entry still routes — failed does not mean exited.
+    * best-effort natives (``codex``, ``pi``, ``antigravity``,
+      ``opencode``) and in-process harnesses — POST ``interrupt``, the
+      path those harnesses actually honor. No runner-side hard-stop is
+      wired for them, so the result is reported best-effort rather
+      than implying process termination (#5086).
 
     :param args: Tool arguments containing ``task_id`` or
         ``handle_id``, e.g. ``{"task_id": "conv_child456"}``.
@@ -7088,7 +7151,7 @@ async def _cancel_subagent_task(
         return "Error: sys_cancel_task requires conversation_id"
     entry = _runner_app.get_subagent_work(str(task_id))
     if entry is None:
-        return await _cancel_evicted_claude_native_subagent(
+        return await _cancel_evicted_native_subagent(
             str(task_id),
             conversation_id=conversation_id,
             server_client=server_client,
@@ -7100,9 +7163,13 @@ async def _cancel_subagent_task(
     # route to the child during that window — otherwise cancelling a slow-to-
     # start sub-agent would silently no-op and leave it running. A failed
     # claude-native entry still falls through because its pane may be alive.
-    is_claude_native = entry.wrapper_label == CLAUDE_NATIVE_WRAPPER_VALUE
-    can_stop_failed_claude = is_claude_native and entry.status == "failed"
-    if entry.status not in ("launching", "running", "waiting") and not can_stop_failed_claude:
+    capability = _native_cancel_capability(entry.wrapper_label)
+    # A failed native entry with a hard-stop still routes: its process may be
+    # alive (failed ≠ exited), and the stop frees it. Failed entries without
+    # a hard-stop return their cached terminal status — there is nothing this
+    # path could forward that would change it (#5086).
+    can_stop_failed = capability == "stop" and entry.status == "failed"
+    if entry.status not in ("launching", "running", "waiting") and not can_stop_failed:
         return json.dumps(
             {
                 "cancelled": entry.status == "cancelled",
@@ -7113,9 +7180,10 @@ async def _cancel_subagent_task(
     if server_client is None:
         return "Error: sys_cancel_task requires server access for sub-agent tasks"
 
-    # claude-native is the only harness with a runner-side hard-stop; every
-    # other harness 204 no-ops on stop_session, so route them to interrupt.
-    event_type = "stop_session" if is_claude_native else "interrupt"
+    # Route from the harness capability: stop-capable natives get the
+    # runner-side hard-stop; the rest (best-effort natives + in-process
+    # harnesses) get the interrupt the child actually honors (#5086).
+    event_type = "stop_session" if capability == "stop" else "interrupt"
 
     try:
         resp = await server_client.post(
@@ -7134,7 +7202,7 @@ async def _cancel_subagent_task(
     updated = _runner_app.get_subagent_work(str(task_id)) or entry
     if updated.status == "cancelled":
         return json.dumps({"cancelled": True, "task_id": task_id, "status": "cancelled"})
-    if updated.wrapper_label == CODEX_NATIVE_WRAPPER_VALUE:
+    if updated.wrapper_label in _BEST_EFFORT_NATIVE_WRAPPERS:
         return json.dumps(
             {
                 "cancel_requested": True,
@@ -7143,9 +7211,9 @@ async def _cancel_subagent_task(
                 "task_id": task_id,
                 "status": updated.status,
                 "message": (
-                    "Interrupt forwarded, but a runner-side hard-stop is not wired "
-                    "for codex-native workers yet; the child may keep running and no "
-                    "terminal inbox status is guaranteed."
+                    "Interrupt forwarded, but no runner-side hard-stop is wired for "
+                    "this harness; the child may keep running and no terminal inbox "
+                    "status is guaranteed."
                 ),
             }
         )

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5030,8 +5030,15 @@ async def test_sys_cancel_task_interrupts_non_native_subagent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sys_cancel_task_stops_terminal_claude_native_entry() -> None:
+async def test_sys_cancel_task_stops_terminal_claude_native_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A failed work status does not block cleanup of a live Claude pane."""
+
+    async def _alive(_task_id: str, _wrapper: str | None) -> bool:
+        return True
+
+    _patch_pane_probe(monkeypatch, _alive)
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import _cancel_subagent_task
 
@@ -5078,7 +5085,7 @@ async def test_sys_cancel_task_stops_uniform_native_subagent() -> None:
     Six native harnesses expose runner-side hard-stops through
     ``_UNIFORM_STOP`` (cursor, goose, kiro, kimi, hermes, qwen); the cancel
     used to route by the Claude wrapper label alone, so those children got a
-    bare interrupt and the resident process could stay alive (#5086).
+    bare interrupt and the resident process could stay alive.
     """
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import _cancel_subagent_task
@@ -5115,8 +5122,55 @@ async def test_sys_cancel_task_stops_uniform_native_subagent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sys_cancel_task_stops_terminal_uniform_native_entry() -> None:
-    """A failed uniform-native entry still routes its (possibly live) stop."""
+async def test_sys_cancel_task_stops_terminal_uniform_native_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed uniform-native entry still routes its stop while its pane lives."""
+
+    async def _alive(_task_id: str, _wrapper: str | None) -> bool:
+        return True
+
+    _patch_pane_probe(monkeypatch, _alive)
+    posts, _ = await _cancel_failed_qwen_native()
+
+    assert posts == [{"type": "stop_session", "data": {}}], (
+        "a failed stop-capable native entry with a live pane must still "
+        "hard-stop its resident process"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_preserves_cached_failure_for_dead_pane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed entry whose pane already died returns the cached failure.
+
+    A required-terminal exit fails the work entry after the process died,
+    and the uniform bridge stop cannot kill a dead tmux session — routing
+    it would answer 503 instead of the task's terminal failure.
+    """
+
+    async def _dead(_task_id: str, _wrapper: str | None) -> bool:
+        return False
+
+    _patch_pane_probe(monkeypatch, _dead)
+    posts, output = await _cancel_failed_qwen_native()
+
+    assert posts == [], "a dead pane must not be routed to the bridge stop"
+    assert output == {"cancelled": False, "task_id": "conv_child_uniform_failed", "status": "failed"}
+
+
+def _patch_pane_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    probe: object,
+) -> None:
+    from omnigent.runner import tool_dispatch
+
+    monkeypatch.setattr(tool_dispatch, "_native_child_pane_alive", probe)
+
+
+async def _cancel_failed_qwen_native():
+    """Drive sys_cancel_task against one failed qwen-native work entry."""
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import _cancel_subagent_task
 
@@ -5131,6 +5185,7 @@ async def test_sys_cancel_task_stops_terminal_uniform_native_entry() -> None:
     )
     entry.status = "failed"
     posts: list[dict[str, Any]] = []
+    output: dict[str, Any] = {}
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         posts.append(json.loads(request.content))
@@ -5141,18 +5196,17 @@ async def test_sys_cancel_task_stops_terminal_uniform_native_entry() -> None:
             transport=httpx.MockTransport(_server_handler),
             base_url="http://server",
         ) as server_client:
-            await _cancel_subagent_task(
-                {"task_id": child_id},
-                conversation_id=parent_id,
-                server_client=server_client,
+            output = json.loads(
+                await _cancel_subagent_task(
+                    {"task_id": child_id},
+                    conversation_id=parent_id,
+                    server_client=server_client,
+                )
             )
     finally:
         runner_app.unregister_subagent_work(child_id)
 
-    assert posts == [{"type": "stop_session", "data": {}}], (
-        "a failed stop-capable native entry must still hard-stop its "
-        "potentially live process"
-    )
+    return posts, output
 
 
 @pytest.mark.asyncio
@@ -5161,7 +5215,7 @@ async def test_sys_cancel_task_returns_cached_status_for_failed_best_effort_nati
 
     There is no event this path could forward that would change a terminal
     best-effort entry, so unlike stop-capable natives its ``failed`` status
-    is final for the cancel path (#5086).
+    is final for the cancel path.
     """
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import _cancel_subagent_task
@@ -5198,7 +5252,7 @@ async def test_cancel_evicted_native_subagent_checks_ownership_and_capability() 
     The recovery path trusts the caller's task id after the local work entry
     is gone, so it must verify the snapshot's parent AND that the wrapper
     names a harness with a runner-side hard-stop — for every stop-capable
-    native, not just Claude (#5086).
+    native, not just Claude.
     """
     from omnigent.runner.tool_dispatch import _cancel_evicted_native_subagent
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -4948,9 +4948,9 @@ async def test_sys_cancel_task_reports_codex_native_cancel_as_best_effort() -> N
         "task_id": child_id,
         "status": "launching",
         "message": (
-            "Interrupt forwarded, but a runner-side hard-stop is not wired "
-            "for codex-native workers yet; the child may keep running and no "
-            "terminal inbox status is guaranteed."
+            "Interrupt forwarded, but no runner-side hard-stop is wired for "
+            "this harness; the child may keep running and no terminal inbox "
+            "status is guaranteed."
         ),
     }
 
@@ -5069,6 +5069,174 @@ async def test_sys_cancel_task_stops_terminal_claude_native_entry() -> None:
 
     assert posts == [{"type": "stop_session", "data": {}}]
     assert output == {"cancelled": True, "task_id": child_id, "status": "cancelled"}
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_stops_uniform_native_subagent() -> None:
+    """A uniform-stop native (cursor) routes to stop_session, not interrupt.
+
+    Six native harnesses expose runner-side hard-stops through
+    ``_UNIFORM_STOP`` (cursor, goose, kiro, kimi, hermes, qwen); the cancel
+    used to route by the Claude wrapper label alone, so those children got a
+    bare interrupt and the resident process could stay alive (#5086).
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_uniform"
+    child_id = "conv_child_uniform"
+    runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="cursor_impl",
+        title="native",
+        wrapper_label="cursor-native-ui",
+    )
+    posts: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content))
+        return httpx.Response(204)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            await _cancel_subagent_task(
+                {"task_id": child_id},
+                conversation_id=parent_id,
+                server_client=server_client,
+            )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert posts == [{"type": "stop_session", "data": {}}]
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_stops_terminal_uniform_native_entry() -> None:
+    """A failed uniform-native entry still routes its (possibly live) stop."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_uniform_failed"
+    child_id = "conv_child_uniform_failed"
+    entry = runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="qwen_impl",
+        title="native",
+        wrapper_label="qwen-native-ui",
+    )
+    entry.status = "failed"
+    posts: list[dict[str, Any]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content))
+        return httpx.Response(204)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            await _cancel_subagent_task(
+                {"task_id": child_id},
+                conversation_id=parent_id,
+                server_client=server_client,
+            )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert posts == [{"type": "stop_session", "data": {}}], (
+        "a failed stop-capable native entry must still hard-stop its "
+        "potentially live process"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_cancel_task_returns_cached_status_for_failed_best_effort_native() -> None:
+    """A failed best-effort native (no hard-stop) returns cached status.
+
+    There is no event this path could forward that would change a terminal
+    best-effort entry, so unlike stop-capable natives its ``failed`` status
+    is final for the cancel path (#5086).
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import _cancel_subagent_task
+
+    parent_id = "conv_parent_pi_failed"
+    child_id = "conv_child_pi_failed"
+    entry = runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        agent="pi_impl",
+        title="native",
+        wrapper_label="pi-native-ui",
+    )
+    entry.status = "failed"
+
+    try:
+        output = json.loads(
+            await _cancel_subagent_task(
+                {"task_id": child_id},
+                conversation_id=parent_id,
+                server_client=None,
+            )
+        )
+    finally:
+        runner_app.unregister_subagent_work(child_id)
+
+    assert output == {"cancelled": False, "task_id": child_id, "status": "failed"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_evicted_native_subagent_checks_ownership_and_capability() -> None:
+    """Evicted-work recovery stops only OWNED stop-capable native children.
+
+    The recovery path trusts the caller's task id after the local work entry
+    is gone, so it must verify the snapshot's parent AND that the wrapper
+    names a harness with a runner-side hard-stop — for every stop-capable
+    native, not just Claude (#5086).
+    """
+    from omnigent.runner.tool_dispatch import _cancel_evicted_native_subagent
+
+    posts: list[dict[str, Any]] = []
+
+    def _snapshot(parent: str, wrapper: str) -> dict[str, Any]:
+        return {
+            "parent_session_id": parent,
+            "labels": {"omnigent.wrapper": wrapper},
+        }
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=_snapshot("conv_owner", "goose-native-ui"))
+        posts.append(json.loads(request.content))
+        return httpx.Response(204)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        # Wrong parent: refused without a stop.
+        refused = await _cancel_evicted_native_subagent(
+            "conv_evicted",
+            conversation_id="conv_someone_else",
+            server_client=server_client,
+        )
+        assert refused.startswith("Error:")
+        assert posts == []
+
+        # Owned + stop-capable native: the stop fires.
+        result = await _cancel_evicted_native_subagent(
+            "conv_evicted",
+            conversation_id="conv_owner",
+            server_client=server_client,
+        )
+    assert posts == [{"type": "stop_session", "data": {}}]
+    assert json.loads(result) == {"cancelled": True, "task_id": "conv_evicted", "status": "cancelled"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #5086 — parent-side generalization to match the child side #5040 already generalized.

## What was wrong

The **child** runner's `stop_session` handler already routes through `NativeInterruptRunner.stop` → the `_UNIFORM_STOP` registry (claude special + cursor/goose/kiro/kimi/hermes/qwen uniform stops, codex/pi aliasing to interrupt, in-process fallback for antigravity/opencode). But the **parent-side** `sys_cancel_task` still routed by the Claude wrapper label:

- active work got `stop_session` only for `claude-code-native-ui`; every other native got a bare `interrupt` — so cancelling a cursor/goose/kiro/kimi/hermes/qwen sub-agent never invoked the hard-stop those harnesses have, and the resident process could stay alive;
- a terminal `failed` entry could still clean up only a Claude pane;
- evicted-work recovery stopped only claude-labeled children.

## The fix

Cancellation now resolves from `_native_cancel_capability(wrapper_label)`, a classification mirroring the child's own dispatch:

| capability | wrappers | event | failed-entry behavior |
| --- | --- | --- | --- |
| `stop` | claude + the uniform six | `stop_session` | still routes — failed ≠ exited, the stop frees a live process |
| `best_effort` | codex, pi, antigravity, opencode | `interrupt` | cached terminal status (nothing forwardable would change it) |
| `inprocess` | everything else | `interrupt` | cached terminal status (unchanged) |

- The best-effort **result message** is now generic ("no runner-side hard-stop is wired for this harness") instead of codex-specific — the existing codex test's expected copy is updated with it.
- **Evicted-work recovery keeps the ownership verification** (`parent_session_id` must match — an evicted entry means the parent no longer knows the child's state) and now accepts any stop-capable native wrapper, still refusing everyone else's children.
- The docstring's stale claim that the runner "204 no-ops stop_session for every non-claude harness" is corrected — that stopped being true when the uniform stop registry landed; this PR makes the parent trust it.

## Tests

- `test_sys_cancel_task_stops_uniform_native_subagent` — cursor routes to `stop_session`. **Fails on `main`** (interrupt).
- `test_sys_cancel_task_stops_terminal_uniform_native_entry` — a `failed` qwen entry still hard-stops. **Fails on `main`** (cached status, no post).
- `test_sys_cancel_task_returns_cached_status_for_failed_best_effort_native` — failed pi returns cached status (pins the boundary on both sides).
- `test_cancel_evicted_native_subagent_checks_ownership_and_capability` — a goose-labeled evicted child: wrong parent refused with no stop, owned parent stopped. **Fails on `main`** (non-claude label refused).
- Updated: the codex best-effort message expectation (copy change only).

12/12 cancel-task tests pass with the fix; 4 fail on unpatched `main`. Full `test_runner_dispatch.py`: 190 passed / 6 pre-existing environment failures, identical set on clean `main` — zero regressions.
