### PR TITLE
[OMNI-3742] Enable emojis as project icons

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -648,7 +648,12 @@ def register_core_routes(
             by_name: dict[str, SessionProjectSummary] = {}
             if project_store is not None:
                 for proj in project_store.list(user_id=user_id):
-                    by_name[proj.name] = SessionProjectSummary(id=proj.id, name=proj.name)
+                    icon = proj.config.get("icon")
+                    by_name[proj.name] = SessionProjectSummary(
+                        id=proj.id,
+                        name=proj.name,
+                        icon=icon if isinstance(icon, str) else None,
+                    )
             # Legacy path: label-derived projects (id=None unless already first-class).
             for name in conversation_store.list_projects(owned_by=user_id):
                 by_name.setdefault(name, SessionProjectSummary(id=None, name=name))

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4399,10 +4399,14 @@ class SessionProjectSummary(BaseModel):
     :param id: First-class project id when one exists, or ``None`` for a
         label-only project not yet promoted to the ``projects`` table.
     :param name: Project name (the folder's display name and union key).
+    :param icon: The project's chosen emoji icon (a unicode grapheme), read
+        from its ``config``; ``None`` when unset or for a label-only folder,
+        so the sidebar falls back to the default folder glyph.
     """
 
     id: str | None = None
     name: str
+    icon: str | None = None
 
 
 class CreateProjectRequest(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -4894,6 +4894,18 @@
       "SessionProjectSummary": {
         "description": "One entry of `GET /v1/sessions/projects` \u2014 a sidebar project folder.\n\nDual-read union of first-class projects and legacy `omni_project`\nlabel-projects, keyed by name.",
         "properties": {
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The project's chosen emoji icon (a unicode grapheme), read from its `config`; `None` when unset or for a label-only folder, so the sidebar falls back to the default folder glyph.",
+            "title": "Icon"
+          },
           "id": {
             "anyOf": [
               {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
+      '@emoji-mart/react':
+        specifier: ^1.1.1
+        version: 1.1.1(emoji-mart@5.6.0)(react@18.3.1)
       '@fontsource-variable/geist-mono':
         specifier: ^5.2.7
         version: 5.3.0
@@ -235,6 +241,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      emoji-mart:
+        specifier: ^5.6.0
+        version: 5.6.0
       katex:
         specifier: ^0.16.47
         version: 0.16.47
@@ -4122,6 +4131,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}

--- a/tests/server/routes/test_projects_crud.py
+++ b/tests/server/routes/test_projects_crud.py
@@ -225,9 +225,30 @@ async def test_session_projects_unions_first_class_and_labels(
     resp = await project_client.get("/v1/sessions/projects")
     assert resp.status_code == 200
     assert resp.json() == [
-        {"id": both["id"], "name": "Both"},
-        {"id": empty["id"], "name": "Empty FC"},
-        {"id": None, "name": "Label Only"},
+        {"id": both["id"], "name": "Both", "icon": None},
+        {"id": empty["id"], "name": "Empty FC", "icon": None},
+        {"id": None, "name": "Label Only", "icon": None},
+    ]
+
+
+async def test_session_projects_surfaces_config_icon(
+    project_client: httpx.AsyncClient,
+) -> None:
+    """A first-class project's ``config.icon`` surfaces in the sidebar listing
+    so the folder can render the emoji; a non-string/absent icon stays None."""
+    fire = (
+        await project_client.post("/v1/projects", json={"name": "Fire", "config": {"icon": "🔥"}})
+    ).json()
+    # A config without an icon key surfaces None (default folder glyph).
+    plain = (
+        await project_client.post("/v1/projects", json={"name": "Plain", "config": {"host_id": "h"}})
+    ).json()
+
+    resp = await project_client.get("/v1/sessions/projects")
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"id": fire["id"], "name": "Fire", "icon": "🔥"},
+        {"id": plain["id"], "name": "Plain", "icon": None},
     ]
 
 

--- a/tests/server/routes/test_projects_crud.py
+++ b/tests/server/routes/test_projects_crud.py
@@ -241,7 +241,9 @@ async def test_session_projects_surfaces_config_icon(
     ).json()
     # A config without an icon key surfaces None (default folder glyph).
     plain = (
-        await project_client.post("/v1/projects", json={"name": "Plain", "config": {"host_id": "h"}})
+        await project_client.post(
+            "/v1/projects", json={"name": "Plain", "config": {"host_id": "h"}}
+        )
     ).json()
 
     resp = await project_client.get("/v1/sessions/projects")

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -304,8 +304,8 @@ async def test_list_projects_returns_names_sorted(
     assert resp.status_code == 200
     # Label-only projects (no first-class row) list with id=None, sorted by name.
     assert resp.json() == [
-        {"id": None, "name": "Customer X"},
-        {"id": None, "name": "Sprint 42"},
+        {"id": None, "name": "Customer X", "icon": None},
+        {"id": None, "name": "Sprint 42", "icon": None},
     ]
 
 

--- a/tests/server/routes/test_sessions_shared_projects.py
+++ b/tests/server/routes/test_sessions_shared_projects.py
@@ -94,7 +94,7 @@ def test_shared_project_not_listed_as_recipients_own_project(db_uri: str) -> Non
     # so it lists with id=None.
     bob = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": BOB})
     assert bob.status_code == 200
-    assert bob.json() == [{"id": None, "name": "Bob Project"}]
+    assert bob.json() == [{"id": None, "name": "Bob Project", "icon": None}]
 
     # Alice can access the session, but doesn't own it — no folder for her.
     alice = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": ALICE})

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@lobehub/fluent-emoji": "^4.1.0",
     "@lobehub/icons": "^5.6.0",
@@ -61,6 +63,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "emoji-mart": "^5.6.0",
     "katex": "^0.16.47",
     "lucide-react": "^1.12.0",
     "monaco-editor": "^0.55.1",

--- a/web/src/components/ProjectIconPicker.test.tsx
+++ b/web/src/components/ProjectIconPicker.test.tsx
@@ -1,0 +1,118 @@
+// Integration test for the project emoji-icon flow (OMNI-3742). Drives the real
+// ProjectLandingIcon + useUpdateProjectConfig + projects API client end to end,
+// mocking only the network (@/lib/projectsApi) and the emoji-mart picker (its
+// ~600KB JSON dataset can't load under vitest). The focus is the data-loss
+// guard: because the config PATCH replaces the whole blob, every set/remove
+// must merge onto a fully-loaded config and must not fire before it loads.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ProjectLandingIcon } from "./ProjectIconPicker";
+import { createProject, updateProjectConfig } from "@/lib/projectsApi";
+import type { ProjectConfig } from "@/lib/projectsApi";
+
+vi.mock("@/lib/projectsApi", () => ({
+  getProject: vi.fn(),
+  updateProjectConfig: vi.fn(),
+  createProject: vi.fn(),
+}));
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+// The real emoji-mart picker fetches a large JSON dataset that Node rejects
+// under vitest; stub it to one button that reports a chosen emoji, so the
+// open → select → save path is exercised without the dataset.
+vi.mock("@emoji-mart/react", () => ({
+  default: ({ onEmojiSelect }: { onEmojiSelect: (e: { native: string }) => void }) => (
+    <button type="button" data-testid="pick-fire" onClick={() => onEmojiSelect({ native: "🔥" })}>
+      🔥
+    </button>
+  ),
+}));
+vi.mock("@emoji-mart/data", () => ({ default: {} }));
+
+const updateMock = vi.mocked(updateProjectConfig);
+const createMock = vi.mocked(createProject);
+
+interface Overrides {
+  projectId?: string | null;
+  projectName?: string;
+  config?: ProjectConfig | undefined;
+  configReady?: boolean;
+}
+
+function renderIcon(overrides: Overrides = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <ProjectLandingIcon
+        projectId={"projectId" in overrides ? (overrides.projectId ?? null) : "p_1"}
+        projectName={overrides.projectName ?? "Work"}
+        config={"config" in overrides ? overrides.config : {}}
+        configReady={overrides.configReady ?? true}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  updateMock.mockReset();
+  createMock.mockReset();
+  updateMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+  createMock.mockResolvedValue({ id: "p_new", name: "Work", config: {} });
+});
+
+afterEach(cleanup);
+
+describe("ProjectLandingIcon", () => {
+  it("merges the picked emoji onto the loaded config, preserving other defaults", async () => {
+    const config: ProjectConfig = {
+      host_id: "h1",
+      workspace: "/repo",
+      agent_id: "a1",
+      use_worktree: true,
+      base_branch: "main",
+    };
+    renderIcon({ config });
+
+    fireEvent.click(screen.getByTestId("project-icon-tile"));
+    fireEvent.click(await screen.findByTestId("pick-fire"));
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
+    // The whole prior config survives; only `icon` is added.
+    expect(updateMock).toHaveBeenCalledWith("p_1", { ...config, icon: "🔥" });
+  });
+
+  it("removes the icon while preserving the other defaults", async () => {
+    renderIcon({ config: { host_id: "h1", icon: "🔥" } });
+
+    fireEvent.click(screen.getByTestId("project-icon-remove"));
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
+    expect(updateMock).toHaveBeenCalledWith("p_1", { host_id: "h1" });
+  });
+
+  it("does not write before the config has loaded (guards the data-loss race)", async () => {
+    renderIcon({ config: undefined, configReady: false });
+
+    // The edit affordance is disabled and the tile won't open the picker, so a
+    // config-wiping `{ icon }` PATCH can't be issued against unloaded state.
+    expect(screen.getByTestId("project-icon-edit")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("project-icon-tile"));
+    expect(screen.queryByTestId("pick-fire")).toBeNull();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("promotes a label-only folder (no id) when an icon is first set", async () => {
+    renderIcon({ projectId: null, config: undefined, configReady: true });
+
+    fireEvent.click(screen.getByTestId("project-icon-tile"));
+    fireEvent.click(await screen.findByTestId("pick-fire"));
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
+    // The label-only folder is promoted (created) first, then the icon is set
+    // on the fresh first-class id.
+    expect(createMock).toHaveBeenCalledWith("Work");
+    expect(updateMock).toHaveBeenCalledWith("p_new", { icon: "🔥" });
+  });
+});

--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -1,0 +1,130 @@
+// Emoji icon picker for projects. Two exports:
+//   - `EmojiPicker`: a themed emoji-mart picker, code-split so its ~600KB
+//     dataset never lands in the main bundle (loaded on first open).
+//   - `ProjectLandingIcon`: the big project-header icon on the new-chat landing
+//     — pink folder by default, the chosen emoji in a gray tile once set, with
+//     hover-revealed edit/remove affordances (the OMNI-3742 design).
+
+import { lazy, Suspense, useState } from "react";
+import { useTheme } from "next-themes";
+import { FolderIcon, PencilIcon, Trash2Icon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { useUpdateProjectConfig } from "@/hooks/useConversations";
+import type { ProjectConfig } from "@/lib/projectsApi";
+import { cn } from "@/lib/utils";
+
+// Both the picker component and its dataset are dynamically imported so they
+// stay out of the initial bundle and off the static graph (tests that render a
+// closed picker never touch the emoji JSON, which Node refuses under vitest).
+const Picker = lazy(() => import("@emoji-mart/react"));
+const loadEmojiData = async () => (await import("@emoji-mart/data")).default;
+
+/** A themed emoji-mart picker. Calls `onSelect` with the chosen unicode glyph. */
+export function EmojiPicker({ onSelect }: { onSelect: (native: string) => void }) {
+  const { resolvedTheme } = useTheme();
+  return (
+    <Suspense fallback={<div className="h-[420px] w-[352px]" aria-hidden />}>
+      <Picker
+        data={loadEmojiData}
+        onEmojiSelect={(emoji: { native: string }) => onSelect(emoji.native)}
+        theme={resolvedTheme === "dark" ? "dark" : "light"}
+        navPosition="top"
+        previewPosition="none"
+        skinTonePosition="none"
+        maxFrequentRows={2}
+        perLine={8}
+        autoFocus
+      />
+    </Suspense>
+  );
+}
+
+/**
+ * The project-header icon on the new-chat landing. Reads/writes the emoji
+ * through the project's `config.icon`, merging so the other stored defaults
+ * (host / workspace / agent) survive an icon change or removal. A label-only
+ * folder (`projectId === null`) is promoted on demand by the mutation.
+ */
+export function ProjectLandingIcon({
+  projectId,
+  projectName,
+  config,
+}: {
+  projectId: string | null;
+  projectName: string;
+  config: ProjectConfig | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  const update = useUpdateProjectConfig();
+  const icon = config?.icon;
+
+  const save = (native: string) => {
+    update.mutate({
+      id: projectId,
+      name: projectName,
+      config: { ...(config ?? {}), icon: native },
+    });
+    setOpen(false);
+  };
+  const clear = () => {
+    const next = { ...(config ?? {}) };
+    delete next.icon;
+    update.mutate({ id: projectId, name: projectName, config: next });
+  };
+
+  return (
+    <span className="group/icon relative flex h-16 shrink-0 items-center">
+      {/* Edit / remove affordances, revealed above the tile on hover. Remove is
+          hidden until an emoji is set (nothing to reset to). */}
+      <div className="absolute -top-1 left-1/2 flex -translate-x-1/2 -translate-y-full items-center gap-0.5 rounded-lg bg-popover p-0.5 opacity-0 shadow-menu ring-1 ring-foreground/10 transition-opacity focus-within:opacity-100 group-hover/icon:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Change project icon"
+          onClick={() => setOpen(true)}
+        >
+          <PencilIcon className="size-3.5" />
+        </Button>
+        {icon ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Remove project icon"
+            onClick={clear}
+          >
+            <Trash2Icon className="size-3.5" />
+          </Button>
+        ) : null}
+      </div>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverAnchor asChild>
+          <button
+            type="button"
+            aria-label="Change project icon"
+            onClick={() => setOpen((o) => !o)}
+            className={cn(
+              "flex size-14 items-center justify-center rounded-xl transition-colors",
+              icon ? "bg-muted" : "bg-tag-pink",
+            )}
+          >
+            {icon ? (
+              <span className="text-[30px] leading-none">{icon}</span>
+            ) : (
+              <FolderIcon className="size-6 text-brand-accent" />
+            )}
+          </button>
+        </PopoverAnchor>
+        <PopoverContent
+          align="center"
+          className="w-auto border-0 bg-transparent p-0 shadow-none ring-0"
+        >
+          <EmojiPicker onSelect={save} />
+        </PopoverContent>
+      </Popover>
+    </span>
+  );
+}

--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -46,21 +46,32 @@ export function EmojiPicker({ onSelect }: { onSelect: (native: string) => void }
  * through the project's `config.icon`, merging so the other stored defaults
  * (host / workspace / agent) survive an icon change or removal. A label-only
  * folder (`projectId === null`) is promoted on demand by the mutation.
+ *
+ * `configReady` gates editing: the PATCH replaces the whole config blob, so a
+ * write before the config has loaded would merge onto `{}` and silently wipe
+ * those defaults. The caller passes `true` only once the config has resolved
+ * (or when there's no first-class config to lose).
  */
 export function ProjectLandingIcon({
   projectId,
   projectName,
   config,
+  configReady,
 }: {
   projectId: string | null;
   projectName: string;
   config: ProjectConfig | undefined;
+  configReady: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const update = useUpdateProjectConfig();
   const icon = config?.icon;
 
+  const openPicker = () => {
+    if (configReady) setOpen(true);
+  };
   const save = (native: string) => {
+    if (!configReady) return;
     update.mutate({
       id: projectId,
       name: projectName,
@@ -69,6 +80,7 @@ export function ProjectLandingIcon({
     setOpen(false);
   };
   const clear = () => {
+    if (!configReady) return;
     const next = { ...(config ?? {}) };
     delete next.icon;
     update.mutate({ id: projectId, name: projectName, config: next });
@@ -84,7 +96,9 @@ export function ProjectLandingIcon({
           variant="ghost"
           size="icon-xs"
           aria-label="Change project icon"
-          onClick={() => setOpen(true)}
+          data-testid="project-icon-edit"
+          disabled={!configReady}
+          onClick={openPicker}
         >
           <PencilIcon className="size-3.5" />
         </Button>
@@ -94,6 +108,8 @@ export function ProjectLandingIcon({
             variant="ghost"
             size="icon-xs"
             aria-label="Remove project icon"
+            data-testid="project-icon-remove"
+            disabled={!configReady}
             onClick={clear}
           >
             <Trash2Icon className="size-3.5" />
@@ -104,8 +120,9 @@ export function ProjectLandingIcon({
         <PopoverAnchor asChild>
           <button
             type="button"
-            aria-label="Change project icon"
-            onClick={() => setOpen((o) => !o)}
+            aria-label="Project icon"
+            data-testid="project-icon-tile"
+            onClick={openPicker}
             className={cn(
               "flex size-14 items-center justify-center rounded-xl transition-colors",
               icon ? "bg-muted" : "bg-tag-pink",

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -1336,6 +1336,9 @@ export { PROJECT_LABEL_KEY };
 export interface ProjectSummary {
   id: string | null;
   name: string;
+  /** Chosen emoji icon (a unicode grapheme), or null/absent for the default
+      folder glyph. Sourced from the project's `config.icon`. */
+  icon?: string | null;
 }
 
 /**
@@ -1919,7 +1922,7 @@ export function useUpdateProjectConfig() {
       // config to `{}` and drop the saved defaults on that first visit.
       queryClient.setQueryData<ProjectSummary[]>(["projects"], (prev) => {
         if (!prev) return prev;
-        const summary = { id: project.id, name: project.name };
+        const summary = { id: project.id, name: project.name, icon: project.config?.icon };
         return prev.some((p) => p.name === project.name)
           ? prev.map((p) => (p.name === project.name ? summary : p))
           : [...prev, summary];

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -25,6 +25,8 @@ export interface ProjectConfig {
   workspace?: string;
   /** Default agent id for new sessions. */
   agent_id?: string;
+  /** Chosen emoji icon (a unicode grapheme, e.g. "🔥"). Unset → default folder. */
+  icon?: string;
   /**
    * Opt-in worktree default: only `true` is meaningful. When `true`, a new
    * session in a git workspace starts in a fresh randomly-named worktree; unset

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -63,6 +63,7 @@ import {
   MODEL_SELECT_SMART,
   RoutingModelSelect,
 } from "@/components/HarnessConfigControls";
+import { ProjectLandingIcon } from "@/components/ProjectIconPicker";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -4101,15 +4102,15 @@ export function NewChatLandingScreen() {
       <div className="flex w-full max-w-[840px] flex-col items-center gap-6 px-4 pt-8 pb-16 md:select-none md:px-10">
         <div className="flex w-full flex-col items-center justify-center gap-3.5">
           {selectedProject ? (
-            // Landing inside a project: swap Otto's eyes for the same folder
-            // icon the sidebar uses for a project, and name the project. Sized
-            // to Otto's h-16 box so the centered composer doesn't shift when
-            // toggling between the two landings.
-            <span className="flex h-16 shrink-0 items-center">
-              <div className="w-14 h-14 flex rounded-xl bg-tag-pink items-center justify-center">
-                <FolderIcon className="size-6 text-brand-accent" />
-              </div>
-            </span>
+            // Landing inside a project: swap Otto's eyes for the project's
+            // icon — the default pink folder, or a chosen emoji — and name the
+            // project. Sized to Otto's h-16 box so the centered composer doesn't
+            // shift when toggling between the two landings.
+            <ProjectLandingIcon
+              projectId={configProjectId}
+              projectName={selectedProject}
+              config={storedProjectConfig}
+            />
           ) : (
             <BrandLogo variant="eyes" className="h-14 w-auto shrink-0" />
           )}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4110,6 +4110,14 @@ export function NewChatLandingScreen() {
               projectId={configProjectId}
               projectName={selectedProject}
               config={storedProjectConfig}
+              // Gate editing until the config resolves: the PATCH replaces the
+              // whole blob, so a write before the name→id and config have loaded
+              // would wipe the project's other defaults. A label-only folder
+              // (`configProjectId === null`) has no first-class config to lose.
+              configReady={
+                !projectListLoading &&
+                (configProjectId === null || storedProjectConfig !== undefined)
+              }
             />
           ) : (
             <BrandLogo variant="eyes" className="h-14 w-auto shrink-0" />

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -43,6 +43,8 @@ import {
   SearchIcon,
   Settings2Icon,
   ShareIcon,
+  SmileIcon,
+  SmilePlusIcon,
   SquareIcon,
   SquareCheckIcon,
   SquarePenIcon,
@@ -115,6 +117,8 @@ import {
   useMoveToProject,
   useDeleteProject,
   useRenameProject,
+  useProjectConfig,
+  useUpdateProjectConfig,
   PROJECT_LABEL_KEY,
   PINNED_CONVERSATIONS_KEY,
   usePinnedConversations,
@@ -133,6 +137,7 @@ import { relativeTime } from "@/lib/relativeTime";
 import { showToast } from "@/components/ui/toast";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
+import { EmojiPicker } from "@/components/ProjectIconPicker";
 import { SessionStateBadge } from "@/components/SessionStateBadge";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useActiveRootSessionId } from "@/hooks/useSession";
@@ -1071,6 +1076,7 @@ function InfiniteScrollSentinel({
 function ProjectFolder({
   name,
   projectId,
+  icon,
   windowConversations,
   expanded,
   active,
@@ -1091,6 +1097,9 @@ function ProjectFolder({
   name: string;
   /** First-class project id, or null for a label-only folder. */
   projectId: string | null;
+  /** Chosen emoji icon (unicode grapheme), or null/absent for the default
+      folder glyph. */
+  icon?: string | null;
   /** This folder's members from the globally-loaded window (may lag or lead
       the folder's own pages — e.g. a just-moved row carries its optimistic
       membership here before the folder query returns it). */
@@ -1169,7 +1178,9 @@ function ProjectFolder({
       <ConversationSection
         title={name}
         icon={
-          expanded ? (
+          icon ? (
+            <span className="text-[14px] leading-none">{icon}</span>
+          ) : expanded ? (
             <FolderOpenIcon
               className={cn(
                 "ui-icon",
@@ -1218,7 +1229,12 @@ function ProjectFolder({
         }
         indentRows
         headerAction={
-          <ProjectFolderActions projectName={name} projectId={projectId} onNavigate={onRowClick} />
+          <ProjectFolderActions
+            projectName={name}
+            projectId={projectId}
+            icon={icon}
+            onNavigate={onRowClick}
+          />
         }
         footer={
           loadingFirstPage ? (
@@ -1442,24 +1458,29 @@ function ConversationList({
     // (and out of the flat Shared list via filedIds). Each folder holds its
     // non-pinned sessions — pinning a project's last one leaves it empty.
     const filedIds = new Set<string>();
-    const projectGroups: { id: string | null; name: string; conversations: Conversation[] }[] =
-      projects.map(({ id, name }) => {
-        // Dual-read membership: a session belongs to this folder if it has
-        // the first-class id OR the legacy omni_project label of this name,
-        // and (filing being owner-only) the viewer owns it.
-        const inProject = notArchived.filter(
-          (c) =>
-            isOwnedByViewer(c, viewerId) &&
-            ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
-            !pinnedIdSet.has(c.id),
-        );
-        inProject.forEach((c) => filedIds.add(c.id));
-        return {
-          id,
-          name,
-          conversations: sortByUpdatedAtDesc(inProject, activeOverride, frozenKeys),
-        };
-      });
+    const projectGroups: {
+      id: string | null;
+      name: string;
+      icon?: string | null;
+      conversations: Conversation[];
+    }[] = projects.map(({ id, name, icon }) => {
+      // Dual-read membership: a session belongs to this folder if it has
+      // the first-class id OR the legacy omni_project label of this name,
+      // and (filing being owner-only) the viewer owns it.
+      const inProject = notArchived.filter(
+        (c) =>
+          isOwnedByViewer(c, viewerId) &&
+          ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
+          !pinnedIdSet.has(c.id),
+      );
+      inProject.forEach((c) => filedIds.add(c.id));
+      return {
+        id,
+        name,
+        icon,
+        conversations: sortByUpdatedAtDesc(inProject, activeOverride, frozenKeys),
+      };
+    });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
     // conversations — either genuinely empty or because its chats live on an
@@ -1942,6 +1963,7 @@ function ConversationList({
                       key={group.name}
                       name={group.name}
                       projectId={group.id}
+                      icon={group.icon}
                       windowConversations={group.conversations}
                       expanded={expandedProjects.includes(group.name)}
                       active={newSessionProjectName === group.name}
@@ -3886,11 +3908,14 @@ function ArchivingRow({ label }: { label: string }) {
 function ProjectFolderActions({
   projectName,
   projectId,
+  icon,
   onNavigate,
 }: {
   projectName: string;
   /** First-class project id, or null for a label-only folder. */
   projectId: string | null;
+  /** Current emoji icon, or null/absent when unset. */
+  icon?: string | null;
   /** Plain-left-click nav handler — closes the mobile overlay so the
       pre-filed new-session page isn't left hidden behind the sidebar. */
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
@@ -3927,7 +3952,12 @@ function ProjectFolderActions({
         </TooltipTrigger>
         <TooltipContent side="bottom">New session in project</TooltipContent>
       </Tooltip>
-      <ProjectFolderMenu projectName={projectName} projectId={projectId} onNavigate={onNavigate} />
+      <ProjectFolderMenu
+        projectName={projectName}
+        projectId={projectId}
+        icon={icon}
+        onNavigate={onNavigate}
+      />
     </div>
   );
 }
@@ -3943,10 +3973,13 @@ function ProjectFolderActions({
 function ProjectFolderMenu({
   projectName,
   projectId,
+  icon,
   onNavigate,
 }: {
   projectName: string;
   projectId: string | null;
+  /** Current emoji icon, or null/absent when unset (gates "Remove icon"). */
+  icon?: string | null;
   /** Nav handler for the mobile-only "New session" item (desktop uses the
       hover-revealed pencil). Closes the sidebar overlay on mobile. */
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
@@ -3955,9 +3988,35 @@ function ProjectFolderMenu({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [iconOpen, setIconOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(projectName);
   const deleteProject = useDeleteProject();
   const renameProject = useRenameProject();
+  const updateConfig = useUpdateProjectConfig();
+  // Fetch the full config only while the menu or picker is open, so we can
+  // merge the icon onto the other stored defaults (host / workspace / agent)
+  // without a per-folder request on every sidebar render — and without wiping
+  // those defaults on set/remove.
+  const { data: iconConfig, isLoading: iconConfigLoading } = useProjectConfig(
+    menuOpen || iconOpen ? projectId : null,
+  );
+  const setIcon = (native: string) => {
+    updateConfig.mutate(
+      { id: projectId, name: projectName, config: { ...(iconConfig ?? {}), icon: native } },
+      {
+        onSuccess: () => {
+          setIconOpen(false);
+          setMenuOpen(false);
+        },
+      },
+    );
+  };
+  const removeIcon = () => {
+    const next = { ...(iconConfig ?? {}) };
+    delete next.icon;
+    updateConfig.mutate({ id: projectId, name: projectName, config: next });
+    setMenuOpen(false);
+  };
 
   return (
     <>
@@ -4005,6 +4064,20 @@ function ProjectFolderMenu({
             <Settings2Icon className="size-3.5" />
             Project settings
           </DropdownMenuItem>
+          <DropdownMenuItem data-testid="change-project-icon" onSelect={() => setIconOpen(true)}>
+            <SmilePlusIcon className="size-3.5" />
+            Change icon…
+          </DropdownMenuItem>
+          {icon ? (
+            <DropdownMenuItem
+              data-testid="remove-project-icon"
+              disabled={iconConfigLoading}
+              onSelect={removeIcon}
+            >
+              <SmileIcon className="size-3.5" />
+              Remove icon
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem
             data-testid="delete-project"
             variant="destructive"
@@ -4084,6 +4157,29 @@ function ProjectFolderMenu({
         projectId={projectId}
         projectName={projectName}
       />
+      <Dialog
+        open={iconOpen}
+        onOpenChange={(o) => {
+          setIconOpen(o);
+          if (!o) setMenuOpen(false);
+        }}
+      >
+        <DialogContent
+          onClick={(e) => e.stopPropagation()}
+          className="w-auto items-center gap-3 p-4"
+        >
+          <DialogHeader>
+            <DialogTitle>Choose an icon</DialogTitle>
+          </DialogHeader>
+          {iconConfigLoading ? (
+            <div className="flex h-[420px] w-[352px] items-center justify-center">
+              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <EmojiPicker onSelect={setIcon} />
+          )}
+        </DialogContent>
+      </Dialog>
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -4000,7 +4000,14 @@ function ProjectFolderMenu({
   const { data: iconConfig, isLoading: iconConfigLoading } = useProjectConfig(
     menuOpen || iconOpen ? projectId : null,
   );
+  // The config PATCH replaces the whole blob, so a set/remove must merge onto a
+  // fully-loaded config or it silently wipes the other defaults. "Ready" means
+  // the config actually resolved (`!== undefined` — `isLoading` alone is false
+  // on a query *error* too, leaving no data to merge onto) — except a
+  // label-only folder (`projectId === null`), whose base is legitimately `{}`.
+  const configReady = projectId === null || iconConfig !== undefined;
   const setIcon = (native: string) => {
+    if (!configReady) return;
     updateConfig.mutate(
       { id: projectId, name: projectName, config: { ...(iconConfig ?? {}), icon: native } },
       {
@@ -4012,6 +4019,7 @@ function ProjectFolderMenu({
     );
   };
   const removeIcon = () => {
+    if (!configReady) return;
     const next = { ...(iconConfig ?? {}) };
     delete next.icon;
     updateConfig.mutate({ id: projectId, name: projectName, config: next });
@@ -4071,7 +4079,7 @@ function ProjectFolderMenu({
           {icon ? (
             <DropdownMenuItem
               data-testid="remove-project-icon"
-              disabled={iconConfigLoading}
+              disabled={!configReady}
               onSelect={removeIcon}
             >
               <SmileIcon className="size-3.5" />
@@ -4171,12 +4179,16 @@ function ProjectFolderMenu({
           <DialogHeader>
             <DialogTitle>Choose an icon</DialogTitle>
           </DialogHeader>
-          {iconConfigLoading ? (
+          {configReady ? (
+            <EmojiPicker onSelect={setIcon} />
+          ) : iconConfigLoading ? (
             <div className="flex h-[420px] w-[352px] items-center justify-center">
               <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <EmojiPicker onSelect={setIcon} />
+            <div className="flex h-[420px] w-[352px] items-center justify-center px-6 text-center text-ui text-muted-foreground">
+              Couldn&apos;t load this project&apos;s settings. Close and try again.
+            </div>
           )}
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Related issue

Tracked in Linear: [OMNI-3742 — Enable emojis as Project icons](https://linear.app/omnigent/issue/OMNI-3742/enable-emojis-as-project-icons) (no GitHub issue).

## Summary

Let a project carry an **emoji icon** in place of the default pink folder.

- **Storage (no migration).** The emoji is a single unicode grapheme stored in the project's existing opaque `config` blob as `config.icon` — no new column, no schema change. The sidebar listing (`GET /v1/sessions/projects`) gains an optional `icon` field (read from `config`) so folders render it without an extra per-project fetch.
- **Picker.** A bespoke in-app picker (`emoji-mart`, already present transitively; now declared direct and **lazy-loaded** so its ~600 KB dataset stays out of the main bundle) inside the app's existing Popover. The OS emoji picker can't be triggered/styled from the web, so a bespoke one is required to match the design.
- **Edit surfaces.** The new-chat project landing header (pink folder ↔ emoji tile, with hover pencil / trash) and the sidebar folder menu (*Change icon…* / *Remove icon*). A label-only folder is promoted to a first-class project on first icon set.
- **No data loss.** The config PATCH replaces the whole blob, so every set/remove **merges onto a fully-loaded config and is gated until it resolves** — a write can't fire against unloaded or errored state and silently wipe the project's host / workspace / agent / base-branch / worktree defaults.

ELI5: pick an emoji for a project; it shows on the project's folder and header; picking or clearing it never clobbers the project's other saved defaults.

```
config (opaque JSON, already round-trips DB → API → UI)
  └─ icon: "🔥"      ← new key; set/clear merges onto the loaded blob
GET /v1/sessions/projects → { id, name, icon }   ← sidebar renders folder-or-emoji
```

## Test Plan

**Automated**
- UI integration (`web/src/components/ProjectIconPicker.test.tsx`, vitest, emoji-mart + network mocked): open → select merges the emoji onto the loaded config with defaults preserved; remove preserves defaults; **no write before config loads** (the data-loss guard); label-only folder is promoted on first set.
- Backend (`tests/server/routes/`): `test_session_projects_surfaces_config_icon` asserts `config.icon` surfaces in the listing (and stays `null` when unset); the union / shared-projects shape tests are updated for the new field.
- Full web suite green (590 tests); `tsc`, oxlint, prettier, and `ruff` clean; `openapi.json` regenerated and `--check`-clean.

**Manual**
1. Open a project's new-chat landing → hover the icon → **pencil** opens the picker; pick 🔥 → the tile turns gray with the emoji; **trash** resets to the pink folder.
2. The sidebar folder shows the emoji; the folder ⋯ menu → *Change icon…* / *Remove icon* work too.
3. Set host/workspace via *Project settings*, then change/remove the icon → those defaults stay intact.
4. Toggle dark mode → the picker follows the theme.

## Demo

https://github.com/user-attachments/assets/d58abdd6-d7b9-4056-9639-b9176f865d4e

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the visual / interaction behaviour the automated tests don't assert: picker rendering (search, categories, recents), the pink-folder ↔ gray-emoji tile swap, hover affordances, dark-mode theming, and the sidebar folder reflecting the emoji after a save. The automated tests cover the risky logic — the config merge and the load-gate that prevents wiping other defaults — plus the backend listing field.

## Changelog

Assign an emoji as a project's icon — from the project header or the sidebar folder menu.
