### PR TITLE
test(e2e-ui): cover native Codex web tools

### DIFF
--- a/tests/e2e_ui/chat/test_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_codex_goal_mode.py
@@ -43,10 +43,10 @@ def _goal_response(session_id: str, method: str, suffix: str = ""):
 @pytest.mark.timeout(300)
 def test_codex_goal_mode_processes_first_message_with_untrusted_hooks(
     page: Page,
-    mocked_native_codex_goal_session: MockedCodexNativeSession,
+    mocked_native_codex_session: MockedCodexNativeSession,
 ) -> None:
     """Bypass hook review, then exercise goal controls through the real UI path."""
-    session = mocked_native_codex_goal_session
+    session = mocked_native_codex_session
     page.goto(f"{session.base_url}/c/{session.session_id}")
 
     _open_terminal_view(page)

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -694,8 +694,8 @@ def set_fallback_mock_llm(
     resp.raise_for_status()
 
 
-def _codex_cli_supports_goal_mode(codex_path: str) -> bool:
-    """Return whether the installed Codex CLI has app-server goal APIs."""
+def _codex_cli_supports_mocked_app_server(codex_path: str) -> bool:
+    """Return whether the Codex CLI supports the mocked app-server tests."""
     version = subprocess.run(
         [codex_path, "--version"],
         text=True,
@@ -2798,7 +2798,7 @@ providers:
 
 
 @pytest.fixture
-def mocked_native_codex_goal_session(
+def mocked_native_codex_session(
     built_spa: None,
     tmp_path_factory: pytest.TempPathFactory,
     request: pytest.FixtureRequest,
@@ -2813,23 +2813,23 @@ def mocked_native_codex_goal_session(
     in the same shard.
     """
     if request.config.getoption("--ui-base-url"):
-        pytest.skip("mocked native Codex goal e2e requires an isolated spawned server")
+        pytest.skip("mocked native Codex e2e requires an isolated spawned server")
 
     codex_path = shutil.which("codex")
     if codex_path is None:
-        pytest.skip("codex CLI is required for mocked native Codex goal e2e")
-    if not _codex_cli_supports_goal_mode(codex_path):
-        pytest.skip("codex CLI >= 0.139.0 is required for app-server goal APIs")
+        pytest.skip("codex CLI is required for mocked native Codex e2e")
+    if not _codex_cli_supports_mocked_app_server(codex_path):
+        pytest.skip("codex CLI >= 0.139.0 is required for mocked app-server e2e")
 
     try:
         sidecar_bin = build_sidecar_bin()
     except RuntimeError:
         pytest.skip("cargo is required for Codex parity sidecar")
 
-    server_tmp = tmp_path_factory.mktemp("e2e_ui_codex_goal_server")
-    sidecar = start_codex_responses_sidecar(
-        sidecar_bin,
-        server_tmp / "responses.json",
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_mocked_codex_server")
+    responses = getattr(
+        request,
+        "param",
         [
             [
                 ev_response_created("resp-goal-ui-bootstrap"),
@@ -2837,6 +2837,11 @@ def mocked_native_codex_goal_session(
                 ev_completed("resp-goal-ui-bootstrap"),
             ]
         ],
+    )
+    sidecar = start_codex_responses_sidecar(
+        sidecar_bin,
+        server_tmp / "responses.json",
+        responses,
     )
 
     config_home = server_tmp / "config-home"

--- a/tests/e2e_ui/messages/test_native_codex_web_tools.py
+++ b/tests/e2e_ui/messages/test_native_codex_web_tools.py
@@ -1,0 +1,73 @@
+"""E2E regression: native Codex web turns can use built-in tools."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.codex_parity.helpers import (
+    ev_completed,
+    ev_function_call,
+    ev_response_created,
+)
+from tests.e2e_ui.conftest import MockedCodexNativeSession
+
+from .test_message_render_parity import _ASSISTANT, _select_view_mode, _send
+
+_SHELL_OUTPUT = "E2E_NATIVE_CODEX_WEB_SHELL_OUTPUT"
+_COMMAND = f"printf '{_SHELL_OUTPUT}\\n'"
+_PROMPT = "Run the shell command supplied by the mocked response."
+_TOOL_RESPONSES = [
+    [
+        ev_response_created("resp-web-shell-tool"),
+        ev_function_call(
+            "call_web_shell_tool",
+            "exec_command",
+            json.dumps({"cmd": _COMMAND}),
+        ),
+        ev_completed("resp-web-shell-tool"),
+    ]
+]
+_NATIVE_CODEX_TIMEOUT_MS = 180_000
+
+
+@pytest.mark.parametrize(
+    "mocked_native_codex_session",
+    [_TOOL_RESPONSES],
+    indirect=True,
+    ids=["shell-tool"],
+)
+@pytest.mark.timeout(300)
+def test_native_codex_web_turn_runs_shell_tool(
+    page: Page,
+    mocked_native_codex_session: MockedCodexNativeSession,
+) -> None:
+    """A composer-started native Codex turn executes and renders its shell tool."""
+    session = mocked_native_codex_session
+    page.goto(f"{session.base_url}/c/{session.session_id}")
+    _select_view_mode(page, "Chat")
+
+    _send(page, _PROMPT)
+
+    assistant_turn = page.locator(_ASSISTANT).last
+    shell_run = assistant_turn.get_by_role("button", name="Ran 1 shell command")
+    expect(shell_run).to_be_visible(timeout=_NATIVE_CODEX_TIMEOUT_MS)
+    shell_run.click()
+    command_row = assistant_turn.get_by_role("button", name=re.compile(r"^printf "))
+    expect(command_row).to_be_visible(timeout=30_000)
+    command_row.click()
+    expect(assistant_turn.get_by_text(_SHELL_OUTPUT, exact=True)).to_be_visible(timeout=30_000)
+
+    requests = session.sidecar.requests(min_count=1, timeout_ms=30_000)
+    turn_request = next(
+        request for request in requests if _PROMPT in str(request["body"]["input"])
+    )
+    advertised_tools = {
+        tool.get("name")
+        for tool in turn_request["body"].get("tools", [])
+        if isinstance(tool, dict)
+    }
+    assert "exec_command" in advertised_tools


### PR DESCRIPTION
## Related issue

Follow-up regression coverage for OMNI-2531 and #5048.

## Summary

- Add a browser-driven native Codex regression that starts a turn from Chat and executes `exec_command` through the real Codex app-server.
- Assert the turn advertises `exec_command` and the SPA renders the shell command and its output.
- Generalize the isolated mocked native Codex fixture so the goal-mode and web-tool journeys share the same deterministic Responses sidecar setup.

## Test Plan

- `/Users/corey.zumar/omnigent/.venv/bin/python3 -m pre_commit run --files tests/e2e_ui/conftest.py tests/e2e_ui/chat/test_codex_goal_mode.py tests/e2e_ui/messages/test_native_codex_web_tools.py`
- Run the E2E UI workflow against this branch.
- Confirm the same test fails on the temporary pre-fix proof branch based on `0b0fc3f2`.

## Demo

N/A — test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Playwright journey uses the real native Codex CLI with the deterministic Responses sidecar and verifies the expanded shell output in the rendered chat transcript. The pre-fix proof run fails because the web-started Codex turn does not receive its tool environment.

## Changelog

N/A — test-only change with no user-facing behavior change.