### PR TITLE
fix(codex-native): bypass intermittent hook trust gate

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4129,18 +4129,14 @@ async def _auto_create_codex_terminal(
                     # hook sources itself; skip the interactive trust prompt
                     # that headless sub-agents can never answer.
                     #
-                    # Requires a *positively parsed* version, unlike the
-                    # hooks-file gate in ``codex_native_app_server``, which
-                    # treats an unknown version as supported. The two differ
-                    # because their failure modes do: an unsupported hooks
-                    # file is ignored by codex and caught downstream at the
-                    # trust check, whereas an unknown CLI flag aborts argv
-                    # parsing — so a transient ``codex --version`` hiccup on a
-                    # pre-0.131 codex would turn a recoverable trust prompt
-                    # into a dead terminal.
+                    # A failed version probe must not restore the interactive
+                    # gate: Omnigent's supported Codex floor is newer than the
+                    # release that added this flag. Otherwise a transient
+                    # ``codex --version`` failure strands the queued web
+                    # message behind the terminal-only review screen.
                     bypass_hook_trust=(
-                        app_server.codex_cli_version is not None
-                        and app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+                        app_server.codex_cli_version is None
+                        or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
                     ),
                 ),
                 env=codex_terminal_env(app_server),

--- a/tests/e2e_ui/chat/test_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_codex_goal_mode.py
@@ -41,11 +41,11 @@ def _goal_response(session_id: str, method: str, suffix: str = ""):
 # multi-minute cargo build runs here). timeout(300) matches the sibling
 # native-Codex render-parity tests now that the sidecar build is out of band.
 @pytest.mark.timeout(300)
-def test_codex_goal_mode_with_mocked_responses(
+def test_codex_goal_mode_processes_first_message_with_untrusted_hooks(
     page: Page,
     mocked_native_codex_goal_session: MockedCodexNativeSession,
 ) -> None:
-    """Set, pause/resume, and clear a Codex goal through the real UI/API path."""
+    """Bypass hook review, then exercise goal controls through the real UI path."""
     session = mocked_native_codex_goal_session
     page.goto(f"{session.base_url}/c/{session.session_id}")
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -710,6 +710,23 @@ def _codex_cli_supports_goal_mode(codex_path: str) -> bool:
     return tuple(int(part) for part in match.groups()) >= _CODEX_GOAL_MIN_VERSION
 
 
+def _write_codex_unknown_version_shim(directory: Path, codex_path: str) -> Path:
+    """Write a Codex shim whose version probe fails without blocking launches."""
+    shim = directory / "codex-unknown-version"
+    shim.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import sys\n"
+        "if sys.argv[1:] == ['--version']:\n"
+        "    print('codex-cli version unavailable')\n"
+        "    raise SystemExit(0)\n"
+        f"os.execv({codex_path!r}, [{codex_path!r}, *sys.argv[1:]])\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return shim
+
+
 def _assert_service_worker_tombstone(build_output: Path) -> None:
     """Fail if the built SPA ships anything but the tombstone service worker.
 
@@ -2829,6 +2846,22 @@ def mocked_native_codex_goal_session(
     artifact_dir = server_tmp / "artifacts"
     for path in (source_codex_home, home_dir, state_dir, artifact_dir):
         path.mkdir(parents=True, exist_ok=True)
+    # Reproduce the intermittent production path deterministically: a user
+    # hook needs review while the runner's version probe is unparseable. The
+    # real Codex binary still handles every non-version invocation.
+    (source_codex_home / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "UserPromptSubmit": [
+                        {"hooks": [{"type": "command", "command": "/usr/bin/true"}]}
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    codex_shim = _write_codex_unknown_version_shim(server_tmp, codex_path)
     _write_mock_codex_provider_config(config_home, sidecar.base_url)
 
     port = _find_free_port()
@@ -2852,6 +2885,7 @@ def mocked_native_codex_goal_session(
         "OMNIGENT_CODEX_NATIVE_STATE_DIR": str(state_dir),
         "CODEX_HOME": str(source_codex_home),
         "HOME": str(home_dir),
+        "OMNIGENT_CODEX_PATH": str(codex_shim),
     }
     server_env = {
         **shared_env,

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -1421,14 +1421,11 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     assert launched_sandbox is not None and launched_sandbox.type == "none"
     assert launch_captured["parent_os_env"] is codex_os_env
 
-    # This fake app-server reports no codex version (an unparseable / failed
-    # probe). The argv flag requires a positively parsed version: on a
-    # pre-0.131 codex an unknown flag aborts argv parsing outright, which is
-    # strictly worse than the recoverable trust prompt. (The app-server's
-    # hooks-file gate keeps the opposite "unknown = supported" policy, since
-    # an unsupported hooks file is only ignored.)
+    # A transient / unparseable version probe must not strand a runner-owned
+    # session behind Codex's terminal-only hook review screen. Omnigent's
+    # supported Codex floor is newer than the release that added this flag.
     assert app_server.codex_cli_version is None
-    assert "--dangerously-bypass-hook-trust" not in launch_captured["spec"].args
+    assert launch_captured["spec"].args[0] == "--dangerously-bypass-hook-trust"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

OMNI-2531

## Summary

- Keep `--dangerously-bypass-hook-trust` enabled for runner-owned Codex terminals when `codex --version` is transiently unavailable or unparseable.
- Add a deterministic real-Codex UI regression with an untrusted user hook and an unknown-version shim, matching the terminal-only “Hooks need review” gate.

**ELI5:** Omnigent already knows supported Codex versions understand the automation flag. A flaky version check should not make a headless web session stop and wait for a terminal click that the web message path cannot provide.

```text
Web message -> runner starts Codex -> version probe fails
                                |
                                v
Before: omit bypass -> Hooks need review -> message blocked
After:  keep bypass -> Codex thread starts -> message processed
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest tests/test_codex_native.py -k 'bypass_hook_trust' tests/runner/test_app_sessions_native_terminals_runtime.py::test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir -q`
- `.venv/bin/pytest tests/e2e_ui/messages/test_native_codex_render_parity.py::test_native_codex_message_render_parity -q -s`
- CI-only deterministic regression: `tests/e2e_ui/chat/test_codex_goal_mode.py::test_codex_goal_mode_processes_first_message_with_untrusted_hooks` uses the prebuilt Codex parity sidecar.

## Demo

N/A — native launch behavior; no web UI code or visual layout changed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified locally with Codex CLI 0.146.0 that two web-composer turns and one terminal-originated turn complete and render identically in the web transcript. The deterministic unknown-version + untrusted-hook journey requires the parity sidecar supplied by CI.

## Changelog

Codex sessions launched from the web no longer get stuck behind the “Hooks need review” terminal prompt when version detection briefly fails.
