### PR TITLE
fix(native): retry preflight forwarder failures

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -146,6 +146,10 @@ def post_may_have_been_delivered(exc: httpx.HTTPError) -> bool:
     - Connection-establishment / pool-acquire failures
       (:data:`_DELIVERY_SAFE_RETRY_ERRORS`): no bytes were sent → not
       delivered → safe to retry, so ``False``.
+    - An unbound ``RequestError``: the failure occurred before httpx
+      associated the exception with the outbound request (for example,
+      an auth flow failed before yielding it). No bytes were sent → safe
+      to retry, so ``False``.
     - Any other transport error (read/write timeout, read/write error,
       remote protocol error): the request was sent and we never saw a
       response, so the server may have processed it → ambiguous →
@@ -158,6 +162,10 @@ def post_may_have_been_delivered(exc: httpx.HTTPError) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return False
     if isinstance(exc, _DELIVERY_SAFE_RETRY_ERRORS):
+        return False
+    try:
+        _ = exc.request
+    except RuntimeError:
         return False
     return True
 

--- a/tests/e2e/test_claude_native_preflight_delivery_e2e.py
+++ b/tests/e2e/test_claude_native_preflight_delivery_e2e.py
@@ -1,0 +1,132 @@
+"""End-to-end regression for OMNI-2530 pre-flight forwarder failures."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+
+import omnigent.claude_native_forwarder as forwarder
+
+
+class _FailFirstAuth(httpx.Auth):
+    """Fail once before yielding a request, then allow retries through."""
+
+    def __init__(self) -> None:
+        self.failed = False
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        if not self.failed:
+            self.failed = True
+            raise httpx.RequestError("token refresh returned no token")
+        yield request
+
+
+class _RecordingServer(ThreadingHTTPServer):
+    requests: queue.Queue[dict[str, Any]]
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        cast(_RecordingServer, self.server).requests.put(payload)
+        self.send_response(202)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+
+@contextmanager
+def _recording_server() -> Iterator[tuple[_RecordingServer, str]]:
+    server = _RecordingServer(("127.0.0.1", 0), _RecordingHandler)
+    server.requests = queue.Queue()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    address = server.server_address
+    host = str(address[0])
+    port = int(address[1])
+    try:
+        yield server, f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_preflight_auth_failure_retries_claude_tool_call_after_recovery(
+    tmp_path: Path,
+) -> None:
+    """A request that failed before send must not burn the transcript item id."""
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "assistant-tool-call",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_omni_2530",
+                            "name": "Read",
+                            "input": {"file_path": "/tmp/example.txt"},
+                        }
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    retry_tracker = forwarder._PostRetryTracker(base_delay_s=0.0, max_delay_s=0.0)
+    dedupe = forwarder._ForwardDedupeState()
+
+    with _recording_server() as (server, base_url):
+        async with httpx.AsyncClient(base_url=base_url, auth=_FailFirstAuth()) as client:
+            after_failure = await forwarder._forward_available_items(
+                client=client,
+                session_id="conv_omni_2530",
+                bridge_dir=bridge_dir,
+                agent_name="claude-native-ui",
+                state=state,
+                retry_tracker=retry_tracker,
+                dedupe=dedupe,
+            )
+            after_recovery = await forwarder._forward_available_items(
+                client=client,
+                session_id="conv_omni_2530",
+                bridge_dir=bridge_dir,
+                agent_name="claude-native-ui",
+                state=after_failure,
+                retry_tracker=retry_tracker,
+                dedupe=dedupe,
+            )
+
+    assert after_failure.byte_offset == 0
+    assert after_failure.seen_source_ids == ()
+    assert after_recovery.byte_offset == transcript_path.stat().st_size
+    posted = server.requests.get_nowait()
+    assert posted["type"] == "external_conversation_item"
+    assert posted["data"]["item_type"] == "function_call"
+    assert posted["data"]["item_data"]["name"] == "Read"
+    assert server.requests.empty()

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -83,8 +83,18 @@ def _read_records(path: Path) -> list[dict[str, object]]:
             False,
         ),
         (httpx.PoolTimeout("no slot", request=httpx.Request("POST", "http://test")), False),
+        # Auth flows can fail before yielding the request to the transport.
+        # httpx leaves those RequestErrors unbound, proving no bytes were sent.
+        (httpx.RequestError("auth failed before send"), False),
         # Request was sent and no response was seen — the server may have
         # committed it. Ambiguous: a retry could duplicate.
+        (
+            httpx.RequestError(
+                "transport failed after binding",
+                request=httpx.Request("POST", "http://test"),
+            ),
+            True,
+        ),
         (httpx.ReadTimeout("no response", request=httpx.Request("POST", "http://test")), True),
         (httpx.WriteError("write failed", request=httpx.Request("POST", "http://test")), True),
         (


### PR DESCRIPTION
## Related issue

Closes #4333

## Summary

- Treat unbound `httpx.RequestError` failures as provably pre-flight, so native transcript items remain queued for retry instead of being permanently marked seen.
- Preserve the existing ambiguous-delivery behavior for request-bound transport failures where retrying could duplicate a committed item.
- Add an e2e regression that sends a Claude tool call through the real forwarder and HTTP auth flow, fails before the first network send, then verifies delivery after auth recovery.

**ELI5:** If authentication fails before a message leaves the computer, Omnigent now keeps the message and tries again instead of assuming the server may already have it.

```text
Claude transcript -> auth pre-flight fails -> keep cursor/item id -> retry
                                                        |
                                                        v
auth recovers -> POST reaches server -> advance cursor/mark seen
```

## Test Plan

- Confirmed the new e2e test fails on latest `origin/main` (`9fc0c382`) before the production fix.
- `.venv/bin/python -m pytest tests/e2e/test_claude_native_preflight_delivery_e2e.py tests/test_native_post_delivery.py -q`
- `.venv/bin/python -m pytest tests/test_claude_native_forwarder.py -k 'forwarder_skips_user_item_on_ambiguous_post_failure or forwarder_retries_user_item_on_connect_error or ambiguous_boundary_post_marks_persisted' -q`
- `.venv/bin/ruff check omnigent/_native_post_delivery.py tests/test_native_post_delivery.py tests/e2e/test_claude_native_preflight_delivery_e2e.py`
- `.venv/bin/pyrefly check omnigent/_native_post_delivery.py tests/e2e/test_claude_native_preflight_delivery_e2e.py`

## Demo

N/A — non-visual forwarding fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises both the pre-flight failure/recovery path and the existing genuinely ambiguous transport-failure behavior.

## Changelog

Claude-native sessions no longer silently lose tool calls when authentication fails before a transcript POST is sent.
