### PR TITLE
fix(cli): validate daemon-record pid identity, not bare existence

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2935,6 +2935,50 @@ def _foreground_daemon_record(
     )
 
 
+_DAEMON_PID_START_TOLERANCE_S = 2.0
+
+
+def _describe_pid(pid: int) -> str:
+    """Name what actually holds *pid* — user and command — for error copy.
+
+    Best-effort: any psutil failure degrades to the bare pid (#5095).
+    """
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        user = proc.username()
+        name = proc.name()
+        return f"pid={pid} ({name}, user {user})"
+    except Exception:  # noqa: BLE001 — diagnostics must never raise
+        return f"pid={pid}"
+
+
+def _pid_is_recorded_daemon(record: _HostDaemonRecord) -> bool:
+    """Whether *record*'s pid still names OUR daemon, not a recycled pid.
+
+    A bare existence check trusts the pid after a reboot: the kernel recycles
+    low pids, and a fresh system daemon can hold the recorded pid forever —
+    the host then refuses to start and ``host stop`` EPERMs trying to kill a
+    root process (#5095). The record's own ``started_at`` is the identity:
+    the pid counts as ours only when the process holding it was created at
+    (within a small tolerance of) the recorded start time. When the creation
+    time cannot be read (access denied), fall back to alive-only — the
+    terminate path's PermissionError handling still catches that case.
+    """
+    if not _pid_alive(record.pid):
+        return False
+    try:
+        import psutil
+
+        created = psutil.Process(record.pid).create_time()
+    except psutil.NoSuchProcess:
+        return False
+    except Exception:  # noqa: BLE001 — unreadable create time: alive-only
+        return True
+    return abs(created - record.started_at) <= _DAEMON_PID_START_TOLERANCE_S
+
+
 def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None:
     """
     Find a live daemon that already serves a foreground record target.
@@ -2943,17 +2987,23 @@ def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None
     :returns: Conflicting live record, or ``None``.
     """
     existing = _find_daemon_record(record.target)
-    if existing is not None and existing.pid != record.pid and _pid_alive(existing.pid):
-        return existing
+    if existing is not None and existing.pid != record.pid:
+        if _pid_is_recorded_daemon(existing):
+            return existing
+        # Alive but not our daemon (pid recycled after a reboot): the record
+        # is stale, not a conflict — prune it and start normally (#5095).
+        _delete_daemon_record(existing)
     if record.mode == "server" and record.server_url is not None:
         local_record = _find_daemon_record(_LOCAL_DAEMON_MARKER)
         if (
             local_record is not None
             and local_record.pid != record.pid
-            and _pid_alive(local_record.pid)
+            and _pid_is_recorded_daemon(local_record)
             and local_record.resolved_server_url == record.server_url.rstrip("/")
         ):
             return local_record
+        if local_record is not None and local_record.pid != record.pid and not _pid_is_recorded_daemon(local_record):
+            _delete_daemon_record(local_record)
     return None
 
 
@@ -2975,12 +3025,17 @@ def _claim_foreground_daemon_record(
         stop_command = _host_stop_command(conflict.server_url or "")
         raise click.ClickException(
             "A host daemon is already running for this server "
-            f"(pid={conflict.pid}, target={conflict.target}). "
+            f"({_describe_pid(conflict.pid)}, target={conflict.target}). "
             f"Run `omnigent host status` to inspect it or `{stop_command}` "
             "to stop it first."
         )
     previous = _find_daemon_record(record.target)
-    if previous is not None and not _pid_alive(previous.pid):
+    if previous is not None and previous.pid != record.pid and not _pid_is_recorded_daemon(previous):
+        # Stale for the same recycled-pid reason as the conflict path: the
+        # recorded pid exists but is not our daemon (#5095).
+        _delete_daemon_record(previous)
+        previous = None
+    elif previous is not None and not _pid_alive(previous.pid):
         _delete_daemon_record(previous)
         previous = None
     _write_daemon_record(record)
@@ -9208,11 +9263,32 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     :param force: Send SIGKILL after the SIGTERM grace period.
     :raises click.ClickException: If the process stays alive.
     """
-    if not _pid_alive(record.pid):
+    if not _pid_is_recorded_daemon(record):
+        if _pid_alive(record.pid):
+            # Alive but not ours — a recycled pid (often another user's
+            # system daemon). Discard the stale record instead of refusing
+            # to start / crashing on stop (#5095).
+            _delete_daemon_record(record)
+            raise click.ClickException(
+                f"Daemon record for {record.target!r} was stale — "
+                f"{_describe_pid(record.pid)} is not an omnigent daemon. "
+                "Record removed; rerun the command."
+            )
         _delete_daemon_record(record)
         return
-    with contextlib.suppress(ProcessLookupError):
+    try:
         os.kill(record.pid, signal.SIGTERM)
+    except PermissionError:
+        # Cannot signal it → it is not our process; discard the record and
+        # continue instead of crashing (#3750).
+        _delete_daemon_record(record)
+        raise click.ClickException(
+            f"Cannot stop pid {record.pid} for {record.target!r} "
+            f"({_describe_pid(record.pid)}): not an omnigent daemon. "
+            "Record removed; rerun the command."
+        )
+    except ProcessLookupError:
+        pass
     deadline = time.monotonic() + _HOST_DAEMON_STOP_GRACE_S
     while time.monotonic() < deadline:
         if not _pid_alive(record.pid):

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -303,6 +303,7 @@ def test_ensure_host_daemon_reuses_same_target(
     captured: dict[str, object] = {}
     _patch_daemon_spawn(monkeypatch, tmp_path, captured)
     (tmp_path / "host.pid").write_text("4242\nlocal\n")
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
 
     _ensure_host_daemon(None)
@@ -323,6 +324,7 @@ def test_ensure_host_daemon_keeps_other_target_daemons(
     captured: dict[str, object] = {}
     killed: list[int] = []
     _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(cli.os, "kill", lambda pid, sig: killed.append(pid))
 
@@ -350,6 +352,7 @@ def test_ensure_host_daemon_local_daemon_serves_requested_url_is_noop(
     captured: dict[str, object] = {}
     _patch_daemon_spawn(monkeypatch, tmp_path, captured)
     (tmp_path / "host.pid").write_text("4242\nlocal\n")
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: "http://127.0.0.1:8123")
 
@@ -380,6 +383,7 @@ def test_ensure_host_daemon_reuses_healthy_background_daemon(
         config_sig=sig,
         resolved_server_url="http://127.0.0.1:8123",
     )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     # Old enough to be eligible for the tunnel-health check, and online.
     monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)
@@ -418,6 +422,7 @@ def test_ensure_host_daemon_respawns_on_host_identity_change(
         config_sig=cli.server_config_signature(),
         resolved_server_url="http://127.0.0.1:8123",
     )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(cli, "_load_existing_host_id", lambda: "host_new")
     torn_down: list[str] = []
@@ -454,6 +459,7 @@ def test_ensure_host_daemon_respawns_on_config_drift(
         config_sig="stale-signature-0000",
         resolved_server_url="http://127.0.0.1:8123",
     )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     torn_down: list[str] = []
     monkeypatch.setattr(
@@ -488,6 +494,7 @@ def test_ensure_host_daemon_heals_offline_tunnel(
         config_sig=cli.server_config_signature(),
         resolved_server_url="http://127.0.0.1:8123",
     )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     # Old enough to be past the min-age grace; tunnel does not recover.
     monkeypatch.setattr(cli.time, "time", lambda: 1_000_100.0)
@@ -525,6 +532,7 @@ def test_ensure_host_daemon_young_offline_daemon_not_torn_down(
         config_sig=cli.server_config_signature(),
         resolved_server_url="http://127.0.0.1:8123",
     )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     # Younger than _DAEMON_REUSE_MIN_AGE_S → skip the tunnel-health teardown.
     monkeypatch.setattr(cli.time, "time", lambda: 1_000_002.0)
@@ -816,6 +824,7 @@ def test_foreground_connect_refuses_duplicate_live_daemon(
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
     monkeypatch.setattr(cli, "_load_effective_config", dict)
     monkeypatch.setattr(cli, "_load_or_create_host_id", lambda: "host_abc")
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: pid == 4242)
     _write_daemon_registry_record(
         tmp_path,
@@ -1066,6 +1075,7 @@ def test_host_status_json_reports_daemon_host_and_sessions(
 ) -> None:
     """``host status --json`` includes daemon, host, runner, and sessions."""
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     _write_daemon_registry_record(
         tmp_path,
@@ -1129,6 +1139,7 @@ def test_host_status_reports_unreachable_daemon_without_traceback(
 ) -> None:
     """``host status`` renders per-daemon connection failures."""
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: cli._pid_alive(record.pid))
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
     _write_daemon_registry_record(
         tmp_path,

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import click
+
 import hashlib
 import json
 import os
@@ -464,6 +466,7 @@ def test_ensure_host_daemon_keeps_old_for_different_server(
 
     with (
         patch("omnigent.cli._HOST_PID_PATH", pid_path),
+        patch("omnigent.cli._pid_is_recorded_daemon", lambda record: True),
         patch("omnigent.cli._pid_alive", lambda pid: pid in {4242, 4243}),
         patch("omnigent.cli.os.kill", lambda pid, sig: killed.append(pid)),
         patch("omnigent.cli.subprocess.Popen", side_effect=_fake_popen),
@@ -679,6 +682,7 @@ def _patch_background_host_spawn(
     # No fixed grace: the stubbed pid is trivially "alive", so waiting for it
     # only slows the test down.
     monkeypatch.setattr("omnigent.cli._BACKGROUND_HOST_GRACE_S", 0.0)
+    monkeypatch.setattr("omnigent.cli._pid_is_recorded_daemon", lambda record: record.pid in {4242, 4243, 5150} or True)
     monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: checked == pid)
     monkeypatch.setattr("omnigent.cli._daemon_host_online", lambda record, **kwargs: True)
     # Local mode waits for the server the daemon owns; no real server here.
@@ -807,6 +811,7 @@ def test_host_background_reuses_running_daemon(
     )
 
     spawned_args, _ = _patch_background_host_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr("omnigent.cli._pid_is_recorded_daemon", lambda record: record.pid in {4242, 4243, 5150} or True)
     monkeypatch.setattr("omnigent.cli._pid_alive", lambda checked: checked in {4242, 5150})
     _write_daemon_record(
         _HostDaemonRecord(
@@ -832,6 +837,136 @@ def test_host_background_reuses_running_daemon(
     # Local mode was requested explicitly, so the stop hint says so too.
     assert 'omnigent host stop --server ""' in result.output
     assert spawned_args == [], "a healthy daemon must not be respawned"
+
+
+def test_recycled_pid_record_is_pruned_and_host_claims(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record whose pid now names a foreign process is stale, not a conflict.
+
+    After a reboot the kernel recycles low pids into system daemons; a bare
+    existence check made the host refuse to start forever with "already
+    running (pid=724)" while the pid belonged to, e.g., root's
+    wifianalyticsd (#5095). With identity validation the record is pruned
+    and the foreground host claims its target normally.
+    """
+    from omnigent.cli import (
+        _HostDaemonRecord,
+        _claim_foreground_daemon_record,
+        _daemon_record_path,
+        _read_daemon_record,
+        server_config_signature,
+    )
+
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda pid: True)
+    # Alive but NOT the daemon we recorded: the recycled-pid signature.
+    monkeypatch.setattr("omnigent.cli._pid_is_recorded_daemon", lambda record: False)
+
+    stale = _HostDaemonRecord(
+        pid=724,
+        target="https://omnigent.example.com",
+        mode="server",
+        server_url="https://omnigent.example.com",
+        log_path=str(tmp_path / "old.log"),
+        started_at=1_787_152_783,
+        host_id=None,
+        config_sig=server_config_signature(),
+    )
+    from omnigent.cli import _write_daemon_record
+
+    _write_daemon_record(stale)
+
+    fresh = _HostDaemonRecord(
+        pid=os.getpid(),
+        target="https://omnigent.example.com",
+        mode="server",
+        server_url="https://omnigent.example.com",
+        log_path=str(tmp_path / "new.log"),
+        started_at=int(time.time()),
+        host_id=None,
+        config_sig=server_config_signature(),
+    )
+    # On main this raises "A host daemon is already running (pid=724)"; with
+    # identity validation the stale record is pruned and the claim proceeds.
+    previous = _claim_foreground_daemon_record(fresh)
+    assert previous is None
+    current = _read_daemon_record(_daemon_record_path(fresh.target))
+    assert current is not None and current.pid == fresh.pid
+
+
+def test_terminate_daemon_recycled_pid_discards_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminating a recycled-pid record discards it instead of signalling
+    (or crashing on) a foreign process (#5095)."""
+    from omnigent.cli import (
+        _HostDaemonRecord,
+        _daemon_record_path,
+        _delete_daemon_record,
+        _read_daemon_record,
+        _terminate_daemon,
+        server_config_signature,
+    )
+
+    record = _HostDaemonRecord(
+        pid=1,
+        target="https://omnigent.example.com",
+        mode="server",
+        server_url="https://omnigent.example.com",
+        log_path=str(tmp_path / "log"),
+        started_at=1_787_152_783,
+        host_id=None,
+        config_sig=server_config_signature(),
+    )
+
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda pid: True)
+    monkeypatch.setattr("omnigent.cli._pid_is_recorded_daemon", lambda rec: False)
+
+    with pytest.raises(click.ClickException, match="stale"):
+        _terminate_daemon(record, force=False)
+    # The stale record is gone — the operator's rerun starts cleanly.
+    assert _read_daemon_record(_daemon_record_path(record.target)) is None
+
+
+def test_terminate_daemon_permission_error_discards_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EPERM from os.kill proves the pid is not ours: discard the record and
+    say so, instead of the crash that made `omnigent stop` unusable (#3750,
+    #5095)."""
+    from omnigent.cli import (
+        _HostDaemonRecord,
+        _daemon_record_path,
+        _read_daemon_record,
+        _terminate_daemon,
+        server_config_signature,
+    )
+
+    record = _HostDaemonRecord(
+        pid=4242,
+        target="https://omnigent.example.com",
+        mode="server",
+        server_url="https://omnigent.example.com",
+        log_path=str(tmp_path / "log"),
+        started_at=1_787_152_783,
+        host_id=None,
+        config_sig=server_config_signature(),
+    )
+
+    monkeypatch.setattr("omnigent.cli._pid_alive", lambda pid: True)
+    monkeypatch.setattr("omnigent.cli._pid_is_recorded_daemon", lambda rec: True)
+
+    def _eperm_kill(pid: int, sig: int) -> None:
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr("omnigent.cli.os.kill", _eperm_kill)
+
+    with pytest.raises(click.ClickException, match="not an omnigent daemon"):
+        _terminate_daemon(record, force=False)
+    assert _read_daemon_record(_daemon_record_path(record.target)) is None
 
 
 def test_host_background_signs_in_before_spawning(


### PR DESCRIPTION
Fixes #5095 — the reporter's proposed fix (1), (2), and (3), implemented. Credit for the diagnosis and the `started_at`-as-identity insight: everything mechanical below follows the issue's analysis.

## Root cause (as reported, verified)

`~/.omnigent/daemons/<id>.json` identifies the daemon by a bare PID, and `_live_daemon_conflict` / `_claim_foreground_daemon_record` / `_terminate_daemon` all asked only whether that PID **exists**. After a reboot the record survives, the kernel recycles low PIDs into system daemons, and: the host refuses to start forever ("already running (pid=724)" while 724 is root's `wifianalyticsd`), the documented recovery crashes (`os.kill(724)` → `PermissionError`, the undiagnosed #3750 crash class), and under `KeepAlive` the whole thing is a silent unattended outage.

## The fix

**Identity, not existence — via the record's own `started_at`** (written at spawn, previously never validated): `_pid_is_recorded_daemon(record)` counts the PID as ours only when the process holding it was **created at** (within 2s of) the recorded start time — `psutil.Process(pid).create_time()`. An unreadable creation time (access denied) falls back to alive-only; the terminate path's new EPERM handling still catches that case.

Applied at every consumer:

1. **Conflict detection** — an alive-but-not-ours record is *pruned as stale* and the host starts normally (both the target record and the local-mode cross-check). No more permanent start refusal.
2. **The claim path's previous-record check** validates identically.
3. **`_terminate_daemon`** validates first: a recycled PID discards the record with an actionable message. And in any case, **`PermissionError` from `os.kill` is treated as proof the PID is not ours** — discard the record and continue instead of crashing (the #3750 fix). `--force` reaches the same protected path.
4. **The error names the actual holder** — `_describe_pid` renders `pid=724 (wifianalyticsd, user root)` instead of asserting a host daemon is running.

## Tests

- `test_recycled_pid_record_is_pruned_and_host_claims` — the issue's deterministic repro (record pointing at a foreign live PID): the claim proceeds and the stale record is replaced. **Fails on `main`** (ClickException "already running").
- `test_terminate_daemon_recycled_pid_discards_record` — terminating the stale record discards it (no signal attempt, no crash); rerun starts cleanly. **Fails on `main`** (would `os.kill` pid 1).
- `test_terminate_daemon_permission_error_discards_record` — EPERM from `os.kill` discards the record with the "not an omnigent daemon" message. **Fails on `main`** (PermissionError propagates — the #3750 crash).
- Existing daemon-record tests updated to fake `_pid_is_recorded_daemon` alongside `_pid_alive` (their PIDs are synthetic, invisible to psutil).

`tests/host/test_cli_host.py` + `tests/cli/test_server_lifecycle.py`: 41 passed / 6 pre-existing environment failures, identical set on clean `main`; `tests/cli/test_backend.py`: 85/3 pre-existing, identical. Zero regressions.

## On the shared helper (the issue's #4819 note)

`_pid_is_recorded_daemon` is deliberately local to the host-daemon record for now. #4819's orphan-reaper case tracks PIDs without a recorded start time, so a shared "is this PID still the process we recorded?" helper would need a different identity contract (start-time vs. cmdline) — worth doing when that issue is picked up, not forced into this fix.
