### PR TITLE
fix(web): remember new-session harness settings

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -522,12 +522,13 @@ async def _save_config(page) -> None:
 
 
 def test_start_session_select_permission_mode(seeded_session: tuple[str, str]) -> None:
-    """Picking a non-default permission mode rides along to the create call.
+    """A launched permission mode reaches create and seeds the next session.
 
     Selecting "Accept edits" in the Claude Code config modal
     must (a) update the permission select as immediate feedback and
     (b) reach ``POST /v1/sessions`` as
-    ``terminal_launch_args: ["--permission-mode", "acceptEdits"]``.
+    ``terminal_launch_args: ["--permission-mode", "acceptEdits"]``, then
+    (c) remain selected when the user opens the next New Session screen.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_permission_mode(base_url, session_id))
@@ -605,6 +606,15 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
             assert body.get("terminal_launch_args") == ["--permission-mode", "acceptEdits"], body
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_entry_config(page, "ag_claude_e2e")
+            await expect(
+                page.get_by_test_id("new-chat-landing-config-permission")
+            ).to_contain_text("Accept edits")
         finally:
             await browser.close()
 
@@ -1642,6 +1652,18 @@ async def _drive_model_effort(base_url: str, session_id: str) -> None:
             assert body["agent_id"] == "ag_claude_e2e", body
             assert body.get("model_override") == "opus", body
             assert body.get("reasoning_effort") == "high", body
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_entry_config(page, "ag_claude_e2e")
+            await expect(page.get_by_test_id("new-chat-landing-config-model")).to_contain_text(
+                "Opus 4.8"
+            )
+            await expect(page.get_by_test_id("new-chat-landing-config-effort")).to_contain_text(
+                "High"
+            )
         finally:
             await browser.close()
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1904,14 +1904,15 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
 
 
 def test_start_session_bypass_sandbox(seeded_session: tuple[str, str]) -> None:
-    """Arming DANGEROUS Codex full-bypass rides along to the create.
+    """Codex full-bypass reaches create and seeds the next session.
 
     Bypass is the most-permissive option in the Codex config modal's Approval
     dropdown — Codex's ``--dangerously-bypass-approvals-and-sandbox`` stance.
     It reads back like Claude's "Bypass permissions": a plain dropdown pick with
     no warning banner. When armed, the create ``POST /v1/sessions`` must carry
     the ``omnigent.codex_native.bypass_sandbox: "1"`` conversation label so the
-    runner launches Codex with the bypass flag.
+    runner launches Codex with the bypass flag. After returning to New Session,
+    the same dropdown must still show bypass rather than resetting to Default.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_bypass_sandbox(base_url, session_id))
@@ -1978,6 +1979,15 @@ async def _drive_bypass_sandbox(base_url: str, session_id: str) -> None:
             # label alongside the codex-native wrapper labels.
             labels = body.get("labels") or {}
             assert labels.get("omnigent.codex_native.bypass_sandbox") == "1", body
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_entry_config(page, "ag_codex_e2e")
+            await expect(page.get_by_test_id("new-chat-landing-config-approval")).to_contain_text(
+                "Bypass approvals & sandbox"
+            )
         finally:
             await browser.close()
 

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -867,6 +867,37 @@ describe("NewChatLandingScreen create flow", () => {
     );
   });
 
+  it("persists Codex bypass so the next session shows it instead of Default", async () => {
+    setAgents([agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_codex" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_codex");
+    pickSelectOption("new-chat-landing-config-approval", "Bypass approvals & sandbox");
+    saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() =>
+      expect(
+        JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")["codex-native"]
+          ?.mode,
+      ).toBe("bypass"),
+    );
+
+    cleanup();
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_codex");
+    expect(screen.getByTestId("new-chat-landing-config-approval").textContent).toContain(
+      "Bypass approvals & sandbox",
+    );
+  });
+
   it("does not leak one harness's mode onto another harness", async () => {
     // Codex has a pick on record; selecting Claude Code (no pick) must stay on
     // its default — modes are keyed per harness, not shared.

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -760,6 +760,10 @@ describe("NewChatLandingScreen create flow", () => {
     // bare single token) means the runner would launch claude with the wrong
     // permission mode.
     expect(body.terminal_launch_args).toEqual(["--permission-mode", "bypassPermissions"]);
+    expect(
+      JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")["claude-native"]
+        ?.mode,
+    ).toBe("bypassPermissions");
   });
 
   it("seeds the permission mode from the last pick for claude-native on a new session", async () => {
@@ -789,6 +793,55 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toEqual(["--permission-mode", "plan"]);
   });
 
+  it.each([
+    {
+      harness: "codex-native",
+      agentName: "codex-native-ui",
+      displayName: "Codex",
+      mode: "full-access",
+      expectedArgs: ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
+    },
+    {
+      harness: "cursor-native",
+      agentName: "cursor-native-ui",
+      displayName: "Cursor",
+      mode: "plan",
+      expectedArgs: ["--mode", "plan"],
+    },
+    {
+      harness: "antigravity-native",
+      agentName: "antigravity-native-ui",
+      displayName: "Antigravity",
+      mode: "skip",
+      expectedArgs: ["--dangerously-skip-permissions"],
+    },
+  ])("seeds the last launched mode for $harness", async (testCase) => {
+    localStorage.setItem(
+      "omnigent:last-mode-by-harness",
+      JSON.stringify({ [testCase.harness]: { mode: testCase.mode } }),
+    );
+    setAgents([
+      agent({
+        id: `ag_${testCase.harness}`,
+        name: testCase.agentName,
+        display_name: testCase.displayName,
+      }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: `conv_${testCase.harness}` }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).terminal_launch_args).toEqual(testCase.expectedArgs);
+  });
+
   it("persists the picked permission mode for claude-native so the next session seeds it", async () => {
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
@@ -801,10 +854,11 @@ describe("NewChatLandingScreen create flow", () => {
     openAgentConfig("ag_native");
     pickSelectOption("new-chat-landing-config-permission", "Accept edits");
     saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
 
-    // The pick is snapshotted under the harness key on Save, so the next
-    // visit can seed from it. (Saving also records the empty model/effort,
-    // which stay unset for this default-model session.)
+    // The successfully-created session leaves its launched mode as the next
+    // session's default.
     await waitFor(() =>
       expect(
         JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")["claude-native"]
@@ -969,6 +1023,33 @@ describe("NewChatLandingScreen create flow", () => {
     // `["--permission-mode", ...]` pair would be rejected by agy, which has no
     // such flag — so assert the exact spelling, not merely "some args".
     expect(body.terminal_launch_args).toEqual(["--dangerously-skip-permissions"]);
+    expect(
+      JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")[
+        "antigravity-native"
+      ]?.mode,
+    ).toBe("skip");
+  });
+
+  it("remembers the launched execution mode for cursor-native", async () => {
+    setAgents([agent({ id: "ag_cursor", name: "cursor-native-ui", display_name: "Cursor" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_cursor" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_cursor");
+    pickSelectOption("new-chat-landing-config-cursor-mode", "Plan");
+    saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const stored = JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")[
+      "cursor-native"
+    ];
+    expect(stored?.mode).toBe("plan");
   });
 
   it("omits terminal_launch_args when antigravity-native permissions are left at default", async () => {
@@ -1109,6 +1190,9 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.model_override).toBe("omnigent-openai/system.ai.gpt-5-6-sol");
     expect(body.reasoning_effort).toBeUndefined();
     expect(body.labels?.["omnigent.wrapper"]).toBe("pi-native-ui");
+    expect(
+      JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")["pi-native"]?.model,
+    ).toBe("omnigent-openai/system.ai.gpt-5-6-sol");
   });
 
   it("seeds the model + effort from the last pick for claude-native on a new session", async () => {
@@ -1145,14 +1229,21 @@ describe("NewChatLandingScreen create flow", () => {
       JSON.stringify({ "claude-native": { effort: "high" } }),
     );
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_native" }),
+    } as unknown as Response);
 
     renderLanding();
     await waitForWorkspaceSeed();
     openAgentConfig("ag_native");
     pickSelectOption("new-chat-landing-config-model", "Opus");
     saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
 
-    // Save merges the model pick with the stored effort — both seed next time.
+    // The launched snapshot contains both the new model and seeded effort.
     await waitFor(() => {
       const stored = JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")[
         "claude-native"
@@ -1235,6 +1326,10 @@ describe("NewChatLandingScreen create flow", () => {
       "--ask-for-approval",
       "never",
     ]);
+    expect(
+      JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")["codex-native"]
+        ?.mode,
+    ).toBe("full-access");
   });
 
   it("omits terminal_launch_args when approval mode is left at default for codex-native", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -123,7 +123,7 @@ import {
 import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { readDefaultBaseBranch } from "@/lib/baseBranchPreferences";
-import { readHarnessOptions, writeHarnessOption } from "@/lib/modePreferences";
+import { readHarnessOptions, writeHarnessOption, type HarnessOptions } from "@/lib/modePreferences";
 import {
   AUTO_HARNESS_DESCRIPTION,
   AUTO_HARNESS_ID,
@@ -389,6 +389,58 @@ const CODEX_NATIVE_BYPASS_APPROVAL_OPTION = {
   description: "Runs Codex with no approval prompts and no command sandbox",
   args: [] as string[],
 };
+
+function createdHarnessOptions({
+  harness,
+  supportsPermissionMode,
+  supportsApprovalMode,
+  supportsCursorMode,
+  supportsAgySkipPermissions,
+  supportsModelPicker,
+  permissionMode,
+  approvalMode,
+  cursorExecMode,
+  agySkipMode,
+  pickedModel,
+  pickedEffort,
+  smartRoutingEligible,
+  costControlMode,
+}: {
+  harness: string | null;
+  supportsPermissionMode: boolean;
+  supportsApprovalMode: boolean;
+  supportsCursorMode: boolean;
+  supportsAgySkipPermissions: boolean;
+  supportsModelPicker: boolean;
+  permissionMode: string;
+  approvalMode: string;
+  cursorExecMode: string;
+  agySkipMode: string;
+  pickedModel: string;
+  pickedEffort: string;
+  smartRoutingEligible: boolean;
+  costControlMode: CostControlMode;
+}): HarnessOptions | null {
+  if (harness === null) return null;
+
+  const options: HarnessOptions = {};
+  if (supportsModelPicker) options.model = pickedModel;
+  if (supportsPermissionMode) {
+    options.mode = permissionMode;
+    options.effort = pickedEffort;
+  } else if (supportsApprovalMode) {
+    options.mode = approvalMode;
+  } else if (supportsCursorMode) {
+    options.mode = cursorExecMode;
+  } else if (supportsAgySkipPermissions) {
+    options.mode = agySkipMode;
+  }
+
+  if (smartRoutingEligible) {
+    options.routing = costControlMode === "on" ? "on" : "off";
+  }
+  return Object.keys(options).length > 0 ? options : null;
+}
 
 function displayModelId(option: Pick<NativeModelOption, "id">): string {
   return option.id;
@@ -1642,12 +1694,13 @@ function HarnessConfigModal({
       setPickedModel(draftModel);
       setPickedEffort(draftEffort);
       setPermissionMode(draftPermission);
-      if (entryHarness)
+      if (entryHarness) {
         writeHarnessOption(entryHarness, {
           model: draftModel,
           effort: draftEffort,
           mode: draftPermission,
         });
+      }
     } else if (hasModelPicker) {
       setPickedModel(draftModel);
       if (entryHarness) writeHarnessOption(entryHarness, { model: draftModel });
@@ -1655,11 +1708,12 @@ function HarnessConfigModal({
       if (isCodex) setPickedModel(draftModel);
       setApprovalMode(draftApproval);
       setBypassSandbox(draftBypass);
-      if (entryHarness)
+      if (entryHarness) {
         writeHarnessOption(entryHarness, {
           mode: draftApproval,
           ...(isCodex ? { model: draftModel } : {}),
         });
+      }
     } else if (hasCursor) {
       setCursorExecMode(draftCursor);
       if (entryHarness) writeHarnessOption(entryHarness, { mode: draftCursor });
@@ -1685,11 +1739,12 @@ function HarnessConfigModal({
         setPickedModel("");
         setPickedEffort("");
       }
-      if (entryHarness)
+      if (entryHarness) {
         writeHarnessOption(entryHarness, {
           routing: draftRouting === "on" ? "on" : "off",
           ...(draftRouting === "on" ? { model: "", effort: "" } : {}),
         });
+      }
     }
     onOpenChange(false);
   };
@@ -3995,6 +4050,31 @@ export function NewChatLandingScreen() {
           return;
         }
         data = { id: created.id };
+      }
+      // Persist the configuration that actually launched. Modal Save updates
+      // storage eagerly so an immediate Send cannot observe stale state; this
+      // successful-create snapshot also covers restored drafts and every
+      // harness-specific creation path.
+      if (!smartRoutingHarnessSelected) {
+        const launchedOptions = createdHarnessOptions({
+          harness: selectedNativeHarness,
+          supportsPermissionMode,
+          supportsApprovalMode,
+          supportsCursorMode,
+          supportsAgySkipPermissions,
+          supportsModelPicker: agentSupportsModelPicker || nativeAgent?.harness === "codex-native",
+          permissionMode,
+          approvalMode,
+          cursorExecMode,
+          agySkipMode,
+          pickedModel,
+          pickedEffort,
+          smartRoutingEligible,
+          costControlMode,
+        });
+        if (launchedOptions !== null) {
+          writeHarnessOption(selectedNativeHarness, launchedOptions);
+        }
       }
       // Promote the born-filed session to first-class project membership. The
       // create above already stamped the `omni_project` label (so the row

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4058,10 +4058,10 @@ export function NewChatLandingScreen() {
       if (!smartRoutingHarnessSelected) {
         const launchedOptions = createdHarnessOptions({
           harness: selectedNativeHarness,
-          supportsPermissionMode,
-          supportsApprovalMode,
-          supportsCursorMode,
-          supportsAgySkipPermissions,
+          supportsPermissionMode: agentSupportsPermissionMode,
+          supportsApprovalMode: agentSupportsApprovalMode,
+          supportsCursorMode: agentSupportsCursorMode,
+          supportsAgySkipPermissions: agentSupportsAgySkip,
           supportsModelPicker: agentSupportsModelPicker || nativeAgent?.harness === "codex-native",
           permissionMode,
           approvalMode,
@@ -4069,7 +4069,7 @@ export function NewChatLandingScreen() {
           agySkipMode,
           pickedModel,
           pickedEffort,
-          smartRoutingEligible,
+          smartRoutingEligible: effectiveAgentId !== PENDING_AGENT_ID && smartRoutingEligible,
           costControlMode,
         });
         if (launchedOptions !== null) {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -399,6 +399,7 @@ function createdHarnessOptions({
   supportsModelPicker,
   permissionMode,
   approvalMode,
+  bypassSandbox,
   cursorExecMode,
   agySkipMode,
   pickedModel,
@@ -414,6 +415,7 @@ function createdHarnessOptions({
   supportsModelPicker: boolean;
   permissionMode: string;
   approvalMode: string;
+  bypassSandbox: boolean;
   cursorExecMode: string;
   agySkipMode: string;
   pickedModel: string;
@@ -429,7 +431,7 @@ function createdHarnessOptions({
     options.mode = permissionMode;
     options.effort = pickedEffort;
   } else if (supportsApprovalMode) {
-    options.mode = approvalMode;
+    options.mode = bypassSandbox ? CODEX_NATIVE_BYPASS_APPROVAL_VALUE : approvalMode;
   } else if (supportsCursorMode) {
     options.mode = cursorExecMode;
   } else if (supportsAgySkipPermissions) {
@@ -1710,7 +1712,7 @@ function HarnessConfigModal({
       setBypassSandbox(draftBypass);
       if (entryHarness) {
         writeHarnessOption(entryHarness, {
-          mode: draftApproval,
+          mode: isCodex && draftBypass ? CODEX_NATIVE_BYPASS_APPROVAL_VALUE : draftApproval,
           ...(isCodex ? { model: draftModel } : {}),
         });
       }
@@ -3020,10 +3022,13 @@ export function NewChatLandingScreen() {
   // first id, or a persisted/draft pick resolving on mount), which would wipe a
   // costControlMode/bypass restored from the landing draft.
   const prevAgentIdRef = useRef<string | null | undefined>(undefined);
+  const suppressBypassSeedRef = useRef(false);
   useEffect(() => {
     const prev = prevAgentIdRef.current;
     prevAgentIdRef.current = effectiveAgentId;
-    if (prev === undefined || prev === effectiveAgentId) return;
+    suppressBypassSeedRef.current =
+      prev !== undefined && prev !== null && prev !== effectiveAgentId;
+    if (!suppressBypassSeedRef.current) return;
     setBypassSandbox(false);
     setCostControlMode(null);
   }, [effectiveAgentId, setCostControlMode]);
@@ -3080,6 +3085,11 @@ export function NewChatLandingScreen() {
           : "",
       );
     } else if (supportsApprovalMode) {
+      setBypassSandbox(
+        !suppressBypassSeedRef.current &&
+          selectedNativeHarness === "codex-native" &&
+          stored.mode === CODEX_NATIVE_BYPASS_APPROVAL_VALUE,
+      );
       setApprovalMode(resolve(CODEX_NATIVE_APPROVAL_MODES, CODEX_NATIVE_DEFAULT_APPROVAL_MODE));
       // A remembered routing "on" outranks a remembered concrete model, and
       // also drops any model/effort left in the shared state (e.g. seeded for
@@ -4065,6 +4075,7 @@ export function NewChatLandingScreen() {
           supportsModelPicker: agentSupportsModelPicker || nativeAgent?.harness === "codex-native",
           permissionMode,
           approvalMode,
+          bypassSandbox,
           cursorExecMode,
           agySkipMode,
           pickedModel,


### PR DESCRIPTION
## Related issue

Closes #5109

## Summary

- Persist the model, reasoning effort, routing choice, and permission/approval mode that actually launched a web-created session.
- Keep preferences scoped per harness, including Claude Code, Codex, Pi, Cursor, and Antigravity.
- Preserve the eager modal-save path so clicking Send immediately cannot observe stale defaults.

ELI5: after choosing how a harness should run once, the next New Session screen opens with those same harness-specific choices instead of resetting them.

`Configure session → Create succeeds → Save per-harness preferences → Seed next New Session`

## Test Plan

- `pnpm --dir web exec vitest run src/lib/modePreferences.test.ts src/shell/NewChatDialog.flow.test.tsx`
- `.venv/bin/pre-commit run --files web/src/shell/NewChatDialog.tsx web/src/shell/NewChatDialog.flow.test.tsx tests/e2e_ui/start_session/test_start_session.py`
- `.venv/bin/pytest tests/e2e_ui/start_session/test_start_session.py -k 'bypass_sandbox' -q`
- Verified TypeScript, Oxlint, Prettier, Pyrefly, Ruff, mobile formatting, and repository hygiene hooks through pre-commit.

## Demo

![Before defaults and next-session remembered settings](https://raw.githubusercontent.com/omnigent-ai/omnigent/pr-assets-5110/.github/pr-assets/5110/remembered-settings.png)

Playwright-driven local capture: create a Claude Code session using Accept edits plus Opus/High, return to New Session, reopen Configure, and confirm all three selections remain populated.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Flow tests cover persisting and reseeding launch settings for Claude Code, Codex, Pi, Cursor, and Antigravity, including Codex's bypass-approvals-and-sandbox sentinel. Playwright verifies permission mode, model/effort, and Codex bypass survive a completed create and appear in the next New Session UI. Local E2E command: `uv run pytest tests/e2e_ui/start_session/test_start_session.py -k 'select_permission_mode or select_model_and_effort' -q` (2 passed).

## Changelog

New sessions remember your last model, effort, and permission settings for each harness.




